### PR TITLE
#11005: Added CreateKernelFromString()

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/kernels/CreateKernelFromString.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/kernels/CreateKernelFromString.rst
@@ -1,0 +1,4 @@
+CreateKernelFromString
+=======================
+
+.. doxygenfunction:: CreateKernelFromString

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/kernels/kernels.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/kernels/kernels.rst
@@ -3,3 +3,4 @@ Kernels
 
 .. toctree::
   CreateKernel
+  CreateKernelFromString

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -33,6 +33,7 @@ set (TT_METAL_TESTS_SRCS
     test_compile_program.cpp
     test_kernel_path_env_var.cpp
     test_clean_init.cpp
+    test_create_kernel_from_string.cpp
 )
 
 foreach (TEST_SRC ${TT_METAL_TESTS_SRCS})

--- a/tests/tt_metal/tt_metal/test_create_kernel_from_string.cpp
+++ b/tests/tt_metal/tt_metal/test_create_kernel_from_string.cpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <unordered_set>
+
+#include "core_coord.h"
+#include "detail/tt_metal.hpp"
+#include "host_api.hpp"
+#include "impl/device/device.hpp"
+#include "impl/kernels/data_types.hpp"
+#include "impl/kernels/kernel_types.hpp"
+#include "impl/program/program.hpp"
+#include "tt_cluster_descriptor_types.h"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+class CompileProgramWithKernelCreatedFromString : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        vector<chip_id_t> device_ids;
+        const uint32_t num_devices = GetNumAvailableDevices();
+        for (chip_id_t i = 0; i < num_devices; i++) {
+            device_ids.push_back(i);
+        }
+        this->devices_ = detail::CreateDevices(device_ids);
+    }
+
+    void TearDown() override { detail::CloseDevices(this->devices_); }
+
+    std::map<chip_id_t, Device *> devices_;
+};
+
+TEST_F(CompileProgramWithKernelCreatedFromString, DataMovementKernel) {
+    const CoreRange cores({0, 0}, {1, 1});
+    const string &kernel_src_code = R"(
+    #include <stdint.h>
+    #include "dataflow_api.h"
+
+    void kernel_main() {
+        uint32_t src_addr = get_arg_val<uint32_t>(0);
+        uint32_t src_noc_x = get_arg_val<uint32_t>(1);
+        uint32_t src_noc_y = get_arg_val<uint32_t>(2);
+        uint32_t num_tiles = get_arg_val<uint32_t>(3);
+
+        constexpr uint32_t cb_id_in0 = 0;
+
+        constexpr uint32_t ublock_size_tiles = 4;
+        uint32_t ublock_size_bytes = get_tile_size(cb_id_in0) * ublock_size_tiles;
+
+        for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+            uint64_t src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, src_addr);
+
+            cb_reserve_back(cb_id_in0, ublock_size_tiles);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+            noc_async_read(src_noc_addr, l1_write_addr, ublock_size_bytes);
+
+            noc_async_read_barrier();
+
+            cb_push_back(cb_id_in0, ublock_size_tiles);
+            src_addr += ublock_size_bytes;
+        }
+    }
+    )";
+
+    Program program = CreateProgram();
+    tt_metal::CreateKernelFromString(
+        program,
+        kernel_src_code,
+        cores,
+        tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    for (auto [_, device] : this->devices_) {
+        detail::CompileProgram(device, program);
+    };
+}
+
+TEST_F(CompileProgramWithKernelCreatedFromString, ComputeKernel) {
+    const CoreRange cores({0, 0}, {1, 1});
+    const string &kernel_src_code = R"(
+#include "debug/dprint.h"
+#include "compute_kernel_api.h"
+
+namespace NAMESPACE {
+
+    void MAIN {
+
+        DPRINT_MATH(DPRINT << "Hello, I am running a void compute kernel." << ENDL());
+
+    }
+
+}
+    )";
+
+    Program program = CreateProgram();
+    tt_metal::CreateKernelFromString(
+        program,
+        kernel_src_code,
+        cores,
+        tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = {}});
+
+    for (auto [_, device] : this->devices_) {
+        detail::CompileProgram(device, program);
+    };
+}
+
+TEST_F(CompileProgramWithKernelCreatedFromString, EthernetKernel) {
+    const string &kernel_src_code = R"(
+#include <cstdint>
+#include "debug/ring_buffer.h"
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+void kernel_main() {
+#else
+#include "compute_kernel_api/common.h"
+namespace NAMESPACE {
+void MAIN {
+#endif
+
+#if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
+    (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
+    (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
+    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+    for (uint32_t idx = 0; idx < 40; idx++) {
+        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
+    }
+#endif
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+}
+#else
+}
+}
+#endif
+)";
+
+    for (auto [device_id, device] : this->devices_) {
+        const std::unordered_set<CoreCoord> &active_ethernet_cores = device->get_active_ethernet_cores(true);
+        if (active_ethernet_cores.empty()) {
+            log_info(LogTest, "Skipping this test on device {} because it has no active ethernet cores.", device_id);
+            continue;
+        }
+        Program program = CreateProgram();
+        tt_metal::CreateKernelFromString(
+            program,
+            kernel_src_code,
+            *active_ethernet_cores.begin(),
+            tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+        detail::CompileProgram(device, program);
+    };
+}

--- a/tests/tt_metal/tt_metal/test_create_kernel_from_string.cpp
+++ b/tests/tt_metal/tt_metal/test_create_kernel_from_string.cpp
@@ -4,8 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <unordered_set>
-
 #include "core_coord.h"
 #include "detail/tt_metal.hpp"
 #include "host_api.hpp"
@@ -13,28 +11,13 @@
 #include "impl/kernels/data_types.hpp"
 #include "impl/kernels/kernel_types.hpp"
 #include "impl/program/program.hpp"
-#include "tt_cluster_descriptor_types.h"
+
+#include "tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
-class CompileProgramWithKernelCreatedFromString : public ::testing::Test {
-   protected:
-    void SetUp() override {
-        vector<chip_id_t> device_ids;
-        const uint32_t num_devices = GetNumAvailableDevices();
-        for (chip_id_t i = 0; i < num_devices; i++) {
-            device_ids.push_back(i);
-        }
-        this->devices_ = detail::CreateDevices(device_ids);
-    }
-
-    void TearDown() override { detail::CloseDevices(this->devices_); }
-
-    std::map<chip_id_t, Device *> devices_;
-};
-
-TEST_F(CompileProgramWithKernelCreatedFromString, DataMovementKernel) {
+TEST_F(CommonFixture, ProgramWithDataMovementKernelCreatedFromString) {
     const CoreRange cores({0, 0}, {1, 1});
     const string &kernel_src_code = R"(
     #include <stdint.h>
@@ -74,12 +57,13 @@ TEST_F(CompileProgramWithKernelCreatedFromString, DataMovementKernel) {
         cores,
         tt_metal::DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    for (auto [_, device] : this->devices_) {
+    for (Device *device : this->devices_) {
         detail::CompileProgram(device, program);
+        this->RunProgram(device, program);
     };
 }
 
-TEST_F(CompileProgramWithKernelCreatedFromString, ComputeKernel) {
+TEST_F(CommonFixture, ProgramWithComputeKernelCreatedFromString) {
     const CoreRange cores({0, 0}, {1, 1});
     const string &kernel_src_code = R"(
 #include "debug/dprint.h"
@@ -107,12 +91,13 @@ namespace NAMESPACE {
             .math_approx_mode = false,
             .compile_args = {}});
 
-    for (auto [_, device] : this->devices_) {
+    for (Device *device : this->devices_) {
         detail::CompileProgram(device, program);
+        this->RunProgram(device, program);
     };
 }
 
-TEST_F(CompileProgramWithKernelCreatedFromString, EthernetKernel) {
+TEST_F(CommonFixture, ProgramWithEthernetKernelCreatedFromString) {
     const string &kernel_src_code = R"(
 #include <cstdint>
 #include "debug/ring_buffer.h"
@@ -142,9 +127,10 @@ void MAIN {
 #endif
 )";
 
-    for (auto [device_id, device] : this->devices_) {
+    for (Device *device : this->devices_) {
         const std::unordered_set<CoreCoord> &active_ethernet_cores = device->get_active_ethernet_cores(true);
         if (active_ethernet_cores.empty()) {
+            const chip_id_t device_id = device->id();
             log_info(LogTest, "Skipping this test on device {} because it has no active ethernet cores.", device_id);
             continue;
         }
@@ -155,5 +141,6 @@ void MAIN {
             *active_ethernet_cores.begin(),
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::NOC_0});
         detail::CompileProgram(device, program);
+        this->RunProgram(device, program);
     };
 }

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -128,7 +128,7 @@ KernelHandle CreateKernel(
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
 
 /**
- * Creates a data movement kernel with no compile time arguments and adds it to the program.
+ * Creates a compute or data movement kernel with the given compile time arguments and adds it to the program.
  *
  * Return value: Kernel ID (uintptr_t)
  *

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -127,6 +127,24 @@ KernelHandle CreateKernel(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
 
+/**
+ * Creates a data movement kernel with no compile time arguments and adds it to the program.
+ *
+ * Return value: Kernel ID (uintptr_t)
+ *
+ * | Argument           | Description                                                                                                                          | Type                                                     | Valid Range | Required |
+ * |--------------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|-------------|----------|
+ * | program            | The program to which this kernel will be added to                                                                                    | Program &                                                |             | Yes      |
+ * | kernel_src_code    | Source code for kernel                                                                                                               | const std::string &                                      |             | Yes      |
+ * | core_spec          | Either a single logical core, a range of logical cores or a set of logical core ranges that indicate which cores kernel is placed on | const std::variant<CoreCoord, CoreRange, CoreRangeSet> & |             | Yes      |
+ * | config             | Config for data movement or compute kernel                                                                                           | const std::variant<DataMovementConfig,ComputeConfig,EthernetConfig> &   |             | No       |
+ */
+KernelHandle CreateKernelFromString(
+    Program &program,
+    const std::string &kernel_src_code,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
+
 // ==================================================
 //                  HOST API: buffers
 // ==================================================

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -247,7 +247,7 @@ void Device::build_firmware() {
     ZoneScoped;
 
     this->generate_device_headers(this->build_env_.get_out_firmware_root_path());
-    jit_build_set(this->firmware_build_states_, nullptr, "");
+    jit_build_set(this->firmware_build_states_, nullptr);
 }
 
 void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -22,18 +22,18 @@ namespace tt {
 namespace tt_metal {
 
 Kernel::Kernel(
-    const std::string &kernel_path_file_name,
+    const KernelSource &kernel_src,
     const CoreRangeSet &core_range_set,
     const std::vector<uint32_t> &compile_args,
     const std::map<std::string, std::string> &defines) :
-    watcher_kernel_id_(watcher_register_kernel(kernel_path_file_name)),
-    kernel_path_file_name_(kernel_path_file_name),
+    kernel_src_(kernel_src),
     core_range_set_(core_range_set),
     binary_size16_(0),
     max_runtime_args_per_core_(0),
     core_with_max_runtime_args_({0, 0}),
     compile_time_args_(compile_args),
     defines_(defines) {
+    this->register_kernel_with_watcher();
 
     size_t max_x = 0, max_y = 0;
     for (auto core_range : this->core_range_set_.ranges()) {
@@ -50,8 +50,8 @@ Kernel::Kernel(
     }
     this->core_to_runtime_args_ = {max_x + 1, std::vector<std::vector<uint32_t>>(max_y + 1, std::vector<uint32_t>())};
     this->core_to_runtime_args_data_ = {max_x + 1, std::vector<RuntimeArgsData>(max_y + 1, RuntimeArgsData{})};
-    for (auto& runtime_args_data_x : this->core_to_runtime_args_data_) {
-        for (auto& runtime_args_data: runtime_args_data_x) {
+    for (auto &runtime_args_data_x : this->core_to_runtime_args_data_) {
+        for (auto &runtime_args_data : runtime_args_data_x) {
             runtime_args_data.rt_args_data = nullptr;
             runtime_args_data.rt_args_count = 0;
         }
@@ -59,12 +59,16 @@ Kernel::Kernel(
     this->common_runtime_args_count_ = 0;
 }
 
-std::string Kernel::name() const {
-    auto pos_of_name = kernel_path_file_name_.rfind("/") + 1;
-    auto pos_of_dot = kernel_path_file_name_.rfind(".");
-    std::string kernel_name = kernel_path_file_name_.substr(pos_of_name, (pos_of_dot - pos_of_name));
-    return kernel_name;
+void Kernel::register_kernel_with_watcher() {
+    if (this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
+        this->watcher_kernel_id_ = watcher_register_kernel(this->kernel_src_.source_);
+    } else {
+        TT_FATAL(this->kernel_src_.source_type_ == KernelSource::SOURCE_CODE, "Unsupported kernel source type!");
+        this->watcher_kernel_id_ = watcher_register_kernel(this->name());
+    }
 }
+
+std::string Kernel::name() const { return this->kernel_src_.name(); }
 
 const std::set<CoreCoord> &Kernel::logical_cores() const { return this->logical_cores_; }
 
@@ -164,7 +168,7 @@ std::string ComputeKernel::config_hash() const {
 std::string Kernel::compute_hash() const {
     return fmt::format(
         "{}_{}_{}_{}",
-        std::hash<std::string>{}(this->kernel_path_file_name_),
+        std::hash<std::string>{}(this->kernel_src_.source_),
         fmt::join(this->compile_time_args_, "_"),
         KernelDefinesHash{}(this->defines_),
         this->config_hash());
@@ -285,15 +289,13 @@ bool Kernel::is_idle_eth() {
     return std::holds_alternative<EthernetConfig>(this->config()) && std::get<EthernetConfig>(this->config()).eth_mode == Eth::IDLE;
 }
 
-void DataMovementKernel::set_build_options(JitBuildOptions& build_options) const {
+void DataMovementKernel::set_build_options(JitBuildOptions &build_options) const {
     ZoneScoped;
     switch (this->config_.processor) {
         case DataMovementProcessor::RISCV_0: {
-            build_options.brisc_kernel_file_name = this->kernel_path_file_name_;
             build_options.brisc_defines = this->defines_;
         } break;
         case DataMovementProcessor::RISCV_1: {
-            build_options.ncrisc_kernel_file_name = this->kernel_path_file_name_;
             build_options.ncrisc_defines = this->defines_;
         } break;
         default: TT_THROW("Unsupported data movement processor!"); break;
@@ -301,12 +303,10 @@ void DataMovementKernel::set_build_options(JitBuildOptions& build_options) const
 }
 
 void EthernetKernel::set_build_options(JitBuildOptions &build_options) const {
-    build_options.erisc_kernel_file_name = this->kernel_path_file_name_;
     build_options.erisc_defines = this->defines_;
 }
 
 void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
-    build_options.set_hlk_file_name_all_cores(this->kernel_path_file_name_);
     build_options.set_hlk_math_fidelity_all_cores(this->config_.math_fidelity);
     build_options.set_hlk_math_approx_mode_all_cores(this->config_.math_approx_mode);
     build_options.fp32_dest_acc_en = this->config_.fp32_dest_acc_en;
@@ -315,25 +315,23 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 }
 
 void DataMovementKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
-    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_path_file_name_);
+    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
     device->generate_device_headers(build_options.path);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    jit_build(
-        device->build_kernel_state(JitBuildProcessorType::DATA_MOVEMENT, riscv_id), this, this->kernel_path_file_name_);
+    jit_build(device->build_kernel_state(JitBuildProcessorType::DATA_MOVEMENT, riscv_id), this);
 }
 
 void EthernetKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
-    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_path_file_name_);
+    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
     device->generate_device_headers(build_options.path);
     int erisc_id = this->config_.eth_mode == Eth::IDLE ? 1 : 0;
-    jit_build(
-        device->build_kernel_state(JitBuildProcessorType::ETHERNET, erisc_id), this, this->kernel_path_file_name_);
+    jit_build(device->build_kernel_state(JitBuildProcessorType::ETHERNET, erisc_id), this);
 }
 
 void ComputeKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
-    jit_build_genfiles_triscs_src(device->build_env(), *this, this->kernel_path_file_name_);
+    jit_build_genfiles_triscs_src(device->build_env(), *this, this->kernel_src_);
     JitBuildStateSubset build_states = device->build_kernel_states(JitBuildProcessorType::COMPUTE);
-    jit_build_subset(build_states, this, this->kernel_path_file_name_);
+    jit_build_subset(build_states, this);
 }
 
 void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory> &&binaries) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -171,7 +171,8 @@ void JitBuildState::finish_init() {
         if (this->target_name_ != "erisc") {
             this->link_objs_ += build_dir + "tmu-crt0.o ";
         }
-        if (this->target_name_ == "ncrisc" and ((this->env_.arch_ == tt::ARCH::GRAYSKULL or this->env_.arch_ == tt::ARCH::WORMHOLE_B0))) {
+        if (this->target_name_ == "ncrisc" and
+            ((this->env_.arch_ == tt::ARCH::GRAYSKULL or this->env_.arch_ == tt::ARCH::WORMHOLE_B0))) {
             this->link_objs_ += build_dir + "ncrisc-halt.o ";
         }
     } else {
@@ -196,7 +197,8 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
 
     this->defines_ = env_.defines_;
 
-    uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    uint32_t l1_cache_disable_mask =
+        tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
 
     // TODO(pgk): build these once at init into built/libs!
     this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
@@ -264,8 +266,11 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, int which, bool is_fw) 
     this->cflags_ = env_.cflags_ + "-O3 ";
 
     this->defines_ = env_.defines_;
-    uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
-    uint32_t debug_compute_mask = (tt::llrt::DebugHartFlags::RISCV_TR0 | tt::llrt::DebugHartFlags::RISCV_TR1 | tt::llrt::DebugHartFlags::RISCV_TR2);
+    uint32_t l1_cache_disable_mask =
+        tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    uint32_t debug_compute_mask =
+        (tt::llrt::DebugHartFlags::RISCV_TR0 | tt::llrt::DebugHartFlags::RISCV_TR1 |
+         tt::llrt::DebugHartFlags::RISCV_TR2);
     if ((l1_cache_disable_mask & debug_compute_mask) == debug_compute_mask) {
         this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
     }
@@ -348,7 +353,8 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
                       "/metal/llk_io ";
 
     this->defines_ = env_.defines_;
-    uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    uint32_t l1_cache_disable_mask =
+        tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
     if ((l1_cache_disable_mask & tt::llrt::DebugHartFlags::RISCV_ER) == tt::llrt::DebugHartFlags::RISCV_ER) {
         this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
     }
@@ -436,8 +442,6 @@ static void build_failure(const string& target_name, const string& op, const str
     }
     TT_THROW("{} build failed", target_name);
 }
-
-void JitBuildState::pre_compile(const string& kernel_in_path, const string& op_out_path) const {}
 
 void JitBuildState::compile_one(
     const string& log_file,
@@ -647,48 +651,29 @@ void JitBuildState::build(const JitBuildSettings* settings) const {
     extract_zone_src_locations(log_file);
 }
 
-void jit_build(const JitBuildState& build, const JitBuildSettings* settings, const string& kernel_in_path) {
+void jit_build(const JitBuildState& build, const JitBuildSettings* settings) {
     ZoneScoped;
-
-    if (settings != nullptr) {
-        build.pre_compile(kernel_in_path, settings->get_full_kernel_name());
-    }
 
     build.build(settings);
 }
 
-void jit_build_set(const JitBuildStateSet& build_set, const JitBuildSettings* settings, const string& kernel_in_path) {
+void jit_build_set(const JitBuildStateSet& build_set, const JitBuildSettings* settings) {
     ZoneScoped;
     std::vector<std::shared_future<void>> events;
     for (size_t i = 0; i < build_set.size(); ++i) {
         // Capture the necessary objects by reference
         auto& build = build_set[i];
-        launch_build_step(
-            [build, settings, &kernel_in_path] {
-                if (settings != nullptr) {
-                    build->pre_compile(kernel_in_path, settings->get_full_kernel_name());
-                }
-                build->build(settings);
-            },
-            events);
+        launch_build_step([build, settings] { build->build(settings); }, events);
     }
     sync_build_step(events);
 }
 
-void jit_build_subset(
-    const JitBuildStateSubset& build_subset, const JitBuildSettings* settings, const string& kernel_in_path) {
+void jit_build_subset(const JitBuildStateSubset& build_subset, const JitBuildSettings* settings) {
     std::vector<std::shared_future<void>> events;
     for (size_t i = 0; i < build_subset.size; ++i) {
         // Capture the necessary objects by reference
         auto& build = build_subset.build_ptr[i];
-        launch_build_step(
-            [build, settings, &kernel_in_path] {
-                if (settings != nullptr) {
-                    build->pre_compile(kernel_in_path, settings->get_full_kernel_name());
-                }
-                build->build(settings);
-            },
-            events);
+        launch_build_step([build, settings] { build->build(settings); }, events);
     }
     sync_build_step(events);
 }

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -113,7 +113,6 @@ class alignas(CACHE_LINE_ALIGNMENT) JitBuildState {
     virtual ~JitBuildState() = default;
     void finish_init();
 
-    virtual void pre_compile(const string& kernel_in_path, const string& op_out_path) const;
     void build(const JitBuildSettings *settings) const;
 
     const string& get_out_path() const { return this->out_path_; };
@@ -165,9 +164,9 @@ class JitBuildSettings {
     bool use_multi_threaded_compile = true;
 };
 
-void jit_build(const JitBuildState& build, const JitBuildSettings *settings, const string& kernel_in_path);
-void jit_build_set(const JitBuildStateSet& builds, const JitBuildSettings *settings, const string& kernel_in_path);
-void jit_build_subset(const JitBuildStateSubset& builds, const JitBuildSettings *settings, const string& kernel_in_path);
+void jit_build(const JitBuildState& build, const JitBuildSettings* settings);
+void jit_build_set(const JitBuildStateSet& builds, const JitBuildSettings* settings);
+void jit_build_subset(const JitBuildStateSubset& builds, const JitBuildSettings* settings);
 
 inline const string jit_build_get_kernel_compile_outpath(int build_key) {
     // TODO(pgk), get rid of this

--- a/tt_metal/jit_build/genfiles.hpp
+++ b/tt_metal/jit_build/genfiles.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "common/core_coord.h"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
@@ -16,9 +17,9 @@ class JitBuildSettings;
 class JitBuildOptions;
 
 void jit_build_genfiles_kernel_include(
-    const JitBuildEnv& env, const JitBuildSettings& settings, const std::string& input_hlk_file_path);
+    const JitBuildEnv& env, const JitBuildSettings& settings, const KernelSource& kernel_src);
 void jit_build_genfiles_triscs_src(
-    const JitBuildEnv& env, const JitBuildSettings& settings, const std::string& kernel_in_path);
+    const JitBuildEnv& env, const JitBuildSettings& settings, const KernelSource& kernel_src);
 
 void jit_build_genfiles_bank_to_noc_coord_descriptor(
     const std::string& path,

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -7,9 +7,9 @@
 #include <string>
 
 #include "hostdevcommon/kernel_structs.h"
+#include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/base_types.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
-#include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/utils.hpp"
 
 namespace tt
@@ -25,11 +25,10 @@ class tt_hlk_desc
     MathFidelity math_fidelity;
     bool approximation_mode;
 
-    std::string hlk_file_name; // HLK kernel file name (user writes)
-    void *hlk_args; // void ptr to user-defined hlk_args_t struct (user writes)
-    size_t hlk_args_size; // size of hlk_args_t in bytes (result of sizeof())
+    void* hlk_args;        // void ptr to user-defined hlk_args_t struct (user writes)
+    size_t hlk_args_size;  // size of hlk_args_t in bytes (result of sizeof())
 
-    public:
+   public:
     DataFormat input_buf_dataformat_arr[8];
     DataFormat param_buf_dataformat_arr[8];
     DataFormat output_buf_dataformat_arr[8];
@@ -42,10 +41,8 @@ class tt_hlk_desc
     uint32_t buf_tile_c_dim_arr[32];
     uint32_t buf_tile_size_arr[32];
 
-    tt_hlk_desc()
-    {
+    tt_hlk_desc() {
         math_fidelity = MathFidelity::Invalid;
-        hlk_file_name = "";
         hlk_args = nullptr;
         hlk_args_size = 0;
         approximation_mode = true;
@@ -92,7 +89,6 @@ class tt_hlk_desc
         }
 
         math_fidelity = in.math_fidelity;
-        hlk_file_name = in.hlk_file_name;
         hlk_args = in.hlk_args;
         hlk_args_size = in.hlk_args_size;
         approximation_mode = in.approximation_mode;
@@ -217,16 +213,6 @@ class tt_hlk_desc
     void* get_hlk_args() const
     {
         return hlk_args;
-    }
-
-    void set_hlk_file_name(std::string file_name)
-    {
-        hlk_file_name = file_name;
-    }
-
-    const std::string & get_hlk_file_name() const
-    {
-        return hlk_file_name;
     }
 
     void set_hlk_math_fidelity(MathFidelity math_fi)

--- a/tt_metal/jit_build/settings.cpp
+++ b/tt_metal/jit_build/settings.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_metal/common/assert.hpp"
-#include "tt_metal/common/core_coord.h"
 #include "jit_build/settings.hpp"
 #include "jit_build/build.hpp"
 #include <iostream>
@@ -20,11 +18,6 @@ namespace tt::tt_metal
     {
         name = n;
         path = build_env.get_out_kernel_root_path() + n;
-    }
-
-    void JitBuildOptions::set_hlk_file_name_all_cores(std::string file_name)
-    {
-        hlk_desc.set_hlk_file_name(file_name);
     }
 
     void JitBuildOptions::set_hlk_math_fidelity_all_cores(MathFidelity math_fidelity)

--- a/tt_metal/jit_build/settings.hpp
+++ b/tt_metal/jit_build/settings.hpp
@@ -6,8 +6,6 @@
 
 #include <map>
 
-#include "common/core_coord.h"
-#include "common/utils.hpp"
 #include "hlk_desc.hpp"
 #include "hostdevcommon/kernel_structs.h"
 
@@ -29,15 +27,6 @@ class JitBuildOptions {
     bool fp32_dest_acc_en;
     std::vector<UnpackToDestMode> unpack_to_dest_mode;
 
-    // BRISC config
-    std::string brisc_kernel_file_name;
-
-    // NCRISC config
-    std::string ncrisc_kernel_file_name;
-
-    // ERISC config
-    std::string erisc_kernel_file_name;
-
     std::map<std::string, std::string> hlk_defines;  // preprocessor defines for HLK
     std::map<std::string, std::string> ncrisc_defines;
     std::map<std::string, std::string> brisc_defines;
@@ -46,7 +35,6 @@ class JitBuildOptions {
     JitBuildOptions(const JitBuildEnv& env);
     void set_name(const std::string& name);
 
-    void set_hlk_file_name_all_cores(std::string file_name);
     void set_hlk_math_fidelity_all_cores(MathFidelity math_fidelity);
     void set_hlk_math_approx_mode_all_cores(bool approx_mode);
     void set_hlk_args_all_cores(void* args, size_t size);

--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -154,12 +154,12 @@ static inline json get_kernels_json(const Program& program) {
             MathFidelity mathFidelity = std::get<ComputeConfig>(computeKernel->config()).math_fidelity;
             json computeKernelObj;
             computeKernelObj["math_fidelity"] = fmt::format("{}", magic_enum::enum_name(mathFidelity));
-            computeKernelObj["path"] = computeKernel->kernel_path_file_name();
+            computeKernelObj["source"] = computeKernel->kernel_source().source_;
             computeKernelObj["name"] = computeKernel->get_full_kernel_name();
             computeKernels.push_back(computeKernelObj);
         } else {
             json datamovementKernelObj;
-            datamovementKernelObj["path"] = kernel->kernel_path_file_name();
+            datamovementKernelObj["source"] = kernel->kernel_source().source_;
             datamovementKernelObj["name"] = kernel->get_full_kernel_name();
             datamovementKernels.push_back(datamovementKernelObj);
         }
@@ -329,7 +329,6 @@ inline std::string op_meta_data_serialized_json(
     const auto& operation_attributes,
     const auto& tensor_args,
     auto& tensor_return_value) {
-
     const bool useCachedOps = std::getenv("TT_METAL_PROFILER_NO_CACHE_OP_INFO") == nullptr;
     auto program_hash = compute_program_hash<device_operation_t>(operation_attributes, tensor_args);
 

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -61,9 +61,9 @@ OPS_CSV_HEADER = [
     "DEVICE COMPUTE CB RESERVE BACK [ns]",
     "INPUTS",
     "OUTPUTS",
-    "COMPUTE KERNEL PATH",
+    "COMPUTE KERNEL SOURCE",
     "COMPUTE KERNEL HASH",
-    "DATA MOVEMENT KERNEL PATH",
+    "DATA MOVEMENT KERNEL SOURCE",
     "DATA MOVEMENT KERNEL HASH",
     "PM IDEAL [ns]",
     "PM COMPUTE [ns]",
@@ -477,17 +477,17 @@ def generate_reports(ops, deviceOps, signposts, outputFolder, date, nameAppend):
                 rowDict["HOST DURATION [ns]"] = int(opData["host_time"]["exec_time_ns"])
 
                 if "kernel_info" in opData.keys():
-                    rowDict["COMPUTE KERNEL PATH"] = []
+                    rowDict["COMPUTE KERNEL SOURCE"] = []
                     rowDict["COMPUTE KERNEL HASH"] = []
-                    rowDict["DATA MOVEMENT KERNEL PATH"] = []
+                    rowDict["DATA MOVEMENT KERNEL SOURCE"] = []
                     rowDict["DATA MOVEMENT KERNEL HASH"] = []
                     for computeKernel in opData["kernel_info"]["compute_kernels"]:
                         rowDict["MATH FIDELITY"] = computeKernel["math_fidelity"]
-                        rowDict["COMPUTE KERNEL PATH"].append(computeKernel["path"])
+                        rowDict["COMPUTE KERNEL SOURCE"].append(computeKernel["source"])
                         rowDict["COMPUTE KERNEL HASH"].append(computeKernel["name"])
 
                     for dmKernel in opData["kernel_info"]["datamovement_kernels"]:
-                        rowDict["DATA MOVEMENT KERNEL PATH"].append(dmKernel["path"])
+                        rowDict["DATA MOVEMENT KERNEL SOURCE"].append(dmKernel["source"])
                         rowDict["DATA MOVEMENT KERNEL HASH"].append(dmKernel["name"])
 
                 if "core_usage" in opData.keys():


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11005

### What's changed
Created a new function called `CreateKernelFromString()` that does the same thing as `CreateKernel()` but instead of taking in a path to a file, it takes in a string that has the source code of the kernel.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
