### PR TITLE
#0: Set WH_ARCH_YAML only if we have a wormhole machine

### DIFF
--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -35,14 +35,18 @@ run_perf_models_llm_javelin() {
     local tt_arch=$1
     local test_marker=$2
 
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b_common/tests -m $test_marker
-
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker
+        export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
     fi
 
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/tests -m $test_marker
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/llama31_8b/tests -m $test_marker
+    env pytest -n auto models/demos/falcon7b_common/tests -m $test_marker
+
+    if [ "$tt_arch" == "wormhole_b0" ]; then
+        env pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker
+    fi
+
+    env pytest -n auto models/demos/wormhole/mistral7b/tests -m $test_marker
+    env pytest -n auto models/demos/wormhole/llama31_8b/tests -m $test_marker
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py


### PR DESCRIPTION
### Ticket

Quick pipeline fix.

### Problem description

After some bash shebang script fixes, looks we broke some things.

### What's changed

Set `WH_ARCH_YAML` only if it's wormhole_b0, as setting it for grayskull may break it.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
