### PR TITLE
#12954: pip install only build in wheel build since that's all we should need

### DIFF
--- a/.github/workflows/_build-wheels-impl.yaml
+++ b/.github/workflows/_build-wheels-impl.yaml
@@ -38,9 +38,7 @@ jobs:
             tt_metal/python_env/requirements-dev.txt
             pyproject.toml
       - name: Install python deps for packaging
-        run: |
-          pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
-          pip install -r tt_metal/python_env/requirements-dev.txt
+        run: pip install build
       - name: Use g++ as umd compiler for ubuntu 22.04
         if: ${{ inputs.os == 'ubuntu-22.04' }}
         run: |


### PR DESCRIPTION
…

### Ticket

#12954

### Problem description

The wheel step, even with precompiled assets, takes ~7 minutes on the GitHub hosted runners.

This is a little unnecessary, and a big part is that we're installing the entire dev requirements. We only need `build`.

### What's changed

`pip install` only `build` in the wheel build step

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
