### PR TITLE
#0: move Layout enum to device accessible location

### DIFF
--- a/ttnn/cpp/ttnn/tensor/enum_types.hpp
+++ b/ttnn/cpp/ttnn/tensor/enum_types.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+
+#include <cstdint>
+
+namespace tt {
+
+namespace tt_metal {
+
+enum class Layout { ROW_MAJOR = 0, TILE = 1, INVALID = 2 };
+
+} // namespace tt_metal
+
+} // namespace tt

--- a/ttnn/cpp/ttnn/tensor/enum_types.hpp
+++ b/ttnn/cpp/ttnn/tensor/enum_types.hpp
@@ -1,18 +1,11 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-
-#include <cstdint>
-
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal {
 
 enum class Layout { ROW_MAJOR = 0, TILE = 1, INVALID = 2 };
 
-} // namespace tt_metal
-
-} // namespace tt
+} // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -17,14 +17,13 @@
 #include "tt_metal/tt_stl/concepts.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
 #include "ttnn/tensor/host_buffer/types.hpp"
+#include "ttnn/cpp/ttnn/tensor/enum_types.hpp"
 
 namespace tt {
 
 namespace tt_metal {
 
 static constexpr std::uint8_t VERSION_ID = 3;
-
-enum class Layout { ROW_MAJOR = 0, TILE = 1, INVALID = 2 };
 
 enum class DataType {
     BFLOAT16 = 0,


### PR DESCRIPTION
Moving the Layout enum to a device accessible location for allow kernels to handle this as a kernel arg. For example, reduce scatter would like to use this enum on device side.


### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11038492008
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
