### PR TITLE
#0: TT_NO_FIRMWARE hack

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -248,6 +248,13 @@ void Device::initialize_build() {
 
 void Device::build_firmware() {
     log_debug(tt::LogMetal, "Building base firmware for device {}", this->id_);
+
+    // hack
+    if (std::getenv("TT_NO_FIRMWARE"))
+    {
+        return;
+    }
+
     ZoneScoped;
 
     this->generate_device_headers(this->build_env_.get_out_firmware_root_path());
@@ -394,6 +401,12 @@ void Device::reset_cores() {
 
 void Device::initialize_and_launch_firmware() {
     ZoneScoped;
+
+        // hack
+    if (std::getenv("TT_NO_FIRMWARE"))
+    {
+        return;
+    }
 
     launch_msg_t launch_msg;
     std::memset(&launch_msg, 0, sizeof(launch_msg_t));

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -281,7 +281,14 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
         device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
     }
 
+
+
     const auto enqueue_or_launch_program = [=](Program& program) {
+        // hack
+        if (std::getenv("TT_NO_FIRMWARE"))
+        {
+            return;
+        }
         if (USE_FAST_DISPATCH) {
             ZoneScopedN("EnqueueProgram");
             auto& queue = device->command_queue(cq_id);


### PR DESCRIPTION
Merging to the internal feature branch, required reviewers no actions required from your side.

--

Hacky way to avoid any firmware compilation for dispatcher or op with TT_NO_FIRMWARE
e2e softmax tests 336ms => 12ms. 
get_softmax_circular_buffers_l1_allocations took down to 5ms first run, 1ms other runs. First run was 326ms. 

to run graph capture at full speed, use 
TT_METAL_MOCKUP_EN=1 TT_NO_FIRMWARE=1 ARCH_NAME=wormhole_b0 TT_METAL_SLOW_DISPATCH_MODE=1  TTNN_MLIR_INTERFACE_USE_GRAPH_CAPTURE=1

there is likely better way to achieve this; this is temp solution for the experimentation.