### PR TITLE
#12141: Fixed matmul shape validation issue

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -1871,14 +1871,16 @@ def test_swin_s_conv(
 @pytest.mark.parametrize(
     "batch_size, input_channels, output_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, groups, shard_layout, config_override, use_shallow_conv_variant",
     (
-        # mlp sub_module
-        # (1, 3, 32, 512, 512, 7, 7, 4, 4, 3, 3, 1, ttnn.TensorMemoryLayout.WIDTH_SHARDED, None, False),
-        # efficient selfattention sub_module
         (1, 32, 32, 128, 128, 8, 8, 8, 8, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
         (1, 64, 64, 64, 64, 4, 4, 4, 4, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
         (1, 256, 150, 128, 128, 1, 1, 1, 1, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
         (1, 32, 16, 64, 64, 1, 1, 1, 1, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
         (1, 96, 24, 32, 32, 1, 1, 1, 1, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
+        (1, 576, 576, 8, 8, 3, 3, 1, 1, 0, 0, 576, ttnn.TensorMemoryLayout.WIDTH_SHARDED, None, False),
+        (1, 576, 576, 8, 8, 3, 3, 2, 2, 0, 0, 576, ttnn.TensorMemoryLayout.WIDTH_SHARDED, None, False),
+        (1, 960, 960, 4, 4, 3, 3, 1, 1, 0, 0, 960, ttnn.TensorMemoryLayout.WIDTH_SHARDED, None, False),
+        (1, 144, 24, 32, 32, 1, 1, 1, 1, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
+        (1, 144, 32, 16, 16, 1, 1, 1, 1, 0, 0, 1, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, None, False),
     ),
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -556,8 +556,8 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     uint32_t window_h = weights_shape[2];
     uint32_t window_w = weights_shape[3];
     uint32_t out_channel_padding = tt::round_up(out_channels, 32) - out_channels;
-    uint32_t in_channel_padding = tt::round_up(in_channels, input_channels_alignment) - in_channels;
-
+    tt::tt_metal::LegacyShape weights_channels_padded_shape = tt::tt_metal::LegacyShape(std::array<uint32_t, 4>(
+        {tt::round_up(out_channels, 32), tt::round_up(in_channels, input_channels_alignment), window_h, window_w}));
     if (weights_bias_dtype == DataType::BFLOAT8_B) {
         TT_ASSERT(weight_tensor_.get_dtype() == DataType::FLOAT32);
         if (bias_tensor.has_value()) {
@@ -570,6 +570,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
             TT_ASSERT(bias_tensor.value().get_dtype() == weights_bias_dtype);
         }
     }
+    weight_tensor_ = ttnn::pad(weight_tensor_, weights_channels_padded_shape.to_array_4D(), tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
 
     // for conv op, pad the weights to block shape
     if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
@@ -579,14 +580,19 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
         weight_tensor_ = tt::tt_metal::convert_conv_weight_tensor_to_tiled_layout(
             weight_tensor_, weight_block_h_ntiles, weight_block_w_ntiles, weights_bias_dtype);
     }
-    //convert_conv_weight_tensor adds the padding to the base shape.
-    //Reshape the weights to remove padding from the base shape.
+
+    uint32_t weight_matrix_height = in_channels * window_h * window_w;
+    int32_t weight_matrix_height_padding = weight_tensor_.shape()[2] - weight_matrix_height;
+    TT_FATAL(weight_matrix_height_padding >= 0," Matrix Height Padding can't be negative");
+
+    // convert_conv_weight_tensor adds the padding to the base shape.
+    // Reshape the weights to remove padding from the base shape.
     weight_tensor_.set_shape(
-        ttnn::Shape(std::array<uint32_t,4>{1, 1, in_channels * window_h * window_w, out_channels},
+        ttnn::Shape(std::array<uint32_t,4>{1, 1, weight_matrix_height, out_channels},
         std::array<std::array<uint32_t, 2>, 4>{
             std::array<uint32_t, 2>{0, 0},
             std::array<uint32_t, 2>{0, 0},
-            std::array<uint32_t, 2>{0, in_channel_padding},
+            std::array<uint32_t, 2>{0, weight_matrix_height_padding},
             std::array<uint32_t, 2>{0, out_channel_padding}
     }));
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -982,10 +982,10 @@ void Matmul::validate(
         (input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE),
         "Inputs to matmul must be tilized");
     TT_FATAL(
-        a_shape[-1] == b_shape[-2],
+        a_shape.with_tile_padding()[-1] == b_shape.with_tile_padding()[-2],
         "The width of the first tensor must be equal to the height of the second tensor. Mismatch: width={} height={}",
-        a_shape[-1],
-        b_shape[-2]);
+        a_shape.with_tile_padding()[-1],
+        b_shape.with_tile_padding()[-2]);
 
     TT_FATAL(this->bcast_batch.has_value(), "Error");
     if (this->bcast_batch.value()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -982,10 +982,10 @@ void Matmul::validate(
         (input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE),
         "Inputs to matmul must be tilized");
     TT_FATAL(
-        a_shape.with_tile_padding()[-1] == b_shape.with_tile_padding()[-2],
+        a_shape[-1] == b_shape[-2],
         "The width of the first tensor must be equal to the height of the second tensor. Mismatch: width={} height={}",
-        a_shape.with_tile_padding()[-1],
-        b_shape.with_tile_padding()[-2]);
+        a_shape[-1],
+        b_shape[-2]);
 
     TT_FATAL(this->bcast_batch.has_value(), "Error");
     if (this->bcast_batch.value()) {


### PR DESCRIPTION
### Ticket
#12141 

### Problem description
Mobilenet Conv, which uses matmul fails shape validation.

### What's changed
Compare only padded shape sizes. 

### Checklist
- [ ] Post commit CI passes
- [ ] New/Existing tests provide coverage for changes
