### PR TITLE
#12778: Speed up sweeps parameter generation

### DIFF
--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -105,9 +105,17 @@ def export_suite_vectors(module_name, suite_name, vectors):
         )
         for old_vector_id in old_vector_ids:
             client.update(index=index_name, id=old_vector_id, doc={"status": str(VectorStatus.ARCHIVED)})
-        for new_vector_hash in serialized_vectors.keys():
-            client.index(index=index_name, body=serialized_vectors[new_vector_hash])
-        print(f"SWEEPS: Generated {len(serialized_vectors)} test vectors for suite {suite_name}.")
+        serialized_vectors = list(serialized_vectors.values())
+        while serialized_vectors != []:
+            bulk = serialized_vectors[: min(200, len(serialized_vectors))]
+            serialized_vectors = serialized_vectors[min(200, len(serialized_vectors)) :]
+            bulk_query = []
+            for vector in bulk:
+                bulk_query.append({"create": {"_index": index_name}})
+                bulk_query.append(vector)
+            client.bulk(index=index_name, body=bulk_query)
+
+        print(f"SWEEPS: Generated {len(new_vector_hashes)} test vectors for suite {suite_name}.")
 
 
 # Generate one or more sets of test vectors depending on module_name


### PR DESCRIPTION
### Ticket
#12778 

### Problem description
See issue.

### What's changed
Change to uploading the tests in batches of up to 200 at once, instead of making a request to the database for every single test.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
