### PR TITLE
#12701: Split nightly tests into specific models for better reading

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -27,20 +27,6 @@ jobs:
               timeout: 40
             },
             {
-              name: "Common models N300 WH B0",
-              arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
-              cmd: tests/scripts/single_card/nightly/run_common_models.sh,
-              timeout: 40,
-            },
-            {
-              name: "Common models N150 WH BO",
-              arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
-              cmd: tests/scripts/single_card/nightly/run_common_models.sh,
-              timeout: 40,
-            },
-            {
               name: "GS ttnn nightly",
               arch: grayskull,
               runs-on: ["cloud-virtual-machine", "E150", "in-service"],
@@ -69,39 +55,25 @@ jobs:
               timeout: 40
             },
             {
-              name: "N300 WH-only models",
-              arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
-              cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
-              timeout: 100
-            },
-            {
-              name: "N150 WH-only models",
-              arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
-              cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
-              timeout: 100
-            },
-            {
               name: "API tests GS",
               arch: grayskull,
               runs-on: ["cloud-virtual-machine", "E150", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
-              timeout: 40
+              timeout: 10
             },
             {
               name: "API tests N300 WH B0",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N300", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
-              timeout: 40
+              timeout: 10
             },
             {
               name: "API tests N150 WH B0",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N150", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
-              timeout: 40
+              timeout: 10
             },
             {
               name: "[Unstable] N150 models",
@@ -120,7 +92,6 @@ jobs:
           ]
     name: FD ${{ matrix.test-group.name }} ${{ matrix.test-group.arch }}
     env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
@@ -149,6 +120,55 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"
+  nightly-wh-models:
+    needs: build-artifact
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        card: [N150, N300]
+        model: [common_models, functional_unet, llama31_8b, mamba, mistral7b, mistral7b_eth, resnet50]
+    name: Nightly ${{ matrix.card }} ${{ matrix.model }}
+    env:
+      ARCH_NAME: wormhole_b0
+      LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.card }}"]
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - uses: ./.github/actions/retry-command
+        with:
+          timeout-seconds: 100
+          max-retries: 10
+          backoff-seconds: 60
+          command: ./.github/scripts/cloud_utils/mount_weka.sh
+      - name: Set up dyanmic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - name: Set up WH_ARCH_YAML for eth-enabled models
+        if: ${{ matrix.model != 'mistral7b' }}
+        run: |
+          echo "WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml" >> $GITHUB_ENV
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_wormhole_b0
+      - name: Extract files
+        run: tar -xvf ttm_wormhole_b0.tar
+      - uses: ./.github/actions/install-python-deps
+      - name: Run frequent reg tests scripts
+        timeout-minutes: 30
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          pytest -n auto tests/nightly/single_card/${{ matrix.model }}
       - uses: ./.github/actions/upload-artifact-with-job-uuid
         if: ${{ !cancelled() }}
         with:

--- a/tests/nightly/common_models/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/tests/nightly/common_models/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py

--- a/tests/nightly/common_models/models/demos/metal_BERT_large_11/tests/test_demo.py
+++ b/tests/nightly/common_models/models/demos/metal_BERT_large_11/tests/test_demo.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/metal_BERT_large_11/tests/test_demo.py

--- a/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_attention.py
+++ b/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_attention.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_attention.py

--- a/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
+++ b/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py

--- a/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
+++ b/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py

--- a/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
+++ b/tests/nightly/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py

--- a/tests/nightly/single_card/common_models/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/tests/nightly/single_card/common_models/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py

--- a/tests/nightly/single_card/common_models/models/demos/metal_BERT_large_11/tests/test_demo.py
+++ b/tests/nightly/single_card/common_models/models/demos/metal_BERT_large_11/tests/test_demo.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/metal_BERT_large_11/tests/test_demo.py

--- a/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_attention.py
+++ b/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_attention.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_attention.py

--- a/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
+++ b/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py

--- a/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
+++ b/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py

--- a/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
+++ b/tests/nightly/single_card/common_models/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_bottleneck.py

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_downblock.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_downblock.py

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_model.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_model.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_model.py

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_multi_device.py

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_output_layer.py

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_upblock.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_upblock.py

--- a/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_attention.py
+++ b/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_attention.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_attention.py

--- a/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_attention_prefill.py
+++ b/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_attention_prefill.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_attention_prefill.py

--- a/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_decoder.py
+++ b/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_decoder.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_decoder.py

--- a/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_decoder_prefill.py
+++ b/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_decoder_prefill.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_decoder_prefill.py

--- a/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_mlp.py
+++ b/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_mlp.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_mlp.py

--- a/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_rms_norm.py
+++ b/tests/nightly/single_card/llama31_8b/models/demos/wormhole/llama31_8b/tests/test_llama_rms_norm.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_rms_norm.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_benchmarks.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_benchmarks.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_benchmarks.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_cache.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_cache.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_cache.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_block.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_block.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_block.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_conv.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_conv.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_conv.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_demo.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_demo.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_demo.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_model.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_model.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_model.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_perplexity.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_perplexity.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_perplexity.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_ssm.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_mamba_ssm.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_ssm.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_preprocessing.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_preprocessing.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_preprocessing.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_reference_model.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_reference_model.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_reference_model.py

--- a/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_residual_block.py
+++ b/tests/nightly/single_card/mamba/models/demos/wormhole/mamba/test_residual_block.py
@@ -1,0 +1,1 @@
+../../../../../../../../models/demos/wormhole/mamba/tests/test_residual_block.py

--- a/tests/nightly/single_card/mistral7b/models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py
+++ b/tests/nightly/single_card/mistral7b/models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py

--- a/tests/nightly/single_card/mistral7b/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
+++ b/tests/nightly/single_card/mistral7b/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py

--- a/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention.py
+++ b/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_attention.py

--- a/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention_prefill.py
+++ b/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention_prefill.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_attention_prefill.py

--- a/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
+++ b/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py

--- a/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder_prefill.py
+++ b/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder_prefill.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_decoder_prefill.py

--- a/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py
+++ b/tests/nightly/single_card/mistral7b_eth/models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py

--- a/tests/nightly/single_card/resnet50/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
+++ b/tests/nightly/single_card/resnet50/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
@@ -1,0 +1,1 @@
+../../../../../../../../../models/demos/wormhole/resnet50/tests/test_resnet50_performant.py

--- a/tests/nightly/single_card/wh_b0_unstable/tests/ttnn/integration_tests/stable_diffusion
+++ b/tests/nightly/single_card/wh_b0_unstable/tests/ttnn/integration_tests/stable_diffusion
@@ -1,0 +1,1 @@
+../../../../../../../tests/ttnn/integration_tests/stable_diffusion

--- a/tests/nightly/wh_b0_only/models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py
+++ b/tests/nightly/wh_b0_only/models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py

--- a/tests/nightly/wh_b0_only/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
+++ b/tests/nightly/wh_b0_only/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -1,1 +1,0 @@
-../../../../../../models/experimental/functional_unet/tests/test_unet_bottleneck.py

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_downblock.py
@@ -1,1 +1,0 @@
-../../../../../../models/experimental/functional_unet/tests/test_unet_downblock.py

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_model.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_model.py
@@ -1,1 +1,0 @@
-../../../../../../models/experimental/functional_unet/tests/test_unet_model.py

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -1,1 +1,0 @@
-../../../../../../models/experimental/functional_unet/tests/test_unet_multi_device.py

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -1,1 +1,0 @@
-../../../../../../models/experimental/functional_unet/tests/test_unet_output_layer.py

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_upblock.py
@@ -1,1 +1,0 @@
-../../../../../../models/experimental/functional_unet/tests/test_unet_upblock.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_attention.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_attention.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_attention.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_attention_prefill.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_attention_prefill.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_attention_prefill.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_decoder.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_decoder.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_decoder.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_decoder_prefill.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_decoder_prefill.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_decoder_prefill.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_mlp.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_mlp.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_mlp.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_rms_norm.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/llama31_8b/tests/test_llama_rms_norm.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/llama31_8b/tests/test_llama_rms_norm.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_benchmarks.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_benchmarks.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_benchmarks.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_cache.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_cache.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_cache.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_block.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_block.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_block.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_conv.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_conv.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_conv.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_demo.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_demo.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_demo.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_model.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_model.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_model.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_perplexity.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_perplexity.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_perplexity.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_ssm.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_ssm.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_ssm.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_preprocessing.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_preprocessing.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_preprocessing.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_reference_model.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_reference_model.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_reference_model.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_residual_block.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_residual_block.py
@@ -1,1 +1,0 @@
-../../../../../../../models/demos/wormhole/mamba/tests/test_residual_block.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_attention.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention_prefill.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_attention_prefill.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_attention_prefill.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder_prefill.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_decoder_prefill.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_decoder_prefill.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
@@ -1,1 +1,0 @@
-../../../../../../../../models/demos/wormhole/resnet50/tests/test_resnet50_performant.py

--- a/tests/nightly/wh_b0_unstable/tests/ttnn/integration_tests/stable_diffusion
+++ b/tests/nightly/wh_b0_unstable/tests/ttnn/integration_tests/stable_diffusion
@@ -1,1 +1,0 @@
-../../../../../../tests/ttnn/integration_tests/stable_diffusion

--- a/tests/scripts/single_card/nightly/run_common_models.sh
+++ b/tests/scripts/single_card/nightly/run_common_models.sh
@@ -10,7 +10,7 @@ fail=0
 
 echo "Running common models for archs"
 
-env pytest -n auto tests/nightly/common_models/ ; fail+=$?
+env pytest -n auto tests/nightly/single_card/common_models/ ; fail+=$?
 
 if [[ $fail -ne 0 ]]; then
   exit 1

--- a/tests/scripts/single_card/nightly/run_wh_b0_unstable.sh
+++ b/tests/scripts/single_card/nightly/run_wh_b0_unstable.sh
@@ -10,7 +10,7 @@ fail=0
 
 echo "Running unstable nightly tests for WH B0 only"
 
-env SLOW_MATMULS=1 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/ttnn/integration_tests/stable_diffusion --timeout=600; fail+=$?
+env SLOW_MATMULS=1 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/nightly/single_card/wh_b0_unstable/ --timeout=600; fail+=$?
 
 if [[ $fail -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
### Ticket

#12701

### Problem description

We would like more granularity on the nightly tests

### What's changed

Split into specific models because of ownership model on models team (haha)

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
