### PR TITLE
#13058: update matmul bias size validation

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1026,10 +1026,13 @@ void Matmul::validate(
         uint32_t bias_batch_size = get_batch_size(bias_shape);
         TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size not equal to 1.");
         TT_FATAL(
-            bias_shape.with_tile_padding()[-2] == in0_tile_shape[0], "Unsupported bias shape: second last dimension not equal to tile height");
+            bias_shape.with_tile_padding()[-2] == in0_tile_shape[0], "Unsupported bias shape: padded second last dimension of bias, {}, not equal to tile height, {}", bias_shape.with_tile_padding()[-2], in0_tile_shape[0]);
         TT_FATAL(
             bias_shape.with_tile_padding()[-1] == b_shape.with_tile_padding()[-1],
-            "Unsupported bias shape: last dimension not equal to second input's last dimension.", bias_shape.with_tile_padding()[-1], b_shape.with_tile_padding()[-1]);
+            "Unsupported bias shape: padded last dimension of bias, {}, not equal to second input's padded last dimension, {}.", bias_shape.with_tile_padding()[-1], b_shape.with_tile_padding()[-1]);
+        TT_FATAL(
+            bias_shape[-1] >= b_shape[-1],
+            "Unsupported bias shape: last dimension of bias, {}, not equal to or greater than second input's last dimension, {}.", bias_shape[-1], b_shape[-1]);
     }
 
     if (this->untilize_out) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #13058

### Problem description
- biases that are smaller than the output may be used in matmul op because previous validation was switched to use padding

### What's changed
- add extra validation to ensure bias is at least as long as output

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11038507936/job/30666962707
- [ ] Blackhole Post commit (if applicable) N/A
- [x] Model regression CI testing passes (if applicable) Fails same way as main: https://github.com/tenstorrent/tt-metal/actions/runs/11034604371
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11034601465
- [ ] New/Existing tests provide coverage for changes N/A
