### PR TITLE
#12750: Replace zeros_like with empty_like in backward ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
@@ -21,10 +21,9 @@ from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     ),
 )
 # Pytorch Reference
-# - name: fill.Tensor(Tensor self, Tensor value) -> Tensor
+# - name: fill.Scalar(Tensor self, Scalar value) -> Tensor
 #   self: zeros_like(grad)
-#   value: grad.sum()
-#   result: at::fill(self_t, value_t)
+#   result: at::fill(self_t, 0)
 def test_bw_fill(input_shapes, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
@@ -34,7 +33,7 @@ def test_bw_fill(input_shapes, device):
     golden_function = ttnn.get_golden_function(ttnn.fill_bw)
     golden_tensor = golden_function(grad_data, in_data)
 
-    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=150, rtol=1e-6)
+    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=0, rtol=0)
     assert comp_pass
 
 
@@ -61,5 +60,5 @@ def test_bw_fill_opt_tensor(input_shapes, device):
     golden_tensor = golden_function(grad_data, in_data)
 
     tt_output_tensor_on_device = [input_grad]
-    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=150, rtol=1e-6)
+    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=0, rtol=0)
     assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -815,7 +815,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardMul::invoke(
     uint8_t queue_id, const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
      if(!input_grad.has_value()){
-        input_grad = ttnn::zeros_like(grad);
+        input_grad = ttnn::empty_like(grad);
     }
     ttnn::multiply(queue_id, grad, scalar, std::nullopt, output_mem_config, input_grad);
     result.push_back(input_grad);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -393,7 +393,7 @@ std::vector<Tensor> _sigmoid_bw(
 std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(uint8_t queue_id, const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     if(!input_grad.has_value()){
-        input_grad = ttnn::zeros_like(grad);
+        input_grad = ttnn::empty_like(grad);
     }
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
@@ -415,8 +415,8 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(uint8
     return result;
 }
 
-std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-    return ExecuteUnaryBackwardRsqrt::invoke(DefaultQueueId, grad, input, output_mem_config);
+std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardRsqrt::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    return ExecuteUnaryBackwardRsqrt::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(uint8_t queue_id, const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
@@ -426,6 +426,10 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(uint8_t queue
     return result;
 }
 
+std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    return ExecuteUnaryBackwardNeg::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
+}
+
 std::vector<Tensor> _relu_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(ttnn::gtz(input, output_mem_config), grad, std::nullopt, output_mem_config);
@@ -433,18 +437,19 @@ std::vector<Tensor> _relu_bw(const Tensor& grad, const Tensor& input, const std:
     return grad_tensor;
 }
 
+// fill_bw:
+// name: fill.Scalar(Tensor self, Scalar value) -> Tensor
+// self: zeros_like(grad)
+// result: at::fill(self_t, 0)
 std::vector<std::optional<Tensor>> ExecuteUnaryBackwardFill::invoke(uint8_t queue_id, const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     auto output_memory_config = output_mem_config.value_or(input.memory_config());
     std::vector<std::optional<Tensor>> result = {std::nullopt};
-    input_grad = input_grad.value_or(ttnn::zeros_like(input));
-
-    Tensor val = grad;
-    val = ttnn::sum(val);
-    Tensor result_val = ttnn::full_like(grad, 0.0f);
-    ttnn::add(queue_id, result_val, val, std::nullopt, output_mem_config, input_grad);
-
-    result[0] = input_grad;
+    result[0] = input_grad.has_value() ? ttnn::zeros_like(grad, std::nullopt, std::nullopt, std::nullopt, std::nullopt, input_grad) : ttnn::zeros_like(grad);
     return result;
+}
+
+std::vector<std::optional<Tensor>> ExecuteUnaryBackwardFill::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    return ExecuteUnaryBackwardFill::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
 std::vector<Tensor> _hardsigmoid_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
@@ -1354,7 +1359,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     if(!input_grad.has_value()){
-        input_grad = ttnn::zeros_like(grad);
+        input_grad = ttnn::empty_like(grad);
     }
 
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
@@ -1404,8 +1409,9 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
     const Tensor& grad,
     const Tensor& input,
     string approximate,
-    const std::optional<MemoryConfig>& output_mem_config) {
-        return ExecuteUnaryBackwardGelu::invoke(DefaultQueueId, grad, input, approximate, output_mem_config);
+    const std::optional<MemoryConfig>& output_mem_config,
+    std::optional<Tensor> input_grad) {
+        return ExecuteUnaryBackwardGelu::invoke(DefaultQueueId, grad, input, approximate, output_mem_config, input_grad);
 }
 
 std::vector<Tensor> _repeat_bw(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -20,6 +20,12 @@ struct ExecuteUnaryBackwardNeg {
         const Tensor &input_tensor_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 };
 
 struct ExecuteUnaryBackwardThreshold {
@@ -110,7 +116,8 @@ struct ExecuteUnaryBackwardRsqrt {
     static std::vector<std::optional<Tensor>> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 };
 
 struct ExecuteUnaryBackwardClamp {
@@ -243,6 +250,12 @@ struct ExecuteUnaryBackwardFill {
         const Tensor &input_tensor_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 };
 
 struct ExecuteUnaryBackwardProd {
@@ -283,13 +296,14 @@ struct ExecuteUnaryBackwardAbs {
 
 struct ExecuteUnaryBackwardGelu{
     static std::vector<std::optional<ttnn::Tensor>> invoke(
+        uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         string parameter_a,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
 
     static std::vector<std::optional<ttnn::Tensor>> invoke(
-        uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         string parameter_a,

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -831,14 +831,14 @@ def _golden_function(grad_tensor, input_tensor, sizes, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.repeat_bw, golden_function=_golden_function)
 
 
-def _golden_function(grad_tensor, input_tensor, *args, **kwargs):
+def _golden_function(grad_tensor, input_tensor, *args, value=2.0, **kwargs):
     import torch
 
-    pyt_y = torch.zeros_like(grad_tensor)
-    grad_sum = grad_tensor.sum()
-    pyt_y.fill_(grad_sum)
+    input_tensor.retain_grad()
+    pyt_y = torch.fill(input_tensor, value)
+    pyt_y.backward(gradient=grad_tensor)
 
-    return [pyt_y]
+    return [input_tensor.grad]
 
 
 ttnn.attach_golden_function(ttnn.fill_bw, golden_function=_golden_function)


### PR DESCRIPTION
### Ticket
Link to Github Issue #12750 

### Problem description
E 	ttnn.add_bw: measured duration 1.716ms, reference duration 0.071ms
E 	ttnn.bias_gelu_bw_none: measured duration 1.825ms, reference duration 0.503ms
E 	ttnn.bias_gelu_bw_tanh: measured duration 1.689ms, reference duration 0.926ms
E 	ttnn.bias_gelu_unary_bw_none: measured duration 1.333ms, reference duration 0.538ms
E 	ttnn.bias_gelu_unary_bw_tanh: measured duration 1.624ms, reference duration 1.113ms
E 	ttnn.fill_bw: measured duration 2.286ms, reference duration 1.8ms
E 	ttnn.gelu_bw_none: measured duration 1.201ms, reference duration 0.478ms
E 	ttnn.gelu_bw_tanh: measured duration 1.622ms, reference duration 0.912ms
E 	ttnn.mul_bw: measured duration 1.719ms, reference duration 0.078ms
E 	ttnn.rsqrt_bw: measured duration 1.608ms, reference duration 0.795ms
E 	ttnn.rsub_bw: measured duration 1.68ms, reference duration 0.105ms
E 	ttnn.sub_bw: measured duration 1.682ms, reference duration 0.085ms
E 	ttnn.subalpha_bw: measured duration 1.654ms, reference duration 0.117ms
E 	ttnn.unary_add_bw: measured duration 0.858ms, reference duration 0.025ms

### What's changed
- Replace `zeros_like` with `empty_like` in backward ops for device tensor creation
- some cleanup

**op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)**

- ttnn.add_bw,800,**0.078**,0.081,0.21,24.045
- ttnn.bias_gelu_bw_none,800,**0.393**,0.408,1.62,0.136
- ttnn.bias_gelu_bw_tanh,800,**0.71**,0.801,2.537,0.266
- ttnn.bias_gelu_unary_bw_none,800,**0.416**,0.443,1.595,0.15
- ttnn.bias_gelu_unary_bw_tanh,800,**0.728**,0.789,2.506,0.264
- ttnn.fill_bw,800,**0.753**,0.759,0.774,0.21
- ttnn.gelu_bw_none,800,**0.371**,0.38,1.482,0.13
- ttnn.gelu_bw_tanh,800,**0.719**,0.787,2.4,0.262
- ttnn.mul_bw,800,**0.075**,0.077,0.278,0.019
- ttnn.rsqrt_bw,800,**0.733**,0.779,3.406,0.246
- ttnn.rsub_bw,800,**0.057**,0.06,0.195,0.017
- ttnn.sub_bw,800,**0.058**,0.063,0.197,0.017
- ttnn.subalpha_bw,800,**0.059**,0.061,0.196,0.016
- ttnn.unary_add_bw,800,**0.034**,0.036,0.1,0.008


### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10963002398
https://github.com/tenstorrent/tt-metal/actions/runs/10970793507
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
