### PR TITLE
#0: Remove CCL stalls, since Fabric VC support is merged

### DIFF
--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -142,9 +142,6 @@ class Program {
     void finalize();
     std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
 
-    void capture_multi_device_dependencies() { capture_multi_device_dependencies_ = true; }
-    bool has_multi_device_dependencies() { return capture_multi_device_dependencies_; }
-
     ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
 
     // debug/test
@@ -219,7 +216,6 @@ class Program {
 
     std::vector<ProgramConfig> program_configs_;
     std::vector<uint32_t> program_config_sizes_;
-    bool capture_multi_device_dependencies_ = false;
     friend CBHandle CreateCircularBuffer(Program &program, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const CircularBufferConfig &config);
     friend std::shared_ptr<CircularBuffer> detail::GetCircularBuffer(const Program &program, CBHandle id);
     friend void detail::ValidateCircularBufferRegion(const Program &program, const Device *device);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -244,8 +244,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
         num_edm_buffers_per_channel = user_defined_num_buffers_per_channel.value();
     }
 
-    // Issue #10978: CCLs need to be tagged as having multi-device dependencies, when running on Galaxy.
-    program.capture_multi_device_dependencies();
     const auto& device = input_tensor.device();
 
     /* All gather fusion */

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -770,8 +770,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
 
     //////////////////
     tt::tt_metal::Program program{};
-    // Issue #10978: CCLs need to be tagged as having multi-device dependencies, when running on Galaxy.
-    program.capture_multi_device_dependencies();
+
     const auto& device = local_chip_tensor.device();
 
     auto const& topology_config =


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10978

### Problem description
Explicit stalls when running CCLs on TG/TGG are no longer needed, now that we have Fabric VCs.

### What's changed
Remove stalls issued using `program.capture_multi_device_dependencies()`.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
