### PR TITLE
Flash decode improvements r2

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -312,13 +312,10 @@ class TtLlamaAttention_optimized:
             )
 
         else:
-            # Have to reshape back since sdpa expects batch in dim 1
-            keys_reshaped = ttnn.reshape(keys, [self.n_local_kv_heads, self.max_batch_size, -1, self.head_dim])
-            values_reshaped = ttnn.reshape(values, [self.n_local_kv_heads, self.max_batch_size, -1, self.head_dim])
             attn_output = ttnn.transformer.scaled_dot_product_attention_decode(
                 query_layer,
-                keys_reshaped,
-                values_reshaped,
+                keys,
+                values,
                 # [start_pos for _ in range(self.max_batch_size)],
                 cur_pos_tensor=cache_idxs,
                 scale=self.scale,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -240,9 +240,6 @@ class TtMixtralAttention(LightweightModule):
         k_heads_1B1D.deallocate(True)
         v_heads_1B1D.deallocate(True)
 
-        keys_1BPD = ttnn.reshape(keys_1BPD, [self.n_local_kv_heads, self.max_batch_size, -1, self.head_dim])
-        values_1BPD = ttnn.reshape(values_1BPD, [self.n_local_kv_heads, self.max_batch_size, -1, self.head_dim])
-
         attn_output_1B4D = ttnn.transformer.scaled_dot_product_attention_decode(
             q_heads_1B4D,
             keys_1BPD,

--- a/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
@@ -395,9 +395,9 @@ def run_test_LlamaAttention_inference(
     tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaAttention_model.layer_past]
 
     tt_layer_present_all = [
-        ttnn.to_torch(
-            lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(1, 0), cluster_shape=cluster_shape)
-        ).transpose(0, 1)[:batch, ...]
+        ttnn.to_torch(lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(0, 1), cluster_shape=cluster_shape))[
+            :batch, ...
+        ]
         for lp in tt_layer_present_all
     ]
 

--- a/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
@@ -359,9 +359,9 @@ def run_test_LlamaDecoder_inference(
 
     tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaDecoder_model.attention.layer_past]
     tt_layer_present_all = [
-        ttnn.to_torch(
-            lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(1, 0), cluster_shape=cluster_shape)
-        ).transpose(0, 1)[:batch, ...]
+        ttnn.to_torch(lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(0, 1), cluster_shape=cluster_shape))[
+            :batch, ...
+        ]
         for lp in tt_layer_present_all
     ]
 

--- a/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy.py
@@ -199,8 +199,8 @@ def run_test_LlamaModel_inference(
         tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_model.layers[layer_id].attention.layer_past]
         tt_layer_present_all = [
             ttnn.to_torch(
-                lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(1, 0), cluster_shape=cluster_shape)
-            ).transpose(0, 1)[:batch, ...]
+                lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(0, 1), cluster_shape=cluster_shape)
+            )[:batch, ...]
             for lp in tt_layer_present_all
         ]
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -240,7 +240,7 @@ def run_test_sdpa_decode_multi_pos(
         Q = fa_rand(1, b, padded_num_heads, d)
 
         tt_Q = ttnn.as_tensor(
-            Q,
+            Q[:, :, :nh],
             device=device,
             dtype=q_dtype,
             layout=ttnn.TILE_LAYOUT,
@@ -377,7 +377,7 @@ def run_test_sdpa_decode_single_iter(
     Q = fa_rand(1, b, padded_num_heads, d)
 
     tt_Q = ttnn.as_tensor(
-        Q,
+        Q[:, :, :nh],
         device=device,
         dtype=q_dtype,
         layout=ttnn.TILE_LAYOUT,
@@ -457,11 +457,19 @@ def run_test_sdpa_decode_single_iter(
         [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
         [4, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
         [32, 8, 1, 32768, 128, (8, 8), True, True],  # Mixtral8x7b
+        [32, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
+        [4, 32, 8, 32768, 128, (8, 8), True, False],  # llama 3.1 8b
+        [4, 32, 8, 32768, 128, (8, 8), True, True],  # llama 3.1 8b
+        [4, 32, 8, 32768, 128, (8, 8), False, False],  # llama 3.1 8b
+        [4, 16, 4, 32768, 128, (8, 8), False, False],  # llama 3.1 8b
     ),
 )
 def test_sdpa_decode(
     device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, single_iter, cur_pos_tensor, use_program_cache
 ):
+    if nkv > 1 and q_dtype != ttnn.bfloat16:
+        pytest.skip("nkv > 1 requires q_dtype to be bfloat16")
+
     ttnn.device.DisablePersistentKernelCache()
     if single_iter:
         run_test_sdpa_decode_single_iter(
@@ -538,13 +546,12 @@ def run_test_sdpa_decode_paged_attention(
     max_num_blocks = b * s // block_size
     assert max_num_blocks * block_size == b * s
 
-    K = fa_rand(nkv, b, s, d)
-    V = fa_rand(nkv, b, s, d)
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
 
     def to_paged_cache(cache, batch, num_kv, max_num_blocks_per_seq, block_size, head_dim, max_seq_len):
         return (
-            cache.reshape(batch, num_kv, max_seq_len, head_dim)
-            .reshape(batch, num_kv, max_num_blocks_per_seq, block_size, head_dim)
+            cache.reshape(batch, num_kv, max_num_blocks_per_seq, block_size, head_dim)
             .transpose(1, 2)
             .reshape(batch * max_num_blocks_per_seq, num_kv, block_size, head_dim)
         )
@@ -554,7 +561,6 @@ def run_test_sdpa_decode_paged_attention(
             paged_cache.reshape(batch, max_num_blocks_per_seq, num_kv, block_size, head_dim)
             .transpose(1, 2)
             .reshape(batch, num_kv, max_seq_len, head_dim)
-            .reshape(num_kv, batch, max_seq_len, head_dim)
         )
 
     # Create paged K and V based on block size\
@@ -637,15 +643,15 @@ def run_test_sdpa_decode_paged_attention(
         logger.info(f"Using padded layer length: {padded_layer_len}")
         logger.info(f"Using padded num heads: {padded_num_heads}")
 
-        attn_mask = torch.zeros((1, b, padded_num_heads, padded_layer_len))
+        attn_mask = torch.zeros((b, padded_num_heads, 1, padded_layer_len))
         for i in range(b):
             start_idx = start_indices[i]
-            attn_mask[:, i, :, start_idx + 1 :] = torch.finfo(torch.float32).min
+            attn_mask[i, :, :, start_idx + 1 :] = torch.finfo(torch.float32).min
 
         Q = fa_rand(1, b, padded_num_heads, d)
 
         tt_Q = ttnn.as_tensor(
-            Q,
+            Q[:, :, :nh],
             device=device,
             dtype=q_dtype,
             layout=ttnn.TILE_LAYOUT,
@@ -671,9 +677,15 @@ def run_test_sdpa_decode_paged_attention(
         tt_back = tt_back[:, :, :nh, :]
 
         Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, d
-        K_slice = K[:, :, :padded_layer_len, :].permute(1, 0, 2, 3)  # nh, b, S, d
-        V_slice = V[:, :, :padded_layer_len, :].permute(1, 0, 2, 3)  # nh, b, S, d
-        attn_mask_slice = attn_mask[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, S
+        K_slice = K[:, :, :padded_layer_len, :]  # b, nkv, S, d
+        K_slice = torch.cat(
+            [K_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
+        )  # b, nh, d, S
+        V_slice = V[:, :, :padded_layer_len, :]  # b, nkv, S, d
+        V_slice = torch.cat(
+            [V_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
+        )  # b, nh, d, S
+        attn_mask_slice = attn_mask[:, :nh, :, :]  # b, nh, 1, S
 
         expect = torch.nn.functional.scaled_dot_product_attention(
             Q_slice, K_slice, V_slice, attn_mask_slice, scale=scale, is_causal=False
@@ -712,6 +724,8 @@ def run_test_sdpa_decode_paged_attention(
     "b, nh, nkv, s, d, grid_size, cur_pos_tensor",
     (
         [32, 8, 1, 32768, 128, (8, 6), True],  # Llama2-70B
+        [4, 32, 8, 32768, 128, (8, 8), True],  # llama 3.1 8b
+        [4, 16, 4, 32768, 128, (8, 8), True],
         # [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
         # [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
         # [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
@@ -737,7 +751,7 @@ def test_sdpa_decode_paged_attention(
         cur_pos_tensor,
         block_size=block_size,
         sharded_in=True,
-        sharded_out=True,
+        sharded_out=False,
     )
 
 
@@ -997,7 +1011,7 @@ def run_test_sdpa_decode_ndpcc(device, b, nh, nkv, s, d, dtype, grid_size, q_dty
 
         for i in range(200):
             tt_Q = ttnn.as_tensor(
-                Q,
+                Q[:, :, :nh],
                 device=device,
                 dtype=q_dtype,
                 layout=ttnn.TILE_LAYOUT,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode_gqa.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode_gqa.py
@@ -328,4 +328,7 @@ def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, transpose_q,
             share_cache=share_cache,
         )
 
-    assert device.num_program_cache_entries() == 5
+    if transpose_q:
+        assert device.num_program_cache_entries() == 4
+    else:
+        assert device.num_program_cache_entries() == 1

--- a/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
+++ b/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
@@ -924,7 +924,7 @@ def run_test_sdpa_decode_single_iter(
     V = torch.randn(nkv, b, s, d)
 
     tt_K = ttnn.from_torch(
-        K,
+        K.permute(1, 0, 2, 3),
         device=mesh_device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
@@ -933,7 +933,7 @@ def run_test_sdpa_decode_single_iter(
     )
 
     tt_V = ttnn.from_torch(
-        V,
+        V.permute(1, 0, 2, 3),
         device=mesh_device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -447,6 +447,7 @@ void MAIN {
     constexpr uint32_t out_num_blocks = get_compile_time_arg_val(15);
     constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(16);
     constexpr uint32_t k_chunk_size = get_compile_time_arg_val(17);
+    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(18);
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
@@ -479,12 +480,14 @@ void MAIN {
     constexpr uint32_t cb_out_l = tt::CB::c_out2;
     constexpr uint32_t cb_out_final = tt::CB::c_out4;
 
-    const bool do_reduce = get_arg_val<uint32_t>(0) == 1;
-    const uint32_t core_num = get_arg_val<uint32_t>(1);
-    const uint32_t cur_batch = get_arg_val<uint32_t>(2);
-    const uint32_t cur_pos_arg = get_arg_val<uint32_t>(3);
-
-    // const uin32_t idle_core = get_arg_val<uint32_t>(4);
+    uint32_t arg_idx = 0;
+    const bool do_reduce = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const bool do_output = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t cur_head = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t cur_batch = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t core_num_in_output = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t cur_pos_arg = get_arg_val<uint32_t>(arg_idx++);
 
     // idle core
     // get_arg_val<uint32_t>(0) can go from 0-63 for the core_num; for active cores 65 is out of range so 65 indicates an idle_core
@@ -512,12 +515,12 @@ void MAIN {
         return;
     }
     // Sequence length assignment
-    auto [PSt, k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(cur_pos, cur_batch, core_num, num_cores_per_batch, k_chunk_size);
+    auto [PSt, k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(cur_pos, cur_batch, core_num_in_reduce, num_cores_per_head, k_chunk_size);
     if (k_chunk_start == k_chunk_end) {
         return; // early exit because no computes needs to be done
     }
-    uint32_t num_cores_to_wait = num_cores_per_batch-1;
-    if (num_cores_per_batch>k_num_chunks) num_cores_to_wait = k_num_chunks-1;
+    uint32_t num_cores_to_wait = num_cores_per_head-1;
+    if (num_cores_per_head>k_num_chunks) num_cores_to_wait = k_num_chunks-1;
 
     mm_init();
     cb_wait_front(cb_q_in, q_chunk_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -260,16 +260,28 @@ void kernel_main() {
     constexpr uint32_t scale_val = get_compile_time_arg_val(5);
     constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(6);  // num cores per batch
     constexpr uint32_t num_cores = get_compile_time_arg_val(7);  // num running cores in total
-    uint32_t semaphore_addr   = get_semaphore(get_compile_time_arg_val(8));  // semaphore for reciever
-    constexpr bool is_out_sharded = get_compile_time_arg_val(9);
-    constexpr uint32_t k_chunk_size = get_compile_time_arg_val(10);
+    uint32_t reducer_semaphore_addr   = get_semaphore(get_compile_time_arg_val(8));  // semaphore for reducer
+    uint32_t output_semaphore_addr   = get_semaphore(get_compile_time_arg_val(9));  // semaphore for sender
+    constexpr bool is_out_sharded = get_compile_time_arg_val(10);
+    constexpr uint32_t k_chunk_size = get_compile_time_arg_val(11);
+    constexpr uint32_t num_q_heads = get_compile_time_arg_val(12);
+    constexpr uint32_t num_kv_heads = get_compile_time_arg_val(13);
+    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(14);
+    constexpr uint32_t num_reducer_cores = get_compile_time_arg_val(15);
+    constexpr uint32_t num_output_cores = get_compile_time_arg_val(16);
+    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(17);
 
-    const uint32_t out_addr  = get_arg_val<uint32_t>(0);
-    const uint32_t cur_batch = get_arg_val<uint32_t>(1);
-    const uint32_t worker_id = get_arg_val<uint32_t>(2);
-    const bool is_worker = get_arg_val<uint32_t>(3) == 1;
-    const uint32_t core_num = get_arg_val<uint32_t>(4);
-    const uint32_t cur_pos_arg = get_arg_val<uint32_t>(5);
+    uint32_t arg_idx = 0;
+    const uint32_t out_addr  = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t worker_id_for_reduce = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t worker_id_for_output = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_worker = get_arg_val<uint32_t>(arg_idx++) == 0;
+    const bool do_output = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t cur_head = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t cur_batch = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t core_num_in_output = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t cur_pos_arg = get_arg_val<uint32_t>(arg_idx++);
 
     // idle core
     if (out_addr == 0){
@@ -294,23 +306,29 @@ void kernel_main() {
         return;
     }
     // Sequence length assignment
-    auto [PSt, k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(cur_pos, cur_batch, core_num, num_cores_per_batch, k_chunk_size);
+    auto [PSt, k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(cur_pos, cur_batch, core_num_in_reduce, num_cores_per_head, k_chunk_size);
 
-    tt_l1_ptr uint32_t * all_reducer_noc_x          = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
-    tt_l1_ptr uint32_t * all_reducer_noc_y          = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + B));
+    tt_l1_ptr uint32_t * all_reducer_noc_x          = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_reducer_cores;
+    tt_l1_ptr uint32_t * all_reducer_noc_y          = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_reducer_cores;
+    tt_l1_ptr uint32_t * all_output_noc_x          = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_output_cores;
+    tt_l1_ptr uint32_t * all_output_noc_y          = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx++));
 
-    uint32_t reduce_core_noc_x = all_reducer_noc_x[cur_batch];
-    uint32_t reduce_core_noc_y = all_reducer_noc_y[cur_batch];
+    uint32_t reduce_core_index = (cur_batch * num_cores_per_batch) / num_cores_per_head + cur_head;
+    uint32_t reduce_core_noc_x = all_reducer_noc_x[reduce_core_index];
+    uint32_t reduce_core_noc_y = all_reducer_noc_y[reduce_core_index];
 
-    const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, semaphore_addr);
+    const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, reducer_semaphore_addr);
 
     if (k_chunk_start == k_chunk_end) {
         return; // early exit because no computes needs to be done
     }
 
     constexpr uint32_t out_chunk_tiles = PNHt * DHt;
-    uint32_t num_cores_to_wait = num_cores_per_batch-1;
-    if (num_cores_per_batch>k_num_chunks) num_cores_to_wait = k_num_chunks-1;
+    uint32_t num_cores_to_wait = num_cores_per_head-1;
+    if (num_cores_per_head>k_num_chunks) num_cores_to_wait = k_num_chunks-1;
     uint32_t num_tiles_to_wait = (out_chunk_tiles+2*PNHt)*num_cores_to_wait;
 
     constexpr bool is_dram = true;
@@ -332,7 +350,7 @@ void kernel_main() {
     generate_bcast_unary_scalar(cb_scale_in, scale_val);
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
     if (is_worker) {
-        worker_compute<out_chunk_tiles, cb_out_worker, cb_out_m, cb_out_l, cb_intermed_out, PNHt>(in0_sender_semaphore_noc_addr, worker_id, reduce_core_noc_x, reduce_core_noc_y);
+        worker_compute<out_chunk_tiles, cb_out_worker, cb_out_m, cb_out_l, cb_intermed_out, PNHt>(in0_sender_semaphore_noc_addr, worker_id_for_reduce, reduce_core_noc_x, reduce_core_noc_y);
         return;
     }
 
@@ -349,7 +367,7 @@ void kernel_main() {
 
     uint64_t intermed_l1_read_addr = get_noc_addr(get_read_ptr(cb_intermed_out));
 
-    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reducer_semaphore_addr);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_cores>();
     uint32_t barrier_count = 0;
@@ -409,24 +427,110 @@ void kernel_main() {
 
         // DPRINT << "[Writer Reducer] Done sending intermediate chunks to compute" << ENDL();
     }
-
     // Offset for current batch
     const uint32_t out_batch_offset = cur_batch * out_chunk_tiles;
 
     // Write entire out into its corresponding batch
     uint32_t out_tile_id = out_batch_offset;
     cb_wait_front(cb_out, out_chunk_tiles);
-
     // DPRINT << "[Writer Reducer] recieved output chunk from reduce compute" << ENDL();
-    if (! is_out_sharded){
-        uint32_t l1_read_addr = get_read_ptr(cb_out);
-        for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
-            noc_async_write_tile(out_tile_id, out_writer, l1_read_addr);
-            ++out_tile_id;
-            l1_read_addr += tile_bytes;
-            if (++barrier_count == barrier_threshold) {
-                noc_async_writes_flushed();
-                barrier_count = 0;
+
+    if constexpr(num_kv_heads > 1){
+        // if gqa, we will need to write partial outputs for each head
+        constexpr uint32_t TILE_WIDTH = 32;
+        // we are assuming here that num_heads_to_write = nh/nkv is a power of 2 here, so that we don't write partial across phase
+        uint32_t num_heads_to_write = num_q_heads/num_kv_heads; // each head is one row in a tile
+        uint32_t SUBTILE_LINE_BYTES = 16*ELEMENT_SIZE; //size of 16 elements (in a row)
+        uint32_t starting_row = cur_head * num_heads_to_write;
+        uint32_t in_tile_offset_by_starting_head = starting_row < 16 ? starting_row * SUBTILE_LINE_BYTES : (starting_row - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+
+        if (! is_out_sharded){
+            for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
+
+                uint64_t out_writer_noc_addr = get_noc_addr(out_tile_id, out_writer) + in_tile_offset_by_starting_head;
+                uint32_t l1_read_addr = get_read_ptr(cb_out) + tile*tile_bytes + in_tile_offset_by_starting_head;
+
+                // write partial output for each head
+                for (uint32_t head = 0; head < num_heads_to_write; ++head) {
+
+                    // Write first phase
+                    noc_async_write(l1_read_addr, out_writer_noc_addr, SUBTILE_LINE_BYTES);
+
+                    // Write second phase
+                    noc_async_write(l1_read_addr+256*ELEMENT_SIZE, out_writer_noc_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+
+                    l1_read_addr += SUBTILE_LINE_BYTES;
+                    out_writer_noc_addr += SUBTILE_LINE_BYTES;
+
+                    if (++barrier_count == barrier_threshold) {
+                        noc_async_writes_flushed();
+                        barrier_count = 0;
+                    }
+                }
+
+                ++out_tile_id;
+            }
+        }
+        // sharded out case
+        else if (do_output){
+            // read from reducer cores
+            constexpr uint32_t num_reducers_per_output = num_reducer_cores / num_output_cores;
+            constexpr uint32_t num_reducers_to_wait = num_reducers_per_output-1;
+            volatile tt_l1_ptr uint32_t* output_self_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_semaphore_addr);
+            noc_semaphore_wait(output_self_semaphore_addr_ptr, num_reducers_to_wait);
+
+            uint32_t reduce_core_read_index_start = (cur_batch * num_cores_per_batch) / num_cores_per_head;
+
+            for (uint32_t reduce_core_read_index = reduce_core_read_index_start + 1; reduce_core_read_index < reduce_core_read_index_start+num_reducers_per_output; reduce_core_read_index++){
+                uint32_t reduce_core_read_noc_x = all_reducer_noc_x[reduce_core_read_index];
+                uint32_t reduce_core_read_noc_y = all_reducer_noc_y[reduce_core_read_index];
+
+                uint64_t out_reader_base_noc_addr = get_noc_addr(reduce_core_read_noc_x, reduce_core_read_noc_y, get_read_ptr(cb_out)) + in_tile_offset_by_starting_head;
+
+                for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
+                    uint32_t l1_write_addr = get_write_ptr(cb_out) + tile*tile_bytes + in_tile_offset_by_starting_head;
+                    uint32_t out_reader_noc_addr = out_reader_base_noc_addr;
+
+                    // write partial output for each head
+                    for (uint32_t head = 0; head < num_heads_to_write; ++head) {
+
+                        // Write first phase
+                        noc_async_read(out_reader_noc_addr, l1_write_addr, SUBTILE_LINE_BYTES);
+
+                        // Write second phase
+                        noc_async_read(out_reader_noc_addr+256*ELEMENT_SIZE, l1_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+
+                        l1_write_addr += SUBTILE_LINE_BYTES;
+                        out_reader_noc_addr += SUBTILE_LINE_BYTES;
+
+                        if (++barrier_count == barrier_threshold) {
+                            noc_async_read_barrier();
+                            barrier_count = 0;
+                        }
+                    }
+                    out_reader_noc_addr += tile_bytes;
+                }
+            }
+            noc_async_read_barrier();
+        } else {
+            // tell output core that its output is ready
+            uint32_t output_core_noc_x = all_output_noc_x[cur_batch];
+            uint32_t output_core_noc_y = all_output_noc_y[cur_batch];
+            const uint64_t output_core_semaphore_noc_addr = get_noc_addr(output_core_noc_x, output_core_noc_y, output_semaphore_addr);
+            noc_semaphore_inc(output_core_semaphore_noc_addr, 1);
+        }
+    } else {
+        // if mqa, we don't need to gather outputs for other heads so we can just write entire tiles to memory
+        if (! is_out_sharded){
+            uint32_t l1_read_addr = get_read_ptr(cb_out);
+            for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
+                noc_async_write_tile(out_tile_id, out_writer, l1_read_addr);
+                ++out_tile_id;
+                l1_read_addr += tile_bytes;
+                if (++barrier_count == barrier_threshold) {
+                    noc_async_writes_flushed();
+                    barrier_count = 0;
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -24,6 +24,7 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
     }
 
     const auto q_shape = input_tensors.at(0).get_legacy_shape();
+    const auto q_shape_unpadded = input_tensors.at(0).get_shape();
     const auto k_shape = input_tensors.at(1).get_legacy_shape();
     const auto v_shape = input_tensors.at(2).get_legacy_shape();
 
@@ -45,6 +46,7 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
 
     if (this->paged_attention) {
         // Paged attention verification
+        TT_FATAL(! this->share_cache.value_or(false), "Share cache feature not supported for paged attention");
         TT_FATAL(optional_input_tensors.at(0).has_value(), "Must have cur_pos tensor for paged attention");
         TT_FATAL(optional_input_tensors.at(1).has_value(), "Must have page_table tensor for paged attention");
 
@@ -64,7 +66,6 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
         TT_FATAL(cur_pos_shape[0] == B, "cur_pos must have batch size equal to Q");
         TT_FATAL(page_table_shape[0] == B, "page_table must have hidden size equal to Q");
 
-        TT_FATAL(k_shape[1] == 1 && v_shape[1] == 1, "Paged attention only supports 1 head");
         TT_FATAL(k_shape[2] == v_shape[2], "K and V must have same block size");
         TT_FATAL(k_shape[3] == v_shape[3] && k_shape[3] == q_shape[3], "Q, K, V must have same hidden size");
     } else {
@@ -77,14 +78,17 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
 
         // Batch must match
         const auto B = q_shape[1];
-        TT_FATAL(k_shape[0] == B, "Error");
-        TT_FATAL(v_shape[0] == B, "Error");
+        if (this->share_cache.value_or(false)) {
+            TT_FATAL(k_shape[0] == 1, "Share cache expects K to have batch size of 1, but got {}", k_shape[0]);
+            TT_FATAL(v_shape[0] == 1, "Share cache expects V to have batch size of 1, but got {}", v_shape[0]);
+        } else {
+            TT_FATAL(k_shape[0] == B, "Error");
+            TT_FATAL(v_shape[0] == B, "Error");
+        }
         // TT_FATAL(Q_memcfg.shard_spec.value().grid.num_cores() == B, "Q must be height sharded by batch ");
 
-        // NKV must be 1 if we are running in this decode mode
+        // Q seqlen must be 1 if we are running decode mode
         TT_FATAL(q_shape[0] == 1, "Error");
-        TT_FATAL(k_shape[1] == 1, "Error");
-        TT_FATAL(v_shape[1] == 1, "Error");
 
         // Check sequence lengths
         TT_FATAL(k_shape[-2] == v_shape[-2], "Error");
@@ -100,6 +104,17 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
         }
     }
 
+    // Check gqa specific validation
+    TT_FATAL(k_shape[1] == v_shape[1], "Flash decode expects K and V to have same number of heads, but got {} and {}", k_shape[1], v_shape[1]);
+    bool is_gqa = (k_shape[1] > 1);
+    if (is_gqa) {
+        TT_FATAL(! output_mem_config.is_sharded(), "Sharded output not supported for GQA");
+        TT_FATAL(input_tensors.at(0).get_dtype() == DataType::BFLOAT16, "GQA expects BFLOAT16 input tensor, but got {}", input_tensors.at(0).get_dtype());
+        uint32_t num_heads_per_kv = q_shape_unpadded[2]/k_shape[1];
+        TT_FATAL(q_shape_unpadded[2]%k_shape[1] == 0, "GQA expects Q to have a multiple of K heads, but got {} and {}", q_shape_unpadded[2], k_shape[1]);
+        // check that num_heads_per_kv is a power of 2
+        TT_FATAL(num_heads_per_kv != 0 && (num_heads_per_kv & (num_heads_per_kv - 1)) == 0, "GQA expects Q to have a power of 2 number of heads per kv head, but got {}", num_heads_per_kv);
+    }
 
     // Check compute kernel config
     std::visit(
@@ -157,7 +172,7 @@ operation::ProgramWithCallbacks ScaledDotProductAttentionDecode::create_program(
         this->compute_kernel_config,
         this->program_config,
         this->k_chunk_size,
-        false);
+        this->share_cache);
 }
 
 operation::Hash ScaledDotProductAttentionDecode::compute_program_hash(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -77,14 +77,14 @@ void ScaledDotProductAttentionDecode::validate(const std::vector<Tensor>& input_
 
         // Batch must match
         const auto B = q_shape[1];
-        TT_FATAL(k_shape[1] == B, "Error");
-        TT_FATAL(v_shape[1] == B, "Error");
+        TT_FATAL(k_shape[0] == B, "Error");
+        TT_FATAL(v_shape[0] == B, "Error");
         // TT_FATAL(Q_memcfg.shard_spec.value().grid.num_cores() == B, "Q must be height sharded by batch ");
 
         // NKV must be 1 if we are running in this decode mode
         TT_FATAL(q_shape[0] == 1, "Error");
-        TT_FATAL(k_shape[0] == 1, "Error");
-        TT_FATAL(v_shape[0] == 1, "Error");
+        TT_FATAL(k_shape[1] == 1, "Error");
+        TT_FATAL(v_shape[1] == 1, "Error");
 
         // Check sequence lengths
         TT_FATAL(k_shape[-2] == v_shape[-2], "Error");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.hpp
@@ -21,6 +21,7 @@ struct ScaledDotProductAttentionDecode {
     const DeviceComputeKernelConfig compute_kernel_config;
     const uint32_t k_chunk_size;
     const bool paged_attention;
+    const std::optional<bool> share_cache;
 
     void validate(const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -52,7 +52,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     // Use k_shape for S and DH since Q might be different for decode
     uint32_t B = q_shape[1], PNH = q_shape[2], S = k_shape[2], DH = k_shape[3];
 
-    uint32_t num_kv_heads = 0;
+    uint32_t num_kv_heads = k_shape[1];
     uint32_t page_block_size_t = 0;
 
     if (is_paged_attention) {
@@ -60,10 +60,9 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         uint32_t max_blocks_per_seq = page_table_shape[1];
         uint32_t block_size = k_shape[2];
         S = max_blocks_per_seq * block_size;
-        num_kv_heads = k_shape[1];
         page_block_size_t = block_size / TILE_HEIGHT;
     }
-    uint32_t Bkv = k_shape[1];
+    uint32_t Bkv = k_shape[0];
     uint32_t St = S/TILE_HEIGHT;
     uint32_t DHt = DH/TILE_WIDTH;
     uint32_t PNHt = PNH/TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -48,11 +48,13 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     const bool is_paged_attention = page_table_tensor.has_value();
 
     const auto q_shape = input_tensor_q.get_legacy_shape();
+    const auto q_shape_unpadded = input_tensor_q.get_shape();
     const auto k_shape = input_tensor_k.get_legacy_shape();
     // Use k_shape for S and DH since Q might be different for decode
     uint32_t B = q_shape[1], PNH = q_shape[2], S = k_shape[2], DH = k_shape[3];
 
     uint32_t num_kv_heads = k_shape[1];
+    uint32_t num_q_heads = q_shape_unpadded[2];
     uint32_t page_block_size_t = 0;
 
     if (is_paged_attention) {
@@ -79,8 +81,11 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
     // log_debug all of the above
     log_debug("B: {}", B);
+    log_debug("PNH: {}", PNH);
     log_debug("S: {}", S);
     log_debug("DH: {}", DH);
+    log_debug("num_kv_heads: {}", num_kv_heads);
+    log_debug("Bkv: {}", Bkv);
     log_debug("St: {}", St);
     log_debug("DHt: {}", DHt);
     log_debug("PNHt: {}", PNHt);
@@ -135,14 +140,23 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     // balance the number of cores to use based on batch
     uint32_t num_cores_per_batch = num_cores_available / B;
     uint32_t num_active_cores = num_cores_per_batch * B;
+    uint32_t num_cores_per_head = num_cores_per_batch / num_kv_heads;
+    uint32_t num_reducer_cores = (num_cores_per_head == 0) ? B : num_kv_heads*B;
+    uint32_t num_output_cores = B;
 
-    // create core group, which is a 1D list of cores sorted by reducer1, worker, ..., reducer2, worker, ..., reducer n, worker, ...
+    TT_FATAL(num_cores_per_head > 0, "Case not supported for more n_kv_heads*batch > number of cores. Got batch={}, n_kv_heads={} and num_cores_available={}. Let's assume each core can handle at most one head", B, num_kv_heads, num_cores_available);
+
+    // create core group, assume n batch and k_heads:
+    // this is a 1D list of cores sorted by batch_output1, worker, ..., batch_output2, worker, ..., batch_output n, worker, ...
+    // Within each batch, we will assign head reducers. e.g. the following mapping:
+    // (batch_output1, worker1,   worker2),   (worker3,       worker4,   worker5),   ..., (... worker3*k-1, worker3*k)
+    // (head_reducer1,  h_worker1, h_worker2), (head_reducer2, h_worker1, h_worker2), ..., (head_reducerk, h_worker1, h_worker2)
+    // head_reducer2 to head_reducerk then send the result to head_reducer1, which is also the batch_output1
     std::vector<CoreCoord> core_group;
     std::vector<CoreCoord> core_group_idle;
-    uint32_t num_reducers = B;
     if (is_q_sharded || is_output_sharded) {
         int reducer_idx = 0;
-        int worker_idx = num_reducers;
+        int worker_idx = num_output_cores;
 
         for (int i = 0; i < num_cores_available; ++i) {
             CoreCoord core;
@@ -174,7 +188,10 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     log_debug("Parallelization scheme:");
     log_debug("num_cores_available: {}", num_cores_available);
     log_debug("num_cores_per_batch: {}", num_cores_per_batch);
+    log_debug("num_cores_per_head: {}", num_cores_per_head);
     log_debug("num_active_cores: {}", num_active_cores);
+    log_debug("num_reducer_cores: {}", num_reducer_cores);
+    log_debug("num_output_cores: {}", num_output_cores);
     log_debug("core_group: {}", core_group);
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
@@ -429,18 +446,18 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
     union {float f; uint32_t u;} scale_union; scale_union.f = scale.value_or(1.0f);
 
+    // Create core groups for reduce cores
     std::vector<uint32_t> reduce_core_physical_xs;
     std::vector<uint32_t> reduce_core_physical_ys;
     uint32_t reduce_core_noc_x{};
     uint32_t reduce_core_noc_y{};
-    reduce_core_physical_xs.reserve(B); // num reducers is equal to batch size
-    reduce_core_physical_ys.reserve(B);
+    reduce_core_physical_xs.reserve(num_reducer_cores);
+    reduce_core_physical_ys.reserve(num_reducer_cores);
 
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        uint32_t worker_id = i % num_cores_per_batch - 1;
-        bool do_reduce = (worker_id == -1);
-        uint32_t cur_batch = i / num_cores_per_batch;
+        uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? -1 : i % num_cores_per_head - 1;
+        bool do_reduce = (worker_id_for_reduce == -1);
         if (do_reduce) {
             reduce_core_noc_x = core.x;
             reduce_core_noc_y = core.y;
@@ -455,11 +472,41 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     log_debug("reduce_core_physical_xs: {}", reduce_core_physical_xs);
     log_debug("reduce_core_physical_ys: {}", reduce_core_physical_ys);
 
+    // Create core ggroups for output cores
+    std::vector<uint32_t> output_core_physical_xs;
+    std::vector<uint32_t> output_core_physical_ys;
+    uint32_t output_core_noc_x{};
+    uint32_t output_core_noc_y{};
+    output_core_physical_xs.reserve(num_output_cores); // num output cores is equal to batch size
+    output_core_physical_ys.reserve(num_output_cores);
+
+    for (uint32_t i = 0; i < num_active_cores; ++i) {
+        CoreCoord core = core_group[i];
+        uint32_t worker_id_for_output = i % num_cores_per_batch - 1;
+        bool do_output = (worker_id_for_output == -1);
+        if (do_output) {
+            output_core_noc_x = core.x;
+            output_core_noc_y = core.y;
+            // get physical core
+            CoreCoord output_core = {(std::size_t)output_core_noc_x, (std::size_t)output_core_noc_y};
+            auto output_core_physical = device->worker_core_from_logical_core(output_core);
+            output_core_physical_xs.push_back((uint32_t) output_core_physical.x);
+            output_core_physical_ys.push_back((uint32_t) output_core_physical.y);
+        }
+    }
+
+    log_debug("output_core_physical_xs: {}", output_core_physical_xs);
+    log_debug("output_core_physical_ys: {}", output_core_physical_ys);
+
     // Common Compile time Args
-    auto in0_mcast_reducer_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
+    auto reducer_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
+    auto output_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
 
     std::vector<uint32_t> reader_compile_time_args_common = {
-        B, PNHt, St, DHt, Sk_chunk_t, num_active_cores, is_q_sharded, num_cores_per_batch, k_chunk_size, log2_page_size, index_stick_size, (uint32_t)is_paged_attention, num_kv_heads, page_block_size_t, log2_page_table_page_size, page_table_stick_size, Bkv
+        B, PNHt, St, DHt, Sk_chunk_t, num_active_cores, is_q_sharded,
+        num_cores_per_batch, k_chunk_size, log2_page_size, index_stick_size,
+        (uint32_t)is_paged_attention, num_kv_heads, page_block_size_t,
+        log2_page_table_page_size, page_table_stick_size, Bkv, num_cores_per_head, num_output_cores
     };
 
     std::vector<uint32_t> writer_compile_time_args_common = {
@@ -468,16 +515,23 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         scale_union.u,
         num_cores_per_batch,
         num_active_cores,
-        in0_mcast_reducer_semaphore_id,
+        reducer_semaphore_id,
+        output_semaphore_id,
         is_output_sharded,
-        k_chunk_size
+        k_chunk_size,
+        num_q_heads,
+        num_kv_heads,
+        num_cores_per_head,
+        num_reducer_cores,
+        num_output_cores,
+        output_tensor.element_size()
     };
 
     std::vector<uint32_t> compute_compile_time_args_common = {
         St, DHt, PNHt, Sk_chunk_t,
         qk_in0_block_w, qk_out_subblock_w, qk_out_subblock_h, qk_in0_num_subblocks, qk_in1_num_subblocks, qk_num_blocks,
         out_in0_block_w, out_out_subblock_w, out_out_subblock_h, out_in0_num_subblocks, out_in1_num_subblocks, out_num_blocks,
-        num_cores_per_batch, k_chunk_size
+        num_cores_per_batch, k_chunk_size, num_cores_per_head
     };
 
     std::map<string, string> defines;
@@ -528,30 +582,53 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     uint32_t page_table_addr = is_paged_attention ? page_table_tensor.value().buffer()->address() : 0;
     uint32_t out_addr = out0_buffer->address();
 
-    // Set reader rt args
+    // Set rt args
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        uint32_t worker_id = i % num_cores_per_batch - 1;
-        bool do_reduce = (worker_id == -1);
+        uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? -1 : i % num_cores_per_head - 1;
+        uint32_t worker_id_for_output = i % num_cores_per_batch - 1;
+        bool do_reduce = (worker_id_for_reduce == -1);
+        bool do_output = (worker_id_for_output == -1);
 
+        // 64 cores, 4 batch, 8 head
+        // num_cores_per_batch = 16
+        // num_cores_per_head = 2
+        uint32_t cur_head = (num_cores_per_head == 0) ? 0 : (i % num_cores_per_batch) / num_cores_per_head;
         uint32_t cur_batch = i / num_cores_per_batch;
-        uint32_t core_num = i % num_cores_per_batch;
+        uint32_t core_num_in_reduce = (num_cores_per_head == 0) ? 0 : i % num_cores_per_head;
+        uint32_t core_num_in_output = i % num_cores_per_batch;
 
         uint32_t cur_pos = use_cur_pos_tensor ? -1 : cur_pos_ids.at(cur_batch);
 
+        log_trace("---- core_id: {}, coord: {} ----", i, core);
+        log_trace("worker_id_for_reduce: {}", worker_id_for_reduce);
+        log_trace("worker_id_for_output: {}", worker_id_for_output);
+        log_trace("do_reduce: {}", do_reduce);
+        log_trace("do_output: {}", do_output);
+        log_trace("cur_head: {}", cur_head);
+        log_trace("cur_batch: {}", cur_batch);
+        log_trace("core_num_in_reduce: {}", core_num_in_reduce);
+        log_trace("core_num_in_output: {}", core_num_in_output);
+        log_trace("cur_pos: {}", cur_pos);
+
         // reader runtime args
-        std::vector<uint32_t> reader_rt_args = { q_addr, k_addr, v_addr, pos_addr, page_table_addr, cur_batch, !do_reduce, core_num, cur_pos};
-        reader_rt_args.insert(reader_rt_args.end(), reduce_core_physical_xs.begin(), reduce_core_physical_xs.end());
-        reader_rt_args.insert(reader_rt_args.end(), reduce_core_physical_ys.begin(), reduce_core_physical_ys.end());
+        std::vector<uint32_t> reader_rt_args = { q_addr, k_addr, v_addr, pos_addr, page_table_addr, do_reduce, do_output, cur_head, cur_batch, core_num_in_reduce, core_num_in_output, cur_pos};
+        reader_rt_args.insert(reader_rt_args.end(), output_core_physical_xs.begin(), output_core_physical_xs.end());
+        reader_rt_args.insert(reader_rt_args.end(), output_core_physical_ys.begin(), output_core_physical_ys.end());
 
         // writer runtime args
-        std::vector<uint32_t> writer_rt_args = { out_addr, cur_batch, worker_id, !do_reduce, core_num, cur_pos};
+        std::vector<uint32_t> writer_rt_args = { out_addr, worker_id_for_reduce, worker_id_for_output, do_reduce, do_output, cur_head, cur_batch, core_num_in_reduce, core_num_in_output, cur_pos};
         writer_rt_args.insert(writer_rt_args.end(), reduce_core_physical_xs.begin(), reduce_core_physical_xs.end());
         writer_rt_args.insert(writer_rt_args.end(), reduce_core_physical_ys.begin(), reduce_core_physical_ys.end());
+        writer_rt_args.insert(writer_rt_args.end(), output_core_physical_xs.begin(), output_core_physical_xs.end());
+        writer_rt_args.insert(writer_rt_args.end(), output_core_physical_ys.begin(), output_core_physical_ys.end());
+
+        // compute runtime args
+        std::vector<uint32_t> compute_rt_args = {do_reduce, do_output, cur_head, cur_batch, core_num_in_reduce, core_num_in_output, cur_pos};
 
         SetRuntimeArgs(program, reader_kernels_id, core, reader_rt_args);
         SetRuntimeArgs(program, writer_kernels_id, core, writer_rt_args);
-        SetRuntimeArgs(program, compute_kernels_id, core, {do_reduce, core_num, cur_batch, cur_pos});
+        SetRuntimeArgs(program, compute_kernels_id, core, compute_rt_args);
     }
     if (num_active_cores < num_cores_available) {
         log_debug("idle cores {}", core_group_idle.size());
@@ -560,14 +637,14 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
             CoreCoord core = core_group_idle[i];
             log_debug("Setting core {} to idle", core);
             // reader runtime args
-            std::vector<uint32_t> reader_rt_args = { 0, 0, 0, 0, 0, 0, 0, 0};
+            std::vector<uint32_t> reader_rt_args = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
             // writer runtime args
-            std::vector<uint32_t> writer_rt_args = { 0, 0, 0, 0, 0, 0};
+            std::vector<uint32_t> writer_rt_args = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
             SetRuntimeArgs(program, reader_kernels_id, core, reader_rt_args);
             SetRuntimeArgs(program, writer_kernels_id, core, writer_rt_args);
-            SetRuntimeArgs(program, compute_kernels_id, core, { 65, 0, 0, 0});
+            SetRuntimeArgs(program, compute_kernels_id, core, { 65, 0, 0, 0, 0, 0, 0});
         }
     }
 
@@ -578,6 +655,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         writer_kernels_id,
         compute_kernels_id,
         num_cores_per_batch,
+        num_cores_per_head,
+        num_output_cores,
         is_output_sharded,
         cb_out4_id,
         B,
@@ -613,39 +692,58 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         // Set rt args
         for (uint32_t i = 0; i < num_active_cores; ++i) {
             CoreCoord core = core_group[i];
-            uint32_t worker_id = i % num_cores_per_batch - 1;
-            bool do_reduce = (worker_id == -1);
-            uint32_t core_num = i % num_cores_per_batch;
+            uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? -1 : i % num_cores_per_head - 1;
+            uint32_t worker_id_for_output = i % num_cores_per_batch - 1;
+            bool do_reduce = (worker_id_for_reduce == -1);
+            bool do_output = (worker_id_for_output == -1);
+            uint32_t cur_head = (num_cores_per_head == 0) ? 0 : (i % num_cores_per_batch) / num_cores_per_head;
             uint32_t cur_batch = i / num_cores_per_batch;
+            uint32_t core_num_in_reduce = (num_cores_per_head == 0) ? 0 : i % num_cores_per_head;
+            uint32_t core_num_in_output = i % num_cores_per_batch;
+            uint32_t cur_pos = use_cur_pos_tensor ? -1 : cur_pos_ids.at(cur_batch);
 
             auto& reader_args = reader_args_by_core[core.x][core.y];
             auto& writer_args = writer_args_by_core[core.x][core.y];
             auto& compute_args = compute_args_by_core[core.x][core.y];
 
             // reader runtime args
-            reader_args[0] = q_addr;
-            reader_args[1] = k_addr;
-            reader_args[2] = v_addr;
-            reader_args[3] = pos_addr;
-            reader_args[4] = page_table_addr;
-            reader_args[5] = cur_batch;
-            reader_args[6] = !do_reduce;
-            reader_args[7] = core_num;
-            reader_args[8] = use_cur_pos_tensor ? -1: cur_pos_ids.at(cur_batch);
+            uint32_t arg_idx = 0;
+            reader_args[arg_idx++] = q_addr;
+            reader_args[arg_idx++] = k_addr;
+            reader_args[arg_idx++] = v_addr;
+            reader_args[arg_idx++] = pos_addr;
+            reader_args[arg_idx++] = page_table_addr;
+            reader_args[arg_idx++] = do_reduce;
+            reader_args[arg_idx++] = do_output;
+            reader_args[arg_idx++] = cur_head;
+            reader_args[arg_idx++] = cur_batch;
+            reader_args[arg_idx++] = core_num_in_reduce;
+            reader_args[arg_idx++] = core_num_in_output;
+            reader_args[arg_idx++] = cur_pos;
 
             // writer runtime args
-            writer_args[0] = out_addr;
-            writer_args[1] = cur_batch;
-            writer_args[2] = worker_id;
-            writer_args[3] = !do_reduce;
-            writer_args[4] = core_num;
-            writer_args[5] = use_cur_pos_tensor ? -1: cur_pos_ids.at(cur_batch);
+            arg_idx = 0;
+            writer_args[arg_idx++] = out_addr;
+            writer_args[arg_idx++] = worker_id_for_reduce;
+            writer_args[arg_idx++] = worker_id_for_output;
+            writer_args[arg_idx++] = do_reduce;
+            writer_args[arg_idx++] = do_output;
+            writer_args[arg_idx++] = cur_head;
+            writer_args[arg_idx++] = cur_batch;
+            writer_args[arg_idx++] = core_num_in_reduce;
+            writer_args[arg_idx++] = core_num_in_output;
+            writer_args[arg_idx++] = cur_pos;
+
 
             // compute runtime args
-            compute_args[0] = do_reduce;
-            compute_args[1] = core_num;
-            compute_args[2] = cur_batch;
-            compute_args[3] = use_cur_pos_tensor ? -1: cur_pos_ids.at(cur_batch);
+            arg_idx = 0;
+            compute_args[arg_idx++] = do_reduce;
+            compute_args[arg_idx++] = do_output;
+            compute_args[arg_idx++] = cur_head;
+            compute_args[arg_idx++] = cur_batch;
+            compute_args[arg_idx++] = core_num_in_reduce;
+            compute_args[arg_idx++] = core_num_in_output;
+            compute_args[arg_idx++] = cur_pos;
         }
 
         if (is_output_sharded) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -600,16 +600,16 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
 
         uint32_t cur_pos = use_cur_pos_tensor ? -1 : cur_pos_ids.at(cur_batch);
 
-        log_trace("---- core_id: {}, coord: {} ----", i, core);
-        log_trace("worker_id_for_reduce: {}", worker_id_for_reduce);
-        log_trace("worker_id_for_output: {}", worker_id_for_output);
-        log_trace("do_reduce: {}", do_reduce);
-        log_trace("do_output: {}", do_output);
-        log_trace("cur_head: {}", cur_head);
-        log_trace("cur_batch: {}", cur_batch);
-        log_trace("core_num_in_reduce: {}", core_num_in_reduce);
-        log_trace("core_num_in_output: {}", core_num_in_output);
-        log_trace("cur_pos: {}", cur_pos);
+        log_debug("---- core_id: {}, coord: {} ----", i, core);
+        log_debug("worker_id_for_reduce: {}", worker_id_for_reduce);
+        log_debug("worker_id_for_output: {}", worker_id_for_output);
+        log_debug("do_reduce: {}", do_reduce);
+        log_debug("do_output: {}", do_output);
+        log_debug("cur_head: {}", cur_head);
+        log_debug("cur_batch: {}", cur_batch);
+        log_debug("core_num_in_reduce: {}", core_num_in_reduce);
+        log_debug("core_num_in_output: {}", core_num_in_output);
+        log_debug("cur_pos: {}", cur_pos);
 
         // reader runtime args
         std::vector<uint32_t> reader_rt_args = { q_addr, k_addr, v_addr, pos_addr, page_table_addr, do_reduce, do_output, cur_head, cur_batch, core_num_in_reduce, core_num_in_output, cur_pos};

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_pybind.cpp
@@ -23,9 +23,9 @@ void py_bind_sdpa_decode(py::module &module) {
 
 
         Args:
-            input_tensor_q (ttnn.Tensor): the input tensor [1 x b x pnh x dh]
-            input_tensor_k (ttnn.Tensor): the input tensor [1 x b x   s x dh]
-            input_tensor_v (ttnn.Tensor): the input tensor [1 x b x   s x dh]
+            input_tensor_q (ttnn.Tensor): the input tensor [1 x b x nh x dh]
+            input_tensor_k (ttnn.Tensor): the input tensor [b x nkv x   s x dh]
+            input_tensor_v (ttnn.Tensor): the input tensor [b x nkv x   s x dh]
             cur_pos (List of int): list of integers of length b.
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/sdpa_decode_gqa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/sdpa_decode_gqa.cpp
@@ -71,9 +71,9 @@ ttnn::Tensor ExecuteScaledDotProductAttentionGQADecode::invoke(
         ttnn::to_layout(input_tensor_q_gqa, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
 
     auto input_tensor_k_gqa =
-        ttnn::reshape(input_tensor_k, ttnn::Shape{std::array<uint32_t, 4>{1, Bkv * NKH, k_shape[2], D}});
+        ttnn::reshape(input_tensor_k, ttnn::Shape{std::array<uint32_t, 4>{Bkv * NKH, 1, k_shape[2], D}});
     auto input_tensor_v_gqa =
-        ttnn::reshape(input_tensor_v, ttnn::Shape{std::array<uint32_t, 4>{1, Bkv * NKH, k_shape[2], D}});
+        ttnn::reshape(input_tensor_v, ttnn::Shape{std::array<uint32_t, 4>{Bkv * NKH, 1, k_shape[2], D}});
 
     uint32_t k_chunk_size;
     // since we can't get the max cur_pos value from the tensor, we default to 512

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/sdpa_decode_gqa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/sdpa_decode_gqa.cpp
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #include "sdpa_decode_gqa.hpp"
 
-#include "device/sdpa_decode_gqa_op.hpp"
+#include "ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
@@ -48,32 +47,23 @@ ttnn::Tensor ExecuteScaledDotProductAttentionGQADecode::invoke(
 
     auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? input_tensor_q.device()->arch()
                                                                      : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
-    // formatting input tensors
-    auto q_shape = input_tensor_q.get_shape();
-    auto k_shape = input_tensor_k.get_shape();
-    uint32_t Bkv = k_shape[0];
-    uint32_t Bq = transpose_q.value() ? q_shape[2] : q_shape[1];
-    uint32_t NQH = transpose_q.value() ? q_shape[1] : q_shape[2];
-    uint32_t NKH = k_shape[1];
-    uint32_t D = k_shape[3];
-    uint32_t NG = NQH / NKH;
 
-    // Q (if transpose q): 1, heads, batch, dim -> 1, batch, heads, dim -> 1, batch*k_heads, q_heads/k_heads, dim
-    // K: batch, k_heads, seqlen, dim -> 1, batch*k_heads, seqlen, dim
-
-    auto input_tensor_q_gqa =
-        ttnn::to_layout(input_tensor_q, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+    // Q (if transpose q): 1, heads, batch, dim -> 1, batch, heads, dim
+    auto input_tensor_q_gqa = input_tensor_q;
     if (transpose_q.value()) {
-        input_tensor_q_gqa = ttnn::transpose(input_tensor_q_gqa, 1, 2);
-    }
-    input_tensor_q_gqa = ttnn::reshape(input_tensor_q_gqa, ttnn::Shape{std::array<uint32_t, 4>{1, Bq * NKH, NG, D}});
-    input_tensor_q_gqa =
-        ttnn::to_layout(input_tensor_q_gqa, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+        // formatting input tensors
+        auto q_shape = input_tensor_q.get_shape();
+        uint32_t Bq = transpose_q.value() ? q_shape[2] : q_shape[1];
+        uint32_t NQH = transpose_q.value() ? q_shape[1] : q_shape[2];
+        uint32_t D = q_shape[3];
 
-    auto input_tensor_k_gqa =
-        ttnn::reshape(input_tensor_k, ttnn::Shape{std::array<uint32_t, 4>{Bkv * NKH, 1, k_shape[2], D}});
-    auto input_tensor_v_gqa =
-        ttnn::reshape(input_tensor_v, ttnn::Shape{std::array<uint32_t, 4>{Bkv * NKH, 1, k_shape[2], D}});
+        input_tensor_q_gqa =
+        ttnn::to_layout(input_tensor_q, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+        input_tensor_q_gqa = ttnn::transpose(input_tensor_q_gqa, 1, 2);
+        input_tensor_q_gqa = ttnn::reshape(input_tensor_q_gqa, ttnn::Shape{std::array<uint32_t, 4>{1, Bq, NQH, D}});
+        input_tensor_q_gqa =
+        ttnn::to_layout(input_tensor_q_gqa, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+    }
 
     uint32_t k_chunk_size;
     // since we can't get the max cur_pos value from the tensor, we default to 512
@@ -89,25 +79,22 @@ ttnn::Tensor ExecuteScaledDotProductAttentionGQADecode::invoke(
         input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
     auto output_tensors = operation::run(
-        ScaledDotProductAttentionGQADecode{
+        ScaledDotProductAttentionDecode{
             .cur_pos = cur_pos,
-            .share_cache = share_cache,
             .scale = scale,
             .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
             .program_config = program_config,
             .compute_kernel_config = kernel_config_val,
-            .k_chunk_size = k_chunk_size},
-        {input_tensor_q_gqa, input_tensor_k_gqa, input_tensor_v_gqa},
+            .k_chunk_size = k_chunk_size,
+            .paged_attention = false,
+            .share_cache = share_cache},
+        {input_tensor_q_gqa, input_tensor_k, input_tensor_v},
         {cur_pos_tensor, std::nullopt},
         {},
         queue_id);
 
     // formatting output tensor
     auto output_tensor = output_tensors.at(0);
-    output_tensor =
-        ttnn::to_layout(output_tensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
-    output_tensor = ttnn::reshape(output_tensor, ttnn::Shape{std::array<uint32_t, 4>{1, Bq, NQH, D}});
-    output_tensor = ttnn::to_layout(output_tensor, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
     return output_tensor;
 }
 


### PR DESCRIPTION
### Ticket
#12330

### The following round 2 improvements are in this PR:
Round 2 (Major changes + refactoring):
Turns out that to enable paged attention support for GQA, we need to natively support group heads in flash decode rather than doing our current way of work around. Below are the set of new features:
- [x] Change flash decode to take in cache with shape [b x nkv x S x d] rather than current [nkv x b x S x d]
- [x] Add multi-kv head (GQA) support for flash decode
- [x] Add multi-kv head (GQA) support for paged flash decode
- - Few limitations. (1) sharded output is not supported due to complications. (2) it asserts num_cores >= batch*num_kv_heads. These features will be added in future prs
- [x] Refactor GQA -- now alias to flash decode

### Checklist
- [x] All Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11019686921
- [x] Model regression CI testing passes: https://github.com/tenstorrent/tt-metal/actions/runs/11016958518
- [x] T3k CI tests passes: https://github.com/tenstorrent/tt-metal/actions/runs/11016916590
- [x] TG CI tests passes: https://github.com/tenstorrent/tt-metal/actions/runs/11038920955
