### PR TITLE
#0: move BufferType to device kernel accessible location

### DIFF
--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -28,14 +28,6 @@ namespace tt_metal {
 
 class Device;
 
-enum class BufferType {
-    DRAM,
-    L1,
-    SYSTEM_MEMORY,
-    L1_SMALL,
-    TRACE,
-};
-
 struct ShardSpec {
     /* The individual cores the shard grid is mapped to */
     CoreRangeSet grid;

--- a/tt_metal/impl/buffers/buffer_constants.hpp
+++ b/tt_metal/impl/buffers/buffer_constants.hpp
@@ -23,6 +23,14 @@ enum class ShardOrientation {
     COL_MAJOR,
 };
 
+enum class BufferType {
+    DRAM,
+    L1,
+    SYSTEM_MEMORY,
+    L1_SMALL,
+    TRACE,
+};
+
 } // namespace tt_metal
 
 } // namespace tt


### PR DESCRIPTION
### Ticket
No specific issue

### Problem description
To help commonize/unify addrgen building in device kernels, we need the base types (particularly enums) to be accessible by device kernels. This change is required for some in progress changes (like line reduce scatter) and is included in a PR for that but it is preferred to do this as a standalone commit.

### What's changed
Moved BufferType enum to a header that doesn't have further includes (and include headers that are not compatible with device). 

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10986661380
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
