### PR TITLE
 #13065: Use the same action for building and running

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -80,7 +80,7 @@ runs:
           ${{ inputs.device }}
           -w ${{ github.workspace }}
         run: |
-          if [ ${{ inputs.install_wheel }} ]; then
+          if [ ${{ inputs.install_wheel }} = "true" ]; then
             WHEEL_FILENAME=$(ls -1 *.whl)
             pip3 install $WHEEL_FILENAME
           fi

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -90,7 +90,7 @@ jobs:
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
             -e ARCH_NAME=${{ matrix.arch }}
-          run: |
+          run_args: |
             nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
             nice -n 19 cmake --build build --target tests
             nice -n 19 cmake --build build --target install

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -84,37 +84,16 @@ jobs:
       - name: Update submodules
         run: |
           git submodule update --init --recursive
-      - name: Generate docker tag
-        id: generate-docker-tag
-        uses: ./.github/actions/generate-docker-tag
-        with:
-          image: ${{ inputs.os }}
-      - name: Docker login
-        uses: docker/login-action@v3
-        with:
-          registry: https://ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull docker image
-        run: docker pull ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
       - name: Build tt-metal and libs
-        uses: addnab/docker-run-action@v3
+        uses: ./.github/actions/docker-run
         with:
-          image: ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
-          options: |
-            --rm
-            -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
-            -v ${{ github.workspace }}:${{ github.workspace }}
-            -v /etc/passwd:/etc/passwd:ro
-            -v /etc/shadow:/etc/shadow:ro
-            -v /etc/bashrc:/etc/bashrc:ro
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
             -e ARCH_NAME=${{ matrix.arch }}
-            -w ${{ github.workspace }}
           run: |
             nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
             nice -n 19 cmake --build build --target tests
             nice -n 19 cmake --build build --target install
-
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -80,12 +80,9 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_username: ${{ github.actor }}
+          install_wheel: true
           docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_image_arch: ${{ inputs.arch }}
           run_args: |
-            WHEEL_FILENAME=$(ls -1 *.whl)
-            pip3 install --user $WHEEL_FILENAME
             ${{ matrix.test-group.cmd }}
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}


### PR DESCRIPTION
### Ticket

#13065 

### Problem description

We were working at the same time and solving similar issues from different angles resulting in very similar solutions.

1. Docker Run Action
https://github.com/tenstorrent/tt-metal/blob/cef573094c2b1ab296fc018477feabfb71576ccb/.github/actions/docker-run/action.yml#L56

2. Docker Run Action in Build Step
https://github.com/tenstorrent/tt-metal/blob/cef573094c2b1ab296fc018477feabfb71576ccb/.github/workflows/build-artifact.yaml#L100


### What's changed

The actions are actually near identical and so the generic Docker Run Action just needs to be incorporated into the build step.

Couple of other fixes:
- TTNN All Commit tests were modified during the rebase and I did not notice. Fixed.
- Boolean condition in Docker Run Action should be evaluated as string.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
