### PR TITLE
#9370: Workaround: replace WRCFG with RMWCIB instructions in reduce_revert_delta

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -72,7 +72,6 @@ void reduce_c() {
     }
 
    reduce_revert_delta<reduce_dim>(out_cb);
-   UNPACK(tensix_sync()); // Workaround for issue #9370
 }
 
 void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {


### PR DESCRIPTION
### 9370
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9370)

### Problem description
The Unpacker uses stale value for address for SrcB even though it is written. It seems to be colliding with WRCFG instructions used in the reduce_revert_delta function. We kept the timing the same and replaced WRCFG instructions with RMWCIB instructions to do the bare minimum and the problem goes away. 

### What's changed
 The workaround uses RMWCIB instructions in the reduce_revert_delta function for wh_b0.  It does not have the same timing and consumes more cycles but is functionally the same as what was in the original function.


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
