### PR TITLE
#12877: Cache pip dependencies for data collection (infra) to save some time

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -85,8 +85,9 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+          cache-dependency-path: 'infra/requirements-infra.txt'
       - name: Install infra dependencies
-        run: pip3 install -r infra/requirements-infra.txt
+        run: pip install -r infra/requirements-infra.txt
       - name: Create JSON
         env:
           PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
…

### Ticket

#12877

### Problem description

We weren't properly referencing the `infra/requirements-infra.txt` req file for environment requirements.

Now that we are, we are actually caching the environment when we need to.

### What's changed

Fix `cache-dependency-path` key.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
