### PR TITLE
#13084: fix return vector optional tensor with launch_op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_examples.py
+++ b/tests/ttnn/unit_tests/operations/test_examples.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal
 
 
 @pytest.mark.parametrize("height", [64])
@@ -23,7 +23,7 @@ def test_example(device, height, width):
     output_tensor = ttnn.prim.example(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("height", [64])
@@ -38,38 +38,66 @@ def test_composite_example(device, height, width):
     output_tensor = ttnn.composite_example(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+    assert_equal(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("height", [64])
 @pytest.mark.parametrize("width", [128])
-def test_example_multiple_return(device, height, width):
+@pytest.mark.parametrize("return_outputs", [[False, True], [True, False], [True, True]])
+def test_example_multiple_return(device, height, width, return_outputs):
     torch.manual_seed(0)
 
+    return_output1, return_output2 = return_outputs
+
+    # run torch
     torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor
 
+    # run TT
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output1, output2 = ttnn.prim.example_multiple_return(input_tensor)
-    output_tensor1 = ttnn.to_torch(output1)
-    output_tensor2 = ttnn.to_torch(output2)
+    output1, output2 = ttnn.prim.example_multiple_return(
+        input_tensor, return_output1=return_output1, return_output2=return_output2
+    )
 
-    assert_with_pcc(torch_output_tensor, output_tensor1, 0.99)
-    assert_with_pcc(torch_output_tensor, output_tensor2, 0.99)
+    if return_output1:
+        output_tensor1 = ttnn.to_torch(output1)
+        assert_equal(torch_output_tensor, output_tensor1)
+    else:
+        assert output1 == None
+
+    if return_output2:
+        output_tensor2 = ttnn.to_torch(output2)
+        assert_equal(torch_output_tensor, output_tensor2)
+    else:
+        assert output2 == None
 
 
 @pytest.mark.parametrize("height", [64])
 @pytest.mark.parametrize("width", [128])
-def test_composite_example_multiple_return(device, height, width):
+@pytest.mark.parametrize("return_outputs", [[False, True], [True, False], [True, True]])
+def test_composite_example_multiple_return(device, height, width, return_outputs):
     torch.manual_seed(0)
 
+    return_output1, return_output2 = return_outputs
+
+    # run torch
     torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor
 
+    # run TT
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output1, output2 = ttnn.composite_example_multiple_return(input_tensor)
-    output_tensor1 = ttnn.to_torch(output1)
-    output_tensor2 = ttnn.to_torch(output2)
+    output1, output2 = ttnn.composite_example_multiple_return(
+        input_tensor, return_output1=return_output1, return_output2=return_output2
+    )
 
-    assert_with_pcc(torch_output_tensor, output_tensor1, 0.99)
-    assert_with_pcc(torch_output_tensor, output_tensor2, 0.99)
+    if return_output1:
+        output_tensor1 = ttnn.to_torch(output1)
+        assert_equal(torch_output_tensor, output_tensor1)
+    else:
+        assert output1 == None
+
+    if return_output2:
+        output_tensor2 = ttnn.to_torch(output2)
+        assert_equal(torch_output_tensor, output_tensor2)
+    else:
+        assert output2 == None

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -290,12 +290,15 @@ struct registered_operation_t {
             return output_tensors;
         } else if constexpr (std::is_same_v<execute_on_worker_thread_return_t, OptionalTensors>) {
             // convert tensor to optional tensor
-            std::vector<std::optional<Tensor>> ret;
-
             auto size = output_tensors.size();
-            ret.reserve(size);
+            std::vector<std::optional<Tensor>> ret(size);
+
+            auto return_flags = operation_t::create_async_return_flag(std::forward<decltype(args)>(args)...);
+
             for (uint32_t i = 0 ; i < size; i++) {
-                ret.push_back(output_tensors.at(i));
+                if (return_flags.at(i)) {
+                    ret[i] = output_tensors.at(i);
+                }
             }
             return ret;
         } else if constexpr (detail::is_homogenous_tuple<execute_on_worker_thread_return_t, Tensor>()) {

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
@@ -13,11 +13,7 @@ ExampleMultipleReturnDeviceOperation::program_factory_t ExampleMultipleReturnDev
 
 void ExampleMultipleReturnDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        TT_FATAL(attributes.return_output1 || attributes.return_output2,
-        "At least one output must be returned. return_output1 = {}, return_output2 = {} ",
-        attributes.return_output1,
-        attributes.return_output2);
-
+    validate_on_program_cache_hit(attributes, tensor_args);
 }
 
 void ExampleMultipleReturnDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
@@ -18,8 +18,10 @@ namespace ttnn::operations::examples {
 struct ExampleMultipleReturnDeviceOperation {
     // Define the operation attributes. This is it to store all variables needed by operations that aren't tensors
     struct operation_attributes_t {
-        bool attribute;
-        int some_other_attribute;
+        bool attribute = true;
+        int some_other_attribute = 42;
+        uint32_t return_output1 = true;
+        uint32_t return_output2 = true;
     };
 
     // Define the tensor arguments. This is it to store all tensors passed in and/or out of the operation
@@ -106,7 +108,7 @@ struct ExampleMultipleReturnDeviceOperation {
     // The user will be able to call the operation using `tensor_return_value_t output = ttnn::prim::example(input_tensor)` after the op is registered
     // Keep in mind that the the overload with `queue_id` argument will be added automatically for primitive operations
     // So, the user can also call this operation using `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor, bool return_output1, bool return_output2);
 
     // Optional methods
 

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
@@ -15,10 +15,6 @@ void kernel_main() {
     constexpr bool dst_is_dram1 = get_compile_time_arg_val(1) == 1;
     constexpr bool dst_is_dram2 = get_compile_time_arg_val(2) == 1;
 
-    #ifdef OUT_SHARDED
-    cb_wait_front(cb_id_out, num_tiles);
-    #else
-
     // single-tile ublocks
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
@@ -36,23 +32,21 @@ void kernel_main() {
         .data_format = data_format
     };
 
-    #ifdef BACKWARDS
-    uint32_t end_id = start_id - num_tiles;
-    for (uint32_t i = start_id; i != end_id; -- i) {
-    #else
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++ i) {
-    #endif
         cb_wait_front(cb_id_out, onetile);
 
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        noc_async_write_tile(i, s1, l1_read_addr);
-        noc_async_write_barrier();
+        if (dst_addr1 != 0) {
+            noc_async_write_tile(i, s1, l1_read_addr);
+            noc_async_write_barrier();
+        }
 
-        noc_async_write_tile(i, s2, l1_read_addr);
-        noc_async_write_barrier();
+        if (dst_addr2 != 0) {
+            noc_async_write_tile(i, s2, l1_read_addr);
+            noc_async_write_barrier();
+        }
 
         cb_pop_front(cb_id_out, onetile);
     }
-    #endif
 }

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
@@ -7,8 +7,8 @@
 
 namespace ttnn::operations::examples {
 
-std::vector<std::optional<Tensor>> CompositeExampleMutipleReturnOperation::invoke(const Tensor& input_tensor) {
-    return prim::example_multiple_return(input_tensor);
+std::vector<std::optional<Tensor>> CompositeExampleMutipleReturnOperation::invoke(const Tensor& input_tensor, bool return_output1, bool return_output2) {
+    return prim::example_multiple_return(input_tensor, return_output1, return_output2);
 }
 
 std::vector<Tensor> CompositeExampleMutipleReturnOperation::create_async_output_tensors(
@@ -17,6 +17,11 @@ std::vector<Tensor> CompositeExampleMutipleReturnOperation::create_async_output_
     return {
         Tensor(operation::get_workers_for_op_output({input_tensor})),
         Tensor(operation::get_workers_for_op_output({input_tensor}))};
+}
+
+std::vector<bool> CompositeExampleMutipleReturnOperation::create_async_return_flag(const Tensor& input_tensor, bool return_output1, bool return_output2) {
+
+    return {return_output1, return_output2};
 }
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp
@@ -14,10 +14,15 @@ namespace ttnn::operations::examples {
 struct CompositeExampleMutipleReturnOperation {
     // The user will be able to call this method as `Tensor output = ttnn::composite_example(input_tensor)` after the op
     // is registered
-    static std::vector<std::optional<Tensor>> invoke(const Tensor& input_tensor);
+    static std::vector<std::optional<Tensor>> invoke(const Tensor& input_tensor, bool return_output1, bool return_output2);
 
     static std::vector<Tensor> create_async_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
+
+    // The parameters of this function must be identical to those of invoke.
+    static std::vector<bool> create_async_return_flag(
+        const Tensor& input_tensor, bool return_output1, bool return_output2
+    );
 };
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.cpp
@@ -16,13 +16,21 @@ void bind_example_multiple_return_operation(py::module& module) {
         module,
         ttnn::prim::example_multiple_return,
         R"doc(example_multiple_return(input_tensor: ttnn.Tensor) -> std::vector<std::optional<ttnn.Tensor>>)doc",
-        ttnn::pybind_arguments_t{py::arg("input_tensor")});
+        ttnn::pybind_arguments_t{
+            py::arg("input_tensor"),
+            py::arg("return_output1"),
+            py::arg("return_output2")
+            });
 
     bind_registered_operation(
         module,
         ttnn::composite_example_multiple_return,
         R"doc(composite_example_multiple_return(input_tensor: ttnn.Tensor) -> std::vector<std::optional<Tensor>>)doc",
-        ttnn::pybind_arguments_t{py::arg("input_tensor")});
+        ttnn::pybind_arguments_t{
+            py::arg("input_tensor"),
+            py::arg("return_output1"),
+            py::arg("return_output2")
+            });
 }
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/run_operation_inl.hpp
+++ b/ttnn/cpp/ttnn/run_operation_inl.hpp
@@ -216,6 +216,12 @@ void launch_op(
                         if (!output_tensor || !local_tensor) {
                             continue;
                         }
+
+                        // The return type is vector<optional<Tensor>>, and this refers to the case where the i-th value is nullopt.
+                        if (output_tensor->tensor_attributes.use_count() != 0 && local_tensor->tensor_attributes.use_count() == 0) {
+                            continue;
+                        }
+
                         if (std::holds_alternative<OwnedStorage>(local_tensor->tensor_attributes->storage)) {
                             TT_ASSERT(
                                 output_tensor->tensor_attributes->dynamic_storage,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13084


### Problem description
There was an issue with the build not working when using vector<optional<tensor>> return along with launch_op, so I had to work on it. (https://github.com/tenstorrent/tt-metal/issues/12355)

However, after the changes, I confirmed that it works correctly with primitive ops using `register_operation`. But after merging, using `register_operation_with_auto_launch_op` results in a segmentation fault.

### What's changed

In this issue, I plan to modify the example that returns `vector<optional<tensor>>` so that it works correctly even when using `register_operation_with_auto_launch_op.`

While making modifications, I needed a way to determine which return values are `None` in Python. Since I couldn't verify this using the tensor's deallocated flag or `tensor_attributes.use_count()`, I created a function to indicate the position of `None`.

 The newly created `create_async_return_flag` function takes the same inputs as `invoke`, returns a boolean vector, and only needs to be implemented when the output type is `vector<optional<tensor>>`.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
