### PR TITLE
Don't install dependencies on self-hosted  builders

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,12 +28,12 @@ jobs:
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Install dependencies
-        if: ${{ matrix.build.runs-on != 'build' }}
+        if: ${{ !contains(matrix.build.runs-on, 'build') && !contains(matrix.build.runs-on, 'in-service') }}
         uses: ./.github/actions/install-metal-deps
         with:
           os: ${{ matrix.build.os }}
       - name: Install dev dependencies
-        if: ${{ matrix.build.runs-on != 'build' }}
+        if: ${{ !contains(matrix.build.runs-on, 'build') && !contains(matrix.build.runs-on, 'in-service') }}
         uses: ./.github/actions/install-metal-dev-deps
         with:
           os: ${{ matrix.build.os }}


### PR DESCRIPTION
### Problem description
Some self-hosted  runners don't like the fact that we re-install dependencies on them every time

### What's changed
Skip installing dependencies on self-hosted runners

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
