### PR TITLE
Add llk support for cumsum and transpose_wh_dest with relevant tests

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/cumsum.h"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr int onetile = 1;
+    constexpr uint32_t Ht = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t NC = get_compile_time_arg_val(2);
+
+    init_sfpu(tt::CB::c_in0);
+    cumsum_tile_init();
+
+    for (uint32_t nc = 0; nc < NC; ++nc) {
+        for(uint32_t wt = 0; wt < Wt; ++wt) {
+            for(uint32_t ht = 0; ht < Ht; ++ht) {
+                cb_reserve_back(tt::CB::c_out0, onetile);
+                acquire_dst(tt::DstMode::Half);
+                cb_wait_front(tt::CB::c_in0, onetile);
+
+                copy_tile(tt::CB::c_in0, 0, 0);
+                cumsum_tile(0, ht == 0);
+
+                pack_tile(0, tt::CB::c_out0);
+
+                cb_pop_front(tt::CB::c_in0, onetile);
+                release_dst(tt::DstMode::Half);
+                cb_push_back(tt::CB::c_out0, onetile);
+            }
+        }
+    }
+}
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
@@ -6,6 +6,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/transpose_wh_dest.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"

--- a/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/common.h"
+#include "compute_kernel_api/transpose_wh.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
@@ -17,7 +18,11 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
 
+#ifndef ROWWISE
     init_sfpu(tt::CB::c_in0);
+#else
+    transpose_wh_init(tt::CB::c_in0);
+#endif
     cumsum_tile_init();
 
     for (uint32_t nc = 0; nc < NC; ++nc) {
@@ -27,8 +32,17 @@ void MAIN {
                 acquire_dst(tt::DstMode::Half);
                 cb_wait_front(tt::CB::c_in0, onetile);
 
-                copy_tile(tt::CB::c_in0, 0, 0);
+                #ifndef ROWWISE
+                    copy_tile(tt::CB::c_in0, 0, 0);
+                #else
+                    transpose_wh_init_short(tt::CB::c_in0);
+                    transpose_wh_tile(tt::CB::c_in0, 0, 0);
+                #endif
                 cumsum_tile(0, ht == 0);
+                #ifdef ROWWISE
+                    transpose_wh_dest_init_short();
+                    transpose_wh_dest(0);
+                #endif
 
                 pack_tile(0, tt::CB::c_out0);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_transpose_wh.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_transpose_wh.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t dst_noc_x = get_arg_val<uint32_t>(1);
+    uint32_t dst_noc_y = get_arg_val<uint32_t>(2);
+    //uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t N = get_arg_val<uint32_t>(4);
+    uint32_t Ht = get_arg_val<uint32_t>(5);
+    uint32_t Wt = get_arg_val<uint32_t>(6);
+    uint32_t HtWt = get_arg_val<uint32_t>(7);
+    uint32_t HtWtTileBytes = HtWt*2048; // TODO(AP): assumed 16-bits
+    uint32_t WtTileBytes = Wt*2048; // TODO(AP): assumed 16-bits
+
+    constexpr uint32_t cb_id_out0 = 16;
+
+    // single-tile ublocks
+    uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
+    uint32_t ublock_size_tiles = 1;
+
+    uint32_t dst_addrN = dst_addr;
+    // this writer will write a NWH tensor in NHW order
+    for (uint32_t n = 0; n<N; n++) {
+        dst_addr = dst_addrN;
+        for (uint32_t w = 0; w<Wt; w++) {
+            for (uint32_t h = 0; h<Ht; h++) {
+                uint64_t dst_noc_addr = get_noc_addr(dst_noc_x, dst_noc_y, dst_addr);
+                cb_wait_front(cb_id_out0, ublock_size_tiles);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
+                noc_async_write_barrier();
+
+                cb_pop_front(cb_id_out0, ublock_size_tiles);
+                dst_addr += WtTileBytes; // stride in H
+            } // Ht
+            dst_addr -= HtWtTileBytes; // go back to H=0
+            dst_addr += ublock_size_bytes; // increment Wt
+        } // Wt
+        dst_addrN += HtWtTileBytes;
+    } // N
+}

--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_reconfig.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_transpose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_broadcast.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_cumsum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_adjacent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_contains.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_intersects.cpp

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_cumsum.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "test_golden_impls.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+using namespace tt::tt_metal;
+
+namespace unit_tests::compute::cumsum {
+
+struct CumsumConfig {
+    int N;
+    int Wt;
+    int Ht;
+};
+
+std::vector<tt::test_utils::df::bfloat16> gold_cumsum(std::vector<tt::test_utils::df::bfloat16>& src, const std::vector<uint32_t> &shape) {
+    int N = shape.at(0);
+    int W = shape.at(1);
+    int H = shape.at(2);
+
+    std::vector<tt::test_utils::df::bfloat16> golden(N * W * H);
+
+    for (int i = 0; i < N; i++) {
+        for (int k = 0; k < W; k++) {
+            float res = 0;
+            for (int j = 0; j < H; j++) {
+                res += src[i * H * W + j * W + k].to_float();
+                golden[i * (H * W) + j * W + k] = res;
+            }
+        }
+    }
+
+    return golden;
+}
+
+void run_single_core_cumsum(tt_metal::Device* device, const CumsumConfig& test_config) {
+    Program program = tt_metal::CreateProgram();
+
+    CoreCoord core = {0, 0};
+
+    constexpr uint32_t tile_width = 32;
+    constexpr uint32_t tile_height = 32;
+
+    constexpr uint32_t single_tile_size = tile_width * tile_height * tt::test_utils::df::bfloat16::SIZEOF;
+
+    uint32_t W = test_config.Wt * tile_width;
+    uint32_t H = test_config.Ht * tile_height;
+    uint32_t dram_buffer_size = single_tile_size * test_config.N * test_config.Wt * test_config.Ht;
+
+    tt_metal::InterleavedBufferConfig dram_config{
+        .device=device,
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = tt_metal::BufferType::DRAM
+    };
+
+    auto src_dram_buffer = CreateBuffer(dram_config);
+    uint32_t dram_buffer_src_addr = src_dram_buffer->address();
+    auto src_dram_noc_xy = src_dram_buffer->noc_coordinates();
+    tt_metal::CircularBufferConfig l1_src_cb_config = tt_metal::CircularBufferConfig(dram_buffer_size, {{0, tt::DataFormat::Float16_b}})
+        .set_page_size(0, single_tile_size);
+    auto l1_src_cb = tt_metal::CreateCircularBuffer(program, core, l1_src_cb_config);
+
+    auto dst_dram_buffer = CreateBuffer(dram_config);
+    uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+    auto dst_dram_noc_xy = dst_dram_buffer->noc_coordinates();
+    tt_metal::CircularBufferConfig l1_dst_cb_config = tt_metal::CircularBufferConfig(dram_buffer_size, {{16, tt::DataFormat::Float16_b}})
+        .set_page_size(16, single_tile_size);
+    auto l1_dst_cb = tt_metal::CreateCircularBuffer(program, core, l1_dst_cb_config);
+
+    auto reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh.cpp",
+        core,
+        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+    auto writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_transpose_wh.cpp",
+        core,
+        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    auto compute_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp",
+        core,
+        tt_metal::ComputeConfig{.compile_args = {test_config.Ht, test_config.Wt, test_config.N}, .defines = {}});
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        reader_kernel,
+        core,
+        {
+            (uint32_t)dram_buffer_src_addr,
+            (uint32_t)src_dram_noc_xy.x,
+            (uint32_t)src_dram_noc_xy.y,
+            (uint32_t)test_config.N * test_config.Ht * test_config.Wt, // Unused
+            (uint32_t)test_config.N,
+            (uint32_t)test_config.Ht,
+            (uint32_t)test_config.Wt,
+            (uint32_t)test_config.Ht * test_config.Wt
+        });
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        writer_kernel,
+        core,
+        {
+            (uint32_t)dram_buffer_dst_addr,
+            (uint32_t)dst_dram_noc_xy.x,
+            (uint32_t)dst_dram_noc_xy.y,
+            (uint32_t)test_config.N * test_config.Ht * test_config.Wt, // Unused
+            (uint32_t)test_config.N,
+            (uint32_t)test_config.Ht,
+            (uint32_t)test_config.Wt,
+            (uint32_t)test_config.Ht * test_config.Wt
+        });
+
+    std::vector<tt::test_utils::df::bfloat16> input = generate_uniform_random_vector<tt::test_utils::df::bfloat16>(
+        -1.0f,
+        1.0f,
+        dram_buffer_size / tt::test_utils::df::bfloat16::SIZEOF,
+        std::chrono::system_clock::now().time_since_epoch().count());
+
+    std::vector<tt::test_utils::df::bfloat16> golden = gold_cumsum(input, {test_config.N, W, H});
+    auto golden_packed = pack_vector<uint32_t, tt::test_utils::df::bfloat16>(golden);
+
+    auto input_packed = pack_vector<uint32_t, tt::test_utils::df::bfloat16>(input);
+    auto input_packed_tilized = unit_tests::compute::gold_standard_tilize(input_packed, {test_config.N * H, W});
+
+    tt_metal::detail::WriteToBuffer(src_dram_buffer, input_packed_tilized);
+
+    tt_metal::detail::LaunchProgram(device, program);
+
+    std::vector<uint32_t> output_packed_tilized;
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, output_packed_tilized);
+    auto output_packed = unit_tests::compute::gold_standard_untilize(output_packed_tilized, {test_config.N * H, W});
+
+    log_info(tt::LogTest, "Running test for N = {}, Wt = {}, Ht = {}", test_config.N, test_config.Wt, test_config.Ht);
+
+    bool result = is_close_packed_vectors<tt::test_utils::df::bfloat16, uint32_t>(
+        output_packed,
+        golden_packed,
+        [&](const tt::test_utils::df::bfloat16& a, const tt::test_utils::df::bfloat16& b) {
+            return is_close(a, b, 0.01f);
+        });
+    ASSERT_TRUE(result);
+}
+}
+
+TEST_F(DeviceFixture, ComputeCumsum) {
+    for (int i = 1; i <= 3; i++) {
+        for (int j = 1; j <= 3; j++) {
+            for (int k = 1; k <= 3; k++) {
+                unit_tests::compute::cumsum::CumsumConfig test_config =
+                {
+                    .N = i,
+                    .Wt = j,
+                    .Ht = k
+                };
+                unit_tests::compute::cumsum::run_single_core_cumsum(this->devices_.at(0), test_config);
+            }
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_cumsum.cpp
@@ -159,6 +159,11 @@ void run_single_core_cumsum(tt_metal::Device* device, const CumsumConfig& test_c
 }
 
 TEST_F(DeviceFixture, ComputeCumsum) {
+    auto arch = this->arch_;
+    if (arch == tt::ARCH::GRAYSKULL) {
+        GTEST_SKIP(); // Not implemented for GRAYSKULL
+    }
+
     for (int i = 1; i <= 3; i++) {
         for (int j = 1; j <= 3; j++) {
             for (int k = 1; k <= 3; k++) {

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_cumsum.cpp
@@ -136,7 +136,7 @@ void run_single_core_cumsum(tt_metal::Device* device, const CumsumConfig& test_c
     auto golden_packed = pack_vector<uint32_t, tt::test_utils::df::bfloat16>(golden);
 
     auto input_packed = pack_vector<uint32_t, tt::test_utils::df::bfloat16>(input);
-    auto input_packed_tilized = unit_tests::compute::gold_standard_tilize(input_packed, {test_config.N * H, W});
+    auto input_packed_tilized = unit_tests::compute::gold_standard_tilize(input_packed, {test_config.N * test_config.Ht, test_config.Wt});
 
     tt_metal::detail::WriteToBuffer(src_dram_buffer, input_packed_tilized);
 
@@ -144,7 +144,7 @@ void run_single_core_cumsum(tt_metal::Device* device, const CumsumConfig& test_c
 
     std::vector<uint32_t> output_packed_tilized;
     tt_metal::detail::ReadFromBuffer(dst_dram_buffer, output_packed_tilized);
-    auto output_packed = unit_tests::compute::gold_standard_untilize(output_packed_tilized, {test_config.N * H, W});
+    auto output_packed = unit_tests::compute::gold_standard_untilize(output_packed_tilized, {test_config.N * test_config.Ht, test_config.Wt});
 
     log_info(tt::LogTest, "Running test for N = {}, Wt = {}, Ht = {}", test_config.N, test_config.Wt, test_config.Ht);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_common_api.h"
+#include "llk_math_transpose_dest.h"
+
+inline void llk_math_transpose_dest(uint dst_index) {
+    _llk_math_transpose_dest_(dst_index);
+}
+
+inline void llk_math_transpose_dest_init() {
+   _llk_math_transpose_dest_init_();
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_cumsum.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
+inline void calculate_cumsum(bool first)
+{
+    _calculate_cumsum_<false, 1>(first); // There is only non APPROXIMATE implementation and one iteration
+}
+
+template <bool APPROXIMATION_MODE /*unused*/>
+inline void cumsum_init() {
+    _cumsum_init_<false>(); // There is only non APPROXIMATE implementation
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -15,8 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
-inline void calculate_cumsum(bool first)
-{
+inline void calculate_cumsum(bool first) {
     _calculate_cumsum_<false, 1>(first); // There is only non APPROXIMATE implementation and one iteration
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_cumsum.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE /*unused*/>
+inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cumsum, false>(sfpu::cumsum_init<false>); // There is only non APPROXIMATE implementation
+}
+
+template <bool APPROXIMATE /*unused*/>
+inline void llk_math_eltwise_unary_sfpu_cumsum(uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
+    llk_math_eltwise_unary_sfpu_params<false>(
+        ckernel::sfpu::calculate_cumsum<false>, // There is only non APPROXIMATE implementation
+        dst_index,
+        VectorMode::RC_custom, // Can only work in RC_custom mode
+        first);
+}
+
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_params.h
@@ -34,7 +34,7 @@ inline void llk_math_eltwise_unary_sfpu_params(
             _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
             _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
         }
-    } else {
+    } else if (vector_mode == (int)VectorMode::RC) {
         // Do all four faces, and iterate through all 4 blocks of 4 rows each
 #pragma GCC unroll 0
         for (int face = 0; face < 4; face++) {
@@ -42,6 +42,8 @@ inline void llk_math_eltwise_unary_sfpu_params(
             // Move to the next face
             _llk_math_eltwise_unary_sfpu_inc_dst_face_addr_();
         }
+    } else {
+        sfpu_func(static_cast<ARGS&&>(args)...);
     }
     _llk_math_eltwise_unary_sfpu_done_();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -86,4 +86,5 @@ enum SfpuType {
     fmod,
     ceil,
     unused,
+    cumsum
 };

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -117,6 +117,8 @@ inline void llk_unpack_clear_dbg_feature_disable() { _llk_unpack_clear_dbg_featu
 
 inline void llk_enable_int8_fpu_math() { _llk_enable_int8_fpu_math_(); }
 
+inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
+
 // All TILE_SIZE related functions were deprecared in BBE for WH.  The following is needed for pack_shifted so just
 // keeping here.
 // FIXME: Need to review and adjust accordingly

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_transpose_dest_api.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_common_api.h"
+#include "llk_math_transpose_dest.h"
+
+inline void llk_math_transpose_dest(uint dst_index) {
+    _llk_math_transpose_dest_(dst_index);
+}
+
+inline void llk_math_transpose_dest_init() {
+   _llk_math_transpose_dest_init_();
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_cumsum.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
+inline void calculate_cumsum(bool first)
+{
+    _calculate_cumsum_<false, 1>(first); // There is only non APPROXIMATE implementation and one iteration
+}
+
+template <bool APPROXIMATION_MODE /*unused*/>
+inline void cumsum_init() {
+    _cumsum_init_<false>(); // There is only non APPROXIMATE implementation
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cumsum.h
@@ -15,8 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE /*unused*/, int ITERATIONS = 8 /*unused*/>
-inline void calculate_cumsum(bool first)
-{
+inline void calculate_cumsum(bool first) {
     _calculate_cumsum_<false, 1>(first); // There is only non APPROXIMATE implementation and one iteration
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_cumsum.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_cumsum.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE /*unused*/>
+inline void llk_math_eltwise_unary_sfpu_cumsum_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::cumsum, false>(sfpu::cumsum_init<false>); // There is only non APPROXIMATE implementation
+}
+
+template <bool APPROXIMATE /*unused*/>
+inline void llk_math_eltwise_unary_sfpu_cumsum(uint dst_index, bool first, int vector_mode = (int)VectorMode::RC_custom /*unused*/) {
+    llk_math_eltwise_unary_sfpu_params<false>(
+        ckernel::sfpu::calculate_cumsum<false>, // There is only non APPROXIMATE implementation
+        dst_index,
+        VectorMode::RC_custom, // Can only work in RC_custom mode
+        first);
+}
+
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -87,4 +87,5 @@ enum SfpuType {
     ceil,
     unused,
     reshuffle_rows,
+    cumsum
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -117,6 +117,8 @@ inline void llk_unpack_clear_dbg_feature_disable() { _llk_unpack_clear_dbg_featu
 
 inline void llk_enable_int8_fpu_math() { _llk_enable_int8_fpu_math_(); }
 
+inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }
+
 // All TILE_SIZE related functions were deprecared in BBE for WH.  The following is needed for pack_shifted so just
 // keeping here.
 // FIXME: Need to review and adjust accordingly

--- a/tt_metal/include/compute_kernel_api/cumsum.h
+++ b/tt_metal/include/compute_kernel_api/cumsum.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_cumsum.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// Cumulative sum
+/**
+ * Calculates the columnwise (top to bottom) cumulative sum.
+ * For multi tile comulative sum, tiles must come in NWH order (for example using reader_unary_transpose_wh) and
+ * *first* must be false for all tiles where H != 0.
+ * Tiles are also output in NWH order so writer_unary_transpose_wh can be used to store them correctly in L1
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | first           | Set true for tiles in the first row                                        | bool     |                                                       | False    |
+ */
+ALWI void cumsum_tile(uint32_t idst, bool first = true) {
+    MATH(( llk_math_eltwise_unary_sfpu_cumsum<false>(idst, first) )); // There is only non APPROXIMATE implementation
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void cumsum_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_cumsum_init<false>() )); // There is only non APPROXIMATE implementation
+}
+
+} // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -7,6 +7,7 @@
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
 #include "llk_math_unary_datacopy_api.h"
+#include "llk_math_transpose_dest_api.h"
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_A_api.h"
@@ -76,6 +77,15 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst)
     MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(idst) ));
 }
 
+ALWI void transpose_wh_dest_init_short()
+{
+    MATH(( llk_math_transpose_dest_init() ));
+}
 
+ALWI void transpose_wh_dest(uint32_t idst)
+{
+    UNPACK(( llk_unpack_set_srcb_dummy_valid() ));
+    MATH(( llk_math_transpose_dest(idst) ));
+}
 
 } // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -77,11 +77,25 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst)
     MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(idst) ));
 }
 
+/**
+ * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for transpose_wh_dest to be executed correctly.
+ */
 ALWI void transpose_wh_dest_init_short()
 {
     MATH(( llk_math_transpose_dest_init() ));
 }
 
+/**
+ * Performs a 32x32 in place transpose operation *B[w,h] = A[h,w]* on a tile in the DST register at idst.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                             | Type     | Valid Range                                    | Required |
+ * |----------------|---------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST REG to transpose           | uint32_t | Must be less than the acquired size of DST REG | True     |
+ */
 ALWI void transpose_wh_dest(uint32_t idst)
 {
     UNPACK(( llk_unpack_set_srcb_dummy_valid() ));

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -7,7 +7,6 @@
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
 #include "llk_math_unary_datacopy_api.h"
-#include "llk_math_transpose_dest_api.h"
 #endif
 #ifdef TRISC_UNPACK
 #include "llk_unpack_A_api.h"
@@ -75,31 +74,6 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst)
         #endif
     ));
     MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(idst) ));
-}
-
-/**
- * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for transpose_wh_dest to be executed correctly.
- */
-ALWI void transpose_wh_dest_init_short()
-{
-    MATH(( llk_math_transpose_dest_init() ));
-}
-
-/**
- * Performs a 32x32 in place transpose operation *B[w,h] = A[h,w]* on a tile in the DST register at idst.
- * The DST register buffer must be in acquired state via *acquire_dst* call.
- * This call is blocking and is only available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                             | Type     | Valid Range                                    | Required |
- * |----------------|---------------------------------------------------------|----------|------------------------------------------------|----------|
- * | idst           | The index of the tile in DST REG to transpose           | uint32_t | Must be less than the acquired size of DST REG | True     |
- */
-ALWI void transpose_wh_dest(uint32_t idst)
-{
-    UNPACK(( llk_unpack_set_srcb_dummy_valid() ));
-    MATH(( llk_math_transpose_dest(idst) ));
 }
 
 } // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/transpose_wh_dest.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh_dest.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common.h"
+#ifdef TRISC_MATH
+#include "llk_math_unary_datacopy_api.h"
+#include "llk_math_transpose_dest_api.h"
+#endif
+#ifdef TRISC_UNPACK
+#include "llk_unpack_A_api.h"
+#endif
+
+
+namespace ckernel {
+
+/**
+ * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for transpose_wh_dest to be executed correctly.
+ */
+ALWI void transpose_wh_dest_init_short()
+{
+    MATH(( llk_math_transpose_dest_init() ));
+}
+
+/**
+ * Performs a 32x32 in place transpose operation *B[w,h] = A[h,w]* on a tile in the DST register at idst.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                             | Type     | Valid Range                                    | Required |
+ * |----------------|---------------------------------------------------------|----------|------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST REG to transpose           | uint32_t | Must be less than the acquired size of DST REG | True     |
+ */
+ALWI void transpose_wh_dest(uint32_t idst)
+{
+    UNPACK(( llk_unpack_set_srcb_dummy_valid() ));
+    MATH(( llk_math_transpose_dest(idst) ));
+}
+
+} // namespace ckernel


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Implementing cumulative sum using existing llk apis would not be very performant,
this PR provides direct llk support for calculating column-wise cumulative sum as well as an example of using column-wise cumulative sum primitve to implement row-wise cumulative sum.

### What's changed
Updated WH_b0 and BH llk submodules to include cumsum functionality.
Added cumsum and transpose_wh_dest (needed for row-wise cumulative sum example) to compute_kernel and llk apis on WH_b0 and BH.
Added an explicit check for VectorMode::RC in llk_math_eltwise_unary_sfpu_params to enable proper functioning of VectorMode::RC_custom on BH.
Added cumsum example kernel and writer_unary_tranpose data movement kernel (required for multi tile cumulative sum).
Added cumsum tests for both column-wise and row-wise that sweep block sizes.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10958080211)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10958077405)
- [N/A] Model regression CI testing passes (if applicable)
- [N/A] Device performance regression CI testing passes (if applicable)
- [X] New/Existing tests provide coverage for changes
