### PR TITLE
Add numeric stable option for softmax

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/test_softmax.py
@@ -9,8 +9,162 @@ import torch.nn.functional as F
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import skip_for_wormhole_b0, is_grayskull
 from models.utility_functions import torch_random
+
+
+@pytest.mark.parametrize(
+    "input_vector",
+    [[100.0, 101.0], [100.0, 1000.0], [-100.0, -101.0], [-1000.0, -100.0], [-100, -108, -99, -100, -101, -98]],
+)
+def test_softmax_stable_neg_values(device, input_vector):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.tensor([[[input_vector]]], dtype=torch.bfloat16)
+    torch_output_tensor = F.softmax(torch_input_tensor, dim=-1, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.softmax(input_tensor, dim=-1, numeric_stable=True)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+
+
+def run_softmax_stable_with_program_cache(device, batch_size, h, w, skip_scale_mask, math_approx):
+    torch.manual_seed(0)
+
+    scale = 1.0
+    attention_mask = torch.rand(batch_size, 1, 1, w)
+    attention_mask = (attention_mask > 0.5).float()
+    attention_mask = attention_mask.masked_fill(attention_mask == 0, torch.tensor(float("-inf"), dtype=torch.bfloat16))
+    attention_mask = attention_mask.masked_fill(attention_mask == 1, 0)
+    attention_mask_t = ttnn.from_torch(attention_mask, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    torch_input_tensor = torch_random((batch_size, 1, h, w), -1000, 1000, dtype=torch.bfloat16)
+    if not skip_scale_mask:
+        torch_output_tensor = torch_input_tensor * scale + attention_mask
+    else:
+        torch_output_tensor = torch_input_tensor
+    torch_output_tensor = F.softmax(torch_output_tensor, dim=-1, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    if is_grayskull():
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=math_approx,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=math_approx,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+    if not skip_scale_mask:
+        output_tensor = ttnn.scale_mask_softmax(
+            input_tensor, scale, attention_mask_t, compute_kernel_config=compute_kernel_config, numeric_stable=True
+        )
+    else:
+        output_tensor = ttnn.softmax(
+            input_tensor, dim=-1, compute_kernel_config=compute_kernel_config, numeric_stable=True
+        )
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+@pytest.mark.parametrize("h", [32, 128])
+@pytest.mark.parametrize("w", [1024, 1500])
+@pytest.mark.parametrize("skip_scale_mask", [True, False])
+@pytest.mark.parametrize("math_approx", [True, False])
+def test_softmax_stable_with_program_cache(device, batch_size, h, w, skip_scale_mask, math_approx, use_program_cache):
+    for _ in range(2):
+        run_softmax_stable_with_program_cache(device, batch_size, h, w, skip_scale_mask, math_approx)
+        # dummy tensor to change tensor alloc
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttnn.from_torch(
+            py_dummy_tensor,
+            dtype=ttnn.DataType.BFLOAT16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+    assert device.num_program_cache_entries() == 1
+
+
+def run_softmax_sharded_stable(device, batch_size, num_heads, h, w, skip_scale_mask):
+    torch.manual_seed(0)
+
+    grid_size = (batch_size, num_heads)
+
+    scale = 1.0
+    attention_mask = torch.rand(batch_size, 1, 1, w)
+    attention_mask = (attention_mask > 0.5).float()
+    attention_mask = attention_mask.masked_fill(attention_mask == 0, torch.tensor(float("-inf"), dtype=torch.bfloat16))
+    attention_mask = attention_mask.masked_fill(attention_mask == 1, 0)
+    attention_mask_t = ttnn.from_torch(attention_mask, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    torch_input_tensor = torch_random((batch_size, num_heads, h, w), -1000, 1000, dtype=torch.bfloat16)
+    if not skip_scale_mask:
+        torch_output_tensor = torch_input_tensor * scale + attention_mask
+    else:
+        torch_output_tensor = torch_input_tensor
+    torch_output_tensor = F.softmax(torch_output_tensor, dim=-1, dtype=torch.bfloat16)
+
+    memory_config = ttnn.create_sharded_memory_config(
+        torch_input_tensor.shape,
+        core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    program_config = ttnn.SoftmaxShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        subblock_w=6,
+        block_h=h // 32,
+        block_w=w // 32,
+    )
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config
+    )
+    if not skip_scale_mask:
+        output_tensor = ttnn.scale_mask_softmax_in_place(
+            input_tensor, scale, attention_mask_t, program_config=program_config, numeric_stable=True
+        )
+    else:
+        output_tensor = ttnn.scale_mask_softmax_in_place(
+            input_tensor, program_config=program_config, numeric_stable=True
+        )
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+
+
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("num_heads", [4])
+@pytest.mark.parametrize("h", [384])
+@pytest.mark.parametrize("w", [384])
+@pytest.mark.parametrize("skip_scale_mask", [True, False])
+def test_softmax_sharded_stable_with_program_cache(
+    device, batch_size, num_heads, h, w, skip_scale_mask, use_program_cache
+):
+    for _ in range(2):
+        run_softmax_sharded_stable(device, batch_size, num_heads, h, w, skip_scale_mask)
+        # dummy tensor to change tensor alloc
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttnn.from_torch(
+            py_dummy_tensor,
+            dtype=ttnn.DataType.BFLOAT16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+    assert device.num_program_cache_entries() == 1
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -13,7 +13,8 @@
 #include "compute_kernel_api/softmax.h"
 #include "compute_kernel_api/reduce.h"
 
-// #include "debug/dprint.h"
+#include "debug/dprint.h"
+#include "debug/dprint_tensix.h"
 
 ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
 ALWI void REL() { release_dst(tt::DstMode::Half); }
@@ -24,6 +25,46 @@ ALWI void REL() { release_dst(tt::DstMode::Half); }
 // Note that the attention mask will not fit in L1 for the entire tensor
 // The buffer for the att mask is currently sized as (1t,Wt) so we only reuse it for one HtWt-sized batch of x
 // then read another Wt tiles of mask for the next batch
+
+void calc_numeric_stable(uint32_t Wt, uint32_t ndst, uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t cb_max, uint32_t cb_out) {
+    // calculate max val per row
+    ACQ();
+    unpack_reconfig_data_format(cb_in, cb_bcast_scaler);
+    cb_reserve_back(cb_max, 1);
+    cb_wait_front(cb_bcast_scaler, 1);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>();
+    for (uint32_t wt = 0; wt < Wt; wt++) {
+        cb_wait_front(cb_in, wt+1);
+        constexpr uint32_t bcast_scaler0 = 0;
+        reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, wt, bcast_scaler0, 0);
+    }
+    reduce_revert_delta<ReduceDim::REDUCE_ROW>();
+    pack_tile(0, cb_max);
+    cb_push_back(cb_max, 1);
+    REL();
+
+    // calculate x-max(x)
+    exp_tile_init<EXP_APPROX>();
+    unpack_reconfig_data_format_srcb(cb_max);
+    cb_wait_front(cb_max, 1);
+    sub_bcast_cols_init_short();
+    for (uint32_t wt = 0; wt < Wt; wt += ndst) {
+        ACQ();
+        for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            sub_tiles_bcast_cols(cb_in, cb_max, wt+wt8, 0, wt8);
+        }
+        cb_reserve_back(cb_out, ndst);
+        for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
+            pack_tile(wt8, cb_out); // reuse the exps buffer again, this time in a circular manner
+        }
+        cb_push_back(cb_out, ndst);
+        REL();
+    }
+    cb_pop_front(cb_in, Wt);
+    cb_pop_front(cb_max, 1);
+    cb_wait_front(cb_out, Wt);
+}
 
 namespace NAMESPACE {
 void MAIN {
@@ -50,7 +91,12 @@ void MAIN {
     constexpr auto cb_recipsumexps = tt::CB::c_intermed1;
     constexpr auto cb_in0 = tt::CB::c_in0;
     constexpr auto cb_out0 = tt::CB::c_out0;
-
+    #ifdef NUMERIC_STABLE
+        constexpr auto cb_max = tt::CB::c_intermed2;
+        constexpr auto cb_x = tt::CB::c_intermed4;
+    #else
+        constexpr auto cb_x = cb_exps;
+    #endif
 
     cb_wait_front(cb_bcast_scaler, 1); // comes from the reader
 
@@ -81,38 +127,50 @@ void MAIN {
             }
             unpack_reconfig_data_format(cb_scale_mask, cb_fused_attn);
 
-            exp_tile_init<EXP_APPROX>();
+            #ifndef NUMERIC_STABLE
+                exp_tile_init<EXP_APPROX>();
+            #endif
+
             #ifdef CAUSAL_MASK
-            add_tiles_init();
+                add_tiles_init();
             #else
-            add_bcast_rows_init_short();
+                add_bcast_rows_init_short();
             #endif
             for (uint32_t wt = 0; wt < Wt; wt+=ndst) {
                 ACQ();
                 cb_wait_front(cb_scale_mask, ndst);
                 #ifdef CAUSAL_MASK
-                cb_wait_front(cb_fused_attn, wt+ndst); // cumulative wait for up to Wt tiles
-                for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
-                    add_tiles(cb_scale_mask, cb_fused_attn, wt8, wt+wt8, wt8); // tile *= 1/(sum(exp(x)))
-                }
+                    cb_wait_front(cb_fused_attn, wt+ndst); // cumulative wait for up to Wt tiles
+                    for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+                        add_tiles(cb_scale_mask, cb_fused_attn, wt8, wt+wt8, wt8); // tile *= 1/(sum(exp(x)))
+                    }
                 #else
-                if (wait_mask) {
-                    cb_wait_front(cb_fused_attn, wt+ndst); // cumulative wait for up to Wt tiles, only at first ht
-                }
+                    if (wait_mask) {
+                        cb_wait_front(cb_fused_attn, wt+ndst); // cumulative wait for up to Wt tiles, only at first ht
+                    }
 
-                for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
-                    add_tiles_bcast_rows(cb_scale_mask, cb_fused_attn, wt8, wt+wt8, wt8); // tile *= 1/(sum(exp(x)))
-                }
+                    for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+                        add_tiles_bcast_rows(cb_scale_mask, cb_fused_attn, wt8, wt+wt8, wt8); // tile *= 1/(sum(exp(x)))
+                    }
                 #endif
                 cb_pop_front(cb_scale_mask, ndst);
-                cb_reserve_back(cb_exps, ndst);
+                cb_reserve_back(cb_x, ndst);
                 for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
-                    exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
-                    pack_tile(wt8, cb_exps); // reuse the exps buffer again, this time in a circular manner
+                    #ifndef NUMERIC_STABLE
+                        exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
+                    #endif
+                    pack_tile(wt8, cb_x); // reuse the exps buffer again, this time in a circular manner
                 }
-                cb_push_back(cb_exps, ndst);
+                cb_push_back(cb_x, ndst);
                 REL();
             }
+
+            // add numeric_stable
+            // fuse exp with sub tiles
+            #ifdef NUMERIC_STABLE
+                calc_numeric_stable(Wt, ndst, cb_x, cb_bcast_scaler, cb_max, cb_exps);
+            #endif
+
             #ifdef CAUSAL_MASK
                 cb_pop_front(cb_fused_attn, Wt);
             #else
@@ -132,7 +190,9 @@ void MAIN {
             unpack_reconfig_data_format(cb_in0, cb_in0);
             pack_reconfig_data_format(cb_exps);
             copy_tile_to_dst_init_short(); // need to copy from CB to DST to be able to run sfpu math
-            exp_tile_init<EXP_APPROX>();
+            #ifndef NUMERIC_STABLE
+                exp_tile_init<EXP_APPROX>();
+            #endif
             if (mask_padded_data) {
                 for (uint32_t wt = 0; wt < Wt; wt+=ndst) {
                     ACQ();
@@ -149,32 +209,46 @@ void MAIN {
                     }
                     cb_pop_front(cb_in0, ndst);
 
-                    cb_reserve_back(cb_exps, ndst);
+                    cb_reserve_back(cb_x, ndst);
                     for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
-                        exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
-                        pack_tile(wt8, cb_exps); // DST[0]->cb_id[wt]
+                        #ifndef NUMERIC_STABLE
+                            exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
+                        #endif
+                        pack_tile(wt8, cb_x); // DST[0]->cb_id[wt]
                     }
-                    cb_push_back(cb_exps, ndst);
+                    cb_push_back(cb_x, ndst);
                     REL();
                 }
+
+                // add numeric_stable
+                // fuse exp with sub tiles
+                #ifdef NUMERIC_STABLE
+                    calc_numeric_stable(Wt, ndst, cb_x, cb_bcast_scaler, cb_max, cb_exps);
+                #endif
 
             } else {
-                for (uint32_t wt = 0; wt < Wt; wt+=ndst) {
-                    ACQ();
-                    cb_wait_front(cb_in0, ndst);
-                    for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
-                        copy_tile(cb_in0, wt8, wt8); // copy from c_in[0] to DST[0]
-                    }
-                    cb_pop_front(cb_in0, ndst);
+                // add numeric_stable
+                // fuse exp with sub tiles
+                #ifdef NUMERIC_STABLE
+                    calc_numeric_stable(Wt, ndst, cb_in0, cb_bcast_scaler, cb_max, cb_exps);
+                #else
+                    for (uint32_t wt = 0; wt < Wt; wt+=ndst) {
+                        ACQ();
+                        cb_wait_front(cb_in0, ndst);
+                        for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                            copy_tile(cb_in0, wt8, wt8); // copy from c_in[0] to DST[0]
+                        }
+                        cb_pop_front(cb_in0, ndst);
 
-                    cb_reserve_back(cb_exps, ndst);
-                    for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
-                        exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
-                        pack_tile(wt8, cb_exps); // DST[0]->cb_id[wt]
+                        cb_reserve_back(cb_exps, ndst);
+                        for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                            exp_tile<EXP_APPROX>(wt8); // exp on DST[0]
+                            pack_tile(wt8, cb_exps); // DST[0]->cb_id[wt]
+                        }
+                        cb_push_back(cb_exps, ndst);
+                        REL();
                     }
-                    cb_push_back(cb_exps, ndst);
-                    REL();
-                }
+                #endif
             }
 
             unpack_reconfig_data_format(cb_exps, cb_bcast_scaler);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -13,8 +13,54 @@
 #include "compute_kernel_api/softmax.h"
 #include "compute_kernel_api/reduce.h"
 
+#include "debug/dprint.h"
+
 ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
 ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+template<uint32_t block_w, uint32_t num_subblocks_w, uint32_t subblock_w>
+ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t cb_max, uint32_t cb_out) {
+    // calculate max val per row
+    ACQ();
+    unpack_reconfig_data_format(cb_in, cb_bcast_scaler);
+    cb_reserve_back(cb_max, 1);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>();
+    cb_wait_front(cb_bcast_scaler, 1);
+    for (uint32_t w = 0; w < block_w; w++) {
+        constexpr uint32_t bcast_scaler0 = 0;
+        reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, w, bcast_scaler0, 0);
+    }
+    reduce_revert_delta<ReduceDim::REDUCE_ROW>();
+    pack_tile(0, cb_max);
+    cb_push_back(cb_max, 1);
+    REL();
+
+    // calculate x-max(x)
+    exp_tile_init<EXP_APPROX>();
+    unpack_reconfig_data_format_srcb(cb_max);
+    cb_wait_front(cb_max, 1);
+    sub_bcast_cols_init_short();
+    uint32_t index_subblock_w_offset = 0;
+    for (uint32_t j = 0; j < num_subblocks_w; j++) {
+        ACQ();
+        cb_reserve_back(cb_out, subblock_w);
+        for (uint32_t w = 0; w < subblock_w; w++) {
+            uint32_t index = w + index_subblock_w_offset;
+            sub_tiles_bcast_cols(cb_in, cb_max, index, 0, w);
+        }
+        cb_reserve_back(cb_out, subblock_w);
+        for (uint32_t w = 0; w < subblock_w; w++) {
+            exp_tile<EXP_APPROX>(w);
+            pack_tile(w, cb_out);
+        }
+        cb_push_back(cb_out, subblock_w);
+        REL();
+        index_subblock_w_offset += subblock_w;
+    }
+    cb_pop_front(cb_in, block_w);
+    cb_pop_front(cb_max, 1);
+    cb_wait_front(cb_out, block_w);
+}
 
 namespace NAMESPACE {
 void MAIN {
@@ -34,6 +80,12 @@ void MAIN {
     constexpr auto cb_recipsumexps = tt::CB::c_intermed1;
     constexpr auto cb_scale_mask = tt::CB::c_intermed2;
     constexpr auto cb_out0 = tt::CB::c_out0;
+    #ifdef NUMERIC_STABLE
+        constexpr auto cb_max = tt::CB::c_intermed3;
+        constexpr auto cb_x = tt::CB::c_intermed4;
+    #else
+        constexpr auto cb_x = cb_exps;
+    #endif
 
     constexpr int dst0 = 0;
     int index_subblock_w_offset = 0;
@@ -45,7 +97,6 @@ void MAIN {
             unpack_reconfig_data_format(cb_in0, cb_fused_scale);
             pack_reconfig_data_format(cb_scale_mask);
             cb_wait_front(cb_fused_scale, 1);
-            // UNPACK(( DPRINT  << TSLICE(cb_fused_scale, 0, SliceRange::h0_w0_32()) << ENDL() ));
             mul_tiles_bcast_scalar_init_short();
             index_subblock_w_offset = 0;
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -78,7 +129,9 @@ void MAIN {
                 add_bcast_rows_init_short();
             #endif
 
-            exp_tile_init<EXP_APPROX>();
+            #ifndef NUMERIC_STABLE
+                exp_tile_init<EXP_APPROX>();
+            #endif
             for (uint32_t j = 0; j < num_subblocks_w; j++) {
                 ACQ();
                 #ifdef CAUSAL_MASK
@@ -92,16 +145,25 @@ void MAIN {
                         add_tiles_bcast_rows(cb_scale_mask, cb_fused_attn, index, index, w);
                     }
                 #endif
-                cb_reserve_back(cb_exps, subblock_w);
+                cb_reserve_back(cb_x, subblock_w);
                 for (uint32_t w = 0; w < subblock_w; w++) {
-                    exp_tile<EXP_APPROX>(w);
-                    pack_tile(w, cb_exps);
+                    #ifndef NUMERIC_STABLE
+                        exp_tile<EXP_APPROX>(w);
+                    #endif
+                    pack_tile(w, cb_x);
                 }
-                cb_push_back(cb_exps, subblock_w);
+                cb_push_back(cb_x, subblock_w);
                 REL();
                 index_subblock_w_offset += subblock_w;
             }
             cb_pop_front(cb_scale_mask, block_w);
+
+            // add numeric_stable
+            // fuse exp with sub tiles
+            #ifdef NUMERIC_STABLE
+                cb_wait_front(cb_x, block_w);
+                calc_numeric_stable<block_w, num_subblocks_w, subblock_w>(cb_x, cb_bcast_scaler, cb_max, cb_exps);
+            #endif
 
             #ifdef CAUSAL_MASK
                 cb_pop_front(cb_fused_attn, block_w);
@@ -109,29 +171,34 @@ void MAIN {
             unpack_reconfig_data_format(cb_exps, cb_bcast_scaler);
 
         #else
-            unpack_reconfig_data_format(cb_in0, cb_in0);
-            pack_reconfig_data_format(cb_exps);
-            // exp(x)
-            index_subblock_w_offset = 0;
-            copy_tile_to_dst_init_short();
-            exp_tile_init<EXP_APPROX>();
-            for (uint32_t j = 0; j < num_subblocks_w; j++) {
-                ACQ();
-                for (uint32_t w = 0; w < subblock_w; w++) {
-                    index = w + index_subblock_w_offset;
-                    copy_tile(cb_in0, index, w);
+
+            #ifdef NUMERIC_STABLE
+                calc_numeric_stable<block_w, num_subblocks_w, subblock_w>(cb_in0, cb_bcast_scaler, cb_max, cb_exps);
+            #else
+                unpack_reconfig_data_format(cb_in0, cb_in0);
+                pack_reconfig_data_format(cb_exps);
+                // exp(x)
+                index_subblock_w_offset = 0;
+                copy_tile_to_dst_init_short();
+                exp_tile_init<EXP_APPROX>();
+                for (uint32_t j = 0; j < num_subblocks_w; j++) {
+                    ACQ();
+                    for (uint32_t w = 0; w < subblock_w; w++) {
+                        index = w + index_subblock_w_offset;
+                        copy_tile(cb_in0, index, w);
+                    }
+                    cb_reserve_back(cb_exps, subblock_w);
+                    for (uint32_t w = 0; w < subblock_w; w++) {
+                        exp_tile<EXP_APPROX>(w);
+                        pack_tile(w, cb_exps);
+                    }
+                    cb_push_back(cb_exps, subblock_w);
+                    REL();
+                    index_subblock_w_offset += subblock_w;
                 }
-                cb_reserve_back(cb_exps, subblock_w);
-                for (uint32_t w = 0; w < subblock_w; w++) {
-                    exp_tile<EXP_APPROX>(w);
-                    pack_tile(w, cb_exps);
-                }
-                cb_push_back(cb_exps, subblock_w);
-                REL();
-                index_subblock_w_offset += subblock_w;
-            }
-            cb_pop_front(cb_in0, block_w);
-            unpack_reconfig_data_format(cb_exps, cb_bcast_scaler);
+                cb_pop_front(cb_in0, block_w);
+                unpack_reconfig_data_format(cb_exps, cb_bcast_scaler);
+            #endif
         #endif // FUSED_SCALE_MASK
 
         // sum(exp(x))

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.cpp
@@ -14,7 +14,8 @@ ttnn::Tensor ExecuteSoftmax::invoke(
     const ttnn::Tensor& input_tensor,
     const int dim_arg,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const bool numeric_stable) {
 
     auto input_shape = input_tensor.get_shape();
     auto rank = input_shape.size();
@@ -26,7 +27,7 @@ ttnn::Tensor ExecuteSoftmax::invoke(
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     if (dim == rank - 1) {
         auto output_tensor = ttnn::operations::normalization::softmax(
-            input_tensor_4D, memory_config.value_or(input_tensor.memory_config()), compute_kernel_config);
+            input_tensor_4D, memory_config.value_or(input_tensor.memory_config()), compute_kernel_config, numeric_stable);
         return ttnn::reshape(output_tensor, input_shape);
     } else {
         auto dim_4D = dim + 4 - rank;
@@ -41,26 +42,28 @@ ttnn::Tensor ExecuteScaleMaskSoftmax::invoke(
     const std::optional<const Tensor> mask,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const bool is_causal_mask,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const bool numeric_stable) {
 
     auto input_shape = input_tensor.get_shape();
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor =
-        ttnn::operations::normalization::scale_mask_softmax(input_tensor_4D, scale, mask, memory_config.value_or(input_tensor.memory_config()), is_causal_mask, compute_kernel_config);
+        ttnn::operations::normalization::scale_mask_softmax(input_tensor_4D, scale, mask, memory_config.value_or(input_tensor.memory_config()), is_causal_mask, compute_kernel_config, numeric_stable);
     return ttnn::reshape(output_tensor, input_shape);
 }
 
 ttnn::Tensor ExecuteSoftmaxInPlace::invoke(
     const ttnn::Tensor& input_tensor,
     const SoftmaxProgramConfig& program_config,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const bool numeric_stable) {
 
     auto input_shape = input_tensor.get_shape();
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor =
-        ttnn::operations::normalization::softmax_in_place(input_tensor_4D, program_config, compute_kernel_config);
+        ttnn::operations::normalization::softmax_in_place(input_tensor_4D, program_config, compute_kernel_config, numeric_stable);
     return ttnn::reshape(output_tensor, input_shape);
 }
 
@@ -70,13 +73,14 @@ ttnn::Tensor ExecuteScaleMaskSoftmaxInPlace::invoke(
     const std::optional<const Tensor> mask,
     const SoftmaxProgramConfig& program_config,
     const bool is_causal_mask,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const bool numeric_stable) {
 
     auto input_shape = input_tensor.get_shape();
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor =
-        ttnn::operations::normalization::scale_mask_softmax_in_place(input_tensor_4D, scale, mask, program_config, is_causal_mask, compute_kernel_config);
+        ttnn::operations::normalization::scale_mask_softmax_in_place(input_tensor_4D, scale, mask, program_config, is_causal_mask, compute_kernel_config, numeric_stable);
     return ttnn::reshape(output_tensor, input_shape);
 }
 
@@ -85,13 +89,14 @@ ttnn::Tensor ExecuteScaleCausalMaskHWSoftmaxInPlace::invoke(
     const std::optional<float> scale,
     const std::optional<const Tensor> mask,
     const SoftmaxProgramConfig& program_config,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const bool numeric_stable) {
 
     auto input_shape = input_tensor.get_shape();
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor =
-        ttnn::operations::normalization::scale_causal_mask_hw_dims_softmax_in_place(input_tensor_4D, scale, mask, program_config, compute_kernel_config);
+        ttnn::operations::normalization::scale_causal_mask_hw_dims_softmax_in_place(input_tensor_4D, scale, mask, program_config, compute_kernel_config, numeric_stable);
     return ttnn::reshape(output_tensor, input_shape);
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
@@ -18,7 +18,8 @@ struct ExecuteSoftmax {
         const ttnn::Tensor& input_tensor,
         const int dim_arg,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const bool numeric_stable = false);
 };
 
 struct ExecuteScaleMaskSoftmax {
@@ -29,7 +30,8 @@ struct ExecuteScaleMaskSoftmax {
         const std::optional<const Tensor> mask = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const bool is_causal_mask = false,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const bool numeric_stable = false);
 };
 
 struct ExecuteSoftmaxInPlace {
@@ -38,7 +40,8 @@ struct ExecuteSoftmaxInPlace {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const bool numeric_stable = false);
 };
 
 struct ExecuteScaleMaskSoftmaxInPlace {
@@ -50,7 +53,8 @@ struct ExecuteScaleMaskSoftmaxInPlace {
         const std::optional<const Tensor> mask = std::nullopt,
         const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
         const bool is_causal_mask = false,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const bool numeric_stable = false);
 };
 
 struct ExecuteScaleCausalMaskHWSoftmaxInPlace {
@@ -61,7 +65,8 @@ struct ExecuteScaleCausalMaskHWSoftmaxInPlace {
         const std::optional<float> scale = std::nullopt,
         const std::optional<const Tensor> mask = std::nullopt,
         const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const bool numeric_stable = false);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
@@ -66,14 +66,16 @@ void bind_normalization_softmax_operation(py::module& module) {
                 const ttnn::Tensor& input_tensor,
                 const int8_t dim,
                 const std::optional<ttnn::MemoryConfig>& memory_config,
-                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config) {
-                    return self(input_tensor, dim, memory_config, compute_kernel_config);
+                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config,
+                const bool numeric_stable) {
+                    return self(input_tensor, dim, memory_config, compute_kernel_config, numeric_stable);
                 },
                 py::arg("input_tensor").noconvert(),
                 py::arg("dim") = -1,
                 py::kw_only(),
                 py::arg("memory_config") = std::nullopt,
-                py::arg("compute_kernel_config").noconvert() = std::nullopt});
+                py::arg("compute_kernel_config").noconvert() = std::nullopt,
+                py::arg("numeric_stable").noconvert() = false});
 }
 
 void bind_normalization_scale_mask_softmax_operation(py::module& module) {
@@ -110,8 +112,9 @@ void bind_normalization_scale_mask_softmax_operation(py::module& module) {
                 const std::optional<const Tensor> mask,
                 const std::optional<ttnn::MemoryConfig>& memory_config,
                 const bool is_causal_mask,
-                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config) {
-                    return self(input_tensor, scale, mask, memory_config, is_causal_mask, compute_kernel_config);
+                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config,
+                const bool numeric_stable) {
+                    return self(input_tensor, scale, mask, memory_config, is_causal_mask, compute_kernel_config, numeric_stable);
                 },
                 py::arg("input_tensor").noconvert(),
                 py::arg("scale").noconvert() = std::nullopt,
@@ -119,7 +122,8 @@ void bind_normalization_scale_mask_softmax_operation(py::module& module) {
                 py::kw_only(),
                 py::arg("memory_config") = std::nullopt,
                 py::arg("is_causal_mask") = false,
-                py::arg("compute_kernel_config") = std::nullopt});
+                py::arg("compute_kernel_config") = std::nullopt,
+                py::arg("numeric_stable") = false});
 }
 
 void bind_normalization_softmax_in_place_operation(py::module& module) {
@@ -150,13 +154,15 @@ void bind_normalization_softmax_in_place_operation(py::module& module) {
             [] (const OperationType& self,
                 const ttnn::Tensor& input_tensor,
                 const SoftmaxProgramConfig& program_config,
-                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config) {
-                    return self(input_tensor, program_config, compute_kernel_config);
+                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config,
+                const bool numeric_stable) {
+                    return self(input_tensor, program_config, compute_kernel_config, numeric_stable);
                 },
                 py::arg("input_tensor").noconvert(),
                 py::kw_only(),
                 py::arg("program_config") = SoftmaxDefaultProgramConfig{},
-                py::arg("compute_kernel_config") = std::nullopt});
+                py::arg("compute_kernel_config") = std::nullopt,
+                py::arg("numeric_stable") = false});
 }
 
 void bind_normalization_scale_mask_softmax_in_place_operation(py::module& module) {
@@ -190,8 +196,9 @@ void bind_normalization_scale_mask_softmax_in_place_operation(py::module& module
                 const std::optional<const Tensor> mask,
                 const SoftmaxProgramConfig& program_config,
                 const bool is_causal_mask,
-                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config) {
-                    return self(input_tensor, scale, mask, program_config, is_causal_mask, compute_kernel_config);
+                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config,
+                const bool numeric_stable) {
+                    return self(input_tensor, scale, mask, program_config, is_causal_mask, compute_kernel_config, numeric_stable);
                 },
                 py::arg("input_tensor").noconvert(),
                 py::arg("scale").noconvert() = std::nullopt,
@@ -199,7 +206,8 @@ void bind_normalization_scale_mask_softmax_in_place_operation(py::module& module
                 py::kw_only(),
                 py::arg("program_config") = SoftmaxDefaultProgramConfig{},
                 py::arg("is_causal_mask") = false,
-                py::arg("compute_kernel_config") = std::nullopt});
+                py::arg("compute_kernel_config") = std::nullopt,
+                py::arg("numeric_stable") = false});
 }
 
 void bind_normalization_scale_causal_mask_hw_dims_softmax_in_place_operation(py::module& module) {
@@ -232,15 +240,17 @@ void bind_normalization_scale_causal_mask_hw_dims_softmax_in_place_operation(py:
                 const std::optional<float> scale,
                 const std::optional<const Tensor> mask,
                 const SoftmaxProgramConfig& program_config,
-                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config) {
-                    return self(input_tensor, scale, mask, program_config, compute_kernel_config);
+                const std::optional<const DeviceComputeKernelConfig>& compute_kernel_config,
+                const bool numeric_stable) {
+                    return self(input_tensor, scale, mask, program_config, compute_kernel_config, numeric_stable);
                 },
                 py::arg("input_tensor").noconvert(),
                 py::arg("scale").noconvert() = std::nullopt,
                 py::arg("mask").noconvert() = std::nullopt,
                 py::kw_only(),
                 py::arg("program_config") = SoftmaxDefaultProgramConfig{},
-                py::arg("compute_kernel_config") = std::nullopt});
+                py::arg("compute_kernel_config") = std::nullopt,
+                py::arg("numeric_stable") = false});
 }
 
 void bind_normalization_softmax(py::module& module) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12661

### Problem description
ttnn.softmax is unstable when numbers are large
tested input vectors ( all pos or all negs):
[100.0, 101.0], [100.0, 1000.0], [-100.0, -101.0], [-1000.0, -100.0], [-100, -108, -99, -100, -101, -98]

as well as large random inputs


### What's changed
add numeric_stable option for softmax, for each input x, we find the max value within a row, and x-max for each row

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/11035924652