### PR TITLE
#13083: eltwise unary zero op

### DIFF
--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -1893,6 +1893,11 @@ all_unary_ops = [
         "name": "ttnn.zeros_like",
     },
     {
+        "op": ttnn.zeros_like,
+        "name": "ttnn.zeros_like_rm",
+        "layout": "ROW_MAJOR",
+    },
+    {
         "op": full_like,
         "name": "ttnn.full_like",
     },

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -36,6 +36,7 @@ def test_zeros_like(device, input_shape):
     "input_shape",
     [
         [32, 32],
+        [20, 24],
         [5, 96, 64],
     ],
 )

--- a/tests/ttnn/unit_tests/operations/test_zero.py
+++ b/tests/ttnn/unit_tests/operations/test_zero.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 20, 31])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([2, 4, 320, 1024])),
+    ),
+)
+def test_zero(device, input_shapes):
+    torch_input_tensor = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.zeros((input_shapes), dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output = ttnn.zero(input_tensor)
+    output_tensor = ttnn.to_torch(output)
+    assert_equal(torch_output_tensor, output_tensor)

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -19,6 +19,7 @@
 #include "llk_math_eltwise_unary_sfpu_topk.h"
 #include "llk_math_eltwise_unary_sfpu_trigonometry.h"
 #include "llk_math_eltwise_unary_sfpu_unary_comp.h"
+#include "llk_math_eltwise_unary_sfpu_zeros.h"
 
 namespace ckernel {
 

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_zeros.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_zeros.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+inline void calculate_zeros()
+{
+    vFloat fill_val = 0.0f;
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat val = dst_reg[0];
+        dst_reg[0] = fill_val;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_zeros.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_zeros.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_zeros.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_zeros_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::zeros, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_zeros(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_zeros<APPROXIMATE>,
+        dst_index,
+        vector_mode);
+}
+
+}

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu_types.h
@@ -65,4 +65,5 @@ enum SfpuType {
   unary_lt,
   tiled_prod,
   unused,
+  zeros,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -35,3 +35,4 @@
 #include "llk_math_eltwise_unary_sfpu_bitwise_or.h"
 #include "llk_math_eltwise_unary_sfpu_right_shift.h"
 #include "llk_math_eltwise_unary_sfpu_left_shift.h"
+#include "llk_math_eltwise_unary_sfpu_zeros.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_zeros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_zeros.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_zeros()
+{
+    vFloat fill_val = 0.0f;
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat val = dst_reg[0];
+        dst_reg[0] = fill_val;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_zeros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_zeros.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_zeros.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_zeros_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::zeros, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_zeros(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_zeros<APPROXIMATE>,
+        dst_index,
+        vector_mode);
+}
+
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -87,4 +87,5 @@ enum SfpuType {
     ceil,
     unused,
     reshuffle_rows,
+    zeros,
 };

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -120,6 +120,10 @@
 #include "compute_kernel_api/eltwise_unary/dropout.h"
 #endif
 
+#if SFPU_OP_ZEROS_INCLUDE
+#include "compute_kernel_api/eltwise_unary/zeros.h"
+#endif
+
 #if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "compute_kernel_api.h"
 #endif

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/zeros.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/zeros.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_zeros.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+
+ALWI void zeros_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_zeros_init<APPROX>() ));
+}
+
+/**
+ * Performs element-wise fill_zero for each element of a tile
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+ALWI void zeros_tile(uint32_t idst) {
+    MATH(( llk_math_eltwise_unary_sfpu_zeros<APPROX>(idst) ));
+}
+
+} // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -13,6 +13,10 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
+
 
 namespace ttnn {
 namespace operations {
@@ -199,10 +203,8 @@ struct FullLikeWith {
     }
 };
 
-struct ZerosLike : FullLikeWith<0.0f> {};
 struct OnesLike : FullLikeWith<1.0f> {};
 
-inline constexpr ZerosLike zeros_like{};
 inline constexpr OnesLike ones_like{};
 
 struct Empty {
@@ -229,6 +231,51 @@ struct EmptyLike {
     MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
         return create_device_tensor(tensor.get_shape(), dtype_value, layout_value, device, mem_cfg);
     }
+};
+
+
+struct ZerosLike {
+   static ttnn::Tensor invoke(
+    uint8_t queue_id,
+    const ttnn::Tensor& tensor,
+    const std::optional<DataType>& dtype = std::nullopt,
+    const std::optional<Layout>& layout = std::nullopt,
+    const std::optional<std::reference_wrapper<Device>>& device_arg = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt ) {
+
+        if(!optional_output_tensor.has_value()) {
+            Device* device = device_arg.has_value() ? &(device_arg.value().get()) : tensor.device();
+            Layout layout_value = layout.value_or(tensor.get_layout());
+            DataType dtype_value = dtype.value_or(tensor.get_dtype());
+            MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
+            optional_output_tensor = create_device_tensor(tensor.get_shape(), dtype_value, layout_value, device, mem_cfg);
+        }
+
+        // this if() {...} can be skipped if RM support is not needed for zeros_like
+        if(optional_output_tensor.value().get_layout() == Layout::ROW_MAJOR){
+            Tensor x = optional_output_tensor.value();
+            x = ttnn::to_layout(x, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+            ttnn::zero(x, std::nullopt, x);
+            x = ttnn::to_layout(x, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+            ttnn::assign(x, optional_output_tensor.value());
+            return optional_output_tensor.value();
+        }
+
+        ttnn::zero(optional_output_tensor.value(), std::nullopt, optional_output_tensor);
+        return optional_output_tensor.value();
+    }
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& tensor,
+        const std::optional<DataType>& dtype = std::nullopt,
+        const std::optional<Layout>& layout = std::nullopt,
+        const std::optional<std::reference_wrapper<Device>>& device = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt) {
+        return invoke(ttnn::DefaultQueueId, tensor, dtype, layout, device, memory_config, optional_output_tensor);
+    }
+
 };
 
 struct Full {

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -13,6 +13,10 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
+
 
 namespace ttnn {
 namespace operations {
@@ -199,10 +203,8 @@ struct FullLikeWith {
     }
 };
 
-struct ZerosLike : FullLikeWith<0.0f> {};
 struct OnesLike : FullLikeWith<1.0f> {};
 
-inline constexpr ZerosLike zeros_like{};
 inline constexpr OnesLike ones_like{};
 
 struct Empty {
@@ -229,6 +231,51 @@ struct EmptyLike {
     MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
         return create_device_tensor(tensor.get_shape(), dtype_value, layout_value, device, mem_cfg);
     }
+};
+
+
+struct ZerosLike {
+   static ttnn::Tensor invoke(
+    uint8_t queue_id,
+    const ttnn::Tensor& tensor,
+    const std::optional<DataType>& dtype = std::nullopt,
+    const std::optional<Layout>& layout = std::nullopt,
+    const std::optional<std::reference_wrapper<Device>>& device_arg = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt ) {
+
+        if(!optional_output_tensor.has_value()) {
+            Device* device = device_arg.has_value() ? &(device_arg.value().get()) : tensor.device();
+            Layout layout_value = layout.value_or(tensor.get_layout());
+            DataType dtype_value = dtype.value_or(tensor.get_dtype());
+            MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
+            optional_output_tensor = create_device_tensor(tensor.get_shape(), dtype_value, layout_value, device, mem_cfg);
+        }
+
+        // this if() {...} can be skipped if RM support is not needed for zeros_like
+        if(optional_output_tensor.value().get_layout() == Layout::ROW_MAJOR){
+            Tensor x = optional_output_tensor.value();
+            x = ttnn::to_layout(x, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+            ttnn::mul_sfpu(x, 0.0f, std::nullopt, x);
+            x = ttnn::to_layout(x, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
+            ttnn::assign(x, optional_output_tensor.value());
+            return optional_output_tensor.value();
+        }
+
+        ttnn::mul_sfpu(optional_output_tensor.value(), 0.0f, std::nullopt, optional_output_tensor);
+        return optional_output_tensor.value();
+    }
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& tensor,
+        const std::optional<DataType>& dtype = std::nullopt,
+        const std::optional<Layout>& layout = std::nullopt,
+        const std::optional<std::reference_wrapper<Device>>& device = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt) {
+        return invoke(ttnn::DefaultQueueId, tensor, dtype, layout, device, memory_config, optional_output_tensor);
+    }
+
 };
 
 struct Full {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -83,7 +83,8 @@ enum class UnaryOpType {
     LEFT_SHIFT,
     REMAINDER,
     FMOD,
-    DROPOUT
+    DROPOUT,
+    ZEROS,
 };
 
 struct UnaryWithParam {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -71,6 +71,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
         case UnaryOpType::REMAINDER: defines["SFPU_OP_REMAINDER_INCLUDE"] = "1"; break;
         case UnaryOpType::FMOD: defines["SFPU_OP_FMOD_INCLUDE"] = "1"; break;
         case UnaryOpType::DROPOUT: defines["SFPU_OP_DROPOUT_INCLUDE"] = "1"; break;
+        case UnaryOpType::ZEROS: defines["SFPU_OP_ZEROS_INCLUDE"] = "1"; break;
         default: defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1"; break;
     };
 }
@@ -314,6 +315,7 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, std:
         case UnaryOpType::ATAN: op_init_and_name = {"atan_tile_init();", fmt::format("atan_tile({});", idst)}; break;
         case UnaryOpType::TAN: op_init_and_name = {"tan_tile_init();", fmt::format("tan_tile({});", idst)}; break;
         case UnaryOpType::SILU: op_init_and_name = {"silu_tile_init();", fmt::format("silu_tile({});", idst)}; break;
+        case UnaryOpType::ZEROS: op_init_and_name = {"zeros_tile_init();", fmt::format("zeros_tile({});", idst)}; break;
         case UnaryOpType::IDENTITY:
             op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile({});", idst)};
             break;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -120,6 +120,7 @@ template struct ExecuteUnary<UnaryOpType::TAN>;
 template struct ExecuteUnary<UnaryOpType::TANH>;
 template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;
 template struct ExecuteUnary<UnaryOpType::TILED_PROD>;
+template struct ExecuteUnary<UnaryOpType::ZEROS>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFastAndApproximateMode<unary_op_type>::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -299,6 +299,7 @@ REGISTER_UNARY_OPERATION(square, SQUARE);
 REGISTER_UNARY_OPERATION(tan, TAN);
 REGISTER_UNARY_OPERATION(tanh, TANH);
 REGISTER_UNARY_OPERATION(tiled_prod, TILED_PROD);
+REGISTER_UNARY_OPERATION(zero, ZEROS);
 
 constexpr auto log_sigmoid = ttnn::register_operation_with_auto_launch_op<"ttnn::log_sigmoid", ttnn::operations::unary::ExecuteUnary<
     ttnn::operations::unary::UnaryOpType::SIGMOID,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1372,6 +1372,7 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::tan);
     detail::bind_unary_operation(module, ttnn::tanh);
     detail::bind_unary_operation(module, ttnn::log_sigmoid);
+    detail::bind_unary_operation(module, ttnn::zero);
 
     //  Unaries with fast_and_approximate_mode
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::exp,


### PR DESCRIPTION
### Ticket
Link to Github Issue #13083

### Problem description
To implement a `zeros_like` op that does not rely on `tt::numpy` 
op profiling:

**ttnn.zeros_like,800,**0.773**,0.789,0.807**

### What's changed
A try at using eltwise unary sfpu op with LLK that to implement `zeros_like` op

_op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)_
**ttnn.zeros_like,800,0.029,0.032,0.106,0.01
ttnn.zeros_like_rm,800,0.121,0.136,0.413,0.034**

[with_eltwise_zero_final.csv](https://github.com/user-attachments/files/17133172/with_eltwise_zero_final.csv)

**Note:** 
This implementation in `tt_metal/include/compute_kernel_api/eltwise_unary/zeros.h` is just to get an opinion from TT team on whether to use eltwise sfpu for creation ops `(full_like, zeros_like, ones_like)`
If everyone is ok with this as an acceptable solution, we will implement this as a generalised `fill` unary op with a `fill_value` parameter. 

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/11035680120
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
