### PR TITLE
LLK Test Coverage - MathFid and DestAcc in reduce API

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -34,8 +34,14 @@ void MAIN {
             acquire_dst(tt::DstMode::Half);
             for(uint32_t ht = 0; ht < Ht; ++ht) {
                 cb_wait_front(tt::CB::c_in0, onetile);
+#if (MATH_ONLY == 1)
+                UNPACK(( llk_unpack_AB(tt::CB::c_in0, tt::CB::c_in2, 0, 0) ));
+                // REDUCE_OP is expected to come from add_define
+                reduce_tile_math(reduce_dst_idx);
+#elif (MATH_ONLY == 0)
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile(tt::CB::c_in0, tt::CB::c_in2, 0, 0, reduce_dst_idx);
+#endif
                 cb_pop_front(tt::CB::c_in0, onetile);
             }
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -34,8 +34,14 @@ void MAIN {
             // in this case we just sequentially add to accumulator all the W-tiles in a row
             for(uint32_t wt = 0; wt < Wt; ++wt) {
                 cb_wait_front(tt::CB::c_in0, onetile);
-                // REDUCE_OP/DIM is expected to come from add_define
+#if (MATH_ONLY == 1)
+                UNPACK(( llk_unpack_AB(tt::CB::c_in0, tt::CB::c_in2, 0, 0) ));
+                // REDUCE_OP is expected to come from add_define
+                reduce_tile_math(reduce_dst_idx);
+#elif (MATH_ONLY == 0)
+                // REDUCE_OP is expected to come from add_define
                 reduce_tile(tt::CB::c_in0, tt::CB::c_in2, 0, 0, reduce_dst_idx);
+#endif
                 cb_pop_front(tt::CB::c_in0, onetile);
             }
         }

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.cpp
@@ -159,9 +159,6 @@ std::vector<uint16_t> gold_reduce_h(const std::vector<uint16_t> &src_vec, const 
             else
                 sum += bfloat16(src_vec[offs]).to_float();
         }
-        if (red_type == 1) {
-            sum /= shape[2];
-        }
         auto dest_offs = addr_dst.offs(n, c, 0, w);
         reduced[dest_offs] = bfloat16(sum*scaler).to_uint16();
     }
@@ -189,9 +186,6 @@ std::vector<uint16_t> gold_reduce_w(const vector<uint16_t> &src_vec, const std::
                 sum = fmaxf(bfloat16(src_vec[offs]).to_float(), sum);
             else
                 sum += bfloat16(src_vec[offs]).to_float();
-        }
-        if (red_type == 1) {
-            sum /= shape[3];
         }
         auto dest_offs = addr_dst.offs(n, c, h, 0);
         reduced[dest_offs] = bfloat16(sum*scaler).to_uint16();
@@ -222,9 +216,6 @@ std::vector<uint16_t> gold_reduce_hw(const std::vector<uint16_t> &src_vec, const
                 else
                     sum += bfloat16(src_vec[offs]).to_float();
             }
-        }
-        if (red_type == 1) {
-            sum /= (shape[2] * shape[3]);
         }
         auto dest_offs = addr_dst.offs(n, c, 0, 0);
         reduced[dest_offs] = bfloat16(sum*scaler).to_uint16();

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.hpp
@@ -34,17 +34,20 @@ std::vector<uint16_t> gold_transpose_wh(const std::vector<uint16_t> &src_vec, co
 // input shape.x is assumed to have the full number of elements in bfloat16
 // src_vec is expected to be untilized
 // result is also untilized
-std::vector<uint16_t> gold_reduce_h(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, bool red_max = false, bool zeropad = true);
+// red_type : {SUM, AVG, MAX}; i.e. {0, 1, 2};
+std::vector<uint16_t> gold_reduce_h(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, uint8_t red_type = 0, bool zeropad = true);
 
 // input shape.x is assumed to have the full number of elements in bfloat16
 // src_vec is expected to be untilized
 // result is also untilized
-std::vector<uint16_t> gold_reduce_w(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, bool red_max = false, bool zeropad = true);
+// red_type : {SUM, AVG, MAX}; i.e. {0, 1, 2};
+std::vector<uint16_t> gold_reduce_w(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, uint8_t red_type = 0, bool zeropad = true);
 
 // input shape.x is assumed to have the full number of elements in bfloat16
 // src_vec is expected to be untilized
 // result is also untilized
-std::vector<uint16_t> gold_reduce_hw(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, bool red_max = false, bool zeropad = true);
+// red_type : {SUM, AVG, MAX}; i.e. {0, 1, 2};
+std::vector<uint16_t> gold_reduce_hw(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, uint8_t red_type = 0, bool zeropad = true);
 
 // Takes untilized src0_vec and tilized src1_vec
 // returns tilized result of eltwise addition

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
@@ -437,6 +437,7 @@ TEST_F(DeviceFixture, ComputeReduceW) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
+                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
                 log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
                 ReduceConfig test_config = {
                     .shape = shape,
@@ -531,6 +532,7 @@ TEST_F(DeviceFixture, ComputeReduceWMathOnly) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
+                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
                 log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
                 ReduceConfig test_config = {
                     .shape = shape,
@@ -627,6 +629,7 @@ TEST_F(DeviceFixture, ComputeReduceWShortInit) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
+                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
                 log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
                 ReduceConfig test_config = {
                     .short_init = true,

--- a/tt_metal/common/bfloat16.hpp
+++ b/tt_metal/common/bfloat16.hpp
@@ -396,8 +396,13 @@ inline bool packed_uint32_t_vector_comparison(
         float b2 = bs.second.to_float();
 
         if (not (comparison_function(a1, b1) and comparison_function(a2, b2)))  {
-            if (argfail)
+            if (argfail) {
                 *argfail = i;
+                std::cout << "a1 = " << std::hex << a1 << std::endl;
+                std::cout << "b1 = " << std::hex << b1 << std::endl;
+                std::cout << "a2 = " << std::hex << a2 << std::endl;
+                std::cout << "b2 = " << std::hex << b2 << std::endl;
+            }
             return false;
         }
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Not all BH LLK APIs used by OPs are covered by tests. The existing test usually don't implement template argument sweeps.

### What's changed

Expanded BH LLK API Test Coverage in reduce API in the following way:

1. Expanded test_reduce with AVG pool
2. Added Math Fidelity for all reduce tests
3. Added FP32 DEST Accumulation but skipped for scalar pool since it isn't supported

### Checklist
- [x] Post commit CI passes [#16057](https://github.com/tenstorrent/tt-metal/actions/runs/10940132840)
- [x] Blackhole Post commit (if applicable) [#786](https://github.com/tenstorrent/tt-metal/actions/runs/10941470239)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
