### PR TITLE
#13088: Cleanup set-1 unary backward ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -666,7 +666,7 @@ std::vector<Tensor> ExecuteUnaryBackwardCelu::invoke(
 }
 
 
-std::vector<Tensor> _rpow_bw(
+std::vector<Tensor> ExecuteUnaryBackwardRpow::invoke(
     const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_nan = std::nanf("");
@@ -1139,7 +1139,7 @@ std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const std:
 }
 
 
-std::vector<Tensor> _div_no_nan_bw(
+std::vector<Tensor> ExecuteUnaryBackwardDivNoNan::invoke(
     const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor zeros = ttnn::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
@@ -1258,7 +1258,7 @@ std::vector<Tensor> _digamma_bw(const Tensor& grad, const Tensor& input, const s
     return grad_tensor;
 }
 
-std::vector<Tensor> _polygamma_bw(
+std::vector<Tensor> ExecuteUnaryBackwardPolygamma::invoke(
     const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input.memory_config());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -60,7 +60,6 @@ enum class UnaryBackwardOpType {
     DIV_NO_NAN_BW,
     EXP2_BW,
     EXPM1_BW,
-    RECIPROCAL_BW,
     DIGAMMA_BW,
     ERFINV_BW,
     ERF_BW,
@@ -78,7 +77,6 @@ std::vector<Tensor> _fill_zero_bw( const Tensor& grad, const Tensor& input, cons
 std::vector<Tensor> _i0_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _tan_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _sigmoid_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _reciprocal_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _softsign_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _cosh_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -176,13 +174,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::SIGMOID_BW> {
     static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
         return _sigmoid_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RECIPROCAL_BW> {
-    static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-        return _reciprocal_bw(grad, input, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -35,7 +35,6 @@ enum class UnaryBackwardOpType {
     SIGMOID_BW,
     RELU_BW,
     LOGIT_BW,
-    RPOW_BW,
     FLOOR_BW,
     ROUND_BW,
     LOG_BW,
@@ -57,14 +56,12 @@ enum class UnaryBackwardOpType {
     COSH_BW,
     LOG2_BW,
     SIGN_BW,
-    DIV_NO_NAN_BW,
     EXP2_BW,
     EXPM1_BW,
     DIGAMMA_BW,
     ERFINV_BW,
     ERF_BW,
     DEG2RAD_BW,
-    POLYGAMMA_BW,
 };
 
 std::vector<Tensor> _acos_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -102,9 +99,6 @@ std::vector<Tensor> _relu6_bw(const Tensor& grad, const Tensor& input, const std
 std::vector<Tensor> _selu_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _square_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 
-std::vector<Tensor> _rpow_bw( const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _div_no_nan_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _polygamma_bw( const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _sub_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _gt_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config);
 
@@ -127,13 +121,6 @@ Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_
 // OpHandler struct template
 template <UnaryBackwardOpType OpType>
 struct OpHandler;
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RPOW_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _rpow_bw(grad, input, exponent, output_mem_config);
-    }
-};
 
 template <>
 struct OpHandler<UnaryBackwardOpType::ACOS_BW> {
@@ -370,20 +357,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::SQUARE_BW> {
     static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
         return _square_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::DIV_NO_NAN_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float exponent, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _div_no_nan_bw(grad, input, exponent, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::POLYGAMMA_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, int n, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _polygamma_bw(grad, input, n, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -72,14 +72,22 @@ struct ExecuteUnaryBackwardWoFloat {
 
 };
 
-#define DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(op_name) \
-struct ExecuteUnaryBackward##op_name { \
-    static std::vector<Tensor> invoke( \
-         const Tensor &grad_tensor_arg, \
-        const Tensor &input_tensor_arg, \
-        float parameter_a, \
-        float parameter_b, \
-        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
+struct ExecuteUnaryBackwardSoftplus {
+    static std::vector<Tensor> invoke(
+         const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        float parameter_b,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardHardtanh {
+    static std::vector<Tensor> invoke(
+         const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        float parameter_b,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
 #define DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(op_name) \
@@ -300,9 +308,6 @@ struct ExecuteUnaryBackwardGelu{
         std::optional<Tensor> input_grad = std::nullopt);
 
 };
-
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Softplus)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_2_DEFAULT_FLOATS(Hardtanh)
 
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Hardshrink)
 DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Softshrink)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -392,10 +392,6 @@ constexpr auto acosh_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardWoFloat<
         operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
 
-constexpr auto rpow_bw = ttnn::register_operation<"ttnn::rpow_bw", operations::unary_backward::ExecuteUnaryBackwardRpow>();
-constexpr auto div_no_nan_bw = ttnn::register_operation<"ttnn::div_no_nan_bw", operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
-constexpr auto polygamma_bw = ttnn::register_operation<"ttnn::polygamma_bw",operations::unary_backward::ExecuteUnaryBackwardPolygamma>();
-
 //ExecuteUnaryBackwardOp : get_function_type1
 constexpr auto acos_bw = ttnn::register_operation<
     "ttnn::acos_bw",
@@ -575,20 +571,9 @@ constexpr auto erfc_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardOp<
         operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>();
 
-constexpr auto logiteps_bw = ttnn::register_operation<"ttnn::logiteps_bw", operations::unary_backward::ExecuteUnaryBackwardLogiteps>();
-constexpr auto celu_bw = ttnn::register_operation<"ttnn::celu_bw", operations::unary_backward::ExecuteUnaryBackwardCelu>();
-constexpr auto elu_bw = ttnn::register_operation<"ttnn::elu_bw", operations::unary_backward::ExecuteUnaryBackwardElu>();
-constexpr auto leaky_relu_bw = ttnn::register_operation<"ttnn::leaky_relu_bw", operations::unary_backward::ExecuteUnaryBackwardLeakyRelu>();
-constexpr auto softshrink_bw = ttnn::register_operation<"ttnn::softshrink_bw", operations::unary_backward::ExecuteUnaryBackwardSoftshrink>();
-constexpr auto hardshrink_bw = ttnn::register_operation<"ttnn::hardshrink_bw", operations::unary_backward::ExecuteUnaryBackwardHardshrink>();
-
 constexpr auto clamp_bw = ttnn::register_operation<
     "ttnn::clamp_bw",
     operations::unary_backward::ExecuteUnaryBackwardClamp>();
-
-constexpr auto hardtanh_bw = ttnn::register_operation<"ttnn::hardtanh_bw", operations::unary_backward::ExecuteUnaryBackwardHardtanh>();
-constexpr auto softplus_bw = ttnn::register_operation<"ttnn::softplus_bw", operations::unary_backward::ExecuteUnaryBackwardSoftplus>();
-
 
 constexpr auto rdiv_bw = ttnn::register_operation<
     "ttnn::rdiv_bw",
@@ -620,10 +605,6 @@ constexpr auto silu_bw = ttnn::register_operation<
     "ttnn::silu_bw",
     operations::unary_backward::ExecuteUnaryBackwardSilu>();
 
-constexpr auto prod_bw = ttnn::register_operation<
-    "ttnn::prod_bw",
-    operations::unary_backward::ExecuteUnaryBackwardProd>();
-
 constexpr auto relu_bw = ttnn::register_operation<
     "ttnn::relu_bw",
     operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::RELU_BW>>();
@@ -640,13 +621,19 @@ constexpr auto log_bw = ttnn::register_operation<
     "ttnn::log_bw",
     operations::unary_backward::ExecuteUnaryBackwardWoFloat<operations::unary_backward::UnaryBackwardOpType::LOG_BW>>();
 
-// overload
-constexpr auto reciprocal_bw = ttnn::register_operation<
-    "ttnn::reciprocal_bw",
-    operations::unary_backward::ExecuteUnaryBackwardRecip>();
-
-constexpr auto abs_bw = ttnn::register_operation<
-    "ttnn::abs_bw",
-    operations::unary_backward::ExecuteUnaryBackwardAbs>();
+constexpr auto logiteps_bw = ttnn::register_operation<"ttnn::logiteps_bw", operations::unary_backward::ExecuteUnaryBackwardLogiteps>();
+constexpr auto celu_bw = ttnn::register_operation<"ttnn::celu_bw", operations::unary_backward::ExecuteUnaryBackwardCelu>();
+constexpr auto elu_bw = ttnn::register_operation<"ttnn::elu_bw", operations::unary_backward::ExecuteUnaryBackwardElu>();
+constexpr auto leaky_relu_bw = ttnn::register_operation<"ttnn::leaky_relu_bw", operations::unary_backward::ExecuteUnaryBackwardLeakyRelu>();
+constexpr auto softshrink_bw = ttnn::register_operation<"ttnn::softshrink_bw", operations::unary_backward::ExecuteUnaryBackwardSoftshrink>();
+constexpr auto hardshrink_bw = ttnn::register_operation<"ttnn::hardshrink_bw", operations::unary_backward::ExecuteUnaryBackwardHardshrink>();
+constexpr auto hardtanh_bw = ttnn::register_operation<"ttnn::hardtanh_bw", operations::unary_backward::ExecuteUnaryBackwardHardtanh>();
+constexpr auto softplus_bw = ttnn::register_operation<"ttnn::softplus_bw", operations::unary_backward::ExecuteUnaryBackwardSoftplus>();
+constexpr auto rpow_bw = ttnn::register_operation<"ttnn::rpow_bw", operations::unary_backward::ExecuteUnaryBackwardRpow>();
+constexpr auto div_no_nan_bw = ttnn::register_operation<"ttnn::div_no_nan_bw", operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
+constexpr auto polygamma_bw = ttnn::register_operation<"ttnn::polygamma_bw", operations::unary_backward::ExecuteUnaryBackwardPolygamma>();
+constexpr auto reciprocal_bw = ttnn::register_operation<"ttnn::reciprocal_bw", operations::unary_backward::ExecuteUnaryBackwardRecip>();
+constexpr auto abs_bw = ttnn::register_operation<"ttnn::abs_bw", operations::unary_backward::ExecuteUnaryBackwardAbs>();
+constexpr auto prod_bw = ttnn::register_operation<"ttnn::prod_bw", operations::unary_backward::ExecuteUnaryBackwardProd>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -37,28 +37,29 @@ struct ExecuteUnaryBackwardThreshold {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-template <UnaryBackwardOpType unary_backward_op_type>
-struct ExecuteUnaryBackwardFloat {
+struct ExecuteUnaryBackwardRpow {
     static std::vector<Tensor> invoke(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float scalar,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, scalar, output_memory_config);
-        }
-
-    static std::vector<Tensor> invoke(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
-        }
-
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
+struct ExecuteUnaryBackwardDivNoNan {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float scalar,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardPolygamma {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        int scalar,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
 
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardWoFloat {
@@ -391,20 +392,9 @@ constexpr auto acosh_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardWoFloat<
         operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
 
-constexpr auto rpow_bw = ttnn::register_operation<
-    "ttnn::rpow_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloat<
-        operations::unary_backward::UnaryBackwardOpType::RPOW_BW>>();
-
-constexpr auto div_no_nan_bw = ttnn::register_operation<
-    "ttnn::div_no_nan_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloat<
-        operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>();
-
-constexpr auto polygamma_bw = ttnn::register_operation<
-    "ttnn::polygamma_bw",
-    operations::unary_backward::ExecuteUnaryBackwardFloat<
-        operations::unary_backward::UnaryBackwardOpType::POLYGAMMA_BW>>();
+constexpr auto rpow_bw = ttnn::register_operation<"ttnn::rpow_bw", operations::unary_backward::ExecuteUnaryBackwardRpow>();
+constexpr auto div_no_nan_bw = ttnn::register_operation<"ttnn::div_no_nan_bw", operations::unary_backward::ExecuteUnaryBackwardDivNoNan>();
+constexpr auto polygamma_bw = ttnn::register_operation<"ttnn::polygamma_bw",operations::unary_backward::ExecuteUnaryBackwardPolygamma>();
 
 //ExecuteUnaryBackwardOp : get_function_type1
 constexpr auto acos_bw = ttnn::register_operation<
@@ -585,7 +575,6 @@ constexpr auto erfc_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardOp<
         operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>();
 
-// Tensor + Float(Default)
 constexpr auto logiteps_bw = ttnn::register_operation<"ttnn::logiteps_bw", operations::unary_backward::ExecuteUnaryBackwardLogiteps>();
 constexpr auto celu_bw = ttnn::register_operation<"ttnn::celu_bw", operations::unary_backward::ExecuteUnaryBackwardCelu>();
 constexpr auto elu_bw = ttnn::register_operation<"ttnn::elu_bw", operations::unary_backward::ExecuteUnaryBackwardElu>();
@@ -597,7 +586,6 @@ constexpr auto clamp_bw = ttnn::register_operation<
     "ttnn::clamp_bw",
     operations::unary_backward::ExecuteUnaryBackwardClamp>();
 
-// Tensor + Float(Default) + Float(Default)
 constexpr auto hardtanh_bw = ttnn::register_operation<"ttnn::hardtanh_bw", operations::unary_backward::ExecuteUnaryBackwardHardtanh>();
 constexpr auto softplus_bw = ttnn::register_operation<"ttnn::softplus_bw", operations::unary_backward::ExecuteUnaryBackwardSoftplus>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -90,13 +90,60 @@ struct ExecuteUnaryBackwardHardtanh {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
-#define DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(op_name) \
-struct ExecuteUnaryBackward##op_name { \
-    static std::vector<Tensor> invoke( \
-        const Tensor &grad_tensor_arg, \
-        const Tensor &input_tensor_arg, \
-        float parameter_a, \
-        const std::optional<MemoryConfig> &memory_config = std::nullopt); \
+struct ExecuteUnaryBackward {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardHardshrink {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardSoftshrink {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardLeakyRelu {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardElu {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardCelu {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
+struct ExecuteUnaryBackwardLogiteps {
+    static std::vector<Tensor> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float parameter_a,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
 template <UnaryBackwardOpType unary_backward_op_type>
@@ -308,13 +355,6 @@ struct ExecuteUnaryBackwardGelu{
         std::optional<Tensor> input_grad = std::nullopt);
 
 };
-
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Hardshrink)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Softshrink)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(LeakyRelu)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Elu)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Celu)
-DEFINE_UNARY_BACKWARD_OPERATION_WITH_1_DEFAULT_FLOAT(Logiteps)
 
 }  // operations::unary
 


### PR DESCRIPTION
Issue : #13088

[CI](https://github.com/tenstorrent/tt-metal/actions/runs/11031028313) : PASSED

**Test Files :** 

- hardshrink_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_hardshrink.py` - PASSED
- softshrink_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_softshrink.py` - PASSED
- leaky_relu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_leaky_relu.py` - PASSED
- elu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_elu.py` - PASSED
- celu_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_celu.py` - PASSED
- logiteps_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_logiteps.py` - PASSED
- rpow_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_rpow.py` - PASSED
- polygamma_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_polygammapy` - PASSED
- div_no_nan_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_div_no_nan.py` - PASSED
- Softplus_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_sofplus.py` - PASSED
- hardtanh_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_hardtanh.py` - PASSED
- reciprocal_bw : 
  - `tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_recip.py` - PASSED
  - `tests/ttnn/unit_tests/operations/backward/test_backward_reciprocal.py` - PASSED