### PR TITLE
#0: Conv act split reader speed up

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -581,7 +581,7 @@ class resnet50:
             reshard_if_not_optimal=False,
         )
         if whb0_and_b16:
-            self.conv1_config.act_block_h_override = 64
+            self.conv1_config.act_block_h_override = 256
 
         self.conv1_kernel_size = (4, 4)
         self.conv1_stride = (1, 1)

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -12,7 +12,7 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5020],
+        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 5255],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -33,7 +33,7 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((2, 1, 650.0),),
+    ((2, 1, 683.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"


### PR DESCRIPTION
Small optimization/cleanup of split_reader activation reader for convs

De-duplicated code for activation split reader in  reader_writer_tiled_out_1d_mcast_***_conv_weights_tiled_col_to_rm_blocks.cpp
which turned out to speed things up.
Removed codepath in activation readers for caching indices on stack, also small speed up.

These two things brought ~5% device perf e2e improvement on Unet.

On Resnet changed act_block_h_override 64 -> 256 for first conv to get best perf
out of first and most expensive conv in the model.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/10939468642
- [x] (Single-card) Device perf regressions - https://github.com/tenstorrent/tt-metal/actions/runs/10939477978
- [x] (Single-card) Model perf tests - https://github.com/tenstorrent/tt-metal/actions/runs/10955367209 (a bit red by same as main) 
- [x] Nightly fast dispatch tests - https://github.com/tenstorrent/tt-metal/actions/runs/10958342744
