### PR TITLE
Revert "#10016: jit_build: link substitutes, tdma_xmov, noc"

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -82,7 +82,7 @@ add_custom_command(
 add_custom_command(
     OUTPUT tdma_xmov
     COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -Os -fno-tree-loop-distribute-patterns -c -o ${HW_LIB_DIR}/tdma_xmov.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/tdma_xmov.c
+    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/tdma_xmov.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/tdma_xmov.c
     COMMENT "Building hw lib tdma_xmov.o"
     VERBATIM
 )
@@ -90,7 +90,7 @@ add_custom_command(
 add_custom_command(
     OUTPUT noc
     COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -Os -fno-tree-loop-distribute-patterns -c -o ${HW_LIB_DIR}/noc.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/${ALIAS_ARCH_NAME}/noc.c
+    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/noc.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/${ALIAS_ARCH_NAME}/noc.c
     COMMENT "Building hw lib noc.o"
     VERBATIM
 )

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -13,6 +13,7 @@
 #include "ckernel_structs.h"
 #include "stream_io_map.h"
 #include "c_tensix_core.h"
+#include "tdma_xmov.h"
 #include "noc_nonblocking_api.h"
 #include "firmware_common.h"
 #include "tools/profiler/kernel_profiler.hpp"

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -168,9 +168,6 @@ void JitBuildState::finish_init() {
     // Append hw build objects compiled offline
     std::string build_dir = llrt::OptionsG.get_root_dir() + "runtime/hw/lib/";
     if (this->is_fw_) {
-        if (this->target_name_ == "brisc") {
-            this->link_objs_ += build_dir + "tdma_xmov.o ";
-        }
         if (this->target_name_ != "erisc") {
             this->link_objs_ += build_dir + "tmu-crt0.o ";
         }
@@ -180,10 +177,6 @@ void JitBuildState::finish_init() {
     } else {
         this->link_objs_ += build_dir + "tmu-crt0k.o ";
     }
-    if (this->target_name_ == "brisc" or this->target_name_ == "idle_erisc") {
-        this->link_objs_ += build_dir + "noc.o ";
-    }
-    this->link_objs_ += build_dir + "substitutes.o ";
 
     // Note the preceding slash which defies convention as this gets appended to
     // the kernel name used as a path which doesn't have a slash
@@ -205,6 +198,9 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
 
     uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
 
+    // TODO(pgk): build these once at init into built/libs!
+    this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
+
     this->lflags_ = env_.lflags_ + "-Os ";
 
     switch (this->core_id_) {
@@ -215,6 +211,9 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
             if ((l1_cache_disable_mask & tt::llrt::DebugHartFlags::RISCV_BR) == tt::llrt::DebugHartFlags::RISCV_BR) {
                 this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
             }
+
+            this->srcs_.push_back("tt_metal/hw/firmware/src/tdma_xmov.c");
+            this->srcs_.push_back("tt_metal/hw/firmware/src/" + env_.aliased_arch_name_ + "/noc.c");
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/brisc.cc");
             } else {
@@ -271,6 +270,7 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, int which, bool is_fw) 
                       "tt_metal/third_party/sfpi/include " + "-I" + env_.root_ + "tt_metal/hw/firmware/src " + "-I" +
                       env_.root_ + "tt_metal/third_party/tt_llk_" + env.arch_name_ + "/llk_lib ";
 
+    this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
     if (this->is_fw_) {
         this->srcs_.push_back("tt_metal/hw/firmware/src/trisc.cc");
     } else {
@@ -348,6 +348,7 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
 
             this->includes_ += "-I " + env_.root_ + "tt_metal/hw/inc/ethernet ";
 
+            this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/erisc.cc");
             } else {
@@ -381,6 +382,9 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
 
             this->includes_ += "-I " + env_.root_ + "tt_metal/hw/firmware/src ";
 
+            // TODO(pgk): build these once at init into built/libs!
+            this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
+            this->srcs_.push_back("tt_metal/hw/firmware/src/" + env_.aliased_arch_name_ + "/noc.c");
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/idle_erisc.cc");
             } else {


### PR DESCRIPTION
This reverts commit 0679c1988385f6ac0a78008f14be57b9298d40bd.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10016)

### Problem description
Commit to link build objects tanking pgm dispatch perf.

### What's changed
Reverting for now.
### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
