### PR TITLE
Adding core grid size to MLIR constraint framework

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_binary_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_binary_interface.cpp
@@ -51,6 +51,7 @@ class BinaryInterfaceTestFixture : public TTNNFixtureWithDevice,
                                        InputShapeTestParam,
                                        InputShapeTestParam,
                                        InputShapeTestParam,
+                                       CoreCoord,
                                        tt::tt_metal::IGraphProcessor::RunMode>> {};
 
 TEST_P(BinaryInterfaceTestFixture, BinaryInterfaceTest) {
@@ -58,7 +59,8 @@ TEST_P(BinaryInterfaceTestFixture, BinaryInterfaceTest) {
     auto input_a = std::get<0>(param_combination);
     auto input_b = std::get<1>(param_combination);
     auto input_o = std::get<2>(param_combination);
-    auto run_mode = std::get<3>(param_combination);
+    auto core_chip_grid = std::get<3>(param_combination);
+    auto run_mode = std::get<4>(param_combination);
 
     // pad input shapes (this isn't happening automagically)
     auto pad_shape_to_tile = [](const ttnn::Shape& shape) {
@@ -84,7 +86,12 @@ TEST_P(BinaryInterfaceTestFixture, BinaryInterfaceTest) {
     // Check input params against op constraints
     try {
         std::unique_ptr<EltwiseOpConstraintsBuilder> builder = EltwiseOpConstraintsFactory::Make(
-            input_a.shape, input_a.memory_config, input_b.shape, input_b.memory_config, input_o.memory_config);
+            input_a.shape,
+            input_a.memory_config,
+            input_b.shape,
+            input_b.memory_config,
+            input_o.memory_config,
+            core_chip_grid);
         if (builder) {
             const auto op_constraints =
                 (*builder)
@@ -261,8 +268,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
             }),
 
-        // ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH,
-        // tt::tt_metal::IGraphProcessor::RunMode::NORMAL)
+        ::testing::Values(CoreCoord{8, 8}),
         ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH)));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -342,9 +348,7 @@ INSTANTIATE_TEST_SUITE_P(
                              {160, 32},
                              ShardOrientation::COL_MAJOR}},
             }),
-
-        // ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH,
-        // tt::tt_metal::IGraphProcessor::RunMode::NORMAL)
+        ::testing::Values(CoreCoord{8, 8}),
         ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH)));
 
 }  // namespace test

--- a/tests/ttnn/unit_tests/gtests/test_matmul_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_interface.cpp
@@ -52,6 +52,7 @@ class MatmulInterfaceTestFixture : public TTNNFixtureWithDevice,
                                        InputShapeTestParam,
                                        InputShapeTestParam,
                                        InputShapeTestParam,
+                                       CoreCoord,
                                        tt::tt_metal::IGraphProcessor::RunMode>> {};
 
 TEST_P(MatmulInterfaceTestFixture, MatmulInterfaceTest) {
@@ -59,7 +60,8 @@ TEST_P(MatmulInterfaceTestFixture, MatmulInterfaceTest) {
     auto input_a = std::get<0>(param_combination);
     auto input_b = std::get<1>(param_combination);
     auto input_o = std::get<2>(param_combination);
-    auto run_mode = std::get<3>(param_combination);
+    auto core_chip_grid = std::get<3>(param_combination);
+    auto run_mode = std::get<4>(param_combination);
 
     // pad input shapes (this isn't happening automagically)
     auto pad_shape_to_tile = [](const ttnn::Shape& shape) {
@@ -100,7 +102,8 @@ TEST_P(MatmulInterfaceTestFixture, MatmulInterfaceTest) {
             input_b.shape,
             input_b.memory_config,
             input_o.memory_config,
-            matmul_program_config);
+            matmul_program_config,
+            core_chip_grid);
         if (builder) {
             const auto op_constraints =
                 (*builder)
@@ -229,7 +232,7 @@ INSTANTIATE_TEST_SUITE_P(
                              {32, 160},
                              ShardOrientation::COL_MAJOR}},
             }),
-
+        ::testing::Values(CoreCoord{8, 8}),  // Change this for more than 2-row harvested.
         ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH)));
 
 }  // namespace test

--- a/tests/ttnn/unit_tests/gtests/test_mlir_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_mlir_interface.cpp
@@ -266,11 +266,16 @@ TEST_P(EltwiseBinaryOpInterfaceTestFixture, MlirInterfaceTest) {
     input_a.shape = pad_shape_to_tile(input_a.shape);
     input_b.shape = pad_shape_to_tile(input_b.shape);
     std::cout << "OP = " << input_a.shape << " + " << input_b.shape << std::endl;
-
+    const CoreCoord chip_size{8, 8};
     // Check input params against op constraints
     try {
         std::unique_ptr<EltwiseOpConstraintsBuilder> builder = EltwiseOpConstraintsFactory::Make(
-            input_a.shape, input_a.memory_config, input_b.shape, input_b.memory_config, output.memory_config);
+            input_a.shape,
+            input_a.memory_config,
+            input_b.shape,
+            input_b.memory_config,
+            output.memory_config,
+            chip_size);
         if (builder) {
             const auto op_constraints =
                 (*builder)

--- a/tests/ttnn/unit_tests/gtests/test_softmax_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_softmax_interface.cpp
@@ -49,13 +49,14 @@ struct InputShapeTestParam {
 class SoftmaxInterfaceTestFixture
     : public TTNNFixtureWithDevice,
       public testing::WithParamInterface<
-          std::tuple<InputShapeTestParam, InputShapeTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
+          std::tuple<InputShapeTestParam, InputShapeTestParam, CoreCoord, tt::tt_metal::IGraphProcessor::RunMode>> {};
 
 TEST_P(SoftmaxInterfaceTestFixture, SoftmaxInterfaceTest) {
     auto param_combination = GetParam();
     auto input_a = std::get<0>(param_combination);
     auto input_o = std::get<1>(param_combination);
-    auto run_mode = std::get<2>(param_combination);
+    auto core_chip_grid = std::get<2>(param_combination);
+    auto run_mode = std::get<3>(param_combination);
 
     // pad input shapes (this isn't happening automagically)
     auto pad_shape_to_tile = [](const ttnn::Shape& shape) {
@@ -80,7 +81,7 @@ TEST_P(SoftmaxInterfaceTestFixture, SoftmaxInterfaceTest) {
     // Check input params against op constraints
     try {
         std::unique_ptr<SoftmaxOpConstraintsBuilder> builder = SoftmaxOpConstraintsFactory::Make(
-            input_a.shape, input_a.memory_config, input_o.shape, input_o.memory_config);
+            input_a.shape, input_a.memory_config, input_o.shape, input_o.memory_config, core_chip_grid);
         if (builder) {
             const auto op_constraints =
                 (*builder)
@@ -187,7 +188,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .shape = ttnn::Shape(tt::tt_metal::Array4D{4, 2, 5 * 32, 5 * 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
             }),
-
+        ::testing::Values(CoreCoord{8, 8}),
         ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH)));
 
 }  // namespace test

--- a/ttnn/cpp/ttnn/common/op_constraints.cpp
+++ b/ttnn/cpp/ttnn/common/op_constraints.cpp
@@ -214,7 +214,7 @@ bool OpConstraintsBuilder::can_allocate_sharded_buffer(
     return true;
 }
 
-bool OpConstraintsFactory::Can_fit_op_on_chip(const MemoryConfig& memory_config, const CoreCoord& chip_grid) {
+bool OpConstraintsFactory::can_fit_op_on_chip(const MemoryConfig& memory_config, const CoreCoord& chip_grid) {
     if (!memory_config.is_sharded()) {
         return true;
     }

--- a/ttnn/cpp/ttnn/common/op_constraints.cpp
+++ b/ttnn/cpp/ttnn/common/op_constraints.cpp
@@ -213,3 +213,25 @@ bool OpConstraintsBuilder::can_allocate_sharded_buffer(
     }
     return true;
 }
+
+bool OpConstraintsFactory::Can_fit_op_on_chip(const MemoryConfig& memory_config, const CoreCoord& chip_grid) {
+    if (!memory_config.is_sharded()) {
+        return true;
+    }
+
+    uint32_t num_compute_banks = chip_grid.x * chip_grid.y;
+    uint32_t sharding_num_cores = memory_config.shard_spec.value().grid.num_cores();
+    if (num_compute_banks < sharding_num_cores) {
+        return false;
+    }
+    return true;
+}
+
+const uint32_t OpConstraintsFactory::Volume(const ttnn::Shape& shape) {
+    auto rank = shape.rank();
+    auto volume = 1;
+    for (auto index = 0; index < rank; index++) {
+        volume *= shape.operator[](index);
+    }
+    return volume;
+}

--- a/ttnn/cpp/ttnn/common/op_constraints.hpp
+++ b/ttnn/cpp/ttnn/common/op_constraints.hpp
@@ -119,5 +119,5 @@ class OpConstraintsFactory {
    public:
     static const uint32_t Volume(const ttnn::Shape& shape);
 
-    static bool Can_fit_op_on_chip(const MemoryConfig& memory_config, const CoreCoord& chip_grid);
+    static bool can_fit_op_on_chip(const MemoryConfig& memory_config, const CoreCoord& chip_grid);
 };

--- a/ttnn/cpp/ttnn/common/op_constraints.hpp
+++ b/ttnn/cpp/ttnn/common/op_constraints.hpp
@@ -117,12 +117,7 @@ class OpConstraintsBuilder {
 
 class OpConstraintsFactory {
    public:
-    static const uint32_t Volume(const ttnn::Shape& shape) {
-        auto rank = shape.rank();
-        auto volume = 1;
-        for (auto index = 0; index < rank; index++) {
-            volume *= shape.operator[](index);
-        }
-        return volume;
-    }
+    static const uint32_t Volume(const ttnn::Shape& shape);
+
+    static bool Can_fit_op_on_chip(const MemoryConfig& memory_config, const CoreCoord& chip_grid);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
@@ -126,13 +126,13 @@ std::unique_ptr<EltwiseOpConstraintsBuilder> EltwiseOpConstraintsFactory::Make(
     const tt::tt_metal::MemoryConfig& memory_config_b,
     const tt::tt_metal::MemoryConfig& memory_config_o,
     const CoreCoord& chip_grid) {
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_a, chip_grid)) {
         return nullptr;
     }
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_b, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_b, chip_grid)) {
         return nullptr;
     }
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_o, chip_grid)) {
         return nullptr;
     }
     auto eltwise_op_type =

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
@@ -11,7 +11,7 @@ std::vector<OpConstraint> EltwiseOpConstraintsBuilder::build_constraints() {
     }
     std::vector<Layout> tile_layouts_b = {Layout::ROW_MAJOR, Layout::TILE};
     if (tile_layout_b.has_value()) {
-        tile_layouts_a = {tile_layout_b.value()};
+        tile_layouts_b = {tile_layout_b.value()};
     }
     std::vector<Layout> tile_layouts_o = {Layout::ROW_MAJOR, Layout::TILE};
     if (tile_layout_o.has_value()) {
@@ -124,7 +124,17 @@ std::unique_ptr<EltwiseOpConstraintsBuilder> EltwiseOpConstraintsFactory::Make(
     const tt::tt_metal::MemoryConfig& memory_config_a,
     const ttnn::Shape& input_shape_b,
     const tt::tt_metal::MemoryConfig& memory_config_b,
-    const tt::tt_metal::MemoryConfig& memory_config_o) {
+    const tt::tt_metal::MemoryConfig& memory_config_o,
+    const CoreCoord& chip_grid) {
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+        return nullptr;
+    }
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_b, chip_grid)) {
+        return nullptr;
+    }
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+        return nullptr;
+    }
     auto eltwise_op_type =
         GetEltwiseOpType(input_shape_a, memory_config_a, input_shape_b, memory_config_b, memory_config_o);
     switch (eltwise_op_type) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp
@@ -5,13 +5,11 @@
 #include <optional>
 
 #include "impl/buffers/buffer_constants.hpp"
+#include "ttnn/common/op_constraints.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 
-#include "ttnn/common/op_constraints.hpp"
-
-enum class EltwiseOpTypes
-{
+enum class EltwiseOpTypes {
     ElementWiseMultiCore,
     BroadcastWidthMultiCore,
     BroadcastHeightMultiCore,
@@ -21,30 +19,32 @@ enum class EltwiseOpTypes
     NotSupported
 };
 
-class EltwiseOpConstraintsBuilder : public OpConstraintsBuilder
-{
-    protected:
-        const ttnn::Shape shape_a;
-        const tt::tt_metal::MemoryConfig memory_config_a;
-        const ttnn::Shape shape_b;
-        const tt::tt_metal::MemoryConfig memory_config_b;
-        const tt::tt_metal::MemoryConfig memory_config_o;
+class EltwiseOpConstraintsBuilder : public OpConstraintsBuilder {
+   protected:
+    const ttnn::Shape shape_a;
+    const tt::tt_metal::MemoryConfig memory_config_a;
+    const ttnn::Shape shape_b;
+    const tt::tt_metal::MemoryConfig memory_config_b;
+    const tt::tt_metal::MemoryConfig memory_config_o;
 
-        EltwiseOpConstraintsBuilder(const ttnn::Shape& _shape_a,
-                                    const tt::tt_metal::MemoryConfig& _memory_config_a,
-                                    const ttnn::Shape& _shape_b,
-                                    const tt::tt_metal::MemoryConfig& _memory_config_b,
-                                    const tt::tt_metal::MemoryConfig& _memory_config_o) :
-                                    shape_a(_shape_a), memory_config_a(_memory_config_a),
-                                    shape_b(_shape_b), memory_config_b(_memory_config_b),
-                                    memory_config_o(_memory_config_o) {}
+    EltwiseOpConstraintsBuilder(
+        const ttnn::Shape& _shape_a,
+        const tt::tt_metal::MemoryConfig& _memory_config_a,
+        const ttnn::Shape& _shape_b,
+        const tt::tt_metal::MemoryConfig& _memory_config_b,
+        const tt::tt_metal::MemoryConfig& _memory_config_o) :
+        shape_a(_shape_a),
+        memory_config_a(_memory_config_a),
+        shape_b(_shape_b),
+        memory_config_b(_memory_config_b),
+        memory_config_o(_memory_config_o) {}
 
-    public:
-        virtual ~EltwiseOpConstraintsBuilder() = default;
+   public:
+    virtual ~EltwiseOpConstraintsBuilder() = default;
 
-        virtual std::vector<OpConstraint> build_constraints() override;
+    virtual std::vector<OpConstraint> build_constraints() override;
 
-        virtual bool is_valid_op_constraint(const OpConstraint& constraint) const override;
+    virtual bool is_valid_op_constraint(const OpConstraint& constraint) const override;
 };
 
 class ElementWiseMultiCoreConstraintsBuilder : public EltwiseOpConstraintsBuilder {
@@ -60,38 +60,34 @@ class ElementWiseMultiCoreConstraintsBuilder : public EltwiseOpConstraintsBuilde
         std::cout << "ElementWiseMultiCoreConstraintsBuilder" << std::endl;
     }
 
-    std::string get_op_name() const override
-    {
-        return "ElementWiseMultiCore";
-    }
+    std::string get_op_name() const override { return "ElementWiseMultiCore"; }
 
     static bool check_input_parameters(
         const ttnn::Shape& input_shape_a,
         const tt::tt_metal::MemoryConfig& memory_config_a,
         const ttnn::Shape& input_shape_b,
         const tt::tt_metal::MemoryConfig& memory_config_b);
-
 };
 
-class BroadcastWidthMultiCoreConstraintsBuilder : public EltwiseOpConstraintsBuilder
-{
-public:
-    BroadcastWidthMultiCoreConstraintsBuilder(const ttnn::Shape& _shape_a,
-                                              const tt::tt_metal::MemoryConfig& _memory_config_a,
-                                              const ttnn::Shape& _shape_b,
-                                              const tt::tt_metal::MemoryConfig& _memory_config_b,
-                                              const tt::tt_metal::MemoryConfig& _memory_config_o)
-    : EltwiseOpConstraintsBuilder(_shape_a, _memory_config_a, _shape_b, _memory_config_b, _memory_config_o)
-    {
+class BroadcastWidthMultiCoreConstraintsBuilder : public EltwiseOpConstraintsBuilder {
+   public:
+    BroadcastWidthMultiCoreConstraintsBuilder(
+        const ttnn::Shape& _shape_a,
+        const tt::tt_metal::MemoryConfig& _memory_config_a,
+        const ttnn::Shape& _shape_b,
+        const tt::tt_metal::MemoryConfig& _memory_config_b,
+        const tt::tt_metal::MemoryConfig& _memory_config_o) :
+        EltwiseOpConstraintsBuilder(_shape_a, _memory_config_a, _shape_b, _memory_config_b, _memory_config_o) {
         std::cout << "BroadcastWidthMultiCoreConstraintsBuilder" << std::endl;
     }
 
     virtual std::string get_op_name() const override { return "BroadcastWidthMultiCoreConstraintsBuilder"; }
 
-    static bool check_input_parameters(const ttnn::Shape& input_shape_a,
-                                       const tt::tt_metal::MemoryConfig& memory_config_a,
-                                       const ttnn::Shape& input_shape_b,
-                                       const tt::tt_metal::MemoryConfig& memory_config_b);
+    static bool check_input_parameters(
+        const ttnn::Shape& input_shape_a,
+        const tt::tt_metal::MemoryConfig& memory_config_a,
+        const ttnn::Shape& input_shape_b,
+        const tt::tt_metal::MemoryConfig& memory_config_b);
 };
 
 class EltwiseOpConstraintsFactory {
@@ -102,11 +98,13 @@ class EltwiseOpConstraintsFactory {
         const tt::tt_metal::MemoryConfig& memory_config_a,
         const ttnn::Shape& input_shape_b,
         const tt::tt_metal::MemoryConfig& memory_config_b,
-        const tt::tt_metal::MemoryConfig& memory_config_o);
+        const tt::tt_metal::MemoryConfig& memory_config_o,
+        const CoreCoord& chip_grid);
 
-    static EltwiseOpTypes GetEltwiseOpType(const ttnn::Shape& input_shape_a,
-                                           const tt::tt_metal::MemoryConfig& memory_config_a,
-                                           const ttnn::Shape& input_shape_b,
-                                           const tt::tt_metal::MemoryConfig& memory_config_b,
-                                           const tt::tt_metal::MemoryConfig& memory_config_o);
+    static EltwiseOpTypes GetEltwiseOpType(
+        const ttnn::Shape& input_shape_a,
+        const tt::tt_metal::MemoryConfig& memory_config_a,
+        const ttnn::Shape& input_shape_b,
+        const tt::tt_metal::MemoryConfig& memory_config_b,
+        const tt::tt_metal::MemoryConfig& memory_config_o);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.cpp
@@ -121,10 +121,10 @@ std::unique_ptr<UnaryOpConstraintsBuilder> UnaryOpConstraintsFactory::Make(
     const ttnn::Shape& input_shape_o,
     const tt::tt_metal::MemoryConfig& memory_config_o,
     const CoreCoord& chip_grid) {
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_a, chip_grid)) {
         return nullptr;
     }
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_o, chip_grid)) {
         return nullptr;
     }
     auto Unary_op_type = GetUnaryOpType(_op_type, arch, input_shape_a, memory_config_a, memory_config_o);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.cpp
@@ -119,7 +119,14 @@ std::unique_ptr<UnaryOpConstraintsBuilder> UnaryOpConstraintsFactory::Make(
     const ttnn::Shape& input_shape_a,
     const tt::tt_metal::MemoryConfig& memory_config_a,
     const ttnn::Shape& input_shape_o,
-    const tt::tt_metal::MemoryConfig& memory_config_o) {
+    const tt::tt_metal::MemoryConfig& memory_config_o,
+    const CoreCoord& chip_grid) {
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+        return nullptr;
+    }
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+        return nullptr;
+    }
     auto Unary_op_type = GetUnaryOpType(_op_type, arch, input_shape_a, memory_config_a, memory_config_o);
     switch (Unary_op_type) {
         case UnaryOpTypes::Unary:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.hpp
@@ -93,7 +93,8 @@ class UnaryOpConstraintsFactory {
         const ttnn::Shape& input_shape_a,
         const tt::tt_metal::MemoryConfig& memory_config_a,
         const ttnn::Shape& input_shape_o,
-        const tt::tt_metal::MemoryConfig& memory_config_o);
+        const tt::tt_metal::MemoryConfig& memory_config_o,
+        const CoreCoord& chip_size);
 
     static bool is_supported_arch(tt::ARCH arch, UnaryOpType op_type);
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.cpp
@@ -91,7 +91,17 @@ std::unique_ptr<MatmulOpConstraintsBuilder> MatmulOpConstraintsFactory::Make(
     const ttnn::Shape& input_shape_b,
     tt::tt_metal::MemoryConfig& memory_config_b,
     tt::tt_metal::MemoryConfig& memory_config_o,
-    const ttnn::operations::matmul::MatmulProgramConfig& program_config) {
+    const ttnn::operations::matmul::MatmulProgramConfig& program_config,
+    const CoreCoord& chip_grid) {
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+        return nullptr;
+    }
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_b, chip_grid)) {
+        return nullptr;
+    }
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+        return nullptr;
+    }
     auto matmul_op_type = GetMatmulOpType(
         input_shape_a, memory_config_a, input_shape_b, memory_config_b, memory_config_o, program_config);
     switch (matmul_op_type) {

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.cpp
@@ -93,13 +93,13 @@ std::unique_ptr<MatmulOpConstraintsBuilder> MatmulOpConstraintsFactory::Make(
     tt::tt_metal::MemoryConfig& memory_config_o,
     const ttnn::operations::matmul::MatmulProgramConfig& program_config,
     const CoreCoord& chip_grid) {
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_a, chip_grid)) {
         return nullptr;
     }
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_b, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_b, chip_grid)) {
         return nullptr;
     }
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_o, chip_grid)) {
         return nullptr;
     }
     auto matmul_op_type = GetMatmulOpType(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.hpp
@@ -92,7 +92,8 @@ class MatmulOpConstraintsFactory {
         const ttnn::Shape& input_shape_b,
         tt::tt_metal::MemoryConfig& memory_config_b,
         tt::tt_metal::MemoryConfig& memory_config_o,
-        const ttnn::operations::matmul::MatmulProgramConfig& program_config);
+        const ttnn::operations::matmul::MatmulProgramConfig& program_config,
+        const CoreCoord& chip_grid);
 
     static const uint32_t Volume(const ttnn::Shape& shape);
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.cpp
@@ -80,8 +80,15 @@ std::unique_ptr<SoftmaxOpConstraintsBuilder> SoftmaxOpConstraintsFactory::Make(
     const tt::tt_metal::MemoryConfig& memory_config_a,
     const ttnn::Shape& input_shape_o,
     const tt::tt_metal::MemoryConfig& memory_config_o,
+    const CoreCoord& chip_grid,
     const std::optional<const ttnn::Shape>& input_shape_b,
     const std::optional<const tt::tt_metal::MemoryConfig>& memory_config_b) {
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+        return nullptr;
+    }
+    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+        return nullptr;
+    }
     auto Softmax_op_type = GetSoftmaxOpType(input_shape_a, memory_config_a, input_shape_b, memory_config_b);
     switch (Softmax_op_type) {
         case SoftmaxOpTypes::Softmax:

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.cpp
@@ -83,10 +83,10 @@ std::unique_ptr<SoftmaxOpConstraintsBuilder> SoftmaxOpConstraintsFactory::Make(
     const CoreCoord& chip_grid,
     const std::optional<const ttnn::Shape>& input_shape_b,
     const std::optional<const tt::tt_metal::MemoryConfig>& memory_config_b) {
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_a, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_a, chip_grid)) {
         return nullptr;
     }
-    if (!OpConstraintsFactory::Can_fit_op_on_chip(memory_config_o, chip_grid)) {
+    if (!OpConstraintsFactory::can_fit_op_on_chip(memory_config_o, chip_grid)) {
         return nullptr;
     }
     auto Softmax_op_type = GetSoftmaxOpType(input_shape_a, memory_config_a, input_shape_b, memory_config_b);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.hpp
@@ -66,6 +66,7 @@ class SoftmaxOpConstraintsFactory {
         const tt::tt_metal::MemoryConfig& memory_config_a,
         const ttnn::Shape& input_shape_o,
         const tt::tt_metal::MemoryConfig& memory_config_o,
+        const CoreCoord& chip_grid,
         const std::optional<const ttnn::Shape>& input_shape_b = std::nullopt,
         const std::optional<const tt::tt_metal::MemoryConfig>& memory_config_b = std::nullopt);
 


### PR DESCRIPTION
To all folks who are code owners, no review required from the code owners, this is our internal branch that we are working on TTNN <-> optimiser interface.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/304)

### Problem description
The op constraint depend on the size of the grid (number of harvested rows) of the tt card that the op is ran on. To avoid linking the knowledge about the card to the compiler, that is now the parameter of the constraint framework, so that the user can specify the chip grid. The tests are also updated accordingly.

