### PR TITLE
#12945: update galaxy/n150 eth dispatch cores

### DIFF
--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
@@ -15,7 +15,7 @@ galaxy:
       []
 
     dispatch_cores:
-      [[0, 10], [0, 11], [0, 12], [0, 13]]
+      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
     dispatch_core_type:
       "ethernet"
@@ -29,7 +29,7 @@ galaxy:
       []
 
     dispatch_cores:
-      [[0, 10], [0, 11], [0, 12], [0, 13]]
+      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
     dispatch_core_type:
       "ethernet"
@@ -44,7 +44,7 @@ nebula_x1:
       []
 
     dispatch_cores:
-      [[0, 10], [0, 11], [0, 12], [0, 13]]
+      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
     dispatch_core_type:
       "ethernet"
@@ -58,7 +58,7 @@ nebula_x1:
       []
 
     dispatch_cores:
-      [[0, 10], [0, 11], [0, 12], [0, 13]]
+      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
     dispatch_core_type:
       "ethernet"


### PR DESCRIPTION
### Ticket
[12945](https://github.com/tenstorrent/tt-metal/issues/12945)

### Problem description
Seeing dispatch core assignment issues on yyz-lab-60.

### What's changed
Increase eth dispatch core for unharvested n300 case.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
