### PR TITLE
#12435: Add queue_id and optional output tensors to div_bw op

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_div.py
@@ -38,6 +38,7 @@ def test_bw_div_binary(input_shapes, round_mode, device):
 
     if round_mode == None:
         round_mode = "None"
+
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
@@ -174,4 +175,102 @@ def test_bw_unary_div_default(input_shapes, scalar, device):
     golden_tensor = golden_function(grad_data, in_data, scalar)
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "round_mode",
+    (
+        "None",
+        "trunc",
+        "floor",
+    ),
+)
+@pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
+def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode, input_grad=input_grad, queue_id=cq_id)
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+    tt_output_tensor_on_device = [input_grad]
+
+    if round_mode == "None":
+        round_mode = None
+    golden_function = ttnn.get_golden_function(ttnn.div_bw)
+    golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "round_mode",
+    (
+        "None",
+        "trunc",
+        "floor",
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    input_grad = None
+    other_grad = None
+    tt_output_tensor_on_device = None
+
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+    if are_required_outputs[1]:
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.div_bw(
+        grad_tensor,
+        input_tensor,
+        other_tensor,
+        round_mode=round_mode,
+        are_required_outputs=are_required_outputs,
+        input_grad=input_grad,
+        other_grad=other_grad,
+        queue_id=cq_id,
+    )
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+    tt_output_tensor_on_device = [input_grad, other_grad]
+
+    if round_mode == "None":
+        round_mode = None
+
+    golden_function = ttnn.get_golden_function(ttnn.div_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
     assert status

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -203,14 +203,17 @@ struct ExecuteBackwardAdd {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float scalar,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
 
     static std::vector<ComplexTensor> invoke(
         const ComplexTensor &grad_tensor_arg,
@@ -244,15 +247,17 @@ struct ExecuteBackwardSub {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float scalar,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
-
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<Tensor>> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
 
     static std::vector<ComplexTensor> invoke(
         const ComplexTensor &grad_tensor_arg,
@@ -381,7 +386,9 @@ struct ExecuteBackwardSubAlpha {
         const Tensor &input_tensor_b_arg,
         float alpha,
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
 
 };
 
@@ -401,7 +408,9 @@ struct ExecuteBackwardRsub {
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
 
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -264,19 +264,43 @@ struct ExecuteBackwardSub {
 };
 
 struct ExecuteBackwardDiv  {
-    static std::vector<Tensor> invoke(
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float scalar,
         string round_mode = "None",
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 
-    static std::vector<Tensor> invoke(
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         const Tensor &other_tensor_arg,
         string round_mode = "None",
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float scalar,
+        string round_mode = "None",
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const Tensor &other_tensor_arg,
+        string round_mode = "None",
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
 
     static std::vector<ComplexTensor> invoke(
         const ComplexTensor &grad_tensor_arg,
@@ -452,7 +476,9 @@ constexpr auto sub_bw = ttnn::register_operation<
     "ttnn::sub_bw",
     operations::binary_backward::ExecuteBackwardSub>();
 
-constexpr auto div_bw = ttnn::register_operation<"ttnn::div_bw", operations::binary_backward::ExecuteBackwardDiv>();
+constexpr auto div_bw = ttnn::register_operation<
+    "ttnn::div_bw",
+    operations::binary_backward::ExecuteBackwardDiv>();
 
 constexpr auto remainder_bw = ttnn::register_operation<
     "ttnn::remainder_bw",

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -790,8 +790,10 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             * :attr:`input_tensor_b` (ComplexTensor or ttnn.Tensor or Number): the tensor or number to add to :attr:`input_tensor_a`.
 
         Keyword args:
+            * :attr:`are_required_outputs` (Optional[bool]): required output gradients
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
-            * :attr:`dtype` (Optional[ttnn.DataType]): data type for the output tensor
+            * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
+            * :attr:`queue_id` (Optional[uint8]): command queue id
 
         Supported dtypes, layouts, and ranks:
 
@@ -822,15 +824,19 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
                const Tensor& input_tensor_a,
                const float scalar,
                std::string round_mode,
-               const std::optional<MemoryConfig>& memory_config){
-                return self(grad_tensor, input_tensor_a, scalar, round_mode, memory_config);
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& input_grad,
+               const uint8_t& queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(queue_id, grad_tensor, input_tensor_a, scalar, round_mode, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("scalar"),
             py::kw_only(),
             py::arg("round_mode") = "None",
-            py::arg("memory_config") = std::nullopt},
+            py::arg("memory_config") = std::nullopt,
+            py::arg("input_grad") = std::nullopt,
+            py::arg("queue_id") = ttnn::DefaultQueueId},
 
         // tensor and tensor
         ttnn::pybind_overload_t{
@@ -839,15 +845,23 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
                const ttnn::Tensor& input_tensor,
                const ttnn::Tensor& other_tensor,
                std::string round_mode,
-               const std::optional<ttnn::MemoryConfig>& memory_config) {
-                return self(grad_tensor, input_tensor, other_tensor, round_mode, memory_config);
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& input_grad,
+               const std::optional<ttnn::Tensor>& other_grad,
+               const uint8_t& queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(queue_id, grad_tensor, input_tensor, other_tensor, round_mode, are_required_outputs, memory_config, input_grad, other_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::arg("other_tensor"),
             py::kw_only(),
             py::arg("round_mode") = "None",
-            py::arg("memory_config") = std::nullopt},
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("memory_config") = std::nullopt,
+            py::arg("input_grad") = std::nullopt,
+            py::arg("other_grad") = std::nullopt,
+            py::arg("queue_id") = ttnn::DefaultQueueId},
 
         // complex tensor
         ttnn::pybind_overload_t{

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -137,23 +137,26 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardSubAlpha::invoke(
     const Tensor& other,
     float alpha,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteBackwardSubAlpha::invoke(DefaultQueueId, grad, input, other, alpha, are_required_outputs, output_mem_config);
+    const std::optional<MemoryConfig>& output_mem_config,
+    std::optional<Tensor> input_grad,
+    std::optional<Tensor> other_grad) {
+
+    return ExecuteBackwardSubAlpha::invoke(DefaultQueueId, grad, input, other, alpha, are_required_outputs, output_mem_config, input_grad, other_grad);
 
 }
 
 std::vector<std::optional<Tensor>> ExecuteBackwardAdd::invoke(
     uint8_t queue_id, const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
-    input_grad = input_grad.value_or(ttnn::zeros_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input));
     ttnn::assign(queue_id, grad, input_grad.value());
     result.emplace_back(input_grad);
     return result;
 }
 
 std::vector<std::optional<Tensor>> ExecuteBackwardAdd::invoke(
-    const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteBackwardAdd::invoke(DefaultQueueId, grad, input, alpha, output_mem_config);
+    const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    return ExecuteBackwardAdd::invoke(DefaultQueueId, grad, input, alpha, output_mem_config, input_grad);
 }
 
 std::vector<std::optional<Tensor>> ExecuteBackwardAdd::invoke(
@@ -179,8 +182,8 @@ std::vector<std::optional<Tensor>> ExecuteBackwardAdd::invoke(
     return result;
 }
 
-std::vector<std::optional<Tensor>> ExecuteBackwardAdd::invoke(const Tensor& grad, const Tensor& input, const Tensor& other, const std::vector<bool>& are_required_outputs, const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteBackwardAdd::invoke(DefaultQueueId, grad, input, other, are_required_outputs, output_mem_config);
+std::vector<std::optional<Tensor>> ExecuteBackwardAdd::invoke(const Tensor& grad, const Tensor& input, const Tensor& other, const std::vector<bool>& are_required_outputs, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad) {
+    return ExecuteBackwardAdd::invoke(DefaultQueueId, grad, input, other, are_required_outputs, output_mem_config, input_grad, other_grad);
 }
 
 std::vector<ComplexTensor> ExecuteBackwardAdd::invoke(
@@ -198,15 +201,15 @@ std::vector<ComplexTensor> ExecuteBackwardAdd::invoke(
 std::vector<std::optional<Tensor>> ExecuteBackwardSub::invoke(
     uint8_t queue_id, const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
-    input_grad = input_grad.value_or(ttnn::zeros_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input));
     ttnn::assign(queue_id, grad, input_grad.value());
     result.emplace_back(input_grad);
     return result;
 }
 
 std::vector<std::optional<Tensor>> ExecuteBackwardSub::invoke(
-    const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteBackwardSub::invoke(grad, input, alpha, output_mem_config);
+    const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    return ExecuteBackwardSub::invoke(DefaultQueueId, grad, input, alpha, output_mem_config, input_grad);
 }
 
 std::vector<std::optional<Tensor>> ExecuteBackwardSub::invoke(
@@ -226,8 +229,10 @@ std::vector<std::optional<Tensor>> ExecuteBackwardSub::invoke(
     const Tensor& input,
     const Tensor& other,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& output_mem_config) {
-        return ExecuteBackwardSub::invoke(DefaultQueueId, grad, input, other, are_required_outputs, output_mem_config);
+    const std::optional<MemoryConfig>& output_mem_config,
+    std::optional<Tensor> input_grad,
+    std::optional<Tensor> other_grad) {
+        return ExecuteBackwardSub::invoke(DefaultQueueId, grad, input, other, are_required_outputs, output_mem_config, input_grad, other_grad);
 }
 std::vector<ComplexTensor> ExecuteBackwardSub::invoke(
     const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
@@ -548,8 +553,10 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardRsub::invoke(
     const Tensor& input,
     const Tensor& other,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteBackwardRsub::invoke(DefaultQueueId, grad, input, other, are_required_outputs, output_mem_config);
+    const std::optional<MemoryConfig>& output_mem_config,
+    std::optional<Tensor> input_grad,
+    std::optional<Tensor> other_grad) {
+    return ExecuteBackwardRsub::invoke(DefaultQueueId, grad, input, other, are_required_outputs, output_mem_config, input_grad, other_grad);
 }
 
 std::vector<Tensor> ExecuteBackwardBiasGelu::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -659,83 +659,124 @@ template std::vector<Tensor> _min_or_max_bw<false>(
     const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
 
-std::vector<Tensor> ExecuteBackwardDiv::invoke(
-    const Tensor& grad, const Tensor& input, float scalar, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
+std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
+    uint8_t queue_id, const Tensor& grad, const Tensor& input, float scalar, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
-    float inv_scalar = 1.0f / scalar;
+
+    std::vector<std::optional<Tensor>> result;
+    input_grad = input_grad.value_or(ttnn::empty_like(input));
+
     if (round_mode == "None") {
-        Tensor t_inf = ttnn::operations::creation::full_like(input, std::numeric_limits<float>::infinity());
+        ttnn::full_like(queue_id, input, std::numeric_limits<float>::infinity(), std::nullopt, std::nullopt, std::nullopt, output_mem_config, input_grad);
         if (scalar == 0.0) {
             float t_nan = std::nanf("");
-            grad_tensor.emplace_back(where(
-                ttnn::eqz(grad, output_mem_config),
-                t_nan,
-                ttnn::multiply(ttnn::sign(grad, output_mem_config), t_inf, std::nullopt, output_mem_config),
-                output_mem_config));
+            where(queue_id, ttnn::eqz(queue_id, grad, output_mem_config),t_nan, ttnn::multiply(queue_id, ttnn::sign(queue_id, grad, output_mem_config), input_grad.value(), std::nullopt, output_mem_config), output_mem_config, input_grad);
+            result.push_back(input_grad);
         } else {
-            grad_tensor.emplace_back(ttnn::multiply(grad, inv_scalar, std::nullopt, output_mem_config));
+            float inv_scalar = 1.0f / scalar;
+            ttnn::multiply(queue_id, grad, inv_scalar, std::nullopt, output_mem_config, input_grad);
+            result.push_back(input_grad);
         }
     } else {
-        Tensor result = ttnn::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
-        grad_tensor.emplace_back(result);
+        ttnn::full_like(queue_id, grad, 0.0f, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config, input_grad);
+        result.push_back(input_grad);
     }
-    return grad_tensor;
+    return result;
 }
 
+std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
+    const Tensor& grad, const Tensor& input, float scalar, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    return ExecuteBackwardDiv::invoke(DefaultQueueId, grad, input, scalar, round_mode, output_mem_config, input_grad);
+}
 
-std::vector<Tensor> ExecuteBackwardDiv::invoke(
+std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
+    uint8_t queue_id,
     const Tensor& grad,
     const Tensor& input,
     const Tensor& other,
     std::string round_mode,
-    const std::optional<MemoryConfig>& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<MemoryConfig>& output_mem_config,
+    std::optional<Tensor> input_grad,
+    std::optional<Tensor> other_grad) {
+    std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
+    preallocated_tensors_check(input_grad, other_grad, input, other, {are_required_outputs[0], are_required_outputs[1]});
+
     if (round_mode == "None") {
-        Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(other, output_mem_config), std::nullopt, output_mem_config);
-        Tensor t_inf = ttnn::operations::creation::full_like(input, std::numeric_limits<float>::infinity(), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
-        Tensor t_nan = ttnn::operations::creation::full_like(input, std::nanf(""), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
-        grad_tensor.emplace_back(ttnn::where(
-            ttnn::eqz(other, output_mem_config),
+        Tensor t_inf = ttnn::full_like(queue_id, input, std::numeric_limits<float>::infinity(), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
+        Tensor t_nan = ttnn::full_like(queue_id, input, std::nanf(""), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
+        if (are_required_outputs.at(0))
+        {
+            ttnn::multiply(queue_id, grad, ttnn::reciprocal(other, output_mem_config), std::nullopt, output_mem_config, input_grad);
             ttnn::where(
-                ttnn::eqz(grad, output_mem_config),
-                t_nan,
-                ttnn::multiply(t_inf, ttnn::sign(grad, output_mem_config), std::nullopt, output_mem_config),
-                output_mem_config),
-            grad_a,
-            output_mem_config));
-        Tensor grad_b = ttnn::multiply(
-            ttnn::neg(grad, output_mem_config),
-            (ttnn::multiply(input, ttnn::reciprocal(ttnn::square(other, output_mem_config), output_mem_config), std::nullopt, output_mem_config)),
-            std::nullopt,
-            output_mem_config);
-        grad_tensor.emplace_back(ttnn::where(
-            ttnn::eqz(other, output_mem_config),
-            ttnn::where(
-                ttnn::eqz(grad, output_mem_config),
-                t_nan,
+                queue_id,
+                ttnn::eqz(queue_id, other, output_mem_config),
                 ttnn::where(
-                    ttnn::eqz(input, output_mem_config),
+                    queue_id,
+                    ttnn::eqz(queue_id, grad, output_mem_config),
                     t_nan,
-                    ttnn::multiply(ttnn::multiply(ttnn::neg(t_inf, output_mem_config),
-                            ttnn::sign(input, output_mem_config),
+                    ttnn::multiply(queue_id, t_inf, ttnn::sign(grad, output_mem_config), std::nullopt, output_mem_config),
+                    output_mem_config),
+                input_grad.value(),
+                output_mem_config);
+            result[0] = input_grad;
+        }
+        if (are_required_outputs.at(1))
+        {
+            ttnn::multiply(queue_id,
+            ttnn::neg(queue_id, grad, output_mem_config),
+            (ttnn::multiply(queue_id, input, ttnn::reciprocal(queue_id, ttnn::square(queue_id, other, output_mem_config), output_mem_config), std::nullopt, output_mem_config)),
+            std::nullopt,
+            output_mem_config, other_grad);
+            ttnn::where(
+                queue_id,
+                ttnn::eqz(queue_id, other, output_mem_config),
+                ttnn::where(
+                    queue_id,
+                    ttnn::eqz(queue_id, grad, output_mem_config),
+                    t_nan,
+                    ttnn::where(
+                        queue_id,
+                        ttnn::eqz(queue_id, input, output_mem_config),
+                        t_nan,
+                        ttnn::multiply(queue_id, ttnn::multiply(queue_id, ttnn::neg(queue_id, t_inf, output_mem_config),
+                                ttnn::sign(queue_id, input, output_mem_config),
+                                std::nullopt,
+                                output_mem_config),
+                            ttnn::sign(queue_id, grad, output_mem_config),
                             std::nullopt,
                             output_mem_config),
-                        ttnn::sign(grad, output_mem_config),
-                        std::nullopt,
                         output_mem_config),
                     output_mem_config),
-                output_mem_config),
-            grad_b,
-            output_mem_config));
+                other_grad.value(),
+                output_mem_config);
+            result[1] = other_grad;
+        }
     } else {
-        Tensor grad_a = ttnn::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
-        grad_tensor.emplace_back(grad_a);
-        Tensor grad_b = ttnn::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
-        grad_tensor.emplace_back(grad_b);
+        if (are_required_outputs.at(0))
+        {
+            ttnn::zeros_like(queue_id, grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config, input_grad);
+            result[0] = input_grad;
+        }
+        if (are_required_outputs.at(1))
+        {
+            ttnn::zeros_like(queue_id, grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config, other_grad);
+            result[1] = other_grad;
+        }
     }
+    return result;
+}
 
-    return grad_tensor;
+std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& other,
+    std::string round_mode,
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<MemoryConfig>& output_mem_config,
+    std::optional<Tensor> input_grad,
+    std::optional<Tensor> other_grad) {
+    return ExecuteBackwardDiv::invoke(DefaultQueueId, grad, input, other, round_mode, are_required_outputs, output_mem_config, input_grad, other_grad);
 }
 
 std::vector<ComplexTensor> ExecuteBackwardDiv::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -25,8 +25,6 @@ enum class BinaryBackwardOpType {
     BIAS_GELU_BW,
     MIN_BW,
     MAX_BW,
-    DIV_BW,
-    MUL_BW,
     REMAINDER_BW,
     FMOD_BW,
 };
@@ -41,9 +39,6 @@ std::vector<Tensor> _logaddexp2_bw( const Tensor& grad, const Tensor& input, con
 std::vector<Tensor> _squared_difference_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 template <bool>
 std::vector<Tensor> _min_or_max_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
-
-std::vector<ttnn::Tensor> _div_bw( const Tensor& grad, const Tensor& input, const Tensor& other, string round_mode = "None" , const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-
 std::vector<std::optional<ttnn::Tensor>> _eq_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
 
 // OpHandler struct template
@@ -114,11 +109,5 @@ struct OpHandler<BinaryBackwardOpType::MAX_BW> {
     }
 };
 
-template <>
-struct OpHandler<BinaryBackwardOpType::DIV_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _div_bw(grad, input, other, round_mode, output_mem_config);
-    }
-};
 
 }  // namespace ttnn::operations::binary_backward


### PR DESCRIPTION
### Ticket
Link to Github Issue #12435

### What's changed

- Added queue_id and optional output tensors to ttnn.div_bw

Perf before vs after:
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms)

ttnn.div_bw, 120, 3.538, 3.542, 6.291, 0.372 - Before
ttnn.div_bw, 120, 1.212, 1.266, 4.877, 0.395 - After

### Checklist
- [x] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/10881948225)