### PR TITLE
Add supports/examples for placing Reads and Writes on CQ1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 For the latest model updates and features, please see [MODEL_UPDATES.md](models/MODEL_UPDATES.md)
 
 ## TT-NN Tech Reports
-- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Sept 11th)
+- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Sept 18th)
 - [Programming Mesh of Devices](./tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md) (updated Sept 9th)
 ---
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
@@ -343,3 +343,125 @@ def test_reshard_with_program_cache(
     assert passing, output
 
     assert device.num_program_cache_entries() == 3
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_layout, input_shard_grid, input_shard_shape, input_shard_orientation, input_sharding_scheme, input_buffer_type, output_shard_grid, output_shard_shape, output_shard_orientation, output_sharding_scheme, output_buffer_type",
+    [
+        (
+            [1, 1, 768, 64],
+            ttnn.TILE_LAYOUT,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (96, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.DRAM,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 2))}),
+            (32, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+        ),
+        (
+            [1, 1, 768, 64],
+            ttnn.TILE_LAYOUT,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 2))}),
+            (32, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (96, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.DRAM,
+        ),
+        (
+            [1, 1, 768, 64],
+            ttnn.TILE_LAYOUT,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (96, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.DRAM,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            (192, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+        ),
+        (
+            [1, 1, 768, 64],
+            ttnn.TILE_LAYOUT,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            (192, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (96, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.DRAM,
+        ),
+        (
+            [1, 1, 768, 64],
+            ttnn.TILE_LAYOUT,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (96, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            (192, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.DRAM,
+        ),
+        (
+            [1, 1, 768, 64],
+            ttnn.TILE_LAYOUT,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            (192, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.DRAM,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (96, 64),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+        ),
+    ],
+)
+def test_dram_reshard(
+    device,
+    input_shape,
+    input_layout,
+    input_shard_grid,
+    input_shard_shape,
+    input_shard_orientation,
+    input_sharding_scheme,
+    input_buffer_type,
+    output_shard_grid,
+    output_shard_shape,
+    output_shard_orientation,
+    output_sharding_scheme,
+    output_buffer_type,
+):
+    input_shard_spec = ttnn.ShardSpec(input_shard_grid, input_shard_shape, input_shard_orientation, False)
+    input_mem_config = ttnn.MemoryConfig(input_sharding_scheme, input_buffer_type, input_shard_spec)
+    output_shard_spec = ttnn.ShardSpec(output_shard_grid, output_shard_shape, output_shard_orientation, False)
+    output_mem_config = ttnn.MemoryConfig(output_sharding_scheme, output_buffer_type, output_shard_spec)
+
+    input = torch.randn(input_shape).bfloat16()
+
+    input_tensor = ttnn.Tensor(input, ttnn.bfloat16).to(input_layout).to(device, input_mem_config)
+
+    output_tensor = ttnn.reshard(input_tensor, output_mem_config)
+
+    output = ttnn.to_torch(output_tensor)
+
+    passing, output_log = comp_equal(input, output)
+
+    assert passing, output_log

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1036,8 +1036,9 @@ void pytensor_module(py::module &m_tensor) {
         )doc")
         .def(
             "cpu",
-            [](const Tensor &self, bool blocking) { return self.cpu(blocking); },
+            [](const Tensor &self, bool blocking, uint8_t cq_id) { return self.cpu(blocking, cq_id); },
             py::arg("blocking") = true,
+            py::arg("cq_id") = ttnn::DefaultQueueId,
             R"doc(
             Move TT Tensor from TT accelerator device to host device.
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+	constexpr uint32_t shard_cb_id = get_compile_time_arg_val(0);
+
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t read_offset = get_arg_val<uint32_t>(1);
+    uint32_t num_writes = get_arg_val<uint32_t>(2);
+    tt_l1_ptr uint32_t * args = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
+    uint32_t args_idx = 0;
+
+    uint32_t l1_read_addr = get_read_ptr(shard_cb_id) + read_offset;
+    for (uint32_t i = 0; i < num_writes; ++i) {
+        uint32_t x_coord = args[args_idx++];
+        uint32_t y_coord = args[args_idx++];
+        uint32_t addr = dst_addr + args[args_idx++];
+        uint64_t dst_noc_addr = get_noc_addr(x_coord, y_coord, addr);
+        uint32_t write_size = args[args_idx++];
+        noc_async_write(l1_read_addr, dst_noc_addr, write_size);
+        l1_read_addr += write_size;
+    }
+    noc_async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
@@ -29,7 +29,12 @@ void ReshardDeviceOperation::validate_with_output_tensors(const std::vector<Tens
     }
     const auto& out_mem_config = has_output_tensor ? output_tensors[0].value().memory_config() : this->output_mem_config;
     TT_FATAL(out_mem_config.is_sharded(), "output must be sharded");
-    TT_FATAL(out_mem_config.buffer_type == BufferType::L1, "Error");
+    if ((input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+        out_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED)) {
+        TT_FATAL((input_tensor.memory_config().buffer_type == BufferType::L1 || out_mem_config.buffer_type == BufferType::L1), "Resharding height shard to height shard must have at least one buffer in L1");
+    } else {
+        TT_FATAL(out_mem_config.buffer_type == BufferType::L1, "Resharding requires output buffer to be in L1");
+    }
     if(input_tensor.get_layout() == Layout::ROW_MAJOR) {
         bool same_row_size = input_tensor.memory_config().shard_spec.value().shape[1] == out_mem_config.shard_spec.value().shape[1];
         TT_FATAL(same_row_size, "row major must have shard_spec[1] be the same on both input and output");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -298,108 +298,115 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges(
     return runtime_args;
 }
 
+
+template<bool is_reader>
 operation::ProgramWithCallbacks reshard_multi_core_same_width(const Tensor& input, Tensor& output) {
     auto device = input.device();
 
     tt::tt_metal::Program program{};
 
-    const auto input_shard_spec = input.shard_spec().value();
-    const auto output_shard_spec = output.shard_spec().value();
-    const auto& all_cores = output_shard_spec.grid;
-    auto grid = input.buffer()->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
-                                                                  : device->compute_with_storage_grid_size();
-    auto input_core_type = input.buffer()->core_type();
-    constexpr uint32_t dst_cb_index = tt::CB::c_in0;
-    auto input_cores = corerange_to_cores(
-        input_shard_spec.grid, std::nullopt, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
-    auto output_cores =
-        corerange_to_cores(all_cores, std::nullopt, output_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+    const auto& local_tensor = is_reader ? output : input;
+    const auto& remote_tensor = is_reader ? input : output;
 
-    uint32_t total_size, unit_size, input_units_per_shard, output_units_per_shard;
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    const auto local_shard_spec = local_tensor.shard_spec().value();
+    const auto remote_shard_spec = remote_tensor.shard_spec().value();
+    const auto& all_cores = local_shard_spec.grid;
 
-    uint32_t num_output_units = input.buffer()->num_pages();
-    if (input.get_layout() == Layout::TILE) {
+    auto local_core_type = local_tensor.buffer()->core_type();
+    auto remote_core_type = remote_tensor.buffer()->core_type();
+    constexpr uint32_t cb_index = tt::CB::c_in0;
+    auto local_cores = corerange_to_cores(
+        local_shard_spec.grid, std::nullopt, local_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+    auto remote_cores =
+        corerange_to_cores(remote_shard_spec.grid, std::nullopt, remote_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+
+    uint32_t total_size, unit_size, local_units_per_shard, remote_units_per_shard;
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.get_dtype());
+
+    uint32_t num_units = local_tensor.buffer()->num_pages();
+    if (local_tensor.get_layout() == Layout::TILE) {
         unit_size = tt::tt_metal::detail::TileSize(data_format);
-        input_units_per_shard = input_shard_spec.numel() / TILE_HW;
-        output_units_per_shard = output_shard_spec.numel() / TILE_HW;
-        total_size = output_units_per_shard * unit_size;
+        local_units_per_shard = local_shard_spec.numel() / TILE_HW;
+        remote_units_per_shard = remote_shard_spec.numel() / TILE_HW;
+        total_size = remote_units_per_shard * unit_size;
     } else {
-        unit_size = output_shard_spec.shape[1] * output.element_size();
-        input_units_per_shard = input_shard_spec.shape[0];
-        output_units_per_shard = output_shard_spec.shape[0];
-        total_size = output_units_per_shard * unit_size;
+        unit_size = local_shard_spec.shape[1] * local_tensor.element_size();
+        local_units_per_shard = local_shard_spec.shape[0];
+        remote_units_per_shard = remote_shard_spec.shape[0];
+        total_size = remote_units_per_shard * unit_size;
     }
+
+    const std::string kernel_name = is_reader ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp" : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp";
 
     tt::tt_metal::KernelHandle kernel_id_0 = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp",
+        kernel_name,
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig({dst_cb_index}));
+        tt::tt_metal::ReaderDataMovementConfig({cb_index}));
 
     tt::tt_metal::KernelHandle kernel_id_1 = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp",
+        kernel_name,
         all_cores,
-        tt::tt_metal::WriterDataMovementConfig({dst_cb_index}));
+        tt::tt_metal::WriterDataMovementConfig({cb_index}));
 
-    tt::tt_metal::CircularBufferConfig cb_dst_config =
-        tt::tt_metal::CircularBufferConfig(total_size, {{dst_cb_index, data_format}})
-            .set_page_size(dst_cb_index, unit_size)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_dst0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_dst_config);
+    tt::tt_metal::CircularBufferConfig cb_config =
+        tt::tt_metal::CircularBufferConfig(total_size, {{cb_index, data_format}})
+            .set_page_size(cb_index, unit_size)
+            .set_globally_allocated_address(*local_tensor.buffer());
+    auto cb_0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
 
-    uint32_t input_core_idx = 0;
-    uint32_t input_core_units_rem = input_units_per_shard;
-    uint32_t input_address = input.buffer()->address();
-    auto input_buffer_type = input.buffer()->buffer_type();
-    auto bank_id = device->bank_ids_from_logical_core(input_buffer_type, input_cores[input_core_idx])[0];
-    uint32_t bank_offset = device->bank_offset(input_buffer_type, bank_id);
-    auto input_core = device->physical_core_from_logical_core(input_cores[input_core_idx], input_core_type);
+    uint32_t remote_core_idx = 0;
+    uint32_t remote_core_units_rem = remote_units_per_shard;
+    uint32_t remote_address = remote_tensor.buffer()->address();
+    auto remote_buffer_type = remote_tensor.buffer()->buffer_type();
+    auto bank_id = device->bank_ids_from_logical_core(remote_buffer_type, remote_cores[remote_core_idx])[0];
+    uint32_t bank_offset = device->bank_offset(remote_buffer_type, bank_id);
+    auto remote_core = device->physical_core_from_logical_core(remote_cores[remote_core_idx], remote_core_type);
 
     std::array<tt::tt_metal::KernelHandle, 2> kernels = {kernel_id_0, kernel_id_1};
-    uint32_t output_units_left = num_output_units;
-    for (const auto& core : output_cores) {
-        uint32_t output_units_per_core = std::min(output_units_left, output_units_per_shard);
-        output_units_left -= output_units_per_core;
-        uint32_t output_units_per_kernel = tt::div_up(output_units_per_core, kernels.size());
-        uint32_t output_start_offset = 0;
+    uint32_t local_units_left = num_units;
+    for (const auto& core : local_cores) {
+        uint32_t local_units_per_core = std::min(local_units_left, local_units_per_shard);
+        local_units_left -= local_units_per_core;
+        uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, kernels.size());
+        uint32_t local_start_offset = 0;
         for (const auto& kernel_id : kernels) {
-            std::vector<uint32_t> kernel_args = {input_address, 0, 0};
-            uint32_t output_units_to_get = std::min(output_units_per_core, output_units_per_kernel);
-            if (output_units_to_get != 0) {
-                uint32_t num_reads = 0;
-                kernel_args[1] = output_start_offset;
-                output_start_offset += output_units_to_get * unit_size;
-                while (output_units_to_get > 0) {
-                    if (input_core_units_rem == 0) {
-                        input_core_idx++;
-                        input_core_units_rem = input_units_per_shard;
-                        bank_id = device->bank_ids_from_logical_core(input_buffer_type, input_cores[input_core_idx])[0];
-                        bank_offset = device->bank_offset(input_buffer_type, bank_id);
-                        input_core = device->physical_core_from_logical_core(input_cores[input_core_idx], input_core_type);
+            std::vector<uint32_t> kernel_args = {remote_address, 0, 0};
+            uint32_t local_units_to_transfer = std::min(local_units_per_core, local_units_per_kernel);
+            if (local_units_to_transfer != 0) {
+                uint32_t num_transfers = 0;
+                kernel_args[1] = local_start_offset;
+                local_start_offset += local_units_to_transfer * unit_size;
+                while (local_units_to_transfer > 0) {
+                    if (remote_core_units_rem == 0) {
+                        remote_core_idx++;
+                        remote_core_units_rem = remote_units_per_shard;
+                        bank_id = device->bank_ids_from_logical_core(remote_buffer_type, remote_cores[remote_core_idx])[0];
+                        bank_offset = device->bank_offset(remote_buffer_type, bank_id);
+                        remote_core = device->physical_core_from_logical_core(remote_cores[remote_core_idx], remote_core_type);
                     }
-                    uint32_t units_to_read = std::min(input_core_units_rem, output_units_to_get);
-                    auto input_core =
-                        device->physical_core_from_logical_core(input_cores[input_core_idx], input_core_type);
+                    uint32_t units_to_transfer = std::min(remote_core_units_rem, local_units_to_transfer);
+                    auto remote_core =
+                        device->physical_core_from_logical_core(remote_cores[remote_core_idx], remote_core_type);
                     kernel_args.insert(
                         kernel_args.end(),
-                        {static_cast<uint32_t>(input_core.x),
-                         static_cast<uint32_t>(input_core.y),
-                         (input_units_per_shard - input_core_units_rem) * unit_size + bank_offset,
-                         units_to_read * unit_size});
-                    output_units_per_core -= units_to_read;
-                    output_units_to_get -= units_to_read;
-                    input_core_units_rem -= units_to_read;
-                    num_reads++;
+                        {static_cast<uint32_t>(remote_core.x),
+                         static_cast<uint32_t>(remote_core.y),
+                         (remote_units_per_shard - remote_core_units_rem) * unit_size + bank_offset,
+                         units_to_transfer * unit_size});
+                    local_units_per_core -= units_to_transfer;
+                    local_units_to_transfer -= units_to_transfer;
+                    remote_core_units_rem -= units_to_transfer;
+                    num_transfers++;
                 }
-                kernel_args[2] = num_reads;
+                kernel_args[2] = num_transfers;
             }
             SetRuntimeArgs(program, kernel_id, core, kernel_args);
         }
     }
 
-    auto override_runtime_arguments_callback = [kernel_id_0, kernel_id_1, cb_dst0, grid, output_cores](
+    auto override_runtime_arguments_callback = [kernel_id_0, kernel_id_1, cb_0, local_cores](
                                                    const void* operation,
                                                    Program& program,
                                                    const std::vector<Tensor>& input_tensors,
@@ -407,20 +414,23 @@ operation::ProgramWithCallbacks reshard_multi_core_same_width(const Tensor& inpu
                                                    const std::vector<Tensor>& output_tensors) {
         const auto& input = input_tensors.at(0);
         const auto& output = output_tensors.at(0);
-        uint32_t input_addr = input.buffer()->address();
+        const auto& local_tensor = is_reader ? output : input;
+        const auto& remote_tensor = is_reader ? input : output;
+        uint32_t remote_addr = remote_tensor.buffer()->address();
         auto& runtime_args_0_by_core = GetRuntimeArgs(program, kernel_id_0);
         auto& runtime_args_1_by_core = GetRuntimeArgs(program, kernel_id_1);
-        for (auto core : output_cores) {
+        for (auto core : local_cores) {
             auto& runtime_args_0 = runtime_args_0_by_core[core.x][core.y];
             auto& runtime_args_1 = runtime_args_1_by_core[core.x][core.y];
-            runtime_args_0[0] = input_addr;
-            runtime_args_1[0] = input_addr;
+            runtime_args_0[0] = remote_addr;
+            runtime_args_1[0] = remote_addr;
         }
-        UpdateDynamicCircularBufferAddress(program, cb_dst0, *output.buffer());
+        UpdateDynamicCircularBufferAddress(program, cb_0, *local_tensor.buffer());
     };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
+
 
 operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, Tensor& output) {
     auto device = input.device();
@@ -532,7 +542,11 @@ operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, 
 operation::ProgramWithCallbacks reshard_multi_core(const Tensor& input, Tensor& output) {
     if (input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
         output.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        return reshard_multi_core_same_width(input, output);
+        if (output.memory_config().buffer_type == BufferType::L1) {
+            return reshard_multi_core_same_width<true>(input, output);
+        } else {
+            return reshard_multi_core_same_width<false>(input, output);
+        }
     } else {
         return reshard_multi_core_generic(input, output);
     }


### PR DESCRIPTION
### Problem description
Need to show an example of using multiple CQs where both input and output are on the same CQ. Requires adding support for resharding L1->DRAM and supporting reading on non-default CQ.

### What's changed
Add support for resharding from L1->DRAM and expose cq_id flag to .cpu call.
Added examples of using multi CQ where writing input and reading output are done on the same CQ.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
