### PR TITLE
#11169: Watcher to report if eth link retraining occurred during teardown

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -26,6 +26,7 @@ set(UNIT_TESTS_COMMON_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_pause.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_ringbuf.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_waypoint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp
 )
 add_library(unit_tests_common_o OBJECT ${UNIT_TESTS_COMMON_SRC})
 target_link_libraries(unit_tests_common_o PUBLIC compiler_flags metal_header_directories gtest gtest_main)

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_link_training.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "watcher_fixture.hpp"
+#include "test_utils.hpp"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking watcher polling the eth link training counter.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+static void RunTest(WatcherFixture* fixture, Device* device) {
+}
+
+TEST_F(WatcherFixture, TestWatcherEthLinkCheck) {
+    // Eth link retraining only supported on WH for now, this test is also dispatch-agnostic so just pick one.
+    if (this->slow_dispatch_ || this->arch_ != tt::ARCH::WORMHOLE_B0 || this->devices_.size() == 1) {
+        log_info(LogTest, "Test only runs on fast dispatch + multi-chip WH, skipping...");
+        GTEST_SKIP();
+    }
+
+    // Just try forcing an eth retrain on Device 0
+    Device *device = this->devices_[0];
+    vector<uint32_t> reset_val = {0x1};
+    for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
+        // Only force a retrain on odd-numbered eth cores
+        if (eth_core.y % 2) {
+            CoreCoord phys_core = device->ethernet_core_from_logical_core(eth_core);
+            tt::llrt::write_hex_vec_to_core(device->id(), phys_core, reset_val, eth_l1_mem::address_map::RETRAIN_FORCE_ADDR);
+        }
+    }
+
+    // Just wait a few seconds to let the link retrain
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    vector<string> expected_strings;
+    for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
+        CoreCoord phys_core = device->ethernet_core_from_logical_core(eth_core);
+        expected_strings.push_back(fmt::format(
+            "\tDevice {} Ethernet Core {} retraining events: {}", device->id(), phys_core, (eth_core.y % 2) ? 1 : 0));
+    }
+
+    // Close devices to trigger watcher check on teardown.
+    for (Device *device : this->devices_) {
+        tt::tt_metal::CloseDevice(device);
+    }
+    EXPECT_TRUE(FileContainsAllStrings(this->log_file_name, expected_strings));
+}

--- a/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
@@ -85,5 +85,7 @@ struct address_map {
                                                                    // at RISC_LOCAL_MEM_BASE address
 
   static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
+  static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC; // Not implemented for BH yet!
+  static constexpr std::uint32_t RETRAIN_FORCE_ADDR = 0x1EFC;
 };
 }  // namespace eth_l1_mem

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -39,5 +39,8 @@ struct address_map {
 
   static constexpr std::int32_t ERISC_L1_UNRESERVED_SIZE = 0;
   static constexpr std::int32_t ERISC_L1_TUNNEL_BUFFER_SIZE = 0;
+
+  static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC;
+  static constexpr std::uint32_t RETRAIN_FORCE_ADDR = 0x1EFC;
 };
 }  // namespace llk

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -85,5 +85,7 @@ struct address_map {
                                                                    // at RISC_LOCAL_MEM_BASE address
 
   static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
+  static constexpr std::uint32_t RETRAIN_COUNT_ADDR = 0x1EDC;
+  static constexpr std::uint32_t RETRAIN_FORCE_ADDR = 0x1EFC;
 };
 }  // namespace eth_l1_mem

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -24,14 +24,8 @@ typedef struct {
 class WatcherDeviceReader {
     public:
      WatcherDeviceReader(
-         FILE *f,
-         Device *device,
-         vector<string> &kernel_names,
-         void (* set_watcher_exception_message)(const string &)) :
-         f(f),
-         device(device),
-         kernel_names(kernel_names),
-         set_watcher_exception_message(set_watcher_exception_message) {}
+         FILE *f, Device *device, vector<string> &kernel_names, void (*set_watcher_exception_message)(const string &));
+     ~WatcherDeviceReader();
      void Dump(FILE *file = nullptr);
 
     private:
@@ -62,6 +56,7 @@ class WatcherDeviceReader {
     std::set<std::pair<CoreCoord, riscv_id_t>> paused_cores;
     std::map<riscv_id_t, stack_usage_info_t> highest_stack_usage;
     std::map<int, bool> used_kernel_names;
+    std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
 };
 
 }  // namespace tt::watcher


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11169)

### What's changed
At device detach (called during device close), watcher server polls ethernet retrain count register and reports if retraining occurred during Device lifetime.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/10913381413
- [ ] Blackhole Post commit (if applicable) - main hanging
- [ ] Model regression CI testing passes (if applicable) - N/A
- [ ] Device performance regression CI testing passes (if applicable) - N/A
- [x] New/Existing tests provide coverage for changes - New test checked in: `tests/tt_metal/tt_metal/unit_tests_common/watcher/test_link_training.cpp`
