### PR TITLE
#12985: Expose `ttnn::ccl::Topology` at python level

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -155,7 +155,7 @@ TEST(GalaxyTests, TestAllGatherDeadlock) {
                 uint32_t receiver_device_id = device_ids[(dev_idx) + 1 % num_devices_in_row];
                 uint32_t sender_device_id = device_ids[(dev_idx + num_devices_in_row - 1) % num_devices_in_row];
                 auto all_gather_op = ttnn::AllGather{
-                                        3, 2, num_devices_in_row, dev_idx, std::nullopt, std::nullopt, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::all_gather_op::Topology::Linear};
+                                        3, 2, num_devices_in_row, dev_idx, std::nullopt, std::nullopt, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::ccl::Topology::Linear};
                 // Send CCL to this device. All CCLs will complete simultaneously.
                 output_tensors.push_back(async_detail::run_operation(0, all_gather_op, {input_tensor}).at(0));
                 // Expose deadlock: After the CCL is sent to the first device in the tunnel, send enough data to it to backpressure prefetch_h. This will block the
@@ -249,7 +249,7 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
             uint32_t receiver_device_id = device_ids[(dev_idx + 1) % ring_devices.size()];
             uint32_t sender_device_id = device_ids[(dev_idx + ring_devices.size() - 1) % ring_devices.size()];
             auto all_gather_op = ttnn::ReduceScatter{
-                                    ttnn::operations::binary::BinaryOpType::ADD, scatter_dim, 1, static_cast<uint32_t>(ring_devices.size()), dev_idx, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::all_gather_op::Topology::Ring};
+                                    ttnn::operations::binary::BinaryOpType::ADD, scatter_dim, 1, static_cast<uint32_t>(ring_devices.size()), dev_idx, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::ccl::Topology::Ring};
             // Send CCL to this device. All CCLs will complete simultaneously.
             output_tensors.push_back(async_detail::run_operation(0, all_gather_op, {input_tensor}).at(0));
             // Expose deadlock: After the CCL is sent to a device in the first tunnel, send enough data to it to backpressure prefetch_h. This will block the

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
@@ -8,8 +8,8 @@
 
 namespace ttnn::operations::ccl {
 
-ttnn::Tensor ExecuteAllGather::invoke(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config, const std::optional<size_t> num_workers, const std::optional<size_t> num_buffers_per_channel) {
-    return ttnn::operations::ccl::all_gather(input_tensor, dim, num_links, memory_config, num_workers, num_buffers_per_channel);
+ttnn::Tensor ExecuteAllGather::invoke(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config, const std::optional<size_t> num_workers, const std::optional<size_t> num_buffers_per_channel, const all_gather_op::Topology topology) {
+    return ttnn::operations::ccl::all_gather(input_tensor, dim, num_links, memory_config, num_workers, num_buffers_per_channel, topology);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
@@ -8,7 +8,7 @@
 
 namespace ttnn::operations::ccl {
 
-ttnn::Tensor ExecuteAllGather::invoke(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config, const std::optional<size_t> num_workers, const std::optional<size_t> num_buffers_per_channel, const all_gather_op::Topology topology) {
+ttnn::Tensor ExecuteAllGather::invoke(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config, const std::optional<size_t> num_workers, const std::optional<size_t> num_buffers_per_channel, const ttnn::ccl::Topology topology) {
     return ttnn::operations::ccl::all_gather(input_tensor, dim, num_links, memory_config, num_workers, num_buffers_per_channel, topology);
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 
 namespace ttnn {
 namespace operations {
@@ -17,7 +18,8 @@ struct ExecuteAllGather {
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const std::optional<size_t> num_workers = std::nullopt,
-        const std::optional<size_t> num_buffers_per_channel = std::nullopt);
+        const std::optional<size_t> num_buffers_per_channel = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring);
 };
 
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -67,7 +67,7 @@ void py_bind_all_gather(pybind11::module& module) {
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
             * :attr:`num_workers` (int): Number of workers to use for the operation.
             * :attr:`num_buffers_per_channel` (int): Number of buffers per channel to use for the operation.
-            * :attr:`topology`: Topology to be used for the operation.
+            * :attr:`topology`: Topology to be used for the operation. Allowable options are Linear and Ring
 
         Example:
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_pybind.cpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn::operations::ccl {
@@ -17,6 +18,10 @@ namespace detail {
 
 template <typename ccl_operation_t>
 void bind_all_gather(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
+    py::enum_<ttnn::ccl::Topology>(module, "Topology")
+        .value("Ring", ttnn::ccl::Topology::Ring)
+        .value("Linear", ttnn::ccl::Topology::Linear);
+
     bind_registered_operation(
         module,
         operation,
@@ -28,8 +33,9 @@ void bind_all_gather(pybind11::module& module, const ccl_operation_t& operation,
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<size_t> num_workers,
-               const std::optional<size_t> num_buffers_per_channel) -> ttnn::Tensor {
-                return self(input_tensor, dim, num_links, memory_config, num_workers, num_buffers_per_channel);
+               const std::optional<size_t> num_buffers_per_channel,
+               const ttnn::ccl::Topology topology) -> ttnn::Tensor {
+                return self(input_tensor, dim, num_links, memory_config, num_workers, num_buffers_per_channel, topology);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
@@ -37,7 +43,8 @@ void bind_all_gather(pybind11::module& module, const ccl_operation_t& operation,
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
             py::arg("num_workers") = std::nullopt,
-            py::arg("num_buffers_per_channel") = std::nullopt});
+            py::arg("num_buffers_per_channel") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring});
 }
 
 }  // namespace detail
@@ -47,7 +54,7 @@ void py_bind_all_gather(pybind11::module& module) {
     detail::bind_all_gather(
         module,
         ttnn::all_gather,
-        R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None, num_workers: int = None, num_buffers_per_channel: int = None) -> ttnn.Tensor
+        R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None, num_workers: int = None, num_buffers_per_channel: int = None, Topology: ttnn.Topology = ttnn.Topology.Ring) -> ttnn.Tensor
 
         Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
 
@@ -60,6 +67,7 @@ void py_bind_all_gather(pybind11::module& module) {
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
             * :attr:`num_workers` (int): Number of workers to use for the operation.
             * :attr:`num_buffers_per_channel` (int): Number of buffers per channel to use for the operation.
+            * :attr:`topology`: Topology to be used for the operation.
 
         Example:
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -21,7 +21,7 @@ AllGather create_all_gather_struct(
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const std::vector<Device*>& devices,
-    const all_gather_op::Topology topology
+    const ttnn::ccl::Topology topology
 ) {
     uint32_t num_devices = devices.size();
 
@@ -58,14 +58,14 @@ AllGatherBidirectionalMode AllGatherConfig::choose_bidirectional_mode(Tensor con
     return AllGatherBidirectionalMode::FULL_TENSOR;
 }
 
-AllGatherConfig::AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links, all_gather_op::Topology topology, std::size_t num_edm_buffers_per_channel, bool fuse_op, const std::optional<size_t> user_defined_num_workers) :
+AllGatherConfig::AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links, ttnn::ccl::Topology topology, std::size_t num_edm_buffers_per_channel, bool fuse_op, const std::optional<size_t> user_defined_num_workers) :
     num_links(num_links),
     semaphore_size(32),
     ring_size(ring_size),
 
     erisc_handshake_address(tt::round_up(eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE, 16)),
     topology(topology),
-    enable_bidirectional(topology == all_gather_op::Topology::Ring),
+    enable_bidirectional(topology == ttnn::ccl::Topology::Ring),
 
     input_is_dram(input_tensor.buffer()->buffer_type() == BufferType::DRAM),
     output_is_dram(output_tensor.buffer()->buffer_type() == BufferType::DRAM),
@@ -91,7 +91,7 @@ AllGatherConfig::AllGatherConfig(Tensor const& input_tensor, Tensor const& outpu
 
     // "duplicate" directions are a short hand to enable linear/mesh all-gather topologies with
     // less code-changes. Ideally a new concept is added amongst "num_eth_buffers", "num_workers_per_link", etc.
-    uint32_t num_duplicate_directions = (topology == all_gather_op::Topology::Ring && bidirectional_mode != AllGatherBidirectionalMode::FULL_TENSOR) ? 1 : 2;
+    uint32_t num_duplicate_directions = (topology == ttnn::ccl::Topology::Ring && bidirectional_mode != AllGatherBidirectionalMode::FULL_TENSOR) ? 1 : 2;
 
     constexpr uint32_t total_l1_buffer_space = eth_l1_mem::address_map::MAX_L1_LOADING_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
 
@@ -99,7 +99,7 @@ AllGatherConfig::AllGatherConfig(Tensor const& input_tensor, Tensor const& outpu
     if (user_defined_num_workers.has_value()) {
         this->num_eth_buffers = user_defined_num_workers.value() / num_duplicate_directions;
     } else {
-        this->num_eth_buffers = (this->enable_bidirectional ? 8 /*1*/ : (topology != all_gather_op::Topology::Linear ? 8 : 4));
+        this->num_eth_buffers = (this->enable_bidirectional ? 8 /*1*/ : (topology != ttnn::ccl::Topology::Linear ? 8 : 4));
     }
 
     if (bidirectional_mode == AllGatherBidirectionalMode::FULL_TENSOR) {
@@ -181,15 +181,15 @@ namespace operations {
 namespace ccl {
 
 Tensor all_gather(
-    const Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<MemoryConfig>& memory_config, const std::optional<size_t> user_defined_num_workers, const std::optional<size_t> user_defined_num_buffers_per_channel, const all_gather_op::Topology topology) {
+    const Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<MemoryConfig>& memory_config, const std::optional<size_t> user_defined_num_workers, const std::optional<size_t> user_defined_num_buffers_per_channel, const ttnn::ccl::Topology topology) {
 
     TT_FATAL(std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "This op is only supported for Fast Dispatch");
     auto devices = input_tensor.get_workers();
     uint32_t num_devices = devices.size();
-    all_gather_op::Topology ccl_topology = all_gather_op::Topology::Ring;
+    ttnn::ccl::Topology ccl_topology = ttnn::ccl::Topology::Ring;
 
     if (num_devices == 2){
-        ccl_topology = all_gather_op::Topology::Linear;
+        ccl_topology = ttnn::ccl::Topology::Linear;
     }
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -33,17 +33,13 @@ enum AllGatherBidirectionalMode {
     FULL_TENSOR
 };
 
-namespace all_gather_op {
-using ccl::Topology;
-}; // namespace all_gather_op
-
 using ccl::EriscDatamoverBuilder;
 
 class AllGatherConfig {
     static AllGatherBidirectionalMode choose_bidirectional_mode(Tensor const& input_tensor, bool fuse_op);
 
    public:
-    AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links, all_gather_op::Topology topology, std::size_t num_buffers_per_worker, bool fuse_op=false, const std::optional<size_t> user_defined_num_workers=std::nullopt);
+    AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links, ccl::Topology topology, std::size_t num_buffers_per_worker, bool fuse_op=false, const std::optional<size_t> user_defined_num_workers=std::nullopt);
 
     uint32_t get_erisc_handshake_address() const { return this->erisc_handshake_address; }
 
@@ -114,7 +110,7 @@ class AllGatherConfig {
     uint32_t semaphore_offset;
     uint32_t eth_buffers_l1_base_byte_address;
     uint32_t eth_sems_l1_base_byte_address;
-    const all_gather_op::Topology topology;
+    const ccl::Topology topology;
     AllGatherBidirectionalMode bidirectional_mode;
     bool is_sharded;
     bool enable_bidirectional;
@@ -133,7 +129,7 @@ struct AllGather {
     const std::optional<chip_id_t> receiver_device_id;
     const std::optional<chip_id_t> sender_device_id;
     const MemoryConfig output_mem_config;
-    const all_gather_op::Topology topology;
+    const ccl::Topology topology;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -149,7 +145,7 @@ AllGather create_all_gather_struct(
     const std::optional<size_t> user_defined_num_workersm,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const std::vector<Device*>& devices,
-    const all_gather_op::Topology topology
+    const ccl::Topology topology
 );
 
 // All Gather Variants
@@ -164,7 +160,7 @@ operation::ProgramWithCallbacks all_gather_full_shard_grid(
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology);
+    ccl::Topology topology);
 operation::ProgramWithCallbacks all_gather_multi_core_with_workers(
     const Tensor& input_tensor,
     Tensor& output_tensor,
@@ -174,7 +170,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(
     const uint32_t ring_index,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology,
+    ccl::Topology topology,
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel);
 operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
@@ -187,7 +183,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     const uint32_t ring_index,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology,
+    ccl::Topology topology,
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
@@ -205,7 +201,7 @@ Tensor all_gather(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<size_t> user_defined_num_workers = std::nullopt,
     const std::optional<size_t> user_defined_num_buffers_per_channel = std::nullopt,
-    const all_gather_op::Topology topology = all_gather_op::Topology::Ring);
+    const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring);
 
 } // namespace ccl
 } // namespace operations

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -204,7 +204,8 @@ Tensor all_gather(
     const uint32_t num_links = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<size_t> user_defined_num_workers = std::nullopt,
-    const std::optional<size_t> user_defined_num_buffers_per_channel = std::nullopt);
+    const std::optional<size_t> user_defined_num_buffers_per_channel = std::nullopt,
+    const all_gather_op::Topology topology = all_gather_op::Topology::Ring);
 
 } // namespace ccl
 } // namespace operations

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -94,7 +94,7 @@ get_all_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_link
 }
 
 static std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
-    AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, all_gather_op::Topology topology, uint32_t direction
+    AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, ccl::Topology topology, uint32_t direction
 ) {
     std::vector<std::vector<uint32_t>> worker_sender_num_transfers;
     worker_sender_num_transfers.reserve(num_links);
@@ -103,11 +103,11 @@ static std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
         for(uint32_t b = 0; b < all_gather_config.get_num_workers_per_link(); ++b) {
             uint32_t &worker_num_transfers = worker_sender_num_transfers.at(l).at(b);
             switch (topology) {
-                case all_gather_op::Topology::Linear:
+                case ccl::Topology::Linear:
                     worker_num_transfers = direction == 0 ? ring_index + 1 : ring_size - ring_index;
                     break;
 
-                case all_gather_op::Topology::Ring:
+                case ccl::Topology::Ring:
                     switch (all_gather_config.get_bidirectional_mode()) {
                         case ttnn::AllGatherBidirectionalMode::SPLIT_TENSOR:
                             worker_num_transfers = ring_size - 1;
@@ -133,7 +133,7 @@ static std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
     return worker_sender_num_transfers;
 }
 static std::vector<std::vector<uint32_t>> compute_worker_receiver_num_transfers(
-    AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, all_gather_op::Topology topology, uint32_t direction) {
+    AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, ccl::Topology topology, uint32_t direction) {
     std::vector<std::vector<uint32_t>> worker_sender_num_transfers;
     worker_sender_num_transfers.reserve(num_links);
     for (uint32_t l = 0; l < num_links; ++l) {
@@ -141,11 +141,11 @@ static std::vector<std::vector<uint32_t>> compute_worker_receiver_num_transfers(
         for(uint32_t b = 0; b < all_gather_config.get_num_workers_per_link(); ++b) {
             uint32_t &worker_num_transfers = worker_sender_num_transfers.at(l).at(b);
             switch (topology) {
-                case all_gather_op::Topology::Linear:
+                case ccl::Topology::Linear:
                     worker_num_transfers = (direction == 0 ? ring_index + 1: ring_size - ring_index) - 1;
                     break;
 
-                case all_gather_op::Topology::Ring:
+                case ccl::Topology::Ring:
                     switch (all_gather_config.get_bidirectional_mode()) {
                         case ttnn::AllGatherBidirectionalMode::SPLIT_TENSOR:
                             worker_num_transfers = ring_size - 1;
@@ -209,7 +209,7 @@ static void log_sharded_tensor_kernel_args(Tensor const& tensor, std::size_t pag
 // For ring all-gather, we can send sub-sections of input tensor in opposite directions
 // For linear all-gather though, we must ensure we send full tensors in BOTH directions
 //   (in other words, disable the "bidirectional" send flag)
-operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor& input_tensor, Tensor& output_tensor, const uint32_t dim, const uint32_t num_links, const uint32_t ring_size, const uint32_t ring_index, const std::optional<chip_id_t> receiver_device_id, const std::optional<chip_id_t> sender_device_id, all_gather_op::Topology topology, const std::optional<size_t> user_defined_num_workers, const std::optional<size_t> user_defined_num_buffers_per_channel) {
+operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor& input_tensor, Tensor& output_tensor, const uint32_t dim, const uint32_t num_links, const uint32_t ring_size, const uint32_t ring_index, const std::optional<chip_id_t> receiver_device_id, const std::optional<chip_id_t> sender_device_id, ccl::Topology topology, const std::optional<size_t> user_defined_num_workers, const std::optional<size_t> user_defined_num_buffers_per_channel) {
 
     tt::tt_metal::Program program{};
     std::optional<experimental::ccl::AllGatherFusedOpSignaler> empty_fused_op_signaler;
@@ -226,7 +226,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     const uint32_t ring_index,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology,
+    ccl::Topology topology,
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
@@ -234,7 +234,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
 
     TT_FATAL(!(receiver_device_id == std::nullopt && sender_device_id == std::nullopt), "At least one of receiver_device_id or sender_device_id must be specified");
 
-    bool is_linear = topology == all_gather_op::Topology::Linear;
+    bool is_linear = topology == ccl::Topology::Linear;
     std::unique_ptr<ccl::CclOpTensorConfig> input_tensor_config = ttnn::ccl::CclOpTensorConfig::build_all_gather_tensor_config(input_tensor);
     std::unique_ptr<ccl::CclOpTensorConfig> output_tensor_config = ttnn::ccl::CclOpTensorConfig::build_all_gather_tensor_config(output_tensor);
 
@@ -300,8 +300,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     }
 
     bool full_send_both_directions =
-        (topology == all_gather_op::Topology::Linear ||
-         (topology == all_gather_op::Topology::Ring &&
+        (topology == ccl::Topology::Linear ||
+         (topology == ccl::Topology::Ring &&
           all_gather_config.get_bidirectional_mode() == ttnn::AllGatherBidirectionalMode::FULL_TENSOR));
     const uint32_t num_full_send_directions = full_send_both_directions ? 2 : 1;
     constexpr uint32_t max_num_full_send_directions = 2;
@@ -942,7 +942,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                     uint32_t receiver_output_start_addr_offset = receiver_ring_index * tensor_slicer.output_addr_offset;
 
                     uint32_t receiver_output_start_page_idx = tensor_slicer.output_start_page_idx;
-                    if (topology == all_gather_op::Topology::Linear) {
+                    if (topology == ccl::Topology::Linear) {
                         if (is_clockwise_direction) {
                             receiver_output_start_page_idx -= tensor_slicer.output_page_offset;
                         } else {

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -54,7 +54,7 @@ Tensor line_all_gather(
 
             return operation::run(
                 ttnn::AllGather{
-                    dim, num_links, num_devices, device_index, user_defined_num_workers, user_defined_num_buffers_per_channel, receiver_device_id, sender_device_id, memory_config.value_or(input_tensor.memory_config()), ttnn::all_gather_op::Topology::Linear},
+                    dim, num_links, num_devices, device_index, user_defined_num_workers, user_defined_num_buffers_per_channel, receiver_device_id, sender_device_id, memory_config.value_or(input_tensor.memory_config()), ttnn::ccl::Topology::Linear},
                 {input_tensor});
         },
         {input_tensor},
@@ -106,7 +106,7 @@ Tensor line_all_gather(
 
             return operation::run(
                 ttnn::AllGather{
-                    dim, num_links, num_devices, device_index, user_defined_num_workers, user_defined_num_buffers_per_channel, receiver_device_id, sender_device_id, memory_config.value_or(input_device_tensor.memory_config()), ttnn::all_gather_op::Topology::Linear},
+                    dim, num_links, num_devices, device_index, user_defined_num_workers, user_defined_num_buffers_per_channel, receiver_device_id, sender_device_id, memory_config.value_or(input_device_tensor.memory_config()), ttnn::ccl::Topology::Linear},
                 {input_device_tensor});
         },
         {input_tensor},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -155,7 +155,7 @@ std::vector <ttnn::Tensor> all_gather_matmul(
             const auto& weight_tensor = input_tensors[1];
 
             /* AllGather setup */
-            ttnn::AllGather all_gather_struct = ttnn::create_all_gather_struct(input_tensor, dim, num_links, memory_config_ag, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, all_gather_op::Topology::Ring);
+            ttnn::AllGather all_gather_struct = ttnn::create_all_gather_struct(input_tensor, dim, num_links, memory_config_ag, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, ttnn::ccl::Topology::Ring);
 
             // Create the all gather output tensor used as input (activation) to the matmul
             ttnn::Tensor all_gather_out_tensor = all_gather_struct.create_output_tensors({input_tensor})[0];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
@@ -67,7 +67,7 @@ operation::ProgramWithCallbacks all_gather_matmul_multi_core_with_workers(
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology,
+    ttnn::ccl::Topology topology,
     const CoreCoord core_grid_offset,
 
     /* Matmul Params */

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -47,7 +47,7 @@ DatacopyParams setup_datacopy(
     const uint32_t num_links,
     const uint32_t ring_size,
     const uint32_t ring_index,
-    all_gather_op::Topology topology,
+    ttnn::ccl::Topology topology,
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
 
@@ -217,7 +217,7 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology,
+    ttnn::ccl::Topology topology,
     const CoreCoord core_grid_offset,
 
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -311,6 +311,10 @@ from ttnn.operations.reduction import (
     ReduceType,
 )
 
+from ttnn.operations.ccl import (
+    Topology,
+)
+
 from ttnn.operations.conv2d import Conv2dConfig, get_conv_output_dim, get_conv_padded_input_shape_and_mem_config
 from ttnn.operations.pool import avg_pool2d
 from ttnn.operations.conv1d import Conv1d, Conv1dConfig

--- a/ttnn/ttnn/operations/ccl.py
+++ b/ttnn/ttnn/operations/ccl.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+__all__ = []
+
+Topology = ttnn._ttnn.operations.ccl.Topology
+
+# TODO: Add golden functions (#12747)
+
+
+__all__ = []


### PR DESCRIPTION
Tracking Issue : #12985 

Expose ccl Ring and Linear topology to be accessed from python

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/10991198137
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
