### PR TITLE
Llama tg/sharded ccls

### DIFF
--- a/models/demos/tg/llama3_70b/tt/llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_attention_galaxy.py
@@ -17,6 +17,8 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,
     tt_all_gather,
+    tt_sharded_all_reduce,
+    tt_sharded_all_gather,
 )
 from models.demos.t3000.falcon40b.tt.model_utils import (
     matmul_2d_config_from_tensor_shapes as get_matmul_2d_config_from_tensor_shapes,
@@ -174,6 +176,22 @@ class TtLlamaAttention_galaxy:
             self.SDPA_HEIGHT_SHARDED_MEMCFG = ttnn.MemoryConfig(
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec
             )
+            mesh_rows, mesh_cols = 8, 4
+            self.QKV_OUT_GATHERED_MEMCFG = ttnn.create_sharded_memory_config(
+                shape=(32 * mesh_cols, 1280 // 40),
+                core_grid=ttnn.CoreGrid(y=5, x=8),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            self.SELF_OUT_GATHERED_MEMCFG = ttnn.create_sharded_memory_config(
+                shape=(32 * mesh_rows, 2048 // 32),
+                core_grid=ttnn.CoreGrid(y=4, x=8),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
         elif self.model_config["LLM_MODE"] == "prefill":
             self.COMPUTE_KERNEL_QKV = ttnn.WormholeComputeKernelConfig(
                 math_fidelity=ttnn.MathFidelity.HiFi2,
@@ -369,6 +387,11 @@ class TtLlamaAttention_galaxy:
         )
         xs.deallocate(True)
 
+        # TODO: Use sharded all reduce once, the PCC issue is fixed in this particular all reduce
+        # fused_query_key_value = tt_sharded_all_reduce(
+        #     fused_query_key_value, self.mesh_device, cluster_axis=1, num_links=2, memory_config=self.QKV_OUT_GATHERED_MEMCFG
+        # )
+
         fused_query_key_value = tt_all_reduce(
             fused_query_key_value, self.mesh_device, cluster_axis=1, num_links=2, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
@@ -378,7 +401,7 @@ class TtLlamaAttention_galaxy:
             self.slice_mat,
             fused_query_key_value,
             dtype=ttnn.bfloat16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         )
 
         # Reshape such that true unpadded batch is tracked in shape
@@ -503,12 +526,12 @@ class TtLlamaAttention_galaxy:
             compute_kernel_config=self.COMPUTE_KERNEL_SELFOUT,
         )
 
-        attn_output = tt_all_reduce(
+        attn_output = tt_sharded_all_reduce(
             attn_output,
             self.mesh_device,
             cluster_axis=0,
             num_links=2,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            memory_config=self.SELF_OUT_GATHERED_MEMCFG,
         )
 
         return attn_output

--- a/models/demos/tg/llama3_70b/tt/llama_common.py
+++ b/models/demos/tg/llama3_70b/tt/llama_common.py
@@ -52,3 +52,33 @@ def tt_all_gather(input_tensor, mesh_device, cluster_axis, dim, num_links=2, mem
     return ttnn.line_all_gather(
         input_tensor, dim, num_links=num_links, cluster_axis=cluster_axis, mesh_device=mesh_device
     )
+
+
+def tt_sharded_all_reduce(input_tensor, mesh_device, cluster_axis, dim=0, num_links=2, memory_config=None):
+    gathered_tensor = ttnn.line_all_gather(
+        input_tensor,
+        dim,
+        num_links=num_links,
+        cluster_axis=cluster_axis,
+        mesh_device=mesh_device,
+        memory_config=memory_config,
+    )
+    # Fast_reduce_nc does not support sharded memory configuration, convert to interleaved
+    gathered_tensor = ttnn.to_memory_config(gathered_tensor, ttnn.L1_MEMORY_CONFIG)
+    reduced_tensors = ttnn.experimental.fast_reduce_nc(
+        gathered_tensor, dims=[dim], output=None, compute_kernel_config=None
+    )
+    return reduced_tensors
+
+
+def tt_sharded_all_gather(input_tensor, mesh_device, cluster_axis, dim, num_links=2, memory_config=None):
+    # Ensure the input tensor is in the correct memory configuration
+
+    return ttnn.line_all_gather(
+        input_tensor,
+        dim,
+        num_links=num_links,
+        cluster_axis=cluster_axis,
+        mesh_device=mesh_device,
+        memory_config=memory_config,
+    )

--- a/models/demos/tg/llama3_70b/tt/llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_mlp_galaxy.py
@@ -9,7 +9,7 @@ import ttnn
 from ttnn import ReplicateTensorToMesh
 from models.demos.t3000.llama2_70b.tt.llama_common import ShardTensor2dMesh, ConcatMesh2DToTensor
 from models.utility_functions import nearest_32
-from models.demos.tg.llama3_70b.tt.llama_common import tt_all_reduce
+from models.demos.tg.llama3_70b.tt.llama_common import tt_all_reduce, tt_sharded_all_reduce
 from models.demos.t3000.falcon40b.tt.model_utils import (
     matmul_2d_config_from_tensor_shapes as get_matmul_2d_config_from_tensor_shapes,
 )
@@ -141,6 +141,22 @@ class TtLlamaMLP_galaxy:
                 use_height_and_width_as_shard_shape=True,
             )
 
+            mesh_rows, mesh_cols = 8, 4
+            self.FF1_OUT_GATHERED_MEMCFG = ttnn.create_sharded_memory_config(
+                shape=(M * mesh_cols, N // 8),
+                core_grid=ttnn.CoreGrid(y=1, x=8),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            self.FF2_OUT_GATHERED_MEMCFG = ttnn.create_sharded_memory_config(
+                shape=(32 * mesh_rows, 2048 // 8),
+                core_grid=ttnn.CoreGrid(y=1, x=8),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
         elif self.model_config["LLM_MODE"] == "prefill":
             hidden_dim_per_chip = self.hidden_size // self.cluster_shape[0]  # 2048
             ff_outer_dim_per_chip = (
@@ -266,11 +282,11 @@ class TtLlamaMLP_galaxy:
         )
         x.deallocate(True)
 
-        w1_out = tt_all_reduce(
-            w1_out, self.mesh_device, cluster_axis=1, num_links=2, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
+        w1_out = tt_sharded_all_reduce(
+            w1_out, self.mesh_device, cluster_axis=1, num_links=2, memory_config=self.FF1_OUT_GATHERED_MEMCFG
         )
-        w3_out = tt_all_reduce(
-            w3_out, self.mesh_device, cluster_axis=1, num_links=2, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
+        w3_out = tt_sharded_all_reduce(
+            w3_out, self.mesh_device, cluster_axis=1, num_links=2, memory_config=self.FF1_OUT_GATHERED_MEMCFG
         )
 
         w1_out = ttnn.to_memory_config(w1_out, self.FULL_GRID_MEMCFG)
@@ -297,12 +313,12 @@ class TtLlamaMLP_galaxy:
             memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
         )
 
-        hidden_states = tt_all_reduce(
+        hidden_states = tt_sharded_all_reduce(
             hidden_states,
             self.mesh_device,
             cluster_axis=0,
             num_links=2,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            memory_config=self.FF2_OUT_GATHERED_MEMCFG,
         )
 
         hidden_states = ttnn.to_memory_config(hidden_states, self.FF1_ACT_MEMCFG)


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11069)
### Problem description
Converted existing interleaved CCLs  in Llama-TG[Decode] to their sharded version.

### What's changed
1. Using sharded_all_reduce() and sharded_line_all_gather() in decode mode only.  Prefill is not affected.
2. Added sharded CCL memory configs for different input configurations in attention and MLP modules.

### Note
* Skipped sharded line_all_gather after fused_qkv_matmul due to PCC bug in sharded CCL for that particular configuration.

### Checklist
- [x] TG-Frequent https://github.com/tenstorrent/tt-metal/actions/runs/10920683972
- [x] TG-Nightly https://github.com/tenstorrent/tt-metal/actions/runs/10920905769
