### PR TITLE
#12615: Add queue_id output tensor to slice op, concat_bw

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_concat.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_concat.py
@@ -67,3 +67,130 @@ def test_bw_concat_Default(input_shapes, input_shapes_2, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes, input_shapes_2",
+    (
+        ((torch.Size([12, 1, 30, 32])), (torch.Size([2, 1, 30, 32]))),
+        ((torch.Size([4, 1, 32, 32])), (torch.Size([5, 1, 32, 32]))),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_concat_Default_with_output(input_shapes, input_shapes_2, device, are_required_outputs):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
+
+    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
+
+    pyt_y = torch.concat((in_data, other_data))
+
+    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
+
+    input_grad = None
+    other_grad = None
+
+    opt_tensor1 = torch.zeros(input_shapes, dtype=torch.bfloat16)
+    opt_tensor2 = torch.zeros(input_shapes_2, dtype=torch.bfloat16)
+
+    if are_required_outputs[0]:
+        input_grad = ttnn.from_torch(
+            opt_tensor1, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+    if are_required_outputs[1]:
+        other_grad = ttnn.from_torch(
+            opt_tensor2, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+    cq_id = 0
+
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.concat_bw(
+        grad_tensor,
+        input_tensor,
+        other_tensor,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
+    )
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+
+    tt_output_tensor_on_device = [input_grad, other_grad]
+
+    golden_function = ttnn.get_golden_function(ttnn.concat_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data)
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes, input_shapes_2, dimension",
+    (
+        ((torch.Size([12, 1, 30, 32])), (torch.Size([2, 1, 30, 32])), 0),
+        ((torch.Size([1, 2, 45, 64])), (torch.Size([1, 1, 45, 64])), 1),
+        ((torch.Size([1, 1, 125, 32])), (torch.Size([1, 1, 32, 32])), 2),
+        (
+            (torch.Size([1, 1, 64, 80])),
+            (torch.Size([1, 1, 64, 16])),
+            3,
+        ),  # size must be divisible by sizeof(uint32_t) because buffers hold uint32_t values
+        # Tile shape
+        ((torch.Size([4, 1, 32, 32])), (torch.Size([5, 1, 32, 32])), 0),
+        ((torch.Size([1, 2, 64, 64])), (torch.Size([1, 1, 64, 64])), 1),
+        ((torch.Size([1, 1, 64, 32])), (torch.Size([1, 1, 32, 32])), 2),
+        ((torch.Size([1, 1, 64, 64])), (torch.Size([1, 1, 64, 32])), 3),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_concat_with_output(input_shapes, input_shapes_2, dimension, device, are_required_outputs):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
+
+    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
+
+    pyt_y = torch.concat((in_data, other_data), dim=dimension)
+
+    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
+
+    input_grad = None
+    other_grad = None
+
+    opt_tensor1 = torch.zeros(input_shapes, dtype=torch.bfloat16)
+    opt_tensor2 = torch.zeros(input_shapes_2, dtype=torch.bfloat16)
+
+    if are_required_outputs[0]:
+        input_grad = ttnn.from_torch(
+            opt_tensor1, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+    if are_required_outputs[1]:
+        other_grad = ttnn.from_torch(
+            opt_tensor2, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+
+    cq_id = 0
+
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.concat_bw(
+        grad_tensor,
+        input_tensor,
+        other_tensor,
+        dimension,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
+    )
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+
+    tt_output_tensor_on_device = [input_grad, other_grad]
+
+    golden_function = ttnn.get_golden_function(ttnn.concat_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data, dimension)
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
+    assert status

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -16,38 +16,43 @@ struct SliceOperation {
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::LegacyShape output_tensor_start,
         tt::tt_metal::LegacyShape output_tensor_end,
-        const std::optional<tt::tt_metal::LegacyShape> step,
-        const std::optional<MemoryConfig>& memory_config_arg);
+        const std::optional<tt::tt_metal::LegacyShape> step = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::LegacyShape output_tensor_start,
         tt::tt_metal::LegacyShape output_tensor_end,
-        const std::optional<tt::tt_metal::LegacyShape> step,
-        const std::optional<MemoryConfig>& memory_config_arg);
+        const std::optional<tt::tt_metal::LegacyShape> step = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::Array1D output_tensor_start,
         tt::tt_metal::Array1D output_tensor_end,
-        const std::optional<tt::tt_metal::Array1D> step,
-        const std::optional<MemoryConfig>& memory_config_arg);
+        const std::optional<tt::tt_metal::Array1D> step = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::Array4D output_tensor_start,
         tt::tt_metal::Array4D output_tensor_end,
-        const std::optional<tt::tt_metal::Array4D> step,
-        const std::optional<MemoryConfig>& memory_config_arg);
+        const std::optional<tt::tt_metal::Array4D> step = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::Array4D output_tensor_start,
         tt::tt_metal::Array4D output_tensor_end,
-        const std::optional<tt::tt_metal::Array4D> step,
-        const std::optional<MemoryConfig>& memory_config_arg);
+        const std::optional<tt::tt_metal::Array4D> step = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
@@ -50,8 +50,9 @@ void bind_slice(py::module& module) {
                 const tt::tt_metal::Array4D & slice_end,
                 const std::optional<tt::tt_metal::Array4D> &step,
                 const std::optional<ttnn::MemoryConfig>& memory_config,
+                const std::optional<Tensor>& optional_output_tensor,
                 uint8_t queue_id) {
-                    return self(queue_id, input_tensor, slice_start, slice_end, step, memory_config);
+                    return self(queue_id, input_tensor, slice_start, slice_end, step, memory_config, optional_output_tensor);
                 },
                 py::arg("input_tensor"),
                 py::arg("slice_start"),
@@ -59,6 +60,7 @@ void bind_slice(py::module& module) {
                 py::arg("step") = std::nullopt,
                 py::kw_only(),
                 py::arg("memory_config") = std::nullopt,
+                py::arg("output_tensor") = std::nullopt,
                 py::arg("queue_id") = 0,
                 }
         );

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -381,6 +381,30 @@ struct ExecuteBackwardRsub {
 
 };
 
+struct ExecuteBackwardConcat {
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        int dim,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        int dim,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
+
+};
+
 }  // operations::binary
 
 constexpr auto atan2_bw = ttnn::register_operation<"ttnn::atan2_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>();
@@ -402,7 +426,7 @@ constexpr auto rsub_bw = ttnn::register_operation<
     "ttnn::rsub_bw",
     operations::binary_backward::ExecuteBackwardRsub>();
 
-constexpr auto concat_bw = ttnn::register_operation<"ttnn::concat_bw", operations::binary_backward::ExecuteBinaryBackwardIntDefault<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>();
+constexpr auto concat_bw = ttnn::register_operation<"ttnn::concat_bw", operations::binary_backward::ExecuteBackwardConcat>();
 
 constexpr auto mul_bw = ttnn::register_operation<"ttnn::mul_bw", operations::binary_backward::ExecuteBackwardMul>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -122,15 +122,23 @@ void bind_binary_backward_int_default(py::module& module, const binary_backward_
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
                int parameter,
-               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
-                return self(grad_tensor, input_tensor_a, input_tensor_b, parameter, memory_config);
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& input_grad,
+               const std::optional<ttnn::Tensor>& other_grad,
+               const uint8_t& queue_id) -> std::vector<std::optional<ttnn::Tensor>>  {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, parameter, are_required_outputs, memory_config, input_grad, other_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
             py::arg(parameter_name.c_str()) = parameter_value,
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt}
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("memory_config") = std::nullopt,
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt,
+            py::arg("queue_id") = ttnn::DefaultQueueId}
     );
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -22,7 +22,6 @@ enum class BinaryBackwardOpType {
     LOGADDEXP2_BW,
     SQUARED_DIFFERENCE_BW,
     ASSIGN_BW,
-    CONCAT_BW,
     BIAS_GELU_BW,
     MIN_BW,
     MAX_BW,
@@ -44,8 +43,6 @@ template <bool>
 std::vector<Tensor> _min_or_max_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
 std::vector<ttnn::Tensor> _div_bw( const Tensor& grad, const Tensor& input, const Tensor& other, string round_mode = "None" , const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-
-std::vector<ttnn::Tensor> _concat_bw( const Tensor& grad, const Tensor& input, const Tensor& other, int dim = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
 std::vector<std::optional<ttnn::Tensor>> _eq_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
 
@@ -121,13 +118,6 @@ template <>
 struct OpHandler<BinaryBackwardOpType::DIV_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
         return _div_bw(grad, input, other, round_mode, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<BinaryBackwardOpType::CONCAT_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _concat_bw(grad, input, other, dim, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -532,8 +532,8 @@ std::vector<Tensor> split_tensor_for_glu(const Tensor& input_a, int32_t dim, con
     std::vector<uint32_t> s_b = {0, 0, 0, inshape[3] / 2};
     std::vector<uint32_t> e_b = {inshape[0] - 1, inshape[1] - 1, inshape[2] - 1, inshape[3] - 1};
 
-    Tensor t_a = ttnn::slice(0, input_a, s_a, e_a, std::nullopt, output_mem_config);
-    Tensor t_b = ttnn::slice(0, input_a, s_b, e_b, std::nullopt, output_mem_config);
+    Tensor t_a = ttnn::slice(DefaultQueueId, input_a, s_a, e_a, std::nullopt, output_mem_config);
+    Tensor t_b = ttnn::slice(DefaultQueueId, input_a, s_b, e_b, std::nullopt, output_mem_config);
 
     t_split.emplace_back(t_a);
     t_split.emplace_back(t_b);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -7,7 +7,7 @@
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include "tt_metal/common/constants.hpp"
-#include "ttnn/cpp/ttnn/common/constants.hpp"
+#include "ttnn/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
@@ -1493,7 +1493,7 @@ std::vector<Tensor> _prod_bw(
             std::vector<uint32_t> start_index = {0, 0, 0, 0};
             std::vector<uint32_t> end_index = {
                 grad.get_legacy_shape()[0] - 1, 0, grad.get_legacy_shape()[1] - 1, grad.get_legacy_shape()[2] - 1};
-            Tensor new_slice_tensor = ttnn::slice(0, required, start_index, end_index, std::nullopt, std::nullopt);
+            Tensor new_slice_tensor = ttnn::slice(DefaultQueueId, required, start_index, end_index);
             after_permute_dims = {0, 2, 3, 1};
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
             if(updated_grad.storage_type() != StorageType::DEVICE && updated_grad.storage_type() != StorageType::MULTI_DEVICE) {
@@ -1507,7 +1507,7 @@ std::vector<Tensor> _prod_bw(
             std::vector<uint32_t> start_index = {0, 0, 0, 0};
             std::vector<uint32_t> end_index = {
                 grad.get_legacy_shape()[0] - 1, 0, grad.get_legacy_shape()[1] - 1, grad.get_legacy_shape()[3] - 1};
-            Tensor new_slice_tensor = ttnn::slice(0, required, start_index, end_index, std::nullopt, std::nullopt);
+            Tensor new_slice_tensor = ttnn::slice(DefaultQueueId, required, start_index, end_index);
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
             if(updated_grad.get_layout()==Layout::ROW_MAJOR){
                 updated_grad = ttnn::operations::unary_backward::change_layout_to_tile(updated_grad, output_memory_config);
@@ -1557,7 +1557,7 @@ std::vector<Tensor> _prod_bw(
                 input.get_legacy_shape()[1] - 1,
                 input.get_legacy_shape()[2] - 1,
                 input.get_legacy_shape()[3] - 1};
-            grad_result = ttnn::slice(0, result, start_index, end_index, std::nullopt, std::nullopt);
+            grad_result = ttnn::slice(DefaultQueueId, result, start_index, end_index);
         }
         grad_tensor.emplace_back(grad_result);
         return grad_tensor;
@@ -1591,7 +1591,7 @@ std::vector<Tensor> _prod_bw(
             input.get_legacy_shape()[1] - 1,
             input.get_legacy_shape()[2] - 1,
             input.get_legacy_shape()[3] - 1};
-        grad_result = ttnn::slice(0, result, start_index, end_index, std::nullopt, std::nullopt);
+        grad_result = ttnn::slice(DefaultQueueId, result, start_index, end_index);
     }
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -159,7 +159,7 @@ Tensor AutoFormat::format_output_tensor(
             if ((formatted_output.get_layout() == Layout::TILE && AutoFormat::legal_tile_shape(shape)) ||
                 (formatted_output.get_layout() == Layout::ROW_MAJOR && AutoFormat::legal_rm_shape(shape))) {
                 formatted_output = ttnn::slice(
-                    0,
+                    DefaultQueueId,
                     formatted_output,
                     std::vector<uint32_t>({0, 0, 0, 0}),
                     std::vector<uint32_t>({shape[0] - 1, shape[1] - 1, shape[2] - 1, shape[3] - 1}),
@@ -186,7 +186,7 @@ Tensor AutoFormat::format_output_tensor(
                 formatted_output.get_layout() == Layout::ROW_MAJOR && target_layout == Layout::TILE &&
                 AutoFormat::legal_tile_shape(shape)) {
                 formatted_output = ttnn::slice(
-                    0,
+                    DefaultQueueId,
                     formatted_output,
                     std::vector<uint32_t>({0, 0, 0, 0}),
                     std::vector<uint32_t>({shape[0] - 1, shape[1] - 1, shape[2] - 1, shape[3] - 1}),

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "tt_numpy/functions.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/common/constants.hpp"
 
 namespace ttnn::operations::reduction {
 
@@ -106,7 +107,7 @@ Tensor ProdOperation::invoke(const Tensor& input_a, bool all_dimensions, int64_t
         tt::tt_metal::LegacyShape input_shape = input_a.get_legacy_shape();
         std::vector<uint32_t> start_index = {0, 0, 0, 0};
         std::vector<uint32_t> end_index = {input_shape[0] - 1, input_shape[1] - 1, 0, input_shape[3] - 1};
-        return ttnn::slice(0, required, start_index, end_index, std::nullopt, std::nullopt);
+        return ttnn::slice(DefaultQueueId, required, start_index, end_index);
     } else {  // dim 3
         // permute
         std::vector<int64_t> after_permute_dims = {1, 2, 0, 3};
@@ -115,7 +116,7 @@ Tensor ProdOperation::invoke(const Tensor& input_a, bool all_dimensions, int64_t
         tt::tt_metal::LegacyShape input_shape = input_a.get_legacy_shape();
         std::vector<uint32_t> start_index = {0, 0, 0, 0};
         std::vector<uint32_t> end_index = {input_shape[0] - 1, input_shape[1] - 1, 0, input_shape[2] - 1};
-        Tensor new_unpad_tensor = ttnn::slice(0, required, start_index, end_index, std::nullopt, std::nullopt);
+        Tensor new_unpad_tensor = ttnn::slice(DefaultQueueId, required, start_index, end_index);
         // permute back
         after_permute_dims = {0, 1, 3, 2};
         Tensor res_host = ttnn::permute(new_unpad_tensor, after_permute_dims, output_mem_config);


### PR DESCRIPTION
### Ticket
Link to Github Issue #12615

### Problem description
Add queue_id and optional output tensor to slice op, concat_bw

### What's changed
Add queue_id and optional output tensor to slice op, concat_bw

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10902612202
https://github.com/tenstorrent/tt-metal/actions/runs/10937632933
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
