### PR TITLE
Expose L1 usage interface through MLIR interface lib

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_mlir_interface_lib.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_mlir_interface_lib.cpp
@@ -1,119 +1,431 @@
 #include <gtest/gtest.h>
+
 #include <cstddef>
 
 #include "mlir_interface_api.hpp"
 
-
-TEST(MLIR_INTERFACE_API, binary_op)
-{
-  std::vector<uint32_t> shape = {1, 1, 32, 32};
-  ttnn::mlir_interface::memory_config_tuple memory_config = {"interleaved", "l1", std::nullopt};
-  std::string data_type = "bf16";
-  EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+static void compare_cb_allocations(
+    const std::vector<uint32_t>& expected, const std::optional<std::vector<uint32_t>>& output) {
+    EXPECT_TRUE(output.has_value());
+    for (auto x : output.value()) {
+        std::cout << "CB " << x << std::endl;
+    }
+    EXPECT_EQ(expected.size(), output.value().size());
+    for (int i = 0; i < expected.size(); i++) {
+        EXPECT_EQ(expected[i], output.value()[i]);
+    }
 }
 
-TEST(MLIR_INTERFACE_API, binary_op_batch_broadcast)
-{
-  std::vector<uint32_t> shape_a = {2, 1, 32, 32};
-  std::vector<uint32_t> shape_b = {1, 1, 32, 32};
-  ttnn::mlir_interface::memory_config_tuple memory_config = {"interleaved", "dram", std::nullopt};
-  std::string data_type = "bf16";
+TEST(MLIR_INTERFACE_API, binary_op) {
+    std::vector<uint32_t> shape = {1, 1, 32, 32};
+    ttnn::mlir_interface::memory_config_tuple memory_config = {"interleaved", "l1", std::nullopt};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(shape_a, memory_config, data_type, shape_b, memory_config, data_type, memory_config, data_type));
-  EXPECT_FALSE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(shape_b, memory_config, data_type, shape_a, memory_config, data_type, memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(
+        shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    compare_cb_allocations(
+        {4096, 4096, 4096},
+        ttnn::mlir_interface::get_binary_circular_buffers_l1_allocations(
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout));
+    EXPECT_TRUE(ttnn::mlir_interface::get_binary_tensor_buffers_l1_allocations(
+                    shape,
+                    memory_config,
+                    data_type,
+                    layout,
+                    shape,
+                    memory_config,
+                    data_type,
+                    layout,
+                    shape,
+                    memory_config,
+                    data_type,
+                    layout)
+                    .has_value());
 }
 
-TEST(MLIR_INTERFACE_API, binary_op_width_sharded)
-{
-  std::vector<uint32_t> shape = {1, 1, 32, 32 * 64 * 5};
-  ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32, 32 * 5}, "col_major", false};
-  ttnn::mlir_interface::memory_config_tuple memory_config = {"width_sharded", "l1", shard_spec};
-  std::string data_type = "bf16";
+TEST(MLIR_INTERFACE_API, binary_op_batch_broadcast) {
+    std::vector<uint32_t> shape_a = {2, 1, 32, 32};
+    std::vector<uint32_t> shape_b = {1, 1, 32, 32};
+    ttnn::mlir_interface::memory_config_tuple memory_config = {"interleaved", "dram", std::nullopt};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(
+        shape_a, memory_config, data_type, shape_b, memory_config, data_type, memory_config, data_type));
+    compare_cb_allocations(
+        {4096, 4096, 4096, 4096},
+        ttnn::mlir_interface::get_binary_circular_buffers_l1_allocations(
+            shape_a,
+            memory_config,
+            data_type,
+            layout,
+            shape_b,
+            memory_config,
+            data_type,
+            layout,
+            shape_a,
+            memory_config,
+            data_type,
+            layout));
+
+    EXPECT_FALSE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(
+        shape_b, memory_config, data_type, shape_a, memory_config, data_type, memory_config, data_type));
 }
 
-TEST(MLIR_INTERFACE_API, binary_op_height_sharded)
-{
-  std::vector<uint32_t> shape = {1, 64, 32 * 5, 32};
-  ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32 * 5, 32}, "col_major", false};
-  ttnn::mlir_interface::memory_config_tuple memory_config = {"height_sharded", "l1", shard_spec};
-  std::string data_type = "bf16";
+TEST(MLIR_INTERFACE_API, binary_op_width_sharded) {
+    std::vector<uint32_t> shape = {1, 1, 32, 32 * 64 * 5};
+    ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32, 32 * 5}, "col_major", false};
+    ttnn::mlir_interface::memory_config_tuple memory_config = {"width_sharded", "l1", shard_spec};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(
+        shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    compare_cb_allocations(
+        {0, 0, 0},
+        ttnn::mlir_interface::get_binary_circular_buffers_l1_allocations(
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout));
 }
 
-TEST(MLIR_INTERFACE_API, binary_op_block_sharded)
-{
-  std::vector<uint32_t> shape = {1, 1, 32 * 5 * 2, 32 * 3 * 2};
-  ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 2, 2}}, {32 * 5, 32 * 3}, "row_major", false};
-  ttnn::mlir_interface::memory_config_tuple memory_config = {"block_sharded", "l1", shard_spec};
-  std::string data_type = "bf16";
+TEST(MLIR_INTERFACE_API, binary_op_height_sharded) {
+    std::vector<uint32_t> shape = {1, 64, 32 * 5, 32};
+    ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32 * 5, 32}, "col_major", false};
+    ttnn::mlir_interface::memory_config_tuple memory_config = {"height_sharded", "l1", shard_spec};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(
+        shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    compare_cb_allocations(
+        {0, 0, 0},
+        ttnn::mlir_interface::get_binary_circular_buffers_l1_allocations(
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout));
 }
 
-TEST(MLIR_INTERFACE_API, unary_op)
-{
-  std::vector<uint32_t> shape = {1, 1, 32, 32 * 5 * 64};
-  ttnn::mlir_interface::memory_config_tuple l1_interleaved_memory_config = {"interleaved", "l1", std::nullopt};
-  ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32, 32 * 5}, "col_major", false};
-  ttnn::mlir_interface::memory_config_tuple l1_sharded_memory_config = {"width_sharded", "l1", shard_spec};
-  ttnn::mlir_interface::memory_config_tuple dram_interleaved_memory_config = {"interleaved", "dram", std::nullopt};
-  std::string data_type = "bf16";
+TEST(MLIR_INTERFACE_API, binary_op_block_sharded) {
+    std::vector<uint32_t> shape = {1, 1, 32 * 5 * 2, 32 * 3 * 2};
+    ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 2, 2}}, {32 * 5, 32 * 3}, "row_major", false};
+    ttnn::mlir_interface::memory_config_tuple memory_config = {"block_sharded", "l1", shard_spec};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, l1_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
-  EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, l1_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
-  EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, l1_sharded_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, l1_sharded_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
-
-  EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, dram_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
-  EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, l1_sharded_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
-  EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, dram_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
-
-  EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, dram_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints("RELU", shape, l1_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_binary_op_support_input_output_constraints(
+        shape, memory_config, data_type, shape, memory_config, data_type, memory_config, data_type));
+    compare_cb_allocations(
+        {0, 0, 0},
+        ttnn::mlir_interface::get_binary_circular_buffers_l1_allocations(
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout,
+            shape,
+            memory_config,
+            data_type,
+            layout));
 }
 
-TEST(MLIR_INTERFACE_API, softmax_op)
-{
-  std::vector<uint32_t> shape = {1, 1, 32, 32 * 5 * 64};
-  ttnn::mlir_interface::memory_config_tuple l1_interleaved_memory_config = {"interleaved", "l1", std::nullopt};
-  ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32, 32 * 5}, "col_major", false};
-  ttnn::mlir_interface::memory_config_tuple l1_sharded_memory_config = {"width_sharded", "l1", shard_spec};
-  ttnn::mlir_interface::memory_config_tuple dram_interleaved_memory_config = {"interleaved", "dram", std::nullopt};
-  std::string data_type = "bf16";
+TEST(MLIR_INTERFACE_API, unary_op) {
+    std::vector<uint32_t> shape = {1, 1, 32, 32 * 5 * 64};
+    ttnn::mlir_interface::memory_config_tuple l1_interleaved_memory_config = {"interleaved", "l1", std::nullopt};
+    ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32, 32 * 5}, "col_major", false};
+    ttnn::mlir_interface::memory_config_tuple l1_sharded_memory_config = {"width_sharded", "l1", shard_spec};
+    ttnn::mlir_interface::memory_config_tuple dram_interleaved_memory_config = {"interleaved", "dram", std::nullopt};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, l1_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, l1_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, l1_sharded_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, l1_sharded_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, l1_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {4096, 4096},
+        ttnn::mlir_interface::get_unary_circular_buffers_l1_allocations(
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout));
+    EXPECT_TRUE(ttnn::mlir_interface::get_unary_tensor_buffers_l1_allocations(
+                    shape,
+                    l1_interleaved_memory_config,
+                    data_type,
+                    layout,
+                    shape,
+                    l1_interleaved_memory_config,
+                    data_type,
+                    layout)
+                    .has_value());
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, dram_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, l1_sharded_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, dram_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, l1_sharded_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    compare_cb_allocations(
+        {0, 0},
+        ttnn::mlir_interface::get_unary_circular_buffers_l1_allocations(
+            shape, l1_sharded_memory_config, data_type, layout, shape, l1_sharded_memory_config, data_type, layout));
 
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, dram_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
-  EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(shape, l1_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, l1_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, l1_sharded_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, dram_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {4096, 4096},
+        ttnn::mlir_interface::get_unary_circular_buffers_l1_allocations(
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout));
+
+    EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, l1_sharded_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    EXPECT_FALSE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, dram_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, dram_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {4096, 4096},
+        ttnn::mlir_interface::get_unary_circular_buffers_l1_allocations(
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_unary_op_support_input_output_constraints(
+        "RELU", shape, l1_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {4096, 4096},
+        ttnn::mlir_interface::get_unary_circular_buffers_l1_allocations(
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout));
 }
 
-TEST(MLIR_INTERFACE_API, matmul_multicast)
-{
-  // [n x k], [k x m] -> [n x m]
-  // size_t n = 2 * 64 * 32, k = 64 * 32, m = 5 * 64 * 32;
-  // std::vector<uint32_t> shape_a = ttnn::Shape(tt::tt_metal::Array4D{1, 1, n, k});
-  // std::vector<uint32_t> shape_b = ttnn::Shape(tt::tt_metal::Array4D{1, 1, k, m});
-  // std::vector<uint32_t> shape_o = ttnn::Shape(tt::tt_metal::Array4D{1, 1, n, m});
+TEST(MLIR_INTERFACE_API, softmax_op) {
+    std::vector<uint32_t> shape = {1, 1, 32, 32 * 5 * 64};
+    ttnn::mlir_interface::memory_config_tuple l1_interleaved_memory_config = {"interleaved", "l1", std::nullopt};
+    ttnn::mlir_interface::shard_spec_tuple shard_spec = {{{0, 0, 7, 7}}, {32, 32 * 5}, "col_major", false};
+    ttnn::mlir_interface::memory_config_tuple l1_sharded_memory_config = {"width_sharded", "l1", shard_spec};
+    ttnn::mlir_interface::memory_config_tuple dram_interleaved_memory_config = {"interleaved", "dram", std::nullopt};
+    std::string data_type = "bf16";
+    std::string layout = "tile";
+    const int dim_arg = -1;
 
-  // ttnn::mlir_interface::memory_config_tuple l1_interleaved_memory_config = {"interleaved", "l1", std::nullopt};
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, l1_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {32768, 32768, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+    EXPECT_TRUE(ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+                    shape,
+                    l1_interleaved_memory_config,
+                    data_type,
+                    layout,
+                    shape,
+                    l1_interleaved_memory_config,
+                    data_type,
+                    layout,
+                    dim_arg)
+                    .has_value());
 
-  // ttnn::mlir_interface::matmul_multicore_reuse_config_tuple matmul_config = {{8,8}, 1, 1, 4, 8, 16, false, false}
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, l1_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    compare_cb_allocations(
+        {32768, 0, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_sharded_memory_config,
+            data_type,
+            layout,
+            dim_arg));
 
-  // ttnn::mlir_interface::does_matmul_multicore_reuse_multicast_support_input_output_constraints()
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, l1_sharded_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {0, 32768, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            l1_sharded_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, l1_sharded_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    compare_cb_allocations(
+        {0, 0, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            l1_sharded_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_sharded_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, dram_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {32768, 32768, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, l1_sharded_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {0, 32768, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            l1_sharded_memory_config,
+            data_type,
+            layout,
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, dram_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
+    compare_cb_allocations(
+        {32768, 0, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_sharded_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, dram_interleaved_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {32768, 32768, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            dim_arg));
+
+    EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
+        shape, l1_interleaved_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
+    compare_cb_allocations(
+        {32768, 32768, 2048, 2048, 655360, 2048},
+        ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
+            shape,
+            l1_interleaved_memory_config,
+            data_type,
+            layout,
+            shape,
+            dram_interleaved_memory_config,
+            data_type,
+            layout,
+            dim_arg));
 }
 
-TEST(MLIR_INTERFACE_API, matmul_multicast_1d)
-{
-  // ttnn::mlir_interface::does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraints()
+TEST(MLIR_INTERFACE_API, matmul_multicast) {
+    // [n x k], [k x m] -> [n x m]
+    // size_t n = 2 * 64 * 32, k = 64 * 32, m = 5 * 64 * 32;
+    // std::vector<uint32_t> shape_a = ttnn::Shape(tt::tt_metal::Array4D{1, 1, n, k});
+    // std::vector<uint32_t> shape_b = ttnn::Shape(tt::tt_metal::Array4D{1, 1, k, m});
+    // std::vector<uint32_t> shape_o = ttnn::Shape(tt::tt_metal::Array4D{1, 1, n, m});
 
+    // ttnn::mlir_interface::memory_config_tuple l1_interleaved_memory_config = {"interleaved", "l1", std::nullopt};
+
+    // ttnn::mlir_interface::matmul_multicore_reuse_config_tuple matmul_config = {{8,8}, 1, 1, 4, 8, 16, false, false}
+
+    // ttnn::mlir_interface::does_matmul_multicore_reuse_multicast_support_input_output_constraints()
+}
+
+TEST(MLIR_INTERFACE_API, matmul_multicast_1d) {
+    // ttnn::mlir_interface::does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraints()
 }

--- a/ttnn/cpp/ttnn/mlir_interface_api.cpp
+++ b/ttnn/cpp/ttnn/mlir_interface_api.cpp
@@ -1,18 +1,26 @@
 #include "mlir_interface_api.hpp"
-#include "operations/eltwise/unary/common/unary_op_types.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <tuple>
+
+#include "tensor/types.hpp"                            // DataType, Lauout, StorageType
+#include "tt_metal/impl/buffers/buffer.hpp"            // BufferType
+#include "tt_metal/impl/buffers/buffer_constants.hpp"  // TensorMemoryLayout, ShardOrientation
+#include "ttnn/operations/common/l1_interface_common.hpp"
+#include "ttnn/operations/eltwise/binary/binary_constraints.hpp"
+#include "ttnn/operations/eltwise/binary/binary_l1_interface.hpp"
+#include "ttnn/operations/eltwise/unary/unary_constraints.hpp"
+#include "ttnn/operations/eltwise/unary/unary_l1_interface.hpp"
+#include "ttnn/operations/matmul/device/matmul_types.hpp"
+#include "ttnn/operations/matmul/matmul_constraints.hpp"
+#include "ttnn/operations/matmul/matmul_l1_interface.hpp"
+#include "ttnn/operations/normalization/softmax/softmax_constraints.hpp"
+#include "ttnn/operations/normalization/softmax/softmax_l1_interface.hpp"
 #include "types_wrapper.hpp"
 
-#include "tensor/types.hpp" // DataType, Lauout, StorageType
-#include "tt_metal/impl/buffers/buffer_constants.hpp" // TensorMemoryLayout, ShardOrientation
-#include "tt_metal/impl/buffers/buffer.hpp" // BufferType
-
-#include "ttnn/operations/eltwise/binary/binary_constraints.hpp"
-#include "ttnn/operations/eltwise/unary/unary_constraints.hpp"
-#include "ttnn/operations/matmul/matmul_constraints.hpp"
-#include "ttnn/operations/normalization/softmax/softmax_constraints.hpp"
-
-namespace ttnn::mlir_interface
-{
+namespace ttnn::mlir_interface {
 
 bool does_binary_op_support_input_output_constraints(
     const std::vector<uint32_t>& _shape_a,
@@ -23,8 +31,6 @@ bool does_binary_op_support_input_output_constraints(
     const std::string& _data_type_b,
     const memory_config_tuple& _memory_config_o,
     const std::string& _data_type_o) {
-
-
     auto shape_a = ttnn::vector_wrapper::to_shape(_shape_a);
     auto memory_config_a = ttnn::tuple_wrapper::to_memory_config(_memory_config_a);
     if (!memory_config_a.has_value()) {
@@ -52,14 +58,19 @@ bool does_binary_op_support_input_output_constraints(
         return false;
     }
 
-    auto builder = EltwiseOpConstraintsFactory::Make(ttnn::Shape(shape_a), memory_config_a.value(), ttnn::Shape(shape_b), memory_config_b.value(), memory_config_o.value(), CoreCoord{8,8});
+    auto builder = EltwiseOpConstraintsFactory::Make(
+        ttnn::Shape(shape_a),
+        memory_config_a.value(),
+        ttnn::Shape(shape_b),
+        memory_config_b.value(),
+        memory_config_o.value(),
+        CoreCoord{8, 8});
     if (builder) {
-        const auto op_constraints =
-            (*builder)
-                .setDataTypeA(data_type_a.value())
-                .setDataTypeB(data_type_b.value())
-                .setDataTypeO(data_type_o.value())
-                .build_constraints();
+        const auto op_constraints = (*builder)
+                                        .setDataTypeA(data_type_a.value())
+                                        .setDataTypeB(data_type_b.value())
+                                        .setDataTypeO(data_type_o.value())
+                                        .build_constraints();
         if (op_constraints.size() == 0) {
             return false;
         }
@@ -78,7 +89,6 @@ bool does_unary_op_support_input_output_constraints(
     const std::vector<uint32_t>& _input_shape_o,
     const memory_config_tuple& _memory_config_o,
     const std::string& _data_type_o) {
-
     auto shape_a = ttnn::vector_wrapper::to_shape(_input_shape_a);
     auto memory_config_a = ttnn::tuple_wrapper::to_memory_config(_memory_config_a);
     if (!memory_config_a.has_value()) {
@@ -106,21 +116,21 @@ bool does_unary_op_support_input_output_constraints(
     // ignoring is_supported_arch for now.
     // because it's GS specific, and we dont care about GS today.
 
-    auto builder = ttnn::operations::unary::UnaryOpConstraintsFactory::Make(op_type.value(), tt::ARCH::WORMHOLE_B0, ttnn::Shape(shape_a), memory_config_a.value(), ttnn::Shape(shape_o), memory_config_o.value(), CoreCoord{8,8});
-    if (builder)
-    {
+    auto builder = ttnn::operations::unary::UnaryOpConstraintsFactory::Make(
+        op_type.value(),
+        tt::ARCH::WORMHOLE_B0,
+        ttnn::Shape(shape_a),
+        memory_config_a.value(),
+        ttnn::Shape(shape_o),
+        memory_config_o.value(),
+        CoreCoord{8, 8});
+    if (builder) {
         const auto op_constraints =
-            (*builder)
-                .setDataTypeA(data_type_a.value())
-                .setDataTypeO(data_type_o.value())
-                .build_constraints();
-        if (op_constraints.size() == 0)
-        {
+            (*builder).setDataTypeA(data_type_a.value()).setDataTypeO(data_type_o.value()).build_constraints();
+        if (op_constraints.size() == 0) {
             return false;
         }
-    }
-    else
-    {
+    } else {
         return false;
     }
 
@@ -134,7 +144,6 @@ bool does_softmax_op_support_input_output_constraints(
     const std::vector<uint32_t>& _input_shape_o,
     const memory_config_tuple& _memory_config_o,
     const std::string& _data_type_o) {
-
     auto shape_a = ttnn::vector_wrapper::to_shape(_input_shape_a);
     auto memory_config_a = ttnn::tuple_wrapper::to_memory_config(_memory_config_a);
     if (!memory_config_a.has_value()) {
@@ -154,21 +163,15 @@ bool does_softmax_op_support_input_output_constraints(
         return false;
     }
 
-    auto builder = SoftmaxOpConstraintsFactory::Make(ttnn::Shape(shape_a), memory_config_a.value(), ttnn::Shape(shape_o), memory_config_o.value(), CoreCoord{8,8});
-    if (builder)
-    {
+    auto builder = SoftmaxOpConstraintsFactory::Make(
+        ttnn::Shape(shape_a), memory_config_a.value(), ttnn::Shape(shape_o), memory_config_o.value(), CoreCoord{8, 8});
+    if (builder) {
         const auto op_constraints =
-            (*builder)
-                .setDataTypeA(data_type_a.value())
-                .setDataTypeO(data_type_o.value())
-                .build_constraints();
-        if (op_constraints.size() == 0)
-        {
+            (*builder).setDataTypeA(data_type_a.value()).setDataTypeO(data_type_o.value()).build_constraints();
+        if (op_constraints.size() == 0) {
             return false;
         }
-    }
-    else
-    {
+    } else {
         return false;
     }
 
@@ -186,8 +189,7 @@ bool does_matmul_multicore_reuse_multicast_support_input_output_constraints(
     const std::string& _data_type_o,
     const matmul_multicore_reuse_config_tuple _matmul_config,
     const bool transpose_mcast,
-    const bool fuse_batch)
-{
+    const bool fuse_batch) {
     auto shape_a = ttnn::vector_wrapper::to_shape(_shape_a);
     auto memory_config_a = ttnn::tuple_wrapper::to_memory_config(_memory_config_a);
     if (!memory_config_a.has_value()) {
@@ -215,16 +217,23 @@ bool does_matmul_multicore_reuse_multicast_support_input_output_constraints(
         return false;
     }
 
-    auto matmul_config = ttnn::tuple_wrapper::to_multicast_matmul_program_config(_matmul_config, transpose_mcast, fuse_batch);
+    auto matmul_config =
+        ttnn::tuple_wrapper::to_multicast_matmul_program_config(_matmul_config, transpose_mcast, fuse_batch);
 
-    auto builder = MatmulOpConstraintsFactory::Make(ttnn::Shape(shape_a), memory_config_a.value(), ttnn::Shape(shape_b), memory_config_b.value(), memory_config_o.value(), matmul_config.value(), CoreCoord{8,8});
+    auto builder = MatmulOpConstraintsFactory::Make(
+        ttnn::Shape(shape_a),
+        memory_config_a.value(),
+        ttnn::Shape(shape_b),
+        memory_config_b.value(),
+        memory_config_o.value(),
+        matmul_config.value(),
+        CoreCoord{8, 8});
     if (builder) {
-        const auto op_constraints =
-            (*builder)
-                .setDataTypeA(data_type_a.value())
-                .setDataTypeB(data_type_b.value())
-                .setDataTypeO(data_type_o.value())
-                .build_constraints();
+        const auto op_constraints = (*builder)
+                                        .setDataTypeA(data_type_a.value())
+                                        .setDataTypeB(data_type_b.value())
+                                        .setDataTypeO(data_type_o.value())
+                                        .build_constraints();
         if (op_constraints.size() == 0) {
             return false;
         }
@@ -246,8 +255,7 @@ bool does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraint
     const std::string& _data_type_o,
     const matmul_multicore_reuse_config_tuple _matmul_config,
     const bool fuse_batch,
-    const bool mcast_in0)
-{
+    const bool mcast_in0) {
     auto shape_a = ttnn::vector_wrapper::to_shape(_shape_a);
     auto memory_config_a = ttnn::tuple_wrapper::to_memory_config(_memory_config_a);
     if (!memory_config_a.has_value()) {
@@ -275,16 +283,23 @@ bool does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraint
         return false;
     }
 
-    auto matmul_config = ttnn::tuple_wrapper::to_multicast_1d_matmul_program_config(_matmul_config, fuse_batch, mcast_in0);
+    auto matmul_config =
+        ttnn::tuple_wrapper::to_multicast_1d_matmul_program_config(_matmul_config, fuse_batch, mcast_in0);
 
-    auto builder = MatmulOpConstraintsFactory::Make(ttnn::Shape(shape_a), memory_config_a.value(), ttnn::Shape(shape_b), memory_config_b.value(), memory_config_o.value(), matmul_config.value(), CoreCoord{8,8});
+    auto builder = MatmulOpConstraintsFactory::Make(
+        ttnn::Shape(shape_a),
+        memory_config_a.value(),
+        ttnn::Shape(shape_b),
+        memory_config_b.value(),
+        memory_config_o.value(),
+        matmul_config.value(),
+        CoreCoord{8, 8});
     if (builder) {
-        const auto op_constraints =
-            (*builder)
-                .setDataTypeA(data_type_a.value())
-                .setDataTypeB(data_type_b.value())
-                .setDataTypeO(data_type_o.value())
-                .build_constraints();
+        const auto op_constraints = (*builder)
+                                        .setDataTypeA(data_type_a.value())
+                                        .setDataTypeB(data_type_b.value())
+                                        .setDataTypeO(data_type_o.value())
+                                        .build_constraints();
         if (op_constraints.size() == 0) {
             return false;
         }
@@ -295,4 +310,527 @@ bool does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraint
     return true;
 }
 
-} // namespace ttnn_mlir_interface
+static std::optional<L1InterfaceOperandParams> get_l1_interface_operand_params(
+    const std::vector<uint32_t>& _shape,
+    const std::string& _data_type,
+    const std::string& _layout,
+    const memory_config_tuple& _memory_config) {
+    auto shape = ttnn::vector_wrapper::to_shape(_shape);
+
+    auto data_type = ttnn::str_wrapper::to_data_type(_data_type);
+    if (!data_type.has_value()) {
+        return std::nullopt;
+    }
+
+    auto layout = ttnn::str_wrapper::to_layout(_layout);
+    if (!layout.has_value()) {
+        return std::nullopt;
+    }
+
+    auto memory_config = ttnn::tuple_wrapper::to_memory_config(_memory_config);
+    if (!memory_config.has_value()) {
+        return std::nullopt;
+    }
+
+    return std::make_tuple(ttnn::Shape(shape), data_type.value(), layout.value(), memory_config.value());
+}
+
+static std::vector<uint32_t> extract_cb_allocations(
+    const std::vector<std::tuple<uint32_t, uint32_t>>& l1_interface_output) {
+    std::vector<uint32_t> circular_buffer_allocations;
+    for (const auto& [cb_size, num_cores] : l1_interface_output) {
+        circular_buffer_allocations.push_back(cb_size == c_cb_shares_space_with_sharded_operand ? 0 : cb_size);
+    }
+
+    return circular_buffer_allocations;
+}
+
+static std::unique_ptr<EltwiseOpL1Usage> get_binary_l1_usage_estimator(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o) {
+    auto l1_input_a = get_l1_interface_operand_params(_shape_a, _data_type_a, _layout_a, _memory_config_a);
+    if (!l1_input_a.has_value()) {
+        return nullptr;
+    }
+
+    auto l1_input_b = get_l1_interface_operand_params(_shape_b, _data_type_b, _layout_b, _memory_config_b);
+    if (!l1_input_b.has_value()) {
+        return nullptr;
+    }
+
+    auto l1_output = get_l1_interface_operand_params(_shape_o, _data_type_o, _layout_o, _memory_config_o);
+    if (!l1_output.has_value()) {
+        return nullptr;
+    }
+
+    return EltwiseOpL1UsageFactory::Make(l1_input_a.value(), l1_input_b.value(), l1_output.value());
+}
+
+std::unique_ptr<UnaryOpL1Usage> get_unary_l1_usage_estimator(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o) {
+    auto l1_input_a = get_l1_interface_operand_params(_shape_a, _data_type_a, _layout_a, _memory_config_a);
+    if (!l1_input_a.has_value()) {
+        return nullptr;
+    }
+
+    auto l1_output = get_l1_interface_operand_params(_shape_o, _data_type_o, _layout_o, _memory_config_o);
+    if (!l1_output.has_value()) {
+        return nullptr;
+    }
+
+    return UnaryOpL1UsageFactory::Make(l1_input_a.value(), l1_output);
+}
+
+static std::unique_ptr<SoftmaxOpL1Usage> get_softmax_l1_usage_estimator(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const int dim_arg) {
+    auto l1_input_a = get_l1_interface_operand_params(_shape_a, _data_type_a, _layout_a, _memory_config_a);
+    if (!l1_input_a.has_value()) {
+        return nullptr;
+    }
+
+    auto l1_output = get_l1_interface_operand_params(_shape_o, _data_type_o, _layout_o, _memory_config_o);
+    if (!l1_output.has_value()) {
+        return nullptr;
+    }
+
+    return SoftmaxOpL1UsageFactory::Make(l1_input_a.value(), dim_arg, l1_output);
+}
+
+static std::unique_ptr<MatmulOPL1Usage> get_matmul_l1_usage_estimator(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const operations::matmul::MatmulProgramConfig& matmul_config) {
+    auto l1_input_a = get_l1_interface_operand_params(_shape_a, _data_type_a, _layout_a, _memory_config_a);
+    if (!l1_input_a.has_value()) {
+        return nullptr;
+    }
+
+    auto l1_input_b = get_l1_interface_operand_params(_shape_b, _data_type_b, _layout_b, _memory_config_b);
+    if (!l1_input_b.has_value()) {
+        return nullptr;
+    }
+
+    auto l1_output = get_l1_interface_operand_params(_shape_o, _data_type_o, _layout_o, _memory_config_o);
+    if (!l1_output.has_value()) {
+        return nullptr;
+    }
+
+    return MatmulOpL1UsageFactory::Make(l1_input_a.value(), l1_input_b.value(), l1_output.value(), matmul_config);
+}
+
+static std::optional<std::vector<uint32_t>> get_matmul_circular_buffers_l1_allocations_helper(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const operations::matmul::MatmulProgramConfig& matmul_config) {
+    auto l1_usage = get_matmul_l1_usage_estimator(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        matmul_config);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return extract_cb_allocations(l1_usage->get_circular_buffer_l1_allocations_per_core());
+}
+
+static std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_matmul_tensor_buffers_l1_allocations_helper(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const operations::matmul::MatmulProgramConfig& matmul_config) {
+    auto l1_usage = get_matmul_l1_usage_estimator(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        matmul_config);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return l1_usage->get_tensor_l1_allocations_per_core();
+}
+
+std::optional<std::vector<uint32_t>> get_binary_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o) {
+    auto l1_usage = get_binary_l1_usage_estimator(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return extract_cb_allocations(l1_usage->get_circular_buffer_l1_allocations_per_core());
+}
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_binary_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o) {
+    auto l1_usage = get_binary_l1_usage_estimator(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return l1_usage->get_tensor_l1_allocations_per_core();
+}
+
+std::optional<std::vector<uint32_t>> get_unary_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o) {
+    auto l1_usage = get_unary_l1_usage_estimator(
+        _shape_a, _memory_config_a, _data_type_a, _layout_a, _shape_o, _memory_config_o, _data_type_o, _layout_o);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return extract_cb_allocations(l1_usage->get_circular_buffer_l1_allocations_per_core());
+}
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_unary_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o) {
+    auto l1_usage = get_unary_l1_usage_estimator(
+        _shape_a, _memory_config_a, _data_type_a, _layout_a, _shape_o, _memory_config_o, _data_type_o, _layout_o);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return l1_usage->get_tensor_l1_allocations_per_core();
+}
+
+std::optional<std::vector<uint32_t>> get_softmax_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const int dim_arg) {
+    auto l1_usage = get_softmax_l1_usage_estimator(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        dim_arg);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return extract_cb_allocations(l1_usage->get_circular_buffer_l1_allocations_per_core());
+}
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_softmax_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const int dim_arg) {
+    auto l1_usage = get_softmax_l1_usage_estimator(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        dim_arg);
+    if (!l1_usage) {
+        return std::nullopt;
+    }
+
+    return l1_usage->get_tensor_l1_allocations_per_core();
+}
+
+std::optional<std::vector<uint32_t>> get_matmul_multicore_reuse_multicast_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const matmul_multicore_reuse_config_tuple _matmul_config,
+    const bool transpose_mcast,
+    const bool fuse_batch) {
+    auto matmul_config =
+        ttnn::tuple_wrapper::to_multicast_matmul_program_config(_matmul_config, transpose_mcast, fuse_batch);
+    if (!matmul_config.has_value()) {
+        return std::nullopt;
+    }
+
+    return get_matmul_circular_buffers_l1_allocations_helper(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        matmul_config.value());
+}
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>>
+get_matmul_multicore_reuse_multicast_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const matmul_multicore_reuse_config_tuple _matmul_config,
+    const bool transpose_mcast,
+    const bool fuse_batch) {
+    auto matmul_config =
+        ttnn::tuple_wrapper::to_multicast_matmul_program_config(_matmul_config, transpose_mcast, fuse_batch);
+    if (!matmul_config.has_value()) {
+        return std::nullopt;
+    }
+
+    return get_matmul_tensor_buffers_l1_allocations_helper(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        matmul_config.value());
+}
+
+std::optional<std::vector<uint32_t>> get_matmul_multicore_reuse_multicast_1d_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const matmul_multicore_reuse_config_tuple _matmul_config,
+    const bool fuse_batch,
+    const bool mcast_in0) {
+    auto matmul_config =
+        ttnn::tuple_wrapper::to_multicast_1d_matmul_program_config(_matmul_config, fuse_batch, mcast_in0);
+    if (!matmul_config.has_value()) {
+        return std::nullopt;
+    }
+
+    return get_matmul_circular_buffers_l1_allocations_helper(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        matmul_config.value());
+}
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>>
+get_matmul_multicore_reuse_multicast_1d_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& _shape_a,
+    const memory_config_tuple& _memory_config_a,
+    const std::string& _data_type_a,
+    const std::string& _layout_a,
+    const std::vector<uint32_t>& _shape_b,
+    const memory_config_tuple& _memory_config_b,
+    const std::string& _data_type_b,
+    const std::string& _layout_b,
+    const std::vector<uint32_t>& _shape_o,
+    const memory_config_tuple& _memory_config_o,
+    const std::string& _data_type_o,
+    const std::string& _layout_o,
+    const matmul_multicore_reuse_config_tuple _matmul_config,
+    const bool fuse_batch,
+    const bool mcast_in0) {
+    auto matmul_config =
+        ttnn::tuple_wrapper::to_multicast_1d_matmul_program_config(_matmul_config, fuse_batch, mcast_in0);
+    if (!matmul_config.has_value()) {
+        return std::nullopt;
+    }
+
+    return get_matmul_tensor_buffers_l1_allocations_helper(
+        _shape_a,
+        _memory_config_a,
+        _data_type_a,
+        _layout_a,
+        _shape_b,
+        _memory_config_b,
+        _data_type_b,
+        _layout_b,
+        _shape_o,
+        _memory_config_o,
+        _data_type_o,
+        _layout_o,
+        matmul_config.value());
+}
+
+}  // namespace ttnn::mlir_interface

--- a/ttnn/cpp/ttnn/mlir_interface_api.hpp
+++ b/ttnn/cpp/ttnn/mlir_interface_api.hpp
@@ -1,73 +1,213 @@
 #pragma once
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
 
-namespace ttnn::mlir_interface
-{
-    // shard_spec_tuple = core_range_set, shard_shape, shard_orientation, halo
-    using shard_spec_tuple = std::tuple<std::vector<std::array<uint32_t, 4>>, std::array<uint32_t, 2>, std::string, bool>;
-    // memory_config_typle = tensor_memory_layout, buffer_type, shard_spec_tuple
-    using memory_config_tuple = std::tuple<std::string, std::string, std::optional<shard_spec_tuple>>;
+namespace ttnn::mlir_interface {
+// shard_spec_tuple = core_range_set, shard_shape, shard_orientation, halo
+using shard_spec_tuple = std::tuple<std::vector<std::array<uint32_t, 4>>, std::array<uint32_t, 2>, std::string, bool>;
+// memory_config_typle = tensor_memory_layout, buffer_type, shard_spec_tuple
+using memory_config_tuple = std::tuple<std::string, std::string, std::optional<shard_spec_tuple>>;
 
-    // struct MatmulMultiCoreReuseProgramConfig
-    // compute_with_storage_grid_size, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N
-    using matmul_multicore_reuse_config_tuple = std::tuple<std::array<uint32_t,2>, size_t, size_t, size_t, size_t, size_t>;
+// struct MatmulMultiCoreReuseProgramConfig
+// compute_with_storage_grid_size, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N
+using matmul_multicore_reuse_config_tuple = std::tuple<std::array<uint32_t, 2>, size_t, size_t, size_t, size_t, size_t>;
 
-    bool does_binary_op_support_input_output_constraints(
-        const std::vector<uint32_t>& shape_a,
-        const memory_config_tuple& memory_config_a,
-        const std::string& data_type_a,
-        const std::vector<uint32_t>& shape_b,
-        const memory_config_tuple& memory_config_b,
-        const std::string& data_type_b,
-        const memory_config_tuple& memory_config_o,
-        const std::string& data_type_o);
+bool does_binary_op_support_input_output_constraints(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o);
 
-    bool does_unary_op_support_input_output_constraints(
-        const std::string op_type, // only RELU supported for now
-        const std::vector<uint32_t>& input_shape_a,
-        const memory_config_tuple& memory_config_a,
-        const std::string& data_type_a,
-        const std::vector<uint32_t>& input_shape_o,
-        const memory_config_tuple& memory_config_o,
-        const std::string& data_type_o);
+bool does_unary_op_support_input_output_constraints(
+    const std::string op_type,  // only RELU supported for now
+    const std::vector<uint32_t>& input_shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::vector<uint32_t>& input_shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o);
 
-    bool does_softmax_op_support_input_output_constraints(
-        const std::vector<uint32_t>& input_shape_a,
-        const memory_config_tuple& memory_config_a,
-        const std::string& data_type_a,
-        const std::vector<uint32_t>& input_shape_o,
-        const memory_config_tuple& memory_config_o,
-        const std::string& data_type_o);
+bool does_softmax_op_support_input_output_constraints(
+    const std::vector<uint32_t>& input_shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::vector<uint32_t>& input_shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o);
 
-    bool does_matmul_multicore_reuse_multicast_support_input_output_constraints(
-        const std::vector<uint32_t>& shape_a,
-        const memory_config_tuple& memory_config_a,
-        const std::string& data_type_a,
-        const std::vector<uint32_t>& shape_b,
-        const memory_config_tuple& memory_config_b,
-        const std::string& data_type_b,
-        const memory_config_tuple& memory_config_o,
-        const std::string& data_type_o,
-        const matmul_multicore_reuse_config_tuple matmul_config,
-        const bool transpose_mcast,
-        const bool fuse_batch = true);
+bool does_matmul_multicore_reuse_multicast_support_input_output_constraints(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const matmul_multicore_reuse_config_tuple matmul_config,
+    const bool transpose_mcast,
+    const bool fuse_batch = true);
 
-    bool does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraints(
-        const std::vector<uint32_t>& shape_a,
-        const memory_config_tuple& memory_config_a,
-        const std::string& data_type_a,
-        const std::vector<uint32_t>& shape_b,
-        const memory_config_tuple& memory_config_b,
-        const std::string& data_type_b,
-        const memory_config_tuple& memory_config_o,
-        const std::string& data_type_o,
-        const matmul_multicore_reuse_config_tuple matmul_config,
-        const bool fuse_batch,
-        const bool mcast_in0);
-}
+bool does_matmul_multicore_reuse_multicast_1d_op_support_input_output_constraints(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const matmul_multicore_reuse_config_tuple matmul_config,
+    const bool fuse_batch,
+    const bool mcast_in0);
+
+std::optional<std::vector<uint32_t>> get_binary_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const std::string& layout_b,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o);
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_binary_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const std::string& layout_b,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o);
+
+std::optional<std::vector<uint32_t>> get_unary_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o);
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_unary_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o);
+
+std::optional<std::vector<uint32_t>> get_softmax_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o,
+    const int dim_arg = -1);
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>> get_softmax_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o,
+    const int dim_arg = -1);
+
+std::optional<std::vector<uint32_t>> get_matmul_multicore_reuse_multicast_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const std::string& layout_b,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o,
+    const matmul_multicore_reuse_config_tuple matmul_config,
+    const bool transpose_mcast,
+    const bool fuse_batch = true);
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>>
+get_matmul_multicore_reuse_multicast_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const std::string& layout_b,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o,
+    const matmul_multicore_reuse_config_tuple matmul_config,
+    const bool transpose_mcast,
+    const bool fuse_batch = true);
+
+std::optional<std::vector<uint32_t>> get_matmul_multicore_reuse_multicast_1d_circular_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const std::string& layout_b,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o,
+    const matmul_multicore_reuse_config_tuple matmul_config,
+    const bool fuse_batch,
+    const bool mcast_in0);
+
+std::optional<std::vector<std::tuple<uint32_t, uint32_t>>>
+get_matmul_multicore_reuse_multicast_1d_tensor_buffers_l1_allocations(
+    const std::vector<uint32_t>& shape_a,
+    const memory_config_tuple& memory_config_a,
+    const std::string& data_type_a,
+    const std::string& layout_a,
+    const std::vector<uint32_t>& shape_b,
+    const memory_config_tuple& memory_config_b,
+    const std::string& data_type_b,
+    const std::string& layout_b,
+    const std::vector<uint32_t>& shape_o,
+    const memory_config_tuple& memory_config_o,
+    const std::string& data_type_o,
+    const std::string& layout_o,
+    const matmul_multicore_reuse_config_tuple matmul_config,
+    const bool fuse_batch,
+    const bool mcast_in0);
+
+}  // namespace ttnn::mlir_interface

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_l1_interface.cpp
@@ -74,11 +74,9 @@ std::vector<std::tuple<uint32_t, uint32_t>> MatmulMultiCoreReuseMultiCastOpL1Usa
     const {
     std::vector<std::tuple<uint32_t, uint32_t>> sizes;
 
-    if (!std::get<tt::tt_metal::MemoryConfig>(output).is_dram()) {
-        sizes.emplace_back(std::make_tuple(
-            calculate_tensor_l1_allocation_size_per_core(output),
-            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
-    }
+    sizes.emplace_back(std::make_tuple(
+        calculate_tensor_l1_allocation_size_per_core(output),
+        get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
 
     return sizes;
 }
@@ -175,11 +173,9 @@ std::vector<std::tuple<uint32_t, uint32_t>>
 MatmulMultiCoreReuseMultiCast1DOpL1Usage::get_tensor_l1_allocations_per_core() const {
     std::vector<std::tuple<uint32_t, uint32_t>> sizes;
 
-    if (!std::get<tt::tt_metal::MemoryConfig>(output).is_dram()) {
-        sizes.emplace_back(std::make_tuple(
-            calculate_tensor_l1_allocation_size_per_core(output),
-            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
-    }
+    sizes.emplace_back(std::make_tuple(
+        calculate_tensor_l1_allocation_size_per_core(output),
+        get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
 
     return sizes;
 }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <tuple>
 
 #include "common/constants.hpp"
@@ -32,12 +33,17 @@ int find_max_divisor(uint32_t val, uint32_t start_max_div) {
     return result;
 }
 
-std::unique_ptr<SoftmaxOpL1Usage> SoftmaxOpL1UsageFactory::Make(const L1InterfaceOperandParams& input, int dim_arg) {
-    return std::make_unique<SoftmaxOpL1Usage>(input, dim_arg);
+std::unique_ptr<SoftmaxOpL1Usage> SoftmaxOpL1UsageFactory::Make(
+    const L1InterfaceOperandParams& input, int dim_arg, const std::optional<L1InterfaceOperandParams>& output) {
+    return std::make_unique<SoftmaxOpL1Usage>(input, dim_arg, output);
 };
 
-SoftmaxOpL1Usage::SoftmaxOpL1Usage(const L1InterfaceOperandParams& input, int dim_arg) :
-    input(input), output(get_softmax_output(input)), dim_arg(dim_arg), block_size(calculate_block_size_impl(input)) {}
+SoftmaxOpL1Usage::SoftmaxOpL1Usage(
+    const L1InterfaceOperandParams& input, int dim_arg, const std::optional<L1InterfaceOperandParams>& output) :
+    input(input),
+    output(output.value_or(get_softmax_output(input))),
+    dim_arg(dim_arg),
+    block_size(calculate_block_size_impl(input)) {}
 
 bool SoftmaxOpL1Usage::should_tilize_input() const {
     return std::get<tt::tt_metal::Layout>(input) != tt::tt_metal::Layout::TILE;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <optional>
+
 #include "ttnn/cpp/ttnn/operations/common/l1_interface_common.hpp"
 
 class SoftmaxOpL1Usage {
    public:
-    SoftmaxOpL1Usage(const L1InterfaceOperandParams& input, int dim_arg);
+    SoftmaxOpL1Usage(
+        const L1InterfaceOperandParams& input, int dim_arg, const std::optional<L1InterfaceOperandParams>& output);
 
     std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const;
     std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const;
@@ -27,5 +30,8 @@ class SoftmaxOpL1Usage {
 class SoftmaxOpL1UsageFactory {
    public:
     SoftmaxOpL1UsageFactory() = delete;
-    static std::unique_ptr<SoftmaxOpL1Usage> Make(const L1InterfaceOperandParams& input, int dim_arg);
+    static std::unique_ptr<SoftmaxOpL1Usage> Make(
+        const L1InterfaceOperandParams& input,
+        int dim_arg,
+        const std::optional<L1InterfaceOperandParams>& output = std::nullopt);
 };


### PR DESCRIPTION
To all folks who are code owners, no review required from the code owners, this is our internal branch that we are working on TTNN <-> optimiser interface.

Exposed op L1 usage interface through MLIR interface lib - added APIs for retrieving  circular buffer allocations per core and tensor buffer allocations per core. Added UTs.
