### PR TITLE
#12196: Use split_reader and act db

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -17,7 +17,7 @@ from models.experimental.functional_unet.tt import unet_shallow_ttnn
 
 @pytest.mark.parametrize("batch", [2])
 @pytest.mark.parametrize("groups", [1])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
     torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
     model = unet_shallow_torch.UNet.from_random_weights(groups=1)
@@ -30,4 +30,4 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
 
     B, C, H, W = torch_output_tensor.shape
     ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.986)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -22,7 +22,7 @@ from models.experimental.functional_unet.tests.common import (
 
 @pytest.mark.parametrize("batch", [2])
 @pytest.mark.parametrize("groups", [1])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, reset_seeds):
     if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300 or T3000")
@@ -51,4 +51,4 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     torch_output_tensor = model(torch_input)
     output_tensor = ttnn_model(ttnn_input)
 
-    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.986)
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.97)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -39,7 +39,7 @@ def synchronize_devices(device):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((2, 1, 556.0),),
+    ((2, 1, 639.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float, reset_seeds):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -64,7 +64,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
     ((2, 1, 16, 25.0, 39.0),),
@@ -140,7 +140,7 @@ def test_unet_perf_e2e(
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
     ((2, 1, 16, 25.0, 61.0),),

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -133,7 +133,7 @@ def test_unet_perf_e2e(
     logger.info(f"Running sanity check against reference model output")
     B, C, H, W = torch_output_tensor.shape
     ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.986)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)
 
 
 @pytest.mark.skip("Crashes on N300/T3K - see issue #12685")
@@ -228,4 +228,4 @@ def test_unet_data_parallel_perf_e2e(
     )
 
     logger.info(f"Running sanity check against reference model output")
-    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.986)
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.97)

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -72,8 +72,13 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
     parameters.c1_2["use_split_reader"] = True
     parameters.c1_2["use_activation_double_buffer"] = True
 
-    parameters.c2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
-    parameters.c2_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 6 * 32}
+    parameters.c2["use_split_reader"] = True
+    parameters.c2["use_activation_double_buffer"] = True
+
+    parameters.c2_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 6 * 32}
+    parameters.c2_2["use_activation_double_buffer"] = True
+    parameters.c2_2["use_split_reader"] = True
     parameters.c2_2["use_activation_double_buffer"] = True
 
     parameters.c3["conv_blocking_and_parallelization_config_override"] = None
@@ -112,7 +117,7 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
 
     parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c7["use_activation_double_buffer"] = True
-    parameters.c6_3["use_split_reader"] = True
+    parameters.c7["use_split_reader"] = True
     parameters.c7["input_channels_alignment"] = 16
 
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
@@ -123,12 +128,16 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
     parameters.c7_3["use_split_reader"] = True
     parameters.c7_3["use_activation_double_buffer"] = True
 
-    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
+    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8["use_activation_double_buffer"] = True
-    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
+    parameters.c8["use_split_reader"] = True
+
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
-    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
+    parameters.c8_2["use_split_reader"] = True
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8_3["use_activation_double_buffer"] = True
+    parameters.c8_3["use_split_reader"] = True
 
     parameters.output_layer["conv_blocking_and_parallelization_config_override"] = None
 


### PR DESCRIPTION
Device fps 556 -> 639
Pcc 0.986 -> 0.97

Use split reader and activation double buffer for all convs in Unet.

### Checklist
- [x] Post commit CI passes -  https://github.com/tenstorrent/tt-metal/actions/runs/10904873779
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/10904887809
