### PR TITLE
Yolov4 optimize 

### DIFF
--- a/models/experimental/yolov4/ttnn/downsample1.py
+++ b/models/experimental/yolov4/ttnn/downsample1.py
@@ -33,15 +33,15 @@ class Down1:
         output_tensor_left = self.conv3(device, output_tensor_split)
         output_tensor_left = ttnn.mish(output_tensor_left)
 
-        res_block_split = self.conv4(device, output_tensor_split)
-        res_block_split = ttnn.mish(res_block_split)
-        output_tensor = self.conv5(device, res_block_split)
+        output_tensor_split_2 = self.conv4(device, output_tensor_split)
+        output_tensor_split_2 = ttnn.mish(output_tensor_split_2)
+        output_tensor = self.conv5(device, output_tensor_split_2)
         output_tensor = ttnn.mish(output_tensor)
         output_tensor = self.conv6(device, output_tensor)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = res_block_split + output_tensor
+        output_tensor = output_tensor_split_2 + output_tensor
 
-        ttnn.deallocate(res_block_split)
+        ttnn.deallocate(output_tensor_split_2)
         output_tensor = self.conv7(device, output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 

--- a/models/experimental/yolov4/ttnn/downsample1.py
+++ b/models/experimental/yolov4/ttnn/downsample1.py
@@ -17,7 +17,7 @@ class Down1:
         self.conv1 = Conv(torch_model, "down1.conv1", [1, 320, 320, 3], (1, 1, 1, 1), act_block_h=128)
         self.conv2 = Conv(torch_model, "down1.conv2", [1, 320, 320, 32], (2, 2, 1, 1), reshard=True)
         self.conv3 = Conv(torch_model, "down1.conv3", [1, 160, 160, 64], (1, 1, 0, 0), deallocate=False)
-        self.conv4 = Conv(torch_model, "down1.conv4", [1, 160, 160, 64], (1, 1, 0, 0), reshard=True)
+        self.conv4 = Conv(torch_model, "down1.conv4", [1, 160, 160, 64], (1, 1, 0, 0))
         self.conv5 = Conv(torch_model, "down1.conv5", [1, 160, 160, 64], (1, 1, 0, 0), deallocate=False)
         self.conv6 = Conv(torch_model, "down1.conv6", [1, 160, 160, 32], (1, 1, 1, 1))
         self.conv7 = Conv(torch_model, "down1.conv7", [1, 160, 160, 64], (1, 1, 0, 0))

--- a/models/experimental/yolov4/ttnn/downsample2.py
+++ b/models/experimental/yolov4/ttnn/downsample2.py
@@ -14,10 +14,10 @@ class Down2:
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
-        self.conv1 = Conv(torch_model, "down2.conv1", [1, 160, 160, 64], (2, 2, 1, 1), reshard=True)
-        self.conv2 = Conv(torch_model, "down2.conv2", [1, 80, 80, 128], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv1 = Conv(torch_model, "down2.conv1", [1, 160, 160, 64], (2, 2, 1, 1))
+        self.conv2 = Conv(torch_model, "down2.conv2", [1, 80, 80, 128], (1, 1, 0, 0), deallocate=False)
         self.conv3 = Conv(torch_model, "down2.conv3", [1, 80, 80, 128], (1, 1, 0, 0))
-        self.conv4 = Conv(torch_model, "down2.conv4", [1, 80, 80, 64], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv4 = Conv(torch_model, "down2.conv4", [1, 80, 80, 64], (1, 1, 0, 0), deallocate=False)
 
         self.res1_conv1 = Conv(
             torch_model, "down2.resblock.module_list.0.0", [1, 80, 80, 64], (1, 1, 0, 0), deallocate=False

--- a/models/experimental/yolov4/ttnn/downsample3.py
+++ b/models/experimental/yolov4/ttnn/downsample3.py
@@ -14,8 +14,13 @@ class Down3:
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
-        self.conv1 = Conv(torch_model, "down3.conv1", [1, 80, 80, 128], (2, 2, 1, 1), reshard=True)
-        self.conv2 = Conv(torch_model, "down3.conv2", [1, 40, 40, 256], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv1 = Conv(
+            torch_model,
+            "down3.conv1",
+            [1, 80, 80, 128],
+            (2, 2, 1, 1),
+        )
+        self.conv2 = Conv(torch_model, "down3.conv2", [1, 40, 40, 256], (1, 1, 0, 0), deallocate=False)
         self.conv3 = Conv(torch_model, "down3.conv3", [1, 40, 40, 256], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
@@ -51,7 +56,7 @@ class Down3:
         )
         self.res8_conv2 = Conv(torch_model, "down3.resblock.module_list.7.1", [1, 40, 40, 128], (1, 1, 1, 1))
 
-        self.conv4 = Conv(torch_model, "down3.conv4", [1, 40, 40, 128], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv4 = Conv(torch_model, "down3.conv4", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False)
 
         self.conv5 = Conv(torch_model, "down3.conv5", [1, 40, 40, 256], (1, 1, 0, 0))
 

--- a/models/experimental/yolov4/ttnn/downsample4.py
+++ b/models/experimental/yolov4/ttnn/downsample4.py
@@ -15,7 +15,7 @@ class Down4:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(torch_model, "down4.conv1", [1, 40, 40, 256], (2, 2, 1, 1), reshard=True)
-        self.conv2 = Conv(torch_model, "down4.conv2", [1, 20, 20, 512], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv2 = Conv(torch_model, "down4.conv2", [1, 20, 20, 512], (1, 1, 0, 0), deallocate=False)
         self.conv3 = Conv(torch_model, "down4.conv3", [1, 20, 20, 512], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
@@ -51,7 +51,7 @@ class Down4:
         )
         self.res8_conv2 = Conv(torch_model, "down4.resblock.module_list.7.1", [1, 20, 20, 256], (1, 1, 1, 1))
 
-        self.conv4 = Conv(torch_model, "down4.conv4", [1, 20, 20, 256], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv4 = Conv(torch_model, "down4.conv4", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False)
 
         self.conv5 = Conv(torch_model, "down4.conv5", [1, 20, 20, 512], (1, 1, 0, 0))
 

--- a/models/experimental/yolov4/ttnn/downsample4.py
+++ b/models/experimental/yolov4/ttnn/downsample4.py
@@ -19,41 +19,142 @@ class Down4:
         self.conv3 = Conv(torch_model, "down4.conv3", [1, 20, 20, 512], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.0.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.0.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            height_sharding=False,
+            deallocate=False,
         )
-        self.res1_conv2 = Conv(torch_model, "down4.resblock.module_list.0.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res1_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.0.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res2_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.1.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.1.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res2_conv2 = Conv(torch_model, "down4.resblock.module_list.1.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res2_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.1.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res3_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.2.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.2.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res3_conv2 = Conv(torch_model, "down4.resblock.module_list.2.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res3_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.2.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res4_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.3.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.3.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res4_conv2 = Conv(torch_model, "down4.resblock.module_list.3.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res4_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.3.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res5_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.4.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.4.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res5_conv2 = Conv(torch_model, "down4.resblock.module_list.4.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res5_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.4.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res6_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.5.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.5.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res6_conv2 = Conv(torch_model, "down4.resblock.module_list.5.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res6_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.5.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res7_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.6.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.6.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res7_conv2 = Conv(torch_model, "down4.resblock.module_list.6.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res7_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.6.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
         self.res8_conv1 = Conv(
-            torch_model, "down4.resblock.module_list.7.0", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down4.resblock.module_list.7.0",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
         )
-        self.res8_conv2 = Conv(torch_model, "down4.resblock.module_list.7.1", [1, 20, 20, 256], (1, 1, 1, 1))
+        self.res8_conv2 = Conv(
+            torch_model,
+            "down4.resblock.module_list.7.1",
+            [1, 20, 20, 256],
+            (1, 1, 1, 1),
+            height_sharding=False,
+        )
 
-        self.conv4 = Conv(torch_model, "down4.conv4", [1, 20, 20, 256], (1, 1, 0, 0), deallocate=False)
+        self.conv4 = Conv(
+            torch_model,
+            "down4.conv4",
+            [1, 20, 20, 256],
+            (1, 1, 0, 0),
+            deallocate=False,
+            height_sharding=False,
+        )
 
-        self.conv5 = Conv(torch_model, "down4.conv5", [1, 20, 20, 512], (1, 1, 0, 0))
+        self.conv5 = Conv(
+            torch_model,
+            "down4.conv5",
+            [1, 20, 20, 512],
+            (1, 1, 0, 0),
+            height_sharding=False,
+        )
 
     def __call__(self, device, input_tensor):
         output_tensor_split = self.conv1(device, input_tensor)

--- a/models/experimental/yolov4/ttnn/downsample5.py
+++ b/models/experimental/yolov4/ttnn/downsample5.py
@@ -17,7 +17,7 @@ class Down5:
         self.conv1 = Conv(
             torch_model, "down5.conv1", [1, 20, 20, 512], (2, 2, 1, 1), reshard=True, height_sharding=False
         )
-        self.conv2 = Conv(torch_model, "down5.conv2", [1, 10, 10, 1024], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv2 = Conv(torch_model, "down5.conv2", [1, 10, 10, 1024], (1, 1, 0, 0), deallocate=False)
         self.conv3 = Conv(torch_model, "down5.conv3", [1, 10, 10, 1024], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
@@ -37,7 +37,7 @@ class Down5:
         )
         self.res4_conv2 = Conv(torch_model, "down5.resblock.module_list.3.1", [1, 10, 10, 512], (1, 1, 1, 1))
 
-        self.conv4 = Conv(torch_model, "down5.conv4", [1, 10, 10, 512], (1, 1, 0, 0), reshard=True, deallocate=False)
+        self.conv4 = Conv(torch_model, "down5.conv4", [1, 10, 10, 512], (1, 1, 0, 0), deallocate=False)
 
         self.conv5 = Conv(torch_model, "down5.conv5", [1, 10, 10, 1024], (1, 1, 0, 0), height_sharding=False)
 

--- a/models/experimental/yolov4/ttnn/downsample5.py
+++ b/models/experimental/yolov4/ttnn/downsample5.py
@@ -17,29 +17,88 @@ class Down5:
         self.conv1 = Conv(
             torch_model, "down5.conv1", [1, 20, 20, 512], (2, 2, 1, 1), reshard=True, height_sharding=False
         )
-        self.conv2 = Conv(torch_model, "down5.conv2", [1, 10, 10, 1024], (1, 1, 0, 0), deallocate=False)
+        self.conv2 = Conv(
+            torch_model, "down5.conv2", [1, 10, 10, 1024], (1, 1, 0, 0), width_sharding=True, deallocate=False
+        )
         self.conv3 = Conv(torch_model, "down5.conv3", [1, 10, 10, 1024], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
-            torch_model, "down5.resblock.module_list.0.0", [1, 10, 10, 512], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down5.resblock.module_list.0.0",
+            [1, 10, 10, 512],
+            (1, 1, 0, 0),
+            deallocate=False,
+            width_sharding=True,
         )
-        self.res1_conv2 = Conv(torch_model, "down5.resblock.module_list.0.1", [1, 10, 10, 512], (1, 1, 1, 1))
+        self.res1_conv2 = Conv(
+            torch_model,
+            "down5.resblock.module_list.0.1",
+            [1, 10, 10, 512],
+            (1, 1, 1, 1),
+            width_sharding=True,
+        )
         self.res2_conv1 = Conv(
-            torch_model, "down5.resblock.module_list.1.0", [1, 10, 10, 512], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down5.resblock.module_list.1.0",
+            [1, 10, 10, 512],
+            (1, 1, 0, 0),
+            deallocate=False,
+            width_sharding=True,
         )
-        self.res2_conv2 = Conv(torch_model, "down5.resblock.module_list.1.1", [1, 10, 10, 512], (1, 1, 1, 1))
+        self.res2_conv2 = Conv(
+            torch_model,
+            "down5.resblock.module_list.1.1",
+            [1, 10, 10, 512],
+            (1, 1, 1, 1),
+            width_sharding=True,
+        )
         self.res3_conv1 = Conv(
-            torch_model, "down5.resblock.module_list.2.0", [1, 10, 10, 512], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down5.resblock.module_list.2.0",
+            [1, 10, 10, 512],
+            (1, 1, 0, 0),
+            deallocate=False,
+            width_sharding=True,
         )
-        self.res3_conv2 = Conv(torch_model, "down5.resblock.module_list.2.1", [1, 10, 10, 512], (1, 1, 1, 1))
+        self.res3_conv2 = Conv(
+            torch_model,
+            "down5.resblock.module_list.2.1",
+            [1, 10, 10, 512],
+            (1, 1, 1, 1),
+            width_sharding=True,
+        )
         self.res4_conv1 = Conv(
-            torch_model, "down5.resblock.module_list.3.0", [1, 10, 10, 512], (1, 1, 0, 0), deallocate=False
+            torch_model,
+            "down5.resblock.module_list.3.0",
+            [1, 10, 10, 512],
+            (1, 1, 0, 0),
+            deallocate=False,
+            width_sharding=True,
         )
-        self.res4_conv2 = Conv(torch_model, "down5.resblock.module_list.3.1", [1, 10, 10, 512], (1, 1, 1, 1))
+        self.res4_conv2 = Conv(
+            torch_model,
+            "down5.resblock.module_list.3.1",
+            [1, 10, 10, 512],
+            (1, 1, 1, 1),
+            width_sharding=True,
+        )
 
-        self.conv4 = Conv(torch_model, "down5.conv4", [1, 10, 10, 512], (1, 1, 0, 0), deallocate=False)
+        self.conv4 = Conv(
+            torch_model,
+            "down5.conv4",
+            [1, 10, 10, 512],
+            (1, 1, 0, 0),
+            deallocate=False,
+            width_sharding=True,
+        )
 
-        self.conv5 = Conv(torch_model, "down5.conv5", [1, 10, 10, 1024], (1, 1, 0, 0), height_sharding=False)
+        self.conv5 = Conv(
+            torch_model,
+            "down5.conv5",
+            [1, 10, 10, 1024],
+            (1, 1, 0, 0),
+            height_sharding=False,
+        )
 
     def __call__(self, device, input_tensor):
         output_tensor_split = self.conv1(device, input_tensor)

--- a/models/experimental/yolov4/ttnn/head.py
+++ b/models/experimental/yolov4/ttnn/head.py
@@ -15,14 +15,13 @@ class TtHead:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(torch_model, "head.conv1", [1, 40, 40, 128], (1, 1, 1, 1), reshard=True, deallocate=False)
-        self.conv2 = Conv(torch_model, "head.conv2", [1, 40, 40, 256], (1, 1, 0, 0), reshard=True, fused_op=False)
+        self.conv2 = Conv(torch_model, "head.conv2", [1, 40, 40, 256], (1, 1, 0, 0), fused_op=False)
         self.conv3 = Conv(torch_model, "head.conv3", [1, 40, 40, 128], (2, 2, 1, 1), reshard=True, deallocate=False)
         self.conv4 = Conv(
             torch_model,
             "head.conv4",
             [1, 20, 20, 512],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
         )
         self.conv5 = Conv(
@@ -30,14 +29,12 @@ class TtHead:
             "head.conv5",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
-            reshard=True,
         )
         self.conv6 = Conv(
             torch_model,
             "head.conv6",
             [1, 20, 20, 512],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
         )
         self.conv7 = Conv(
@@ -45,14 +42,12 @@ class TtHead:
             "head.conv7",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
-            reshard=True,
         )
         self.conv8 = Conv(
             torch_model,
             "head.conv8",
             [1, 20, 20, 512],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
         )
         self.conv9 = Conv(
@@ -60,7 +55,6 @@ class TtHead:
             "head.conv9",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
-            reshard=True,
             deallocate=False,
         )
         self.conv10 = Conv(
@@ -68,7 +62,6 @@ class TtHead:
             "head.conv10",
             [1, 20, 20, 512],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
             fused_op=False,
         )
@@ -84,7 +77,6 @@ class TtHead:
             "head.conv12",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
         )
         self.conv13 = Conv(
@@ -92,7 +84,6 @@ class TtHead:
             "head.conv13",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            reshard=True,
             height_sharding=False,
         )
         self.conv14 = Conv(
@@ -100,7 +91,6 @@ class TtHead:
             "head.conv14",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
         )
         self.conv15 = Conv(
@@ -108,7 +98,6 @@ class TtHead:
             "head.conv15",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            reshard=True,
             height_sharding=False,
         )
         self.conv16 = Conv(
@@ -116,7 +105,6 @@ class TtHead:
             "head.conv16",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
-            reshard=True,
             height_sharding=False,
         )
         self.conv17 = Conv(
@@ -124,7 +112,6 @@ class TtHead:
             "head.conv17",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            reshard=True,
             height_sharding=False,
         )
         self.conv18 = Conv(
@@ -132,7 +119,6 @@ class TtHead:
             "head.conv18",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
-            reshard=True,
             fused_op=False,
             height_sharding=False,
         )

--- a/models/experimental/yolov4/ttnn/head.py
+++ b/models/experimental/yolov4/ttnn/head.py
@@ -84,7 +84,7 @@ class TtHead:
             "head.conv13",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv14 = Conv(
             torch_model,
@@ -98,7 +98,7 @@ class TtHead:
             "head.conv15",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv16 = Conv(
             torch_model,
@@ -112,7 +112,7 @@ class TtHead:
             "head.conv17",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv18 = Conv(
             torch_model,

--- a/models/experimental/yolov4/ttnn/neck.py
+++ b/models/experimental/yolov4/ttnn/neck.py
@@ -29,7 +29,6 @@ class TtNeck:
             [1, 10, 10, 512],
             (1, 1, 1, 1),
             height_sharding=False,
-            reshard=True,
         )
         self.conv3 = Conv(
             torch_model,
@@ -45,7 +44,6 @@ class TtNeck:
             [1, 10, 10, 2048],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
         )
         self.conv5 = Conv(
             torch_model,
@@ -53,7 +51,6 @@ class TtNeck:
             [1, 10, 10, 512],
             (1, 1, 1, 1),
             height_sharding=False,
-            reshard=True,
         )
         self.conv6 = Conv(
             torch_model,
@@ -61,7 +58,6 @@ class TtNeck:
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
         )
         self.conv7 = Conv(
             torch_model,
@@ -69,7 +65,6 @@ class TtNeck:
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
             deallocate=False,
         )
         self.conv7_2 = Conv(
@@ -78,7 +73,6 @@ class TtNeck:
             [1, 20, 20, 512],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
         )
         self.conv7_3 = Conv(
             torch_model,
@@ -86,14 +80,12 @@ class TtNeck:
             [1, 20, 20, 512],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
         )
         self.conv8 = Conv(
             torch_model,
             "neek.conv10",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
-            reshard=True,
         )
         self.conv7_4 = Conv(
             torch_model,
@@ -101,7 +93,6 @@ class TtNeck:
             [1, 20, 20, 512],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
         )
         self.conv8_2 = Conv(
             torch_model,
@@ -116,7 +107,6 @@ class TtNeck:
             [1, 20, 20, 512],
             (1, 1, 0, 0),
             height_sharding=False,
-            reshard=True,
         )
 
         self.conv9 = Conv(
@@ -124,7 +114,6 @@ class TtNeck:
             "neek.conv14",
             [1, 20, 20, 256],
             (1, 1, 0, 0),
-            reshard=True,
             deallocate=False,
         )
         self.conv9_2 = Conv(
@@ -132,21 +121,18 @@ class TtNeck:
             "neek.conv15",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
-            reshard=True,
         )
         self.conv9_3 = Conv(
             torch_model,
             "neek.conv16",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
-            reshard=True,
         )
         self.conv10 = Conv(
             torch_model,
             "neek.conv17",
             [1, 40, 40, 128],
             (1, 1, 1, 1),
-            reshard=True,
         )
 
         self.conv9_4 = Conv(
@@ -154,21 +140,18 @@ class TtNeck:
             "neek.conv18",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
-            reshard=True,
         )
         self.conv10_2 = Conv(
             torch_model,
             "neek.conv19",
             [1, 40, 40, 128],
             (1, 1, 1, 1),
-            reshard=True,
         )
         self.conv9_5 = Conv(
             torch_model,
             "neek.conv20",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
-            reshard=True,
         )
 
     def __call__(self, device, input_tensor):

--- a/models/experimental/yolov4/ttnn/neck.py
+++ b/models/experimental/yolov4/ttnn/neck.py
@@ -28,7 +28,7 @@ class TtNeck:
             "neek.conv2",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv3 = Conv(
             torch_model,
@@ -50,7 +50,7 @@ class TtNeck:
             "neek.conv5",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv6 = Conv(
             torch_model,
@@ -64,7 +64,7 @@ class TtNeck:
             "neek.conv7",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
-            height_sharding=False,
+            width_sharding=True,
             deallocate=False,
         )
         self.conv7_2 = Conv(


### PR DESCRIPTION
This PR contains optimization of yolov4 model further.

Perf sheet before this PR for yolov4 model: [yolov4_on_main.csv](https://github.com/user-attachments/files/17125124/yolov4_on_main.csv)

Perf sheet of this PR for yolov4 model: [yolov4_on_commit.csv](https://github.com/user-attachments/files/17125129/yolov4_on_commit.csv)
 
Before FPS:
```
FPS (MatMul/Conv Ops only): 317.333
FPS (Other Device Ops): 111.086
FPS (All Ops): 87.412
```

FPS of yolov4 model available in this PR commits:
```
FPS (MatMul/Conv Ops only): 374.442
FPS (Other Device Ops): 115.42
FPS (All Ops): 93.463
```

There is a issue related to width_sharding #12930.