### PR TITLE
#12879: Use () so that workflow_call actually captures the call when we trigger off completed workflow runs and add them to workflows to properly capture

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -15,11 +15,24 @@ on:
   workflow_run:
     workflows:
       - "All post-commit tests"
-      - "(T3K) T3000 demo tests"
-      - "(T3K) T3000 model perf tests"
       - "(Single-card) Model perf tests"
       - "(Single-card) Device perf tests"
+      - "(Single-card) Demo tests"
       - "Nightly fast dispatch tests"
+      - "(T3K) T3000 demo tests"
+      - "(T3K) T3000 model perf tests"
+      - "(T3K) T3000 perplexity tests"
+      - "(T3K) T3000 model perf tests"
+      - "(T3K) T3000 profiler tests"
+      - "(T3K) T3000 unit tests"
+      - "(TG) TG unit tests"
+      - "(TG) TG demo tests"
+      - "(TG) TG frequent tests"
+      - "(TG) TG model perf tests"
+      - "(TGG) TGG model perf tests"
+      - "(TGG) TGG unit tests"
+      - "(TGG) TGG demo tests"
+      - "(TGG) TGG frequent tests"
     types:
       - completed
 

--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TG] TG demo tests"
+name: "(TG) TG demo tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TG] TG frequent tests"
+name: "(TG) TG frequent tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tg-model-perf-tests.yaml
+++ b/.github/workflows/tg-model-perf-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TG] TG model perf tests"
+name: "(TG) TG model perf tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TG] TG unit tests"
+name: "(TG) TG unit tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tgg-demo-tests.yaml
+++ b/.github/workflows/tgg-demo-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TGG] TGG demo tests"
+name: "(TGG) TGG demo tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tgg-frequent-tests.yaml
+++ b/.github/workflows/tgg-frequent-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TGG] TGG frequent tests"
+name: "(TGG) TGG frequent tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tgg-model-perf-tests.yaml
+++ b/.github/workflows/tgg-model-perf-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TGG] TGG model perf tests"
+name: "(TGG) TGG model perf tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tgg-unit-tests.yaml
+++ b/.github/workflows/tgg-unit-tests.yaml
@@ -1,4 +1,4 @@
-name: "[TGG] TGG unit tests"
+name: "(TGG) TGG unit tests"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
…

### Ticket

#12879 


### Problem description

We want to capture more pipelines for data collection and fix the names of the workflows so they're callable.

### What's changed

- Use `()` for workflow names so they're captured in `workflow_run` triggers
- Add the remaining T3K, TGG, TG workflows

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
