### PR TITLE
#12867: Cleanup 9 Unary Backward ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_celu.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_celu.py
@@ -29,3 +29,24 @@ def test_bw_celu(input_shapes, device):
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
 
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_celu_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+
+    tt_output_tensor_on_device = ttnn.celu_bw(grad_tensor, input_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.celu_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+
+    assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_elu.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_elu.py
@@ -36,3 +36,23 @@ def test_bw_elu(input_shapes, alpha, device):
     golden_tensor = golden_function(grad_data, in_data, alpha)
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_elu_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+
+    tt_output_tensor_on_device = ttnn.elu_bw(grad_tensor, input_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.elu_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_hardshrink.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_hardshrink.py
@@ -28,3 +28,24 @@ def test_bw_hardshrink(input_shapes, lambd, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_hardshrink_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    tt_output_tensor_on_device = ttnn.hardshrink_bw(grad_tensor, input_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.hardshrink_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_leaky_relu.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_leaky_relu.py
@@ -27,3 +27,23 @@ def test_bw_leaky_relu(input_shapes, negative_slope, device):
     golden_tensor = golden_function(grad_data, in_data, negative_slope)
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_leaky_relu_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+
+    tt_output_tensor_on_device = ttnn.leaky_relu_bw(grad_tensor, input_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.leaky_relu_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_logiteps.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_logiteps.py
@@ -32,3 +32,21 @@ def test_bw_logiteps(input_shapes, eps, device):
     golden_tensor = golden_function(grad_data, in_data, eps)
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_logiteps_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    tt_output_tensor_on_device = ttnn.logiteps_bw(grad_tensor, input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.logiteps_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_softshrink.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_softshrink.py
@@ -35,3 +35,28 @@ def test_bw_softshrink(input_shapes, lambd, device):
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_softshrink_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data.retain_grad()
+
+    pyt_y = torch.nn.functional.softshrink(in_data)
+
+    tt_output_tensor_on_device = ttnn.softshrink_bw(grad_tensor, input_tensor)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -591,7 +591,7 @@ std::vector<Tensor> _square_bw(const Tensor& grad, const Tensor& input, const st
     return grad_tensor;
 }
 
-std::vector<Tensor> _hardshrink_bw(
+std::vector<Tensor> ExecuteUnaryBackwardHardshrink::invoke(
     const Tensor& grad, const Tensor& input_tensor, float lambd, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor hardshrink_result = ttnn::hardshrink(input_tensor, lambd, output_mem_config);
@@ -603,7 +603,7 @@ std::vector<Tensor> _hardshrink_bw(
 
 // softshrink
 //  result: torch.where(self < -lambd, grad, torch.where(self > lambd, grad, torch.tensor(0.0)))
-std::vector<Tensor> _softshrink_bw(
+std::vector<Tensor> ExecuteUnaryBackwardSoftshrink::invoke(
     const Tensor& grad, const Tensor& input_tensor, float lambd, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::where(
@@ -622,7 +622,7 @@ std::vector<Tensor> _softshrink_bw(
 
 // Leaky_Relu
 // result: torch.where(self > 0, grad_output, grad_output * negative_slope)
-std::vector<Tensor> _leaky_relu_bw(
+std::vector<Tensor> ExecuteUnaryBackwardLeakyRelu::invoke(
     const Tensor& grad, const Tensor& input, float negative_slope, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result = where(
@@ -634,7 +634,7 @@ std::vector<Tensor> _leaky_relu_bw(
 
 // ELU
 // result : grad * (torch.where(input >= 0, 1, alpha * torch.exp(input)))
-std::vector<Tensor> _elu_bw(
+std::vector<Tensor> ExecuteUnaryBackwardElu::invoke(
     const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result = where(
@@ -649,7 +649,7 @@ std::vector<Tensor> _elu_bw(
 
 // Celu
 // result: torch.where((input > 0), grad, grad * torch.exp(input / alpha))
-std::vector<Tensor> _celu_bw(
+std::vector<Tensor> ExecuteUnaryBackwardCelu::invoke(
     const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor div_result = ttnn::multiply(
@@ -1074,7 +1074,7 @@ std::vector<Tensor> _cosh_bw(const Tensor& grad, const Tensor& input, const std:
 // #             grad_output / (self * (1.0 - self)),
 // #             self.new_full((), float("nan")),
 // #         )
-std::vector<Tensor> _logiteps_bw(
+std::vector<Tensor> ExecuteUnaryBackwardLogiteps::invoke(
     const Tensor& grad, const Tensor& input, float eps, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float low, high;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -1414,7 +1414,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
         return ExecuteUnaryBackwardGelu::invoke(DefaultQueueId, grad, input, approximate, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> _repeat_bw(
+std::vector<Tensor> ExecuteUnaryBackwardRepeat::invoke(
     const Tensor& grad, const Tensor& input, const tt::tt_metal::LegacyShape& shape, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -101,7 +101,7 @@ std::vector<Tensor> ExecuteUnaryBackwardSoftplus::invoke(
     return grad_tensor;
 }
 
-std::vector<Tensor> _rdiv_bw(
+std::vector<Tensor> ExecuteUnaryBackwardRdiv::invoke(
     const Tensor& grad, const Tensor& input, float scalar, string round_mode, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -36,11 +36,6 @@ enum class UnaryBackwardOpType {
     SIGMOID_BW,
     RELU_BW,
     LOGIT_BW,
-    HARDSHRINK_BW,
-    SOFTSHRINK_BW,
-    LEAKY_RELU_BW,
-    ELU_BW,
-    CELU_BW,
     RPOW_BW,
     FLOOR_BW,
     ROUND_BW,
@@ -61,7 +56,6 @@ enum class UnaryBackwardOpType {
     CEIL_BW,
     SOFTSIGN_BW,
     COSH_BW,
-    LOGITEPS_BW,
     LOG2_BW,
     SIGN_BW,
     DIV_NO_NAN_BW,
@@ -131,13 +125,6 @@ std::vector<Tensor> _log_bw( const Tensor& grad, const Tensor& input, const std:
 
 std::vector<Tensor> _add_bw( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 std::vector<Tensor> _eq_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-
-std::vector<Tensor> _hardshrink_bw( const Tensor& grad, const Tensor& input, float lambd = 0.5, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-std::vector<Tensor> _softshrink_bw( const Tensor& grad, const Tensor& input, float lambd = 0.5, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-std::vector<Tensor> _leaky_relu_bw( const Tensor& grad, const Tensor& input, float negative_slope = 0.01, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-std::vector<Tensor> _elu_bw( const Tensor& grad, const Tensor& input, float alpha = 1.0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-std::vector<Tensor> _celu_bw( const Tensor& grad, const Tensor& input, float aplha = 1.0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-std::vector<Tensor> _logiteps_bw( const Tensor& grad, const Tensor& input, float eps = 0.0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
 std::vector<Tensor> _rdiv_bw( const Tensor& grad, const Tensor& input, float scalar, string round_mode = "None", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
@@ -411,48 +398,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::POLYGAMMA_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config ) {
         return _polygamma_bw(grad, input, n, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::HARDSHRINK_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float lambd, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _hardshrink_bw(grad, input, lambd, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::SOFTSHRINK_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float lambd, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _softshrink_bw(grad, input, lambd, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::LEAKY_RELU_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float negative_slope, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _leaky_relu_bw(grad, input, negative_slope, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::ELU_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _elu_bw(grad, input, alpha, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::CELU_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _celu_bw(grad, input, alpha, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::LOGITEPS_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float eps, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _logiteps_bw(grad, input, eps, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -14,7 +14,6 @@ namespace ttnn::operations::unary_backward {
 
 enum class UnaryBackwardOpType {
     DIV_BW,
-    RDIV_BW,
     MULTIGAMMALN_BW,
     ADD_BW,
     EQ_BW,
@@ -124,8 +123,6 @@ std::vector<Tensor> _log_bw( const Tensor& grad, const Tensor& input, const std:
 
 std::vector<Tensor> _add_bw( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 std::vector<Tensor> _eq_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-
-std::vector<Tensor> _rdiv_bw( const Tensor& grad, const Tensor& input, float scalar, string round_mode = "None", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config);
 
@@ -480,13 +477,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::SUB_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config ) {
         return _sub_bw(grad, input, scalar, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RDIV_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _rdiv_bw(grad, input, scalar, round_mode, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -67,7 +67,6 @@ enum class UnaryBackwardOpType {
     ERF_BW,
     DEG2RAD_BW,
     POLYGAMMA_BW,
-    REPEAT_BW,
 };
 
 std::vector<Tensor> _acos_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -128,7 +127,6 @@ std::vector<Tensor> _eq_bw( const Tensor& grad, const Tensor& input, float other
 
 std::vector<Tensor> _rdiv_bw( const Tensor& grad, const Tensor& input, float scalar, string round_mode = "None", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-std::vector<Tensor> _repeat_bw(const Tensor& grad, const Tensor& input, const tt::tt_metal::LegacyShape& shape, const std::optional<MemoryConfig>& output_mem_config);
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config);
 
 // OpHandler struct template
@@ -489,13 +487,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::RDIV_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
         return _rdiv_bw(grad, input, scalar, round_mode, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::REPEAT_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const tt::tt_metal::LegacyShape& shape, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _repeat_bw(grad, input, shape, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -126,17 +126,13 @@ struct ExecuteUnaryBackwardClamp {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-template <UnaryBackwardOpType unary_backward_op_type>
-struct ExecuteUnaryBackwardFloatStringDefault {
+struct ExecuteUnaryBackwardRdiv {
     static std::vector<Tensor> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float parameter_a,
         string parameter_b,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
-    }
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
 template <UnaryBackwardOpType unary_backward_op_type>
@@ -563,8 +559,7 @@ constexpr auto softplus_bw = ttnn::register_operation<"ttnn::softplus_bw", opera
 
 constexpr auto rdiv_bw = ttnn::register_operation<
     "ttnn::rdiv_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<
-        operations::unary_backward::UnaryBackwardOpType::RDIV_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardRdiv>();
 
 constexpr auto gelu_bw = ttnn::register_operation<
     "ttnn::gelu_bw",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -82,16 +82,13 @@ struct ExecuteUnaryBackward##op_name { \
         const std::optional<MemoryConfig> &memory_config = std::nullopt); \
 };
 
-template <UnaryBackwardOpType unary_backward_op_type>
-struct ExecuteUnaryBackwardFloatWithDefault {
-    static std::vector<Tensor> invoke(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_arg,
-        float parameter_a,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, output_memory_config);
-    }
+#define DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(op_name) \
+struct ExecuteUnaryBackward##op_name { \
+    static std::vector<Tensor> invoke( \
+        const Tensor &grad_tensor_arg, \
+        const Tensor &input_tensor_arg, \
+        float parameter_a, \
+        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
 };
 
 template <UnaryBackwardOpType unary_backward_op_type>
@@ -314,6 +311,13 @@ struct ExecuteUnaryBackwardGelu{
 
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Softplus)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Hardtanh)
+
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Hardshrink)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Softshrink)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(LeakyRelu)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Elu)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Celu)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Logiteps)
 
 }  // operations::unary
 
@@ -544,35 +548,13 @@ constexpr auto erfc_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardOp<
         operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>();
 
-constexpr auto hardshrink_bw = ttnn::register_operation<
-    "ttnn::hardshrink_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatWithDefault<
-        operations::unary_backward::UnaryBackwardOpType::HARDSHRINK_BW>>();
-
-constexpr auto softshrink_bw = ttnn::register_operation<
-    "ttnn::softshrink_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatWithDefault<
-        operations::unary_backward::UnaryBackwardOpType::SOFTSHRINK_BW>>();
-
-constexpr auto leaky_relu_bw = ttnn::register_operation<
-    "ttnn::leaky_relu_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatWithDefault<
-        operations::unary_backward::UnaryBackwardOpType::LEAKY_RELU_BW>>();
-
-constexpr auto elu_bw = ttnn::register_operation<
-    "ttnn::elu_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatWithDefault<
-        operations::unary_backward::UnaryBackwardOpType::ELU_BW>>();
-
-constexpr auto celu_bw = ttnn::register_operation<
-    "ttnn::celu_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatWithDefault<
-        operations::unary_backward::UnaryBackwardOpType::CELU_BW>>();
-
-constexpr auto logiteps_bw = ttnn::register_operation<
-    "ttnn::logiteps_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloatWithDefault<
-        operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>();
+// Tensor + Float(Default)
+constexpr auto logiteps_bw = ttnn::register_operation<"ttnn::logiteps_bw", operations::unary_backward::ExecuteUnaryBackwardLogiteps>();
+constexpr auto celu_bw = ttnn::register_operation<"ttnn::celu_bw", operations::unary_backward::ExecuteUnaryBackwardCelu>();
+constexpr auto elu_bw = ttnn::register_operation<"ttnn::elu_bw", operations::unary_backward::ExecuteUnaryBackwardElu>();
+constexpr auto leaky_relu_bw = ttnn::register_operation<"ttnn::leaky_relu_bw", operations::unary_backward::ExecuteUnaryBackwardLeakyRelu>();
+constexpr auto softshrink_bw = ttnn::register_operation<"ttnn::softshrink_bw", operations::unary_backward::ExecuteUnaryBackwardSoftshrink>();
+constexpr auto hardshrink_bw = ttnn::register_operation<"ttnn::hardshrink_bw", operations::unary_backward::ExecuteUnaryBackwardHardshrink>();
 
 constexpr auto clamp_bw = ttnn::register_operation<
     "ttnn::clamp_bw",
@@ -581,6 +563,7 @@ constexpr auto clamp_bw = ttnn::register_operation<
 // Tensor + Float(Default) + Float(Default)
 constexpr auto hardtanh_bw = ttnn::register_operation<"ttnn::hardtanh_bw", operations::unary_backward::ExecuteUnaryBackwardHardtanh>();
 constexpr auto softplus_bw = ttnn::register_operation<"ttnn::softplus_bw", operations::unary_backward::ExecuteUnaryBackwardSoftplus>();
+
 
 constexpr auto rdiv_bw = ttnn::register_operation<
     "ttnn::rdiv_bw",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -151,16 +151,12 @@ struct ExecuteUnaryBackwardStringDefault {
     }
 };
 
-template <UnaryBackwardOpType unary_backward_op_type>
-struct ExecuteUnaryBackwardShape {
+struct ExecuteUnaryBackwardRepeat {
     static std::vector<Tensor> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         const tt::tt_metal::LegacyShape &parameter_a,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, output_memory_config);
-    }
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
 struct ExecuteUnaryBackwardPow {
@@ -576,8 +572,7 @@ constexpr auto gelu_bw = ttnn::register_operation<
 
 constexpr auto repeat_bw = ttnn::register_operation<
     "ttnn::repeat_bw",
-    operations::unary_backward::ExecuteUnaryBackwardShape<
-        operations::unary_backward::UnaryBackwardOpType::REPEAT_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardRepeat>();
 
 constexpr auto pow_bw = ttnn::register_operation<
     "ttnn::pow_bw",

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -24,22 +24,39 @@ def _golden_function_unary_backward(torch_op, grad_tensor, input_tensor, *args, 
     return golden_tensor
 
 
-def _golden_function_unary_backward_with_float(torch_op, grad_tensor, input_tensor, alpha, *args, **kwargs):
-    if torch_op == "leaky_relu":
-        pyt_y = torch.nn.functional.leaky_relu(input_tensor, negative_slope=alpha, inplace=False)
-    elif torch_op == "elu":
-        pyt_y = torch.nn.functional.elu(input_tensor, alpha=alpha)
-    elif torch_op == "celu":
-        pyt_y = torch.nn.functional.celu(input_tensor, alpha)
-    elif torch_op == "div_no_nan":
-        pyt_y = torch.where(torch.tensor(alpha) == 0, torch.zeros_like(input_tensor), torch.div(input_tensor, alpha))
-    else:
-        pyt_y = torch_op(input_tensor, alpha)
+def _golden_function_div_no_nan(torch_op, grad_tensor, input_tensor, alpha, *args, **kwargs):
+    pyt_y = torch.where(torch.tensor(alpha) == 0, torch.zeros_like(input_tensor), torch.div(input_tensor, alpha))
     input_tensor.retain_grad()
     pyt_y.backward(gradient=grad_tensor)
     golden_tensor = [input_tensor.grad]
-    if torch_op == "div_no_nan":
-        golden_tensor[0] = torch.where(torch.isnan(golden_tensor[0]), torch.zeros_like(input_tensor), golden_tensor[0])
+    golden_tensor[0] = torch.where(torch.isnan(golden_tensor[0]), torch.zeros_like(input_tensor), golden_tensor[0])
+    return golden_tensor
+
+
+def _golden_function_unary_backward_with_float(torch_op, grad_tensor, input_tensor, alpha=None, *args, **kwargs):
+    if torch_op == "leaky_relu":
+        if alpha != None:
+            pyt_y = torch.nn.functional.leaky_relu(input_tensor, negative_slope=alpha)
+        else:
+            pyt_y = torch.nn.functional.leaky_relu(input_tensor)
+    elif torch_op == "elu":
+        if alpha != None:
+            pyt_y = torch.nn.functional.elu(input_tensor, alpha=alpha)
+        else:
+            pyt_y = torch.nn.functional.elu(input_tensor)
+    elif torch_op == "celu":
+        if alpha != None:
+            pyt_y = torch.nn.functional.celu(input_tensor, alpha)
+        else:
+            pyt_y = torch.nn.functional.celu(input_tensor)
+    else:
+        if alpha != None:
+            pyt_y = torch_op(input_tensor, alpha)
+        else:
+            pyt_y = torch_op(input_tensor)
+    input_tensor.retain_grad()
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor.grad]
     return golden_tensor
 
 
@@ -146,35 +163,35 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.hardshrink_bw,
-    golden_function=lambda grad, input, *args, **kwargs: _golden_function_unary_backward(
-        torch.hardshrink, grad, input, *args, **kwargs
+    golden_function=lambda grad, input, alpha=None, *args, **kwargs: _golden_function_unary_backward_with_float(
+        torch.hardshrink, grad, input, alpha, *args, **kwargs
     ),
 )
 
 ttnn.attach_golden_function(
     ttnn.softshrink_bw,
-    golden_function=lambda grad, input, *args, **kwargs: _golden_function_unary_backward(
-        torch.softshrink, grad, input, *args, **kwargs
+    golden_function=lambda grad, input, alpha=None, *args, **kwargs: _golden_function_unary_backward_with_float(
+        torch.softshrink, grad, input, alpha, *args, **kwargs
     ),
 )
 
 ttnn.attach_golden_function(
     ttnn.leaky_relu_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
+    golden_function=lambda grad, input, alpha=None, *args, **kwargs: _golden_function_unary_backward_with_float(
         "leaky_relu", grad, input, alpha, *args, **kwargs
     ),
 )
 
 ttnn.attach_golden_function(
     ttnn.elu_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
+    golden_function=lambda grad, input, alpha=None, *args, **kwargs: _golden_function_unary_backward_with_float(
         "elu", grad, input, alpha, *args, **kwargs
     ),
 )
 
 ttnn.attach_golden_function(
     ttnn.celu_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
+    golden_function=lambda grad, input, alpha=None, *args, **kwargs: _golden_function_unary_backward_with_float(
         "celu", grad, input, alpha, *args, **kwargs
     ),
 )
@@ -188,7 +205,7 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.logiteps_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
+    golden_function=lambda grad, input, alpha=None, *args, **kwargs: _golden_function_unary_backward_with_float(
         torch.logit, grad, input, alpha, *args, **kwargs
     ),
 )
@@ -216,7 +233,7 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.div_no_nan_bw,
-    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_unary_backward_with_float(
+    golden_function=lambda grad, input, alpha, *args, **kwargs: _golden_function_div_no_nan(
         "div_no_nan", grad, input, alpha, *args, **kwargs
     ),
 )


### PR DESCRIPTION
Issue : #12867

**Work Done :** 

- Cleanup the following structs
  - ExecuteUnaryBackwardFloatWithDefault
  - ExecuteUnaryBackwardShape
  - ExecuteUnaryBackwardTanh
  - ExecuteUnaryBackwardFloatStringDefault
- Update test file to check for default value cases
- Update golden function for ops with default values

**Test Files :** 

- hardshrink_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_hardshrink.py` - PASSED
- softshrink_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_softshrink.py` - PASSED
- leaky_relu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_leaky_relu.py` - PASSED
- elu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_elu.py` - PASSED
- celu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_celu.py` - PASSED
- logiteps_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_logiteps.py` - PASSED
- repeat_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_repeat.py` - PASSED
- rdiv_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_rdiv.py` - PASSED
- div_no_nan_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_div_no_nan.py` - PASSED

[CI](https://github.com/tenstorrent/tt-metal/actions/runs/10956760939) : PASSED