### PR TITLE
#0: Change all ops which support page_table to enable non-log2 shapes

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -565,6 +565,10 @@ def run_test_sdpa_decode_paged_attention(
         scale = d**-0.5
         start_indices = np.linspace(max(max_start_idx - b, 0), max_start_idx, b, dtype=np.int32).tolist()
 
+        # Test when page_table does not contain blocks for full sequence length
+        last_block = max(1, int(math.ceil((max_start_idx + 1) / block_size)))
+        tt_page_table = ttnn.Tensor(page_table[:, :last_block], ttnn.int32).to(device)
+
         k_chunk_size = get_chunk_size(max_start_idx + 1)
         program_config = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=grid_size,  # device.compute_with_storage_grid_size(),

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -55,9 +55,9 @@ void kernel_main() {
 
     if constexpr (use_index_tensor) {
 
-        const InterleavedPow2AddrGen<index_is_dram> addrg = {
+        const InterleavedAddrGen<index_is_dram> addrg = {
             .bank_base_address = index_tensor_addr,
-            .log_base_2_of_page_size = log_base_2_of_page_size
+            .page_size = index_stick_size_B
         };
 
         cb_reserve_back(cb_index_id, 1);
@@ -75,9 +75,9 @@ void kernel_main() {
             skip_update = true;
         } else {
             if constexpr (is_paged_cache) {
-                const InterleavedPow2AddrGen<page_table_is_dram> page_table_gen = {
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
                     .bank_base_address = page_table_tensor_addr,
-                    .log_base_2_of_page_size = log2_page_table_stick_size
+                    .page_size = page_table_stick_size
                 };
                 cb_reserve_back(page_table_cb_id, 1);
                 uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -46,9 +46,9 @@ void kernel_main() {
     };
 
 
-    const InterleavedPow2AddrGen<page_table_is_dram> page_table_gen = {
+    const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
         .bank_base_address = page_table_addr,
-        .log_base_2_of_page_size = log2_page_table_stick_size
+        .page_size = page_table_stick_size
     };
     cb_reserve_back(cb_id_page_table, 1);
     uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
@@ -47,8 +47,6 @@ operation::ProgramWithCallbacks paged_fill_cache_multi_core(const Tensor& cache_
     uint32_t log2_page_table_stick_size_B = std::log2(page_table_stick_size_B);
     tt::DataFormat page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.get_dtype());
 
-    // TT_FATAL(1 << log2_page_table_stick_size_B == page_table_stick_size_B, "page_table_stick_size_B must be a power of 2");
-
     tt_metal::Device *device = input_tensor.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_fill_cache_program_factory.cpp
@@ -47,7 +47,7 @@ operation::ProgramWithCallbacks paged_fill_cache_multi_core(const Tensor& cache_
     uint32_t log2_page_table_stick_size_B = std::log2(page_table_stick_size_B);
     tt::DataFormat page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.get_dtype());
 
-    TT_FATAL(1 << log2_page_table_stick_size_B == page_table_stick_size_B, "page_table_stick_size_B must be a power of 2");
+    // TT_FATAL(1 << log2_page_table_stick_size_B == page_table_stick_size_B, "page_table_stick_size_B must be a power of 2");
 
     tt_metal::Device *device = input_tensor.device();
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
@@ -65,9 +65,6 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cach
         index_tensor_tile_size = tt_metal::detail::TileSize(index_data_format);
         index_is_dram = update_idxs_tensor.value().buffer()->buffer_type() == tt_metal::BufferType::DRAM;
         index_stick_size = update_idxs_tensor.value().buffer()->aligned_page_size();
-
-        log2_page_size = std::log2(index_stick_size);
-        TT_FATAL(1 << log2_page_size == index_stick_size, "Error");
     }
 
     // Pagetable-specific parameters
@@ -88,8 +85,6 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cach
         block_size_t = block_size / TILE_HEIGHT;
         max_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
         page_table_stick_size = page_table_tensor.get_legacy_shape()[-1] * page_table_tensor.element_size();
-        log2_page_table_stick_size = std::log2(page_table_stick_size);
-        TT_FATAL(1 << log2_page_table_stick_size == page_table_stick_size, "Error");
 
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.get_dtype());
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -71,9 +71,9 @@ void kernel_main() {
     }
     else {
         constexpr uint32_t cb_index_id = tt::CB::dataflow0;
-        const InterleavedPow2AddrGen<true> addrg = {
+        const InterleavedAddrGen<true> addrg = {
                 .bank_base_address = pos_addr,
-                .log_base_2_of_page_size = log_base_2_of_page_size
+                .page_size = index_stick_size_B
             };
 
         cb_reserve_back(cb_index_id, 1);
@@ -89,9 +89,9 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* page_table_ptr;
     if constexpr (is_paged_attention) {
         constexpr uint32_t cb_id_page_table = tt::CB::dataflow1;
-        const InterleavedPow2AddrGen<true> page_table_gen = {
+        const InterleavedAddrGen<true> page_table_gen = {
             .bank_base_address = page_table_addr,
-            .log_base_2_of_page_size = log2_page_table_page_size
+            .page_size = page_table_page_size
         };
         cb_reserve_back(cb_id_page_table, 1);
         uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -64,10 +64,6 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
         TT_FATAL(cur_pos_shape[0] == B, "cur_pos must have batch size equal to Q");
         TT_FATAL(page_table_shape[0] == B, "page_table must have hidden size equal to Q");
 
-        // const auto max_num_blocks_per_seq = page_table_shape[1];
-        // TT_FATAL(B * max_num_blocks_per_seq == k_shape[0], "Paged K cache must have dim0= B * max_num_blocks_per_seq");
-        // TT_FATAL(B * max_num_blocks_per_seq == v_shape[0], "Paged V cache must have dim0= B * max_num_blocks_per_seq");
-
         TT_FATAL(k_shape[1] == 1 && v_shape[1] == 1, "Paged attention only supports 1 head");
         TT_FATAL(k_shape[2] == v_shape[2], "K and V must have same block size");
         TT_FATAL(k_shape[3] == v_shape[3] && k_shape[3] == q_shape[3], "Q, K, V must have same hidden size");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -64,9 +64,9 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
         TT_FATAL(cur_pos_shape[0] == B, "cur_pos must have batch size equal to Q");
         TT_FATAL(page_table_shape[0] == B, "page_table must have hidden size equal to Q");
 
-        const auto max_num_blocks_per_seq = page_table_shape[1];
-        TT_FATAL(B * max_num_blocks_per_seq == k_shape[0], "Paged K cache must have dim0= B * max_num_blocks_per_seq");
-        TT_FATAL(B * max_num_blocks_per_seq == v_shape[0], "Paged V cache must have dim0= B * max_num_blocks_per_seq");
+        // const auto max_num_blocks_per_seq = page_table_shape[1];
+        // TT_FATAL(B * max_num_blocks_per_seq == k_shape[0], "Paged K cache must have dim0= B * max_num_blocks_per_seq");
+        // TT_FATAL(B * max_num_blocks_per_seq == v_shape[0], "Paged V cache must have dim0= B * max_num_blocks_per_seq");
 
         TT_FATAL(k_shape[1] == 1 && v_shape[1] == 1, "Paged attention only supports 1 head");
         TT_FATAL(k_shape[2] == v_shape[2], "K and V must have same block size");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -280,8 +280,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         tt::DataFormat pos_df = tt_metal::datatype_to_dataformat_converter(cur_pos_tensor.value().get_dtype());
         pos_tensor_tile_size = tt_metal::detail::TileSize(pos_df);
         index_stick_size = pos_buffer->aligned_page_size();
-        log2_page_size = std::log2(index_stick_size);
-        TT_FATAL(1 << log2_page_size == index_stick_size, "Error");
 
         //cb pos
         auto c_in8_config = CircularBufferConfig(pos_tensor_tile_size, {{CB::dataflow0, pos_df}}).set_page_size(CB::dataflow0, pos_tensor_tile_size);
@@ -297,8 +295,6 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         tt::DataFormat page_table_df = tt_metal::datatype_to_dataformat_converter(page_table_tensor.value().get_dtype());
         page_table_tile_size = tt_metal::detail::TileSize(page_table_df);
         page_table_stick_size = page_table_buffer->aligned_page_size();
-        log2_page_table_page_size = std::log2(page_table_stick_size);
-        TT_FATAL(1 << log2_page_table_page_size == page_table_stick_size, "Error");
 
         //cb page_table
         auto c_in9_config = CircularBufferConfig(page_table_tile_size, {{CB::dataflow1, page_table_df}}).set_page_size(CB::dataflow1, page_table_tile_size);


### PR DESCRIPTION
### Ticket
#12841

### Problem description
We need to enable the page table to have a length which is not a power of 2. This is to enable generality of sequence length for vLLM.

### What's changed
This PR changes dram address generators to use the page size rather than the log2 of page size.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/10927349732)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
