### PR TITLE
#12941: Fill backward op

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
@@ -8,6 +8,7 @@ import ttnn
 from models.utility_functions import is_wormhole_b0, is_blackhole
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
+    data_gen_with_val,
     compare_all_close,
 )
 
@@ -21,7 +22,7 @@ from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     ),
 )
 # Pytorch Reference
-# - name: fill.Scalar(Tensor self, Scalar value) -> Tensor
+#   name: fill.Scalar(Tensor self, Scalar value) -> Tensor
 #   self: zeros_like(grad)
 #   result: at::fill(self_t, 0)
 def test_bw_fill(input_shapes, device):
@@ -31,7 +32,7 @@ def test_bw_fill(input_shapes, device):
     tt_output_tensor_on_device = ttnn.fill_bw(grad_tensor, input_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.fill_bw)
-    golden_tensor = golden_function(grad_data, in_data)
+    golden_tensor = golden_function(grad_data, in_data, value=2.0)
 
     comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=0, rtol=0)
     assert comp_pass
@@ -57,8 +58,63 @@ def test_bw_fill_opt_tensor(input_shapes, device):
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
 
     golden_function = ttnn.get_golden_function(ttnn.fill_bw)
-    golden_tensor = golden_function(grad_data, in_data)
+    golden_tensor = golden_function(grad_data, in_data, value=2.0)
 
     tt_output_tensor_on_device = [input_grad]
     comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=0, rtol=0)
     assert comp_pass
+
+
+# Pytorch Reference
+#    name: fill.Tensor(Tensor self, Tensor value) -> Tensor
+#    self: zeros_like(grad)
+#    value: grad.sum()
+#    result: at::fill(self_t, value_t)
+#   This variant is supported only in Wormhole N300 for non-decimals grad_tensor.
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_fill_tensors(input_shapes, device, are_required_outputs):
+    grad_data = torch.zeros(input_shapes)
+    grad_tensor = ttnn.from_torch(grad_data, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    in_data2 = torch.tensor(2.0, requires_grad=True)
+    _, input_tensor2 = data_gen_with_val(torch.Size([1, 1, 32, 32]), device, required_grad=True, val=2.0)
+
+    input_grad = None
+    other_grad = None
+
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+    if are_required_outputs[1]:
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    ttnn.fill_bw(
+        grad_tensor,
+        input_tensor,
+        input_tensor2,
+        are_required_outputs=are_required_outputs,
+        input_grad=input_grad,
+        other_grad=other_grad,
+    )
+
+    tt_output_tensor_on_device = [input_grad, other_grad]
+
+    golden_function = ttnn.get_golden_function(ttnn.fill_bw)
+    golden_tensor = golden_function(grad_data, in_data, value=in_data2)
+
+    status = True
+    if are_required_outputs[0]:
+        status = status & compare_all_close([tt_output_tensor_on_device[0]], [golden_tensor[0]], atol=0, rtol=0)
+    if are_required_outputs[1]:
+        output_tensor = ttnn.from_device(tt_output_tensor_on_device[1])
+        tt_output = ttnn.to_torch(output_tensor)
+        tt_output = torch.tensor(tt_output[0][0][0][0], dtype=torch.float32)
+        status = status & torch.allclose(tt_output, golden_tensor[1], atol=0.001, rtol=0)
+    assert status

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -566,6 +566,25 @@ struct ExecuteUnaryBackwardFill {
         const Tensor &input_tensor_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt,
+        std::optional<Tensor> other_grad = std::nullopt);
 };
 
 struct ExecuteUnaryBackwardProd {

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -851,11 +851,17 @@ ttnn.attach_golden_function(ttnn.repeat_bw, golden_function=_golden_function)
 def _golden_function(grad_tensor, input_tensor, *args, value=2.0, **kwargs):
     import torch
 
-    input_tensor.retain_grad()
-    pyt_y = torch.fill(input_tensor, value)
-    pyt_y.backward(gradient=grad_tensor)
-
-    return [input_tensor.grad]
+    if isinstance(value, float) or isinstance(value, int):
+        input_tensor.retain_grad()
+        pyt_y = torch.fill(input_tensor, value)
+        pyt_y.backward(gradient=grad_tensor)
+        return [input_tensor.grad]
+    else:
+        input_tensor.retain_grad()
+        value.retain_grad()
+        pyt_y = torch.fill(input_tensor, value)
+        pyt_y.backward(gradient=grad_tensor)
+        return [input_tensor.grad, value.grad]
 
 
 ttnn.attach_golden_function(ttnn.fill_bw, golden_function=_golden_function)


### PR DESCRIPTION
### Ticket
Link to Github Issue #12941 

### Problem description
Added a variant of fill_bw which calculates gradient of value tensor (ie. when the fill_value is passed as a tensor)
At present, fill_bw calculates gradient for input_tensor

### What's changed
Added a variant of fill_bw which calculates gradient of value tensor (ie. when the fill_value is passed as a tensor)

Note: 
This second variant depends on reduce op giving the correct ttnn.sum(grad) which is not happening.
ttnn.sum gives correct results on Wormhole n300 for non-decimal inputs; for inputs with decimal values the output gap between TT and torch gets wider for larger shapes.
https://docs.google.com/document/d/1qtovD39ssbMSktVYcwqP5usByq9h3dQR19g9JYDhjAs/edit

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
