### PR TITLE
 #12775: Cleanup docker run action

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -12,6 +12,7 @@ inputs:
   docker_username:
     description: docker login username
     required: true
+    default: ${{ github.actor }}
   docker_password:
     description: docker login password
     required: true
@@ -25,6 +26,11 @@ inputs:
     default: |
       -v /dev/hugepages-1G:/dev/hugepages-1G
       --device /dev/tenstorrent
+  install_wheel:
+    description: "Install the wheel that contains all of the Python environment. The artifact needs to be present."
+    type: boolean
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -32,6 +38,11 @@ runs:
       uses: ./.github/actions/generate-docker-tag
       with:
         image: ${{ inputs.docker_os_arch }}
+    - name: Set 
+      shell: bash
+      run: |
+        echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
+        echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
     - name: Docker login
       uses: docker/login-action@v3
       with:
@@ -49,16 +60,28 @@ runs:
         password: ${{ inputs.docker_password }}
         registry: ghcr.io
         image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
-        # The most important option below is `--rm`. The machines will fill up with containers.
+        # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
+        # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
+        # for newly created files.
+        # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which 
+        # may not be writable by the RUNNER_UID user.
         options: |
+          -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
           --rm
-          -v ${{ github.workspace }}:/github_workspace:ro
+          -v /etc/passwd:/etc/passwd:ro
+          -v /etc/shadow:/etc/shadow:ro
+          -v /etc/bashrc:/etc/bashrc:ro
+          -v ${{ github.workspace }}:${{ github.workspace }}
           --net=host
           ${{ inputs.docker_opts }}
           -e LOGURU_LEVEL=${{ env.LOGURU_LEVEL }}
-          -e PYTHONPATH=/usr/app
+          -e PYTHONPATH=${{ github.workspace }}
+          -e HOME=${{ github.workspace }}
           ${{ inputs.device }}
+          -w ${{ github.workspace }}
         run: |
-          cp -r /github_workspace/* /usr/app/
-          cd /usr/app/
+          if [ ${{ inputs.install_wheel }} ]; then
+            WHEEL_FILENAME=$(ls -1 *.whl)
+            pip3 install $WHEEL_FILENAME
+          fi
           ${{ inputs.run_args }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -57,8 +57,6 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     env:
       LOGURU_LEVEL: INFO
-      # may not need this
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine
@@ -72,12 +70,9 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_username: ${{ github.actor }}
+          install_wheel: true
           docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_image_arch: ${{ inputs.arch }}
           run_args: |
-            WHEEL_FILENAME=$(ls -1 *.whl)
-            pip3 install --user $WHEEL_FILENAME
             ${{ matrix.test-group.cmd }}
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -49,8 +49,6 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     env:
       LOGURU_LEVEL: INFO
-      # may not need this
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
       - in-service
@@ -64,12 +62,9 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_username: ${{ github.actor }}
+          install_wheel: true
           docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_image_arch: ${{ inputs.arch }}
           run_args: |
-            WHEEL_FILENAME=$(ls -1 *.whl)
-            pip3 install --user $WHEEL_FILENAME
             source tests/scripts/run_python_model_tests.sh && run_python_model_tests_${{ inputs.arch }}
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -64,8 +64,6 @@ jobs:
     name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     env:
       LOGURU_LEVEL: INFO
-      # may not need this
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
       - "in-service"


### PR DESCRIPTION
### Ticket

#12775 

### Problem description
   During the review several issues were highlighted of how to make the Docker Run Action be a cleaner interface.

### What's changed
   - Remove unnecessary arch parameter of the docker run action
   - Add a parameter to installing the wheel
   - Remove LD_LIBRARY env variable since it is not used in the wheel environments
   - Remove Github username since it is accessible inside of the custom Action

### Additional features we might want in this PR
 - [ ] Parametrize the image name inside of Docker Run Action
 - [ ] Run the `docker system prune` as the first step for self-healing

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
