### PR TITLE
#12557: bias shape was wrong, and need to create pure torch tensor

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv1d.py
@@ -51,7 +51,7 @@ def run_conv(
     torch.manual_seed(0)
     conv_input_shape = [batch_size, input_channels, input_length]
     conv_weight_shape = [output_channels, input_channels // groups, kernel_size]
-    conv_bias_shape = [1, 1, output_channels]
+    conv_bias_shape = [1, 1, 1, output_channels]
     torch_input_tensor_ncl = torch.randn(conv_input_shape, dtype=torch.bfloat16).float()
     torch_input_tensor = torch.permute(torch_input_tensor_ncl, (0, 2, 1))
     torch_weight_tensor = torch.randn(conv_weight_shape, dtype=torch.bfloat16).float()
@@ -118,7 +118,7 @@ def run_conv(
     )
 
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
-    torch_output_tensor = ttnn.to_torch(tt_output_tensor)
+    torch_output_tensor = torch.Tensor(ttnn.to_torch(tt_output_tensor))
 
     # torch_output_tensor is in row major layout and NLC shape
     # NLC to NCL


### PR DESCRIPTION
### Ticket
#12557 

### Problem description
bias shape was wrong in the conv1d unit test

### What's changed
bias shape was fixed in the conv1d unit test

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
