### PR TITLE
Fix tracking of globally allocated CBs in graph capture

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_mlir_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_mlir_interface.cpp
@@ -88,13 +88,6 @@ void compare_l1_circular_buffer_allocations(
         std::cout << "DBG cb[" << i << "] " << std::get<0>(usage_estimator_result[i]) << " "
                   << graph_circular_buffer_allocations[i] << std::endl;
 
-        // If the size of CB returned by the estimator is c_cb_shares_space_with_sharded_operand that means that the CB
-        // is sharing space with sharded operand, so we skip the comparison as the graph capture doesn't recognize this
-        // case.
-        if (std::get<0>(usage_estimator_result[i]) == c_cb_shares_space_with_sharded_operand) {
-            continue;
-        }
-
         EXPECT_EQ(std::get<0>(usage_estimator_result[i]), graph_circular_buffer_allocations[i]);
     }
 }

--- a/tests/ttnn/unit_tests/gtests/test_mlir_interface_lib.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_mlir_interface_lib.cpp
@@ -3,22 +3,15 @@
 #include <cstddef>
 
 #include "mlir_interface_api.hpp"
-#include "mlir_l1_interface.hpp"
 
 static void compare_cb_allocations(
     const std::vector<uint32_t>& expected, const std::optional<std::vector<uint32_t>>& output) {
-    static const bool graph_capture_en = ttnn::mlir_interface::is_graph_capture_mode_enabled();
-
     EXPECT_TRUE(output.has_value());
     for (auto x : output.value()) {
         std::cout << "CB " << x << std::endl;
     }
     EXPECT_EQ(expected.size(), output.value().size());
     for (int i = 0; i < expected.size(); i++) {
-        // TODO: Graph capture currently doesn't recognize CBs which share space with the corresponding sharded operand.
-        if (expected[i] == 0 && graph_capture_en) {
-            continue;
-        }
         EXPECT_EQ(expected[i], output.value()[i]);
     }
 }
@@ -301,7 +294,7 @@ TEST(MLIR_INTERFACE_API, softmax_op) {
     EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
         shape, l1_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
     compare_cb_allocations(
-        {32768, 0, 2048, 2048, 655360, 2048},
+        {32768, 32768, 2048, 2048, 655360, 2048},
         ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
             shape,
             l1_interleaved_memory_config,
@@ -316,7 +309,7 @@ TEST(MLIR_INTERFACE_API, softmax_op) {
     EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
         shape, l1_sharded_memory_config, data_type, shape, l1_interleaved_memory_config, data_type));
     compare_cb_allocations(
-        {0, 32768, 2048, 2048, 655360, 2048},
+        {32768, 32768, 2048, 2048, 655360, 2048},
         ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
             shape,
             l1_sharded_memory_config,
@@ -331,7 +324,7 @@ TEST(MLIR_INTERFACE_API, softmax_op) {
     EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
         shape, l1_sharded_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
     compare_cb_allocations(
-        {0, 0, 2048, 2048, 655360, 2048},
+        {32768, 32768, 2048, 2048, 655360, 2048},
         ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
             shape,
             l1_sharded_memory_config,
@@ -361,7 +354,7 @@ TEST(MLIR_INTERFACE_API, softmax_op) {
     EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
         shape, l1_sharded_memory_config, data_type, shape, dram_interleaved_memory_config, data_type));
     compare_cb_allocations(
-        {0, 32768, 2048, 2048, 655360, 2048},
+        {32768, 32768, 2048, 2048, 655360, 2048},
         ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
             shape,
             l1_sharded_memory_config,
@@ -376,7 +369,7 @@ TEST(MLIR_INTERFACE_API, softmax_op) {
     EXPECT_TRUE(ttnn::mlir_interface::does_softmax_op_support_input_output_constraints(
         shape, dram_interleaved_memory_config, data_type, shape, l1_sharded_memory_config, data_type));
     compare_cb_allocations(
-        {32768, 0, 2048, 2048, 655360, 2048},
+        {32768, 32768, 2048, 2048, 655360, 2048},
         ttnn::mlir_interface::get_softmax_circular_buffers_l1_allocations(
             shape,
             dram_interleaved_memory_config,

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -45,12 +45,12 @@ void GraphTracker::track_deallocate(Buffer* buffer) {
     }
 }
 
-void GraphTracker::track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size) {
+void GraphTracker::track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated) {
     if (processors.empty()) {
         return;
     }
     for (auto& it : processors) {
-        it->track_allocate_cb(core_range_set, addr, size);
+        it->track_allocate_cb(core_range_set, addr, size, is_globally_allocated);
     }
 }
 

--- a/tt_metal/graph/graph_tracking.hpp
+++ b/tt_metal/graph/graph_tracking.hpp
@@ -28,7 +28,7 @@ namespace tt::tt_metal {
 
         virtual void track_deallocate(tt::tt_metal::Buffer* buffer) {};
 
-        virtual void track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size) {};
+        virtual void track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated) {};
 
         virtual void track_deallocate_cb() {};
 
@@ -77,7 +77,7 @@ namespace tt::tt_metal {
 
         void track_deallocate(Buffer* buffer);
 
-        void track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size);
+        void track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated);
 
         void track_deallocate_cb();
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -483,7 +483,7 @@ void Program::allocate_circular_buffers() {
                 }
             }
         }
-        tt::tt_metal::GraphTracker::instance().track_allocate_cb(circular_buffer->core_ranges(), computed_addr, circular_buffer->size());
+        tt::tt_metal::GraphTracker::instance().track_allocate_cb(circular_buffer->core_ranges(), computed_addr, circular_buffer->size(), circular_buffer->globally_allocated());
         circular_buffer->set_locally_allocated_address(computed_addr);
     }
     this->local_circular_buffer_allocation_needed_ = false;

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -44,7 +44,7 @@ namespace ttnn::graph {
 
         void track_deallocate(tt::tt_metal::Buffer* buffer) override;
 
-        void track_allocate_cb(const CoreRangeSet &core_range, uint64_t addr, uint64_t size) override;
+        void track_allocate_cb(const CoreRangeSet &core_range, uint64_t addr, uint64_t size, bool is_globally_allocated) override;
 
         void track_deallocate_cb() override;
 

--- a/ttnn/cpp/ttnn/operations/common/l1_interface_common.hpp
+++ b/ttnn/cpp/ttnn/operations/common/l1_interface_common.hpp
@@ -26,7 +26,7 @@ struct Shape;
 }
 }  // namespace ttnn
 
-constexpr static uint32_t c_cb_shares_space_with_sharded_operand = std::numeric_limits<uint32_t>::max();
+constexpr static uint32_t c_cb_shares_space_with_sharded_operand = (uint32_t)0;
 
 using L1InterfaceOperandParams =
     std::tuple<ttnn::types::Shape, tt::tt_metal::DataType, tt::tt_metal::Layout, tt::tt_metal::MemoryConfig>;

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_l1_interface.cpp
@@ -49,7 +49,8 @@ MatmulMultiCoreReuseMultiCastOpL1Usage::get_circular_buffer_l1_allocations_per_c
                                : input_cb_size_multiplier * program_config.per_core_M * program_config.in0_block_w *
                                      get_tile_size(input_a);
 
-    uint32_t in1_CB_size = is_sharded(input_b) && !std::get<tt::tt_metal::MemoryConfig>(input_b).is_dram()
+    uint32_t in1_CB_size = has_layout(input_b, tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) &&
+                                   !std::get<tt::tt_metal::MemoryConfig>(input_b).is_dram()
                                ? c_cb_shares_space_with_sharded_operand
                                : input_cb_size_multiplier * program_config.per_core_N * program_config.in0_block_w *
                                      get_tile_size(input_b);
@@ -147,13 +148,11 @@ MatmulMultiCoreReuseMultiCast1DOpL1Usage::get_circular_buffer_l1_allocations_per
     uint32_t in0_CB_tiles = is_sharded(input_a)
                                 ? num_blocks * program_config.per_core_M * program_config.in0_block_w * B
                                 : input_cb_size_multiplier * program_config.per_core_M * program_config.in0_block_w;
-    uint32_t in0_CB_size = is_sharded(input_a) && extract_shard_sub_blocks ? c_cb_shares_space_with_sharded_operand
-                                                                           : in0_CB_tiles * get_tile_size(input_a);
+    uint32_t in0_CB_size = is_sharded(input_a) && !extract_shard_sub_blocks ? c_cb_shares_space_with_sharded_operand
+                                                                            : in0_CB_tiles * get_tile_size(input_a);
 
-    uint32_t in1_CB_size = is_sharded(input_b) && !std::get<tt::tt_metal::MemoryConfig>(input_b).is_dram()
-                               ? c_cb_shares_space_with_sharded_operand
-                               : input_cb_size_multiplier * program_config.per_core_N * program_config.in0_block_w *
-                                     get_tile_size(input_b);
+    uint32_t in1_CB_size =
+        input_cb_size_multiplier * program_config.per_core_N * program_config.in0_block_w * get_tile_size(input_b);
 
     uint32_t out_CB_size = is_sharded(output)
                                ? c_cb_shares_space_with_sharded_operand

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.cpp
@@ -61,13 +61,9 @@ uint32_t SoftmaxOpL1Usage::calculate_block_size_impl(const L1InterfaceOperandPar
     return block_size;
 }
 
-uint32_t SoftmaxOpL1Usage::get_input_cb_size() const {
-    return is_sharded(input) ? c_cb_shares_space_with_sharded_operand : 2 * block_size * get_tile_size(input);
-}
+uint32_t SoftmaxOpL1Usage::get_input_cb_size() const { return 2 * block_size * get_tile_size(input); }
 
-uint32_t SoftmaxOpL1Usage::get_output_cb_size() const {
-    return is_sharded(output) ? c_cb_shares_space_with_sharded_operand : 2 * block_size * get_tile_size(output);
-}
+uint32_t SoftmaxOpL1Usage::get_output_cb_size() const { return 2 * block_size * get_tile_size(output); }
 
 std::vector<uint32_t> SoftmaxOpL1Usage::get_intermediate_cb_sizes() const {
     uint32_t im1_t = 1;  // 1/sum(exp(x))


### PR DESCRIPTION
To all folks who are code owners, no review required from the code owners, this is our internal branch that we are working on TTNN <-> optimiser interface.

Fix tracking of globally allocated CBs in graph capture by adding `globally_allocated` param in the `circular_buffer_allocate` graph node -> this flag can then later be used when processing the trace to conclude that no new bytes for that CB were allocated. 

Simplified comparison with analytical solution to now require the exact CB size values.

Fixed a couple of small bugs in analytical L1 interface solution found during testing.
