### PR TITLE
#0: Remove unused CRT_START label

### DIFF
--- a/tt_metal/hw/toolchain/tmu-crt0.S
+++ b/tt_metal/hw/toolchain/tmu-crt0.S
@@ -3,8 +3,6 @@
 .type   _start, @function
 
 _start:
-
-CRT_START:
 .option push
 .option norelax
 	// Initialize global pointer,

--- a/tt_metal/hw/toolchain/tmu-crt0k.S
+++ b/tt_metal/hw/toolchain/tmu-crt0k.S
@@ -3,7 +3,5 @@
 .type   _start, @function
 
 _start:
-
-CRT_START:
 	tail    _Z13kernel_launchv
 	.size  _start, .-_start


### PR DESCRIPTION
### Ticket
NA

### Problem description
The crt0 assembler defines `CRT_START` in addition to `_start`.  The former symbol is uncommented and appears to be unused.

### What's changed
Remove unneeded symbol.

### Checklist
- [YES ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
