### PR TITLE
#12874: Skip flaky prefill single card perf test for now

### DIFF
--- a/models/demos/wormhole/mistral7b/tests/test_mistral_model_prefill.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_model_prefill.py
@@ -20,7 +20,7 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
 
 
 class Emb(torch.nn.Module):
@@ -33,6 +33,7 @@ class Emb(torch.nn.Module):
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_wormhole_b0("#12874: Flaky, seems to hang after verification, need to fix, otherwise seems fine")
 @pytest.mark.timeout(900)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket

#12874

### Problem description

Skip mistral7b single card prefill perf test as it's flaky. We can focus on fixing it on another time. Other mistral7b perf tests seem ok

### What's changed

Skip for now

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
