### PR TITLE
#12529: Update comment of dataflow api for mcast loopback functions

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1311,9 +1311,10 @@ void noc_semaphore_set_multicast(
  * way of a synchronization mechanism. The same as *noc_async_write_multicast*
  * with preset size of 4 Bytes.
  *
- * With this API, you cannot send data only to the source node. That is, if
- * num_dests is 1 and the encoded destination nodes consist of the node
- * sending the data, then no data will be sent. The method call will be a no-op.
+ * Note: With this API, sending data only to the source node (when num_dests
+ * is 1) may result in unexpected behaviour. For some parameters, hangs have
+ * been observed. For other parameters, nothing happens. Consider using
+ * regular non multicast operations such as *noc_async_write* in this case.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1313,7 +1313,7 @@ void noc_semaphore_set_multicast(
  *
  * Note: With this API, sending data only to the source node (when num_dests
  * is 1) may result in unexpected behaviour. For some parameters, hangs have
- * been observed. For other parameters, nothing happens. Consider using
+ * been observed. For some other parameters, nothing may happen. Consider using
  * regular non multicast operations such as *noc_async_write* in this case.
  *
  * Return value: None


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/12529 https://github.com/tenstorrent/tt-metal/issues/12220

### Problem description
Comment indicates some operations are always a no-op when a certain parameter is 1. However, that is not always the case.

### What's changed
Update the comment to indicate that the behaviour may be unexpected and that hangs have been observed as well.

### Checklist
- [ ] Post commit CI passes N/A
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
