### PR TITLE
#12919: Cleanup 16 Unary Backward ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -241,7 +241,7 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSqrt::invoke(const Tensor
     return ExecuteUnaryBackwardSqrt::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> _multigammaln_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardMultigammaln::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor digamma_result = ttnn::multiply(grad, ttnn::digamma(input, output_mem_config), std::nullopt, output_mem_config);
     Tensor digamma_result_2 = ttnn::multiply(
@@ -284,7 +284,7 @@ std::vector<Tensor> _ge_bw(
     return _unary_comp_bw(grad, output_mem_config);
 }
 
-std::vector<Tensor> _lgamma_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardLgamma::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
     std::vector<Tensor> grad_tensor;
     Tensor grad_result = ttnn::multiply(grad, ttnn::digamma(input, output_mem_config), std::nullopt, output_mem_config);
@@ -430,7 +430,7 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(const Tensor&
     return ExecuteUnaryBackwardNeg::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> _relu_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardRelu::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(ttnn::gtz(input, output_mem_config), grad, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(result);
@@ -452,7 +452,7 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardFill::invoke(const Tensor
     return ExecuteUnaryBackwardFill::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> _hardsigmoid_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardHardsigmoid::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_a = ttnn::where(
         ttnn::logical_or(
@@ -469,7 +469,7 @@ std::vector<Tensor> _hardsigmoid_bw(const Tensor& grad, const Tensor& input, con
 
 // name: cos(Tensor self) -> Tensor
 // self: grad * -self.sin()
-std::vector<Tensor> _cos_bw(const Tensor& grad, const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardCos::invoke(const Tensor& grad, const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result =
         ttnn::multiply(grad, (ttnn::neg(ttnn::sin(input_tensor, output_mem_config), output_mem_config)), std::nullopt, output_mem_config);
@@ -477,7 +477,7 @@ std::vector<Tensor> _cos_bw(const Tensor& grad, const Tensor& input_tensor, cons
     return grad_tensor;
 }
 
-std::vector<Tensor> _acosh_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardAcosh::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor in_rsqrt = ttnn::square(input, output_mem_config);
     in_rsqrt = ttnn::rsqrt(ttnn::subtract(in_rsqrt, 1.0, std::nullopt, output_mem_config), true, output_mem_config);
@@ -555,7 +555,7 @@ std::vector<Tensor> _rad2deg_bw(const Tensor& grad, const Tensor& input, const s
     return grad_tensor;
 }
 
-std::vector<Tensor> _logit_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardLogit::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result =
         ttnn::multiply(grad,
@@ -684,21 +684,21 @@ std::vector<Tensor> ExecuteUnaryBackwardRpow::invoke(
 }
 
 
-std::vector<Tensor> _floor_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardFloor::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = ttnn::zeros_like(grad);
     grad_tensor.emplace_back(t_zero);
     return grad_tensor;
 }
 
-std::vector<Tensor> _round_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardRound::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = ttnn::zeros_like(grad);
     grad_tensor.emplace_back(t_zero);
     return grad_tensor;
 }
 
-std::vector<Tensor> _log_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+std::vector<Tensor> ExecuteUnaryBackwardLog::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(input, output_mem_config), std::nullopt, output_mem_config);
     Tensor t_inf = ttnn::full_like(input, std::numeric_limits<float>::infinity());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -241,7 +241,8 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSqrt::invoke(const Tensor
     return ExecuteUnaryBackwardSqrt::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardMultigammaln::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Multigammaln, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor digamma_result = ttnn::multiply(grad, ttnn::digamma(input, output_mem_config), std::nullopt, output_mem_config);
     Tensor digamma_result_2 = ttnn::multiply(
@@ -284,7 +285,8 @@ std::vector<Tensor> _ge_bw(
     return _unary_comp_bw(grad, output_mem_config);
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardLgamma::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template <>
+std::vector<Tensor> ExecuteUnaryBackward<Lgamma, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
     std::vector<Tensor> grad_tensor;
     Tensor grad_result = ttnn::multiply(grad, ttnn::digamma(input, output_mem_config), std::nullopt, output_mem_config);
@@ -430,7 +432,8 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(const Tensor&
     return ExecuteUnaryBackwardNeg::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardRelu::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Relu, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(ttnn::gtz(input, output_mem_config), grad, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(result);
@@ -452,7 +455,8 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardFill::invoke(const Tensor
     return ExecuteUnaryBackwardFill::invoke(DefaultQueueId, grad, input, output_mem_config, input_grad);
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardHardsigmoid::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Hardsigmoid, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_a = ttnn::where(
         ttnn::logical_or(
@@ -469,7 +473,8 @@ std::vector<Tensor> ExecuteUnaryBackwardHardsigmoid::invoke(const Tensor& grad, 
 
 // name: cos(Tensor self) -> Tensor
 // self: grad * -self.sin()
-std::vector<Tensor> ExecuteUnaryBackwardCos::invoke(const Tensor& grad, const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Cos, 0>::invoke(const Tensor& grad, const Tensor& input_tensor, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result =
         ttnn::multiply(grad, (ttnn::neg(ttnn::sin(input_tensor, output_mem_config), output_mem_config)), std::nullopt, output_mem_config);
@@ -477,7 +482,8 @@ std::vector<Tensor> ExecuteUnaryBackwardCos::invoke(const Tensor& grad, const Te
     return grad_tensor;
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardAcosh::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Acosh, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor in_rsqrt = ttnn::square(input, output_mem_config);
     in_rsqrt = ttnn::rsqrt(ttnn::subtract(in_rsqrt, 1.0, std::nullopt, output_mem_config), true, output_mem_config);
@@ -555,7 +561,8 @@ std::vector<Tensor> _rad2deg_bw(const Tensor& grad, const Tensor& input, const s
     return grad_tensor;
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardLogit::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Logit, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result =
         ttnn::multiply(grad,
@@ -665,8 +672,8 @@ std::vector<Tensor> ExecuteUnaryBackwardCelu::invoke(
     return grad_tensor;
 }
 
-
-std::vector<Tensor> ExecuteUnaryBackwardRpow::invoke(
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Rpow, 1>::invoke(
     const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_nan = std::nanf("");
@@ -683,22 +690,24 @@ std::vector<Tensor> ExecuteUnaryBackwardRpow::invoke(
     return grad_tensor;
 }
 
-
-std::vector<Tensor> ExecuteUnaryBackwardFloor::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<Floor, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = ttnn::zeros_like(grad);
     grad_tensor.emplace_back(t_zero);
     return grad_tensor;
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardRound::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template <>
+std::vector<Tensor> ExecuteUnaryBackward<Round, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = ttnn::zeros_like(grad);
     grad_tensor.emplace_back(t_zero);
     return grad_tensor;
 }
 
-std::vector<Tensor> ExecuteUnaryBackwardLog::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+template <>
+std::vector<Tensor> ExecuteUnaryBackward<Log, 0>::invoke(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(input, output_mem_config), std::nullopt, output_mem_config);
     Tensor t_inf = ttnn::full_like(input, std::numeric_limits<float>::infinity());
@@ -1138,8 +1147,8 @@ std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const std:
     return grad_tensor;
 }
 
-
-std::vector<Tensor> ExecuteUnaryBackwardDivNoNan::invoke(
+template<>
+std::vector<Tensor> ExecuteUnaryBackward<DivNoNan, 1>::invoke(
     const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor zeros = ttnn::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -666,7 +666,7 @@ std::vector<Tensor> ExecuteUnaryBackwardCelu::invoke(
 }
 
 
-std::vector<Tensor> _rpow_bw(
+std::vector<Tensor> ExecuteUnaryBackwardRpow::invoke(
     const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_nan = std::nanf("");
@@ -1139,7 +1139,7 @@ std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const std:
 }
 
 
-std::vector<Tensor> _div_no_nan_bw(
+std::vector<Tensor> ExecuteUnaryBackwardDivNoNan::invoke(
     const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor zeros = ttnn::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
@@ -1258,7 +1258,7 @@ std::vector<Tensor> _digamma_bw(const Tensor& grad, const Tensor& input, const s
     return grad_tensor;
 }
 
-std::vector<Tensor> _polygamma_bw(
+std::vector<Tensor> ExecuteUnaryBackwardPolygamma::invoke(
     const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input.memory_config());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -60,7 +60,6 @@ enum class UnaryBackwardOpType {
     DIV_NO_NAN_BW,
     EXP2_BW,
     EXPM1_BW,
-    RECIPROCAL_BW,
     DIGAMMA_BW,
     ERFINV_BW,
     ERF_BW,
@@ -78,7 +77,6 @@ std::vector<Tensor> _fill_zero_bw( const Tensor& grad, const Tensor& input, cons
 std::vector<Tensor> _i0_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _tan_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _sigmoid_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _reciprocal_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _softsign_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _cosh_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -176,13 +174,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::SIGMOID_BW> {
     static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
         return _sigmoid_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RECIPROCAL_BW> {
-    static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-        return _reciprocal_bw(grad, input, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -35,7 +35,6 @@ enum class UnaryBackwardOpType {
     SIGMOID_BW,
     RELU_BW,
     LOGIT_BW,
-    RPOW_BW,
     FLOOR_BW,
     ROUND_BW,
     LOG_BW,
@@ -57,14 +56,12 @@ enum class UnaryBackwardOpType {
     COSH_BW,
     LOG2_BW,
     SIGN_BW,
-    DIV_NO_NAN_BW,
     EXP2_BW,
     EXPM1_BW,
     DIGAMMA_BW,
     ERFINV_BW,
     ERF_BW,
     DEG2RAD_BW,
-    POLYGAMMA_BW,
 };
 
 std::vector<Tensor> _acos_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -102,9 +99,6 @@ std::vector<Tensor> _relu6_bw(const Tensor& grad, const Tensor& input, const std
 std::vector<Tensor> _selu_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _square_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 
-std::vector<Tensor> _rpow_bw( const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _div_no_nan_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _polygamma_bw( const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _sub_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _gt_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config);
 
@@ -127,13 +121,6 @@ Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_
 // OpHandler struct template
 template <UnaryBackwardOpType OpType>
 struct OpHandler;
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RPOW_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _rpow_bw(grad, input, exponent, output_mem_config);
-    }
-};
 
 template <>
 struct OpHandler<UnaryBackwardOpType::ACOS_BW> {
@@ -370,20 +357,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::SQUARE_BW> {
     static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
         return _square_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::DIV_NO_NAN_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _div_no_nan_bw(grad, input, exponent, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::POLYGAMMA_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _polygamma_bw(grad, input, n, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -14,14 +14,9 @@ namespace ttnn::operations::unary_backward {
 
 enum class UnaryBackwardOpType {
     DIV_BW,
-    MULTIGAMMALN_BW,
     ADD_BW,
     EQ_BW,
     GT_BW,
-    LGAMMA_BW,
-    HARDSIGMOID_BW,
-    COS_BW,
-    ACOSH_BW,
     ACOS_BW,
     ATAN_BW,
     RAD2DEG_BW,
@@ -33,11 +28,6 @@ enum class UnaryBackwardOpType {
     I0_BW,
     TAN_BW,
     SIGMOID_BW,
-    RELU_BW,
-    LOGIT_BW,
-    FLOOR_BW,
-    ROUND_BW,
-    LOG_BW,
     RELU6_BW,
     SELU_BW,
     SQUARE_BW,
@@ -101,17 +91,6 @@ std::vector<Tensor> _square_bw(const Tensor& grad, const Tensor& input, const st
 
 std::vector<Tensor> _sub_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _gt_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config);
-
-std::vector<Tensor> _multigammaln_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _lgamma_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _hardsigmoid_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _cos_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _acosh_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _relu_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _logit_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _floor_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _round_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _log_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 
 std::vector<Tensor> _add_bw( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 std::vector<Tensor> _eq_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
@@ -364,76 +343,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::GT_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _gt_bw(grad, input, other, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::MULTIGAMMALN_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _multigammaln_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::LGAMMA_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _lgamma_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::HARDSIGMOID_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _hardsigmoid_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::COS_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _cos_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::ACOSH_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _acosh_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RELU_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _relu_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::LOGIT_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _logit_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::FLOOR_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _floor_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::ROUND_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _round_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::LOG_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _log_bw(grad, input, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -317,41 +317,29 @@ DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Logiteps)
 
 }  // operations::unary
 
+// Tensor + Float
+constexpr auto div_no_nan_bw = ttnn::register_operation<"ttnn::div_no_nan_bw", operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
+constexpr auto rpow_bw = ttnn::register_operation<"ttnn::rpow_bw", operations::unary_backward::ExecuteUnaryBackwardRpow>();
+
+//Tensor
+constexpr auto multigammaln_bw = ttnn::register_operation< "ttnn::multigammaln_bw", operations::unary_backward::ExecuteUnaryBackwardMultigammaln>();
+constexpr auto lgamma_bw = ttnn::register_operation<"ttnn::lgamma_bw", operations::unary_backward::ExecuteUnaryBackwardLgamma>();
+constexpr auto hardsigmoid_bw = ttnn::register_operation<"ttnn::hardsigmoid_bw", operations::unary_backward::ExecuteUnaryBackwardHardsigmoid>();
+constexpr auto relu_bw = ttnn::register_operation<"ttnn::relu_bw", operations::unary_backward::ExecuteUnaryBackwardRelu>();
+constexpr auto logit_bw = ttnn::register_operation<"ttnn::logit_bw", operations::unary_backward::ExecuteUnaryBackwardLogit>();
+constexpr auto floor_bw = ttnn::register_operation<"ttnn::floor_bw", operations::unary_backward::ExecuteUnaryBackwardFloor>();
+constexpr auto round_bw = ttnn::register_operation<"ttnn::round_bw", operations::unary_backward::ExecuteUnaryBackwardRound>();
+constexpr auto log_bw = ttnn::register_operation<"ttnn::log_bw", operations::unary_backward::ExecuteUnaryBackwardLog>();
+constexpr auto cos_bw = ttnn::register_operation<"ttnn::cos_bw", operations::unary_backward::ExecuteUnaryBackwardCos>();
+constexpr auto acosh_bw = ttnn::register_operation<"ttnn::acosh_bw", operations::unary_backward::ExecuteUnaryBackwardAcosh>();
+
 constexpr auto threshold_bw = ttnn::register_operation<
     "ttnn::threshold_bw",
     operations::unary_backward::ExecuteUnaryBackwardThreshold>();
 
-constexpr auto multigammaln_bw = ttnn::register_operation<
-    "ttnn::multigammaln_bw",
-    operations::unary_backward::ExecuteUnaryBackwardMultigammaln>();
-
-constexpr auto lgamma_bw = ttnn::register_operation<
-    "ttnn::lgamma_bw",
-    operations::unary_backward::ExecuteUnaryBackwardLgamma>();
-
 constexpr auto fill_bw = ttnn::register_operation<
     "ttnn::fill_bw",
     operations::unary_backward::ExecuteUnaryBackwardFill>();
-
-constexpr auto hardsigmoid_bw = ttnn::register_operation<
-    "ttnn::hardsigmoid_bw",
-    operations::unary_backward::ExecuteUnaryBackwardHardsigmoid>();
-
-constexpr auto cos_bw = ttnn::register_operation<
-    "ttnn::cos_bw",
-    operations::unary_backward::ExecuteUnaryBackwardCos>();
-
-constexpr auto acosh_bw = ttnn::register_operation<
-    "ttnn::acosh_bw",
-    operations::unary_backward::ExecuteUnaryBackwardAcosh>();
-
-constexpr auto rpow_bw = ttnn::register_operation<
-    "ttnn::rpow_bw",
-    operations::unary_backward::ExecuteUnaryBackwardRpow>();
-
-constexpr auto div_no_nan_bw = ttnn::register_operation<
-    "ttnn::div_no_nan_bw",
-    operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
 
 constexpr auto polygamma_bw = ttnn::register_operation<
     "ttnn::polygamma_bw",
@@ -586,26 +574,6 @@ constexpr auto silu_bw = ttnn::register_operation<
 constexpr auto prod_bw = ttnn::register_operation<
     "ttnn::prod_bw",
     operations::unary_backward::ExecuteUnaryBackwardProd>();
-
-constexpr auto relu_bw = ttnn::register_operation<
-    "ttnn::relu_bw",
-    operations::unary_backward::ExecuteUnaryBackwardRelu>();
-
-constexpr auto logit_bw = ttnn::register_operation<
-    "ttnn::logit_bw",
-    operations::unary_backward::ExecuteUnaryBackwardLogit>();
-
-constexpr auto floor_bw = ttnn::register_operation<
-    "ttnn::floor_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloor>();
-
-constexpr auto round_bw = ttnn::register_operation<
-    "ttnn::round_bw",
-    operations::unary_backward::ExecuteUnaryBackwardRound>();
-
-constexpr auto log_bw = ttnn::register_operation<
-    "ttnn::log_bw",
-    operations::unary_backward::ExecuteUnaryBackwardLog>();
 
 // overload
 constexpr auto reciprocal_bw = ttnn::register_operation<

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -54,16 +54,12 @@ struct ExecuteUnaryBackwardPolygamma {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-template <UnaryBackwardOpType unary_backward_op_type>
-struct ExecuteUnaryBackwardWoFloat {
-    static std::vector<Tensor> invoke(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, output_memory_config);
-        }
-
+#define DEFINE_UNARY_BACKWARD_OPERATION(op_name) \
+struct ExecuteUnaryBackward##op_name { \
+    static std::vector<Tensor> invoke( \
+        const Tensor &grad_tensor_arg, \
+        const Tensor &input_tensor_arg, \
+        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
 };
 
 #define DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(op_name) \
@@ -295,6 +291,20 @@ struct ExecuteUnaryBackwardGelu{
 
 };
 
+DEFINE_UNARY_BACKWARD_OPERATION(Multigammaln)
+DEFINE_UNARY_BACKWARD_OPERATION(Lgamma)
+DEFINE_UNARY_BACKWARD_OPERATION(Hardsigmoid)
+DEFINE_UNARY_BACKWARD_OPERATION(Cos)
+DEFINE_UNARY_BACKWARD_OPERATION(Acosh)
+DEFINE_UNARY_BACKWARD_OPERATION(Relu)
+DEFINE_UNARY_BACKWARD_OPERATION(Logit)
+DEFINE_UNARY_BACKWARD_OPERATION(Floor)
+DEFINE_UNARY_BACKWARD_OPERATION(Round)
+DEFINE_UNARY_BACKWARD_OPERATION(Log)
+
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(DivNoNan)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(Rpow)
+
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Softplus)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Hardtanh)
 
@@ -305,8 +315,6 @@ DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Elu)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Celu)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Logiteps)
 
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(DivNoNan)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(Rpow)
 }  // operations::unary
 
 constexpr auto threshold_bw = ttnn::register_operation<
@@ -315,13 +323,11 @@ constexpr auto threshold_bw = ttnn::register_operation<
 
 constexpr auto multigammaln_bw = ttnn::register_operation<
     "ttnn::multigammaln_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
-        operations::unary_backward::UnaryBackwardOpType::MULTIGAMMALN_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardMultigammaln>();
 
 constexpr auto lgamma_bw = ttnn::register_operation<
     "ttnn::lgamma_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
-        operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardLgamma>();
 
 constexpr auto fill_bw = ttnn::register_operation<
     "ttnn::fill_bw",
@@ -329,18 +335,15 @@ constexpr auto fill_bw = ttnn::register_operation<
 
 constexpr auto hardsigmoid_bw = ttnn::register_operation<
     "ttnn::hardsigmoid_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
-        operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardHardsigmoid>();
 
 constexpr auto cos_bw = ttnn::register_operation<
     "ttnn::cos_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
-        operations::unary_backward::UnaryBackwardOpType::COS_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardCos>();
 
 constexpr auto acosh_bw = ttnn::register_operation<
     "ttnn::acosh_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
-        operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardAcosh>();
 
 constexpr auto rpow_bw = ttnn::register_operation<
     "ttnn::rpow_bw",
@@ -586,19 +589,23 @@ constexpr auto prod_bw = ttnn::register_operation<
 
 constexpr auto relu_bw = ttnn::register_operation<
     "ttnn::relu_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::RELU_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardRelu>();
+
 constexpr auto logit_bw = ttnn::register_operation<
     "ttnn::logit_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::LOGIT_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardLogit>();
+
 constexpr auto floor_bw = ttnn::register_operation<
     "ttnn::floor_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::FLOOR_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardFloor>();
+
 constexpr auto round_bw = ttnn::register_operation<
     "ttnn::round_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::ROUND_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardRound>();
+
 constexpr auto log_bw = ttnn::register_operation<
     "ttnn::log_bw",
-    operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::LOG_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardLog>();
 
 // overload
 constexpr auto reciprocal_bw = ttnn::register_operation<

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -37,28 +37,22 @@ struct ExecuteUnaryBackwardThreshold {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-template <UnaryBackwardOpType unary_backward_op_type>
-struct ExecuteUnaryBackwardFloat {
+#define DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(op_name) \
+struct ExecuteUnaryBackward##op_name { \
+    static std::vector<Tensor> invoke( \
+        const Tensor &grad_tensor_arg, \
+        const Tensor &input_tensor_arg, \
+        float scalar, \
+        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
+};
+
+struct ExecuteUnaryBackwardPolygamma {
     static std::vector<Tensor> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
-        float scalar,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, scalar, output_memory_config);
-        }
-
-    static std::vector<Tensor> invoke(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
-        }
-
+        int scalar,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
-
 
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardWoFloat {
@@ -311,6 +305,8 @@ DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Elu)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Celu)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Logiteps)
 
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(DivNoNan)
+DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(Rpow)
 }  // operations::unary
 
 constexpr auto threshold_bw = ttnn::register_operation<
@@ -348,18 +344,15 @@ constexpr auto acosh_bw = ttnn::register_operation<
 
 constexpr auto rpow_bw = ttnn::register_operation<
     "ttnn::rpow_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloat<
-        operations::unary_backward::UnaryBackwardOpType::RPOW_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardRpow>();
 
 constexpr auto div_no_nan_bw = ttnn::register_operation<
     "ttnn::div_no_nan_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloat<
-        operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
 
 constexpr auto polygamma_bw = ttnn::register_operation<
     "ttnn::polygamma_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloat<
-        operations::unary_backward::UnaryBackwardOpType::POLYGAMMA_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardPolygamma>();
 
 //ExecuteUnaryBackwardOp : get_function_type1
 constexpr auto acos_bw = ttnn::register_operation<

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -13,6 +13,9 @@ namespace ttnn {
 
 namespace operations::unary_backward {
 
+template <typename Operation, int NumParams>
+struct ExecuteUnaryBackward;
+
 struct ExecuteUnaryBackwardNeg {
     static std::vector<std::optional<Tensor>> invoke(
         uint8_t queue_id,
@@ -37,13 +40,13 @@ struct ExecuteUnaryBackwardThreshold {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-#define DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(op_name) \
-struct ExecuteUnaryBackward##op_name { \
-    static std::vector<Tensor> invoke( \
-        const Tensor &grad_tensor_arg, \
-        const Tensor &input_tensor_arg, \
-        float scalar, \
-        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
+template <typename Operation>
+struct ExecuteUnaryBackward<Operation, 1> {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float scalar,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
 struct ExecuteUnaryBackwardPolygamma {
@@ -54,12 +57,12 @@ struct ExecuteUnaryBackwardPolygamma {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-#define DEFINE_UNARY_BACKWARD_OPERATION(op_name) \
-struct ExecuteUnaryBackward##op_name { \
-    static std::vector<Tensor> invoke( \
-        const Tensor &grad_tensor_arg, \
-        const Tensor &input_tensor_arg, \
-        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
+template <typename Operation>
+struct ExecuteUnaryBackward<Operation, 0> {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
 #define DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(op_name) \
@@ -291,19 +294,19 @@ struct ExecuteUnaryBackwardGelu{
 
 };
 
-DEFINE_UNARY_BACKWARD_OPERATION(Multigammaln)
-DEFINE_UNARY_BACKWARD_OPERATION(Lgamma)
-DEFINE_UNARY_BACKWARD_OPERATION(Hardsigmoid)
-DEFINE_UNARY_BACKWARD_OPERATION(Cos)
-DEFINE_UNARY_BACKWARD_OPERATION(Acosh)
-DEFINE_UNARY_BACKWARD_OPERATION(Relu)
-DEFINE_UNARY_BACKWARD_OPERATION(Logit)
-DEFINE_UNARY_BACKWARD_OPERATION(Floor)
-DEFINE_UNARY_BACKWARD_OPERATION(Round)
-DEFINE_UNARY_BACKWARD_OPERATION(Log)
+struct Multigammaln {};
+struct Lgamma {};
+struct Hardsigmoid {};
+struct Cos {};
+struct Acosh {};
+struct Relu {};
+struct Logit {};
+struct Floor {};
+struct Round {};
+struct Log {};
 
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(DivNoNan)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_FLOAT(Rpow)
+struct DivNoNan {};
+struct Rpow {};
 
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Softplus)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Hardtanh)
@@ -318,20 +321,20 @@ DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Logiteps)
 }  // operations::unary
 
 // Tensor + Float
-constexpr auto div_no_nan_bw = ttnn::register_operation<"ttnn::div_no_nan_bw", operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
-constexpr auto rpow_bw = ttnn::register_operation<"ttnn::rpow_bw", operations::unary_backward::ExecuteUnaryBackwardRpow>();
+constexpr auto div_no_nan_bw = ttnn::register_operation<"ttnn::div_no_nan_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::DivNoNan, 1>>();
+constexpr auto rpow_bw = ttnn::register_operation<"ttnn::rpow_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Rpow, 1>>();
 
 //Tensor
-constexpr auto multigammaln_bw = ttnn::register_operation< "ttnn::multigammaln_bw", operations::unary_backward::ExecuteUnaryBackwardMultigammaln>();
-constexpr auto lgamma_bw = ttnn::register_operation<"ttnn::lgamma_bw", operations::unary_backward::ExecuteUnaryBackwardLgamma>();
-constexpr auto hardsigmoid_bw = ttnn::register_operation<"ttnn::hardsigmoid_bw", operations::unary_backward::ExecuteUnaryBackwardHardsigmoid>();
-constexpr auto relu_bw = ttnn::register_operation<"ttnn::relu_bw", operations::unary_backward::ExecuteUnaryBackwardRelu>();
-constexpr auto logit_bw = ttnn::register_operation<"ttnn::logit_bw", operations::unary_backward::ExecuteUnaryBackwardLogit>();
-constexpr auto floor_bw = ttnn::register_operation<"ttnn::floor_bw", operations::unary_backward::ExecuteUnaryBackwardFloor>();
-constexpr auto round_bw = ttnn::register_operation<"ttnn::round_bw", operations::unary_backward::ExecuteUnaryBackwardRound>();
-constexpr auto log_bw = ttnn::register_operation<"ttnn::log_bw", operations::unary_backward::ExecuteUnaryBackwardLog>();
-constexpr auto cos_bw = ttnn::register_operation<"ttnn::cos_bw", operations::unary_backward::ExecuteUnaryBackwardCos>();
-constexpr auto acosh_bw = ttnn::register_operation<"ttnn::acosh_bw", operations::unary_backward::ExecuteUnaryBackwardAcosh>();
+constexpr auto multigammaln_bw = ttnn::register_operation< "ttnn::multigammaln_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Multigammaln, 0>>();
+constexpr auto lgamma_bw = ttnn::register_operation<"ttnn::lgamma_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Lgamma, 0>>();
+constexpr auto hardsigmoid_bw = ttnn::register_operation<"ttnn::hardsigmoid_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Hardsigmoid, 0>>();
+constexpr auto relu_bw = ttnn::register_operation<"ttnn::relu_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Relu, 0>>();
+constexpr auto logit_bw = ttnn::register_operation<"ttnn::logit_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Logit, 0>>();
+constexpr auto floor_bw = ttnn::register_operation<"ttnn::floor_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Floor, 0>>();
+constexpr auto round_bw = ttnn::register_operation<"ttnn::round_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Round, 0>>();
+constexpr auto log_bw = ttnn::register_operation<"ttnn::log_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Log, 0>>();
+constexpr auto cos_bw = ttnn::register_operation<"ttnn::cos_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Cos, 0>>();
+constexpr auto acosh_bw = ttnn::register_operation<"ttnn::acosh_bw", operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::Acosh, 0>>();
 
 constexpr auto threshold_bw = ttnn::register_operation<
     "ttnn::threshold_bw",


### PR DESCRIPTION
Issue : #12919
[CI](https://github.com/tenstorrent/tt-metal/actions/runs/10991084972) : PASSED
Test Files : 

- reciprocal_bw : 
  - `tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_recip.py` - PASSED
  - `tests/ttnn/unit_tests/operations/backward/test_backward_reciprocal.py` - PASSED
- fill_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_fill.py` - PASSED
- pow_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_pow.py` - PASSED
- rpow_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_rpow.py` - PASSED
- div_no_nan_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_div_no_nan.py` - PASSED
- polygamma_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_polygamma.py` - PASSED
- multigammaln_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_mvlgamma.py` - PASSED
- lgamma_bw : `/tests/ttnn/unit_tests/operations/backward/test_backward_lgamma.py` - PASSED
- hardsigmoid_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_hardsigmoid.py` - PASSED
- cos_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_cos.py` - PASSED
- acosh_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_acosh.py` - PASSED
- relu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_relu.py` - PASSED
- logit_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_logit.py` - PASSED
- floor_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_floor.py` - PASSED
- round_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_round.py` - PASSED
- log_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_log.py` - PASSED