### PR TITLE
#12758: Add queue_id and optional output tensors to div and trunc op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -295,13 +295,40 @@ def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_overload_ttnn(accurate_mode, round_mode, input_shapes, value, device):
+def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device):
     if is_grayskull():
         if round_mode in ["trunc", "floor"]:
             pytest.skip("does not work for Grayskull -skipping")
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    golden_tensor = golden_function(in_data1, value, round_mode)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize("accurate_mode", [False, True])
+@pytest.mark.parametrize("round_mode", ["None", "trunc", "floor"])
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device):
+    if is_grayskull():
+        if round_mode in ["trunc", "floor"]:
+            pytest.skip("does not work for Grayskull -skipping")
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode, output_tensor=output_tensor)
     golden_function = ttnn.get_golden_function(ttnn.div)
     golden_tensor = golden_function(in_data1, value, round_mode)
 

--- a/tests/ttnn/unit_tests/operations/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_composite.py
@@ -547,6 +547,27 @@ def test_unary_composite_trunc_ttnn(input_shapes, device):
     assert comp_pass
 
 
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_composite_trunc_ttnn_opt(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    cq_id = 0
+    ttnn.trunc(input_tensor1, output_tensor=output_tensor, queue_id=cq_id)
+    golden_function = ttnn.get_golden_function(ttnn.trunc)
+    golden_tensor = golden_function(in_data1)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -72,25 +72,39 @@ struct ExecuteDivLikeOps
     }
 };
 
-template <BinaryCompositeOpType binary_comp_op_type>
-struct ExecuteBinaryCompositeOpsDiv
+struct ExecuteDiv
 {
     static Tensor invoke(
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         bool accurate_mode = false,
         const std::string& round_mode = "None",
-        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
-    }
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
     static Tensor invoke(
-        const Tensor& input_tensor_a,
+        const Tensor& input_tensor,
         float value,
         bool accurate_mode = false,
         const std::string& round_mode = "None",
-        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, value, accurate_mode, round_mode, memory_config);
-    }
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        bool accurate_mode = false,
+        const std::string& round_mode = "None",
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor,
+        float value,
+        bool accurate_mode = false,
+        const std::string& round_mode = "None",
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
 };
 
 template <BinaryOpType binary_op_type>
@@ -226,7 +240,7 @@ constexpr auto fmod = ttnn::register_operation_with_auto_launch_op<
     operations::binary::ExecuteBinaryFmod>();
 constexpr auto div = ttnn::register_operation_with_auto_launch_op<
     "ttnn::div",
-    operations::binary::ExecuteBinaryCompositeOpsDiv<operations::binary::BinaryCompositeOpType::DIV>>();
+    operations::binary::ExecuteDiv>();
 constexpr auto div_no_nan = ttnn::register_operation_with_auto_launch_op<
     "ttnn::div_no_nan",
     operations::binary::ExecuteDivLikeOps<operations::binary::BinaryCompositeOpType::DIV_NO_NAN>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -79,14 +79,16 @@ struct ExecuteDiv
         const Tensor& input_tensor_b,
         bool accurate_mode = false,
         const std::string& round_mode = "None",
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
         const Tensor& input_tensor,
         float value,
         bool accurate_mode = false,
         const std::string& round_mode = "None",
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
 
     static Tensor invoke(
         uint8_t queue_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -345,18 +345,20 @@ void bind_div_like_ops(py::module& module, const binary_operation_t& operation, 
 template <typename binary_operation_t>
 void bind_div(py::module& module, const binary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
-        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: Union[ttnn.Tensor, float], *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
             Args:
                 * :attr:`input_tensor_a`
                 * :attr:`input_tensor_b` (ttnn.Tensor or Number)
                 * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true``.
-                * :attr:`round_mode`
+                * :attr:`round_mode` (Default: None)
 
             Keyword Args:
                 * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true`` (Only if the input tensor is not ComplexTensor)
                 * :attr:`round_mode` : (Only if the input tensor is not ComplexTensor)
                 * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+                * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
+                * :attr:`queue_id` (Optional[uint8]): command queue id
 
             Example:
                 >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
@@ -377,15 +379,19 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                const Tensor& input_tensor_b,
                bool accurate_mode,
                const std::string& round_mode,
-               const std::optional<MemoryConfig>& memory_config) {
-                    return self(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               uint8_t queue_id) -> ttnn::Tensor {
+                    return self(queue_id, input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config, output_tensor);
                 },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
             py::kw_only(),
             py::arg("accurate_mode") = false,
             py::arg("round_mode") = "None",
-            py::arg("memory_config") = std::nullopt},
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = ttnn::DefaultQueueId},
 
         ttnn::pybind_overload_t{
             [](const binary_operation_t& self,
@@ -393,15 +399,19 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                float value,
                bool accurate_mode,
                const std::string& round_mode,
-               const std::optional<MemoryConfig>& memory_config) {
-                    return self(input_tensor_a, value, accurate_mode, round_mode, memory_config);
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               uint8_t queue_id) -> ttnn::Tensor {
+                    return self(queue_id, input_tensor_a, value, accurate_mode, round_mode, memory_config, output_tensor);
                 },
             py::arg("input_tensor_a"),
             py::arg("value"),
             py::kw_only(),
             py::arg("accurate_mode") = false,
             py::arg("round_mode") = "None",
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = ttnn::DefaultQueueId});
 }
 
 template <typename binary_operation_t>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -351,7 +351,6 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                 * :attr:`input_tensor_a`
                 * :attr:`input_tensor_b` (ttnn.Tensor or Number)
                 * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true``.
-                * :attr:`round_mode` (Default: None)
 
             Keyword Args:
                 * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true`` (Only if the input tensor is not ComplexTensor)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -24,7 +24,6 @@ enum class BinaryCompositeOpType {
     MAXIMUM,
     ATAN2,
     LOGICAL_XOR,
-    DIV,
     DIV_NO_NAN,
     FLOOR_DIV,
     LOGICAL_XOR_,
@@ -43,8 +42,6 @@ Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig
 Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _subalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _isclose(const Tensor&, const Tensor&, float, float, const bool, const std::optional<MemoryConfig>&);
-Tensor _div(const Tensor&, const Tensor&, bool, const std::string&, const std::optional<MemoryConfig>&);
-Tensor _div_overload(const Tensor&, float, bool, const std::string&, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _floor_div(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
@@ -133,16 +130,6 @@ template <>
 struct OpHandler<BinaryCompositeOpType::ISCLOSE> {
     static Tensor handle(const Tensor& t1, const Tensor& t2, float rtol, float atol, const bool equal_nan, const std::optional<MemoryConfig>& mem_cfg) {
         return _isclose(t1, t2, rtol, atol, equal_nan, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<BinaryCompositeOpType::DIV> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& mem_cfg) {
-        return _div(t1, t2, accurate_mode, round_mode, mem_cfg);
-    }
-    static Tensor handle(const Tensor& t1, float value, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& mem_cfg) {
-        return _div_overload(t1, value, accurate_mode, round_mode, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -367,15 +367,16 @@ Tensor _swish(const Tensor& a, const std::optional<MemoryConfig>& output_mem_con
 
 Tensor ExecuteTrunc::invoke(uint8_t queue_id, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> output_tensor) {
     auto arch = input.device()->arch();
+    output_tensor = output_tensor.value_or(ttnn::empty_like(input));
     TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is not supported on Grayskull");
-    Tensor floor_res = ttnn::floor(queue_id, input, output_mem_config, output_tensor);
+    Tensor floor_res = ttnn::floor(queue_id, input, output_mem_config);
     ttnn::where(queue_id, ttnn::ne(queue_id, input, floor_res), ttnn::add(queue_id, floor_res, 1.0f, std::nullopt, output_mem_config), floor_res, output_mem_config, output_tensor);
     ttnn::where(queue_id, ttnn::gtz(queue_id, input, output_mem_config), floor_res, output_tensor.value(), output_mem_config, output_tensor);
     return output_tensor.value();
 }
 
-Tensor ExecuteTrunc::invoke(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteTrunc::invoke(DefaultQueueId, input, output_mem_config);
+Tensor ExecuteTrunc::invoke(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> output_tensor) {
+    return ExecuteTrunc::invoke(DefaultQueueId, input, output_mem_config, output_tensor);
 }
 
 // Function variance of whole tensor.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -31,7 +31,6 @@ enum class UnaryCompositeOpType {
     SOFTSIGN,
     SWISH,
     TANHSHRINK,
-    TRUNC,
     VAR_HW,
     STD_HW,
     NORMALIZE_HW,
@@ -74,7 +73,6 @@ Tensor _multigammaln(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _sinh(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _softsign(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _swish(const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _trunc(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _variance_impl(const Tensor&, const Tensor&, Tensor&, const std::optional<MemoryConfig>&);
 Tensor _variance_impl(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _variance(const Tensor&, const std::optional<MemoryConfig>&);
@@ -230,13 +228,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::SWISH> {
     static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
         return _swish(t1, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::TRUNC> {
-    static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
-        return _trunc(t1, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -62,6 +62,18 @@ struct ExecuteUnaryCompositeOp {
     }
 };
 
+struct ExecuteTrunc {
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+};
+
 //OpHandler_float : get_function_type_float
 template <UnaryCompositeOpType unary_comp_op_type>
 struct ExecuteUnaryCompositeOpWithFloat {
@@ -226,7 +238,7 @@ constexpr auto swish = ttnn::register_operation_with_auto_launch_op<
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SWISH>>();
 constexpr auto trunc = ttnn::register_operation_with_auto_launch_op<
     "ttnn::trunc",
-    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TRUNC>>();
+    operations::unary::ExecuteTrunc>();
 constexpr auto var_hw = ttnn::register_operation_with_auto_launch_op<
     "ttnn::var_hw",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::VAR_HW>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -71,7 +71,8 @@ struct ExecuteTrunc {
 
     static Tensor invoke(
         const Tensor& input_tensor,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
 };
 
 //OpHandler_float : get_function_type_float

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -946,11 +946,13 @@ void bind_unary_composite_floats(py::module& module, const unary_operation_t& op
 }
 
 template <typename unary_operation_t>
-void bind_unary_composite_operation(py::module& module, const unary_operation_t& operation) {
+void bind_unary_composite_operation(py::module& module, const unary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
-            Applies {0} to :attr:`input_tensor` element-wise.
+            Applies {0} to :attr:`input_tensor` element-wise .
+
+            {2}
 
             .. math::
                 {0}(\\mathrm{{input\\_tensor}}_i)
@@ -969,7 +971,8 @@ void bind_unary_composite_operation(py::module& module, const unary_operation_t&
                 >>> output = {1}(tensor)
         )doc",
         operation.base_name(),
-        operation.python_fully_qualified_name());
+        operation.python_fully_qualified_name(),
+        description);
 
     bind_registered_operation(
         module,
@@ -987,7 +990,7 @@ void bind_unary_composite_operation(py::module& module, const unary_operation_t&
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
-            py::arg("queue_id") = 0});
+            py::arg("queue_id") = ttnn::DefaultQueueId});
 }
 
 
@@ -1410,13 +1413,13 @@ void py_module(py::module& module) {
     detail::bind_unary_composite(module, ttnn::sinh, R"doc(Performs sinh function on :attr:`input_tensor`.)doc", "[supported range -88 to 88]");
     detail::bind_unary_composite(module, ttnn::softsign, R"doc(Performs softsign function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::swish, R"doc(Performs swish function on :attr:`input_tensor`.)doc");
-    detail::bind_unary_composite(module, ttnn::trunc, R"doc(Performs trunc function on :attr:`input_tensor`, not supported for grayskull.)doc");
     detail::bind_unary_composite(module, ttnn::var_hw, R"doc(Performs var_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::std_hw, R"doc(Performs std_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::normalize_hw, R"doc(Performs normalize_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::logical_not_, R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::normalize_global, R"doc(Performs normalize_global function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::frac, R"doc(Performs frac function on :attr:`input_tensor`.)doc");
+    detail::bind_unary_composite_operation(module, ttnn::trunc, R"doc(Not supported for grayskull.)doc");
 
     detail::bind_unary_composite_floats_with_default(
         module,


### PR DESCRIPTION
### Ticket
Link to Github Issue #12758 , #12763

### What's changed

- Added queue_id and optional output tensors to ttnn.div
- Added queue_id and optional output tensors to ttnn.trunc

Perf before vs after:
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms)

ttnn.div, 800, 0.105, 0.132, 0.756, 0.038 (Before)
ttnn.div, 800, 0.112, 0.132, 0.756, 0.037 - (After)

### Checklist
- [x] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/10934479426)