### PR TITLE
#12508: Skip failing test in CI

### DIFF
--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -496,6 +496,9 @@ def test_mixtral8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, ins
     if is_ci_env and prefill_len != 32 * 1024 and prefill_len != 128:
         pytest.skip("CI demo test only runs instruct weights with max prefill length of 32k to reduce CI pipeline load")
 
+    if is_ci_env and prefill_len == 32 * 1024:
+        pytest.skip("Skip failing 32k test in CI: #12508")
+
     # Adjust the batch size based on the max prefill length
     if prefill_len >= 16 * 1024:
         batch_size = 4


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12508)

### Problem description
A mixtral issue is breaking t3k demo CI

### What's changed
Disable the failing test until the issue is investigated and resolved

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10901526146)
- [ ] Blackhole Post commit (not applicable)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/10901529977)
- [ ] Device performance regression CI testing passes (not applicable)
- [ ] New/Existing tests provide coverage for changes (not applicable)
