### PR TITLE
Add support for matmul 1D having L1 sharded weights

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -1173,6 +1173,7 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
 
 
+@run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "in0_dtype, in1_dtype, num_activation_cores, num_compute_cores",
     [

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -4,6 +4,7 @@
 
 import pytest
 import torch
+import math
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -1170,3 +1171,135 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+
+
+@pytest.mark.parametrize(
+    "in0_dtype, in1_dtype, num_activation_cores, num_compute_cores",
+    [
+        (ttnn.bfloat16, ttnn.bfloat4_b, 24, 24),
+    ],
+)
+def test_llama_ff1_matmul_in0_and_in1_sharded(device, in0_dtype, in1_dtype, num_activation_cores, num_compute_cores):
+    def padded_k_per_device_size_for_num_cores(num_cores, hidden_size):
+        padded_k = math.ceil(hidden_size / cluster_size[0] / num_cores / TILE_SIZE) * num_cores * TILE_SIZE
+        return padded_k
+
+    def padded_n_per_device_size_for_num_cores(num_cores, ff_size):
+        padded_n = math.ceil(ff_size / cluster_size[1] / num_cores / TILE_SIZE) * num_cores * TILE_SIZE
+        return padded_n
+
+    def core_range_for_num_cores(num_cores):
+        assert num_cores % 8 == 0
+        end_x_coord = min(num_cores - 1, 7)
+        end_y_coord = num_cores // 8 - 1
+        core_range = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(end_x_coord, end_y_coord),
+                ),
+            }
+        )
+        return core_range
+
+    def core_grid_size_for_num_cores(num_cores):
+        assert num_cores % 8 == 0
+        x = min(num_cores, 8)
+        y = num_cores // 8
+        core_grid = (x, y)
+        return core_grid
+
+    hidden_size = 8192
+    ff_size = 28 * 1024
+    cluster_size = (4, 8)
+    M = 32
+    TILE_SIZE = 32
+
+    K = padded_k_per_device_size_for_num_cores(num_activation_cores, hidden_size)
+    N = ff_size // cluster_size[1]
+    N_padded = padded_n_per_device_size_for_num_cores(num_compute_cores, ff_size)
+
+    # Weights
+    mem_config_weights = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            core_range_for_num_cores(num_compute_cores),
+            [
+                K,
+                N_padded // num_compute_cores,
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+
+    # Input
+    mem_config_input = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            core_range_for_num_cores(num_activation_cores),
+            [
+                M,
+                K // num_activation_cores,
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    input_shape = [1, 1, M, K]
+    input_tensor = torch.randn(input_shape).float()
+    tt_input_tensor = ttnn.as_tensor(
+        input_tensor,
+        dtype=in0_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config_input,
+    )
+
+    weights_tensor = torch.randn([1, 1, K, N]).float()
+    weight_tt = ttnn.as_tensor(
+        weights_tensor,
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config_weights,
+    )
+
+    mm_core_grid = core_grid_size_for_num_cores(num_compute_cores)
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=mm_core_grid,
+        in0_block_w=K // num_compute_cores // 32,  # K // num_cores // 32; how much inner dim you take each time
+        out_subblock_h=1,  # Must be divisible by per_core_M
+        out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4; per_core_N = 5 so can only use 1 here
+        per_core_M=M // 32,  # M / TILE_HEIGHT / Grid_Size
+        per_core_N=N_padded // 32 // (mm_core_grid[0] * mm_core_grid[1]),
+        mcast_in0=True,
+        fused_activation=None,
+        fuse_batch=True,
+    )
+
+    tt_matmul_out_tensor = ttnn.matmul(
+        tt_input_tensor,
+        weight_tt,
+        memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    tt_mm_out = ttnn.from_device(tt_matmul_out_tensor)
+    tt_mm_out = ttnn.to_torch(tt_mm_out)
+
+    # Torch reference
+    matmul_output = torch.matmul(input_tensor, weights_tensor)
+
+    assert_with_pcc(matmul_output, tt_mm_out, pcc=0.993)

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -1185,6 +1185,8 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
 def test_matmul_in0_in1_bias_sharded(
     device, in0_dtype, in1_dtype, num_activation_cores, num_compute_cores, has_bias, config, M, K, N
 ):
+    torch.manual_seed(0)
+
     def padded_size_per_device_for_num_cores(size, num_devices, num_cores):
         padded_size = math.ceil(size / num_devices / num_cores / TILE_SIZE) * num_cores * TILE_SIZE
         return padded_size
@@ -1276,7 +1278,7 @@ def test_matmul_in0_in1_bias_sharded(
     )
 
     input_shape = [1, 1, M, K]
-    input_tensor = torch.randn(input_shape).float()
+    input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
     tt_input_tensor = ttnn.as_tensor(
         input_tensor,
         dtype=in0_dtype,
@@ -1285,7 +1287,7 @@ def test_matmul_in0_in1_bias_sharded(
         memory_config=mem_config_input,
     )
 
-    weights_tensor = torch.randn([1, 1, K, N]).float()
+    weights_tensor = torch.randn([1, 1, K, N], dtype=torch.bfloat16)
     weight_tt = ttnn.as_tensor(
         weights_tensor,
         dtype=in1_dtype,
@@ -1295,7 +1297,7 @@ def test_matmul_in0_in1_bias_sharded(
     )
 
     if has_bias:
-        bias_tensor = torch.randn([1, 1, 1, N]).float() * 2.0
+        bias_tensor = torch.randn([1, 1, 1, N], dtype=torch.bfloat16) * 2.0
         bias_tt = ttnn.as_tensor(
             bias_tensor,
             dtype=ttnn.bfloat16,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -132,8 +132,8 @@ void kernel_main() {
 
 //  READER
 #ifdef IN1_SHARDED
-    cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-    cb_push_back(cb_id_in1, in1_block_num_tiles);
+    cb_reserve_back(cb_id_in1, in1_block_num_tiles*num_blocks);
+    cb_push_back(cb_id_in1, in1_block_num_tiles*num_blocks);
 #else
     uint32_t l1_write_addr_in1;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1123,7 +1123,10 @@ void Matmul::validate(
                         TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                     }
                 }
-                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+                if (input_tensor_b.memory_config().is_sharded()) {
+                    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Operand B can only be interleaved or width sharded.");
+                    TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / TILE_WIDTH), "Shard width must match per core N.");
+                }
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1088,8 +1088,8 @@ void Matmul::validate(
 
                         TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                     }
-                    if (input_tensor_b.memory_config().is_sharded()) {
-                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Operand B can only be interleaved or width sharded.");
+                    if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1 && input_tensor_b.memory_config().is_sharded()) {
+                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Operand B can only be interleaved or L1 width sharded.");
                         TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / in1_tile_shape[1]), "Shard width must match per core N.");
                         if (optional_bias.has_value()) {
                             TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1043,7 +1043,7 @@ void Matmul::validate(
     }
 
     std::visit(
-        [input_tensor_a, input_tensor_b, in0_tile_shape, in1_tile_shape, this](const auto& program_config) {
+        [input_tensor_a, input_tensor_b, optional_bias, in0_tile_shape, in1_tile_shape, this](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core or single row/col
             // We can uplift these variants to skip mcasting to support single core (1D) or single row/col (2D)
@@ -1088,6 +1088,15 @@ void Matmul::validate(
 
                         TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                     }
+                    if (input_tensor_b.memory_config().is_sharded()) {
+                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Operand B can only be interleaved or width sharded.");
+                        TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / in1_tile_shape[1]), "Shard width must match per core N.");
+                        if (optional_bias.has_value()) {
+                            TT_FATAL(
+                                input_tensor_b.shard_spec().value().shape[1] == optional_bias.value().shard_spec().value().shape[1],
+                                "Bias shard spec width must match second inputs shard spec width.");
+                        }
+                    }
                 } else {
                     if (input_tensor_a.memory_config().is_sharded()) {
                         TT_FATAL(program_config.fuse_batch, "Error");
@@ -1122,10 +1131,7 @@ void Matmul::validate(
                         TT_FATAL(N == per_core_N, "Error");
                         TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                     }
-                }
-                if (input_tensor_b.memory_config().is_sharded()) {
-                    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Operand B can only be interleaved or width sharded.");
-                    TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / TILE_WIDTH), "Shard width must match per core N.");
+                    TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
                 }
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,


### PR DESCRIPTION
### Ticket
Link to [Github Issue](https://github.com/tenstorrent/tt-metal/issues/13090)

### Problem description
For DRAM pre-fetching we need to access weight shards from local L1.

### What's changed
Added support for L1 sharded in1 operand.
Changes:
- Validate check for shard width = per core N
- Updating in1 CB creation/buffer binding etc for sharded inputs
- Added test case for llama FF1 type matmul 1D using L1 sharded in1 on 24 cores (as will be the case for dram pre-fetching)

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11143155808
- [x] New/Existing tests provide coverage for changes
