### PR TITLE
Multiple watcher-related updates

### DIFF
--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -50,6 +50,10 @@ Watcher features can be disabled individually using the following environment va
    # In certain cases enabling watcher can cause the binary to be too large. In this case, disable inlining.
    export TT_METAL_WATCHER_NOINLINE=1
 
+   # If the above doesn't work, and dispatch kernels (cq_prefetch.cpp, cq_dispatch.cpp) are still too large, compile out
+   # debug tools on dispatch kernels.
+   export TT_METAL_WATCHER_DISABLE_DISPATCH=1
+
 Details
 -------
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -140,11 +140,11 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
     switch(feature) {
         case SanitizeAddress:
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) phys(x={:2},y={:2}): {} using noc0 tried to access Unknown core w/ physical coords {} [addr=0x{:08x},len=102400]",
+                "Device {} {} core(x={:2},y={:2}) phys(x={:2},y={:2}): {} using noc0 tried to unicast write 102400 bytes from local L1[{:#08x}] to Unknown core w/ physical coords {} [addr=0x{:08x}] (NOC target address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x, core.y, phys_core.x, phys_core.y,
-                (is_eth_core) ? "erisc" : "brisc", output_dram_noc_xy.str(),
+                (is_eth_core) ? "erisc" : "brisc", l1_buffer_addr, output_dram_noc_xy.str(),
                 output_dram_buffer_addr
             );
             break;
@@ -162,13 +162,12 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
             if (use_ncrisc)
                 risc_name = "ncrisc";
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) phys(x={:2},y={:2}): {} using noc{} tried to access DRAM core w/ physical coords {} DRAM[addr=0x{:08x},len=102400], misaligned with local L1[addr=0x{:08x}]",
+                "Device {} {} core(x={:2},y={:2}) phys(x={:2},y={:2}): {} using noc{} tried to unicast read 102400 bytes to local L1[{:#08x}] from DRAM core w/ physical coords {} DRAM[addr=0x{:08x}] (invalid address alignment in NOC transaction).",
                 device->id(),
                 (is_eth_core) ? "ethnet" : "worker",
                 core.x, core.y, phys_core.x, phys_core.y,
-                risc_name, noc, target_phys_core,
-                input_dram_buffer_addr,
-                l1_buffer_addr
+                risc_name, noc, l1_buffer_addr, target_phys_core,
+                input_dram_buffer_addr
             );
             }
             break;

--- a/tt_metal/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/dprint_common.h
@@ -43,7 +43,6 @@ enum DebugPrintHartIndex : unsigned int {
     DPRINT_PREFIX(WAIT)              \
     DPRINT_PREFIX(BFLOAT16)          \
     DPRINT_PREFIX(SETPRECISION)      \
-    DPRINT_PREFIX(NOC_LOG_XFER)      \
     DPRINT_PREFIX(FIXED)             \
     DPRINT_PREFIX(DEFAULTFLOAT)      \
     DPRINT_PREFIX(HEX)               \
@@ -121,3 +120,5 @@ enum TypedU32_ARRAY_Format {
 };
 
 static_assert(sizeof(DebugPrintMemLayout) == DPRINT_BUFFER_SIZE);
+// We use DebugPrintMemLayout to hold noc xfer data, 32 buckets (one for each bit in noc xfer length field).
+static_assert(sizeof(DebugPrintMemLayout().data) >= sizeof(uint32_t) * 8 * sizeof(uint32_t));

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -6,7 +6,7 @@
 
 #include "watcher_common.h"
 
-#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT) && !defined(FORCE_WATCHER_OFF)
 
 void assert_and_hang(uint32_t line_num) {
     // Write the line number into the memory mailbox for host to read.

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -82,7 +82,6 @@ struct HEX  { char tmp; } ATTR_PACK; // Analog of cout << std::hex
 struct OCT  { char tmp; } ATTR_PACK; // Analog of cout << std::oct
 struct DEC  { char tmp; } ATTR_PACK; // Analog of cout << std::dec
 struct SETW { char w; SETW(char w) : w(w) {} } ATTR_PACK; // Analog of cout << std::setw()
-struct NOC_LOG_XFER { uint32_t size; NOC_LOG_XFER(uint32_t sz) : size(sz) {} } ATTR_PACK; // For tracking noc transactions.
 struct U32_ARRAY {
     uint32_t* ptr; uint32_t len;
     U32_ARRAY(uint32_t* ptr, uint32_t len) : ptr(ptr), len(len) {}
@@ -142,7 +141,6 @@ template<> uint8_t DebugPrintTypeToId<RAISE>()         { return DPrintRAISE; }
 template<> uint8_t DebugPrintTypeToId<WAIT>()          { return DPrintWAIT; }
 template<> uint8_t DebugPrintTypeToId<BF16>()          { return DPrintBFLOAT16; }
 template<> uint8_t DebugPrintTypeToId<SETPRECISION>()  { return DPrintSETPRECISION; }
-template<> uint8_t DebugPrintTypeToId<NOC_LOG_XFER>()  { return DPrintNOC_LOG_XFER; }
 template<> uint8_t DebugPrintTypeToId<FIXED>()         { return DPrintFIXED; }
 template<> uint8_t DebugPrintTypeToId<DEFAULTFLOAT>()  { return DPrintDEFAULTFLOAT; }
 template<> uint8_t DebugPrintTypeToId<HEX>()           { return DPrintHEX; }
@@ -297,7 +295,6 @@ template DebugPrinter operator<< <HEX>(DebugPrinter, HEX val);
 template DebugPrinter operator<< <OCT>(DebugPrinter, OCT val);
 template DebugPrinter operator<< <DEC>(DebugPrinter, DEC val);
 template DebugPrinter operator<< <SETPRECISION>(DebugPrinter, SETPRECISION val);
-template DebugPrinter operator<< <NOC_LOG_XFER>(DebugPrinter, NOC_LOG_XFER val);
 template DebugPrinter operator<< <BF16>(DebugPrinter, BF16 val);
 template DebugPrinter operator<< <F32>(DebugPrinter, F32 val);
 template DebugPrinter operator<< <U32>(DebugPrinter, U32 val);

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -35,7 +35,7 @@
 #include "dprint_buffer.h"
 #include "waypoint.h"
 
-#if defined(DEBUG_PRINT_ENABLED)
+#if defined(DEBUG_PRINT_ENABLED) && !defined(FORCE_DPRINT_OFF)
 #define DPRINT DebugPrinter()
 #else
 #define DPRINT if(0) DebugPrinter()
@@ -175,7 +175,7 @@ struct DebugPrinter {
     uint8_t* bufend() { return buf() + DPRINT_BUFFER_SIZE; }
 
     DebugPrinter() {
-#if defined(DEBUG_PRINT_ENABLED)
+#if defined(DEBUG_PRINT_ENABLED) && !defined(FORCE_DPRINT_OFF)
         if (*wpos() == DEBUG_PRINT_SERVER_STARTING_MAGIC) {
             // Host debug print server writes this value
             // we don't want to reset wpos/rpos to 0 unless this is the first time
@@ -264,7 +264,7 @@ void debug_print(DebugPrinter &dp, DebugPrintData data) {
 template<typename T>
 __attribute__((__noinline__))
 DebugPrinter operator <<(DebugPrinter dp, T val) {
-#if defined(DEBUG_PRINT_ENABLED) && !defined(PROFILE_KERNEL)
+#if defined(DEBUG_PRINT_ENABLED) && !defined(FORCE_DPRINT_OFF) && !defined(PROFILE_KERNEL)
     DebugPrintData data{
         .sz = DebugPrintTypeToSize<T>(val), // includes terminating 0 for char*
         .data_ptr = DebugPrintTypeAddr<T>(&val),

--- a/tt_metal/hw/inc/debug/dprint_buffer.h
+++ b/tt_metal/hw/inc/debug/dprint_buffer.h
@@ -7,6 +7,8 @@
 #include "tt_metal/hostdevcommon/dprint_common.h"
 #include <dev_msgs.h>
 
+#include "hostdevcommon/dprint_common.h"
+
 // Returns the buffer address for current thread+core. Differs for NC/BR/ER/TR0-2.
 inline uint8_t* get_debug_print_buffer() {
     #if defined(COMPILE_FOR_NCRISC)

--- a/tt_metal/hw/inc/debug/noc_logging.h
+++ b/tt_metal/hw/inc/debug/noc_logging.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "dprint_buffer.h"
+
+// Add option to skip noc logging for certain cores via a define.
+#if defined(NOC_LOGGING_ENABLED) && !defined(SKIP_NOC_LOGGING)
+void log_noc_xfer(uint32_t len) {
+    // Hijack print buffer for noc logging data.
+    volatile tt_l1_ptr uint32_t *buf_ptr =
+        (volatile tt_l1_ptr uint32_t *)(reinterpret_cast<DebugPrintMemLayout *>(get_debug_print_buffer())->data);
+
+    int highest_bit_position = 0;
+    while (len >>= 1) highest_bit_position++;
+
+    buf_ptr[highest_bit_position]++;
+}
+
+#define LOG_LEN(l) log_noc_xfer(l);
+#define LOG_READ_LEN_FROM_STATE(noc_id) LOG_LEN(NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
+#define LOG_WRITE_LEN_FROM_STATE(noc_id) LOG_LEN(NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
+
+#else
+
+#define LOG_LEN(l)
+#define LOG_READ_LEN_FROM_STATE(noc_id)
+#define LOG_WRITE_LEN_FROM_STATE(noc_id)
+#endif

--- a/tt_metal/hw/inc/debug/pause.h
+++ b/tt_metal/hw/inc/debug/pause.h
@@ -8,7 +8,7 @@
 #include "waypoint.h"
 #include "debug/pause.h"
 
-#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_PAUSE)
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_PAUSE) && !defined(FORCE_WATCHER_OFF)
 
 void watcher_pause() {
     // Write the pause flag for this core into the memory mailbox for host to read.

--- a/tt_metal/hw/inc/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/debug/ring_buffer.h
@@ -13,7 +13,7 @@ constexpr static int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
 
 #include "dev_msgs.h"
 
-#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER)
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
 void push_to_ring_buffer(uint32_t val) {
     auto buf = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -31,7 +31,7 @@
 #if (                                                                                          \
     defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
     defined(COMPILE_FOR_IDLE_ERISC)) &&                                                        \
-    (defined(WATCHER_ENABLED)) && (!defined(WATCHER_DISABLE_NOC_SANITIZE))
+    defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_NOC_SANITIZE) && !defined(FORCE_WATCHER_OFF)
 
 #include "watcher_common.h"
 

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -14,19 +14,8 @@
 //
 #pragma once
 
-#include "dprint.h"
-
-// Add the ability to skip NOC logging, we can't have the tunneling cores stalling waiting for the
-// print server.
-#if !defined(SKIP_NOC_LOGGING)
-#define LOG_LEN(l) DPRINT << NOC_LOG_XFER(l);
-#define LOG_READ_LEN_FROM_STATE(noc_id) LOG_LEN(NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
-#define LOG_WRITE_LEN_FROM_STATE(noc_id) LOG_LEN(NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
-#else
-#define LOG_LEN(l)
-#define LOG_READ_LEN_FROM_STATE(noc_id)
-#define LOG_WRITE_LEN_FROM_STATE(noc_id)
-#endif
+// NOC logging enabled independently of watcher, need to include it here because it hooks into DEBUG_SANITIZE_NOC_*
+#include "noc_logging.h"
 
 #if (                                                                                          \
     defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -48,6 +48,9 @@ typedef bool debug_sanitize_noc_dir_t;
 #define DEBUG_SANITIZE_NOC_MULTICAST true
 #define DEBUG_SANITIZE_NOC_UNICAST false
 typedef bool debug_sanitize_noc_cast_t;
+#define DEBUG_SANITIZE_NOC_TARGET true
+#define DEBUG_SANITIZE_NOC_LOCAL false
+typedef bool debug_sanitize_noc_which_core_t;
 
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y) {
@@ -90,24 +93,55 @@ AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y) {
 }
 
 // TODO(PGK): remove soft reset when fw is downloaded at init
-#define DEBUG_VALID_REG_ADDR(a, l)                                                      \
-    (((((a) >= NOC_OVERLAY_START_ADDR) &&                                               \
-       ((a) < NOC_OVERLAY_START_ADDR + NOC_STREAM_REG_SPACE_SIZE * NOC_NUM_STREAMS)) || \
-      ((a) == RISCV_DEBUG_REG_SOFT_RESET_0)) &&                                         \
-     (l) == 4)
-#define DEBUG_VALID_WORKER_ADDR(a, l) ((a >= MEM_L1_BASE) && (a + l <= MEM_L1_BASE + MEM_L1_SIZE) && ((a) + (l) > (a)))
-inline bool debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
-    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
-    return ((addr) >= core_info->noc_pcie_addr_base) && ((addr) + (len) <= core_info->noc_pcie_addr_end) &&
-           ((addr) + (len) > (addr));
-}
-inline bool debug_valid_dram_addr(uint64_t addr, uint64_t len) {
-    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
-    return ((addr) >= core_info->noc_dram_addr_base) && ((addr) + (len) <= core_info->noc_dram_addr_end) &&
-           ((addr) + (len) > (addr));
+inline bool debug_valid_reg_addr(uint64_t addr, uint64_t len) {
+    return (((addr >= NOC_OVERLAY_START_ADDR) &&
+             (addr < NOC_OVERLAY_START_ADDR + NOC_STREAM_REG_SPACE_SIZE * NOC_NUM_STREAMS)) ||
+            (addr == RISCV_DEBUG_REG_SOFT_RESET_0)) &&
+           (len == 4);
 }
 
-#define DEBUG_VALID_ETH_ADDR(a, l) (((a) >= MEM_ETH_BASE) && ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE))
+inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len) {
+    if (addr + len <= addr)
+        return DebugSanitizeNocAddrZeroLength;
+    if (addr < MEM_L1_BASE)
+        return DebugSanitizeNocAddrUnderflow;
+    if (addr + len > MEM_L1_BASE + MEM_L1_SIZE)
+        return DebugSanitizeNocAddrOverflow;
+    return DebugSanitizeNocOK;
+}
+
+inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
+    if (addr + len <= addr)
+        return DebugSanitizeNocAddrZeroLength;
+
+    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
+    if (addr < core_info->noc_pcie_addr_base)
+        return DebugSanitizeNocAddrUnderflow;
+    if (addr + len > core_info->noc_pcie_addr_end)
+        return DebugSanitizeNocAddrOverflow;
+    return DebugSanitizeNocOK;
+}
+inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
+    if (addr + len <= addr)
+        return DebugSanitizeNocAddrZeroLength;
+
+    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
+    if (addr < core_info->noc_dram_addr_base)
+        return DebugSanitizeNocAddrUnderflow;
+    if (addr + len > core_info->noc_dram_addr_end)
+        return DebugSanitizeNocAddrOverflow;
+    return DebugSanitizeNocOK;
+}
+
+inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len) {
+    if (addr + len <= addr)
+        return DebugSanitizeNocAddrZeroLength;
+    if (addr < MEM_ETH_BASE)
+        return DebugSanitizeNocAddrUnderflow;
+    if (addr + len > MEM_ETH_BASE + MEM_ETH_SIZE)
+        return DebugSanitizeNocAddrOverflow;
+    return DebugSanitizeNocOK;
+}
 
 // Note:
 //  - this isn't racy w/ the host so long as invalid is written last
@@ -118,16 +152,23 @@ inline void debug_sanitize_post_noc_addr_and_hang(
     uint32_t l1_addr,
     uint32_t len,
     debug_sanitize_noc_cast_t multicast,
-    uint16_t invalid) {
+    debug_sanitize_noc_dir_t dir,
+    debug_sanitize_noc_which_core_t which_core,
+    uint16_t return_code) {
+    if (return_code == DebugSanitizeNocOK)
+        return;
+
     debug_sanitize_noc_addr_msg_t tt_l1_ptr *v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize_noc);
 
-    if (v[noc_id].invalid == DebugSanitizeNocInvalidOK) {
+    if (v[noc_id].return_code == DebugSanitizeNocOK) {
         v[noc_id].noc_addr = noc_addr;
         v[noc_id].l1_addr = l1_addr;
         v[noc_id].len = len;
-        v[noc_id].which = debug_get_which_riscv();
-        v[noc_id].multicast = multicast;
-        v[noc_id].invalid = invalid;
+        v[noc_id].which_risc = debug_get_which_riscv();
+        v[noc_id].is_multicast = (multicast == DEBUG_SANITIZE_NOC_MULTICAST);
+        v[noc_id].is_write = (dir == DEBUG_SANITIZE_NOC_WRITE);
+        v[noc_id].is_target = (which_core == DEBUG_SANITIZE_NOC_TARGET);
+        v[noc_id].return_code = return_code;
     }
 
 #if defined(COMPILE_FOR_ERISC)
@@ -176,53 +217,46 @@ uint32_t debug_sanitize_noc_addr(
         AddressableCoreType end_core_type = get_core_type(noc_id, x_end, y_end);
 
         // Multicast supports workers only
-        if (core_type != AddressableCoreType::TENSIX || end_core_type != AddressableCoreType::TENSIX || (x > x_end || y > y_end)) {
-            debug_sanitize_post_noc_addr_and_hang(
-                noc_id, noc_addr, l1_addr, noc_len, multicast, DebugSanitizeNocInvalidMulticast);
-        }
+        uint16_t return_code = DebugSanitizeNocOK;
+        if (core_type != AddressableCoreType::TENSIX || end_core_type != AddressableCoreType::TENSIX)
+            return_code = DebugSanitizeNocMulticastNonWorker;
+        if (x > x_end || y > y_end)
+            return_code = DebugSanitizeNocMulticastInvalidRange;
+        debug_sanitize_post_noc_addr_and_hang(
+            noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, return_code);
     }
 
     // Check noc addr, we save the alignment requirement from the noc src/dst because the L1 address
     // needs to match alignment.
     // Reads and writes may have different alignment requirements, see noc_parameters.h for details.
     uint32_t alignment_mask = (dir == DEBUG_SANITIZE_NOC_READ ? NOC_L1_READ_ALIGNMENT_BYTES : NOC_L1_WRITE_ALIGNMENT_BYTES) - 1;  // Default alignment, only override in ceratin cases.
-    uint32_t invalid = multicast ? DebugSanitizeNocInvalidMulticast : DebugSanitizeNocInvalidUnicast;
     if (core_type == AddressableCoreType::PCIE) {
         alignment_mask = (dir == DEBUG_SANITIZE_NOC_READ ? NOC_PCIE_READ_ALIGNMENT_BYTES : NOC_PCIE_WRITE_ALIGNMENT_BYTES) - 1;
-        if (!debug_valid_pcie_addr(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_id, noc_addr, l1_addr, noc_len, multicast, invalid);
-        }
+        debug_sanitize_post_noc_addr_and_hang(
+            noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, debug_valid_pcie_addr(noc_local_addr, noc_len));
     } else if (core_type == AddressableCoreType::DRAM) {
         alignment_mask = (dir == DEBUG_SANITIZE_NOC_READ ? NOC_DRAM_READ_ALIGNMENT_BYTES : NOC_DRAM_WRITE_ALIGNMENT_BYTES) - 1;
-        if (!debug_valid_dram_addr(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_id, noc_addr, l1_addr, noc_len, multicast, invalid);
-        }
+        debug_sanitize_post_noc_addr_and_hang(
+            noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, debug_valid_dram_addr(noc_local_addr, noc_len));
 #ifndef ARCH_GRAYSKULL
     } else if (core_type == AddressableCoreType::ETH) {
-        if (!DEBUG_VALID_REG_ADDR(noc_local_addr, noc_len) && !DEBUG_VALID_ETH_ADDR(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_id, noc_addr, l1_addr, noc_len, multicast, invalid);
+        if (!debug_valid_reg_addr(noc_local_addr, noc_len)) {
+            debug_sanitize_post_noc_addr_and_hang(
+                noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, debug_valid_eth_addr(noc_local_addr, noc_len));
         }
 #endif
     } else if (core_type == AddressableCoreType::TENSIX) {
-        if (!DEBUG_VALID_REG_ADDR(noc_local_addr, noc_len) && !DEBUG_VALID_WORKER_ADDR(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_id, noc_addr, l1_addr, noc_len, multicast, invalid);
+        if (!debug_valid_reg_addr(noc_local_addr, noc_len) && !debug_valid_worker_addr(noc_local_addr, noc_len)) {
+            debug_sanitize_post_noc_addr_and_hang(
+                noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, debug_valid_worker_addr(noc_local_addr, noc_len));
         }
     } else {
         // Bad XY
-        debug_sanitize_post_noc_addr_and_hang(noc_id, noc_addr, l1_addr, noc_len, multicast, invalid);
+        debug_sanitize_post_noc_addr_and_hang(
+            noc_id, noc_addr, l1_addr, noc_len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, DebugSanitizeNocTargetInvalidXY);
     }
 
     return alignment_mask;
-}
-
-void debug_sanitize_worker_addr(uint8_t noc_id, uint32_t addr, uint32_t len) {
-    // Regs are exempt from standard L1 validation
-    if (DEBUG_VALID_REG_ADDR(addr, len))
-        return;
-
-    if (!DEBUG_VALID_WORKER_ADDR(addr, len)) {
-        debug_sanitize_post_noc_addr_and_hang(noc_id, addr, 0, len, false, DebugSanitizeNocInvalidL1);
-    }
 }
 
 void debug_sanitize_noc_and_worker_addr(
@@ -235,14 +269,14 @@ void debug_sanitize_noc_and_worker_addr(
     // Check noc addr, get any extra alignment req for worker.
     uint32_t alignment_mask = debug_sanitize_noc_addr(noc_id, noc_addr, worker_addr, len, multicast, dir);
 
-    // Check worker addr
-    debug_sanitize_worker_addr(noc_id, worker_addr, len);
+    // Check worker addr and alignment, but these don't apply to regs.
+    if (!debug_valid_reg_addr(worker_addr, len)) {
+        debug_sanitize_post_noc_addr_and_hang(
+            noc_id, noc_addr, worker_addr, len, multicast, dir, DEBUG_SANITIZE_NOC_LOCAL, debug_valid_worker_addr(worker_addr, len));
 
-    // Check alignment, but not for reg addresses.
-    if (!DEBUG_VALID_REG_ADDR(worker_addr, len)) {
         if ((worker_addr & alignment_mask) != (noc_addr & alignment_mask)) {
             debug_sanitize_post_noc_addr_and_hang(
-                noc_id, noc_addr, worker_addr, len, multicast, DebugSanitizeNocInvalidAlignment);
+                noc_id, noc_addr, worker_addr, len, multicast, dir, DEBUG_SANITIZE_NOC_TARGET, DebugSanitizeNocAlignment);
         }
     }
 }

--- a/tt_metal/hw/inc/debug/stack_usage.h
+++ b/tt_metal/hw/inc/debug/stack_usage.h
@@ -7,7 +7,7 @@
 #include "watcher_common.h"
 
 // We don't control the stack size for active erisc, and share the stack with base FW, so don't implement for ERISC.
-#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_STACK_USAGE) && !defined(COMPILE_FOR_ERISC)
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_STACK_USAGE) && !defined(COMPILE_FOR_ERISC) && !defined(FORCE_WATCHER_OFF)
 
 #define STACK_DIRTY_PATTERN 0xBABABABA
 

--- a/tt_metal/hw/inc/debug/waypoint.h
+++ b/tt_metal/hw/inc/debug/waypoint.h
@@ -17,7 +17,7 @@
 
 #include "dev_msgs.h"
 
-#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_WAYPOINT)
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_WAYPOINT) && !defined(FORCE_WATCHER_OFF)
 #include <cstddef>
 
 template <size_t N, size_t... Is>

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -123,16 +123,17 @@ struct debug_waypoint_msg_t {
     volatile uint8_t waypoint[num_waypoint_bytes_per_riscv];
 };
 
-// TODO: Clean up this struct with #6738
 // This structure is populated by the device and read by the host
 struct debug_sanitize_noc_addr_msg_t {
     volatile uint64_t noc_addr;
     volatile uint32_t l1_addr;
     volatile uint32_t len;
-    volatile uint16_t which;
-    volatile uint16_t invalid;
-    volatile uint16_t multicast;
-    volatile uint16_t pad;
+    volatile uint16_t which_risc;
+    volatile uint16_t return_code;
+    volatile uint8_t is_multicast;
+    volatile uint8_t is_write;
+    volatile uint8_t is_target;
+    volatile uint8_t pad;
 };
 
 // Host -> device. Populated with the information on where we want to insert delays.
@@ -143,13 +144,16 @@ struct debug_insert_delays_msg_t {
     volatile uint8_t feedback = 0;                 // Stores the feedback about delays (used for testing)
 };
 
-enum debug_sanitize_noc_invalid_enum {
+enum debug_sanitize_noc_return_code_enum {
     // 0 and 1 are a common stray values to write, so don't use those
-    DebugSanitizeNocInvalidOK = 2,
-    DebugSanitizeNocInvalidL1 = 3,
-    DebugSanitizeNocInvalidUnicast = 4,
-    DebugSanitizeNocInvalidMulticast = 5,
-    DebugSanitizeNocInvalidAlignment = 6,
+    DebugSanitizeNocOK                    = 2,
+    DebugSanitizeNocAddrUnderflow         = 3,
+    DebugSanitizeNocAddrOverflow          = 4,
+    DebugSanitizeNocAddrZeroLength        = 5,
+    DebugSanitizeNocTargetInvalidXY       = 6,
+    DebugSanitizeNocMulticastNonWorker    = 7,
+    DebugSanitizeNocMulticastInvalidRange = 8,
+    DebugSanitizeNocAlignment             = 9,
 };
 
 struct debug_assert_msg_t {

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -18,6 +18,7 @@ set(IMPL_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/dispatch/data_collection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_server.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/debug/noc_logging.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/debug/watcher_server.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/debug/watcher_device_reader.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/trace/trace.cpp

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <set>
+
+#include "hostdevcommon/dprint_common.h"
+#include "tt_metal/impl/device/device.hpp"
+
+// Helper function for comparing CoreDescriptors for using in sets.
+struct CoreDescriptorComparator {
+    bool operator()(const CoreDescriptor &x, const CoreDescriptor &y) const {
+        if (x.coord == y.coord) {
+            return x.type < y.type;
+        } else {
+            return x.coord < y.coord;
+        }
+    }
+};
+#define CoreDescriptorSet std::set<CoreDescriptor, CoreDescriptorComparator>
+
+// Helper function to get CoreDescriptors for all debug-relevant cores on device.
+static CoreDescriptorSet GetAllCores(Device *device) {
+    CoreDescriptorSet all_cores;
+    // The set of all printable cores is Tensix + Eth cores
+    CoreCoord logical_grid_size = device->logical_grid_size();
+    for (uint32_t x = 0; x < logical_grid_size.x; x++) {
+        for (uint32_t y = 0; y < logical_grid_size.y; y++) {
+            all_cores.insert({{x, y}, CoreType::WORKER});
+        }
+    }
+    for (const auto& logical_core : device->get_active_ethernet_cores()) {
+        all_cores.insert({logical_core, CoreType::ETH});
+    }
+    for (const auto& logical_core : device->get_inactive_ethernet_cores()) {
+        all_cores.insert({logical_core, CoreType::ETH});
+    }
+
+    return all_cores;
+}
+
+// Helper function to get CoreDescriptors for all cores that are used for dispatch. Should be a subset of
+// GetAllCores().
+static CoreDescriptorSet GetDispatchCores(Device* device) {
+    CoreDescriptorSet dispatch_cores;
+    unsigned num_cqs = device->num_hw_cqs();
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    tt::log_warning("Dispatch Core Type = {}", dispatch_core_type);
+    for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_type)) {
+        dispatch_cores.insert({logical_core, dispatch_core_type});
+    }
+    return dispatch_cores;
+}
+
+inline uint64_t GetDprintBufAddr(Device *device, const CoreCoord &phys_core, int risc_id) {
+
+    dprint_buf_msg_t *buf = device->get_dev_addr<dprint_buf_msg_t *>(phys_core, HalMemAddrType::DPRINT);
+    return reinterpret_cast<uint64_t>(buf->data[risc_id]);
+}
+
+inline int GetNumRiscs(const CoreDescriptor &core) {
+    return (core.type == CoreType::ETH)? DPRINT_NRISCVS_ETH : DPRINT_NRISCVS;
+}

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -16,6 +16,7 @@
 #include "tt_metal/common/logger.hpp"
 
 #include "dprint_server.hpp"
+#include "debug_helpers.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "llrt/rtoptions.hpp"
 
@@ -42,18 +43,6 @@ using namespace tt;
 namespace {
 
 static string logfile_path = "generated/dprint/";
-
-// Helper function for comparing CoreDescriptors for using in sets.
-struct CoreDescriptorComparator {
-    bool operator()(const CoreDescriptor &x, const CoreDescriptor &y) const {
-        if (x.coord == y.coord) {
-            return x.type < y.type;
-        } else {
-            return x.coord < y.coord;
-        }
-    }
-};
-#define CoreDescriptorSet set<CoreDescriptor, CoreDescriptorComparator>
 
 static inline float bfloat16_to_float(uint16_t bfloat_val) {
     uint32_t uint32_data = ((uint32_t)bfloat_val) << 16;
@@ -85,49 +74,6 @@ static std::string GetRiscName(CoreType core_type, int hart_id) {
         }
     }
     return fmt::format("UNKNOWN_RISC_ID({})", hart_id);
-}
-
-static inline uint64_t GetBaseAddr(Device *device, const CoreCoord &phys_core, int hart_id) {
-
-    dprint_buf_msg_t *buf = device->get_dev_addr<dprint_buf_msg_t *>(phys_core, HalMemAddrType::DPRINT);
-
-    return reinterpret_cast<uint64_t>(buf->data[hart_id]);
-}
-
-static inline int GetNumRiscs(const CoreDescriptor &core) {
-    return (core.type == CoreType::ETH)? DPRINT_NRISCVS_ETH : DPRINT_NRISCVS;
-}
-
-// Helper function to get all (logical) printable cores on a device
-static CoreDescriptorSet get_all_printable_cores(Device *device) {
-    CoreDescriptorSet all_printable_cores;
-    // The set of all printable cores is Tensix + Eth cores
-    CoreCoord logical_grid_size = device->logical_grid_size();
-    for (uint32_t x = 0; x < logical_grid_size.x; x++) {
-        for (uint32_t y = 0; y < logical_grid_size.y; y++) {
-            all_printable_cores.insert({{x, y}, CoreType::WORKER});
-        }
-    }
-    for (const auto& logical_core : device->get_active_ethernet_cores()) {
-        all_printable_cores.insert({logical_core, CoreType::ETH});
-    }
-    for (const auto& logical_core : device->get_inactive_ethernet_cores()) {
-        all_printable_cores.insert({logical_core, CoreType::ETH});
-    }
-
-    return all_printable_cores;
-}
-
-// Helper function to get all (logical) printable cores that are used for dispatch. Should be a subset of
-// get_all_printable_cores().
-static CoreDescriptorSet get_dispatch_printable_cores(Device* device) {
-    CoreDescriptorSet printable_dispatch_cores;
-    unsigned num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
-    for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_type)) {
-        printable_dispatch_cores.insert({logical_core, dispatch_core_type});
-    }
-    return printable_dispatch_cores;
 }
 
 // A null stream for when the print server is muted.
@@ -195,8 +141,6 @@ private:
 
     std::ofstream* outfile_ = nullptr; // non-cout
     std::ostream* stream_ = nullptr; // either == outfile_ or is &cout
-    std::ofstream* noc_log_ = nullptr;
-    std::map<uint32_t, uint32_t> noc_xfer_counts;
 
     // For printing each riscs dprint to a separate file, a map from {device id, core coord x, y, hard index} to files.
     std::map<std::tuple<uint32_t, uint32_t, uint32_t, uint32_t>, std::ofstream *> risc_to_stream_;
@@ -369,7 +313,7 @@ static void PrintTypedUint32Array(ostream& stream, int setwidth, uint32_t raw_el
 // Used for debug print server startup sequence.
 void WriteInitMagic(Device *device, const CoreCoord& phys_core, int hart_id, bool enabled) {
     // compute the buffer address for the requested hart
-    uint64_t base_addr = GetBaseAddr(device, phys_core, hart_id);
+    uint64_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
 
     // TODO(AP): this could use a cleanup - need a different mechanism to know if a kernel is running on device.
     // Force wait for first kernel launch by first writing a non-zero and waiting for a zero.
@@ -384,7 +328,7 @@ void WriteInitMagic(Device *device, const CoreCoord& phys_core, int hart_id, boo
 // Note that this is not a bulletproof way to bootstrap the print server (TODO(AP))
 bool CheckInitMagicCleared(Device *device, const CoreCoord& phys_core, int hart_id) {
     // compute the buffer address for the requested hart
-    uint32_t base_addr = GetBaseAddr(device, phys_core, hart_id);
+    uint32_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
 
     vector<uint32_t> initbuf = { DEBUG_PRINT_SERVER_STARTING_MAGIC };
     auto result = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, 4);
@@ -414,7 +358,6 @@ DebugPrintServerContext::DebugPrintServerContext() {
         outfile_ = new std::ofstream(file_name);
     }
     stream_ = outfile_ ? outfile_ : &cout;
-    noc_log_ = new std::ofstream("noc_log.csv");
 
     stop_print_server_ = false;
     mute_print_server_ = false;
@@ -447,10 +390,6 @@ DebugPrintServerContext::~DebugPrintServerContext() {
         key_and_stream.second->close();
         delete key_and_stream.second;
     }
-    for (auto &size_and_count : noc_xfer_counts)
-        *noc_log_ << size_and_count.first << "," << size_and_count.second << "\n";
-    noc_log_->close();
-    delete noc_log_;
     inst = nullptr;
 } // ~DebugPrintServerContext
 
@@ -480,15 +419,15 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
 
     // A set of all valid printable cores, used for checking the user input. Note that the coords
     // here are physical.
-    CoreDescriptorSet all_printable_cores = get_all_printable_cores(device);
-    CoreDescriptorSet dispatch_printable_cores = get_dispatch_printable_cores(device);
+    CoreDescriptorSet all_cores = GetAllCores(device);
+    CoreDescriptorSet dispatch_cores = GetDispatchCores(device);
 
     // Initialize all print buffers on all cores on the device to have print disabled magic. We
     // will then write print enabled magic for only the cores the user has specified to monitor.
     // This way in the kernel code (dprint.h) we can detect whether the magic value is present and
     // skip prints entirely to prevent kernel code from hanging waiting for the print buffer to be
     // flushed from the host.
-    for (auto &logical_core : all_printable_cores) {
+    for (auto &logical_core : all_cores) {
         CoreCoord phys_core = device->physical_core_from_logical_core(logical_core);
         for (int hart_index = 0; hart_index < GetNumRiscs(logical_core); hart_index++) {
             WriteInitMagic(device, phys_core, hart_index, false);
@@ -508,7 +447,7 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
         if (tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
             tt::llrt::RunTimeDebugClassAll) {
             // Print from all cores of the given type, cores returned here are guaranteed to be valid.
-            for (CoreDescriptor logical_core : all_printable_cores) {
+            for (CoreDescriptor logical_core : all_cores) {
                 if (logical_core.type == core_type)
                     print_cores_sanitized.push_back(logical_core);
             }
@@ -520,7 +459,7 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
         } else if (
             tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
             tt::llrt::RunTimeDebugClassDispatch) {
-            for (CoreDescriptor logical_core : dispatch_printable_cores) {
+            for (CoreDescriptor logical_core : dispatch_cores) {
                 if (logical_core.type == core_type)
                     print_cores_sanitized.push_back(logical_core);
             }
@@ -533,8 +472,8 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
             tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
             tt::llrt::RunTimeDebugClassWorker) {
             // For worker cores, take all cores and remove dispatch cores.
-            for (CoreDescriptor logical_core : all_printable_cores) {
-                if (dispatch_printable_cores.find(logical_core) == dispatch_printable_cores.end()) {
+            for (CoreDescriptor logical_core : all_cores) {
+                if (dispatch_cores.find(logical_core) == dispatch_cores.end()) {
                 if (logical_core.type == core_type)
                     print_cores_sanitized.push_back(logical_core);
                 }
@@ -560,7 +499,7 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
                 } catch (std::runtime_error& error) {
                     valid_logical_core = false;
                 }
-                if (valid_logical_core && all_printable_cores.count({logical_core, core_type}) > 0) {
+                if (valid_logical_core && all_cores.count({logical_core, core_type}) > 0) {
                     print_cores_sanitized.push_back({logical_core, core_type});
                     log_info(
                         tt::LogMetal,
@@ -632,7 +571,7 @@ void DebugPrintServerContext::DetachDevice(Device* device) {
 
                     // Check if rpos < wpos, indicating unprocessed prints.
                     constexpr int eightbytes = 8;
-                    uint32_t base_addr = GetBaseAddr(device, phys_core, risc_id);
+                    uint32_t base_addr = GetDprintBufAddr(device, phys_core, risc_id);
                     auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, phys_core, base_addr, eightbytes);
                     uint32_t wpos = from_dev[0], rpos = from_dev[1];
                     if (rpos < wpos) {
@@ -654,8 +593,8 @@ void DebugPrintServerContext::DetachDevice(Device* device) {
     log_info(tt::LogMetal, "DPRINT Server dettached device {}", device->id());
 
     // When detaching a device, disable prints on it.
-    CoreDescriptorSet all_printable_cores = get_all_printable_cores(device);
-    for (auto &logical_core : all_printable_cores) {
+    CoreDescriptorSet all_cores = GetAllCores(device);
+    for (auto &logical_core : all_cores) {
             CoreCoord phys_core = device->physical_core_from_logical_core(logical_core);
             for (int hart_index = 0; hart_index < GetNumRiscs(logical_core); hart_index++) {
                 WriteInitMagic(device, phys_core, hart_index, false);
@@ -691,7 +630,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
         return false;
 
     // compute the buffer address for the requested hart
-    uint32_t base_addr = GetBaseAddr(device, phys_core, hart_id);
+    uint32_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
     chip_id_t chip_id = device->id();
 
     // Device is incrementing wpos
@@ -823,11 +762,6 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                 case DPrintSETPRECISION:
                     stream << std::setprecision(*ptr);
                     TT_ASSERT(sz == 1);
-                break;
-                case DPrintNOC_LOG_XFER:
-                    if (tt::llrt::OptionsG.get_dprint_noc_transfers())
-                        noc_xfer_counts[*reinterpret_cast<uint32_t*>(ptr)]++;
-                    TT_ASSERT(sz == 4);
                 break;
                 case DPrintFIXED:
                     stream << std::fixed;

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -87,4 +87,9 @@ void DPrintServerClearLogFile();
 */
 void DPrintServerClearSignals();
 
+/**
+@brief Returns true if the DPRINT server reads any dispatch cores on a given device.
+*/
+bool DPrintServerReadsDispatchCores(tt::tt_metal::Device* device);
+
 } // namespace tt

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "noc_logging.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+//#include <iomanip>
+#include <set>
+
+#include "debug_helpers.hpp"
+#include "hostdevcommon/dprint_common.h"
+#include "tt_metal/impl/device/device.hpp"
+
+// 32 buckets to match the number of bits in uint32_t lengths on device
+#define NOC_DATA_SIZE sizeof(uint32_t) * 8
+using noc_data_t = std::array<uint64_t, NOC_DATA_SIZE>;
+
+namespace tt {
+
+static string logfile_path = "generated/noc_data/";
+void PrintNocData(noc_data_t noc_data, string file_name) {
+    std::filesystem::path output_dir(tt::llrt::OptionsG.get_root_dir() + logfile_path);
+    std::filesystem::create_directories(output_dir);
+    std::string filename = tt::llrt::OptionsG.get_root_dir() + logfile_path + file_name;
+    std::ofstream outfile(filename);
+
+    for (uint32_t idx = 0; idx < NOC_DATA_SIZE; idx++) {
+        uint64_t lower = 1UL << idx;
+        uint64_t upper = 1UL << (idx + 1);
+        outfile << fmt::format("[{},{}): {}\n", lower, upper, noc_data[idx]);
+    }
+
+    outfile.close();
+}
+
+void DumpCoreNocData(Device *device, const CoreDescriptor &logical_core, noc_data_t &noc_data) {
+    CoreCoord phys_core = device->physical_core_from_logical_core(logical_core);
+    for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
+        // Read out the DPRINT buffer, we stored our data in the "data field"
+        uint64_t addr = GetDprintBufAddr(device, phys_core, risc_id);
+        auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, addr, DPRINT_BUFFER_SIZE);
+        DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
+        uint32_t *data = reinterpret_cast<uint32_t *>(l->data);
+
+        // Append the data for this core to existing data
+        for (int idx = 0; idx < NOC_DATA_SIZE; idx++) {
+            noc_data[idx] += data[idx];
+        }
+    }
+}
+
+void DumpDeviceNocData(Device *device, noc_data_t &noc_data, noc_data_t &dispatch_noc_data) {
+    // Need to treat dispatch cores and normal cores separately, so keep track of which cores are dispatch.
+    CoreDescriptorSet dispatch_cores = GetDispatchCores(device);
+
+    // Now go through all cores on the device, and dump noc data for them.
+    CoreDescriptorSet all_cores = GetAllCores(device);
+    for (const CoreDescriptor &logical_core : all_cores) {
+        if (dispatch_cores.count(logical_core)) {
+            DumpCoreNocData(device, logical_core, dispatch_noc_data);
+        } else {
+            DumpCoreNocData(device, logical_core, noc_data);
+        }
+    }
+}
+
+void DumpNocData(std::vector<Device *> devices) {
+    // Skip if feature is not enabled
+    if (!tt::llrt::OptionsG.get_record_noc_transfers())
+        return;
+
+    noc_data_t noc_data = {}, dispatch_noc_data = {};
+    for (Device *device : devices) {
+        log_info("Dumping noc data for Device {}...", device->id());
+        DumpDeviceNocData(device, noc_data, dispatch_noc_data);
+    }
+
+    PrintNocData(noc_data, "noc_data.txt");
+    PrintNocData(dispatch_noc_data, "dispatch_noc_data.txt");
+}
+
+void ClearNocData(Device *device) {
+    // Skip if feature is not enabled
+    if (!tt::llrt::OptionsG.get_record_noc_transfers())
+        return;
+
+    // This feature is incomatible with dprint since they share memory space
+    TT_FATAL(
+        tt::llrt::OptionsG.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) == false,
+        "NOC transfer recording is incompatible with DPRINT");
+
+    CoreDescriptorSet all_cores = GetAllCores(device);
+    for (const CoreDescriptor &logical_core : all_cores) {
+        CoreCoord phys_core = device->physical_core_from_logical_core(logical_core);
+        for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
+            uint64_t addr = GetDprintBufAddr(device, phys_core, risc_id);
+            vector<uint32_t> initbuf = vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
+            tt::llrt::write_hex_vec_to_core(device->id(), phys_core, initbuf, addr);
+        }
+    }
+}
+
+}  // namespace tt

--- a/tt_metal/impl/debug/noc_logging.hpp
+++ b/tt_metal/impl/debug/noc_logging.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/impl/device/device.hpp"
+
+namespace tt {
+void ClearNocData(Device *device);
+void DumpNocData(std::vector<Device *> devices);
+}

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -222,9 +222,11 @@ void watcher_init(Device *device) {
         data->sanitize_noc[i].noc_addr = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
         data->sanitize_noc[i].l1_addr = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
         data->sanitize_noc[i].len = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_32;
-        data->sanitize_noc[i].which = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
-        data->sanitize_noc[i].multicast = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
-        data->sanitize_noc[i].invalid = DebugSanitizeNocInvalidOK;
+        data->sanitize_noc[i].which_risc = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_16;
+        data->sanitize_noc[i].return_code = DebugSanitizeNocOK;
+        data->sanitize_noc[i].is_multicast = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        data->sanitize_noc[i].is_write = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
+        data->sanitize_noc[i].is_target = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_8;
     }
 
     // Initialize debug asserts to not tripped.

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -685,6 +685,12 @@ void Device::configure_kernel_variant(
         {"DOWNSTREAM_SLAVE_NOC_Y", std::to_string(NOC_0_Y(downstream_noc_index, grid_size.y, downstream_slave_physical_core.y))},
         {"FD_CORE_TYPE", std::to_string(programmable_core_type_index)},
     };
+    if (llrt::OptionsG.watcher_dispatch_disabled()) {
+        defines["FORCE_WATCHER_OFF"] = "1";
+    }
+    if (!DPrintServerReadsDispatchCores(this)) {
+        defines["FORCE_DPRINT_OFF"] = "1";
+    }
     defines.insert(defines_in.begin(), defines_in.end());
 
     if (dispatch_core_type == CoreType::WORKER) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -465,7 +465,9 @@ void Device::reset_cores() {
             try {
                 llrt::internal_::wait_until_cores_done(id_and_cores.first, RUN_MSG_GO, id_and_cores.second, timeout_ms);
             } catch (std::runtime_error &e) {
-                TT_THROW("Device {} init: failed to reset cores! Try resetting the board.", this->id());
+                log_warning(
+                    "Detected dispatch kernels still running but failed to complete an early exit. This may happen "
+                    "from time to time following a reset, continuing to FW intialization...");
             }
         }
     }
@@ -602,7 +604,12 @@ void Device::initialize_and_launch_firmware() {
     // Wait until fw init is done, ensures the next launch msg doesn't get
     // written while fw is still in init
     log_debug("Waiting for firmware init complete");
-    llrt::internal_::wait_until_cores_done(this->id(), RUN_MSG_INIT, not_done_cores);
+    const int timeout_ms = 10000; // 10 seconds for now
+    try {
+        llrt::internal_::wait_until_cores_done(this->id(), RUN_MSG_INIT, not_done_cores, timeout_ms);
+    } catch (std::runtime_error &e) {
+        TT_THROW("Device {} init: failed to initialize FW! Try resetting the board.", this->id());
+    }
     log_debug("Firmware init complete");
 }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -159,6 +159,7 @@ void DevicePool::initialize_device(Device* dev) const {
         TT_ASSERT(dev->num_hw_cqs() == 1, "num_hw_cqs must be 1 in slow dispatch");
     }
 
+    ClearNocData(dev);
     DprintServerAttach(dev);
     watcher_init(dev);
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -163,7 +163,9 @@ void DevicePool::initialize_device(Device* dev) const {
     watcher_init(dev);
 
     // TODO: as optimization, investigate removing all this call for already initialized devivces
-    dev->reset_cores();
+    if (!llrt::OptionsG.get_skip_reset_cores_on_init()) {
+        dev->reset_cores();
+    }
     dev->initialize_and_launch_firmware();
 
     watcher_attach(dev);

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "impl/debug/dprint_server.hpp"
+#include "impl/debug/noc_logging.hpp"
 #include "impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -108,6 +108,10 @@ void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch) {
         this->defines_ += "-DDEBUG_PRINT_ENABLED ";
     }
 
+    if (tt::llrt::OptionsG.get_record_noc_transfers()) {
+        this->defines_ += "-DNOC_LOGGING_ENABLED ";
+    }
+
     if (tt::llrt::OptionsG.get_kernels_nullified()) {
         this->defines_ += "-DDEBUG_NULL_KERNELS ";
     }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -344,6 +344,12 @@ void wait_until_cores_done(
             }
         }
         loop_count++;
+        // Continuously polling cores here can cause other host-driven noc transactions (dprint, watcher) to drastically
+        // slow down for remote devices. So when debugging with these features, add a small delay to allow other
+        // host-driven transactions through.
+        if (llrt::OptionsG.get_watcher_enabled() ||
+            llrt::OptionsG.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint))
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -212,9 +212,9 @@ void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature) {
         if (core_type_and_cores.second.size() > 0)
             feature_targets[feature].enabled = true;
 
-    const char *print_noc_xfers = std::getenv("TT_METAL_DPRINT_NOC_TRANSFER_DATA");
+    const char *print_noc_xfers = std::getenv("TT_METAL_RECORD_NOC_TRANSFER_DATA");
     if (print_noc_xfers != nullptr)
-        dprint_noc_transfer_data = true;
+        record_noc_transfer_data = true;
 };
 
 void RunTimeOptions::ParseFeatureCoreRange(

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -170,7 +170,8 @@ void RunTimeOptions::ParseWatcherEnv() {
         watcher_assert_str,
         watcher_pause_str,
         watcher_ring_buffer_str,
-        watcher_stack_usage_str};
+        watcher_stack_usage_str,
+        watcher_dispatch_str};
     for (std::string feature : all_features) {
         std::string env_var("TT_METAL_WATCHER_DISABLE_");
         env_var += feature;

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -113,6 +113,7 @@ class RunTimeOptions {
     bool clear_l1 = false;
 
     bool skip_loading_fw = false;
+    bool skip_reset_cores_on_init = false;
 
     bool riscv_debug_info_enabled = false;
     uint32_t watcher_debug_delay = 0;
@@ -262,6 +263,7 @@ class RunTimeOptions {
     inline void set_clear_l1(bool clear) { clear_l1 = clear; }
 
     inline bool get_skip_loading_fw() { return skip_loading_fw; }
+    inline bool get_skip_reset_cores_on_init() { return skip_reset_cores_on_init; }
 
     // Whether to compile with -g to include DWARF debug info in the binary.
     inline bool get_riscv_debug_info_enabled() { return riscv_debug_info_enabled; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -98,7 +98,7 @@ class RunTimeOptions {
     bool watcher_append = false;
     bool watcher_auto_unpause = false;
     bool watcher_noinline = false;
-    bool dprint_noc_transfer_data = false;
+    bool record_noc_transfer_data = false;
 
     TargetSelection feature_targets[RunTimeDebugFeatureCount];
 
@@ -221,8 +221,8 @@ class RunTimeOptions {
         feature_targets[feature] = targets;
     }
 
-    inline bool get_dprint_noc_transfers() { return dprint_noc_transfer_data; }
-    inline void set_dprint_noc_transfers(bool val) { dprint_noc_transfer_data = val; }
+    inline bool get_record_noc_transfers() { return record_noc_transfer_data; }
+    inline void set_record_noc_transfers(bool val) { record_noc_transfer_data = val; }
 
     inline bool get_validate_kernel_binaries() { return validate_kernel_binaries; }
     inline void set_validate_kernel_binaries(bool val) { validate_kernel_binaries = val; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -156,6 +156,7 @@ class RunTimeOptions {
     inline bool watcher_pause_disabled() { return watcher_feature_disabled(watcher_pause_str); }
     inline bool watcher_ring_buffer_disabled() { return watcher_feature_disabled(watcher_ring_buffer_str); }
     inline bool watcher_stack_usage_disabled() { return watcher_feature_disabled(watcher_stack_usage_str); }
+    inline bool watcher_dispatch_disabled() { return watcher_feature_disabled(watcher_dispatch_str); }
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
@@ -297,6 +298,7 @@ class RunTimeOptions {
     const std::string watcher_pause_str = "PAUSE";
     const std::string watcher_ring_buffer_str = "RING_BUFFER";
     const std::string watcher_stack_usage_str = "STACK_USAGE";
+    const std::string watcher_dispatch_str = "DISPATCH";
     std::set<std::string> watcher_disabled_features;
     bool watcher_feature_disabled(const std::string &name) {
         return watcher_disabled_features.find(name) != watcher_disabled_features.end();


### PR DESCRIPTION
### Ticket
Multiple, see below. Can split into separate PRs if that's more convenient.

### What's changed
First commit is for https://github.com/tenstorrent/tt-metal/issues/12949. Models team ran into some issues with dispatch kernels being too large with dprint/watcher enabled, but no way to disable these features just on dispatch kernels in order to debug other kernels. Watcher has a global enable, and DPRINT has a global enable to be compiled in and a per-core enable at runtime. The reason both are like this is because having different sets of cores with debug tools compiled in/not compiled in that is different from our KernelGroups/CoreRanges would require some fundamental changes to KernelGroups. For now: just add an env var to force dprint/watcher to be compiled out even when they're enabled

Second commit is a change that adds an env var to skip resetting the cores on device init, for the specific case where L1 comes up in a way that makes metal think there was a tunneler kernel left running. See commit message for details.

Third commit is for https://github.com/tenstorrent/tt-metal/issues/6738, it cleans up noc sanitize error messages to always have the following format: `{Device} {Core Type} {Logical Core}({Physical Core}): {RISC} tried using {NOC} to {read/write} {Num Bytes} from {Local L1} to {NOC target} ({Error Reason})`

Fourth commit is a bugfix for https://github.com/tenstorrent/tt-metal/issues/9615, see commit message for details

Fifth commit has a re-implementation of on-device noc transfer size recording (https://github.com/tenstorrent/tt-metal/issues/8164). Needed to do this in a faster way in order to run on larger models. New implementation is split off from dprint completely and just dumps using watcher_dump tool after model is run.

### Checklist
- [X] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11134443426
- [ ] Blackhole Post commit (if applicable) - Failing on main
- [ ] Model regression CI testing passes (if applicable) - N/A
- [ ] Device performance regression CI testing passes (if applicable) - N/A
- [ ] New/Existing tests provide coverage for changes - bugfixes + reimplementations should be covered by existing testing
