### PR TITLE
#7493: Proposal for using a mask and keeping the CB enum as part of t…

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -4,6 +4,7 @@
 
 /** @file @brief Main firmware code */
 
+#include <bits/floatn-common.h>
 #include <unistd.h>
 
 #include <cstdint>
@@ -358,6 +359,7 @@ int main() {
 
     mailboxes->launch.go.run = RUN_MSG_DONE;
 
+
     while (1) {
         init_sync_registers();
         reset_ncrisc_with_iram();
@@ -392,7 +394,17 @@ int main() {
             // Run the BRISC kernel
             WAYPOINT("R");
             if (enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
-                setup_cb_read_write_interfaces(cb_l1_base, num_cbs_to_early_init, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
+                uint8_t max_cb_index = calculate_max_cb_index(mailboxes->launch.kernel_config.cb_mask);
+
+                // demo: https://godbolt.org/z/GdTdqT3WE
+                // benchmark: https://quick-bench.com/q/4CI2jfBP5tNW-jS7V4lAvxm6XH4
+                // TODO Move this code into the setup_cb_read_write_interfaces
+                CBSet cbset(mailboxes->launch.kernel_config.cb_mask);
+                std::for_each(cbset.begin(), cbset.end(), [](int cb_index) {
+                    // cb_index set can be used
+                });
+
+                setup_cb_read_write_interfaces(cb_l1_base, num_cbs_to_early_init, max_cb_index, true, true, false);
                 kernel_init();
                 RECORD_STACK_USAGE();
             } else {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -128,7 +128,8 @@ int main() {
             uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::IDLE_ETH, DISPATCH_CLASS_ETH_DM0);
             uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
                 mailboxes->launch.kernel_config.cb_offset);
-            setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
+            uint8_t max_cb_index = calculate_max_cb_index(mailboxes->launch.kernel_config.cb_mask);
+            setup_cb_read_write_interfaces(cb_l1_base, 0, max_cb_index, true, true, false);
 
             flush_icache();
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -95,7 +95,8 @@ int main(int argc, char *argv[]) {
         uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM1);
         uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
             mailboxes->launch.kernel_config.cb_offset);
-        setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
+        uint8_t max_cb_index = calculate_max_cb_index(mailboxes->launch.kernel_config.cb_mask);
+        setup_cb_read_write_interfaces(cb_l1_base, 0, max_cb_index, true, true, false);
 
         WAYPOINT("R");
         kernel_init();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
 #if !defined(UCK_CHLKC_MATH)
         uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
             mailboxes->launch.kernel_config.cb_offset);
-        setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write, cb_init_write);
+        setup_cb_read_write_interfaces(cb_l1_base, 0, max_cb_index, cb_init_read, cb_init_write, cb_init_write);
 #endif
 
         rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -89,12 +89,10 @@ struct kernel_config_msg_t {
     volatile uint8_t mode;                   // dispatch mode host/dev
     volatile uint8_t brisc_noc_id;
     volatile uint8_t enables;
-    volatile uint8_t max_cb_index;
     volatile uint8_t dispatch_core_x;
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
-    volatile uint8_t pad1;
-    volatile uint16_t pad2;
+    volatile uint32_t cb_mask;
 } __attribute__((packed));
 
 struct go_msg_t {

--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -127,6 +127,7 @@ class CircularBufferConfig {
             }
             this->data_formats_[buffer_index] = data_format;
             this->buffer_indices_.insert(buffer_index);
+            this->buffer_mask |= (1 << buffer_index);
         }
     }
 
@@ -135,6 +136,7 @@ class CircularBufferConfig {
     std::array<std::optional<tt::DataFormat>, NUM_CIRCULAR_BUFFERS> data_formats_;
     std::array<std::optional<uint32_t>, NUM_CIRCULAR_BUFFERS> page_sizes_;
     std::unordered_set<uint8_t> buffer_indices_;
+    uint32_t buffer_mask{0};
     bool dynamic_cb_ = false;
     // `max_size_` is used to ensure that total size does not grow beyond associated buffer size
     std::optional<uint32_t> max_size_ = std::nullopt;

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -51,7 +51,8 @@ struct KernelGroup {
         kernel_id_array_t kernel_ids,
         bool erisc_is_idle,
         int last_cb_index,
-        const CoreRangeSet &new_ranges);
+        const CoreRangeSet &new_ranges,
+        uint32_t cb_mask);
 
     uint32_t get_programmable_core_type_index() const;
 


### PR DESCRIPTION
…he api

### Ticket
#7493 

### Problem description
Explore the possibility of keeping the sparse enums by restricting the max to 32 and passing a mask through the mail message for the firmware.   The idea here is to see if we can efficiently iterate over the mask without taking a performance hit.  
See : [https://quick-bench.com/q/4CI2jfBP5tNW-jS7V4lAvxm6XH4](https://quick-bench.com/q/4CI2jfBP5tNW-jS7V4lAvxm6XH4)

### What's changed
Removed the cb_max_index and replacing padding with cb_mask of size unit32 in the message to the firmware.
Note that we are looking at benchmarks to see if we can avoid any performance penalty with this approach.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
