### PR TITLE
#0: DPrint bugfix for which dispatch cores are included in 'all'

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -87,12 +87,10 @@ static map<CoreType, set<CoreCoord>> get_all_physical_printable_cores(Device *de
 static map<CoreType, set<CoreCoord>> get_dispatch_physical_printable_cores(Device* device) {
     map<CoreType, set<CoreCoord>> physical_printable_dispatch_cores;
     unsigned num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
-    for (unsigned int id = 0; id < tt::Cluster::instance().number_of_user_devices(); id++) {
-        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(id);
-        for (auto logical_core : tt::get_logical_dispatch_cores(id, num_cqs, dispatch_core_type)) {
-            CoreCoord physical_core = device->physical_core_from_logical_core(logical_core, dispatch_core_type);
-            physical_printable_dispatch_cores[dispatch_core_type].insert(physical_core);
-        }
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_type)) {
+        CoreCoord physical_core = device->physical_core_from_logical_core(logical_core, dispatch_core_type);
+        physical_printable_dispatch_cores[dispatch_core_type].insert(physical_core);
     }
     return physical_printable_dispatch_cores;
 }


### PR DESCRIPTION
A small bug in the logic for checking all dispatch cores in the dprint server tripping asserts on Galaxy (getting cores form other devices and passing them to logical -> phys conversion for this device). Shouldn't be getting dispatch cores from other devices to begin with so just remove that.

CI - https://github.com/tenstorrent/tt-metal/actions/runs/10894402793
