### PR TITLE
#12892: Add None for sweeps device perf on device execption

### DIFF
--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -69,7 +69,7 @@ def run(test_module, input_queue, output_queue):
         device, device_name = next(device_generator)
         print(f"SWEEPS: Opened device configuration, {device_name}.")
     except AssertionError as e:
-        output_queue.put([False, "DEVICE EXCEPTION: " + str(e), None])
+        output_queue.put([False, "DEVICE EXCEPTION: " + str(e), None, None])
         return
     try:
         while True:


### PR DESCRIPTION
### Ticket
#12892 

### Problem description
See issue.

### What's changed
Add None to the return list when there is a device exception.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
