### PR TITLE
#11207: Make Device type opaque

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/allocator/test_l1_banking_allocator.cpp
@@ -12,7 +12,7 @@
 
 // TODO: Uplift to DeviceFixture once it does not skip GS
 TEST_F(BasicFixture, TestL1BuffersAllocatedTopDown) {
-    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0, 1, 0);
+    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0);
 
     std::vector<uint32_t> alloc_sizes = {32 * 1024, 64 * 1024, 128 * 1024};
     size_t total_size_bytes = 0;
@@ -43,7 +43,7 @@ TEST_F(BasicFixture, TestL1BuffersAllocatedTopDown) {
 
 // TODO: Uplift to DeviceFixture once it does not skip GS
 TEST_F(BasicFixture, TestL1BuffersDoNotGrowBeyondBankSize) {
-    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0, 1, 0);
+    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0);
 
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
     CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -24,7 +24,7 @@ class CommandQueueFixture : public ::testing::Test {
         const int device_id = 0;
 
         const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-        this->device_ = tt::tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        this->device_ = tt::tt_metal::CreateDevice(device_id, {.dispatch_core_type = dispatch_core_type});
     }
 
     void TearDown() override {
@@ -123,7 +123,7 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
         const int device_id = 0;
-        this->device_ = tt::tt_metal::CreateDevice(device_id, num_hw_cqs, 0, buffer_size);;
+        this->device_ = tt::tt_metal::CreateDevice(device_id, {.trace_region_size = buffer_size});
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
@@ -29,7 +29,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_ = tt::tt_metal::CreateDevice(0, num_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        device_ = tt::tt_metal::CreateDevice(0, {.num_hw_cqs = num_cqs, .dispatch_core_type = dispatch_core_type});
     }
 
     void TearDown() override {
@@ -61,7 +61,7 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
         const int device_id = 0;
-        this->device_ = tt::tt_metal::CreateDevice(device_id, num_hw_cqs, 0, buffer_size);;
+        this->device_ = tt::tt_metal::CreateDevice(device_id, {.trace_region_size = buffer_size});
     }
 
     void TearDown() override {

--- a/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
@@ -26,7 +26,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_ = tt::tt_metal::CreateDevice(0, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        device_ = tt::tt_metal::CreateDevice(0, {.num_hw_cqs = 2, .dispatch_core_type = dispatch_core_type});
     }
 
     void TearDown() override {

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -5,7 +5,7 @@
 #include "tt_metal/detail/reports/memory_reporter.hpp"
 #include "tt_metal/detail/reports/report_utils.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/impl/program/program.hpp"
 
 #include <algorithm>

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -58,6 +60,14 @@ size_t GetNumPCIeDevices();
 
 chip_id_t GetPCIeDeviceID(chip_id_t device_id);
 
+struct DeviceOptions {
+    uint8_t num_hw_cqs{1};
+    size_t l1_small_size{DEFAULT_L1_SMALL_SIZE};
+    size_t trace_region_size{DEFAULT_TRACE_REGION_SIZE};
+    DispatchCoreType dispatch_core_type{DispatchCoreType::WORKER};
+    std::vector<uint32_t> l1_bank_remap{};
+};
+
 /**
  * Instantiates a device object.
  *
@@ -65,15 +75,14 @@ chip_id_t GetPCIeDeviceID(chip_id_t device_id);
  *
  * | Argument   | Description                | Type            | Valid Range                       | Required |
  * |------------|----------------------------|-----------------|-----------------------------------|----------|
- * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
+ * | device_id  | ID of the device to target | chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
-Device *CreateDevice(
-    chip_id_t device_id,
-    const uint8_t num_hw_cqs = 1,
-    const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
-    const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER,
-    const std::vector<uint32_t> &l1_bank_remap = {});
+Device *CreateDevice(chip_id_t device_id, DeviceOptions device_options = {});
+
+struct DeviceMinimalOptions {
+    uint8_t num_hw_cqs{1};
+    DispatchCoreType dispatch_core_type{DispatchCoreType::WORKER};
+};
 
 /**
  * Instantiates a device with minimal setup, used to attach to a device in a bad state.
@@ -82,10 +91,9 @@ Device *CreateDevice(
  *
  * | Argument   | Description                | Type            | Valid Range                       | Required |
  * |------------|----------------------------|-----------------|-----------------------------------|----------|
- * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
+ * | device_id  | ID of the device to target | chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
-Device *CreateDeviceMinimal(
-    chip_id_t device_id, const uint8_t num_hw_cqs = 1, DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER);
+Device *CreateDeviceMinimal(chip_id_t device_id, DeviceMinimalOptions device_options = {});
 
 /**
  * Resets device and closes device

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 
 namespace tt {
 

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -8,7 +8,7 @@
 #include "llrt/llrt.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 
 namespace {

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -19,7 +19,7 @@
 #include "llrt/rtoptions.hpp"
 
 #include "hostdevcommon/dprint_common.h"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tensix_types.h"
 
 using std::uint32_t;

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -8,7 +8,7 @@
 #include "common/core_coord.h"
 #include "hw/inc/debug/ring_buffer.h"
 #include "hw/inc/dev_msgs.h"
-#include "impl/device/device.hpp"
+#include "impl/device/device_impl.hpp"
 #include "llrt/rtoptions.hpp"
 #include "noc/noc_overlay_parameters.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -21,6 +21,7 @@
 #include "noc/noc_overlay_parameters.h"
 #include "noc/noc_parameters.h"
 #include "debug/ring_buffer.h"
+#include "device/device_impl.hpp"
 #include "watcher_device_reader.hpp"
 
 namespace tt {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -62,321 +62,75 @@ static constexpr float  INF_WHB0 = 1.7014e+38;
 static constexpr float  INF_BH = INF_WHB0;
 
 // A physical PCIexpress Tenstorrent device
-class Device {
-   public:
-    // friend void tt_gdb(Device* device, int chip_id, const vector<CoreCoord> cores, vector<string> ops);
-    Device () = delete;
-    Device(
-        chip_id_t device_id,
-        const uint8_t num_hw_cqs,
-        std::size_t l1_small_size,
-        std::size_t trace_region_size,
-        const std::vector<uint32_t> &l1_bank_remap = {},
-        bool minimal = false,
-        uint32_t worker_core = 0);
+class Device;
 
-    ~Device();
+ARCH DeviceArch(const Device *device);
 
-    // TODO: Add copy/move semantics
-    Device(const Device &other) = delete;
-    Device& operator=(const Device &other) = delete;
+chip_id_t DeviceId(const Device *device);
 
-    Device(Device &&other) = default;
-    Device& operator=(Device &&other) = default;
+bool DeviceIsInitialized(Device *device);
 
-    tt::ARCH arch() const;
+int DeviceNumDramChannels(Device *device);
 
-    chip_id_t id() const { return id_; }
+uint32_t DeviceL1SizePerCore(Device *device);
 
-    uint32_t build_key() const { return build_key_; }
+CoreCoord DeviceLogicalGridSize(Device *device);
 
-    uint8_t num_hw_cqs() const { return num_hw_cqs_; }
+CoreCoord DeviceComputeWithStorageGridSize(const Device *device);
 
-    bool is_initialized() const { return this->initialized_; }
+CoreCoord DeviceDramGridSize(Device *device);
 
-    int num_dram_channels() const;
+CoreCoord DevicePhysicalCoreFromLogicalCore(const Device *device, const CoreCoord &logical_core, CoreType core_type);
 
-    uint32_t l1_size_per_core() const;
-    uint32_t dram_size_per_channel() const;
+CoreCoord DeviceWorkerCoreFromLogicalCore(const Device *device, const CoreCoord &logical_core);
 
-    CoreCoord grid_size() const;
+CoreCoord DeviceEthernetCoreFromLogicalCore(const Device *device, const CoreCoord &logical_core);
 
-    CoreCoord logical_grid_size() const;
+std::vector<CoreCoord> DeviceGetEthernetSockets(const Device *device, chip_id_t connected_chip_id);
 
-    CoreCoord compute_with_storage_grid_size() const;
+uint32_t DeviceNumBanks(Device *device, BufferType buffer_type);
 
-    CoreCoord dram_grid_size() const;
+CoreCoord DeviceDramCoreFromDramChannel(Device *device, uint32_t dram_channel);
 
-    CoreCoord physical_core_from_logical_core(const CoreCoord &logical_core, const CoreType &core_type) const;
-    CoreType core_type_from_physical_core(const CoreCoord &physical_core) const;
+int32_t DeviceBankOffset(Device *device, BufferType buffer_type, uint32_t bank_id);
 
-    CoreCoord worker_core_from_logical_core(const CoreCoord &logical_core) const;
-    std::vector<CoreCoord> worker_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
+const std::vector<uint32_t> &DeviceBankIdsFromLogicalCore(Device *device, BufferType buffer_type, const CoreCoord &logical_core);
 
-    CoreCoord dram_core_from_logical_core(const CoreCoord &logical_core) const;
-    std::vector<CoreCoord> dram_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
+void DeviceDeallocateBuffers(Device *device);
 
-    // Ethernet API
-    CoreCoord ethernet_core_from_logical_core(const CoreCoord &logical_core) const;
-    CoreCoord logical_core_from_ethernet_core(const CoreCoord &physical_core) const;
+float DeviceSfpuEps(Device *device);
+float DeviceSfpuNan(Device *device);
+float DeviceSfpuInf(Device *device);
 
-    std::vector<CoreCoord> ethernet_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
+CommandQueue &DeviceCommandQueue(Device *device, size_t cq_id = 0);
 
-    std::unordered_set<chip_id_t> get_ethernet_connected_device_ids() const {
-        return tt::Cluster::instance().get_ethernet_connected_device_ids(this->id_);
-    }
+void DeviceBeginTrace(Device *device, uint8_t cq_id, uint32_t tid);
+void DeviceEndTrace(Device *device, uint8_t cq_id, uint32_t tid);
+void DeviceReplayTrace(Device *device, uint8_t cq_id, uint32_t tid, bool blocking);
+void DeviceReleaseTrace(Device *device, uint32_t tid);
 
-    std::unordered_set<CoreCoord> get_active_ethernet_cores(bool skip_reserved_tunnel_cores=false) const {
-        return tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);
-    }
+void DevicePushWork(Device *device, std::function<void()> &&work, bool blocking = false);
 
-    bool is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_tunnel_cores=false) const {
-        auto active_ethernet_cores = tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);
-        return active_ethernet_cores.find(logical_core) != active_ethernet_cores.end();
-    }
+void DeviceSynchronize(Device *device);
 
-    std::unordered_set<CoreCoord> get_inactive_ethernet_cores() const {
-        return tt::Cluster::instance().get_inactive_ethernet_cores(this->id_);
-    }
+void DeviceEnableAsync(Device *device, bool enable);
 
-    bool is_inactive_ethernet_core(CoreCoord logical_core) const {
-        auto inactive_ethernet_cores = tt::Cluster::instance().get_inactive_ethernet_cores(this->id_);
-        return inactive_ethernet_cores.find(logical_core) != inactive_ethernet_cores.end();
-    }
+WorkExecutorMode DeviceGetWorkerMode(Device *device);
 
-    std::tuple<chip_id_t, CoreCoord> get_connected_ethernet_core(CoreCoord eth_core) const {
-        return tt::Cluster::instance().get_connected_ethernet_core(std::make_tuple(this->id_, eth_core));
-    }
+program_cache::detail::ProgramCache &DeviceGetProgramCache(Device *device);
 
-    std::vector<CoreCoord> get_ethernet_sockets(chip_id_t connected_chip_id) const {
-        return tt::Cluster::instance().get_ethernet_sockets(this->id_, connected_chip_id);
-    }
+void DeviceEnableProgramCache(Device *device);
+void DeviceDisableAndClearProgramCache(Device *device);
 
-    bool is_mmio_capable() const {
-        return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
-    }
+size_t DeviceNumProgramCacheEntries(Device *device);
 
-    void setup_tunnel_for_remote_devices();
+bool DeviceInMainThread(Device *device);
 
-    void update_workers_build_settings(std::vector<std::vector<std::tuple<tt_cxy_pair, dispatch_worker_build_settings_t>>> &device_worker_variants);
+Allocator *DeviceGetAllocator(Device *device);
 
-    uint32_t num_banks(const BufferType &buffer_type) const;
-    uint32_t bank_size(const BufferType &buffer_type) const;
+std::set<CoreCoord> &DeviceGetComputeCores(Device *device);
 
-    uint32_t dram_channel_from_bank_id(uint32_t bank_id) const;
-
-    CoreCoord dram_core_from_dram_channel(uint32_t dram_channel) const;
-    CoreCoord logical_core_from_dram_channel(uint32_t dram_channel) const;
-    uint32_t dram_channel_from_logical_core(const CoreCoord& logical_core) const;
-
-    int32_t bank_offset(BufferType buffer_type, uint32_t bank_id) const;
-
-    CoreCoord logical_core_from_bank_id(uint32_t bank_id) const;
-
-    const std::vector<uint32_t> &bank_ids_from_dram_channel(uint32_t dram_channel) const;
-
-    const std::vector<uint32_t> &bank_ids_from_logical_core(
-        BufferType buffer_type, const CoreCoord &logical_core) const;
-
-    allocator::Statistics get_memory_allocation_statistics(const BufferType &buffer_type) const;
-
-    size_t get_l1_small_size() const;
-
-    void dump_memory_blocks(const BufferType &buffer_type, std::ofstream &out) const;
-
-    // Set of logical storage only core coordinates
-    const std::set<CoreCoord> &storage_only_cores() const { return this->storage_only_cores_; }
-
-    // Set of logical dispatch core coordinates
-
-    // Set of logical ethernet core coordinates
-    // core.x represents connectivity to one other chip, i.e. cores with <x> all connect to same chip
-    // core.y represents different channels along one <x>
-    const std::set<CoreCoord> &ethernet_cores() const { return this->ethernet_cores_; }
-
-    uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& physical_core) const;
-    uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& physical_cores) const;
-
-    void deallocate_buffers();
-
-    // machine epsilon
-    float sfpu_eps() const;
-
-    // machine nan
-    float sfpu_nan() const;
-
-    // machine inf
-    float sfpu_inf() const;
-
-    void generate_device_headers(const std::string &path) const;
-    const JitBuildEnv& build_env() const { return this->build_env_; }
-    const string build_firmware_target_path(JitBuildProcessorType t, int i) const;
-    const string build_kernel_target_path(JitBuildProcessorType t, int i, const string& kernel_name) const;
-    const JitBuildState& build_firmware_state(JitBuildProcessorType t, int i) const;
-    const JitBuildState& build_kernel_state(JitBuildProcessorType t, int i) const;
-    const JitBuildStateSubset build_kernel_states(JitBuildProcessorType t) const;
-    SystemMemoryManager& sysmem_manager() { return *sysmem_manager_; }
-    HWCommandQueue& hw_command_queue(size_t cq_id = 0);
-    CommandQueue& command_queue(size_t cq_id = 0);
-
-    // Metal trace device capture mode
-    void begin_trace(const uint8_t cq_id, const uint32_t tid);
-    void end_trace(const uint8_t cq_id, const uint32_t tid);
-    void replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking);
-    void release_trace(const uint32_t tid);
-    std::shared_ptr<TraceBuffer> get_trace(const uint32_t tid);
-
-    bool using_slow_dispatch() const;
-    void check_allocator_is_initialized() const;
-
-    // Checks that the given arch is on the given pci_slot and that it's responding
-    // Puts device into reset
-    bool initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {}, bool minimal = false);
-    void initialize_cluster();
-    void initialize_allocator(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {});
-    void initialize_build();
-    void build_firmware();
-    void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg);
-    void reset_cores();
-    void initialize_and_launch_firmware();
-    void init_command_queue_host();
-    void init_command_queue_device();
-    void initialize_synchronous_sw_cmd_queue();
-    void configure_kernel_variant(Program& program, string path, std::vector<uint32_t> compile_args, CoreCoord kernel_core, CoreCoord Kernel_physical_core,
-                                  CoreType dispatch_core_type, CoreCoord upstream_physical_core, CoreCoord downstream_physical_core, std::map<string, string> defines_in, NOC my_noc_index, NOC upstream_noc_index, NOC downstream_noc_index, bool is_active_eth_core = false);
-    void compile_command_queue_programs();
-    void configure_command_queue_programs();
-    void clear_l1_state();
-    void get_associated_dispatch_phys_cores(
-        std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &my_dispatch_cores,
-        std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &other_dispatch_cores);
-    std::pair<int, int> build_processor_type_to_index(JitBuildProcessorType t) const;
-
-    // Puts device into reset
-    bool close();
-    friend bool CloseDevice(Device *device);
-
-    // APIs to access this device's work executor
-    void push_work(std::function<void()>&& work, bool blocking = false);
-    void push_work(std::shared_ptr<std::function<void()>> work, bool blocking = false);
-    void synchronize();
-    void set_worker_mode(const WorkExecutorMode& mode);
-    void enable_async(bool enable);
-    WorkExecutorMode get_worker_mode() { return work_executor.get_worker_mode(); }
-    void set_worker_queue_mode(const WorkerQueueMode& mode) { this->work_executor.set_worker_queue_mode(mode); }
-    WorkerQueueMode get_worker_queue_mode() { return this->work_executor.get_worker_queue_mode(); }
-    // TODO: Uplift usage of friends. Buffer and Program just need access to allocator
-    friend class Buffer;
-    friend class Program;
-    friend class SystemMemoryManager;
-
-    static constexpr MemoryAllocator allocator_scheme_ = MemoryAllocator::L1_BANKING;
-    chip_id_t id_;
-    uint32_t build_key_;
-    std::unique_ptr<Allocator> allocator_ = nullptr;
-    bool initialized_ = false;
-    std::map<uint32_t, std::map<chip_id_t, std::vector<std::vector<std::tuple<tt_cxy_pair, dispatch_worker_build_settings_t>>>>> tunnel_device_dispatch_workers_;
-    std::vector<std::vector<chip_id_t>> tunnels_from_mmio_;
-
-    JitBuildEnv build_env_;
-    JitBuildStateSet firmware_build_states_;
-    JitBuildStateSet kernel_build_states_;
-
-    std::set<CoreCoord> compute_cores_;
-    std::set<CoreCoord> storage_only_cores_;
-    std::set<CoreCoord> ethernet_cores_;
-
-    // SystemMemoryManager is the interface to the hardware command queue
-    std::vector<std::unique_ptr<HWCommandQueue>> hw_command_queues_;
-    std::vector<std::unique_ptr<CommandQueue>> sw_command_queues_;
-    // Work Executor for this device - can asynchronously process host side work for
-    // all tasks scheduled on this device
-    WorkExecutor work_executor;
-    uint32_t worker_thread_core;
-    std::unique_ptr<SystemMemoryManager> sysmem_manager_;
-    uint8_t num_hw_cqs_;
-
-    vector<std::unique_ptr<Program, tt::tt_metal::detail::ProgramDeleter>> command_queue_programs;
-    bool using_fast_dispatch;
-    program_cache::detail::ProgramCache program_cache;
-
-    // Program cache interface. Syncrhonize with worker worker threads before querying or
-    // modifying this structure, since worker threads use this for compiling ops
-    void enable_program_cache() {
-        log_info(tt::LogMetal, "Enabling program cache on device {}", this->id_);
-        this->synchronize();
-        program_cache.enable();
-    }
-    void disable_and_clear_program_cache() {
-        log_info(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
-        this->synchronize();
-        if (this->program_cache.is_enabled()) {
-            program_cache.disable();
-        }
-        program_cache.clear();
-    }
-    std::size_t num_program_cache_entries() {
-        this->synchronize();
-        return program_cache.num_entries();
-    }
-
-    inline bool in_main_thread() {
-        // Detect if an instruction is being called in the main thread or worker thread
-        return (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->work_executor.get_parent_thread_id())
-                or get_worker_mode() == WorkExecutorMode::SYNCHRONOUS;
-    }
-   uint32_t trace_buffers_size = 0;
-   void update_dispatch_cores_for_multi_cq_eth_dispatch();
-
-    HalProgrammableCoreType get_programmable_core_type(CoreCoord phys_core) const;
-    template <typename T = DeviceAddr>
-    T get_dev_addr(CoreCoord phys_core, HalMemAddrType addr_type) const;
-
-    template <typename CoreRangeContainer>
-    std::vector<pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const CoreRangeContainer& ranges, const CoreType core_type);
-
-   private:
-    void DisableAllocs();
-    void EnableAllocs();
-    std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
-};
-
-inline HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord phys_core) const {
-
-    HalProgrammableCoreType programmable_core_type = HalProgrammableCoreType::TENSIX;
-    if (tt::llrt::is_ethernet_core(phys_core, this->id_)) {
-        // Eth pcores have a different address, but only active ones.
-        CoreCoord logical_core = this->logical_core_from_ethernet_core(phys_core);
-        if (this->is_active_ethernet_core(logical_core)) {
-            programmable_core_type = HalProgrammableCoreType::ACTIVE_ETH;
-        } else {
-            programmable_core_type = HalProgrammableCoreType::IDLE_ETH;
-        }
-    }
-
-    return programmable_core_type;
-}
-
-template <typename T>
-inline T Device::get_dev_addr(CoreCoord phys_core, HalMemAddrType addr_type) const {
-    return hal.get_dev_addr<T>(this->get_programmable_core_type(phys_core), addr_type);
-}
-
-// TODO: Find a better home for this function
-template <typename CoreRangeContainer>
-std::vector<pair<transfer_info_cores, uint32_t>> Device::extract_dst_noc_multicast_info(const CoreRangeContainer& ranges, const CoreType core_type) {
-    // This API extracts all the pairs of noc multicast encodings given a set of core ranges
-    std::vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
-    dst_noc_multicast_info.reserve(ranges.size());
-    for (const CoreRange& core_range : ranges) {
-        CoreCoord physical_start = this->physical_core_from_logical_core(core_range.start_coord, core_type);
-        CoreCoord physical_end = this->physical_core_from_logical_core(core_range.end_coord, core_type);
-
-        uint32_t num_receivers = core_range.size();
-        dst_noc_multicast_info.push_back(std::make_pair(CoreRange(physical_start, physical_end), num_receivers));
-    }
-    return dst_noc_multicast_info;
-}
+WorkExecutor &DeviceGetWorkExecutor(Device *device);
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -1,0 +1,309 @@
+#pragma once
+
+#include "tt_metal/impl/device/device.hpp"
+
+namespace tt {
+namespace tt_metal {
+
+class Device {
+   public:
+    // friend void tt_gdb(Device* device, int chip_id, const vector<CoreCoord> cores, vector<string> ops);
+    Device () = delete;
+    Device(
+        chip_id_t device_id,
+        const uint8_t num_hw_cqs,
+        std::size_t l1_small_size,
+        std::size_t trace_region_size,
+        const std::vector<uint32_t> &l1_bank_remap = {},
+        bool minimal = false,
+        uint32_t worker_core = 0);
+
+    ~Device();
+
+    // TODO: Add copy/move semantics
+    Device(const Device &other) = delete;
+    Device& operator=(const Device &other) = delete;
+
+    Device(Device &&other) = default;
+    Device& operator=(Device &&other) = default;
+
+    tt::ARCH arch() const;
+
+    chip_id_t id() const { return id_; }
+
+    uint32_t build_key() const { return build_key_; }
+
+    uint8_t num_hw_cqs() const { return num_hw_cqs_; }
+
+    bool is_initialized() const { return this->initialized_; }
+
+    int num_dram_channels() const;
+
+    uint32_t l1_size_per_core() const;
+    uint32_t dram_size_per_channel() const;
+
+    CoreCoord grid_size() const;
+
+    CoreCoord logical_grid_size() const;
+
+    CoreCoord compute_with_storage_grid_size() const;
+
+    CoreCoord dram_grid_size() const;
+
+    CoreCoord physical_core_from_logical_core(const CoreCoord &logical_core, const CoreType &core_type) const;
+    CoreType core_type_from_physical_core(const CoreCoord &physical_core) const;
+
+    CoreCoord worker_core_from_logical_core(const CoreCoord &logical_core) const;
+    std::vector<CoreCoord> worker_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
+
+    CoreCoord dram_core_from_logical_core(const CoreCoord &logical_core) const;
+    std::vector<CoreCoord> dram_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
+
+    // Ethernet API
+    CoreCoord ethernet_core_from_logical_core(const CoreCoord &logical_core) const;
+    CoreCoord logical_core_from_ethernet_core(const CoreCoord &physical_core) const;
+
+    std::vector<CoreCoord> ethernet_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
+
+    std::unordered_set<chip_id_t> get_ethernet_connected_device_ids() const {
+        return tt::Cluster::instance().get_ethernet_connected_device_ids(this->id_);
+    }
+
+    std::unordered_set<CoreCoord> get_active_ethernet_cores(bool skip_reserved_tunnel_cores=false) const {
+        return tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);
+    }
+
+    bool is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_tunnel_cores=false) const {
+        auto active_ethernet_cores = tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);
+        return active_ethernet_cores.find(logical_core) != active_ethernet_cores.end();
+    }
+
+    std::unordered_set<CoreCoord> get_inactive_ethernet_cores() const {
+        return tt::Cluster::instance().get_inactive_ethernet_cores(this->id_);
+    }
+
+    bool is_inactive_ethernet_core(CoreCoord logical_core) const {
+        auto inactive_ethernet_cores = tt::Cluster::instance().get_inactive_ethernet_cores(this->id_);
+        return inactive_ethernet_cores.find(logical_core) != inactive_ethernet_cores.end();
+    }
+
+    std::tuple<chip_id_t, CoreCoord> get_connected_ethernet_core(CoreCoord eth_core) const {
+        return tt::Cluster::instance().get_connected_ethernet_core(std::make_tuple(this->id_, eth_core));
+    }
+
+    std::vector<CoreCoord> get_ethernet_sockets(chip_id_t connected_chip_id) const {
+        return tt::Cluster::instance().get_ethernet_sockets(this->id_, connected_chip_id);
+    }
+
+    bool is_mmio_capable() const {
+        return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
+    }
+
+    void setup_tunnel_for_remote_devices();
+
+    void update_workers_build_settings(std::vector<std::vector<std::tuple<tt_cxy_pair, dispatch_worker_build_settings_t>>> &device_worker_variants);
+
+    uint32_t num_banks(const BufferType &buffer_type) const;
+    uint32_t bank_size(const BufferType &buffer_type) const;
+
+    uint32_t dram_channel_from_bank_id(uint32_t bank_id) const;
+
+    CoreCoord dram_core_from_dram_channel(uint32_t dram_channel) const;
+    CoreCoord logical_core_from_dram_channel(uint32_t dram_channel) const;
+    uint32_t dram_channel_from_logical_core(const CoreCoord& logical_core) const;
+
+    int32_t bank_offset(BufferType buffer_type, uint32_t bank_id) const;
+
+    CoreCoord logical_core_from_bank_id(uint32_t bank_id) const;
+
+    const std::vector<uint32_t> &bank_ids_from_dram_channel(uint32_t dram_channel) const;
+
+    const std::vector<uint32_t> &bank_ids_from_logical_core(
+        BufferType buffer_type, const CoreCoord &logical_core) const;
+
+    allocator::Statistics get_memory_allocation_statistics(const BufferType &buffer_type) const;
+
+    size_t get_l1_small_size() const;
+
+    void dump_memory_blocks(const BufferType &buffer_type, std::ofstream &out) const;
+
+    // Set of logical storage only core coordinates
+    const std::set<CoreCoord> &storage_only_cores() const { return this->storage_only_cores_; }
+
+    // Set of logical dispatch core coordinates
+
+    // Set of logical ethernet core coordinates
+    // core.x represents connectivity to one other chip, i.e. cores with <x> all connect to same chip
+    // core.y represents different channels along one <x>
+    const std::set<CoreCoord> &ethernet_cores() const { return this->ethernet_cores_; }
+
+    uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& physical_core) const;
+    uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& physical_cores) const;
+
+    void deallocate_buffers();
+
+    // machine epsilon
+    float sfpu_eps() const;
+
+    // machine nan
+    float sfpu_nan() const;
+
+    // machine inf
+    float sfpu_inf() const;
+
+    void generate_device_headers(const std::string &path) const;
+    const JitBuildEnv& build_env() const { return this->build_env_; }
+    const string build_firmware_target_path(JitBuildProcessorType t, int i) const;
+    const string build_kernel_target_path(JitBuildProcessorType t, int i, const string& kernel_name) const;
+    const JitBuildState& build_firmware_state(JitBuildProcessorType t, int i) const;
+    const JitBuildState& build_kernel_state(JitBuildProcessorType t, int i) const;
+    const JitBuildStateSubset build_kernel_states(JitBuildProcessorType t) const;
+    SystemMemoryManager& sysmem_manager() { return *sysmem_manager_; }
+    HWCommandQueue& hw_command_queue(size_t cq_id = 0);
+    CommandQueue& command_queue(size_t cq_id = 0);
+
+    // Metal trace device capture mode
+    void begin_trace(const uint8_t cq_id, const uint32_t tid);
+    void end_trace(const uint8_t cq_id, const uint32_t tid);
+    void replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking);
+    void release_trace(const uint32_t tid);
+    std::shared_ptr<TraceBuffer> get_trace(const uint32_t tid);
+
+    bool using_slow_dispatch() const;
+    void check_allocator_is_initialized() const;
+
+    // Checks that the given arch is on the given pci_slot and that it's responding
+    // Puts device into reset
+    bool initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {}, bool minimal = false);
+    void initialize_cluster();
+    void initialize_allocator(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {});
+    void initialize_build();
+    void build_firmware();
+    void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg);
+    void reset_cores();
+    void initialize_and_launch_firmware();
+    void init_command_queue_host();
+    void init_command_queue_device();
+    void initialize_synchronous_sw_cmd_queue();
+    void configure_kernel_variant(Program& program, string path, std::vector<uint32_t> compile_args, CoreCoord kernel_core, CoreCoord Kernel_physical_core,
+                                  CoreType dispatch_core_type, CoreCoord upstream_physical_core, CoreCoord downstream_physical_core, std::map<string, string> defines_in, NOC my_noc_index, NOC upstream_noc_index, NOC downstream_noc_index, bool is_active_eth_core = false);
+    void compile_command_queue_programs();
+    void configure_command_queue_programs();
+    void clear_l1_state();
+    void get_associated_dispatch_phys_cores(
+        std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &my_dispatch_cores,
+        std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &other_dispatch_cores);
+    std::pair<int, int> build_processor_type_to_index(JitBuildProcessorType t) const;
+
+    // Puts device into reset
+    bool close();
+    friend bool CloseDevice(Device *device);
+
+    // APIs to access this device's work executor
+    void push_work(std::function<void()>&& work, bool blocking = false);
+    void push_work(std::shared_ptr<std::function<void()>> work, bool blocking = false);
+    void synchronize();
+    void set_worker_mode(const WorkExecutorMode& mode);
+    void enable_async(bool enable);
+    WorkExecutorMode get_worker_mode() { return work_executor.get_worker_mode(); }
+    void set_worker_queue_mode(const WorkerQueueMode& mode) { this->work_executor.set_worker_queue_mode(mode); }
+    WorkerQueueMode get_worker_queue_mode() { return this->work_executor.get_worker_queue_mode(); }
+    // TODO: Uplift usage of friends. Buffer and Program just need access to allocator
+    friend class Buffer;
+    friend class Program;
+    friend class SystemMemoryManager;
+
+    static constexpr MemoryAllocator allocator_scheme_ = MemoryAllocator::L1_BANKING;
+    chip_id_t id_;
+    uint32_t build_key_;
+    std::unique_ptr<Allocator> allocator_ = nullptr;
+    bool initialized_ = false;
+    std::map<uint32_t, std::map<chip_id_t, std::vector<std::vector<std::tuple<tt_cxy_pair, dispatch_worker_build_settings_t>>>>> tunnel_device_dispatch_workers_;
+    std::vector<std::vector<chip_id_t>> tunnels_from_mmio_;
+
+    JitBuildEnv build_env_;
+    JitBuildStateSet firmware_build_states_;
+    JitBuildStateSet kernel_build_states_;
+
+    std::set<CoreCoord> compute_cores_;
+    std::set<CoreCoord> storage_only_cores_;
+    std::set<CoreCoord> ethernet_cores_;
+
+    // SystemMemoryManager is the interface to the hardware command queue
+    std::vector<std::unique_ptr<HWCommandQueue>> hw_command_queues_;
+    std::vector<std::unique_ptr<CommandQueue>> sw_command_queues_;
+    // Work Executor for this device - can asynchronously process host side work for
+    // all tasks scheduled on this device
+    WorkExecutor work_executor;
+    uint32_t worker_thread_core;
+    std::unique_ptr<SystemMemoryManager> sysmem_manager_;
+    uint8_t num_hw_cqs_;
+
+    vector<std::unique_ptr<Program, tt::tt_metal::detail::ProgramDeleter>> command_queue_programs;
+    bool using_fast_dispatch;
+    program_cache::detail::ProgramCache program_cache;
+
+    // Program cache interface. Syncrhonize with worker worker threads before querying or
+    // modifying this structure, since worker threads use this for compiling ops
+    void enable_program_cache() {
+        log_info(tt::LogMetal, "Enabling program cache on device {}", this->id_);
+        this->synchronize();
+        program_cache.enable();
+    }
+    void disable_and_clear_program_cache() {
+        log_info(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
+        this->synchronize();
+        if (this->program_cache.is_enabled()) {
+            program_cache.disable();
+        }
+        program_cache.clear();
+    }
+    std::size_t num_program_cache_entries() {
+        this->synchronize();
+        return program_cache.num_entries();
+    }
+
+    inline bool in_main_thread() {
+        // Detect if an instruction is being called in the main thread or worker thread
+        return (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->work_executor.get_parent_thread_id())
+                or get_worker_mode() == WorkExecutorMode::SYNCHRONOUS;
+    }
+   uint32_t trace_buffers_size = 0;
+   void update_dispatch_cores_for_multi_cq_eth_dispatch();
+
+    HalProgrammableCoreType get_programmable_core_type(CoreCoord phys_core) const;
+    template <typename T = DeviceAddr>
+    T get_dev_addr(CoreCoord phys_core, HalMemAddrType addr_type) const;
+
+    template <typename CoreRangeContainer>
+    std::vector<pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const CoreRangeContainer& ranges, const CoreType core_type);
+
+   private:
+    void DisableAllocs();
+    void EnableAllocs();
+    std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
+};
+
+template <typename T>
+inline T Device::get_dev_addr(CoreCoord phys_core, HalMemAddrType addr_type) const {
+    return hal.get_dev_addr<T>(this->get_programmable_core_type(phys_core), addr_type);
+}
+
+// TODO: Find a better home for this function
+template <typename CoreRangeContainer>
+std::vector<pair<transfer_info_cores, uint32_t>> Device::extract_dst_noc_multicast_info(const CoreRangeContainer& ranges, const CoreType core_type) {
+    // This API extracts all the pairs of noc multicast encodings given a set of core ranges
+    std::vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
+    dst_noc_multicast_info.reserve(ranges.size());
+    for (const CoreRange& core_range : ranges) {
+        CoreCoord physical_start = this->physical_core_from_logical_core(core_range.start_coord, core_type);
+        CoreCoord physical_end = this->physical_core_from_logical_core(core_range.end_coord, core_type);
+
+        uint32_t num_receivers = core_range.size();
+        dst_noc_multicast_info.push_back(std::make_pair(CoreRange(physical_start, physical_end), num_receivers));
+    }
+    return dst_noc_multicast_info;
+}
+
+}
+}

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -6,6 +6,7 @@
 
 #include <numa.h>
 
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
 namespace tt {

--- a/tt_metal/impl/device/mesh_device.cpp
+++ b/tt_metal/impl/device/mesh_device.cpp
@@ -6,6 +6,7 @@
 
 #include "tt_metal/impl/device/mesh_device.hpp"
 #include "tt_metal/impl/device/mesh_device_view.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
@@ -178,6 +179,10 @@ std::shared_ptr<const MeshDeviceView> MeshDevice::get_view() const {
 std::shared_ptr<MeshDeviceView> MeshDevice::get_view() {
     return this->view;
 }
+
+ARCH DeviceArch(const MeshDevice *device) { return device->arch(); }
+
+CoreCoord DeviceComputeWithStorageGridSize(const MeshDevice *device) { return device->compute_with_storage_grid_size(); }
 
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device) {
     return os << mesh_device.to_string();

--- a/tt_metal/impl/device/mesh_device.hpp
+++ b/tt_metal/impl/device/mesh_device.hpp
@@ -63,6 +63,10 @@ public:
     bool is_galaxy_;
 };
 
+ARCH DeviceArch(const MeshDevice *device);
+
+CoreCoord DeviceComputeWithStorageGridSize(const MeshDevice *device);
+
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);
 bool validate_worker_modes(const std::vector<Device*>& workers);
 

--- a/tt_metal/impl/device/mesh_device_view.cpp
+++ b/tt_metal/impl/device/mesh_device_view.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_metal/impl/device/mesh_device_view.hpp"
 #include "tt_metal/impl/device/mesh_device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include <algorithm>
 #include <stdexcept>
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -26,6 +26,7 @@
 #include "tt_metal/impl/buffers/semaphore.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -12,6 +12,7 @@
 #include "llrt/llrt.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "tt_metal/common/utils.hpp"
 #include "tt_metal/common/core_coord.h"

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -18,7 +18,7 @@
 #include "tt_metal/jit_build/genfiles.hpp"
 #include "tt_metal/llrt/llrt.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/graph/graph_tracking.hpp"

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -11,7 +11,7 @@
 #include "tt_metal/common/logger.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/host_api.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/impl/trace/trace.hpp"
 

--- a/tt_metal/impl/trace/trace_buffer.cpp
+++ b/tt_metal/impl/trace/trace_buffer.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "trace_buffer.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -14,7 +14,7 @@
 #include "tt_metal/detail/tt_metal.hpp"
 
 #include "tt_metal/third_party/tracy/public/tracy/TracyTTDevice.hpp"
-#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_impl.hpp"
 
 namespace tt {
 

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -39,7 +39,7 @@ void dump_data(vector<unsigned>& device_ids, bool dump_watcher, bool dump_cqs, b
         string iq_fname = cq_dir.string() + fmt::format("device_{}_issue_q.txt", id);
         std::ofstream iq_file = std::ofstream(iq_fname);
         // Minimal setup, since we'll be attaching to a potentially hanging chip.
-        auto* device = tt::tt_metal::CreateDeviceMinimal(id, num_hw_cqs, DispatchCoreType::WORKER);
+        auto* device = tt::tt_metal::CreateDeviceMinimal(id, {num_hw_cqs, DispatchCoreType::WORKER});
         if (dump_cqs) {
             std::unique_ptr<SystemMemoryManager> sysmem_manager =
                 std::make_unique<SystemMemoryManager>(id, num_hw_cqs);

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -132,7 +132,7 @@ void device_module(py::module &m_device) {
 
     m_device.def(
         "CreateDevice",
-        [](int device_id, uint8_t num_command_queues, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) { return tt::tt_metal::CreateDevice(device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type); },
+        [](int device_id, uint8_t num_command_queues, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) { return tt::tt_metal::CreateDevice(device_id, {num_command_queues, l1_small_size, trace_region_size, dispatch_core_type}); },
         R"doc(
         Creates an instance of TT device.
 
@@ -278,11 +278,11 @@ void device_module(py::module &m_device) {
         [] (Device* device, const std::optional<uint8_t> cq_id) {
             // Send finish command to issue queue through worker thread
             // Worker thread will stall until the device is flushed.
-            device->push_work([device, cq_id] () mutable {
+            DevicePushWork(device, [device, cq_id] () mutable {
                 Synchronize(device, cq_id);
             });
             // Main thread stalls until worker is complete (full device and worker queue flush).
-            device->synchronize();
+            DeviceSynchronize(device);
         }, R"doc(
         Synchronize the device with host by waiting for all operations to complete.
         If cq_id is provided then only the operations associated with that cq_id are waited for,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
@@ -50,7 +50,7 @@ operation::ProgramWithCallbacks moreh_adamw_(
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Device* device = param_in.device();
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
@@ -61,7 +61,7 @@ operation::ProgramWithCallbacks moreh_adamw_(
             split_work_to_cores(core_range, num_units);
 
 
-    auto arch = param_in.device()->arch();
+    auto arch = DeviceArch(param_in.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adamw/moreh_adamw_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adamw/moreh_adamw_op.cpp
@@ -150,11 +150,11 @@ std::vector<std::optional<Tensor>> moreh_adamw(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = param_in.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto compute_kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {
         Tensor(operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
@@ -21,8 +21,8 @@ namespace primary {
 namespace {
 
 inline uint32_t get_num_device_cores(Device *device) {
-    const auto num_cores_x = static_cast<uint32_t>(device->compute_with_storage_grid_size().x);
-    const auto num_cores_y = static_cast<uint32_t>(device->compute_with_storage_grid_size().y);
+    const auto num_cores_x = static_cast<uint32_t>(DeviceComputeWithStorageGridSize(device).x);
+    const auto num_cores_y = static_cast<uint32_t>(DeviceComputeWithStorageGridSize(device).y);
     return num_cores_x * num_cores_y;
 }
 }  // namespace

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/moreh_clip_grad_norm_step1.cpp
@@ -52,7 +52,7 @@ operation::ProgramWithCallbacks moreh_clip_grad_norm_step1_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
     const auto
         [num_cores_to_be_used,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/moreh_clip_grad_norm_step3.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/moreh_clip_grad_norm_step3.cpp
@@ -38,7 +38,7 @@ operation::ProgramWithCallbacks moreh_clip_grad_norm_step3_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_nc/moreh_cumsum_nc.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_nc/moreh_cumsum_nc.cpp
@@ -57,7 +57,7 @@ operation::ProgramWithCallbacks moreh_cumsum_nc(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const uint32_t in0_t = 2;        // input

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp
@@ -194,7 +194,7 @@ Tensor moreh_getitem(
     std::optional<Tensor> output_tensor,
     const MemoryConfig& output_mem_config) {
     auto device = input_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     std::vector<Tensor> new_input_tensors;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm.cpp
@@ -102,7 +102,7 @@ operation::ProgramWithCallbacks moreh_groupnorm_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto
@@ -148,7 +148,7 @@ operation::ProgramWithCallbacks moreh_groupnorm_impl(
     const auto cb_usage = (in0_t + in1_t + in2_t + in3_t + in4_t + in5_t + in6_t + out0_t + out1_t + out2_t + im0_t +
                            im1_t + im2_t + im3_t + im4_t + im5_t + im6_t + im7_t) *
                           single_tile_size;
-    const auto available_L1 = device->l1_size_per_core() - L1_UNRESERVED_BASE;
+    const auto available_L1 = DeviceL1SizePerCore(device) - L1_UNRESERVED_BASE;
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/gamma_beta_grad/moreh_groupnorm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/gamma_beta_grad/moreh_groupnorm_backward_gamma_beta_grad.cpp
@@ -76,7 +76,7 @@ operation::ProgramWithOptionalOutputTensors moreh_groupnorm_backward_gamma_beta_
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/input_grad/moreh_groupnorm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/input_grad/moreh_groupnorm_backward_input_grad.cpp
@@ -72,7 +72,7 @@ operation::ProgramWithCallbacks moreh_groupnorm_backward_input_grad_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto
@@ -116,7 +116,7 @@ operation::ProgramWithCallbacks moreh_groupnorm_backward_input_grad_impl(
     const auto cb_usage = (in0_t + in1_t + in2_t + in3_t + in4_t + in5_t + in6_t + in7_t + out0_t + im0_t + im1_t +
                            im2_t + im3_t + im4_t + im5_t + im6_t + im7_t) *
                           single_tile_size;
-    const auto available_L1 = device->l1_size_per_core() - L1_UNRESERVED_BASE;
+    const auto available_L1 = DeviceL1SizePerCore(device) - L1_UNRESERVED_BASE;
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
@@ -103,7 +103,7 @@ operation::ProgramWithCallbacks moreh_layernorm_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     // core_group_2 works more.
@@ -117,7 +117,7 @@ operation::ProgramWithCallbacks moreh_layernorm_impl(
          num_rows_per_core_group_1,
          num_rows_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_outer);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -162,7 +162,7 @@ operation::ProgramWithCallbacks moreh_layernorm_impl(
     const uint32_t cb_usage =
         (in0_t + in1_t + in2_t + in3_t + in4_t + in5_t + in6_t + out0_t + out1_t + out2_t) * single_tile_size +
         (im0_t + im1_t + im2_t + im3_t + im4_t + im5_t + im6_t + im7_t) * intermed_single_tile_size;
-    const uint32_t available_L1 = device->l1_size_per_core() - L1_UNRESERVED_BASE;
+    const uint32_t available_L1 = DeviceL1SizePerCore(device) - L1_UNRESERVED_BASE;
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {
@@ -523,7 +523,7 @@ std::vector<std::optional<Tensor>> moreh_layernorm(
 
     auto device = input.device();
     auto compute_kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(
         [normalized_dims, eps, memory_config, compute_kernel_config_val, compute_mean, compute_rstd](
@@ -602,7 +602,7 @@ std::vector<std::optional<Tensor>> moreh_layernorm(
     auto device = input.device();
 
     auto compute_kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(
         [normalized_dims, eps, memory_config, compute_kernel_config_val, compute_mean, compute_rstd](

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp
@@ -70,7 +70,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_gamma_beta_grad_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto
@@ -81,7 +81,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_gamma_beta_grad_impl(
          num_cols_per_core_group_1,
          num_cols_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_inner);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp
@@ -81,7 +81,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_input_grad_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto
@@ -92,7 +92,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_input_grad_impl(
          num_rows_per_core_group_1,
          num_rows_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_outer);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
     ////////////////////////////////////////////////////////////////////////////
@@ -127,7 +127,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_input_grad_impl(
 
     const uint32_t cb_usage = (in0_t + in1_t + in2_t + in3_t + in4_t + in5_t + in6_t + in7_t + out0_t) *
                               single_tile_size + (im0_t + im1_t + im2_t + im3_t + im4_t + im5_t + im6_t + im7_t) * intermed_single_tile_size;
-    const uint32_t available_L1 = device->l1_size_per_core() - L1_UNRESERVED_BASE;
+    const uint32_t available_L1 = DeviceL1SizePerCore(device) - L1_UNRESERVED_BASE;
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.cpp
@@ -177,7 +177,7 @@ Tensor moreh_layernorm_backward_input_grad(
 
     auto device = input.device();
     auto compute_kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {
         Tensor(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))};
@@ -216,7 +216,7 @@ std::vector<std::optional<Tensor>> moreh_layernorm_backward_gamma_beta_grad(
 
     auto device = input.device();
     auto compute_kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<std::optional<Tensor>> outputs(2);
     if (!gamma_grad.has_value() && !beta_grad.has_value()) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
@@ -41,9 +41,9 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
     ////////////////////////////////////////////////////////////////////////////
     // This should allocate a DRAM buffer on the device
     Device *device = output_grad.device();
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(device), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/bias_backward_hw/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/bias_backward_hw/moreh_bias_backward_single_core_hw.cpp
@@ -48,7 +48,7 @@ operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor 
 
     // This should allocate a DRAM buffer on the device
     Device *device = output_grad.device();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(device), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
@@ -112,7 +112,7 @@ std::vector<std::optional<Tensor>> moreh_linear_backward(
         "input and weight tensors need to be on device");
 
     TT_FATAL(output_grad.storage_type() == StorageType::DEVICE, "Error");
-    auto kernel_config_val = init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+    auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(output_grad.device()), compute_kernel_config, MathFidelity::HiFi4);
 
     moreh_linear_backward_validate(output_grad, input, weight, input_grad, weight_grad, bias_grad);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
@@ -251,7 +251,7 @@ Tensor moreh_matmul_(
     log_debug(LogOp, "{}:{} run matmul {} {}", __func__, __LINE__, transpose_input, transpose_other);
 
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Error");
-    auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+    auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input.device()), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input, other}, {bias}))};
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
@@ -173,7 +173,7 @@ operation::ProgramWithCallbacks moreh_matmul_multi_core(
         need_other_mask_h, need_other_mask_w,
         other_mask_h, other_mask_w);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(device), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -184,7 +184,7 @@ operation::ProgramWithCallbacks moreh_matmul_multi_core(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Grid Configuration For Workload
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks moreh_mean_h(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp
@@ -71,7 +71,7 @@ operation::ProgramWithCallbacks moreh_mean_nc(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
@@ -115,9 +115,9 @@ Tensor moreh_mean_(
 
     auto device = input.device();
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     operation::launch_op(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks moreh_mean_w(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
@@ -105,7 +105,7 @@ operation::ProgramWithCallbacks moreh_mean_backward_impl(
     }
     const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
-        get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(DeviceArch(output_grad.device()), compute_kernel_config);
 
     for (auto i = 0; i < input_grad_rank; ++i) {
         log_debug(LogOp, "need_bcast_dim [{}] = {}", i, need_bcast_dim[i]);
@@ -123,7 +123,7 @@ operation::ProgramWithCallbacks moreh_mean_backward_impl(
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
 
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp
@@ -103,9 +103,9 @@ Tensor moreh_mean_backward_(
 
     auto device = output_grad.device();
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     operation::launch_op(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
@@ -204,11 +204,11 @@ Tensor moreh_nll_loss_step1(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = target_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(
         operation::get_workers_for_op_output({target_tensor}, {weight_tensor}))};
@@ -249,11 +249,11 @@ Tensor moreh_nll_loss_step2(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = input_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(
         operation::get_workers_for_op_output({input_tensor, target_tensor}, {weight_tensor, divisor_tensor}))};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step1/moreh_nll_loss_step1.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step1/moreh_nll_loss_step1.cpp
@@ -49,7 +49,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_step1_impl(
         split_work_to_cores(core_range, units_to_divide);
 
     auto* device = target.device();
-    auto arch = device->arch();
+    auto arch = DeviceArch(device);
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -64,7 +64,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_step1_impl(
     const auto data_tile_size = tt_metal::detail::TileSize(data_format);
     const auto intermed_tile_size = tt_metal::detail::TileSize(intermed_data_format);
 
-    const uint32_t available_L1 = device->l1_size_per_core() - L1_UNRESERVED_BASE;
+    const uint32_t available_L1 = DeviceL1SizePerCore(device) - L1_UNRESERVED_BASE;
 
     uint32_t target_num_tile = 1;
     uint32_t weight_num_tile = weight_has_value ? div_up(channel_size, TILE_WIDTH) : 0;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
@@ -48,7 +48,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_2d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -224,7 +224,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -409,7 +409,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
@@ -50,7 +50,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -228,7 +228,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -402,7 +402,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward_op.cpp
@@ -128,11 +128,11 @@ Tensor moreh_nll_loss_backward_(
     const MemoryConfig& input_grad_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = output_grad_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(
         operation::get_workers_for_op_output({target_tensor, output_grad_tensor}, {weight_tensor, divisor_tensor}))};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.cpp
@@ -46,7 +46,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_2d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -180,7 +180,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_3d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
@@ -310,7 +310,7 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_4d(
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward_op.cpp
@@ -135,11 +135,11 @@ Tensor moreh_nll_loss_unreduced_backward(
     const MemoryConfig& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = output_grad_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(
         operation::get_workers_for_op_output({target_tensor, output_grad_tensor}, {weight_tensor}))};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_h/moreh_norm_h.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_h/moreh_norm_h.cpp
@@ -53,10 +53,10 @@ operation::ProgramWithCallbacks moreh_norm_h_impl(const Tensor &input, float p, 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
@@ -256,7 +256,7 @@ Tensor moreh_norm_impl(const Tensor &input, float p, int64_t dim,
     auto device = input.device();
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
     operation::launch_op(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_other/moreh_norm_other.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_other/moreh_norm_other.cpp
@@ -65,10 +65,10 @@ operation::ProgramWithCallbacks moreh_norm_other_impl(const Tensor &input, float
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_w/moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_w/moreh_norm_w.cpp
@@ -53,10 +53,10 @@ operation::ProgramWithCallbacks moreh_norm_w_impl(const Tensor &input, float p, 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward.cpp
@@ -118,7 +118,7 @@ operation::ProgramWithCallbacks moreh_norm_backward_(
     }
 
     const auto num_input_grad_tiles = input_grad.volume() / tt::constants::TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(output_grad.device()), compute_kernel_config);
 
     auto [floored_p, decimal, p_is_negative] = get_floored_p_and_decimal_and_p_is_negative(p);
     auto [floored_p_minus_one, decimal_minus_one, p_minus_one_is_negative] =
@@ -141,7 +141,7 @@ operation::ProgramWithCallbacks moreh_norm_backward_(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.cpp
@@ -98,7 +98,7 @@ Tensor moreh_norm_backward_impl(
     auto device = input.device();
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input, output, output_grad}))};
     operation::launch_op(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
@@ -49,7 +49,7 @@ operation::ProgramWithCallbacks moreh_sgd_(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
 
-    auto arch = param_in.device()->arch();
+    auto arch = DeviceArch(param_in.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sgd/moreh_sgd_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sgd/moreh_sgd_op.cpp
@@ -123,11 +123,11 @@ std::vector<std::optional<Tensor>> moreh_sgd(
     const MemoryConfig& momentum_buffer_out_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = param_in.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {
         Tensor(operation::get_workers_for_op_output({param_in, grad}, {momentum_buffer_in}))};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.cpp
@@ -143,11 +143,11 @@ Tensor moreh_softmax(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = input_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
 
@@ -184,11 +184,11 @@ Tensor moreh_softmin(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = input_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
 
@@ -225,11 +225,11 @@ Tensor moreh_logsoftmax(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = input_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -35,7 +35,7 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -35,7 +35,7 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -25,7 +25,7 @@ bool is_moreh_softmax_h_small_available(const Tensor &tensor, const ttnn::Device
     auto h = tensor.get_legacy_shape()[-2];
     int32_t Ht = (h + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
-    auto arch = tensor.device()->arch();
+    auto arch = DeviceArch(tensor.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -25,7 +25,7 @@ bool is_moreh_softmax_w_small_available(const Tensor &tensor, const ttnn::Device
     auto w = tensor.get_legacy_shape()[-1];
     int32_t Wt = (w + TILE_WIDTH - 1) / TILE_WIDTH;
 
-    auto arch = tensor.device()->arch();
+    auto arch = DeviceArch(tensor.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
-    auto arch = input.device()->arch();
+    auto arch = DeviceArch(input.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
@@ -158,11 +158,11 @@ Tensor moreh_softmax_backward(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = output_grad_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {
         Tensor(operation::get_workers_for_op_output({output_tensor, output_grad_tensor}))};
@@ -201,11 +201,11 @@ Tensor moreh_softmin_backward(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = output_grad_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {
         Tensor(operation::get_workers_for_op_output({output_tensor, output_grad_tensor}))};
@@ -244,11 +244,11 @@ Tensor moreh_logsoftmax_backward(
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = output_grad_tensor.device();
-    auto grid_coord = device->compute_with_storage_grid_size();
+    auto grid_coord = DeviceComputeWithStorageGridSize(device);
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     auto kernel_config_val =
-        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(device), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {
         Tensor(operation::get_workers_for_op_output({output_tensor, output_grad_tensor}))};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -60,7 +60,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -61,7 +61,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
-    auto arch = input_grad.device()->arch();
+    auto arch = DeviceArch(input_grad.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const 
     const bool do_mask_h {(origin_H % TILE_HEIGHT) != 0};
     const auto mask_h {do_mask_h ? origin_H % TILE_HEIGHT: TILE_HEIGHT};
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(input.device()), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -63,7 +63,7 @@ operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid{device->compute_with_storage_grid_size()};
+    auto grid{DeviceComputeWithStorageGridSize(device)};
     const auto num_cores_y{grid.y};
 
     const uint32_t in0_t{2};        // input
@@ -224,7 +224,7 @@ operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const 
     // const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
     // const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
 
-    // auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    // auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(input.device()), compute_kernel_config);
     // log_debug(
     //     LogOp,
     //     "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -255,7 +255,7 @@ operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const 
 
     // tt_metal::Device *device = input.device();
 
-    // auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    // auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     // uint32_t num_cores_x = compute_with_storage_grid_size.x;
     // uint32_t num_cores_y = compute_with_storage_grid_size.y;
     // auto num_cols = other_dims_product * Wt;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
     const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
     const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(a.device()), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -64,7 +64,7 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
 
     tt_metal::Device *device = a.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_cols = other_dims_product * Wt;
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_int_sum_nc_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_int_sum_nc_impl.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks moreh_sum_int_nc_impl(const Tensor &input, const
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile {input_shape[dim]};
     const auto num_output_tiles {output.volume() / TILE_HW};
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(input.device()), compute_kernel_config);
 
     log_debug(LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
     log_debug(
@@ -54,7 +54,7 @@ operation::ProgramWithCallbacks moreh_sum_int_nc_impl(const Tensor &input, const
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const uint32_t in0_t = 2;        // input

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_sum_nc_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_sum_nc_impl.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks moreh_sum_nc_impl(const Tensor &input, const Ten
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile = input_shape[dim];
     const auto num_output_tiles = output.volume() / TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(input.device()), compute_kernel_config);
 
     log_debug(LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
     log_debug(
@@ -49,7 +49,7 @@ operation::ProgramWithCallbacks moreh_sum_nc_impl(const Tensor &input, const Ten
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const uint32_t in0_t = 2;        // input
@@ -102,7 +102,7 @@ operation::ProgramWithCallbacks moreh_sum_nc_impl(const Tensor &input, const Ten
     // set preserve_fp32_precision to the same value as fp32_dest_acc_en
     bool preserve_fp32_precision = fp32_dest_acc_en;
     auto compute_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_sum_nc.cpp";
-    if (device->arch() == tt::ARCH::GRAYSKULL) {
+    if (DeviceArch(device) == tt::ARCH::GRAYSKULL) {
         compute_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_sum_nc_gs.cpp";
     }
     const auto compute_kernel_1_id = CreateComputeKernel(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
@@ -33,7 +33,7 @@ Tensor _moreh_sum(
 
     TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE, "Error");
     auto kernel_config_val =
-        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+        init_device_compute_kernel_config(DeviceArch(input.device()), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(
         [dim, keep_batch_dim, output_mem_config, kernel_config_val, queue_id](

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
@@ -44,7 +44,7 @@ operation::ProgramWithCallbacks moreh_sum_int_w_impl(const Tensor &input, const 
     const bool do_mask_w {(origin_W % TILE_WIDTH) != 0};
     const auto mask_w {do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH};
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(input.device()), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -62,7 +62,7 @@ operation::ProgramWithCallbacks moreh_sum_int_w_impl(const Tensor &input, const 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid{device->compute_with_storage_grid_size()};
+    auto grid{DeviceComputeWithStorageGridSize(device)};
     const auto num_cores_y{grid.y};
 
     const uint32_t in0_t{2};        // input

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_sum_w_impl(const Tensor &a, const Tensor &
     const bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
     const auto mask_w = do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(a.device()), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -65,7 +65,7 @@ operation::ProgramWithCallbacks moreh_sum_w_impl(const Tensor &a, const Tensor &
 
     tt_metal::Device *device = a.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_rows = other_dims_product * Ht;
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
@@ -106,7 +106,7 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(
     }
     const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
-        get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(DeviceArch(output_grad.device()), compute_kernel_config);
 
     for (auto i = 0; i < input_grad_rank; ++i) {
         log_debug(LogOp, "need_bcast_dim [{}] = {}", i, need_bcast_dim[i]);
@@ -123,7 +123,7 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const auto

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp
@@ -123,7 +123,7 @@ Tensor moreh_sum_backward(
         input_tensors.emplace_back(*input);
     }
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({output_grad}))};
-    auto kernel_config_val = init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+    auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(output_grad.device()), compute_kernel_config, MathFidelity::HiFi4);
     operation::launch_op(
         [dims, keep_batch_dim, input_grad_mem_config, kernel_config_val](
             const std::vector<Tensor> &input_tensors,

--- a/ttnn/cpp/ttnn/deprecated/tt_numpy/functions.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_numpy/functions.hpp
@@ -88,7 +88,7 @@ static Tensor full(
             bool using_fast_dispatch = (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr);
 
             if (using_fast_dispatch && device != nullptr) {
-                auto& cmd_queue = device->command_queue(queue_id);
+                auto& cmd_queue = DeviceCommandQueue(device, queue_id);
                 if (CommandQueue::default_mode() == CommandQueue::CommandQueueMode::ASYNC) {
                     tt::tt_metal::EnqueueWriteBuffer(cmd_queue, device_buffer, owned_buffer.get_ptr(), false);
                 } else {
@@ -450,7 +450,7 @@ static Tensor fill_first_val_into_tensor(
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         data_vec.resize(size_in_bytes / sizeof(T));
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(
-            input_tensor.device()->command_queue(), device_buffer, data_vec.data(), true);
+            DeviceCommandQueue(input_tensor.device()), device_buffer, data_vec.data(), true);
     } else {
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(device_buffer, data_vec);
     }
@@ -483,7 +483,7 @@ static Tensor prod_result_computation_GS(
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         data_vec.resize(size_in_bytes / sizeof(T));
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(
-            input_tensor.device()->command_queue(), device_buffer, data_vec.data(), true);
+            DeviceCommandQueue(input_tensor.device()), device_buffer, data_vec.data(), true);
     } else {
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(device_buffer, data_vec);
     }
@@ -532,7 +532,7 @@ static Tensor prod_result_computation_WH_B0(
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         data_vec.resize(size_in_bytes / sizeof(T));
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(
-            input_tensor.device()->command_queue(), device_buffer, data_vec.data(), true);
+            DeviceCommandQueue(input_tensor.device()), device_buffer, data_vec.data(), true);
     } else {
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(device_buffer, data_vec);
     }
@@ -659,7 +659,7 @@ static Tensor manual_insertion(
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         data_vec.resize(size_in_bytes / sizeof(T));
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(
-            input_tensor.device()->command_queue(), device_buffer, data_vec.data(), true);
+            DeviceCommandQueue(input_tensor.device()), device_buffer, data_vec.data(), true);
     } else {
         tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(device_buffer, data_vec);
     }

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -19,15 +19,15 @@ bool is_device_open(int device_id){
 }
 
 void enable_program_cache(Device &device) {
-    device.enable_program_cache();
+    DeviceEnableProgramCache(&device);
 }
 
 void disable_and_clear_program_cache(Device &device) {
-    device.disable_and_clear_program_cache();
+    DeviceDisableAndClearProgramCache(&device);
 }
 
 void close_device(Device &device) {
-    tt::DevicePool::instance().close_device(device.id());
+    tt::DevicePool::instance().close_device(DeviceId(&device));
 
 }
 
@@ -36,8 +36,8 @@ bool is_wormhole_or_blackhole(tt::ARCH arch) {
 }
 
 void deallocate_buffers(Device* device) {
-        device->push_work([device] () mutable {
-            device->deallocate_buffers();
+        DevicePushWork(device, [device] () mutable {
+            DeviceDeallocateBuffers(device);
         });
 }
 

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -251,7 +251,7 @@ template <DeviceOperationConcept device_operation_t>
 void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& operation_attributes, const auto& tensor_args, auto &tensor_return_value, auto& device) {
     ZoneScopedN("TT_DNN_DEVICE_OP");
 
-    auto& program_cache = device->program_cache;
+    auto& program_cache = DeviceGetProgramCache(device);
 
     auto program_hash = 0;
     bool program_cache_hit = false;
@@ -264,7 +264,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
 
     log_operation<device_operation_t>(
             device_operation_id,
-            device->id(),
+            DeviceId(device),
             operation_attributes,
             tensor_args,
             program_hash,
@@ -284,7 +284,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
     const auto enqueue_or_launch_program = [=](Program& program) {
         if (USE_FAST_DISPATCH) {
             ZoneScopedN("EnqueueProgram");
-            auto& queue = device->command_queue(cq_id);
+            auto& queue = DeviceCommandQueue(device, cq_id);
             tt::tt_metal::EnqueueProgram(queue, program, false);
         } else {
             ZoneScopedN("LaunchProgram");
@@ -308,7 +308,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
         TracyOpTTNNDevice(
             device_operation_t{},
             device_operation_id,
-            device->id(),
+            DeviceId(device),
             program,
             operation_attributes,
             tensor_args,
@@ -337,7 +337,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
         TracyOpTTNNDevice(
             device_operation_t{},
             device_operation_id,
-            device->id(),
+            DeviceId(device),
             *program,
             operation_attributes,
             tensor_args,

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -27,15 +27,15 @@ std::shared_ptr<Event> create_event(Device* device) {
 
 void record_event(uint8_t cq_id, const std::shared_ptr<Event>& event) {
     Device* device = event->device;
-    device->push_work([device, event, cq_id] {
-        EnqueueRecordEvent(device->command_queue(cq_id), event);
+    DevicePushWork(device, [device, event, cq_id] {
+        EnqueueRecordEvent(DeviceCommandQueue(device, cq_id), event);
     });
 }
 
 void wait_for_event(uint8_t cq_id, const std::shared_ptr<Event>& event) {
     Device* device = event->device;
-    device->push_work([device, event, cq_id] {
-        EnqueueWaitForEvent(device->command_queue(cq_id), event);
+    DevicePushWork(device, [device, event, cq_id] {
+        EnqueueWaitForEvent(DeviceCommandQueue(device, cq_id), event);
     });
 }
 

--- a/ttnn/cpp/ttnn/multi_device.cpp
+++ b/ttnn/cpp/ttnn/multi_device.cpp
@@ -71,10 +71,10 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards)
         std::unordered_map<int, DeviceBuffer> device_buffers;
         for (const auto &shard : tensor_shards) {
             Device* device = std::get<DeviceStorage>(shard.get_storage()).buffer->device();
-            auto device_id = device->id();
+            auto device_id = DeviceId(device);
             ordered_device_ids.push_back(device_id);
-            device_buffers.insert({device->id(), std::get<DeviceStorage>(shard.get_storage()).buffer});
-            shapes.insert({device->id(), shard.get_legacy_shape()});
+            device_buffers.insert({DeviceId(device), std::get<DeviceStorage>(shard.get_storage()).buffer});
+            shapes.insert({DeviceId(device), shard.get_legacy_shape()});
         }
         auto storage = MultiDeviceStorage{AllGatherTensor(), ordered_device_ids, std::move(device_buffers), shapes};
         return Tensor(std::move(storage), tensor_shards.at(0).get_legacy_shape(), tensor_shards.at(0).get_dtype(),  tensor_shards.at(0).get_layout());

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -121,7 +121,7 @@ struct OpPerformanceModelGeneral {
 
     OpPerformanceModelGeneral(Tensors input_tensors, OutputTensors output_tensors, int ideal_compute_cycles) {
         const auto& t = input_tensors.at(0);
-        const auto arch = t.storage_type() == StorageType::DEVICE ? t.device()->arch() : ARCH::WORMHOLE_B0;
+        const auto arch = t.storage_type() == StorageType::DEVICE ? DeviceArch(t.device()) : ARCH::WORMHOLE_B0;
 
         this->ideal_compute_cycles = ideal_compute_cycles;
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -38,7 +38,7 @@ RingTopology::RingTopology(
         // Get the cores for the sender and receiver worker cores
         if (!is_linear || ring_index != ring_size - 1) {
             uint32_t receiver_device = receiver_device_id.value();
-            auto const& sockets = device->get_ethernet_sockets(receiver_device);
+            auto const& sockets = DeviceGetEthernetSockets(device, receiver_device);
             auto eth_sender_core = sockets.at(sender_socket_idx);
             eth_sender_cores.push_back(eth_sender_core);
             log_trace(
@@ -46,7 +46,7 @@ RingTopology::RingTopology(
         }
         if (!is_linear || ring_index != 0) {
             uint32_t sender_device = sender_device_id.value();
-            auto const& sockets = device->get_ethernet_sockets(sender_device);
+            auto const& sockets = DeviceGetEthernetSockets(device, sender_device);
             auto eth_receiver_core = sockets.at(receiver_socket_idx);
             eth_receiver_cores.push_back(eth_receiver_core);
             log_trace(
@@ -179,11 +179,11 @@ static std::pair<std::vector<uint32_t>,std::vector<uint32_t>> shard_noc_cores_fr
     std::vector<uint32_t> logical_to_noc_row_map;
     std::vector<uint32_t> logical_to_noc_col_map;
     for (uint32_t y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-        CoreCoord noc_core = d->physical_core_from_logical_core(CoreCoord(0, y), CoreType::WORKER);
+        CoreCoord noc_core = DevicePhysicalCoreFromLogicalCore(d, CoreCoord(0, y), CoreType::WORKER);
         logical_to_noc_row_map.push_back(noc_core.y);
     }
     for (uint32_t x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-        CoreCoord noc_core = d->physical_core_from_logical_core(CoreCoord(x, 0), CoreType::WORKER);
+        CoreCoord noc_core = DevicePhysicalCoreFromLogicalCore(d, CoreCoord(x, 0), CoreType::WORKER);
         logical_to_noc_col_map.push_back(noc_core.x);
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -34,7 +34,7 @@ void AllGatherFusedOpSignaler::init_all_gather(
     // Get the noc coords for the all gather workers
     this->all_gather_worker_cores_noc.clear();
     for (const auto& core : all_gather_worker_cores) {
-        this->all_gather_worker_cores_noc.push_back(device->worker_core_from_logical_core(core));
+        this->all_gather_worker_cores_noc.push_back(DeviceWorkerCoreFromLogicalCore(device, core));
     }
     initialized_all_gather = true;
 }
@@ -127,14 +127,14 @@ void MatmulFusedOpSignaler::init_fused_op(
             // Handle CoreRange
             const auto& cores = grid_to_cores(arg.start_coord, arg.end_coord, true);
             for (auto& core : cores) {
-                this->fused_op_receiver_cores_noc.push_back(device->worker_core_from_logical_core(core));
+                this->fused_op_receiver_cores_noc.push_back(DeviceWorkerCoreFromLogicalCore(device, core));
             }
         } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
             // Handle CoreRangeSet
             for (const auto& range : arg.ranges()) {
                 const auto& cores = grid_to_cores(range.start_coord, range.end_coord, true);
                 for (auto& core : cores) {
-                    this->fused_op_receiver_cores_noc.push_back(device->worker_core_from_logical_core(core));
+                    this->fused_op_receiver_cores_noc.push_back(DeviceWorkerCoreFromLogicalCore(device, core));
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -374,11 +374,11 @@ static void add_worker_config_to_edm_builders(
         std::vector<ttnn::ccl::WorkerXY> receiver_worker_coords;
         for (uint32_t w = c * num_workers_per_eth_buffer; w < (c + 1) * num_workers_per_eth_buffer; ++w) {
             sender_worker_coords.push_back(ttnn::ccl::WorkerXY(
-                device->worker_core_from_logical_core(worker_cores.at(w)).x,
-                device->worker_core_from_logical_core(worker_cores.at(w)).y));
+                DeviceWorkerCoreFromLogicalCore(device, worker_cores.at(w)).x,
+                DeviceWorkerCoreFromLogicalCore(device, worker_cores.at(w)).y));
             receiver_worker_coords.push_back(ttnn::ccl::WorkerXY(
-                device->worker_core_from_logical_core(worker_cores.at(w)).x,
-                device->worker_core_from_logical_core(worker_cores.at(w)).y));
+                DeviceWorkerCoreFromLogicalCore(device, worker_cores.at(w)).x,
+                DeviceWorkerCoreFromLogicalCore(device, worker_cores.at(w)).y));
         }
 
         // Get the maximum message size we'd like to use. Not the actual packet size
@@ -501,8 +501,8 @@ static void set_reduce_scatter_worker_rt(
         CoreCoord const& receiver_edm = is_in_clockwise_direction ? topology_config.eth_receiver_cores.at(link)
                                                                   : topology_config.eth_sender_cores.at(link);
        ttnn::ccl::WorkerXY receiver_edm_noc_coord =ttnn::ccl::WorkerXY(
-            device->ethernet_core_from_logical_core(receiver_edm).x,
-            device->ethernet_core_from_logical_core(receiver_edm).y);
+            DeviceEthernetCoreFromLogicalCore(device, receiver_edm).x,
+            DeviceEthernetCoreFromLogicalCore(device, receiver_edm).y);
         const uint32_t edm_core_semaphore_address =
             is_in_clockwise_direction
                 ? edm_interface_addresses.worker_receiver_edm_semaphore_addresses.at(global_worker_index)
@@ -537,8 +537,8 @@ static void set_reduce_scatter_worker_rt(
         CoreCoord sender_edm = is_in_clockwise_direction ? topology_config.eth_sender_cores.at(link)
                                                          : topology_config.eth_receiver_cores.at(link);
        ttnn::ccl::WorkerXY const sender_edm_noc_coord =ttnn::ccl::WorkerXY(
-            device->ethernet_core_from_logical_core(sender_edm).x,
-            device->ethernet_core_from_logical_core(sender_edm).y);
+            DeviceEthernetCoreFromLogicalCore(device, sender_edm).x,
+            DeviceEthernetCoreFromLogicalCore(device, sender_edm).y);
         TT_ASSERT(sender_edm_noc_coord.y == 0 || sender_edm_noc_coord.y == 6);
         const uint32_t edm_core_semaphore_address =
             is_in_clockwise_direction

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -97,8 +97,8 @@ Tensor reduce_scatter(
                     bool is_last_chip_in_clockwise_direction = is_ring ? false : i == (input_tensors.size() - 1);
                     bool is_last_chip_in_counter_clockwise_direction = is_ring ? false : i == 0;
                     device_index = i;
-                    receiver_device_id = devices.at((i + 1) % num_devices)->id(); // Next device in the ring
-                    sender_device_id = devices.at((i + num_devices - 1) % num_devices)->id(); // Previous device in the ring
+                    receiver_device_id = DeviceId(devices.at((i + 1) % num_devices)); // Next device in the ring
+                    sender_device_id = DeviceId(devices.at((i + num_devices - 1) % num_devices)); // Previous device in the ring
                     break;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -91,7 +91,7 @@ ParallelConfig determine_parallel_config(
         conv_out_2d_matrix_height_ntiles = conv_out_2d_matrix_height;
         conv_out_2d_matrix_width_ntiles = output_channels;
     }
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     std::vector<uint32_t> device_grid_size = {
         (uint32_t)compute_with_storage_grid_size.x, (uint32_t)compute_with_storage_grid_size.y};
     CoreCoord device_grid_size_coord = {
@@ -722,7 +722,7 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
     bool input_is_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_post_tm);
     TT_ASSERT(input_is_on_device);
     DeviceComputeKernelConfig compute_kernel_config;
-    switch (device->arch()) {
+    switch (DeviceArch(device)) {
         case tt::ARCH::WORMHOLE_B0:
             compute_kernel_config = WormholeComputeKernelConfig(
                 {.math_fidelity = conv_config.math_fidelity,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -392,13 +392,13 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         [&](auto&& compute_kernel_config) {
             using T = std::decay_t<decltype(compute_kernel_config)>;
             if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-                TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+                TT_FATAL(DeviceArch(device) == ARCH::GRAYSKULL, "kernel config is not for graykull");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = false;
                 packer_l1_acc = false;
             } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-                TT_FATAL(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+                TT_FATAL(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
@@ -528,7 +528,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw.second;
     uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
     uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
-    
+
     // Compute the 2d matrix shape
     auto [act_matrix_shape, act_matrix_shape_unpadded] =
         optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(
@@ -895,9 +895,9 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
     CoreCoord top_left_core_plus_one = {(std::size_t)1, (std::size_t)1};
     CoreCoord bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
-    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
-    auto top_left_core_plus_one_physical = device->worker_core_from_logical_core(top_left_core_plus_one);
-    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+    auto top_left_core_physical = DeviceWorkerCoreFromLogicalCore(device, top_left_core);
+    auto top_left_core_plus_one_physical = DeviceWorkerCoreFromLogicalCore(device, top_left_core_plus_one);
+    auto bottom_right_core_physical = DeviceWorkerCoreFromLogicalCore(device, bottom_right_core);
 
     CoreRange mcast_sender_cores(top_left_core, top_left_core);  // If single core, this kernel doesn't do mcasting
     CoreRangeSet mcast_receiver_cores{{}};
@@ -1100,13 +1100,13 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             if (transpose_mcast) {
                 act_mcast_noc_y.reserve(num_cores_y);
                 for (uint32_t core_idx_y = 0; core_idx_y < num_cores_y; ++core_idx_y) {
-                    act_mcast_noc_y.push_back(device->worker_core_from_logical_core({0, core_idx_y}).y);
+                    act_mcast_noc_y.push_back(DeviceWorkerCoreFromLogicalCore(device, {0, core_idx_y}).y);
                 }
             } else {
                 // NOTE: using same var for x as well, this is intentional
                 act_mcast_noc_y.reserve(num_cores_x);
                 for (int32_t core_idx_x = 0; core_idx_x < num_cores_x; ++core_idx_x) {
-                    act_mcast_noc_y.push_back(device->worker_core_from_logical_core({(uint32_t)core_idx_x, 0}).x);
+                    act_mcast_noc_y.push_back(DeviceWorkerCoreFromLogicalCore(device, {(uint32_t)core_idx_x, 0}).x);
                 }
             }
 
@@ -1403,7 +1403,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
             if (transpose_mcast) {
                 CoreCoord bottom_core = {(std::size_t)core_x_i, (std::size_t)num_cores_y - 1};
-                auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+                auto bottom_core_physical = DeviceWorkerCoreFromLogicalCore(device, bottom_core);
 
                 uint32_t act_mcast_dest_noc_start_x = bottom_core_physical.x;
                 uint32_t act_mcast_dest_noc_start_y =
@@ -1425,9 +1425,9 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                     reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());  // act_mcast_sender_noc_y
             } else {
                 CoreCoord core = {core_x_i, core_y_i};
-                auto core_physical = device->worker_core_from_logical_core(core);
+                auto core_physical = DeviceWorkerCoreFromLogicalCore(device, core);
                 CoreCoord bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
-                auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+                auto bottom_right_core_physical = DeviceWorkerCoreFromLogicalCore(device, bottom_right_core);
 
                 uint32_t act_mcast_dest_noc_start_x =
                     reader_is_noc_0 ? top_left_core_physical.x : bottom_right_core_physical.x;
@@ -1503,7 +1503,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             // 2D mcast
             if (transpose_mcast) {
                 CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core_y_i};
-                auto right_core_physical = device->worker_core_from_logical_core(right_core);
+                auto right_core_physical = DeviceWorkerCoreFromLogicalCore(device, right_core);
                 if (core_x_i == 0) {
                     // sender
                     if (writer_mcast_noc == NOC::NOC_0) {
@@ -1535,7 +1535,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                 }
             } else {
                 CoreCoord top_core = {(std::size_t)core_x_i, 0};
-                auto top_core_physical = device->worker_core_from_logical_core(top_core);
+                auto top_core_physical = DeviceWorkerCoreFromLogicalCore(device, top_core);
                 TT_FATAL(writer_mcast_noc == NOC::NOC_0, "Error");
                 if (core_y_i == 0) {
                     // sender

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
@@ -105,8 +105,8 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
                     input_bias_format_params = {.pad_shape=bias.value().get_legacy_shape(), .pad_value=0, .target_layout=Layout::TILE};
                 }
                 auto output_layout = untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
-                auto arch = is_tensor_on_device_or_multidevice(a) ? a.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
-                bool fp32_accum = a.device()->arch() == tt::ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
+                auto arch = is_tensor_on_device_or_multidevice(a) ? DeviceArch(a.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
+                bool fp32_accum = DeviceArch(a.device()) == tt::ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
                 auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
                 return operation::run_without_autoformat(
                     OptimizedConvNew(sliding_window_config, output_channels, groups, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, memory_config, dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val, enable_act_double_buffer, enable_split_reader, enable_subblock_padding
@@ -269,7 +269,7 @@ operation::OpPerformanceModel OptimizedConvNew::create_op_performance_model(cons
         tt::log_warning(tt::LogOp, "Output tensor not on DEVICE?!");
     }
 
-    auto arch = t.storage_type() == StorageType::DEVICE ? t.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = t.storage_type() == StorageType::DEVICE ? DeviceArch(t.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     const int num_cores = (arch == tt::ARCH::WORMHOLE_B0) ? 8 * 8 : 9 * 12;
     const int tensix_mul_adds_per_cycle_lofi = (arch == tt::ARCH::WORMHOLE_B0) ? 4096 : 2048;
 

--- a/ttnn/cpp/ttnn/operations/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/copy.hpp
@@ -50,7 +50,7 @@ struct Typecast {
                 output_dtype == optional_output_tensor.value().get_dtype(),
                 "If both output dtype and output tensor provided dtype should match");
         }
-        if (input.device()->arch() == tt::ARCH::GRAYSKULL) {
+        if (DeviceArch(input.device()) == tt::ARCH::GRAYSKULL) {
             return ttnn::experimental::typecast(queue_id, input, output_dtype, memory_config_arg, optional_output_tensor);
         }
         DataType input_dtype = input.get_dtype();
@@ -88,7 +88,7 @@ struct Typecast {
         const std::optional<MemoryConfig>& memory_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt) {
         TT_ASSERT(
-            input_tensor.device()->arch() != tt::ARCH::GRAYSKULL,
+            DeviceArch(input_tensor.device()) != tt::ARCH::GRAYSKULL,
             "eltwise_typecast is not currently supported on Grayskull");
         TT_FATAL(
             tt_input_dtype == input_tensor.get_dtype(), "input dtype and input tensor's dtype provided should match");

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -31,7 +31,7 @@ inline bool use_multicore_device_tilize(
             : input_single_tile_size;
 
     uint32_t num_tiles_in_row = input.get_shape()[-1] / tt::constants::TILE_WIDTH;
-    uint32_t max_l1_size = input.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    uint32_t max_l1_size = DeviceL1SizePerCore(input.device()) / 2 - L1_UNRESERVED_BASE;
     uint32_t max_tiles = max_l1_size / (input_single_tile_size + output_single_tile_size);  // 2 CBs
 
     return num_tiles_in_row <= max_tiles;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
@@ -54,7 +54,7 @@ operation::ProgramWithCallbacks bcast_multi_core_h(const Tensor &a, const Tensor
     uint32_t src1_single_tile_size = tt_metal::detail::TileSize(src1_cb_data_format);
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
@@ -35,7 +35,7 @@ operation::ProgramWithCallbacks bcast_sharded_h(const Tensor &a, const Tensor &b
     uint32_t ncores = shard_spec.num_cores();
 
 
-    uint32_t ncores_x = device->compute_with_storage_grid_size().x;
+    uint32_t ncores_x = DeviceComputeWithStorageGridSize(device).x;
 
     auto out_shard_spec = output.shard_spec().value();
     TT_FATAL(out_shard_spec.num_cores() == ncores, "Output tensor should have same number of cores {} as input tensor {}", out_shard_spec.num_cores(), ncores);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -35,7 +35,7 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(const Tensor &a, const
     uint32_t ncores = shard_spec.num_cores();
 
 
-    uint32_t ncores_x = device->compute_with_storage_grid_size().x;
+    uint32_t ncores_x = DeviceComputeWithStorageGridSize(device).x;
 
     auto out_shard_spec = output.shard_spec().value();
     TT_FATAL(out_shard_spec.num_cores() == ncores, "Output tensor should have same number of cores {} as input tensor {}", out_shard_spec.num_cores(), ncores);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -60,7 +60,7 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
     uint32_t src1_single_tile_size = tt::tt_metal::detail::TileSize(src1_cb_data_format);
     uint32_t dst_single_tile_size = tt::tt_metal::detail::TileSize(dst_cb_data_format);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
@@ -52,7 +52,7 @@ operation::ProgramWithCallbacks bcast_multi_core_w(const Tensor &a, const Tensor
     uint32_t src1_single_tile_size = tt_metal::detail::TileSize(src1_cb_data_format);
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
 
-	auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+	auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -21,7 +21,7 @@ operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
 
     tt_metal::Device *device = output.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
@@ -146,7 +146,7 @@ operation::ProgramWithCallbacks s2s_rm_concat_multi_core(
 
     tt_metal::Device *device = output.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
@@ -358,7 +358,7 @@ operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
 
     tt_metal::Device *device = output.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     // CoreRangeSet all_cores({CoreRange(CoreCoord(0,0), compute_with_storage_grid_size)});
@@ -523,7 +523,7 @@ operation::ProgramWithCallbacks concat_multi_core(
         single_page_size = tt_metal::detail::TileSize(cb_data_format);
     }
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_program_factory.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor &input, const Tenso
 
     tt::tt_metal::Device *device = output.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] = tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_units);

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
@@ -17,7 +17,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids,
     tt::tt_metal::Program program{};
     Device *device = input_a.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto set_of_core_ranges = tt::tt_metal::num_cores_to_corerange_set(num_cores_x*num_cores_y, compute_with_storage_grid_size);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -669,7 +669,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
     uint32_t ntiles_h = output_tensor_shape[2] / TILE_HEIGHT;
     uint32_t ntiles_w = output_tensor_shape[3] / TILE_WIDTH;
 
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t nbatch = output_tensor_shape[0];
     uint32_t nchannel = output_tensor_shape[1];
     // first the batch dim is distributed along H, and within each batch then the tiles are distributed.
@@ -997,7 +997,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(const Tensor 
 
     Device *device = a.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;
@@ -1241,7 +1241,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // figure out the stick id in a shard, and the core id for the stick.
         std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
-        auto first_core = device->worker_core_from_logical_core(CoreCoord{0, 0});
+        auto first_core = DeviceWorkerCoreFromLogicalCore(device, CoreCoord{0, 0});
         std::pair<uint32_t, uint32_t> prev_xy_pair = std::make_pair(first_core.x, first_core.y);
         for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
             int stick_id = stick_ids_per_core[j];
@@ -1263,7 +1263,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
                 uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
 
                 if (worker_x_logical < num_cores_x_unpadded and worker_y_logical < num_cores_y_unpadded) {
-                    auto core_physical = device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                    auto core_physical = DeviceWorkerCoreFromLogicalCore(device, CoreCoord{worker_x_logical, worker_y_logical});
                     // save stick id in a shard, and core coord into a map
                     std::pair<uint32_t, uint32_t> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
                                                                         : std::make_pair(core_physical.x, core_physical.y);
@@ -1392,7 +1392,7 @@ operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
     tt::log_debug("all_cores_unpadded: {}", all_cores_unpadded);
     tt::log_debug("num_cores_unpadded: {}", num_cores_unpadded);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks repeat_multi_core(
         single_page_size = tt::tt_metal::detail::TileSize(cb_data_format);
     }
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape/device/reshape_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape/device/reshape_program_factory.cpp
@@ -128,7 +128,7 @@ operation::ProgramWithCallbacks reshape_rm_single_core(const Tensor &a, Tensor& 
     uint32_t num_output_tiles = (output_shape[1] * output_shape[2] * output_shape[3] / tt::constants::TILE_HW);
 
     // Currently added to support Bert large, TODO: Make op more generic, parallelize
-    uint32_t available_l1 = device->l1_size_per_core() - L1_UNRESERVED_BASE;
+    uint32_t available_l1 = DeviceL1SizePerCore(device) - L1_UNRESERVED_BASE;
     if (num_input_tiles * single_tile_size + num_output_tiles * single_tile_size > available_l1) {
         if (old_stick_size >= new_stick_size) {
             if (old_stick_size % new_stick_size == 0) {
@@ -383,7 +383,7 @@ operation::ProgramWithCallbacks reshape_rm_multi_core(const Tensor &a, Tensor& o
         TT_FATAL(new_stick_size % old_stick_size == 0, "Error");
     }
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.cpp
@@ -34,7 +34,7 @@ namespace detail {
         if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
             data_vec.resize(size_in_bytes / sizeof(uint16_t));
             tt::tt_metal::tensor_impl::read_data_from_device_buffer<uint16_t>(
-                input_tensor.device()->command_queue(), device_buffer, data_vec.data(), true);
+                DeviceCommandQueue(input_tensor.device()), device_buffer, data_vec.data(), true);
         } else {
             tt::tt_metal::tensor_impl::read_data_from_device_buffer<uint16_t>(device_buffer, data_vec);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -26,7 +26,7 @@ void InterleavedToShardedPartialDeviceOperation::validate(const std::vector<Tens
     if (input_tensor.get_dtype() != this->output_dtype) {
         TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     }
-    auto device_grid = input_tensor.device()->compute_with_storage_grid_size();
+    auto device_grid = DeviceComputeWithStorageGridSize(input_tensor.device());
     TT_FATAL(this->grid_size.x <= device_grid.x && this->grid_size.y <= device_grid.y, "Grid size for sharding must be less than or equal to total grid available");
     // Divisibility of num_cores and shard size with tensor shape is done in tensor creation, so no need to assert here
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -137,7 +137,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
 
     uint32_t num_unpadded_sticks = output.volume() / output.get_legacy_shape()[-1];
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
@@ -493,7 +493,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
 
             if (worker_x_logical < num_cores_x_padded and worker_y_logical < num_cores_y_padded) {
-                auto core_physical = device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                auto core_physical = DeviceWorkerCoreFromLogicalCore(device, CoreCoord{worker_x_logical, worker_y_logical});
                 // save stick id in a shard, and core coord into a map
                 std::pair<uint32_t, uint32_t> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
                                                                     : std::make_pair(core_physical.x, core_physical.y);
@@ -608,7 +608,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core_sharded(
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
@@ -835,7 +835,7 @@ operation::ProgramWithCallbacks slice_tile_multi_core(
 
     uint32_t num_unpadded_tiles = output.volume() / TILE_HW;
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_cores_total = num_cores_x * num_cores_y;

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -114,8 +114,8 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
     uint32_t z = input_shape[1];
     uint32_t num_tiles_dim_2 = input_shape[2] / tt::constants::TILE_HEIGHT;
     uint32_t num_tiles_dim_3 = input_shape[3] / tt::constants::TILE_WIDTH;
-    uint32_t num_cores_x_limit = device->compute_with_storage_grid_size().x;
-    uint32_t num_cores_y_limit = device->compute_with_storage_grid_size().y;
+    uint32_t num_cores_x_limit = DeviceComputeWithStorageGridSize(device).x;
+    uint32_t num_cores_y_limit = DeviceComputeWithStorageGridSize(device).y;
 
     // parallelize z
     auto num_cores_z = z;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
@@ -46,7 +46,7 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& outp
 
     uint32_t num_tiles_in_row = stick_s / TILE_WIDTH;
     // Ensure we don't intrude into storage space
-    uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    uint32_t max_l1_size = DeviceL1SizePerCore(a.device()) / 2 - L1_UNRESERVED_BASE;
     uint32_t max_tiles = max_l1_size / (input_single_tile_size + output_single_tile_size);  // 2 CBs
     // Currently need the number of tiles in a row to be divisible by tiles in a block
     uint32_t num_tiles_per_block = 1;
@@ -169,7 +169,7 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
     uint32_t block_size_nbytes = a.get_legacy_shape()[-1] * a.element_size();
 
     Device* device = a.device();
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(grid_size, nblocks);
 
@@ -328,7 +328,7 @@ operation::ProgramWithCallbacks tilize_multi_core_sharded(const Tensor& input, T
     uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
     uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
     auto all_cores = shard_spec.grid;
-    uint32_t num_cores_x = device->compute_with_storage_grid_size().x;
+    uint32_t num_cores_x = DeviceComputeWithStorageGridSize(device).x;
     uint32_t num_cores = all_cores.num_cores();
 
     auto [src0_cb_index, cb_src0] = create_cb(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
 
     uint32_t num_tiles_in_row = output_x / TILE_WIDTH;
     // Ensure we don't intrude into storage space
-    uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    uint32_t max_l1_size = DeviceL1SizePerCore(a.device()) / 2 - L1_UNRESERVED_BASE;
     // Memory usage is 2 CBs of width W, plus buffer of size alignment + (W * datum size)
     uint32_t max_X = (max_l1_size - alignment) / (a.element_size() * TILE_HEIGHT * 2 + a.element_size());
     uint32_t max_tiles = max_X / TILE_WIDTH;
@@ -205,7 +205,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
     uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
 
     Device* device = a.device();
-    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreCoord grid_size = DeviceComputeWithStorageGridSize(device);
 
     uint32_t num_blocks = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = output.get_legacy_shape()[-1] / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -139,7 +139,7 @@ operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor 
 
     uint32_t num_tensor_tiles = a.volume() / TILE_HW;
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;
@@ -471,7 +471,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
     // This should allocate a DRAM buffer on the device
     tt::tt_metal::Device *device = a.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;
@@ -645,12 +645,12 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
 
     std::vector<uint32_t> shard_grid_x_map;
     for (uint32_t i = 0; i < num_cores_x; ++i) {
-        auto physical_core = device->worker_core_from_logical_core(CoreCoord(i, 0));
+        auto physical_core = DeviceWorkerCoreFromLogicalCore(device, CoreCoord(i, 0));
         shard_grid_x_map.push_back(physical_core.x);
     }
     std::vector<uint32_t> shard_grid_y_map;
     for (uint32_t i = 0; i < num_cores_y; ++i) {
-        auto physical_core = device->worker_core_from_logical_core(CoreCoord(0, i));
+        auto physical_core = DeviceWorkerCoreFromLogicalCore(device, CoreCoord(0, i));
         shard_grid_y_map.push_back(physical_core.y);
     }
 
@@ -819,7 +819,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
             uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
 
             if (worker_x_logical < num_cores_x and worker_y_logical < num_cores_y) {
-                auto core_physical = device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                auto core_physical = DeviceWorkerCoreFromLogicalCore(device, CoreCoord{worker_x_logical, worker_y_logical});
 
                 read_cores_indices.push_back(shard_id);
                 read_stick_offset.push_back(stick_id_in_shard * stick_size_bytes);
@@ -1370,7 +1370,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor &a, Tensor 
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x*num_cores_y;
@@ -1567,7 +1567,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a,
     tt::tt_metal::Device *device = a.device();
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x-1, num_cores_y-1});

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -49,7 +49,7 @@ void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
         uint32_t ntiles_per_block = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
         uint32_t nblocks = ceil((float)ntiles / ntiles_per_block);
         auto num_cores =
-            untilize_helpers::get_num_cores(input_tensor_a.device()->compute_with_storage_grid_size(), nblocks);
+            untilize_helpers::get_num_cores(DeviceComputeWithStorageGridSize(input_tensor_a.device()), nblocks);
         uint32_t fused_height = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1];
         TT_FATAL(fused_height % num_cores == 0, "Error");
     } else {
@@ -84,9 +84,9 @@ std::vector<Tensor> Untilize::create_output_tensors(
             uint32_t ntiles_per_block = input_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
             uint32_t nblocks = ceil((float)ntiles / ntiles_per_block);
             auto num_cores =
-                untilize_helpers::get_num_cores(input_tensor.device()->compute_with_storage_grid_size(), nblocks);
+                untilize_helpers::get_num_cores(DeviceComputeWithStorageGridSize(input_tensor.device()), nblocks);
             auto shard_grid =
-                tt::tt_metal::num_cores_to_corerange_set(num_cores, input_tensor.device()->compute_with_storage_grid_size(), true);
+                tt::tt_metal::num_cores_to_corerange_set(num_cores, DeviceComputeWithStorageGridSize(input_tensor.device()), true);
             uint32_t fused_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
             std::array<uint32_t, 2> shard_shape = {fused_height / num_cores, input_tensor.get_legacy_shape()[-1]};
             ShardSpec shard_spec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -66,7 +66,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
 
     uint32_t num_tiles_in_row = input_x / TILE_WIDTH;
     // Ensure we don't intrude into storage space
-    uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    uint32_t max_l1_size = DeviceL1SizePerCore(a.device()) / 2 - L1_UNRESERVED_BASE;
     // Memory usage is 2 CBs of width W, plus buffer of size alignment + (W * datum size)
     uint32_t max_X = (max_l1_size - alignment) / (output.element_size() * TILE_HEIGHT * 2 + output.element_size());
     uint32_t max_tiles = max_X / TILE_WIDTH;
@@ -216,7 +216,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     const auto& output_shape = output.get_legacy_shape();
 
     Device* device = a.device();
-    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreCoord grid_size = DeviceComputeWithStorageGridSize(device);
 
     uint32_t num_blocks = a.volume() / input_shape[-1] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = a.get_legacy_shape()[-1] / TILE_WIDTH;
@@ -385,7 +385,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
 
     Device* device = a.device();
 
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_rows_block = 0, block_row_size = 0, output_row_size = 0, last_block_row_size_unpadded = 0,
              num_output_rows_unpadded = 0;
     CoreCoord end_core;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -63,7 +63,7 @@ Tensor _addalpha(
 
 // nextafter
 Tensor _nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    const float eps = input_a.device()->sfpu_eps();
+    const float eps = DeviceSfpuEps(input_a.device());
     Tensor result(input_a);
     {
         Tensor eps_gt(input_a);
@@ -172,7 +172,7 @@ Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, con
 
 Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
-    auto arch = input_a.device()->arch();
+    auto arch = DeviceArch(input_a.device());
     if (arch == tt::ARCH::WORMHOLE_B0) {
         DataType input_dtype = input_a.get_dtype();
         Tensor a = typecast(input_a, DataType::FLOAT32);
@@ -240,7 +240,7 @@ Tensor _div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::opti
 
 // Binary remainder will be overloaded by unary remainder in another PR
 Tensor ExecuteBinaryRemainder::invoke(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
+    auto arch = DeviceArch(input_a.device());
     TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
     DataType input_dtype = input_a.get_dtype();
     Tensor a = typecast(input_a, DataType::FLOAT32);
@@ -259,7 +259,7 @@ Tensor ExecuteBinaryRemainder::invoke(const Tensor& input, float scalar, const s
 
 // Binary FMOD will be overloaded by unary FMOD in another PR
 Tensor ExecuteBinaryFmod::invoke(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
+    auto arch = DeviceArch(input_a.device());
     TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
     DataType input_dtype = input_a.get_dtype();
     Tensor a = typecast(input_a, DataType::FLOAT32);
@@ -274,7 +274,7 @@ Tensor ExecuteBinaryFmod::invoke(const Tensor& input, float scalar, const std::o
 }
 
 Tensor _floor_div_overload(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
+    auto arch = DeviceArch(input_a.device());
     TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
     if (value == 0) {
         Tensor t_inf = ttnn::full_like(input_a, std::numeric_limits<float>::infinity());
@@ -289,7 +289,7 @@ Tensor _floor_div_overload(const Tensor& input_a, float value, const std::option
 }
 
 Tensor _floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
+    auto arch = DeviceArch(input_a.device());
     TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
     Tensor temp = ttnn::div(input_a, input_b, true, "None", output_mem_config);
     Tensor result = ttnn::div(input_a, input_b, true, "floor", output_mem_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -91,7 +91,7 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
         if (attributes.memory_config.is_sharded()) {
             TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
             uint32_t num_blocks = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
-            auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+            auto core_grid = DeviceComputeWithStorageGridSize(input_tensor_a.device());
             uint32_t num_cores = core_grid.x * core_grid.y;
             TT_FATAL(num_blocks < num_cores or num_blocks % num_cores == 0, "Error");
 
@@ -195,7 +195,7 @@ BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_outpu
                 shard_spec = input_tensor_b.shard_spec().value();
             } else {
                 uint32_t num_blocks = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
-                auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                auto core_grid = DeviceComputeWithStorageGridSize(input_tensor_a.device());
                 uint32_t num_grid_cores = core_grid.x * core_grid.y;
                 uint32_t target_num_cores = num_blocks < num_grid_cores ? num_blocks : num_grid_cores;
                 shard_spec.grid = tt::tt_metal::num_cores_to_corerange_set(target_num_cores, core_grid, true);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -82,7 +82,7 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
     uint32_t src1_single_tile_size = tt_metal::detail::TileSize(src1_cb_data_format);
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -71,7 +71,7 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
     uint32_t src1_single_tile_size = tt_metal::detail::TileSize(src1_cb_data_format);
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -67,7 +67,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreShardedOptimized::create(
     auto all_cores = shard_spec.grid;
     uint32_t ncores = shard_spec.num_cores();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t ncores_x = compute_with_storage_grid_size.x;
 
     auto out_shard_spec = output.shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
@@ -68,7 +68,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreSharded::create(
     uint32_t ncores = shard_spec.num_cores();
 
 
-    uint32_t ncores_x = device->compute_with_storage_grid_size().x;
+    uint32_t ncores_x = DeviceComputeWithStorageGridSize(device).x;
 
     auto out_shard_spec = output.shard_spec().value();
     TT_FATAL(out_shard_spec.num_cores() == ncores, "Output tensor should have same number of cores {} as input tensor {}", out_shard_spec.num_cores(), ncores);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
@@ -70,7 +70,7 @@ BinaryDeviceOperation::BroadcastWidthMultiCore::cached_program_t BinaryDeviceOpe
     uint32_t src1_single_tile_size = tt_metal::detail::TileSize(src1_cb_data_format);
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_cores_total = num_cores_x * num_cores_y;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -287,7 +287,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     bool src1_sharded = b.memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -67,7 +67,7 @@ void UnaryDeviceOperation::validate_on_program_cache_miss(const operation_attrib
         output_datatype = preallocated_output_tensor->get_dtype();
     }
 
-    auto arch = input_tensor.device()->arch();
+    auto arch = DeviceArch(input_tensor.device());
     auto input_datatype = input_tensor.get_dtype();
     for (const auto& unary_op : args.op_chain) {
         validate_supported_arch_dtype(arch, input_datatype, output_datatype, unary_op.op_type);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -38,7 +38,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
 
     tt::tt_metal::Device *device = input.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -254,7 +254,7 @@ Tensor Softplus::invoke(
     const float threshold,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    TT_ASSERT(input.device()->arch() != tt::ARCH::GRAYSKULL, "Softplus is not currently supported on Grayskull");
+    TT_ASSERT(DeviceArch(input.device()) != tt::ARCH::GRAYSKULL, "Softplus is not currently supported on Grayskull");
     return detail::unary_impl(
         queue_id,
         input,
@@ -269,7 +269,7 @@ Tensor Softplus::invoke(
     const float threshold,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    TT_ASSERT(input.device()->arch() != tt::ARCH::GRAYSKULL, "Softplus is not currently supported on Grayskull");
+    TT_ASSERT(DeviceArch(input.device()) != tt::ARCH::GRAYSKULL, "Softplus is not currently supported on Grayskull");
     return detail::unary_impl(
         DefaultQueueId,
         input,

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks embeddings_tilized(
 
     uint32_t problem_size = num_blocks;
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
@@ -322,7 +322,7 @@ operation::ProgramWithCallbacks embeddings_rm(
 
     uint32_t problem_size = num_blocks;
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -22,7 +22,7 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
     const auto &grad_tensor_shape = grad_tensor.get_legacy_shape();
 
     TT_FATAL(
-        index_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
+        DeviceArch(index_tensor.device()) == tt::ARCH::WORMHOLE_B0,
         "Embedding backwards is only implemented for Wormhole!");
 
     TT_FATAL(index_tensor.get_layout() == Layout::ROW_MAJOR, "Error");

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -66,7 +66,7 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
     uint32_t num_embeddings_tiles = num_embeddings / TILE_HEIGHT;
 
     // We split work based on the number of tiles in the embedding dimension
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(grid_size, embedding_tiles);
     uint32_t max_tiles_per_core = std::max(num_tiles_per_core_group_1, num_tiles_per_core_group_2);

--- a/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
@@ -30,7 +30,7 @@ ExampleDeviceOperation::MultiCore::cached_program_t ExampleDeviceOperation::Mult
 
     tt::tt_metal::Device* device = input_tensor.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -71,7 +71,7 @@ DatacopyParams setup_datacopy(
     std::vector<CoreCoord> all_datacopy_cores = corerange_to_cores(datacopy_workers, std::nullopt, true);
     std::vector<CoreCoord> all_datacopy_cores_noc;
     for (auto core : all_datacopy_cores) {
-        all_datacopy_cores_noc.push_back(device->worker_core_from_logical_core(core));
+        all_datacopy_cores_noc.push_back(DeviceWorkerCoreFromLogicalCore(device, core));
     }
 
     // Setup semaphores used to signal datacopy. TODO: instead of datacopy, this should be matmul cores

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::experimental::matmul {
         const std::optional<MemoryConfig>& memory_config,
         std::optional<Tensor> optional_output_tensor) {
 
-        auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+        auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_a.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
         auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
         return operation::run(AttnMatmulDeviceOperation{std::nullopt, std::nullopt, compute_with_storage_grid_size,
             memory_config.value_or(input_tensor_a.memory_config()), dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val},
@@ -54,7 +54,7 @@ namespace ttnn::operations::experimental::matmul {
         TT_FATAL(num_tokens > 0, "Number of tokens must be at least 1!");
         TT_FATAL(num_tokens <= input_tensor_b.get_legacy_shape()[2], "Number of tokens must be smaller or equal to the max cache length (B.shape[2])!");
         const uint32_t num_tokens_rounded_up_to_32 = ((num_tokens - 1) / 32 + 1) * 32;
-        auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+        auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_a.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
         auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
         return operation::run(AttnMatmulDeviceOperation{num_tokens_rounded_up_to_32,
             transpose_hw, compute_with_storage_grid_size, memory_config.value_or(input_tensor_a.memory_config()),

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -97,7 +97,7 @@ operation::ProgramWithCallbacks AttnMatmulDeviceOperation::create_program(
     const auto& input_tensor_b = input_tensors.at(1);
     auto& output_tensor = output_tensors.at(0);
 
-    auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor_a.device());
     TT_ASSERT(
         (this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
          this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -176,7 +176,7 @@ operation::ProgramWithCallbacks GroupAttnMatmulDeviceOperation::create_program(
     const auto& input_tensor_b = input_tensors.at(1);
     auto& output_tensor = output_tensors.at(0);
 
-    auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor_a.device());
     TT_ASSERT(
         (this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
          this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),
@@ -212,11 +212,11 @@ const operation::Hash GroupAttnMatmulDeviceOperation::compute_program_hash(const
         std::get<DeviceStorage>(input_tensor_a.storage()).memory_config().memory_layout,
         std::get<DeviceStorage>(input_tensor_a.storage()).memory_config().buffer_type,
         input_tensor_a.dtype(),
-        std::get<DeviceStorage>(input_tensor_b.storage()).buffer->device()->id(),
+        DeviceId(std::get<DeviceStorage>(input_tensor_b.storage()).buffer->device()),
         std::get<DeviceStorage>(input_tensor_b.storage()).memory_config().memory_layout,
         std::get<DeviceStorage>(input_tensor_b.storage()).memory_config().buffer_type,
         input_tensor_b.dtype(),
-        std::get<DeviceStorage>(input_tensor_b.storage()).buffer->device()->id());
+        DeviceId(std::get<DeviceStorage>(input_tensor_b.storage()).buffer->device()));
 }
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
@@ -32,7 +32,7 @@ namespace ttnn::operations::experimental::matmul {
             }
         }
 
-        auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+        auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_a.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
         auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
 
         // Need to cache on out_subblock_w because it must be a compile time arg for optimal use of templated pack_untilize APIs

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
@@ -51,7 +51,7 @@ operation::ProgramWithCallbacks paged_fill_cache_multi_core(const Tensor& cache_
 
     tt_metal::Device *device = input_tensor.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
@@ -20,10 +20,10 @@ bool enable_fp32_dest(const tt_metal::Device * device, const ttnn::DeviceCompute
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == ARCH::GRAYSKULL, "kernel config is not for graykull");
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+            TT_ASSERT(DeviceArch(device) == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
             TT_THROW("arch not supported");

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
@@ -14,7 +14,7 @@ namespace operations::experimental::paged_cache {
 
 ttnn::Tensor PagedUpdateCacheOperation::invoke(
     const Tensor& cache_tensor, const Tensor& input_tensor, const std::vector<uint32_t> update_idxs, const std::optional<const Tensor> update_idxs_tensor = std::nullopt, const std::optional<const Tensor> page_table = std::nullopt, const uint32_t batch_offset = 0, std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input_tensor.device()), compute_kernel_config);
     operation::run(PagedUpdateCacheDeviceOperation{0, update_idxs, batch_offset, PagedUpdateCacheOpType::UPDATE, kernel_config_val}, {cache_tensor, input_tensor}, {update_idxs_tensor, page_table});
 
     return cache_tensor; // Updated cache tensor in-place
@@ -22,7 +22,7 @@ ttnn::Tensor PagedUpdateCacheOperation::invoke(
 
 ttnn::Tensor PagedFillCacheOperation::invoke(
     const Tensor& cache_tensor, const Tensor& input_tensor, const Tensor& page_table, const uint32_t batch_idx, std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input_tensor.device()), compute_kernel_config);
     operation::run(PagedUpdateCacheDeviceOperation{batch_idx, {}, 0, PagedUpdateCacheOpType::FILL, kernel_config_val}, {cache_tensor, input_tensor, page_table}, {std::nullopt, std::nullopt});
 
     return cache_tensor; // Updated cache tensor in-place

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -22,7 +22,7 @@ Tensor _fast_reduce_nc(
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
 
     TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE, "Error");
-    auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+    auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input.device()), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(
         [dim, output_mem_config, kernel_config_val, queue_id](

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -60,7 +60,7 @@ operation::ProgramWithCallbacks reduce_nc_factory(const ttnn::Tensor &input, con
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile = input_shape[dim];
     const auto num_output_tiles = output.volume() / TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(DeviceArch(input.device()), compute_kernel_config);
     // choose granularity as the largest factor of num_reduce_input_tile that is less than or equal to 8
     uint32_t input_granularity;
     for (input_granularity = 8; input_granularity > 1; --input_granularity) {
@@ -72,7 +72,7 @@ operation::ProgramWithCallbacks reduce_nc_factory(const ttnn::Tensor &input, con
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const uint32_t in0_t = input_granularity*2;        // input

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks HCSumReduce::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor_a.device());
     return detail::multi_core_ssm_1d_sum_reduce(
         input_tensor_a, output_tensor, math_fidelity, device_compute_with_storage_grid_size);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks PrefixScan::create_program(
     const auto& bx = input_tensors.at(1);
     const auto& h = input_tensors.at(2);
     auto& output = output_tensors.at(0);
-    auto device_compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(a.device());
     return detail::multi_core_ssm_prefix_scan(a, bx, h, output, math_fidelity, device_compute_with_storage_grid_size);
 }
 }  // namespace ttnn::operations::experimental::ssm

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
@@ -86,7 +86,7 @@ operation::ProgramWithCallbacks RepeatAndInterleaveEltwiseMul::create_program(
     auto& output_tensor = output_tensors.at(0);
     const auto hidden_size = HIDDEN_SIZE;
 
-    auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor_a.device());
 
     return detail::multi_core_ssm_eltwise_mul(
         input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -60,7 +60,7 @@ operation::ProgramWithCallbacks ConcatenateHeadsDeviceOperation::create_program(
     auto& output_tensor = output_tensors.at(0);
     const auto batch_size = input_tensor.get_legacy_shape()[0];
 
-    auto device_compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
     TT_FATAL(
         (this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
          this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -20,7 +20,7 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor> &input_te
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
 
     auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
-    TT_FATAL((bbox.end_coord.x < input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_coord.y < input_tensor.device()->compute_with_storage_grid_size().y), "Error");
+    TT_FATAL((bbox.end_coord.x < DeviceComputeWithStorageGridSize(input_tensor.device()).x && bbox.end_coord.y < DeviceComputeWithStorageGridSize(input_tensor.device()).y), "Error");
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
     ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
@@ -51,7 +51,7 @@ std::vector<tt::tt_metal::Shape> CreateQKVHeadsDeviceOperation::compute_output_s
 operation::ProgramWithCallbacks CreateQKVHeadsDeviceOperation::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
 
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
     return  multi_core_create_qkv_heads_sharded(input_tensor, this->num_q_heads, this->num_kv_heads, this->head_dim, this->transpose_k_heads, output_tensors, compute_with_storage_grid_size);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -23,7 +23,7 @@ void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Te
 
 
     auto bbox = q_input_tensor.shard_spec().value().grid.bounding_box();
-    TT_FATAL((bbox.end_coord.x < q_input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_coord.y < q_input_tensor.device()->compute_with_storage_grid_size().y), "Error");
+    TT_FATAL((bbox.end_coord.x < DeviceComputeWithStorageGridSize(q_input_tensor.device()).x && bbox.end_coord.y < DeviceComputeWithStorageGridSize(q_input_tensor.device()).y), "Error");
 
     TT_FATAL(q_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
     TT_FATAL(kv_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
@@ -87,7 +87,7 @@ std::vector<tt::tt_metal::Shape> CreateQKVHeadsSeparateTensorsDeviceOperation::c
 operation::ProgramWithCallbacks CreateQKVHeadsSeparateTensorsDeviceOperation::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor_q = input_tensors.at(0);
     const auto& input_tensor_kv = input_tensors.at(1);
-    CoreCoord compute_with_storage_grid_size = input_tensor_q.device()->compute_with_storage_grid_size();
+    CoreCoord compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor_q.device());
     return  multi_core_create_q_and_kv_heads_sharded(input_tensor_q, input_tensor_kv, this->num_q_heads, this->num_kv_heads, this->head_dim, this->transpose_k_heads, output_tensors, compute_with_storage_grid_size);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -62,7 +62,7 @@ operation::ProgramWithCallbacks NLPConcatHeadsDeviceOperation::create_program(co
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
 
     return  multi_core_nlp_concat_heads(input_tensor, output_tensor, compute_with_storage_grid_size);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -60,7 +60,7 @@ std::vector<Tensor> NLPConcatHeadsDecodeDeviceOperation::create_output_tensors(c
     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
     auto batch = output_shape[2];
 
-    auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+    auto core_grid = DeviceComputeWithStorageGridSize(input_tensor.device());
     auto shard_grid = num_cores_to_corerange_set(num_heads, core_grid, true);
     ShardSpec shard_spec{shard_grid, {batch, head_dim}};
     auto mem_config = tt::tt_metal::MemoryConfig{TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1};
@@ -73,7 +73,7 @@ operation::ProgramWithCallbacks NLPConcatHeadsDecodeDeviceOperation::create_prog
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
 
     return  multi_core_nlp_concat_heads_decode(input_tensor, output_tensor, compute_with_storage_grid_size);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -62,12 +62,12 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     std::vector<uint32_t> noc_x_coords;
     noc_x_coords.reserve(in_num_cores_x);
     for (uint32_t x = 0; x < in_num_cores_x; ++x) {
-        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        noc_x_coords.push_back(DeviceWorkerCoreFromLogicalCore(device, {x, 0}).x);
     }
     std::vector<uint32_t> noc_y_coords;
     noc_y_coords.reserve(in_num_cores_y);
     for (uint32_t y = 0; y < in_num_cores_y; ++y) {
-        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        noc_y_coords.push_back(DeviceWorkerCoreFromLogicalCore(device, {0, y}).y);
     }
 
     // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -26,7 +26,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(const operati
         TT_FATAL(input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1], "Error");
         TT_FATAL(operation_attributes.output_mem_config.is_sharded() && operation_attributes.output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
         TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
-        auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+        auto core_grid = DeviceComputeWithStorageGridSize(input_tensor.device());
         uint32_t num_cores = core_grid.x * core_grid.y;
         // 1 Head Per Core Max for now
         TT_FATAL(operation_attributes.num_q_heads <= num_cores, "Error");
@@ -104,7 +104,7 @@ NlpCreateHeadsDeviceOperation::tensor_return_value_t NlpCreateHeadsDeviceOperati
         return {output_tensors.at(0).value(), output_tensors.at(1).value(), output_tensors.at(2).value()};
     }
     if (operation_attributes.output_mem_config.is_sharded()) {
-        auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+        auto core_grid = DeviceComputeWithStorageGridSize(input_tensor.device());
         auto q_shard_grid = num_cores_to_corerange_set(operation_attributes.num_q_heads, core_grid, true);
         ShardSpec q_shard_spec{q_shard_grid, {TILE_HEIGHT, operation_attributes.head_dim}};
         auto q_mem_config = operation_attributes.output_mem_config;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -26,7 +26,7 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     const uint32_t head_dim = operation_attributes.head_dim;
     const bool transpose_k_heads = operation_attributes.transpose_k_heads;
     auto& output = tensor_return_value;
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
 
     const auto& input_shape = input_tensor.get_legacy_shape();
 
@@ -429,12 +429,12 @@ NlpCreateHeadsDeviceOperation::Sharded::cached_program_t NlpCreateHeadsDeviceOpe
     std::vector<uint32_t> noc_x_coords;
     noc_x_coords.reserve(num_cores_x);
     for (uint32_t x = 0; x < num_cores_x; ++x) {
-        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        noc_x_coords.push_back(DeviceWorkerCoreFromLogicalCore(device, {x, 0}).x);
     }
     std::vector<uint32_t> noc_y_coords;
     noc_y_coords.reserve(num_cores_y);
     for (uint32_t y = 0; y < num_cores_y; ++y) {
-        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        noc_y_coords.push_back(DeviceWorkerCoreFromLogicalCore(device, {0, y}).y);
     }
 
     uint32_t remote_q_head_start_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -82,12 +82,12 @@ namespace ttnn::operations::experimental::transformer {
         std::vector<uint32_t> noc_x_coords;
         noc_x_coords.reserve(in_num_cores_x);
         for (uint32_t x = 0; x < in_num_cores_x; ++x) {
-            noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+            noc_x_coords.push_back(DeviceWorkerCoreFromLogicalCore(device, {x, 0}).x);
         }
         std::vector<uint32_t> noc_y_coords;
         noc_y_coords.reserve(in_num_cores_y);
         for (uint32_t y = 0; y < in_num_cores_y; ++y) {
-            noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+            noc_y_coords.push_back(DeviceWorkerCoreFromLogicalCore(device, {0, y}).y);
         }
 
         // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks NlpCreateHeadsFalcon7BDeviceOperation::create_pr
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    CoreCoord compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
 
     return multi_core_nlp_create_qkv_heads_falcon7b(input_tensor, output_tensors, compute_with_storage_grid_size);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -30,7 +30,7 @@ void NlpKVCacheLoadSliceDeviceOperation::validate(const std::vector<Tensor> &inp
     auto dim0 = input_shape[0];
     auto dim1 = input_shape[1];
     auto fused_batch_heads = dim0 * dim1;
-    auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto core_grid = DeviceComputeWithStorageGridSize(input_tensor_a.device());
     // Need at least fused_batch_heads cores to unpad into sharded tensor
     TT_FATAL(fused_batch_heads <= core_grid.x * core_grid.y, "Error");
     TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
@@ -60,7 +60,7 @@ std::vector<Tensor> NlpKVCacheLoadSliceDeviceOperation::create_output_tensors(co
     auto head_dim = input_shape[3];
     auto fused_batch_heads = dim0 * dim1;
 
-    auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto core_grid = DeviceComputeWithStorageGridSize(input_tensor_a.device());
     auto shard_grid = num_cores_to_corerange_set(fused_batch_heads, core_grid, true);
     ShardSpec shard_spec{shard_grid, {unpad_length, head_dim}};
     auto mem_config = tt::tt_metal::MemoryConfig{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1};

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -77,7 +77,7 @@ std::vector<Tensor> RotaryEmbedding::create_output_tensors(const std::vector<Ten
             shard_spec = input_tensor.shard_spec().value();
         } else {
             uint32_t num_blocks = input_tensor.volume() / input_tensor.get_legacy_shape()[-1] / TILE_HEIGHT;
-            auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+            auto core_grid = DeviceComputeWithStorageGridSize(input_tensor.device());
             uint32_t num_grid_cores = core_grid.x * core_grid.y;
             uint32_t num_cores = 0;
             for (uint32_t i = num_grid_cores; i > 0; --i) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -60,11 +60,11 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, ttnn::GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
@@ -73,7 +73,7 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
 
     }, compute_kernel_config);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
@@ -54,7 +54,7 @@ ttnn::Tensor RotaryEmbeddingOperation::invoke(
                             cos_cache.get_legacy_shape()[-2]));
     }
 
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
 
     tt::tt_metal::MemoryConfig default_memory_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
@@ -55,11 +55,11 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, ttnn::GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
@@ -70,7 +70,7 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
 
 
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.cpp
@@ -22,7 +22,7 @@ Tensor RotaryEmbeddingLlamaOperation::invoke(
             auto& input_tensor = input_tensors.at(0);
             uint32_t seq_len = input_tensor.get_legacy_shape()[-2];
 
-            auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+            auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
             auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
 
             tt::tt_metal::MemoryConfig default_memory_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -107,7 +107,7 @@ operation::ProgramWithCallbacks SplitFusedQKVAndSplitHeadsDeviceOperation::creat
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
-    auto device_compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto device_compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
     TT_ASSERT(
         (this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x &&
          this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y),

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
@@ -36,7 +36,7 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
         // For sharded, we infer number of tiles each core handles from shard so no issues there
         if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED and input_tensor.get_legacy_shape()[1] > 1) {
             const uint32_t num_blocks_of_work = input_tensor.get_legacy_shape()[1] * input_tensor.get_legacy_shape()[-2] / TILE_HEIGHT;
-            const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+            const auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(input_tensor.device());
             TT_FATAL((num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y), "Error");
         }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.hpp
@@ -61,7 +61,7 @@ inline Tensor update_cache_impl(const Tensor& cache_tensor, const Tensor& input_
         [update_idx, batch_offset, compute_kernel_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             auto& cache_tensor = input_tensors.at(0);
             auto& input_tensor = input_tensors.at(1);
-            auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
+            auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input_tensor.device()), compute_kernel_config);
             return operation::run(UpdateCache{0, update_idx, batch_offset, UpdateCacheOpType::UPDATE, kernel_config_val}, {cache_tensor, input_tensor});
         }, {cache_tensor, input_tensor}, dummy_output_tensors);
     return cache_tensor;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -30,10 +30,10 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, ttnn::GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
             TT_THROW("arch not supported");
@@ -69,7 +69,7 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
     uint32_t tile_update_offset = update_idx % tt::constants::TILE_HEIGHT * Wbytes;
     uint32_t batch_read_offset = batch_offset * Wbytes;  // Offset to read from input tensor
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
@@ -330,7 +330,7 @@ operation::ProgramWithCallbacks fill_cache_multi_core(const Tensor& cache_tensor
     uint32_t start_idx = batch_idx * cache_CHtWt + update_idxt * Wt;
     tt::tt_metal::Device *device = input_tensor.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.cpp
@@ -17,7 +17,7 @@ ttnn::Tensor ExecuteUpdateCache::invoke(
     const uint32_t update_index,
     const uint32_t batch_offset,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-        auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config);
+        auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input.device()), compute_kernel_config);
         operation::run(
             UpdateCache{
                 0, update_index, batch_offset, UpdateCacheOpType::UPDATE, kernel_config_val},

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -38,7 +38,7 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
     tt::tt_metal::Device *device = a.device();
     const tt::tt_metal::Shape& cshape = output.get_legacy_shape();  // C=A*B, N1MK*11KN->N1MN
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t c_batch_size = get_batch_size(cshape);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -212,7 +212,7 @@ operation::ProgramWithCallbacks create_program(
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
-    bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+    bmm_op_utils::add_stagger_defines_if_needed(DeviceArch(device), num_cores, mm_kernel_defines);
 
     // Create compute kernel
     auto mm_kernel_group_1_id = tt_metal::CreateKernel(
@@ -500,13 +500,13 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
         [&](auto&& compute_kernel_config) {
             using T = std::decay_t<decltype(compute_kernel_config)>;
             if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-                TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+                TT_FATAL(DeviceArch(device) == ARCH::GRAYSKULL, "kernel config is not for graykull");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = false;
                 packer_l1_acc = false;
             } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-                TT_FATAL(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+                TT_FATAL(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -85,7 +85,7 @@ tt_metal::operation::ProgramWithCallbacks create_program(
     uint32_t num_blocks_x = N / per_core_N;
 
     CoreRangeSet all_cores(num_cores_to_corerange_set(
-        num_blocks_x * num_blocks_y, device->compute_with_storage_grid_size(), true));
+        num_blocks_x * num_blocks_y, DeviceComputeWithStorageGridSize(device), true));
 
     // Create circular buffers
     uint32_t src0_cb_index = 0;
@@ -275,7 +275,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(
 
     // This should allocate a DRAM buffer on the device
     tt_metal::Device *device = a.device();
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
@@ -37,7 +37,7 @@ MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::Program
     auto amsgrad = operation_attributes.amsgrad;
 
     auto compute_kernel_config =
-        init_device_compute_kernel_config(param_in.device()->arch(), operation_attributes.compute_kernel_config);
+        init_device_compute_kernel_config(DeviceArch(param_in.device()), operation_attributes.compute_kernel_config);
 
     uint32_t num_tiles = param_in.volume() / tt::constants::TILE_HW;
 
@@ -47,13 +47,13 @@ MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::Program
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     tt::tt_metal::Device* device = param_in.device();
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         tt::tt_metal::split_work_to_cores(grid, num_tiles);
 
-    auto arch = param_in.device()->arch();
+    auto arch = DeviceArch(param_in.device());
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
@@ -17,7 +17,7 @@ MorehArangeOperation::ProgramFactory::cached_program_t MorehArangeOperation::Pro
     auto start = operation_attributes.start;
     auto step = operation_attributes.step;
 
-    auto grid = tensor_args.any.device()->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(tensor_args.any.device());
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(grid, Wt);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -477,8 +477,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         (std::uint32_t) per_core_Mt,
         (std::uint32_t) TILE_HEIGHT
     };
-    tt::tt_metal::NOC reader_noc = detail::GetPreferredNOCForDRAMWrite(device->arch());
-    tt::tt_metal::NOC writer_noc = detail::GetPreferredNOCForDRAMRead(device->arch());
+    tt::tt_metal::NOC reader_noc = detail::GetPreferredNOCForDRAMWrite(DeviceArch(device));
+    tt::tt_metal::NOC writer_noc = detail::GetPreferredNOCForDRAMRead(DeviceArch(device));
     // reader kernel
     auto reader_mcast_sender_kernels_id = CreateKernel(
         program,
@@ -785,7 +785,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
 
         for (int j=0; j < group.size(); ++j) {
             CoreCoord core = group[j];
-            CoreCoord core_physical = device->worker_core_from_logical_core(core);
+            CoreCoord core_physical = DeviceWorkerCoreFromLogicalCore(device, core);
 
             if (j == 0) { // mcast sender
                 // get the bounding box for the mcast
@@ -796,8 +796,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
                     split_and_form_rectangle_grids(group, mcast_group_first, mcast_group_mid, mcast_group_last);
                 }
 
-                CoreCoord mcast_start = device->worker_core_from_logical_core(mcast_group_mid.front());
-                CoreCoord mcast_end = device->worker_core_from_logical_core(mcast_group_mid.back());
+                CoreCoord mcast_start = DeviceWorkerCoreFromLogicalCore(device, mcast_group_mid.front());
+                CoreCoord mcast_end = DeviceWorkerCoreFromLogicalCore(device, mcast_group_mid.back());
 
                 if (reader_noc == NOC::NOC_1) {
                     std::swap(mcast_start, mcast_end);
@@ -820,8 +820,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
                 log_debug(tt::LogOp, "mcast mid group start coord: {} {} end coord: {} {}", mcast_start.x, mcast_start.y, mcast_end.x, mcast_end.y);
 
                 if (not mcast_group_first.empty()) {
-                    CoreCoord mcast_first_start = device->worker_core_from_logical_core(mcast_group_first.front());
-                    CoreCoord mcast_first_end = device->worker_core_from_logical_core(mcast_group_first.back());
+                    CoreCoord mcast_first_start = DeviceWorkerCoreFromLogicalCore(device, mcast_group_first.front());
+                    CoreCoord mcast_first_end = DeviceWorkerCoreFromLogicalCore(device, mcast_group_first.back());
 
                     if (reader_noc == NOC::NOC_1) {
                         std::swap(mcast_start, mcast_end);
@@ -836,8 +836,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
                     log_debug(tt::LogOp, "mcast first group size: {}", mcast_group_first.size() - 1);
                 }
                 if (not mcast_group_last.empty()) {
-                    CoreCoord mcast_last_start = device->worker_core_from_logical_core(mcast_group_last.front());
-                    CoreCoord mcast_last_end = device->worker_core_from_logical_core(mcast_group_last.back());
+                    CoreCoord mcast_last_start = DeviceWorkerCoreFromLogicalCore(device, mcast_group_last.front());
+                    CoreCoord mcast_last_end = DeviceWorkerCoreFromLogicalCore(device, mcast_group_last.back());
 
                     if (reader_noc == NOC::NOC_1) {
                         std::swap(mcast_start, mcast_end);
@@ -855,11 +855,11 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
                 // add all coords within a group
                 std::vector<uint32_t> mcast_noc_xy;
                 for (int c=0; c < group.size(); ++c) {
-                    CoreCoord coord = device->worker_core_from_logical_core(group[c]);
+                    CoreCoord coord = DeviceWorkerCoreFromLogicalCore(device, group[c]);
                     mcast_noc_xy.push_back(coord.x);
                 }
                 for (int c=0; c < group.size(); ++c) {
-                    CoreCoord coord = device->worker_core_from_logical_core(group[c]);
+                    CoreCoord coord = DeviceWorkerCoreFromLogicalCore(device, group[c]);
                     mcast_noc_xy.push_back(coord.y);
                 }
                 mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());
@@ -868,8 +868,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
             } else { // mcast receiver
                 log_debug(tt::LogOp, "mcast receiver receive from coord: {} {}", group.front().x, group.front().y);
                 std::vector<uint32_t> mcast_receiver_args;
-                mcast_receiver_args.push_back(device->worker_core_from_logical_core(group.front()).x);
-                mcast_receiver_args.push_back(device->worker_core_from_logical_core(group.front()).y);
+                mcast_receiver_args.push_back(DeviceWorkerCoreFromLogicalCore(device, group.front()).x);
+                mcast_receiver_args.push_back(DeviceWorkerCoreFromLogicalCore(device, group.front()).y);
                 tt::tt_metal::SetRuntimeArgs(program, reader_mcast_receiver_kernels_id, core, mcast_receiver_args);
             }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
@@ -17,7 +17,7 @@ ttnn::Tensor ExecuteLayerNorm::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const LayerNormProgramConfig>& program_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     return operation::run(
                 LayerNorm{

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -98,12 +98,12 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
@@ -217,7 +217,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
     TT_ASSERT(intermed7_tiles % block_size == 0 && "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
 
 
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tile_rows_per_core_group_1, num_tile_rows_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, num_tile_rows, true);
 
     tt::log_debug("num_cores: {}", num_cores);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -86,12 +86,12 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
@@ -153,7 +153,7 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
     TT_ASSERT(intermed0_tiles % block_size == 0 && "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
 
 
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tile_rows_per_core_group_1, num_tile_rows_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, num_tile_rows, true);
 
     tt::log_debug("num_cores: {}", num_cores);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
@@ -16,7 +16,7 @@ ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
     const std::optional<const ttnn::Tensor>& bias,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     return operation::run(
                 LayerNormPostAllGather{

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -12,7 +12,7 @@ ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const DataType dtype,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     return operation::run(
                 LayerNormPreAllGather{

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
@@ -18,7 +18,7 @@ ttnn::Tensor ExecuteRMSNorm::invoke(
     const std::optional<const LayerNormProgramConfig>& program_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     return operation::run(
                 LayerNorm{

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
@@ -16,7 +16,7 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
     const std::optional<const ttnn::Tensor>& bias,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     return operation::run(
                 LayerNormPostAllGather{

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -12,7 +12,7 @@ ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const DataType dtype,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor.device()) : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     return operation::run(
                 LayerNormPreAllGather{

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -73,12 +73,12 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
@@ -141,7 +141,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     TT_ASSERT(W <= TILE_WIDTH*im0_t && "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
 
     uint32_t num_tile_rows = NC * Ht;
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     auto all_device_cores = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tile_rows_per_core_group_1, num_tile_rows_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, num_tile_rows, true);
 
@@ -469,12 +469,12 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_ASSERT(DeviceArch(device) == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
         } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
+            TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)), "kernel config is not for wormhole_b0 or blackhole");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
@@ -169,7 +169,7 @@ Tensor scale_mask_softmax_in_place(Tensor& input_tensor, std::optional<float> sc
         [scale, mask, program_config, is_causal_mask, compute_kernel_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             auto& input_tensor = input_tensors.at(0);
             auto& mask = optional_input_tensors.at(0);
-            auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+            auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input_tensor.device()), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
             return operation::run(Softmax{.scale=scale, .inplace=true, .output_mem_config=input_tensor.memory_config(), .program_config=program_config, .is_causal_mask=is_causal_mask, .compute_kernel_config=kernel_config_val}, {input_tensor}, {mask});
         }, {input_tensor}, dummy_output_tensors, {mask});
     return input_tensor;
@@ -181,7 +181,7 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(Tensor& input_tensor, std::opt
         [scale, mask, program_config, compute_kernel_config](const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             auto& input_tensor = input_tensors.at(0);
             auto& mask = optional_input_tensors.at(0);
-            auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+            auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input_tensor.device()), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
             return operation::run(Softmax{.scale=scale, .inplace=true, .output_mem_config=input_tensor.memory_config(), .program_config=program_config, .is_causal_mask=true, .compute_kernel_config=kernel_config_val, .is_scale_causal_mask_hw_dims_softmax=true}, {input_tensor}, {mask});
         }, {input_tensor}, dummy_output_tensors, {mask});
     return input_tensor;
@@ -210,7 +210,7 @@ Tensor scale_mask_softmax(const Tensor& input_tensor, std::optional<float> scale
                 tt::tt_metal::Shape mask_pad_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(mask.value().get_legacy_shape());
                 mask_format_params = {.pad_shape=mask_pad_shape, .pad_value=-std::numeric_limits<float>::infinity(), .target_layout=Layout::TILE};
             }
-            auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+            auto kernel_config_val = init_device_compute_kernel_config(DeviceArch(input_tensor.device()), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
             return operation::run_with_autoformat(Softmax{.scale=scale, .inplace=false, .output_mem_config=output_mem_config, .is_causal_mask=is_causal_mask, .compute_kernel_config=kernel_config_val}, {input_tensor}, {input_format_params}, {Layout::TILE}, {mask}, {mask_format_params});
         }, {input_tensor}, output_tensors, {mask});
     return output_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_program_factory.cpp
@@ -366,7 +366,7 @@ operation::ProgramWithCallbacks downsample_single_core(
     uint32_t unpadded_output_volume = ceil((double)unpadded_input_volume / (double)(img_stride_h * img_stride_w));
     TT_ASSERT(output.volume() >= unpadded_output_volume);
 
-    uint32_t ncores_x_full_grid = device->compute_with_storage_grid_size().x;
+    uint32_t ncores_x_full_grid = DeviceComputeWithStorageGridSize(device).x;
     auto [num_cores_height_sliced, num_cores_width_sliced] = get_num_cores_height_width_sliced(
         a.shard_spec().value().grid, a.memory_config().memory_layout, a.shard_spec().value().orientation);
     uint32_t num_cores = num_cores_height_sliced * num_cores_width_sliced;
@@ -673,7 +673,7 @@ operation::ProgramWithCallbacks downsample_single_core(
 
             TT_ASSERT(
                 (halo_prev_start_addr + halo_prev_addr_offset) % 32 == 0);  // read address should be 32 byte aligned
-            auto halo_noc_coords = device->worker_core_from_logical_core(prev_core);
+            auto halo_noc_coords = DeviceWorkerCoreFromLogicalCore(device, prev_core);
             halo_prev_noc_x = halo_noc_coords.x;
             halo_prev_noc_y = halo_noc_coords.y;
             TT_ASSERT(v.input_flat_h >= halo_prev_start_tile_id_h * TILE_HEIGHT);
@@ -752,7 +752,7 @@ operation::ProgramWithCallbacks downsample_single_core(
             halo_next_start_addr = GetCircularBufferConfig(program, input_cb).globally_allocated_address().value();
             TT_ASSERT(
                 (halo_next_start_addr + halo_next_addr_offset) % 32 == 0);  // read address should be 32 byte aligned
-            auto halo_noc_coords = device->worker_core_from_logical_core(next_core);
+            auto halo_noc_coords = DeviceWorkerCoreFromLogicalCore(device, next_core);
             halo_next_noc_x = halo_noc_coords.x;
             halo_next_noc_y = halo_noc_coords.y;
             TT_ASSERT(halo_prev_input_num_rows_of_tiles == 0);

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_multi_core_program_factory.cpp
@@ -78,7 +78,7 @@ MaxPool2D::MultiCore::cached_program_t max_pool_2d_multi_core_sharded_with_halo_
     uint32_t out_w_loop_count = std::ceil((float)out_w / nblocks);
 
     // distributing out_hw across the grid
-    auto grid_size = device->compute_with_storage_grid_size();
+    auto grid_size = DeviceComputeWithStorageGridSize(device);
     auto all_cores = input.shard_spec().value().grid;
     uint32_t ncores = all_cores.num_cores();
     auto core_range = all_cores;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -42,7 +42,7 @@ operation::ProgramWithCallbacks upsample_multi_core(const Tensor &input, Tensor&
     auto shard_spec = input.shard_spec().value();
     auto all_cores = shard_spec.grid;
     uint32_t ncores = shard_spec.num_cores();
-    uint32_t ncores_x = device->compute_with_storage_grid_size().x;
+    uint32_t ncores_x = DeviceComputeWithStorageGridSize(device).x;
     uint32_t ncores_nhw = ncores;
 
     auto out_shard_spec = output.shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.hpp
@@ -26,7 +26,7 @@ operation::ProgramWithCallbacks argmax_multi_core(
 
     tt::tt_metal::Device *device = output.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     uint32_t num_units = 1;  // single-core

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -28,7 +28,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
     uint32_t HtWt = Ht * Wt;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
-        get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(DeviceArch(a.device()), compute_kernel_config);
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
 
     bool in_sharded = a.is_sharded();
     bool out_sharded = output.is_sharded();
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_cols = NC * Wt;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -29,7 +29,7 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     uint32_t Ht = H / TILE_HEIGHT;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
-        get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(DeviceArch(a.device()), compute_kernel_config);
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
 
     tt_metal::Device *device = a.device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = DeviceComputeWithStorageGridSize(device);
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_rows = NC * Ht;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -172,7 +172,7 @@ Tensor reduce(
     float pad_value = reduce_math == ReduceOpMath::MAX ? -std::numeric_limits<float>::infinity() : 0;
 
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(
-        ttnn::init_device_compute_kernel_config(input_tensor.device()->arch(), std::nullopt, MathFidelity::HiFi4));
+        ttnn::init_device_compute_kernel_config(DeviceArch(input_tensor.device()), std::nullopt, MathFidelity::HiFi4));
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     if (is_multicore_hw) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -24,7 +24,7 @@ operation::ProgramWithCallbacks reduce_single_core_hw(
     uint32_t HW = H * W;
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
-        get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+        get_compute_kernel_config_args(DeviceArch(a.device()), compute_kernel_config);
 
     uint32_t Wt = W / TILE_WIDTH;
     uint32_t Ht = H / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -55,7 +55,7 @@ operation::ProgramWithCallbacks prod_nc_format(const Tensor &input, const Tensor
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
+    auto grid = DeviceComputeWithStorageGridSize(device);
     const auto num_cores_y = grid.y;
 
     const uint32_t in0_t = 2;        // input

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -46,7 +46,7 @@ void TopK::validate_with_output_tensors(
 
         uint32_t value_tile_size = tile_size(value_cb_data_format);
         uint32_t index_tile_size = tile_size(index_cb_data_format);
-        TT_FATAL(topk_utils::verify_available_cores(input_shape[this->dim], 64, input_shape[this->dim]/2, device->compute_with_storage_grid_size(),
+        TT_FATAL(topk_utils::verify_available_cores(input_shape[this->dim], 64, input_shape[this->dim]/2, DeviceComputeWithStorageGridSize(device),
                             this->k, value_tile_size, index_tile_size), "Not enough cores available to run topk operation");
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -232,7 +232,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_t
     auto input_shape = input_tensor.get_legacy_shape();
     uint32_t Ht = (input_shape[0]*input_shape[1]*input_shape[2])/TILE_HEIGHT;
     const auto & [num_cores, local_topk_input_size, rem, final_topk_input_size] =
-    cores_utilized(input_shape[dim], 64, input_shape[dim]/2, device->compute_with_storage_grid_size(), k, value_tile_size, index_tile_size);
+    cores_utilized(input_shape[dim], 64, input_shape[dim]/2, DeviceComputeWithStorageGridSize(device), k, value_tile_size, index_tile_size);
 
     CoreRange core(
         {0, 0},
@@ -346,8 +346,8 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_t
 
 
 
-    CoreCoord local_cores_physical_start = device->worker_core_from_logical_core({0, 0});
-    CoreCoord local_cores_physical_end = device->worker_core_from_logical_core({0, num_cores - 2u});
+    CoreCoord local_cores_physical_start = DeviceWorkerCoreFromLogicalCore(device, {0, 0});
+    CoreCoord local_cores_physical_end = DeviceWorkerCoreFromLogicalCore(device, {0, num_cores - 2u});
     std::vector<uint32_t> reader_compile_time_args =             {
                 (std::uint32_t) receiver_semaphore_id,
                 (std::uint32_t) sender_semaphore_id,
@@ -366,7 +366,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_t
         final_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-    CoreCoord final_cores_physical = device->worker_core_from_logical_core({0, num_cores - 1u});
+    CoreCoord final_cores_physical = DeviceWorkerCoreFromLogicalCore(device, {0, num_cores - 1u});
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t) receiver_semaphore_id,
         (std::uint32_t) sender_semaphore_id,

--- a/ttnn/cpp/ttnn/operations/sliding_window/reference_sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/reference_sliding_window.cpp
@@ -234,10 +234,10 @@ std::vector<uint32_t> input_indices_from_flattened_remote_config(
     bool transpose_mcast) {
     std::vector<uint32_t> abs_indices;
     auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
-        size_t num_cores_x = device->compute_with_storage_grid_size().x;
+        size_t num_cores_x = DeviceComputeWithStorageGridSize(device).x;
         CoreCoord core_coord = is_block_sharded ? (transpose_mcast ? CoreCoord(core_id, 0) : CoreCoord(0, core_id))
                                                 : CoreCoord(core_id % num_cores_x, core_id / num_cores_x);
-        return device->worker_core_from_logical_core(core_coord);
+        return DeviceWorkerCoreFromLogicalCore(device, core_coord);
     };
 
     std::unordered_map<CoreCoord, uint32_t> phy_to_log_core_map;

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -162,9 +162,9 @@ uint32_t generate_max_out_nsticks_per_core(const std::vector<std::pair<uint32_pa
 
 std::tuple<std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tensors(const std::vector<std::pair<bool, uint32_pair_t>>& tensor_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool is_block_sharded, bool transpose_mcast, bool remote_read, Device* device) {
     auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
-        auto num_cores_x = device->compute_with_storage_grid_size().x;
+        auto num_cores_x = DeviceComputeWithStorageGridSize(device).x;
         auto core_coord = is_block_sharded ? (transpose_mcast ? CoreCoord(core_id, 0) : CoreCoord(0, core_id)) : CoreCoord(core_id % num_cores_x, core_id / num_cores_x);
-        return device->worker_core_from_logical_core(core_coord);
+        return DeviceWorkerCoreFromLogicalCore(device, core_coord);
     };
 
     const uint16_t pad_local = 0xFFFF;

--- a/ttnn/cpp/ttnn/operations/transformer/attention_softmax/attention_softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/attention_softmax/attention_softmax.cpp
@@ -32,7 +32,7 @@ ttnn::Tensor ExecuteAttentionSoftmax<in_place>::invoke(
 
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+        DeviceArch(input_tensor.device()), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     auto output_tensor = operation::run(
                             ttnn::operations::normalization::Softmax{
                                     head_size,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -86,13 +86,13 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         [&](auto&& compute_kernel_config) {
             using T = std::decay_t<decltype(compute_kernel_config)>;
             if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-                TT_FATAL(device->arch() == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
+                TT_FATAL(DeviceArch(device) == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = false;
             } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
                 TT_FATAL(
-                    ttnn::device::is_wormhole_or_blackhole(device->arch()),
+                    ttnn::device::is_wormhole_or_blackhole(DeviceArch(device)),
                     "kernel config is not for wormhole_b0 or blackhole");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
@@ -111,12 +111,12 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     auto out0_buffer = output_tensor.buffer();
 
     CoreCoord grid_size = program_config.has_value() ? program_config->compute_with_storage_grid_size
-                                                     : device->compute_with_storage_grid_size();
+                                                     : DeviceComputeWithStorageGridSize(device);
 
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores = grid_size.x * grid_size.y;
 
-    TT_FATAL(num_cores <= device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y, "Error");
+    TT_FATAL(num_cores <= DeviceComputeWithStorageGridSize(device).x * DeviceComputeWithStorageGridSize(device).y, "Error");
 
     // Parallelization scheme
     // We will choose parallelization factors for batch, num_heads, and q_seq_len in that order

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -22,10 +22,10 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
     std::optional<SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<uint32_t> valid_seq_len) {
-    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? input_tensor_q.device()->arch()
-                                                                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_q.device())
+                                                                     : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        DeviceArch(input_tensor_q.device()), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
     return operation::run(
                ScaledDotProductAttention{

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -33,14 +33,14 @@ ttnn::Tensor ExecuteScaledDotProductAttentionDecode::invoke(
     const std::optional<MemoryConfig> &memory_config,
     std::optional<SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? input_tensor_q.device()->arch()
-                                                                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_q.device())
+                                                                     : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     //uint32_t max_cur_pos = *std::max_element(cur_pos.begin(), cur_pos.end());
     uint32_t k_chunk_size = 512; //get_chunk_size(max_cur_pos + 1);
 
     // get chunk size and then pass to sdpa decode as an attribute for prgm cache
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        DeviceArch(input_tensor_q.device()), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
     return operation::run(
                ScaledDotProductAttentionDecode{
@@ -93,14 +93,14 @@ ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
     const std::optional<MemoryConfig> &memory_config,
     std::optional<SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? input_tensor_q.device()->arch()
-                                                                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_q.device())
+                                                                     : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     //uint32_t max_cur_pos = *std::max_element(cur_pos.begin(), cur_pos.end());
     uint32_t k_chunk_size = 512; //get_chunk_size(max_cur_pos + 1);
 
     // get chunk size and then pass to sdpa decode as an attribute for prgm cache
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        DeviceArch(input_tensor_q.device()), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
     return operation::run(
                ScaledDotProductAttentionDecode{

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/sdpa_decode_gqa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/sdpa_decode_gqa.cpp
@@ -34,8 +34,8 @@ ttnn::Tensor ExecuteScaledDotProductAttentionGQADecode::invoke(
     const std::optional<MemoryConfig> &memory_config,
     std::optional<SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
-    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? input_tensor_q.device()->arch()
-                                                                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? DeviceArch(input_tensor_q.device())
+                                                                     : DeviceArch(ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice());
     // formatting input tensors
     auto q_shape = input_tensor_q.get_legacy_shape();
     auto k_shape = input_tensor_k.get_legacy_shape();
@@ -61,7 +61,7 @@ ttnn::Tensor ExecuteScaledDotProductAttentionGQADecode::invoke(
     uint32_t k_chunk_size = get_chunk_size(max_cur_pos + 1);
     // get chunk size and then pass to sdpa decode as an attribute for prgm cache
     auto kernel_config_val = init_device_compute_kernel_config(
-        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+        DeviceArch(input_tensor_q.device()), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
     auto output_tensors = operation::run(
         ScaledDotProductAttentionGQADecode{

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -70,7 +70,7 @@ std::vector<BufferInfo> get_buffers() {
 
         auto num_pages = buffer->num_pages();
         auto page_size = buffer->page_size();
-        auto num_banks = device->num_banks(buffer->buffer_type());
+        auto num_banks = DeviceNumBanks(device, buffer->buffer_type());
 
         std::map<uint32_t, uint32_t> bank_to_num_pages;
         if (buffer->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
@@ -87,7 +87,7 @@ std::vector<BufferInfo> get_buffers() {
             for (int page_index = 0; page_index < num_pages; page_index++) {
                 auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
                 auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
-                auto bank_id = device->bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
+                auto bank_id = DeviceBankIdsFromLogicalCore(device, buffer->buffer_type(), core)[0];
 
                 if (bank_to_num_pages.find(bank_id) == bank_to_num_pages.end()) {
                     bank_to_num_pages[bank_id] = 0;
@@ -135,7 +135,7 @@ std::vector<BufferPageInfo> get_buffer_pages() {
 
         uint32_t page_size = buffer->page_size();
         auto num_pages = buffer->num_pages();
-        auto num_banks = device->num_banks(buffer->buffer_type());
+        auto num_banks = DeviceNumBanks(device, buffer->buffer_type());
 
         if (buffer->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
             uint32_t bank_id = 0;
@@ -162,7 +162,7 @@ std::vector<BufferPageInfo> get_buffer_pages() {
             for (int page_index = 0; page_index < num_pages; page_index++) {
                 auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
                 auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
-                auto bank_id = device->bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
+                auto bank_id = DeviceBankIdsFromLogicalCore(device, buffer->buffer_type(), core)[0];
                 auto page_address = buffer->sharded_page_address(bank_id, dev_page_index);
 
                 BufferPageInfo buffer_page_info = {};

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -609,7 +609,7 @@ std::string to_string(const Tensor& tensor, std::optional<DataType> original_dty
                 auto device_index = 0;
                 std::stringstream ss;
                 apply(host_tensor, [&](const Tensor& device_tensor) {
-                    ss << "device_id:" << devices.at(device_index++)->id() << std::endl;
+                    ss << "device_id:" << DeviceId(devices.at(device_index++)) << std::endl;
                     ss << to_string<T>(device_tensor) << std::endl;
                 });
                 return ss.str();
@@ -656,7 +656,7 @@ Tensor to_host_helper(const Tensor& tensor, bool blocking = true, uint8_t cq_id 
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         data_vec.resize(size_in_bytes / sizeof(T));
-        read_data_from_device_buffer<T>(device->command_queue(cq_id), device_buffer, data_vec.data(), blocking);
+        read_data_from_device_buffer<T>(DeviceCommandQueue(device, cq_id), device_buffer, data_vec.data(), blocking);
     } else {
         read_data_from_device_buffer<T>(device_buffer, data_vec);
     }
@@ -801,7 +801,7 @@ DeviceBuffer initialize_data_on_device(
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         write_data_to_device_buffer<T>(
-            queue.has_value() ? queue.value().get() : device->command_queue(), data_to_write, device_buffer);
+            queue.has_value() ? queue.value().get() : DeviceCommandQueue(device), data_to_write, device_buffer);
     } else {
         write_data_to_device_buffer<T>(data_to_write, *device_buffer);
     }

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -521,7 +521,7 @@ Tensor get_device_tensor(const Tensor& multi_device_tensor, const int device_id)
 }
 
 Tensor get_device_tensor(const Tensor& multi_device_tensor, const Device* device) {
-    return get_device_tensor(multi_device_tensor, device->id());
+    return get_device_tensor(multi_device_tensor, DeviceId(device));
 }
 
 bool is_multi_device_tensor(const Tensor& tensor) {
@@ -586,7 +586,7 @@ Tensor create_multi_device_tensor(
         for (const auto& tensor : tensors) {
             TT_ASSERT(std::holds_alternative<DeviceStorage>(tensor.get_storage()), fmt::format("Unexpected type {} in {}:{} ",tt::stl::get_active_type_name_in_variant(tensor.get_storage()),__FILE__, __LINE__));
             Device* device = std::get<DeviceStorage>(tensor.get_storage()).buffer->device();
-            auto device_id = device->id();
+            auto device_id = DeviceId(device);
             ordered_device_ids.push_back(device_id);
             device_buffers.insert({device_id, std::get<DeviceStorage>(tensor.get_storage()).buffer});
             shapes.insert({device_id, tensor.get_legacy_shape()});
@@ -730,7 +730,7 @@ Tensor copy_borrowed_tensor_in_async_mode(Device* worker, const Tensor& tensor) 
     ZoneScopedN("ConvertBorrowedToOwned");
     // Tensor has workers (on device) or runtime mode is synchronous or tensor has multiple buffers.
     // No need to check for borrowed storage.
-    if (worker->get_worker_mode() == WorkExecutorMode::SYNCHRONOUS or
+    if (DeviceGetWorkerMode(worker) == WorkExecutorMode::SYNCHRONOUS or
         tensor.tensor_attributes->num_shards_to_be_populated > 1)
         return tensor;
 

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -574,28 +574,28 @@ struct MultiDeviceStorage {
         TT_ASSERT(
             device == buffer->device(),
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        buffers.insert({device->id(), buffer});
-        shapes.insert({device->id(), shape});
+        buffers.insert({DeviceId(device), buffer});
+        shapes.insert({DeviceId(device), shape});
     }
 
     inline DeviceBuffer get_buffer_for_device(Device *device) const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
         TT_ASSERT(
-            buffers.find(device->id()) != buffers.end(), "Buffer not found for device " + std::to_string(device->id()));
+            buffers.find(DeviceId(device)) != buffers.end(), "Buffer not found for device " + std::to_string(DeviceId(device)));
         TT_ASSERT(
-            buffers.at(device->id())->device() == device,
+            buffers.at(DeviceId(device))->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffers.at(device->id());
+        return buffers.at(DeviceId(device));
     }
 
     inline DeviceBuffer &get_buffer_for_device(Device *device) {
         std::lock_guard<std::mutex> lock(buffer_mtx);
         TT_ASSERT(
-            buffers.find(device->id()) != buffers.end(), "Buffer not found for device " + std::to_string(device->id()));
+            buffers.find(DeviceId(device)) != buffers.end(), "Buffer not found for device " + std::to_string(DeviceId(device)));
         TT_ASSERT(
-            buffers.at(device->id())->device() == device,
+            buffers.at(DeviceId(device))->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffers.at(device->id());
+        return buffers.at(DeviceId(device));
     }
 
     inline DeviceBuffer get_buffer_for_device_id(uint32_t device_id) const {
@@ -606,8 +606,8 @@ struct MultiDeviceStorage {
     inline Shape get_tensor_shape_for_device(Device *device) const {
         std::lock_guard<std::mutex> lock(shape_mtx);
         TT_ASSERT(
-            shapes.find(device->id()) != shapes.end(), "Shape not found for device " + std::to_string(device->id()));
-        return shapes.at(device->id());
+            shapes.find(DeviceId(device)) != shapes.end(), "Shape not found for device " + std::to_string(DeviceId(device)));
+        return shapes.at(DeviceId(device));
     }
 
     inline uint32_t num_buffers() const {
@@ -617,7 +617,7 @@ struct MultiDeviceStorage {
 
     inline bool has_buffer_for_device(Device *device) const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        return buffers.find(device->id()) != buffers.end();
+        return buffers.find(DeviceId(device)) != buffers.end();
     }
 
     inline bool has_buffer_for_device_id(uint32_t device_id) const {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11207

### Problem description
This work is intended as a proposal in order to formalize the TT Metal API, Metal API types becoming opaque.  
Should this be accepted, the following tasks would be updated similarly.

- [x] #11211
- [x] #11210
- [x] #11208

### What's changed
Add formal API methods for member methods of tt_metal::Device so that it can be an incomplete/opaque type.

1. Moved Device internals to device_impl.hpp
The Device class's internal implementation, including data members and private methods, was moved to a new file device_impl.hpp. This allows the class definition to remain hidden from the public API while still being accessible internally.

2. Introduced forward declaration of Device in public header.
This ensures that the class is incomplete in the public API, with no direct access to its internal structure.

3. API Refactoring
Functions interacting with Device were refactored to use opaque pointers. 
For example:
- ARCH DeviceArch(const Device *device);
- chip_id_t DeviceId(const Device *device);
- bool DeviceIsInitialized(Device *device);

Device internals are now hidden via API functions instead of directly exposing the internal structure. 

4. Refactor Internal Calls to Use device_impl.hpp
All internal calls and logic dealing with the Device internals were updated to use the newly relocated device_impl.hpp. Any existing direct access in public headers were replaced with calls to the refactored API.

5. Replaced arguments with aggregate types.   
For example, CreateDevice now uses the DeviceOptions struct to simplify the CreateDevice process. Instead of passing individual parameters, the configuration options are encapsulated in DeviceOptions:

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
