### PR TITLE
graph capture with mockup device

### DIFF
--- a/tt_metal/common/base.hpp
+++ b/tt_metal/common/base.hpp
@@ -10,40 +10,38 @@
 #include <array>
 #include <cstdint>
 #include <iostream>
-#include <array>
-#include <vector>
 #include <map>
+#include <vector>
 
-#include "tt_metal/common/tt_backend_api_types.hpp" // These are the types exported to frontend team...
-#include "tt_metal/common/assert.hpp"
-#include "hostdevcommon/kernel_structs.h"
-#include "eth_l1_address_map.h"
-#include "common/constants.hpp"
 #include "common/base_types.hpp"
+#include "common/constants.hpp"
+#include "eth_l1_address_map.h"
+#include "hostdevcommon/kernel_structs.h"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/tt_backend_api_types.hpp"  // These are the types exported to frontend team...
 
 using std::array;
+using std::map;
 using std::ostream;
-using std::uint8_t;
+using std::size_t;
+using std::string;
 using std::uint32_t;
 using std::uint64_t;
+using std::uint8_t;
 using std::vector;
-using std::string;
-using std::size_t;
-using std::map;
 
 inline constexpr uint32_t align(uint32_t addr, uint32_t alignment) { return ((addr - 1) | (alignment - 1)) + 1; }
 
-
-namespace tt
-{
+namespace tt {
 
 /**
  * @brief Specifies the target devices on which the graph can be run.
-*/
-enum class TargetDevice : uint8_t
-{
+ */
+enum class TargetDevice : uint8_t {
     Silicon = 0,
     Simulator = 1,
+    Mockup = 2,  // Used for GraphCaptures without dispatching when there is no card attached to the system
+                 // Requires TT_METAL_MOCKUP_EN=1 ARCH_NAME=wormhole_b0 TT_METAL_SLOW_DISPATCH_MODE=1
     Invalid = 0xFF,
 };
 
@@ -51,12 +49,11 @@ constexpr uint32_t MAX_AVAILABLE_CHIPS = 16;
 
 struct pair_hash {
     template <class T1, class T2>
-    std::size_t operator()(const std::pair<T1,T2> &p) const
-    {
+    std::size_t operator()(const std::pair<T1, T2> &p) const {
         auto h1 = std::hash<T1>{}(p.first);
         auto h2 = std::hash<T2>{}(p.second);
         return h1 ^ h2;
     }
 };
 
-} // end namespace tt
+}  // end namespace tt


### PR DESCRIPTION
Merging to the internal feature branch, required reviewers no actions required from your side.

To run graph capture use `TT_METAL_MOCKUP_EN=1` `ARCH_NAME=wormhole_b0` `TT_METAL_SLOW_DISPATCH_MODE=1`

To setup testmate add following to `settings.json`

>     "testMate.cpp.test.advancedExecutables": [
>     {
>         "pattern": "build_Debug/test/ttnn/**/*{test,Test,TEST}*",
>         "cwd": "${absDirpath}",
>         "env": {
>             "ARCH_NAME": "wormhole_b0",
>             "TT_METAL_HOME" : "/localdev/mbezulj/metal24",
>             "TT_METAL_LOGGER_LEVEL" : "TRACE",
>             "TT_METAL_MOCKUP_EN" : "1",
>             "TT_METAL_SLOW_DISPATCH_MODE" : "1",
>         }
>     }
>     ],

(cherry picked from commit 410972b376e5621c97a6e460b3cb724a9c925007)