### PR TITLE
Fix start pos in get_rot_mat

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -370,7 +370,8 @@ def get_rotation_mat_prefill(rot_mat, start_pos, seqlen, batch):
 
 
 def get_rotation_mat(rot_mat, start_pos, seqlen, batch):
-    # position_ids = torch.ones(seqlen, batch, dtype=torch.long) * start_pos
+    if isinstance(start_pos, int):
+        start_pos = torch.ones(seqlen, batch, dtype=torch.long) * start_pos
     position_ids = start_pos.view(seqlen, batch)
     rot_emb = gather_rotary_emb(rot_mat, position_ids)
     return rot_emb

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -227,14 +227,7 @@ class TtLlamaModel_galaxy:
 
             xs = ttnn.to_memory_config(xs, memory_config=ACT_MEMCFG)
 
-            if isinstance(start_pos, int):
-                cache_idxs = torch.tensor([start_pos for _ in range(batch // self.cluster_shape[0])], dtype=torch.int64)
-            else:
-                raise ValueError("start_pos must be an int, different start_pos for each user not supported yet")
-                cache_idxs = start_pos
-
-            # TODO : Create different rot_mat for each user_groups in the cluster
-            rot_mat = get_rotation_mat(self.rot_emb, cache_idxs, seq_len, batch // self.cluster_shape[0])
+            rot_mat = get_rotation_mat(self.rot_emb, start_pos, seq_len, batch // self.cluster_shape[0])
             assert rot_mat.size() == (1, batch // self.cluster_shape[0], self.head_dim, self.head_dim)
 
             shard_spec_n_cores_grid = ttnn.CoreRangeSet({num_to_corerange(batch // 4)})


### PR DESCRIPTION
Summary
1. Fixes start pos in `get_rotation_mat` affecting TG unit tests and demo.
2. Removed previous fix which only patch full_model test

### Checklist
- [x] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/10888787043  
- [x] TG Frequent https://github.com/tenstorrent/tt-metal/actions/runs/10888747582
