### PR TITLE
#12198: Add 2CQ and trace support for UNet Shallow

### DIFF
--- a/models/experimental/functional_unet/README.md
+++ b/models/experimental/functional_unet/README.md
@@ -5,16 +5,18 @@
 To run the demo, make sure to build the project, activate the environment, and set the appropriate environment variables.
 For more information, refer [installation and build guide](https://docs.tenstorrent.com/tt-metalium/latest/get_started/get_started.html#install-and-build).
 
+When running this model on N300 or T3000, make sure to place dispatch on ethernet cores with `export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` for optimal performance
+
 To run UNet Shallow for multiple iterations on single-chip at the best performance:
 
 ```sh
-pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_perf_e2e
+pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq
 ```
 
 To run UNet Shallow for multiple iterations on N300 and T3000 at the best performance:
 
 ```sh
-pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_data_parallel_perf_e2e
+pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq_multi_device
 ````
 
 Use `pytest models/experimental/functional_unet/tests/test_unet_model.py` to run the functional UNet Shallow model on a single-chip.
@@ -23,9 +25,7 @@ Use `pytest models/experimental/functional_unet/tests/test_unet_model.py` to run
 
 - N150
 - N300
-  - Make sure to place dispatch on ethernet cores with `export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` for optimal performance
 - T3K
-  - Make sure to place dispatch on ethernet cores with `export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` for optimal performance
 
 ## Other Details
 

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -74,7 +74,7 @@ def test_unet_downblock(
         ("downblock4", 32, 132, 20),
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (False,), indirect=True)  # Enable when #12685 is resolved
+@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_downblock_multi_device(
     batch, groups, block_name, input_channels, input_height, input_width, mesh_device, reset_seeds, enable_async_mode

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -29,17 +29,11 @@ from models.utility_functions import (
 )
 
 
-def synchronize_devices(device):
-    devices = device.get_devices()
-    for device in devices:
-        ttnn.synchronize_device(device)
-
-
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((2, 1, 639.0),),
+    ((2, 1, 650.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -202,7 +196,7 @@ def test_unet_data_parallel_perf_e2e(
         output_tensor = ttnn.from_device(ttnn_model(ttnn_input), blocking=False)
         profiler.end(f"inference_time_{idx}")
         profiler.end("inference_time")
-    synchronize_devices(mesh_device)
+    ttnn.synchronize_devices(mesh_device)
 
     mean_inference_time = profiler.get("inference_time")
     inference_time = profiler.get(f"inference_time_{iterations - 1}")

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -41,7 +41,7 @@ def synchronize_devices(device):
     "batch, groups, expected_device_perf_fps",
     ((2, 1, 639.0),),
 )
-def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float, reset_seeds):
+def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
@@ -136,7 +136,6 @@ def test_unet_perf_e2e(
     assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)
 
 
-@pytest.mark.skip("Crashes on N300/T3K - see issue #12685")
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
@@ -200,9 +199,7 @@ def test_unet_data_parallel_perf_e2e(
     for idx in range(iterations):
         profiler.start("inference_time")
         profiler.start(f"inference_time_{idx}")
-        logger.info(f"running iter {idx}")
-        output_tensor = ttnn.from_device(ttnn_model(ttnn_input), blocking=True)
-        logger.info(f"done running iter {idx}")
+        output_tensor = ttnn.from_device(ttnn_model(ttnn_input), blocking=False)
         profiler.end(f"inference_time_{idx}")
         profiler.end("inference_time")
     synchronize_devices(mesh_device)

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+import ttnn
+import pytest
+
+from loguru import logger
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+from models.experimental.functional_unet.tt.model_preprocessing import (
+    create_unet_input_tensors,
+    create_unet_model_parameters,
+)
+from models.experimental.functional_unet.tt import unet_shallow_torch
+from models.experimental.functional_unet.tt import unet_shallow_ttnn
+from models.experimental.functional_unet.tests.common import (
+    check_pcc_conv,
+    is_n300_with_eth_dispatch_cores,
+    is_t3k_with_eth_dispatch_cores,
+)
+
+from models.utility_functions import skip_for_grayskull, divup
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864, "trace_region_size": 423936}], indirect=True)
+@pytest.mark.parametrize(
+    "batch, groups, iterations",
+    ((2, 1, 16),),
+)
+def test_unet_trace(
+    batch: int,
+    groups: int,
+    iterations: int,
+    device,
+    use_program_cache,
+    reset_seeds,
+):
+    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+
+    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    torch_output_tensor = model(torch_input)
+
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
+
+    input_tensor = ttnn.allocate_tensor_on_device(
+        ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    logger.info(f"Compiling model with warmup run")
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=0)
+    output_tensor = ttnn_model(input_tensor).cpu()
+
+    logger.info(f"Capturing trace")
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=0)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    output_tensor = ttnn_model(input_tensor)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    logger.info(f"Running trace for {iterations} iterations...")
+
+    outputs = []
+    start = time.time()
+    for _ in range(iterations):
+        ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=0)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        outputs.append(output_tensor.cpu(blocking=False))
+    ttnn.synchronize_device(device)
+    end = time.time()
+    logger.info(f"Average model performance={iterations * batch / (end-start) : .2f} fps")
+
+    logger.info(f"Running sanity check against reference model output")
+    B, C, H, W = torch_output_tensor.shape
+    ttnn_tensor = ttnn.to_torch(outputs[-1]).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 68864, "trace_region_size": 423936, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch, groups, iterations",
+    ((2, 1, 16),),
+)
+def test_unet_trace_2cq(
+    batch: int,
+    groups: int,
+    iterations: int,
+    device,
+    use_program_cache,
+    reset_seeds,
+):
+    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+
+    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    torch_output_tensor = model(torch_input)
+
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
+
+    op_event = ttnn.create_event(device)
+    write_event = ttnn.create_event(device)
+
+    dram_grid_size = device.dram_grid_size()
+    dram_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        ),
+        [
+            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
+            ttnn_input.shape[-1],
+        ],
+        ttnn.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+    dram_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+    )
+
+    input_tensor = ttnn.allocate_tensor_on_device(
+        ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, device, dram_memory_config
+    )
+    ttnn.record_event(0, op_event)
+
+    logger.info(f"Compiling model with warmup run")
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
+
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
+    ttnn.record_event(0, op_event)
+    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+    logger.info(f"Done compile run")
+
+    logger.info(f"Capturing trace")
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
+    ttnn.record_event(0, op_event)
+
+    input_trace_addr = l1_input_tensor.buffer_address()
+    shape = l1_input_tensor.shape
+    dtype = l1_input_tensor.dtype
+    layout = l1_input_tensor.layout
+    output_tensor.deallocate(force=True)
+
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+
+    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
+    l1_input_tensor = ttnn.allocate_tensor_on_device(
+        shape, dtype, layout, device, ttnn_model.input_sharded_memory_config
+    )
+    assert input_trace_addr == l1_input_tensor.buffer_address()
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    outputs = []
+    start = time.time()
+    for _ in range(iterations):
+        ttnn.wait_for_event(1, op_event)
+        ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(0, write_event)
+
+        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
+        ttnn.record_event(0, op_event)
+
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        outputs.append(output_tensor.cpu(blocking=False))
+    ttnn.synchronize_device(device)
+    end = time.time()
+    logger.info(f"Average model performance={iterations * batch / (end-start) : .2f} fps")
+
+    ttnn.DumpDeviceProfiler(device)
+
+    logger.info(f"Running sanity check against reference model output")
+    B, C, H, W = torch_output_tensor.shape
+    ttnn_tensor = ttnn.to_torch(outputs[-1]).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)
+
+    ttnn.release_trace(device, tid)
+
+
+def buffer_address(tensor):
+    addr = []
+    for ten in ttnn.get_device_tensors(tensor):
+        addr.append(ten.buffer_address())
+    return addr
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 68864, "trace_region_size": 423936, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch, groups, iterations",
+    ((2, 1, 16),),
+)
+def test_unet_trace_2cq_multi_device(
+    batch: int, groups: int, iterations: int, mesh_device, use_program_cache, reset_seeds, enable_async_mode
+):
+    if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
+        pytest.skip("Test is only valid for N300 or T3000")
+
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+
+    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=True)
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
+
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, device=mesh_device, mesh_mapper=weights_mesh_mapper)
+
+    num_devices = len(mesh_device.get_device_ids())
+    logger.info(f"Using {num_devices} devices for this test")
+
+    total_batch = num_devices * batch
+    torch_input, ttnn_input = create_unet_input_tensors(
+        mesh_device, total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+    )
+    logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
+    logger.info(
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
+    )
+
+    torch_output_tensor = model(torch_input)
+
+    op_event = ttnn.create_event(mesh_device)
+    write_event = ttnn.create_event(mesh_device)
+
+    dram_grid_size = mesh_device.dram_grid_size()
+    dram_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        ),
+        [
+            divup(ttnn_input.volume() // ttnn_input.shape[-1], dram_grid_size.x),
+            ttnn_input.shape[-1],
+        ],
+        ttnn.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+    dram_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+    )
+
+    input_tensor = ttnn.allocate_tensor_on_device(
+        ttnn_input.shape, ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, mesh_device, dram_memory_config
+    )
+    ttnn.record_event(0, op_event)
+
+    logger.info(f"Compiling model with warmup run")
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
+
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
+    ttnn.record_event(0, op_event)
+    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+    logger.info(f"Done compile run")
+
+    logger.info(f"Capturing trace")
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
+    l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config)
+    ttnn.record_event(0, op_event)
+
+    input_trace_addr = buffer_address(l1_input_tensor)
+    shape = l1_input_tensor.shape
+    dtype = l1_input_tensor.dtype
+    layout = l1_input_tensor.layout
+    output_tensor.deallocate(force=True)
+
+    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    output_tensor = ttnn_model(l1_input_tensor, move_input_tensor_to_device=False)
+
+    # Try allocating our persistent input tensor here and verifying it matches the address that trace captured
+    l1_input_tensor = ttnn.allocate_tensor_on_device(
+        shape, dtype, layout, mesh_device, ttnn_model.input_sharded_memory_config
+    )
+    assert input_trace_addr == buffer_address(l1_input_tensor)
+    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+
+    outputs = []
+    start = time.time()
+    for _ in range(iterations):
+        ttnn.wait_for_event(1, op_event)
+        ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(0, write_event)
+
+        l1_input_tensor = ttnn.reshard(input_tensor, ttnn_model.input_sharded_memory_config, l1_input_tensor)
+        ttnn.record_event(0, op_event)
+
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+        outputs.append(output_tensor.cpu(blocking=False))
+
+    ttnn.synchronize_devices(mesh_device)
+
+    end = time.time()
+    logger.info(f"Average model performance={iterations * total_batch / (end-start) : .2f} fps")
+
+    logger.info(f"Running sanity check against reference model output")
+    B, C, H, W = torch_output_tensor.shape
+    ttnn_tensor = (
+        ttnn.to_torch(outputs[-1], mesh_composer=output_mesh_composer)
+        .reshape(B, H, W, -1)[:, :, :, :C]
+        .permute(0, 3, 1, 2)
+    )
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)
+
+    ttnn.release_trace(mesh_device, tid)

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -85,7 +85,7 @@ def test_unet_upblock(
         ("upblock4", 16, 528, 80, 16),
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (False,), indirect=True)  # Enable when #12685 is resolved
+@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_upblock_multi_device(
     batch,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -531,10 +531,11 @@ class UNet:
         x = self.bnc(x)
         return self.bnc2(x)
 
-    def __call__(self, x):
+    def __call__(self, x, move_input_tensor_to_device=True):
         assert len(x.shape) == 4, f"Expected UNet input tensors to be rank 4 (was {len(x.shape)})"
 
-        x = ttnn.to_device(x, device=self.device, memory_config=self.input_sharded_memory_config)
+        if move_input_tensor_to_device:
+            x = ttnn.to_device(x, device=self.device, memory_config=self.input_sharded_memory_config)
 
         x, c1_residual = self.downblock1(x)
         x, c2_residual = self.downblock2(x)

--- a/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_trace.py
+++ b/tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_trace.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/functional_unet/tests/test_unet_trace.py

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::upsample {
 
 ttnn::Tensor ExecuteUpSample::invoke(const ttnn::Tensor& input_tensor,
     std::variant<int, tt::tt_metal::Array2D, tt::tt_metal::Array3D, tt::tt_metal::Array4D> scale_factor,
-    std::optional<MemoryConfig> output_mem_config) {
+    const std::optional<MemoryConfig>& output_mem_config) {
         MemoryConfig mem_config = output_mem_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
         int scale_h = 1;
         int scale_w = 1;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample.hpp
@@ -16,7 +16,7 @@ struct ExecuteUpSample {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         std::variant<int, tt::tt_metal::Array2D, tt::tt_metal::Array3D, tt::tt_metal::Array4D> scale_factor,
-        std::optional<MemoryConfig> output_mem_config = std::nullopt);
+        const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 };
 } // upsample
 } // operations


### PR DESCRIPTION
### Ticket
- #12198
- #12197

### Changes
- Enable async mode in all multi-device tests
- Add new tests for running UNet on single/multi device with tracing and 2 command queues to improve host performance
   - N150 end-to-end perf is now 253 fps
   - T3K end-to-end perf is now 444 fps
- Fix issue where sometimes program cache entries for Upsample could be corrupted by passing MemoryConfig by const reference instead of by value

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/10928430180)
- [ ] Model regression CI testing passes (if applicable) (https://github.com/tenstorrent/tt-metal/actions/runs/10928404296)
- [x] Device performance regression CI testing passes (https://github.com/tenstorrent/tt-metal/actions/runs/10928411795)
- [x] New/Existing tests provide coverage for changes
