### PR TITLE
#12328: Fix Llama3.1-8B MLP tests running out of L1

### DIFF
--- a/models/demos/wormhole/llama31_8b/tt/llama_mlp.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_mlp.py
@@ -72,6 +72,7 @@ class TtLlamaMLP(torch.nn.Module):
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
         seq_len = x.shape[-2]
+        compute_kernel_config_hifi2 = self.model_config["MLP_KERNEL_CONFIG_HIFI2"]
         if mode == "decode":  # Sharded config
             pc_1 = self.model_config["DECODE_MLP_W1_W3_PRG_CONFIG"]
             pc_2 = self.model_config["DECODE_MLP_W2_PRG_CONFIG"]
@@ -93,7 +94,7 @@ class TtLlamaMLP(torch.nn.Module):
         w1_out = ttnn.linear(
             x,
             self.w1,
-            compute_kernel_config=self.args.compute_kernel_config_hifi2,
+            compute_kernel_config=compute_kernel_config_hifi2,
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_1 else None,
             dtype=ttnn.bfloat16,
             program_config=pc_1,
@@ -102,7 +103,7 @@ class TtLlamaMLP(torch.nn.Module):
         w3_out = ttnn.linear(
             x,
             self.w3,
-            compute_kernel_config=self.args.compute_kernel_config_hifi2,
+            compute_kernel_config=compute_kernel_config_hifi2,
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
             dtype=ttnn.bfloat16,
             program_config=pc_3,
@@ -126,7 +127,7 @@ class TtLlamaMLP(torch.nn.Module):
         w2_out = ttnn.linear(
             w2_in,
             self.w2,
-            compute_kernel_config=self.args.compute_kernel_config_hifi2,
+            compute_kernel_config=compute_kernel_config_hifi2,
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
             dtype=ttnn.bfloat8_b,
             program_config=pc_2,

--- a/models/demos/wormhole/llama31_8b/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b/tt/model_config.py
@@ -337,8 +337,8 @@ class TtModelArgs:
 
             self.model_config["MLP_KERNEL_CONFIG_HIFI2"] = ttnn.WormholeComputeKernelConfig(
                 math_fidelity=ttnn.MathFidelity.HiFi2,  # full precision for bfp8 @ bfp8
-                math_approx_mode=True,
-                fp32_dest_acc_en=True,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
                 packer_l1_acc=True,
             )
 


### PR DESCRIPTION
### Problem description
Fixes an "Out of L1 memory" issue recently introduced that affected the LLama3.1-8B MLP tests.

