### PR TITLE
#13127: Switch python get_legacy_shape to shape.with_tile_padding()

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tensor.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tensor.rst
@@ -74,7 +74,7 @@ Tensor API
 ==========
 
 .. autoclass:: ttnn.Tensor
-    :members: to, buffer, storage_type, device, get_layout, get_dtype, get_legacy_shape, pad, unpad, pad_to_tile, unpad_from_tile
+    :members: to, buffer, storage_type, device, get_layout, get_dtype, pad, unpad, pad_to_tile, unpad_from_tile
     :special-members: __init__
 
 MemoryConfig

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_attn_matmul.py
@@ -102,7 +102,7 @@ def run_falcon_attn_matmul_test(
     logger.debug(f"in1 ({b_shape}): {b_t.memory_config().buffer_type} and {b_t.get_dtype()}")
     logger.debug(f"out ({expected_output_shape}): {out.memory_config().buffer_type} and {out.get_dtype()}")
 
-    assert out.get_legacy_shape() == expected_output_shape
+    assert out.shape.with_tile_padding() == expected_output_shape
     pyt_got_back_rm = tt2torch_tensor(out)
 
     ref_bmm = torch.matmul(A.transpose(0, 2), B).transpose(0, 2)

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
@@ -68,7 +68,7 @@ def run_falcon_lm_head_matmul_2d(
     for i in range(num_slices):
         b_t_slices[i].deallocate(True)
 
-    assert out.get_legacy_shape() == expected_output_shape
+    assert out.shape.with_tile_padding() == expected_output_shape
 
     # check pcc
     out = tt2torch_tensor(out)

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -144,7 +144,7 @@ def run_falcon_matmul_test(
     logger.debug(f"in1 ({b_shape}): {b_t.memory_config().buffer_type} and {b_t.get_dtype()}")
     logger.debug(f"out ({expected_output_shape}): {out.memory_config().buffer_type} and {out.get_dtype()}")
 
-    assert out.get_legacy_shape() == expected_output_shape
+    assert out.shape.with_tile_padding() == expected_output_shape
     pyt_got_back_rm = tt2torch_tensor(out)
 
     ref_bmm = torch.matmul(A, B)

--- a/models/demos/falcon7b_common/tt/falcon_causallm.py
+++ b/models/demos/falcon7b_common/tt/falcon_causallm.py
@@ -24,7 +24,7 @@ def falcon_lm_head_matmul(
     output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
     output_dtype=None,
 ):
-    seq_len = input_tensor_a.get_legacy_shape()[2]
+    seq_len = input_tensor_a.shape.with_tile_padding()[2]
     if seq_len > 512:
         # TODO: Review if this path is used? If not, we can delete
         return ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=output_mem_config, dtype=output_dtype)
@@ -148,7 +148,7 @@ class TtFalconCausalLM(TtFalconModelShared):
         )
 
         if llm_mode == "prefill":
-            if self.model_config["PREFILL_OPTIMIZED_MODE"] and hidden_states.get_legacy_shape()[-2] > 512:
+            if self.model_config["PREFILL_OPTIMIZED_MODE"] and hidden_states.shape.with_tile_padding()[-2] > 512:
                 lm_logits = falcon_lm_head_matmul_2d(
                     hidden_states,
                     self.lm_head_sliced_weights,

--- a/models/demos/falcon7b_common/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b_common/tt/falcon_lm_head.py
@@ -25,7 +25,7 @@ def falcon_lm_head_matmul_2d(
         hidden_states.device().arch() == ttnn.device.Arch.WORMHOLE_B0
     ), "Falcon LM head is only supported for Wormhole BO arch"
 
-    seq_len = hidden_states.get_legacy_shape()[-2]
+    seq_len = hidden_states.shape.with_tile_padding()[-2]
 
     assert seq_len % 32 == 0, f"Sequence length must be a multiple of 32, instead it is {seq_len}"
     assert seq_len > 512, f"Falcon lm head 2d is only supported for sequence length > 512, instead it is {seq_len}"
@@ -34,7 +34,7 @@ def falcon_lm_head_matmul_2d(
     assert (
         len(weights) == num_slices
     ), f"Weights are expected to be split into {num_slices} slices, instead there are {len(weights)}"
-    weights_inner_dim_in_tiles = weights[0].get_legacy_shape()[-2] // 32
+    weights_inner_dim_in_tiles = weights[0].shape.with_tile_padding()[-2] // 32
     assert (
         weights_inner_dim_in_tiles == 144
     ), f"Weights are expected to be padded to the inner dim 144 in tiles, instead they are {weights_inner_dim_in_tiles}"
@@ -50,7 +50,7 @@ def falcon_lm_head_matmul_2d(
 
     grid = hidden_states.device().compute_with_storage_grid_size()
     activations_m_in_tiles = seq_len // 32
-    weights_n_in_tiles = weights[0].get_legacy_shape()[-1] // 32
+    weights_n_in_tiles = weights[0].shape.with_tile_padding()[-1] // 32
 
     # calculate parameters for the given sequence length
     grid = hidden_states.device().compute_with_storage_grid_size()

--- a/models/demos/falcon7b_common/tt/falcon_mlp.py
+++ b/models/demos/falcon7b_common/tt/falcon_mlp.py
@@ -54,7 +54,7 @@ def falcon_dense_h_to_4h_matmul(
     output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
     output_dtype=None,
 ):
-    seq_len = input_tensor_a.get_legacy_shape()[2]
+    seq_len = input_tensor_a.shape.with_tile_padding()[2]
     if seq_len > 1024:
         # TODO: Review if this path is used? If not, we can delete
         assert fused_activation == None

--- a/models/demos/falcon7b_common/tt/model_utils.py
+++ b/models/demos/falcon7b_common/tt/model_utils.py
@@ -71,7 +71,7 @@ def get_falcon_default_core_grid(device):
 
 
 def layernorm(ln_input, ln_eps, ln_gamma, ln_betta, model_config):
-    h_dim = ln_input.get_legacy_shape()[-2]  # corresponds to batch size (decode) or seq_len (prefill)
+    h_dim = ln_input.shape.with_tile_padding()[-2]  # corresponds to batch size (decode) or seq_len (prefill)
     if h_dim in [32, 128, 256, 1024, 2048]:
         ln_output = ttnn.interleaved_to_sharded(ln_input, model_config["LAYERNORM_BLOCK_SHARDED_MEM_CFG"][h_dim])
         ln_output = ttnn.layer_norm(

--- a/models/demos/metal_BERT_large_11/tt/custom_matmuls.py
+++ b/models/demos/metal_BERT_large_11/tt/custom_matmuls.py
@@ -9,10 +9,10 @@ import ttnn
 def bert_large_fused_qkv_matmul(
     input_tensor_a, input_tensor_b, bias=None, output_mem_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=None
 ):
-    batch_size = input_tensor_a.get_legacy_shape()[0]
+    batch_size = input_tensor_a.shape.with_tile_padding()[0]
 
-    assert input_tensor_a.get_legacy_shape() == [batch_size, 1, 384, 1024], "Unsupported input shape"
-    assert input_tensor_b.get_legacy_shape() == [1, 1, 1024, 3072], "Unsupported input shape"
+    assert input_tensor_a.shape.with_tile_padding() == [batch_size, 1, 384, 1024], "Unsupported input shape"
+    assert input_tensor_b.shape.with_tile_padding() == [1, 1, 1024, 3072], "Unsupported input shape"
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=(12, batch_size),
@@ -42,7 +42,7 @@ def bert_large_ff1_matmul(
     output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
     output_dtype=None,
 ):
-    batch_size = input_tensor_a.get_legacy_shape()[0]
+    batch_size = input_tensor_a.shape.with_tile_padding()[0]
 
     assert (
         (
@@ -56,8 +56,8 @@ def bert_large_ff1_matmul(
             and input_tensor_b.memory_config().buffer_type == tttn.BufferType.DRAM
         )
     ), "For BFLOAT16, if output is on L1, one of in0 or in1 must be on DRAM!"
-    assert input_tensor_a.get_legacy_shape() == [batch_size, 1, 384, 1024], "Unsupported input shape"
-    assert input_tensor_b.get_legacy_shape() == [1, 1, 1024, 4096], "Unsupported input shape"
+    assert input_tensor_a.shape.with_tile_padding() == [batch_size, 1, 384, 1024], "Unsupported input shape"
+    assert input_tensor_b.shape.with_tile_padding() == [1, 1, 1024, 4096], "Unsupported input shape"
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=(12, batch_size),
@@ -82,10 +82,10 @@ def bert_large_ff1_matmul(
 def bert_large_ff2_matmul(
     input_tensor_a, input_tensor_b, bias=None, output_mem_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=None
 ):
-    batch_size = input_tensor_a.get_legacy_shape()[0]
+    batch_size = input_tensor_a.shape.with_tile_padding()[0]
 
-    assert input_tensor_a.get_legacy_shape() == [batch_size, 1, 384, 4096], "Unsupported input shape"
-    assert input_tensor_b.get_legacy_shape() == [1, 1, 4096, 1024], "Unsupported input shape"
+    assert input_tensor_a.shape.with_tile_padding() == [batch_size, 1, 384, 4096], "Unsupported input shape"
+    assert input_tensor_b.shape.with_tile_padding() == [1, 1, 4096, 1024], "Unsupported input shape"
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=(12, batch_size),
@@ -110,10 +110,10 @@ def bert_large_ff2_matmul(
 def bert_large_selfout_matmul(
     input_tensor_a, input_tensor_b, bias=None, output_mem_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=None
 ):
-    batch_size = input_tensor_a.get_legacy_shape()[0]
+    batch_size = input_tensor_a.shape.with_tile_padding()[0]
 
-    assert input_tensor_a.get_legacy_shape() == [batch_size, 1, 384, 1024], "Unsupported input shape"
-    assert input_tensor_b.get_legacy_shape() == [1, 1, 1024, 1024], "Unsupported input shape"
+    assert input_tensor_a.shape.with_tile_padding() == [batch_size, 1, 384, 1024], "Unsupported input shape"
+    assert input_tensor_b.shape.with_tile_padding() == [1, 1, 1024, 1024], "Unsupported input shape"
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=(12, batch_size),
@@ -138,10 +138,10 @@ def bert_large_selfout_matmul(
 def bert_large_pre_softmax_bmm(
     input_tensor_a, input_tensor_b, output_mem_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=None
 ):
-    batch_size = input_tensor_a.get_legacy_shape()[0]
+    batch_size = input_tensor_a.shape.with_tile_padding()[0]
 
-    assert input_tensor_a.get_legacy_shape() == [batch_size, 16, 384, 64], "Unsupported input shape"
-    assert input_tensor_b.get_legacy_shape() == [batch_size, 16, 64, 384], "Unsupported input shape"
+    assert input_tensor_a.shape.with_tile_padding() == [batch_size, 16, 384, 64], "Unsupported input shape"
+    assert input_tensor_b.shape.with_tile_padding() == [batch_size, 16, 64, 384], "Unsupported input shape"
 
     program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=(12, batch_size),
@@ -163,10 +163,10 @@ def bert_large_pre_softmax_bmm(
 def bert_large_post_softmax_bmm(
     input_tensor_a, input_tensor_b, output_mem_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=None
 ):
-    batch_size = input_tensor_a.get_legacy_shape()[0]
+    batch_size = input_tensor_a.shape.with_tile_padding()[0]
 
-    assert input_tensor_a.get_legacy_shape() == [batch_size, 16, 384, 384], "Unsupported input shape"
-    assert input_tensor_b.get_legacy_shape() == [batch_size, 16, 384, 64], "Unsupported input shape"
+    assert input_tensor_a.shape.with_tile_padding() == [batch_size, 16, 384, 384], "Unsupported input shape"
+    assert input_tensor_b.shape.with_tile_padding() == [batch_size, 16, 384, 64], "Unsupported input shape"
 
     program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=(12, batch_size),

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -101,7 +101,7 @@ class TtFeedForwardModel:
             encoder0_ff1_bias = ttnn.load_tensor(
                 str(tt_cache_path / f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}.bin")
             ).to(device, model_config["OP9_FF1_MM_BIAS_MEMCFG"])
-            encoder0_ff1_weight_shape = encoder0_ff1_weight.get_legacy_shape()
+            encoder0_ff1_weight_shape = encoder0_ff1_weight.shape.with_tile_padding()
 
             encoder0_ff2_weight = ttnn.load_tensor(
                 str(tt_cache_path / f"{encoder_ff2_str}.weight_{model_config['OP10_FF2_MM_WEIGHTS_DTYPE'].name}.bin")

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -90,7 +90,7 @@ def mha(qkv_weight, qkv_bias, hidden_dim, num_heads, device, model_config):
 
         # Input and output tensors of this fused op is: [9, 1, 6144, 384] instead of [9, 16, 384, 384]
         # No-op reshapes are handled within pre-softmax (op 7) and post-softmax bmms (op 9)
-        shape = qkt.get_legacy_shape()
+        shape = qkt.shape.with_tile_padding()
         qkt = qkt.reshape(shape[0], 1, shape[1] * shape[2], shape[3])
         attention_scores = ttnn.scale_mask_softmax_in_place(
             qkt, freciprocal_of_sqrt_hidden_dim, attention_mask, program_config=softmax_program_config
@@ -240,7 +240,7 @@ class TtMultiHeadAttentionModel:
             )
 
         # Hidden dim
-        hidden_dim = qkv_weight.get_legacy_shape()[-1] // 3
+        hidden_dim = qkv_weight.shape.with_tile_padding()[-1] // 3
 
         self.mha = mha(
             qkv_weight,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
@@ -502,9 +502,9 @@ def test_sharded_nlp_create_qkv_heads_test(
         memory_config=out_mem_config,
     )
 
-    assert list(q.get_legacy_shape()) == [seq_len, num_q_heads, batch, head_dim]
-    assert list(k.get_legacy_shape()) == [seq_len, num_kv_heads, batch, head_dim]
-    assert list(v.get_legacy_shape()) == [seq_len, num_kv_heads, batch, head_dim]
+    assert list(q.shape.with_tile_padding()) == [seq_len, num_q_heads, batch, head_dim]
+    assert list(k.shape.with_tile_padding()) == [seq_len, num_kv_heads, batch, head_dim]
+    assert list(v.shape.with_tile_padding()) == [seq_len, num_kv_heads, batch, head_dim]
 
     pyt_got_back_rm_q = tt2torch_tensor(q)
     pyt_got_back_rm_k = tt2torch_tensor(k)

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
@@ -63,8 +63,8 @@ class TtFalconLayernorm:
 
     def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
         if self.is_sharded:
-            row_height = x.get_legacy_shape()[2]
-            shard_width_hidden_dim_across_32_cores = x.get_legacy_shape()[3] // 32
+            row_height = x.shape.with_tile_padding()[2]
+            shard_width_hidden_dim_across_32_cores = x.shape.with_tile_padding()[3] // 32
             shard_spec_32_cores_grid = ttnn.CoreRangeSet(
                 {
                     ttnn.CoreRange(

--- a/models/demos/t3000/falcon40b/tt/falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_causallm.py
@@ -118,7 +118,7 @@ class TtFalconCausalLM(TtFalconModelShared):
         overwrite_subblock_w = 1 if hidden_states.shape[2] < 512 else 4
 
         should_deallocate_ln_tensors = determine_tensor_deallocation(
-            self.model_config["layernorm_params"]["slice_size"], hidden_states.get_legacy_shape()[2]
+            self.model_config["layernorm_params"]["slice_size"], hidden_states.shape.with_tile_padding()[2]
         )
         # LM Head
         lm_logits = falcon_prefill_matmul(

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -143,7 +143,7 @@ class TtFalconMLP:
     def fwd_prefill(self, x: List[ttnn.Tensor]) -> List[ttnn.Tensor]:
         hidden_states = []
         should_deallocate_ln_tensors = determine_tensor_deallocation(
-            self.model_config["layernorm_params"]["slice_size"], x.get_legacy_shape()[2]
+            self.model_config["layernorm_params"]["slice_size"], x.shape.with_tile_padding()[2]
         )
 
         mlp_num_slices = self.model_config["MLP_NUM_SLICES"]

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -238,7 +238,7 @@ class TtLlamaAttention_optimized:
         )
         xs.deallocate(True)
 
-        d = fused_query_key_value.get_legacy_shape()[-1]
+        d = fused_query_key_value.shape.with_tile_padding()[-1]
         fused_query_key_value = ttnn.reshape(
             fused_query_key_value,
             ttnn.Shape((1, 1, self.max_batch_size, d), (1, 1, self.model_config["PADDED_BATCH_SIZE"], d)),

--- a/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
@@ -205,7 +205,8 @@ class TtLlamaDecoder_galaxy:
         )
 
         tt_stats = ttnn.reshape(
-            tt_stats, ttnn.Shape((1, 1, inp.get_legacy_shape()[-2], 32), (1, 1, inp.get_legacy_shape()[-2], 32))
+            tt_stats,
+            ttnn.Shape((1, 1, inp.shape.with_tile_padding()[-2], 32), (1, 1, inp.shape.with_tile_padding()[-2], 32)),
         )  # TODO: Figure out why we need this
 
         tt_stats = tt_all_gather(

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large_new_conv_api.py
@@ -75,9 +75,9 @@ def ResnetLinear(
     """
 
     matmul_config = hardcoded_matmul_config_linear[batch_size]
-    weight_shape = weight.get_legacy_shape()
+    weight_shape = weight.shape.with_tile_padding()
     weight = weight.reshape(1, 1, weight_shape[-2], weight_shape[-1])
-    bias_shape = bias.get_legacy_shape()
+    bias_shape = bias.shape.with_tile_padding()
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
@@ -574,10 +574,10 @@ class resnet50:
 
         print(f"=================================== layer: 1, module: 1")
         layer1_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         if is_wormhole_b0() and self.batch_size == 20:
             x, x_height, x_width = self.layer1_module1(
@@ -608,10 +608,10 @@ class resnet50:
             x = ttnn.reallocate(x)
 
         layer2_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         print(f"=================================== layer: 2, module: 1")
         if is_wormhole_b0() and self.batch_size == 20:
@@ -644,10 +644,10 @@ class resnet50:
 
         print(f"=================================== layer: 3, module: 1")
         layer3_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         x, x_height, x_width = self.layer3_module1(
             x, device, batch_size, x_height, x_width, conv_op_cache, reshard_if_not_optimal=True, height_sharding=False
@@ -682,10 +682,10 @@ class resnet50:
         print(f"=================================== layer: 4, module: 1")
 
         layer4_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         x, x_height, x_width = self.layer4_module1(
             x, device, batch_size, x_height, x_width, conv_op_cache, reshard_if_not_optimal=True, height_sharding=False
@@ -718,9 +718,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -734,15 +734,15 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -760,20 +760,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -801,9 +807,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
         # for _, tensor in conv_op_cache["reader_patterns_cache"]["conv"].items():
@@ -944,9 +950,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -960,15 +966,15 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -986,20 +992,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -1027,9 +1039,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -67,9 +67,9 @@ def ResnetLinear(
     """
 
     matmul_config = hardcoded_matmul_config_linear[batch_size]
-    weight_shape = weight.get_legacy_shape()
+    weight_shape = weight.shape.with_tile_padding()
     weight = weight.reshape(1, 1, weight_shape[-2], weight_shape[-1])
-    bias_shape = bias.get_legacy_shape()
+    bias_shape = bias.shape.with_tile_padding()
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
@@ -767,7 +767,7 @@ class resnet50:
             x = ttnn.reallocate(x)
 
         logger.debug(f"==== Running layer 1 module 1")
-        layer1_module1_input_shape = ttnn.Shape(x.get_legacy_shape())
+        layer1_module1_input_shape = ttnn.Shape(x.shape.with_tile_padding())
 
         reshard = False
         height_shard = False
@@ -836,7 +836,7 @@ class resnet50:
         if self.batch_size == 20 and is_wormhole_b0():
             x = ttnn.reallocate(x)
 
-        layer2_module1_input_shape = ttnn.Shape(x.get_legacy_shape())
+        layer2_module1_input_shape = ttnn.Shape(x.shape.with_tile_padding())
 
         reshard = False
         height_shard = False
@@ -915,7 +915,7 @@ class resnet50:
             enable_subblock_padding=False,
         )
 
-        layer3_module1_input_shape = ttnn.Shape(x.get_legacy_shape())
+        layer3_module1_input_shape = ttnn.Shape(x.shape.with_tile_padding())
 
         reshard = False
         height_shard = False
@@ -1026,7 +1026,7 @@ class resnet50:
             xshape = x.shape_without_padding()
             x = ttnn.slice(x, [0, 0, 0, 0], [xshape[0], xshape[1], xshape[2], xshape[3]])
 
-        layer4_module1_input_shape = ttnn.Shape(x.get_legacy_shape())
+        layer4_module1_input_shape = ttnn.Shape(x.shape.with_tile_padding())
 
         if is_wormhole_b0():
             shard_config = ttnn.create_sharded_memory_config_(
@@ -1110,8 +1110,8 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
@@ -1135,13 +1135,13 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                x.get_legacy_shape()[2] // self.batch_size,
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                x.shape.with_tile_padding()[2] // self.batch_size,
+                x.shape.with_tile_padding()[3],
             ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -1159,20 +1159,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -1200,9 +1206,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api.py
@@ -75,9 +75,9 @@ def ResnetLinear(
     """
 
     matmul_config = hardcoded_matmul_config_linear[batch_size]
-    weight_shape = weight.get_legacy_shape()
+    weight_shape = weight.shape.with_tile_padding()
     weight = weight.reshape(1, 1, weight_shape[-2], weight_shape[-1])
-    bias_shape = bias.get_legacy_shape()
+    bias_shape = bias.shape.with_tile_padding()
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
@@ -571,10 +571,10 @@ class resnet50:
 
         print(f"=================================== layer: 1, module: 1")
         layer1_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         if is_wormhole_b0() and self.batch_size == 20:
             x, x_height, x_width = self.layer1_module1(
@@ -605,10 +605,10 @@ class resnet50:
             x = ttnn.reallocate(x)
 
         layer2_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         print(f"=================================== layer: 2, module: 1")
         if is_wormhole_b0() and self.batch_size == 20:
@@ -641,10 +641,10 @@ class resnet50:
 
         print(f"=================================== layer: 3, module: 1")
         layer3_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         x, x_height, x_width = self.layer3_module1(
             x, device, batch_size, x_height, x_width, conv_op_cache, reshard_if_not_optimal=True, height_sharding=False
@@ -678,10 +678,10 @@ class resnet50:
 
         print(f"=================================== layer: 4, module: 1")
         layer4_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         x, x_height, x_width = self.layer4_module1(
             x, device, batch_size, x_height, x_width, conv_op_cache, reshard_if_not_optimal=True, height_sharding=False
@@ -714,9 +714,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -730,15 +730,15 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -756,20 +756,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -797,9 +803,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -926,9 +932,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -942,15 +948,15 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -968,20 +974,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -1009,9 +1021,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
@@ -76,9 +76,9 @@ def ResnetLinear(
     """
 
     matmul_config = hardcoded_matmul_config_linear[batch_size]
-    weight_shape = weight.get_legacy_shape()
+    weight_shape = weight.shape.with_tile_padding()
     weight = weight.reshape(1, 1, weight_shape[-2], weight_shape[-1])
-    bias_shape = bias.get_legacy_shape()
+    bias_shape = bias.shape.with_tile_padding()
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
@@ -573,10 +573,10 @@ class resnet50:
 
         print(f"=================================== layer: 1, module: 1")
         layer1_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         if is_wormhole_b0() and self.batch_size == 20:
             x, x_height, x_width = self.layer1_module1(
@@ -607,10 +607,10 @@ class resnet50:
             x = ttnn.reallocate(x)
 
         layer2_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
         print(f"=================================== layer: 2, module: 1")
         if is_wormhole_b0() and self.batch_size == 20:
@@ -643,10 +643,10 @@ class resnet50:
 
         print(f"=================================== layer: 3, module: 1")
         layer3_module1_input_shape = [
-            x.get_legacy_shape()[0],
-            x.get_legacy_shape()[1],
-            x.get_legacy_shape()[2],
-            x.get_legacy_shape()[3],
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[1],
+            x.shape.with_tile_padding()[2],
+            x.shape.with_tile_padding()[3],
         ]
 
         ## using less # cores to demo high utilization
@@ -743,9 +743,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -759,15 +759,15 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -785,20 +785,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -826,9 +832,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -951,9 +957,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 
@@ -967,15 +973,15 @@ class resnet50:
             }
         )
         shard_shape = [
-            x.volume() // x.get_legacy_shape()[-1],
-            x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
+            x.volume() // x.shape.with_tile_padding()[-1],
+            x.shape.with_tile_padding()[-1] // (grid_size[0] * grid_size[1]),
         ]
         shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
         width_sharded_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -993,20 +999,26 @@ class resnet50:
         x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
 
         unpadded_shape_end = [
-            x.get_legacy_shape()[0] - 1,
-            x.get_legacy_shape()[1] - 1,
+            x.shape.with_tile_padding()[0] - 1,
+            x.shape.with_tile_padding()[1] - 1,
             1 - 1,
-            x.get_legacy_shape()[3] - 1,
+            x.shape.with_tile_padding()[3] - 1,
         ]
         x = ttnn.untilize_with_unpadding(
             x, output_tensor_end=unpadded_shape_end, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         )
 
         x = ttnn.reshape(
-            x, (1, x.get_legacy_shape()[1], self.batch_size * x.get_legacy_shape()[2], x.get_legacy_shape()[3])
+            x,
+            (
+                1,
+                x.shape.with_tile_padding()[1],
+                self.batch_size * x.shape.with_tile_padding()[2],
+                x.shape.with_tile_padding()[3],
+            ),
         )
 
-        unpadded_shape = x.get_legacy_shape()
+        unpadded_shape = x.shape.with_tile_padding()
         padded_shape = [
             unpadded_shape[0],
             unpadded_shape[1],
@@ -1034,9 +1046,9 @@ class resnet50:
             x,
             (
                 self.batch_size,
-                x.get_legacy_shape()[1],
-                (int)(x.get_legacy_shape()[2] / self.batch_size),
-                x.get_legacy_shape()[3],
+                x.shape.with_tile_padding()[1],
+                (int)(x.shape.with_tile_padding()[2] / self.batch_size),
+                x.shape.with_tile_padding()[3],
             ),
         )
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_utility_functions.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_utility_functions.py
@@ -31,7 +31,7 @@ def pre_process_input(device, tensor):
     return tensor
     import math
 
-    assert input_channels == tensor.get_legacy_shape()[3]
+    assert input_channels == tensor.shape.with_tile_padding()[3]
     padded_input_channels = math.ceil(input_channels / 32) * 32
     if padded_input_channels != input_channels:
         tensor = fallback_ops.pad(

--- a/models/experimental/bert/fused_ops/add_and_norm.py
+++ b/models/experimental/bert/fused_ops/add_and_norm.py
@@ -16,7 +16,7 @@ def AddAndNorm(gamma: ttnn.Tensor, beta: ttnn.Tensor, epsilon, H, W, device):
 
     def add_and_norm_(activationa, activationb):
         a_plus_b = ttnn.add(activationa, activationb)
-        H = activationa.get_legacy_shape()[2]
+        H = activationa.shape.with_tile_padding()[2]
         lnorm_a_plus_b = layernorm(a_plus_b, overrideH=H)
         return lnorm_a_plus_b
 

--- a/models/experimental/bert/fused_ops/layernorm.py
+++ b/models/experimental/bert/fused_ops/layernorm.py
@@ -52,8 +52,8 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
     # gamma, beta, epsilon should be tt::tensors of size 32*W
     # with a single populated top row
     # H, W need to be from the "true" shape (unpadded)
-    assert gamma is None or gamma.get_legacy_shape() == [1, 1, 32, W]  # single H-tile
-    assert beta is None or beta.get_legacy_shape() == [1, 1, 32, W]  # single H-tile
+    assert gamma is None or gamma.shape.with_tile_padding() == [1, 1, 32, W]  # single H-tile
+    assert beta is None or beta.shape.with_tile_padding() == [1, 1, 32, W]  # single H-tile
 
     H_ = H
     W_ = W
@@ -104,10 +104,10 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
     # 1D variant
     # TODO(AP): merge with 2d? refactor.
     def layernorm_1d_(x, overrideH=None, refx=None, refgamma=None, refbeta=None):
-        N = x.get_legacy_shape()[0]
-        C = x.get_legacy_shape()[1]
-        H = x.get_legacy_shape()[2]
-        W = x.get_legacy_shape()[3]
+        N = x.shape.with_tile_padding()[0]
+        C = x.shape.with_tile_padding()[1]
+        H = x.shape.with_tile_padding()[2]
+        W = x.shape.with_tile_padding()[3]
 
         H_ = 1
         if overrideH is not None:
@@ -147,10 +147,10 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
             return x_gamma
 
     def layernorm_2d_(x):
-        N = x.get_legacy_shape()[0]
-        C = x.get_legacy_shape()[1]
-        H = x.get_legacy_shape()[2]
-        W = x.get_legacy_shape()[3]
+        N = x.shape.with_tile_padding()[0]
+        C = x.shape.with_tile_padding()[1]
+        H = x.shape.with_tile_padding()[2]
+        W = x.shape.with_tile_padding()[3]
 
         # first compute the mean (m)
         redW = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1

--- a/models/experimental/bert/fused_ops/linear.py
+++ b/models/experimental/bert/fused_ops/linear.py
@@ -19,12 +19,12 @@ def Linear(
 
     ``weight`` must be the weight as a tilized list of values.
     """
-    assert weight.get_legacy_shape() == [1, 1, out_features, in_features]
+    assert weight.shape.with_tile_padding() == [1, 1, out_features, in_features]
 
     if bias is None:
         bias = None
     else:
-        assert bias.get_legacy_shape() == [1, 1, 32, out_features]
+        assert bias.shape.with_tile_padding() == [1, 1, 32, out_features]
 
     if bias is not None and bias.get_layout() != ttnn.TILE_LAYOUT:
         bias = ttnn.to_layout(bias, ttnn.TILE_LAYOUT)

--- a/models/experimental/bert/tt/add_and_norm.py
+++ b/models/experimental/bert/tt/add_and_norm.py
@@ -82,7 +82,7 @@ class TtAddAndNormModel(torch.nn.Module):
         )
 
     def forward(self, a, b):
-        print(a.get_legacy_shape(), b.get_legacy_shape())
+        print(a.shape.with_tile_padding(), b.shape.with_tile_padding())
         return self.add_and_norm(a, b)
 
 

--- a/models/experimental/bert/tt/mha.py
+++ b/models/experimental/bert/tt/mha.py
@@ -50,10 +50,10 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
             untilized_x = ttnn.untilize(x)
             reshaped_unt = ttnn.reshape_on_device(
                 untilized_x,
-                x.get_legacy_shape()[0],
-                x.get_legacy_shape()[2],
+                x.shape.with_tile_padding()[0],
+                x.shape.with_tile_padding()[2],
                 num_heads,
-                x.get_legacy_shape()[3] // num_heads,
+                x.shape.with_tile_padding()[3] // num_heads,
             )
 
             # N, 128, 2, 64
@@ -75,7 +75,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
             outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)
             """
             ctx = ttnn.transpose(x, 1, -2)
-            ushape = ctx.get_legacy_shape()
+            ushape = ctx.shape.with_tile_padding()
             reshaped = ttnn.reshape_on_device(ctx, ushape[0], 1, ushape[1], ushape[2] * ushape[3])
             retval = ttnn.tilize(reshaped)
             return retval
@@ -101,7 +101,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
             C,
             H,
             W,
-        ) = qkt.get_legacy_shape()  # Need to reshape right now since multi-C not supported for broadcast yet
+        ) = qkt.shape.with_tile_padding()  # Need to reshape right now since multi-C not supported for broadcast yet
         new_shape = [N, 1, C * H, W]
         ttnn.reshape_on_device(qkt, *new_shape)
         attention_score_input = multiply_by_sqrt_hidden_dim(qkt)

--- a/models/experimental/bert_large_perf/fused_ops/add_and_norm.py
+++ b/models/experimental/bert_large_perf/fused_ops/add_and_norm.py
@@ -16,7 +16,7 @@ def AddAndNorm(gamma: ttnn.Tensor, beta: ttnn.Tensor, epsilon, var_scaler, H, W,
 
     def add_and_norm_(activationa, activationb):
         a_plus_b = ttnn.add(activationa, activationb)
-        H = activationa.get_legacy_shape()[2]
+        H = activationa.shape.with_tile_padding()[2]
         lnorm_a_plus_b = layernorm(a_plus_b, var_scaler=var_scaler, overrideH=H)
         return lnorm_a_plus_b
 

--- a/models/experimental/bert_large_perf/fused_ops/linear.py
+++ b/models/experimental/bert_large_perf/fused_ops/linear.py
@@ -19,7 +19,7 @@ def Linear(
 
     ``weight`` must be the weight as a tilized list of values.
     """
-    assert weight.get_legacy_shape() == [1, 1, out_features, in_features]
+    assert weight.shape.with_tile_padding() == [1, 1, out_features, in_features]
     # weight = ttnn.Tensor(
     #     weight,
     #     [1, 1, out_features, in_features],
@@ -31,7 +31,7 @@ def Linear(
     if bias is None:
         bias = None
     else:
-        assert bias.get_legacy_shape() == [1, 1, 32, out_features]
+        assert bias.shape.with_tile_padding() == [1, 1, 32, out_features]
         # bias = ttnn.Tensor(
         #     bias,
         #     [1, 1, 32, out_features],

--- a/models/experimental/bert_large_perf/tt/mha.py
+++ b/models/experimental/bert_large_perf/tt/mha.py
@@ -84,10 +84,10 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
             untilized_x = ttnn.untilize(x)
             reshaped_unt = ttnn.reshape_on_device(
                 untilized_x,
-                x.get_legacy_shape()[0],
-                x.get_legacy_shape()[2],
+                x.shape.with_tile_padding()[0],
+                x.shape.with_tile_padding()[2],
                 num_heads,
-                x.get_legacy_shape()[3] // num_heads,
+                x.shape.with_tile_padding()[3] // num_heads,
             )
 
             # N, 128, 2, 64
@@ -163,7 +163,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
         # Attention scores computation
         # profiler.start("___op8_scale_mask_softmax")
 
-        N, C, H, W = qkt.get_legacy_shape()
+        N, C, H, W = qkt.shape.with_tile_padding()
         new_shape = [N, 1, C * H, W]
         ttnn.reshape_on_device(qkt, *new_shape)
         attention_score_input = multiply_by_sqrt_hidden_dim(qkt)
@@ -204,7 +204,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
 
             # profiler.start("___op10_unmake_attention_heads")
             ctx = ttnn.transpose(x, 1, -2)
-            ushape = ctx.get_legacy_shape()
+            ushape = ctx.shape.with_tile_padding()
             reshaped = ttnn.reshape_on_device(ctx, ushape[0], 1, ushape[1], ushape[2] * ushape[3])
             retval = ttnn.tilize(reshaped)
             # profiler.end("___op10_unmake_attention_heads")

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
@@ -43,7 +43,7 @@ def run_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config, 
     logger.debug(f"in0: {a_t.memory_config().buffer_type} and {a_t.get_dtype()}")
     logger.debug(f"out: {out.memory_config().buffer_type} and {out.get_dtype()}")
 
-    assert out.get_legacy_shape() == [batch, 1, 384, 1024]
+    assert out.shape.with_tile_padding() == [batch, 1, 384, 1024]
     tt_host_rm_out = out.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm_out = tt_host_rm_out.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
@@ -102,7 +102,7 @@ def run_bert_large_ff1_matmul_test(
         logger.debug(f"bias is on: {bias_t.memory_config().buffer_type}")
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
-    assert t2.get_legacy_shape() == [9, 1, 384, 4096]
+    assert t2.shape.with_tile_padding() == [9, 1, 384, 4096]
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
@@ -83,7 +83,7 @@ def run_bert_large_ff2_matmul_test(device, dtype, in0_mem_config, in1_mem_config
         logger.debug(f"bias is on: {bias_t.memory_config().buffer_type}")
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
-    assert t2.get_legacy_shape() == [9, 1, 384, 1024]
+    assert t2.shape.with_tile_padding() == [9, 1, 384, 1024]
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
@@ -83,7 +83,7 @@ def run_bert_large_fused_qkv_matmul_test(
         logger.debug(f"bias is on: {bias_t.memory_config().buffer_type}")
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
-    assert t2.get_legacy_shape() == [9, 1, 384, 3072]
+    assert t2.shape.with_tile_padding() == [9, 1, 384, 3072]
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
@@ -131,7 +131,7 @@ def run_bert_large_matmul_test(
         logger.debug(f"bias ({bias_shape}): {bias_t.memory_config().buffer_type} and {bias_t.get_dtype()}")
     logger.debug(f"out ({expected_output_shape}): {t2.memory_config().buffer_type} and {t2.get_dtype()}")
 
-    assert t2.get_legacy_shape() == expected_output_shape
+    assert t2.shape.with_tile_padding() == expected_output_shape
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 
@@ -221,7 +221,7 @@ def run_bert_large_bmm_test(
     logger.debug(f"in1 ({b_shape}): {b_t.memory_config().buffer_type} and {b_t.get_dtype()}")
     logger.debug(f"out ({expected_output_shape}): {t2.memory_config().buffer_type} and {t2.get_dtype()}")
 
-    assert t2.get_legacy_shape() == expected_output_shape
+    assert t2.shape.with_tile_padding() == expected_output_shape
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
@@ -66,7 +66,7 @@ def run_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_
     logger.debug(f"in1 is on: {b_t.memory_config().buffer_type}")
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
-    assert t2.get_legacy_shape() == out_shape
+    assert t2.shape.with_tile_padding() == out_shape
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
@@ -82,7 +82,7 @@ def run_bert_large_selfout_matmul_test(device, dtype, in0_mem_config, in1_mem_co
         logger.debug(f"bias is on: {bias_t.memory_config().buffer_type}")
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
-    assert t2.get_legacy_shape() == [9, 1, 384, 1024]
+    assert t2.shape.with_tile_padding() == [9, 1, 384, 1024]
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = tt_host_rm.to_torch()
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
@@ -49,9 +49,9 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
     logger.debug(f"k: {k.memory_config().buffer_type} and {k.get_dtype()}")
     logger.debug(f"v: {v.memory_config().buffer_type} and {v.get_dtype()}")
 
-    assert q.get_legacy_shape() == [batch, 16, 384, 64]
-    assert k.get_legacy_shape() == [batch, 16, 64, 384]
-    assert v.get_legacy_shape() == [batch, 16, 384, 64]
+    assert q.shape.with_tile_padding() == [batch, 16, 384, 64]
+    assert k.shape.with_tile_padding() == [batch, 16, 64, 384]
+    assert v.shape.with_tile_padding() == [batch, 16, 384, 64]
 
     tt_host_rm_q = q.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm_q = tt_host_rm_q.to_torch()

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
@@ -49,9 +49,9 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
     logger.debug(f"k: {k.memory_config().buffer_type} and {k.get_dtype()}")
     logger.debug(f"v: {v.memory_config().buffer_type} and {v.get_dtype()}")
 
-    assert q.get_legacy_shape() == [batch, 16, 384, 64]
-    assert k.get_legacy_shape() == [batch, 16, 64, 384]
-    assert v.get_legacy_shape() == [batch, 16, 384, 64]
+    assert q.shape.with_tile_padding() == [batch, 16, 384, 64]
+    assert k.shape.with_tile_padding() == [batch, 16, 64, 384]
+    assert v.shape.with_tile_padding() == [batch, 16, 384, 64]
 
     tt_host_rm_q = q.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm_q = tt_host_rm_q.to_torch()

--- a/models/experimental/bert_tiny/tt/bert_self_attention.py
+++ b/models/experimental/bert_tiny/tt/bert_self_attention.py
@@ -65,7 +65,11 @@ def mha(
         # Input shape : [1, 1, 128, 128]
         # Expected output shape: [1, 128, 2, 64]
         reshape_unt = fallback_ops.reshape(
-            x, x.get_legacy_shape()[0], x.get_legacy_shape()[2], num_heads, x.get_legacy_shape()[3] // num_heads
+            x,
+            x.shape.with_tile_padding()[0],
+            x.shape.with_tile_padding()[2],
+            num_heads,
+            x.shape.with_tile_padding()[3] // num_heads,
         )
         # Permute expects input to be in TILE layout
         # Input shape: [1, 128, 2, 64]

--- a/models/experimental/bloom/tt/bloom_attention.py
+++ b/models/experimental/bloom/tt/bloom_attention.py
@@ -233,7 +233,7 @@ class TtBloomAttention(torch.nn.Module):
 
     def get_alpha(self, q_length):
         if self.alpha is not None:
-            if self.alpha.get_legacy_shape()[3] == q_length:
+            if self.alpha.shape.with_tile_padding()[3] == q_length:
                 return self.alpha
 
         alpha_beta_shape = [1, self.num_heads, q_length, q_length]
@@ -284,7 +284,7 @@ class TtBloomAttention(torch.nn.Module):
             value_layer, 1, batch_size * self.num_heads, q_length, self.head_dim
         )
 
-        _, _, _, kv_length = reshaped_key_layer.get_legacy_shape()
+        _, _, _, kv_length = reshaped_key_layer.shape.with_tile_padding()
 
         matmul_result = baddbmm.tt_baddbmm(
             device=device,

--- a/models/experimental/bloom/tt/bloom_block.py
+++ b/models/experimental/bloom/tt/bloom_block.py
@@ -63,7 +63,9 @@ class TtBloomBlock(torch.nn.Module):
     ):
         # hidden_states: [batch_size, seq_length, hidden_size]
         # Layer norm at the beginning of the transformer layer.
-        layernorm_output = self.input_layernorm(hidden_states)  # , overrideH=hidden_states.get_legacy_shape()[-2])
+        layernorm_output = self.input_layernorm(
+            hidden_states
+        )  # , overrideH=hidden_states.shape.with_tile_padding()[-2])
 
         # Layer norm post the self attention.
         if self.apply_residual_connection_post_layernorm:
@@ -89,7 +91,7 @@ class TtBloomBlock(torch.nn.Module):
 
         layernorm_output = self.post_attention_layernorm(
             attention_output
-        )  # , overrideH=attention_output.get_legacy_shape()[-2])
+        )  # , overrideH=attention_output.shape.with_tile_padding()[-2])
 
         # Get residual
         if self.apply_residual_connection_post_layernorm:

--- a/models/experimental/bloom/tt/bloom_gelu_forward.py
+++ b/models/experimental/bloom/tt/bloom_gelu_forward.py
@@ -24,13 +24,13 @@ def bloom_gelu_forward(x: torch.Tensor) -> torch.Tensor:
 def tt_bloom_gelu_forward(x, device):
     z = x
 
-    k1 = torch.full(tuple(x.get_legacy_shape()), 0.5)
+    k1 = torch.full(tuple(x.shape.with_tile_padding()), 0.5)
     tt_k1 = bloom_utils.torch2tt_tensor(k1, device)
 
-    k2 = torch.full(tuple(x.get_legacy_shape()), 0.044715)
+    k2 = torch.full(tuple(x.shape.with_tile_padding()), 0.044715)
     tt_k2 = bloom_utils.torch2tt_tensor(k2, device)
 
-    k3 = torch.full(tuple(x.get_legacy_shape()), 0.79788456)
+    k3 = torch.full(tuple(x.shape.with_tile_padding()), 0.79788456)
     tt_k3 = bloom_utils.torch2tt_tensor(k3, device)
 
     # 0.5*x
@@ -50,7 +50,7 @@ def tt_bloom_gelu_forward(x, device):
     sumtanh = ttnn.mul(tt_k3, factor3, memory_config=mem_config)
     tanh = ttnn.tanh(sumtanh, memory_config=mem_config)
 
-    k4 = torch.full(tuple(x.get_legacy_shape()), 1.0)
+    k4 = torch.full(tuple(x.shape.with_tile_padding()), 1.0)
     tt_k4 = bloom_utils.torch2tt_tensor(k4, device)
 
     total = ttnn.add(tt_k4, tanh, memory_config=mem_config)

--- a/models/experimental/bloom/tt/bloom_model.py
+++ b/models/experimental/bloom/tt/bloom_model.py
@@ -516,7 +516,7 @@ class TtBloomModel(torch.nn.Module):
             i = i + 1
 
         # Add last hidden state
-        hidden_states = self.ln_f(hidden_states)  # , overrideH=hidden_states.get_legacy_shape()[-2])
+        hidden_states = self.ln_f(hidden_states)  # , overrideH=hidden_states.shape.with_tile_padding()[-2])
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)

--- a/models/experimental/bloom_old/tt/bloom_attention.py
+++ b/models/experimental/bloom_old/tt/bloom_attention.py
@@ -276,7 +276,7 @@ class TtBloomAttention(torch.nn.Module):
             value_layer, 1, batch_size * self.num_heads, q_length, self.head_dim
         )
 
-        _, _, _, kv_length = reshaped_key_layer.get_legacy_shape()
+        _, _, _, kv_length = reshaped_key_layer.shape.with_tile_padding()
 
         matmul_result = baddbmm.tt_baddbmm(
             device=device,

--- a/models/experimental/bloom_old/tt/bloom_block.py
+++ b/models/experimental/bloom_old/tt/bloom_block.py
@@ -82,7 +82,7 @@ class TtBloomBlock(torch.nn.Module):
     ):
         # hidden_states: [batch_size, seq_length, hidden_size]
         # Layer norm at the beginning of the transformer layer.
-        layernorm_output = self.input_layernorm(hidden_states, overrideH=hidden_states.get_legacy_shape()[-2])
+        layernorm_output = self.input_layernorm(hidden_states, overrideH=hidden_states.shape.with_tile_padding()[-2])
 
         # Layer norm post the self attention.
         if self.apply_residual_connection_post_layernorm:
@@ -107,7 +107,7 @@ class TtBloomBlock(torch.nn.Module):
         outputs = attn_outputs[1:]
 
         layernorm_output = self.post_attention_layernorm(
-            attention_output, overrideH=attention_output.get_legacy_shape()[-2]
+            attention_output, overrideH=attention_output.shape.with_tile_padding()[-2]
         )
 
         # Get residual

--- a/models/experimental/bloom_old/tt/bloom_gelu_forward.py
+++ b/models/experimental/bloom_old/tt/bloom_gelu_forward.py
@@ -31,13 +31,13 @@ def bloom_gelu_forward(x: torch.Tensor) -> torch.Tensor:
 def tt_bloom_gelu_forward(x, device):
     z = x
 
-    k1 = torch.full(tuple(x.get_legacy_shape()), 0.5)
+    k1 = torch.full(tuple(x.shape.with_tile_padding()), 0.5)
     tt_k1 = bloom_utils.torch2tt_tensor(k1, device)
 
-    k2 = torch.full(tuple(x.get_legacy_shape()), 0.044715)
+    k2 = torch.full(tuple(x.shape.with_tile_padding()), 0.044715)
     tt_k2 = bloom_utils.torch2tt_tensor(k2, device)
 
-    k3 = torch.full(tuple(x.get_legacy_shape()), 0.79788456)
+    k3 = torch.full(tuple(x.shape.with_tile_padding()), 0.79788456)
     tt_k3 = bloom_utils.torch2tt_tensor(k3, device)
 
     # 0.5*x
@@ -57,7 +57,7 @@ def tt_bloom_gelu_forward(x, device):
     sumtanh = ttnn.mul(tt_k3, factor3)
     tanh = ttnn.tanh(sumtanh)
 
-    k4 = torch.full(tuple(x.get_legacy_shape()), 1.0)
+    k4 = torch.full(tuple(x.shape.with_tile_padding()), 1.0)
     tt_k4 = bloom_utils.torch2tt_tensor(k4, device)
 
     total = ttnn.add(tt_k4, tanh)

--- a/models/experimental/bloom_old/tt/bloom_model.py
+++ b/models/experimental/bloom_old/tt/bloom_model.py
@@ -523,7 +523,7 @@ class TtBloomModel(torch.nn.Module):
             i = i + 1
 
         # Add last hidden state
-        hidden_states = self.ln_f(hidden_states, overrideH=hidden_states.get_legacy_shape()[-2])
+        hidden_states = self.ln_f(hidden_states, overrideH=hidden_states.shape.with_tile_padding()[-2])
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)

--- a/models/experimental/bloom_old/tt/bloom_qa.py
+++ b/models/experimental/bloom_old/tt/bloom_qa.py
@@ -17,7 +17,7 @@ class TtBloomForQuestionAnswering:
         # self.qa_outputs_weight = bloom_utils.tt_load_layer_weights("qa_outputs.weight", state_dict)
         # self.qa_outputs_bias = bloom_utils.tt_load_layer_weights("qa_outputs.bias", state_dict)
 
-        # out_features = self.qa_outputs_bias.get_legacy_shape()[-1]
+        # out_features = self.qa_outputs_bias.shape.with_tile_padding()[-1]
         # self.qa_outputs = TtLinear(config.hidden_size, out_features, self.qa_outputs_weight, self.qa_outputs_bias, device)
 
         self.qa_outputs = torch.nn.Linear(config.hidden_size, 2)

--- a/models/experimental/convnet_mnist/tt/convnet_mnist.py
+++ b/models/experimental/convnet_mnist/tt/convnet_mnist.py
@@ -41,8 +41,10 @@ class TtConvNet(torch.nn.Module):
         out = ttnn.relu(out)
         out = self.max_pool2d(out)
 
-        last_dim_size = out.get_legacy_shape()[-1] * out.get_legacy_shape()[-2] * out.get_legacy_shape()[-3]
-        out = fallback_ops.reshape(out, out.get_legacy_shape()[0], 1, 1, last_dim_size)
+        last_dim_size = (
+            out.shape.with_tile_padding()[-1] * out.shape.with_tile_padding()[-2] * out.shape.with_tile_padding()[-3]
+        )
+        out = fallback_ops.reshape(out, out.shape.with_tile_padding()[0], 1, 1, last_dim_size)
 
         out = ttnn.matmul(out, self.linear1_weights)
         out = ttnn.add(out, self.linear1_bias)

--- a/models/experimental/deit/tt/deit_for_image_classification_with_teacher.py
+++ b/models/experimental/deit/tt/deit_for_image_classification_with_teacher.py
@@ -75,7 +75,7 @@ class TtDeiTForImageClassificationWithTeacher(nn.Module):
 
         # during inference, return the average of both classifier predictions
         logits = ttnn.add(cls_logits, distillation_logits)
-        half = ttnn.full(logits.get_legacy_shape(), 0.5)
+        half = ttnn.full(logits.shape.with_tile_padding(), 0.5)
         logits = ttnn.mul(logits, half)
 
         # if not return_dict:

--- a/models/experimental/distilbert/tt/distilbert_embedding.py
+++ b/models/experimental/distilbert/tt/distilbert_embedding.py
@@ -58,7 +58,7 @@ class TtDistilBert_Embeddings(nn.Module):
             input_embeds = self.word_embeddings(input_ids)
             input_embeds = torch_to_tt_tensor_rm(input_embeds, self.device, put_on_device=True)
 
-        seq_length = input_embeds.get_legacy_shape()[-2]
+        seq_length = input_embeds.shape.with_tile_padding()[-2]
 
         if hasattr(self, "position_ids"):
             position_ids = self.position_ids[:, :seq_length]

--- a/models/experimental/distilbert/tt/distilbert_ffn.py
+++ b/models/experimental/distilbert/tt/distilbert_ffn.py
@@ -22,8 +22,8 @@ class TtFFN(nn.Module):
         self.linear_1_weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.ffn.lin1.weight"], self.device)
         self.linear_1_bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.ffn.lin1.bias"], self.device)
         self.linear1 = TtLinear(
-            self.linear_1_weight.get_legacy_shape()[-1],
-            self.linear_1_weight.get_legacy_shape()[-2],
+            self.linear_1_weight.shape.with_tile_padding()[-1],
+            self.linear_1_weight.shape.with_tile_padding()[-2],
             self.linear_1_weight,
             self.linear_1_bias,
         )
@@ -31,8 +31,8 @@ class TtFFN(nn.Module):
         self.linear_2_weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.ffn.lin2.weight"], self.device)
         self.linear_2_bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.ffn.lin2.bias"], self.device)
         self.linear2 = TtLinear(
-            self.linear_2_weight.get_legacy_shape()[-1],
-            self.linear_2_weight.get_legacy_shape()[-2],
+            self.linear_2_weight.shape.with_tile_padding()[-1],
+            self.linear_2_weight.shape.with_tile_padding()[-2],
             self.linear_2_weight,
             self.linear_2_bias,
         )

--- a/models/experimental/distilbert/tt/distilbert_for_question_answering.py
+++ b/models/experimental/distilbert/tt/distilbert_for_question_answering.py
@@ -41,8 +41,8 @@ class TtDistilBertForQuestionAnswering(nn.Module):
         self.qa_weight = torch_to_tt_tensor_rm(state_dict["qa_outputs.weight"], self.device)
         self.qa_bias = torch_to_tt_tensor_rm(state_dict["qa_outputs.bias"], self.device)
         self.qa_linear = TtLinear(
-            self.qa_weight.get_legacy_shape()[-1],
-            self.qa_weight.get_legacy_shape()[-2],
+            self.qa_weight.shape.with_tile_padding()[-1],
+            self.qa_weight.shape.with_tile_padding()[-2],
             self.qa_weight,
             self.qa_bias,
         )

--- a/models/experimental/distilbert/tt/distilbert_model.py
+++ b/models/experimental/distilbert/tt/distilbert_model.py
@@ -101,7 +101,7 @@ class TtDistilBertModel(nn.Module):
         elif input_ids is not None:
             input_shape = list(input_ids.shape)
         elif inputs_embeds is not None:
-            input_shape = inputs_embeds.get_legacy_shape()[:-1]
+            input_shape = inputs_embeds.shape.with_tile_padding()[:-1]
 
         if attention_mask is not None:
             input_shape[0:0] = [1, 1]

--- a/models/experimental/distilbert/tt/distilbert_multihead_self_attention.py
+++ b/models/experimental/distilbert/tt/distilbert_multihead_self_attention.py
@@ -28,8 +28,8 @@ class TtMultiHeadSelfAttention(nn.Module):
         self.query_weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.q_lin.weight"], self.device)
         self.query_bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.q_lin.bias"], self.device)
         self.query_linear = TtLinear(
-            self.query_weight.get_legacy_shape()[-1],
-            self.query_weight.get_legacy_shape()[-2],
+            self.query_weight.shape.with_tile_padding()[-1],
+            self.query_weight.shape.with_tile_padding()[-2],
             self.query_weight,
             self.query_bias,
         )
@@ -37,8 +37,8 @@ class TtMultiHeadSelfAttention(nn.Module):
         self.key_weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.k_lin.weight"], self.device)
         self.key_bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.k_lin.bias"], self.device)
         self.key_linear = TtLinear(
-            self.key_weight.get_legacy_shape()[-1],
-            self.key_weight.get_legacy_shape()[-2],
+            self.key_weight.shape.with_tile_padding()[-1],
+            self.key_weight.shape.with_tile_padding()[-2],
             self.key_weight,
             self.key_bias,
         )
@@ -46,8 +46,8 @@ class TtMultiHeadSelfAttention(nn.Module):
         self.value_weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.v_lin.weight"], self.device)
         self.value_bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.v_lin.bias"], self.device)
         self.value_linear = TtLinear(
-            self.value_weight.get_legacy_shape()[-1],
-            self.value_weight.get_legacy_shape()[-2],
+            self.value_weight.shape.with_tile_padding()[-1],
+            self.value_weight.shape.with_tile_padding()[-2],
             self.value_weight,
             self.value_bias,
         )
@@ -55,8 +55,8 @@ class TtMultiHeadSelfAttention(nn.Module):
         self.out_weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.out_lin.weight"], self.device)
         self.out_bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.attention.out_lin.bias"], self.device)
         self.out_linear = TtLinear(
-            self.out_weight.get_legacy_shape()[-1],
-            self.out_weight.get_legacy_shape()[-2],
+            self.out_weight.shape.with_tile_padding()[-1],
+            self.out_weight.shape.with_tile_padding()[-2],
             self.out_weight,
             self.out_bias,
         )
@@ -79,8 +79,8 @@ class TtMultiHeadSelfAttention(nn.Module):
         head_mask: Optional[ttnn.Tensor] = None,
         output_attention: bool = False,
     ) -> Tuple[ttnn.Tensor]:
-        _, bs, q_length, dim = query.get_legacy_shape()
-        k_length = key.get_legacy_shape()[-2]
+        _, bs, q_length, dim = query.shape.with_tile_padding()
+        k_length = key.shape.with_tile_padding()[-2]
 
         dim_per_head = self.dim // self.n_heads
 
@@ -99,7 +99,7 @@ class TtMultiHeadSelfAttention(nn.Module):
         k = shape(self.key_linear(key))
         v = shape(self.value_linear(value))
 
-        dim_per_head_tensor = self.const_tensor(q.get_legacy_shape(), dim_per_head)
+        dim_per_head_tensor = self.const_tensor(q.shape.with_tile_padding(), dim_per_head)
         dim_per_head_tensor = ttnn.sqrt(dim_per_head_tensor)
         dim_per_head_tensor = ttnn.reciprocal(dim_per_head_tensor)
 

--- a/models/experimental/efficientnet/tt/efficientnet_model.py
+++ b/models/experimental/efficientnet/tt/efficientnet_model.py
@@ -170,9 +170,9 @@ class TtEfficientNet(torch.nn.Module):
         x = self.features(x)
         x = self.avgpool(x)
 
-        last_shape = x.get_legacy_shape()[-1] * x.get_legacy_shape()[-2] * x.get_legacy_shape()[-3]
+        last_shape = x.shape.with_tile_padding()[-1] * x.shape.with_tile_padding()[-2] * x.shape.with_tile_padding()[-3]
         # ttnn.reshape_on_device won't work here since input tensor is of shape [1, n, 1, 1]
-        x = fallback_ops.reshape(x, x.get_legacy_shape()[0], 1, 1, last_shape)
+        x = fallback_ops.reshape(x, x.shape.with_tile_padding()[0], 1, 1, last_shape)
 
         x = ttnn.matmul(x, self.classifier_weight)
 

--- a/models/experimental/lenet/tt/lenet.py
+++ b/models/experimental/lenet/tt/lenet.py
@@ -126,7 +126,7 @@ class TtLeNet5(nn.Module):
         out = self.maxp2(out)  # HOST (fallback)
 
         # using fallback since last dimension of tensor is not divisible by 2
-        out_shape = out.get_legacy_shape()
+        out_shape = out.shape.with_tile_padding()
         out = fallback_ops.reshape(
             out, out_shape[0], 1, 1, out_shape[1] * out_shape[2] * out_shape[3]
         )  # HOST (fallback)

--- a/models/experimental/llama/tt/llama_attention.py
+++ b/models/experimental/llama/tt/llama_attention.py
@@ -168,16 +168,16 @@ class TtLlamaAttention(nn.Module):
         self.rotary_emb = LlamaRotaryEmbedding(self.head_dim, max_position_embeddings=self.max_position_embeddings)
 
         self.query_linear = TTLinear(
-            self.q_weights.get_legacy_shape()[-1], self.q_weights.get_legacy_shape()[-2], self.q_weights
+            self.q_weights.shape.with_tile_padding()[-1], self.q_weights.shape.with_tile_padding()[-2], self.q_weights
         )
         self.key_linear = TTLinear(
-            self.k_weights.get_legacy_shape()[-1], self.k_weights.get_legacy_shape()[-2], self.k_weights
+            self.k_weights.shape.with_tile_padding()[-1], self.k_weights.shape.with_tile_padding()[-2], self.k_weights
         )
         self.value_linear = TTLinear(
-            self.v_weights.get_legacy_shape()[-1], self.v_weights.get_legacy_shape()[-2], self.v_weights
+            self.v_weights.shape.with_tile_padding()[-1], self.v_weights.shape.with_tile_padding()[-2], self.v_weights
         )
         self.attn_linear = TTLinear(
-            self.o_weights.get_legacy_shape()[-1], self.o_weights.get_legacy_shape()[-2], self.o_weights
+            self.o_weights.shape.with_tile_padding()[-1], self.o_weights.shape.with_tile_padding()[-2], self.o_weights
         )
 
         self.scalar = pad_by_zero(torch.Tensor([1 / math.sqrt(self.head_dim)]), self.device)[0]
@@ -196,8 +196,8 @@ class TtLlamaAttention(nn.Module):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         """Input shape: Batch x Time x Channel"""
 
-        bsz = hidden_states.get_legacy_shape()[0]
-        q_len = hidden_states.get_legacy_shape()[2]
+        bsz = hidden_states.shape.with_tile_padding()[0]
+        q_len = hidden_states.shape.with_tile_padding()[2]
         query = self.query_linear(hidden_states)
         query_states = shape_tt(query, bsz, q_len, self.num_heads, self.head_dim)
 
@@ -249,17 +249,17 @@ class TtLlamaAttention(nn.Module):
         # TODO: Fuse into softmax
         attn_weights = ttnn.multiply(mul, self.scalar)
 
-        if attn_weights.get_legacy_shape() != [bsz, self.num_heads, q_len, kv_seq_len]:
+        if attn_weights.shape.with_tile_padding() != [bsz, self.num_heads, q_len, kv_seq_len]:
             raise ValueError(
                 f"Attention weights should be of size {(bsz * self.num_heads, q_len, kv_seq_len)}, but is"
-                f" {attn_weights.get_legacy_shape()}"
+                f" {attn_weights.shape.with_tile_padding()}"
             )
 
         # change attention_mask to TT tensor
         if attention_mask is not None:
             if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
                 raise ValueError(
-                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.get_legacy_shape()}"
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.shape.with_tile_padding()}"
                 )
             # TT eltwise add operation, expand attention_mask shape
             attention_mask = attention_mask.repeat(1, self.num_heads, 1, 1)
@@ -276,10 +276,10 @@ class TtLlamaAttention(nn.Module):
         attn_weights = ttnn.softmax_in_place(attn_weights)
         attn_output = ttnn.matmul(attn_weights, value_states)
 
-        if attn_output.get_legacy_shape() != [bsz, self.num_heads, q_len, self.head_dim]:
+        if attn_output.shape.with_tile_padding() != [bsz, self.num_heads, q_len, self.head_dim]:
             raise ValueError(
                 f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
-                f" {attn_output.get_legacy_shape()}"
+                f" {attn_output.shape.with_tile_padding()}"
             )
 
         attn_output = ttnn.transpose(attn_output, 1, -2)

--- a/models/experimental/llama/tt/llama_second_half.py
+++ b/models/experimental/llama/tt/llama_second_half.py
@@ -143,8 +143,8 @@ class TtLlamaModelSecondHFModel(torch.nn.Module):
             raise ValueError("You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time")
         elif input_ids is not None:
             # batch_size, seq_length = input_ids.shape
-            batch_size = input_ids.get_legacy_shape()[0]
-            seq_length = input_ids.get_legacy_shape()[2]
+            batch_size = input_ids.shape.with_tile_padding()[0]
+            seq_length = input_ids.shape.with_tile_padding()[2]
         elif inputs_embeds is not None:
             batch_size, seq_length, _ = inputs_embeds.shape
         else:

--- a/models/experimental/mnist/tt/mnist_model.py
+++ b/models/experimental/mnist/tt/mnist_model.py
@@ -32,9 +32,9 @@ class TtMnistModel(torch.nn.Module):
         self.fc3_weight = ttnn.transpose(self.fc3_weight, -2, -1)
 
     def forward(self, x):
-        # ttnn.reshape_on_device throws an assertion RuntimeError: TT_ASSERT @ tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp:295: input_tensor_a.get_legacy_shape()[3] % TILE_WIDTH == 0 && W % TILE_WIDTH == 0 info:
+        # ttnn.reshape_on_device throws an assertion RuntimeError: TT_ASSERT @ tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp:295: input_tensor_a.shape.with_tile_padding()[3] % TILE_WIDTH == 0 && W % TILE_WIDTH == 0 info:
         # Operand/target width must be a multiple of 32. So using fallback_ops.reshape.
-        x = fallback_ops.reshape(x, x.get_legacy_shape()[0], 1, 1, 784)
+        x = fallback_ops.reshape(x, x.shape.with_tile_padding()[0], 1, 1, 784)
 
         x = ttnn.matmul(x, self.fc1_weight)
         x = ttnn.add(x, self.fc1_bias)

--- a/models/experimental/nanogpt/nanogpt_utils.py
+++ b/models/experimental/nanogpt/nanogpt_utils.py
@@ -12,7 +12,7 @@ import os
 
 
 def unpad_from_zero(x, desired_shape):
-    if x.get_legacy_shape()[-1] == desired_shape[-1] and x.get_legacy_shape()[-2] == desired_shape[-2]:
+    if x.shape.with_tile_padding()[-1] == desired_shape[-1] and x.shape.with_tile_padding()[-2] == desired_shape[-2]:
         x = tt2torch_tensor(x)
     else:
         x = x.cpu()

--- a/models/experimental/nanogpt/tt/nanogpt_attention.py
+++ b/models/experimental/nanogpt/tt/nanogpt_attention.py
@@ -67,7 +67,7 @@ class TtCausalSelfAttention(nn.Module):
             B,
             T,
             C,
-        ) = x.get_legacy_shape()  # batch size, sequence length, embedding dimensionality (n_embd)
+        ) = x.shape.with_tile_padding()  # batch size, sequence length, embedding dimensionality (n_embd)
 
         x1 = self.c_attn(x)
 
@@ -94,7 +94,7 @@ class TtCausalSelfAttention(nn.Module):
         key_layer_transposed = ttnn.transpose(k, -2, -1)
         att = ttnn.matmul(q, key_layer_transposed)
 
-        const_att = self.const_tensor(att.get_legacy_shape(), 1.0 / math.sqrt(k.get_legacy_shape()[-1]))
+        const_att = self.const_tensor(att.shape.with_tile_padding(), 1.0 / math.sqrt(k.shape.with_tile_padding()[-1]))
 
         att = ttnn.mul(att, const_att)
 

--- a/models/experimental/nanogpt/tt/nanogpt_model.py
+++ b/models/experimental/nanogpt/tt/nanogpt_model.py
@@ -112,7 +112,7 @@ class TtGPT(nn.Module):
             # forward the model to get the logits for the index in the sequence
             tt_logits = self.forward(idx_cond)
 
-            logits_shapes = tt_logits.get_legacy_shape()
+            logits_shapes = tt_logits.shape.with_tile_padding()
 
             slice_list = [
                 slice(None),
@@ -122,7 +122,7 @@ class TtGPT(nn.Module):
             ]
             tt_logits = fallback_ops.tensor_slice(tt_logits, slice_list)
 
-            tt_temperature = fallback_ops.full(tt_logits.get_legacy_shape(), temperature)
+            tt_temperature = fallback_ops.full(tt_logits.shape.with_tile_padding(), temperature)
 
             tt_temperature = ttnn.reciprocal(tt_temperature)
             tt_logits = ttnn.multiply(tt_logits, tt_temperature)

--- a/models/experimental/roberta/tests/test_roberta_for_multiple_choice.py
+++ b/models/experimental/roberta/tests/test_roberta_for_multiple_choice.py
@@ -61,7 +61,7 @@ def test_roberta_for_multiple_choice(device):
         print(inputs_dict["attention_mask"].shape)
         inputs_dict["attention_mask"] = torch.unsqueeze(inputs_dict["attention_mask"], 0)
         inputs_dict["attention_mask"] = torch2tt_tensor(inputs_dict["attention_mask"], device)
-        print(inputs_dict["attention_mask"].get_legacy_shape())
+        print(inputs_dict["attention_mask"].shape.with_tile_padding())
 
         logger.info("Running tt model ...")
         tt_output = tt_model(**inputs_dict)

--- a/models/experimental/roberta/tt/roberta_classification_head.py
+++ b/models/experimental/roberta/tt/roberta_classification_head.py
@@ -32,14 +32,14 @@ class TtRobertaClassificationHead(nn.Module):
         self.out_proj_weight = torch2tt_tensor(state_dict[f"{base_address}.out_proj.weight"], self.device)
         self.out_proj_bias = torch2tt_tensor(state_dict[f"{base_address}.out_proj.bias"], self.device)
         self.dense_linear = TTLinear(
-            self.dense_weight.get_legacy_shape()[-1],
-            self.dense_weight.get_legacy_shape()[-2],
+            self.dense_weight.shape.with_tile_padding()[-1],
+            self.dense_weight.shape.with_tile_padding()[-2],
             self.dense_weight,
             self.dense_bias,
         )
         self.out_proj_linear = TTLinear(
-            self.out_proj_weight.get_legacy_shape()[-1],
-            self.out_proj_weight.get_legacy_shape()[-2],
+            self.out_proj_weight.shape.with_tile_padding()[-1],
+            self.out_proj_weight.shape.with_tile_padding()[-2],
             self.out_proj_weight,
             self.out_proj_bias,
         )

--- a/models/experimental/roberta/tt/roberta_for_multiple_choice.py
+++ b/models/experimental/roberta/tt/roberta_for_multiple_choice.py
@@ -87,12 +87,12 @@ class TtRobertaForMultipleChoice(nn.Module):
         flat_position_ids = position_ids.view(-1, position_ids.size(-1)) if position_ids is not None else None
         flat_token_type_ids = token_type_ids.view(-1, token_type_ids.size(-1)) if token_type_ids is not None else None
         flat_attention_mask = (
-            fallback_ops.reshape(attention_mask, 1, 1, -1, attention_mask.get_legacy_shape()[-1])
+            fallback_ops.reshape(attention_mask, 1, 1, -1, attention_mask.shape.with_tile_padding()[-1])
             if attention_mask is not None
             else None
         )
         flat_inputs_embeds = (
-            fallback_ops.reshape(inputs_embeds, 1, 1, -1, inputs_embeds.get_legacy_shape()[-2])
+            fallback_ops.reshape(inputs_embeds, 1, 1, -1, inputs_embeds.shape.with_tile_padding()[-2])
             if inputs_embeds is not None
             else None
         )

--- a/models/experimental/roberta/tt/roberta_intermediate.py
+++ b/models/experimental/roberta/tt/roberta_intermediate.py
@@ -27,8 +27,8 @@ class TtRobertaIntermediate(nn.Module):
         self.dense_weight = pad_by_zero(state_dict[f"{base_address}.dense.weight"], self.device)[0]
         self.dense_bias = pad_by_zero(state_dict[f"{base_address}.dense.bias"], self.device)[0]
         self.dense_linear = TTLinear(
-            self.dense_weight.get_legacy_shape()[-1],
-            self.dense_weight.get_legacy_shape()[-2],
+            self.dense_weight.shape.with_tile_padding()[-1],
+            self.dense_weight.shape.with_tile_padding()[-2],
             self.dense_weight,
             self.dense_bias,
         )

--- a/models/experimental/roberta/tt/roberta_model.py
+++ b/models/experimental/roberta/tt/roberta_model.py
@@ -165,8 +165,8 @@ class TtRobertaModel(nn.Module):
         # positions we want to attend and the dtype's smallest value for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        self.ones_const = ttnn.full(extended_attention_mask.get_legacy_shape(), 1.0)
-        self.mul_const = ttnn.full(extended_attention_mask.get_legacy_shape(), self.dtype_min_const)
+        self.ones_const = ttnn.full(extended_attention_mask.shape.with_tile_padding(), 1.0)
+        self.mul_const = ttnn.full(extended_attention_mask.shape.with_tile_padding(), self.dtype_min_const)
         extended_attention_mask = ttnn.sub(self.ones_const, extended_attention_mask, memory_config=self.mem_config)
 
         extended_attention_mask = ttnn.mul(extended_attention_mask, self.mul_const, memory_config=self.mem_config)
@@ -184,15 +184,15 @@ class TtRobertaModel(nn.Module):
         """
         torch_encoder_attention_mask = tt2torch_tensor(encoder_attention_mask)
 
-        if len(encoder_attention_mask.get_legacy_shape()) == 3:
+        if len(encoder_attention_mask.shape.with_tile_padding()) == 3:
             torch_encoder_extended_attention_mask = torch_encoder_attention_mask[:, None, :, :]
-        if len(encoder_attention_mask.get_legacy_shape()) == 2:
+        if len(encoder_attention_mask.shape.with_tile_padding()) == 2:
             torch_encoder_extended_attention_mask = torch_encoder_attention_mask[:, None, None, :]
 
         encoder_extended_attention_mask = torch2tt_tensor(torch_encoder_extended_attention_mask, self.device)
 
-        self.ones_const = ttnn.full(encoder_extended_attention_mask.get_legacy_shape(), 1.0)
-        self.mul_const = ttnn.full(encoder_extended_attention_mask.get_legacy_shape(), self.dtype_min_const)
+        self.ones_const = ttnn.full(encoder_extended_attention_mask.shape.with_tile_padding(), 1.0)
+        self.mul_const = ttnn.full(encoder_extended_attention_mask.shape.with_tile_padding(), self.dtype_min_const)
 
         encoder_extended_attention_mask = ttnn.sub(
             self.ones_const,
@@ -322,7 +322,7 @@ class TtRobertaModel(nn.Module):
         elif input_ids is not None:
             input_shape = list(input_ids.size())
         elif inputs_embeds is not None:
-            input_shape = inputs_embeds.get_legacy_shape()[:-1]
+            input_shape = inputs_embeds.shape.with_tile_padding()[:-1]
         else:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
@@ -331,7 +331,9 @@ class TtRobertaModel(nn.Module):
         _, _, batch_size, seq_length = input_shape
 
         # past_key_values_length
-        past_key_values_length = past_key_values[0][0].get_legacy_shape()[2] if past_key_values is not None else 0
+        past_key_values_length = (
+            past_key_values[0][0].shape.with_tile_padding()[2] if past_key_values is not None else 0
+        )
 
         if attention_mask is None:
             attention_mask = ttnn.full((1, 1, batch_size, seq_length + past_key_values_length), 0.0)
@@ -356,7 +358,7 @@ class TtRobertaModel(nn.Module):
                 encoder_batch_size,
                 encoder_sequence_length,
                 _,
-            ) = encoder_hidden_states.get_legacy_shape()
+            ) = encoder_hidden_states.shape.with_tile_padding()
             encoder_hidden_shape = (1, 1, encoder_batch_size, encoder_sequence_length)
             if encoder_attention_mask is None:
                 encoder_attention_mask = ttnn.full(encoder_hidden_shape, 1.1)

--- a/models/experimental/roberta/tt/roberta_output.py
+++ b/models/experimental/roberta/tt/roberta_output.py
@@ -42,8 +42,8 @@ class TtRobertaOutput(nn.Module):
         # TODO: Add dropout when supported
         # self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.dense_linear = TTLinear(
-            self.dense_weight.get_legacy_shape()[-1],
-            self.dense_weight.get_legacy_shape()[-2],
+            self.dense_weight.shape.with_tile_padding()[-1],
+            self.dense_weight.shape.with_tile_padding()[-2],
             self.dense_weight,
             self.dense_bias,
         )

--- a/models/experimental/roberta/tt/roberta_pooler.py
+++ b/models/experimental/roberta/tt/roberta_pooler.py
@@ -31,8 +31,8 @@ class TtRobertaPooler(nn.Module):
         self.dense_weight = pad_by_zero(state_dict[f"{base_address}.dense.weight"], self.device)[0]
         self.dense_bias = pad_by_zero(state_dict[f"{base_address}.dense.bias"], self.device)[0]
         self.dense_linear = TTLinear(
-            self.dense_weight.get_legacy_shape()[-1],
-            self.dense_weight.get_legacy_shape()[-2],
+            self.dense_weight.shape.with_tile_padding()[-1],
+            self.dense_weight.shape.with_tile_padding()[-2],
             self.dense_weight,
             self.dense_bias,
         )

--- a/models/experimental/roberta/tt/roberta_self_output.py
+++ b/models/experimental/roberta/tt/roberta_self_output.py
@@ -30,8 +30,8 @@ class TtRobertaSelfOutput(nn.Module):
         # TODO: Add dropout when supported
         # self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.dense_linear = TTLinear(
-            self.dense_weight.get_legacy_shape()[-1],
-            self.dense_weight.get_legacy_shape()[-2],
+            self.dense_weight.shape.with_tile_padding()[-1],
+            self.dense_weight.shape.with_tile_padding()[-2],
             self.dense_weight,
             self.dense_bias,
         )

--- a/models/experimental/ssd/tt/ssd.py
+++ b/models/experimental/ssd/tt/ssd.py
@@ -105,7 +105,7 @@ class TtSSD(nn.Module):
         temporary_image = ttnn.ones([1, 3, size[1], size[0]], device=self.device)
         backbone.eval()
         features = backbone(temporary_image)
-        out_channels = [tensor.get_legacy_shape()[1] for i, tensor in features.items()]
+        out_channels = [tensor.shape.with_tile_padding()[1] for i, tensor in features.items()]
         return out_channels
 
     def postprocess_detections(
@@ -117,7 +117,7 @@ class TtSSD(nn.Module):
         bbox_regression = head_outputs["bbox_regression"]
         pred_scores = fallback_ops.softmax(head_outputs["cls_logits"], dim=-1)
 
-        num_classes = pred_scores.get_legacy_shape()[-1]
+        num_classes = pred_scores.shape.with_tile_padding()[-1]
 
         detections: List[Dict[str, ttnn.Tensor]] = []
 
@@ -172,7 +172,7 @@ class TtSSD(nn.Module):
     ) -> List[Dict[str, ttnn.Tensor]]:
         original_image_sizes: List[tuple[int, int]] = []
 
-        val = image.get_legacy_shape()[-2:]
+        val = image.shape.with_tile_padding()[-2:]
         original_image_sizes.append((val[0], val[1]))
 
         image = tt_to_torch_tensor(image)

--- a/models/experimental/ssd/tt/ssd_box_generator.py
+++ b/models/experimental/ssd/tt/ssd_box_generator.py
@@ -122,8 +122,8 @@ class TtDefaultBoxGenerator(nn.Module):
         return default_boxes_tensor
 
     def forward(self, image: ttnn.Tensor, feature_maps: List[ttnn.Tensor]) -> List[ttnn.Tensor]:
-        grid_sizes = [feature_map.get_legacy_shape()[-2:] for feature_map in feature_maps]
-        image_size = image.get_legacy_shape()[-2:]
+        grid_sizes = [feature_map.shape.with_tile_padding()[-2:] for feature_map in feature_maps]
+        image_size = image.shape.with_tile_padding()[-2:]
         image_sizes = [image_size]
         default_boxes = self._grid_default_boxes(grid_sizes, image_size)
         default_boxes = tt_to_torch_tensor(default_boxes).squeeze(0).squeeze(0)

--- a/models/experimental/stable_diffusion/tt/downsample_2d.py
+++ b/models/experimental/stable_diffusion/tt/downsample_2d.py
@@ -72,13 +72,13 @@ class TtDownsample2D(nn.Module):
             self.conv = conv
 
     def forward(self, hidden_states: ttnn.Tensor) -> ttnn.Tensor:
-        assert hidden_states.get_legacy_shape()[1] == self.in_channels
+        assert hidden_states.shape.with_tile_padding()[1] == self.in_channels
         if self.use_conv and self.padding == 0:
             pad = (0, 1, 0, 1)
 
             hidden_states = fallback_ops.pad(hidden_states, pad, mode="constant", value=0)
 
-        assert hidden_states.get_legacy_shape()[1] == self.in_channels
+        assert hidden_states.shape.with_tile_padding()[1] == self.in_channels
         hidden_states = self.conv(hidden_states)
 
         return hidden_states

--- a/models/experimental/stable_diffusion/tt/residual_block.py
+++ b/models/experimental/stable_diffusion/tt/residual_block.py
@@ -179,7 +179,9 @@ class TtResnetBlock2D(nn.Module):
             temb = self.nonlinearity(temb)
 
             temb = self.time_emb_proj(temb)
-            temb = fallback_ops.reshape(temb, temb.get_legacy_shape()[2], temb.get_legacy_shape()[3], 1, 1)
+            temb = fallback_ops.reshape(
+                temb, temb.shape.with_tile_padding()[2], temb.shape.with_tile_padding()[3], 1, 1
+            )
 
         if temb is not None and self.time_embedding_norm == "default":
             hidden_states = ttnn.add(hidden_states, temb)
@@ -197,7 +199,7 @@ class TtResnetBlock2D(nn.Module):
 
         # create a tensor of size output_scale_factor
         output_sc_recip = 1 / self.output_scale_factor
-        output_sc_recip = ttnn.full(input_tensor.get_legacy_shape(), output_sc_recip)
+        output_sc_recip = ttnn.full(input_tensor.shape.with_tile_padding(), output_sc_recip)
         output_tensor = ttnn.add(input_tensor, hidden_states)
         output_tensor = ttnn.mul(output_tensor, output_sc_recip)
 

--- a/models/experimental/stable_diffusion/tt/transformer_2d.py
+++ b/models/experimental/stable_diffusion/tt/transformer_2d.py
@@ -468,7 +468,7 @@ class TtTransformer2DModel(nn.Module):
         """
         # 1. Input
         if self.is_input_continuous:
-            batch, _, height, width = hidden_states.get_legacy_shape()
+            batch, _, height, width = hidden_states.shape.with_tile_padding()
             residual = hidden_states
 
             hidden_states = self.norm(hidden_states)
@@ -476,12 +476,12 @@ class TtTransformer2DModel(nn.Module):
             if not self.use_linear_projection:
                 hidden_states = self.proj_in(hidden_states)
 
-                inner_dim = hidden_states.get_legacy_shape()[1]
+                inner_dim = hidden_states.shape.with_tile_padding()[1]
 
                 hidden_states = ttnn.permute(hidden_states, (0, 2, 3, 1))
                 hidden_states = fallback_ops.reshape(hidden_states, 1, batch, height * width, inner_dim)
             else:
-                inner_dim = hidden_states.get_legacy_shape()[1]
+                inner_dim = hidden_states.shape.with_tile_padding()[1]
                 hidden_states = ttnn.permute(hidden_states, (0, 2, 3, 1))
                 hidden_states = fallback_ops.reshape(hidden_states, 1, batch, height * width, inner_dim)
 

--- a/models/experimental/stable_diffusion/tt/unet_2d_condition.py
+++ b/models/experimental/stable_diffusion/tt/unet_2d_condition.py
@@ -457,7 +457,7 @@ class UNet2DConditionModel(nn.Module):
         forward_upsample_size = False
         upsample_size = None
 
-        if any(s % default_overall_up_factor != 0 for s in sample.get_legacy_shape()[-2:]):
+        if any(s % default_overall_up_factor != 0 for s in sample.shape.with_tile_padding()[-2:]):
             logger.info("Forward upsample size to force interpolation output size.")
             forward_upsample_size = True
 

--- a/models/experimental/stable_diffusion/tt/upsample_2d.py
+++ b/models/experimental/stable_diffusion/tt/upsample_2d.py
@@ -46,7 +46,7 @@ class TtUpsample2D(nn.Module):
             )
 
     def forward(self, hidden_states: ttnn.Tensor, output_size=None) -> ttnn.Tensor:
-        assert hidden_states.get_legacy_shape()[1] == self.in_channels
+        assert hidden_states.shape.with_tile_padding()[1] == self.in_channels
 
         if output_size is None:
             upsampler_nearest2d = TtUpsampleNearest2d()

--- a/models/experimental/stable_diffusion/tt/upsample_nearest2d.py
+++ b/models/experimental/stable_diffusion/tt/upsample_nearest2d.py
@@ -19,8 +19,8 @@ class TtUpsampleNearest2d(nn.Module):
         self.scale_factor = int(scale_factor)
 
     def forward(self, input: ttnn.Tensor) -> ttnn.Tensor:
-        input_shape = input.get_legacy_shape()
-        output_shape = list(input.get_legacy_shape())
+        input_shape = input.shape.with_tile_padding()
+        output_shape = list(input.shape.with_tile_padding())
         output_shape[-1] *= self.scale_factor
         output_shape[-2] *= self.scale_factor
         input = ttnn.repeat_interleave(input, self.scale_factor, dim=3)

--- a/models/experimental/swin/swin_utils.py
+++ b/models/experimental/swin/swin_utils.py
@@ -43,7 +43,7 @@ def window_partition(input_feature, window_size, device, put_on_device=True):
     """
     Partitions the given input into windows.
     """
-    batch_size, height, width, num_channels = input_feature.get_legacy_shape()
+    batch_size, height, width, num_channels = input_feature.shape.with_tile_padding()
     input_feature = tt_to_torch_tensor(input_feature)
     input_feature = input_feature.view(
         batch_size,
@@ -63,7 +63,7 @@ def window_reverse(windows, window_size, height, width, device, put_on_device=Tr
     """
     Merges windows to produce higher resolution features.
     """
-    num_channels = windows.get_legacy_shape()[-1]
+    num_channels = windows.shape.with_tile_padding()[-1]
     windows = tt_to_torch_tensor(windows)
     windows = windows.view(
         -1,

--- a/models/experimental/swin/tt/swin_embeddings.py
+++ b/models/experimental/swin/tt/swin_embeddings.py
@@ -53,7 +53,7 @@ class TtSwinEmbeddings(nn.Module):
     ) -> Tuple[ttnn.Tensor]:
         embeddings, output_dimensions = self.patch_embeddings(pixel_values)
         embeddings = self.norm(embeddings)
-        _, batch_size, seq_len, _ = embeddings.get_legacy_shape()
+        _, batch_size, seq_len, _ = embeddings.shape.with_tile_padding()
 
         if bool_masked_pos is not None:
             mask_tokens = self.mask_token.expand(batch_size, seq_len, -1)
@@ -66,7 +66,7 @@ class TtSwinEmbeddings(nn.Module):
 
             mask_tokens = ttnn.mul(mask_tokens, mask)
 
-            unit_tensor = self.const_tensor(mask.get_legacy_shape(), 1)
+            unit_tensor = self.const_tensor(mask.shape.with_tile_padding(), 1)
             mask = ttnn.sub(unit_tensor, mask)
 
             embeddings = ttnn.mul(embeddings, mask)

--- a/models/experimental/swin/tt/swin_encoder.py
+++ b/models/experimental/swin/tt/swin_encoder.py
@@ -79,7 +79,7 @@ class TtSwinEncoder(nn.Module):
         all_self_attentions = () if output_attentions else None
 
         if output_hidden_states:
-            _, batch_size, _, hidden_size = hidden_states.get_legacy_shape()
+            _, batch_size, _, hidden_size = hidden_states.shape.with_tile_padding()
 
             reshaped_hidden_state = fallback_ops.reshape(hidden_states, batch_size, *input_dimensions, hidden_size)
             reshaped_hidden_state = ttnn.permute(reshaped_hidden_state, (0, 3, 1, 2))
@@ -125,7 +125,7 @@ class TtSwinEncoder(nn.Module):
                     batch_size,
                     _,
                     hidden_size,
-                ) = hidden_states_before_downsampling.get_legacy_shape()
+                ) = hidden_states_before_downsampling.shape.with_tile_padding()
                 # rearrange b (h w) c -> b c h w
                 # here we use the original (not downsampled) height and width
                 reshaped_hidden_state = fallback_ops.reshape(
@@ -138,7 +138,7 @@ class TtSwinEncoder(nn.Module):
                 all_hidden_states += (hidden_states_before_downsampling,)
                 all_reshaped_hidden_states += (reshaped_hidden_state,)
             elif output_hidden_states and not output_hidden_states_before_downsampling:
-                _, batch_size, _, hidden_size = hidden_states.get_legacy_shape()
+                _, batch_size, _, hidden_size = hidden_states.shape.with_tile_padding()
                 # rearrange b (h w) c -> b c h w
                 reshaped_hidden_state = fallback_ops.reshape(
                     reshaped_hidden_state, batch_size, *input_dimensions, hidden_size

--- a/models/experimental/swin/tt/swin_layer.py
+++ b/models/experimental/swin/tt/swin_layer.py
@@ -148,7 +148,7 @@ class TtSwinLayer(nn.Module):
         else:
             pass
         height, width = input_dimensions
-        _, batch_size, _, channels = hidden_states.get_legacy_shape()
+        _, batch_size, _, channels = hidden_states.shape.with_tile_padding()
         shortcut = hidden_states
 
         hidden_states = self.LayerNorm_before(hidden_states)
@@ -158,7 +158,7 @@ class TtSwinLayer(nn.Module):
         # pad hidden_states to multiples of window size
         hidden_states, pad_values = self.maybe_pad(hidden_states, height, width)
 
-        _, height_pad, width_pad, _ = hidden_states.get_legacy_shape()
+        _, height_pad, width_pad, _ = hidden_states.shape.with_tile_padding()
         hidden_states = tt_to_torch_tensor(hidden_states)
         # cyclic shift
         if self.shift_size > 0:

--- a/models/experimental/swin/tt/swin_patch_embedding.py
+++ b/models/experimental/swin/tt/swin_patch_embedding.py
@@ -57,7 +57,7 @@ class TtSwinPatchEmbeddings(nn.Module):
         return pixel_values
 
     def forward(self, pixel_values: Optional[ttnn.Tensor]) -> Tuple[ttnn.Tensor, Tuple[int]]:
-        _, num_channels, height, width = pixel_values.get_legacy_shape()
+        _, num_channels, height, width = pixel_values.shape.with_tile_padding()
         if num_channels != self.num_channels:
             raise ValueError(
                 "Make sure that the channel dimension of the pixel values match with the one set in the configuration."
@@ -65,7 +65,7 @@ class TtSwinPatchEmbeddings(nn.Module):
         # pad the input to be divisible by self.patch_size, if needed
         pixel_values = self.maybe_pad(pixel_values, height, width)
         embeddings = self.projection(pixel_values)
-        batch, channel, height, width = embeddings.get_legacy_shape()
+        batch, channel, height, width = embeddings.shape.with_tile_padding()
         output_dimensions = (height, width)
         embeddings = fallback_ops.reshape(embeddings, 1, batch, channel, height * width)
         embeddings = ttnn.transpose(embeddings, -2, -1)

--- a/models/experimental/swin/tt/swin_patch_merging.py
+++ b/models/experimental/swin/tt/swin_patch_merging.py
@@ -52,7 +52,7 @@ class TtSwinPatchMerging(nn.Module):
 
     def forward(self, input_feature: ttnn.Tensor, input_dimensions: Tuple[int, int]) -> ttnn.Tensor:
         height, width = input_dimensions
-        _, batch_size, dim, num_channels = input_feature.get_legacy_shape()
+        _, batch_size, dim, num_channels = input_feature.shape.with_tile_padding()
 
         input_feature = fallback_ops.reshape(input_feature, batch_size, height, width, num_channels)
 

--- a/models/experimental/synthetic_gradients/tests/test_batchnorm1d_forward.py
+++ b/models/experimental/synthetic_gradients/tests/test_batchnorm1d_forward.py
@@ -32,7 +32,7 @@ def tt_batch_norm(
 ):
     H = 32
     W = bn_size
-    batch_size = x.get_legacy_shape()[0]
+    batch_size = x.shape.with_tile_padding()[0]
     print("batch_size:", batch_size)
     epsilon_torch = torch.tensor([[[W * [eps]]]])
     epsilon_padded = pad_activation(epsilon_torch)

--- a/models/experimental/t5/tt/t5_block.py
+++ b/models/experimental/t5/tt/t5_block.py
@@ -108,7 +108,7 @@ class TtT5Block(nn.Module):
             # the actual query length is unknown for cross attention
             # if using past key value states. Need to inject it here
             if present_key_value_state is not None:
-                query_length = present_key_value_state[0].get_legacy_shape()[3]
+                query_length = present_key_value_state[0].shape.with_tile_padding()[3]
             else:
                 query_length = None
 

--- a/models/experimental/t5/tt/t5_stack.py
+++ b/models/experimental/t5/tt/t5_stack.py
@@ -282,7 +282,7 @@ class TtT5Stack(nn.Module):
             input_shape = input_ids.size()
             input_ids = input_ids.view(-1, input_shape[-1])
         elif inputs_embeds is not None:
-            input_shape = (inputs_embeds.get_legacy_shape()[1], inputs_embeds.get_legacy_shape()[2])
+            input_shape = (inputs_embeds.shape.with_tile_padding()[1], inputs_embeds.shape.with_tile_padding()[2])
         else:
             err_msg_prefix = "decoder_" if self.is_decoder else ""
             raise ValueError(f"You have to specify either {err_msg_prefix}input_ids or {err_msg_prefix}inputs_embeds")
@@ -326,7 +326,7 @@ class TtT5Stack(nn.Module):
                 _,
                 encoder_sequence_length,
                 _,
-            ) = encoder_hidden_states.get_legacy_shape()
+            ) = encoder_hidden_states.shape.with_tile_padding()
             encoder_extended_attention_mask = self.get_encoder_extended_attention_mask(
                 encoder_attention_mask, encoder_batch_size, encoder_sequence_length
             )

--- a/models/experimental/trocr/tt/trocr_decoder.py
+++ b/models/experimental/trocr/tt/trocr_decoder.py
@@ -160,7 +160,7 @@ class TtTrOCRDecoder(nn.Module):
             raise ValueError("You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time")
         elif input_ids is not None:
             input = input_ids
-            input_ids = fallback_ops.reshape(input_ids, 1, 1, -1, input.get_legacy_shape()[-1])
+            input_ids = fallback_ops.reshape(input_ids, 1, 1, -1, input.shape.with_tile_padding()[-1])
 
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
@@ -189,7 +189,7 @@ class TtTrOCRDecoder(nn.Module):
                 bias=self.layernorm_embedding_bias,
             )
 
-        input_shape = input.get_legacy_shape()
+        input_shape = input.shape.with_tile_padding()
 
         attention_mask = self._prepare_decoder_attention_mask(
             attention_mask, input_shape, inputs_embeds, past_key_values_length

--- a/models/experimental/trocr/tt/trocr_learned_positional_embeddings.py
+++ b/models/experimental/trocr/tt/trocr_learned_positional_embeddings.py
@@ -33,7 +33,7 @@ class TtTrOCRLearnedPositionalEmbedding(nn.Embedding):
 
     def forward(self, input_ids: ttnn.Tensor, past_key_values_length: int = 0):
         """`input_ids' shape is expected to be [bsz x seqlen]."""
-        bsz, seq_len = input_ids.get_legacy_shape()[2:]
+        bsz, seq_len = input_ids.shape.with_tile_padding()[2:]
         positions = torch.arange(
             past_key_values_length,
             past_key_values_length + seq_len,

--- a/models/experimental/vgg/demo/gs_demo.py
+++ b/models/experimental/vgg/demo/gs_demo.py
@@ -49,7 +49,7 @@ def test_gs_demo(device, imagenet_sample_input, imagenet_label_dict, batch_size,
         tt_images = ttnn.concat(tt_images)
 
         tt_output = tt_vgg(tt_images)
-        tt_output = unpad_from_zero(tt_output, tt_output.get_legacy_shape())
+        tt_output = unpad_from_zero(tt_output, tt_output.shape.with_tile_padding())
         tt_output = tt_output.cpu()
 
         logger.info(f"GS's predicted Output: {class_labels[torch.argmax(tt_output).item()]}\n")

--- a/models/experimental/vgg/tt/vgg.py
+++ b/models/experimental/vgg/tt/vgg.py
@@ -47,24 +47,24 @@ class TtVGG(nn.Module):
         linear3_bias = ttnn.load_tensor(f"{tt_cache_path}classifier.6.bias{tt_dtype}.bin")
 
         linear1 = TtLinear(
-            in_features=linear1_weight.get_legacy_shape()[-1],
-            out_features=linear1_weight.get_legacy_shape()[-2],
+            in_features=linear1_weight.shape.with_tile_padding()[-1],
+            out_features=linear1_weight.shape.with_tile_padding()[-2],
             weight=linear1_weight,
             bias=linear1_bias,
             output_mem_config=self.output_mem_config,
         )
 
         linear2 = TtLinear(
-            in_features=linear2_weight.get_legacy_shape()[-1],
-            out_features=linear2_weight.get_legacy_shape()[-2],
+            in_features=linear2_weight.shape.with_tile_padding()[-1],
+            out_features=linear2_weight.shape.with_tile_padding()[-2],
             weight=linear2_weight,
             bias=linear2_bias,
             output_mem_config=self.output_mem_config,
         )
 
         linear3 = TtLinear(
-            in_features=linear3_weight.get_legacy_shape()[-1],
-            out_features=linear3_weight.get_legacy_shape()[-2],
+            in_features=linear3_weight.shape.with_tile_padding()[-1],
+            out_features=linear3_weight.shape.with_tile_padding()[-2],
             weight=linear3_weight,
             bias=linear3_bias,
             output_mem_config=self.output_mem_config,
@@ -85,7 +85,7 @@ class TtVGG(nn.Module):
             else:
                 tt_x = layer(tt_x)
 
-        batch, c, w, h = tt_x.get_legacy_shape()
+        batch, c, w, h = tt_x.shape.with_tile_padding()
         tt_x = self.avgpool(tt_x)
 
         tt_x = fallback_ops.reshape(tt_x, batch, 1, 1, c * w * h)

--- a/models/experimental/vgg/vgg_utils.py
+++ b/models/experimental/vgg/vgg_utils.py
@@ -16,13 +16,13 @@ def format_tensor(x, target_layout, device, output_mem_config, pad_value=0.0):
         return x
 
     if x.get_layout() == ttnn.ROW_MAJOR_LAYOUT and target_layout == ttnn.TILE_LAYOUT:
-        x_padded_shape = ttnn.pad_to_tile_shape(x.get_legacy_shape(), False, False, True, True)
-        if x.get_legacy_shape() != x_padded_shape:
+        x_padded_shape = ttnn.pad_to_tile_shape(x.shape.with_tile_padding(), False, False, True, True)
+        if x.shape.with_tile_padding() != x_padded_shape:
             return ttnn.format_input_tensor(x, device, x_padded_shape, pad_value, target_layout, output_mem_config)
         else:
             return ttnn.tilize(x, memory_config=output_mem_config, use_multicore=True)
     elif x.get_layout() == ttnn.TILE_LAYOUT and target_layout == ttnn.ROW_MAJOR_LAYOUT:
-        if x.get_legacy_shape() != x.shape_without_padding():
+        if x.shape.with_tile_padding() != x.shape_without_padding():
             return ttnn.format_output_tensor(x, x.shape_without_padding(), device, target_layout, output_mem_config)
         else:
             return ttnn.untilize(x, memory_config=output_mem_config, use_multicore=True)

--- a/models/experimental/vit/tt/modeling_vit.py
+++ b/models/experimental/vit/tt/modeling_vit.py
@@ -113,7 +113,7 @@ class TtViTSelfAttention(nn.Module):
         )
 
     def transpose_for_scores(self, x: tt_tensor) -> tt_tensor:
-        new_x_shape = (x.get_legacy_shape()[0], x.get_legacy_shape()[2]) + (
+        new_x_shape = (x.shape.with_tile_padding()[0], x.shape.with_tile_padding()[2]) + (
             self.num_attention_heads,
             self.attention_head_size,
         )
@@ -150,7 +150,7 @@ class TtViTSelfAttention(nn.Module):
         context_layer = ttnn.matmul(attention_probs, value_layer)
 
         context_layer = ttnn.permute(context_layer, (0, 2, 1, 3))
-        new_context_layer_shape = (1,) + tuple(context_layer.get_legacy_shape())[:-2] + (self.all_head_size,)
+        new_context_layer_shape = (1,) + tuple(context_layer.shape.with_tile_padding())[:-2] + (self.all_head_size,)
         context_layer = fallback_ops.reshape(context_layer, *new_context_layer_shape)
 
         outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)

--- a/models/experimental/whisper/tests/test_whisper_encoder.py
+++ b/models/experimental/whisper/tests/test_whisper_encoder.py
@@ -92,7 +92,7 @@ def run_whisper_encoder(device, for_audio_classification=False, encoder_layers=1
             output_hidden_states=False,
         )
 
-        logger.debug(f"Encoder returned {ttm_output.last_hidden_state.get_legacy_shape()}")
+        logger.debug(f"Encoder returned {ttm_output.last_hidden_state.shape.with_tile_padding()}")
 
         # TT Output To Torch
         ttm_output_pt = tt2torch_tensor(ttm_output.last_hidden_state)

--- a/models/experimental/whisper/tests/test_whisper_encoder_layer.py
+++ b/models/experimental/whisper/tests/test_whisper_encoder_layer.py
@@ -87,7 +87,7 @@ def run_whisper_encoder_layer(layer, device, for_audio_classification=False):
     # First check: attention output
 
     # Unpad output tensor
-    input_tensors_shape = ttm_output[0].get_legacy_shape()
+    input_tensors_shape = ttm_output[0].shape.with_tile_padding()
     logger.info(input_tensors_shape)
 
     ttm_output_to_torch_0 = tt2torch_tensor(ttm_output[0])

--- a/models/helper_funcs.py
+++ b/models/helper_funcs.py
@@ -19,10 +19,15 @@ def Linear(
 
     ``weight`` must be tt_tensor.
     """
-    assert weight.get_legacy_shape() == [1, 1, out_features, in_features], "weight does not have the expected shape"
+    assert weight.shape.with_tile_padding() == [
+        1,
+        1,
+        out_features,
+        in_features,
+    ], "weight does not have the expected shape"
 
     if bias is not None:
-        assert bias.get_legacy_shape()[-1] == out_features, "bias does not have the expected shape"
+        assert bias.shape.with_tile_padding()[-1] == out_features, "bias does not have the expected shape"
 
     weight = weight
     bias = bias
@@ -30,7 +35,9 @@ def Linear(
 
     def linear_(activation):
         nonlocal bias
-        assert activation.get_legacy_shape()[-1] == in_features, "activation tensor do not have the expected shape"
+        assert (
+            activation.shape.with_tile_padding()[-1] == in_features
+        ), "activation tensor do not have the expected shape"
         if bias is not None and bias.get_layout() != ttnn.TILE_LAYOUT:
             bias = ttnn.to_layout(bias, ttnn.TILE_LAYOUT)
         return ttnn.linear(activation, weight_T, bias=bias, memory_config=output_mem_config)

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -290,7 +290,7 @@ def pad_by_zero(
 
 
 def unpad_from_zero(x, desired_shape):
-    if x.get_legacy_shape()[-1] == desired_shape[-1] and x.get_legacy_shape()[-2] == desired_shape[-2]:
+    if x.shape.with_tile_padding()[-1] == desired_shape[-1] and x.shape.with_tile_padding()[-2] == desired_shape[-2]:
         x = tt2torch_tensor(x)
     else:
         x = x.cpu()

--- a/tests/end_to_end_tests/test_unit_ops.py
+++ b/tests/end_to_end_tests/test_unit_ops.py
@@ -20,7 +20,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
 
     xtt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
     xtt = ttnn.reshape_on_device(xtt, 5, 3, 96, 64)
-    assert xtt.get_legacy_shape() == [5, 3, 96, 64]
+    assert xtt.shape.with_tile_padding() == [5, 3, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([5, 3, 96, 64])
@@ -28,7 +28,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, 64, 96)
-    assert xtt.get_legacy_shape() == [3, 5, 64, 96]
+    assert xtt.shape.with_tile_padding() == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -36,7 +36,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, -1, 5, 96, 64)
-    assert xtt.get_legacy_shape() == [3, 5, 96, 64]
+    assert xtt.shape.with_tile_padding() == [3, 5, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 96, 64])
@@ -44,7 +44,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, -1, 64, 96)
-    assert xtt.get_legacy_shape() == [3, 5, 64, 96]
+    assert xtt.shape.with_tile_padding() == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -52,7 +52,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, -1, 64)
-    assert xtt.get_legacy_shape() == [3, 5, 96, 64]
+    assert xtt.shape.with_tile_padding() == [3, 5, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 96, 64])
@@ -60,7 +60,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, 64, -1)
-    assert xtt.get_legacy_shape() == [3, 5, 64, 96]
+    assert xtt.shape.with_tile_padding() == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -68,7 +68,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, 32, -1)
-    assert xtt.get_legacy_shape() == [3, 5, 32, 96 * 2]
+    assert xtt.shape.with_tile_padding() == [3, 5, 32, 96 * 2]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 32, 96 * 2])

--- a/tests/tt_eager/python_api_testing/conv/conv_unit_test_utils.py
+++ b/tests/tt_eager/python_api_testing/conv/conv_unit_test_utils.py
@@ -40,7 +40,7 @@ def create_conv_bias_tensor(torch_tensor, N, K, padded_K, pad=0):
         bias_padded_shape, (0, 0, 0, 0), 0.0
     )
     tt_tensor = tt_tensor.pad_to_tile(pad).to(ttnn.TILE_LAYOUT)
-    print(f"tt_tensor shape: {tt_tensor.get_legacy_shape()}")
+    print(f"tt_tensor shape: {tt_tensor.shape.with_tile_padding()}")
     return tt_tensor
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/test_sweep_conv_with_address_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/test_sweep_conv_with_address_map.py
@@ -84,7 +84,7 @@ def run_conv_as_large_matmul(conv_op_test_params, pytorch_inputs_and_golden, dev
         K,
     )
     out = out.cpu()
-    assert out.get_legacy_shape() == conv_output_shape
+    assert out.shape.with_tile_padding() == conv_output_shape
     assert out.get_layout() == ttnn.ROW_MAJOR_LAYOUT
 
     # Copy output to host and convert tt tensor to pytorch tensor

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -60,7 +60,7 @@ def linear(
     if bias is not None:
         tt_bias = setup_tt_tensor(bias, device, layout[2], input_mem_config[2], dtype[2])
 
-    _, __, out_features, in_features = tt_weight.get_legacy_shape()
+    _, __, out_features, in_features = tt_weight.shape.with_tile_padding()
     tt_linear = tt_Linear(in_features, out_features, tt_weight, tt_bias)
 
     t1 = tt_linear(t0)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py
@@ -84,9 +84,11 @@ def test_bcast(
         input, device=device, memory_config=ttnn.L1_MEMORY_CONFIG, layout=ttnn.TILE_LAYOUT, dtype=in0_dtype
     )
     input_2d_height = (
-        input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[1] * input_tensor.get_legacy_shape()[2]
+        input_tensor.shape.with_tile_padding()[0]
+        * input_tensor.shape.with_tile_padding()[1]
+        * input_tensor.shape.with_tile_padding()[2]
     )
-    input_2d_width = input_tensor.get_legacy_shape()[3]
+    input_2d_width = input_tensor.shape.with_tile_padding()[3]
     if shard_strategy == ttnn.ShardStrategy.BLOCK:
         input_2d_height_padded = _nearest_y(input_2d_height, shard_grid[0] * 32)
         shard_height = math.ceil(input_2d_height_padded / shard_grid[0])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
@@ -73,13 +73,13 @@ def run_create_qkv_heads_test(
         memory_config=out_mem_config,
     )
 
-    assert list(q.get_legacy_shape()) == [batch, num_q_heads, seq_len, head_dim]
+    assert list(q.shape.with_tile_padding()) == [batch, num_q_heads, seq_len, head_dim]
     if transpose_k:
-        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, head_dim, seq_len]
+        assert list(k.shape.with_tile_padding()) == [batch, num_kv_heads, head_dim, seq_len]
     else:
-        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, seq_len, head_dim]
+        assert list(k.shape.with_tile_padding()) == [batch, num_kv_heads, seq_len, head_dim]
 
-    assert list(v.get_legacy_shape()) == [batch, num_kv_heads, seq_len, head_dim]
+    assert list(v.shape.with_tile_padding()) == [batch, num_kv_heads, seq_len, head_dim]
 
     pyt_got_back_rm_q = tt2torch_tensor(q)
     pyt_got_back_rm_k = tt2torch_tensor(k)
@@ -251,13 +251,13 @@ def run_create_q_and_kv_heads_test(
         memory_config=out_mem_config,
     )
 
-    assert list(q.get_legacy_shape()) == [batch, num_q_heads, q_seq_len, head_dim]
+    assert list(q.shape.with_tile_padding()) == [batch, num_q_heads, q_seq_len, head_dim]
     if transpose_k:
-        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, head_dim, kv_seq_len]
+        assert list(k.shape.with_tile_padding()) == [batch, num_kv_heads, head_dim, kv_seq_len]
     else:
-        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, kv_seq_len, head_dim]
+        assert list(k.shape.with_tile_padding()) == [batch, num_kv_heads, kv_seq_len, head_dim]
 
-    assert list(v.get_legacy_shape()) == [batch, num_kv_heads, kv_seq_len, head_dim]
+    assert list(v.shape.with_tile_padding()) == [batch, num_kv_heads, kv_seq_len, head_dim]
 
     pyt_got_back_rm_q = tt2torch_tensor(q)
     pyt_got_back_rm_k = tt2torch_tensor(k)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_downsample.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_downsample.py
@@ -98,11 +98,11 @@ def test_run_downsample(
         device,
         ttnn.L1_MEMORY_CONFIG,
     )
-    assert A_interleaved.get_legacy_shape()[0] == 1 and A_interleaved.get_legacy_shape()[1] == 1
+    assert A_interleaved.shape.with_tile_padding()[0] == 1 and A_interleaved.shape.with_tile_padding()[1] == 1
 
     # image flattened params
-    input_2d_height = A_interleaved.get_legacy_shape()[2]
-    input_2d_width = A_interleaved.get_legacy_shape()[3]
+    input_2d_height = A_interleaved.shape.with_tile_padding()[2]
+    input_2d_width = A_interleaved.shape.with_tile_padding()[3]
     input_2d_height_padded = _nearest_y(input_2d_height, num_cores_height_slices * 32)
     input_shard_height = (int)(input_2d_height_padded / num_cores_height_slices)
     output_2d_height_padded = _nearest_y(batch_size * output_height * output_width, num_cores_height_slices * 32)
@@ -145,7 +145,7 @@ def test_run_downsample(
     )
     out = A_downsampled
     out_shape = [1, 1, _nearest_y(batch_size * output_height * output_width, 32), input_channels]
-    assert out_shape == list(out.get_legacy_shape())
+    assert out_shape == list(out.shape.with_tile_padding())
     out_shape_unpadded = [1, 1, batch_size * output_height * output_width, input_channels]
     assert out_shape_unpadded == list(out.shape_without_padding())
     out = ttnn.format_output_tensor(out, out.shape_without_padding(), device, ttnn.ROW_MAJOR_LAYOUT)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_examplerst.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_examplerst.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     # Move TT Tensor tt_relu_out to host and convert it to PyTorch tensor py_relu_out
     tt_relu_out = tt_relu_out.cpu()
-    py_relu_out = torch.Tensor(tt_relu_out.data()).reshape(tt_relu_out.get_legacy_shape())
+    py_relu_out = torch.Tensor(tt_relu_out.data()).reshape(tt_relu_out.shape.with_tile_padding())
 
     # Execute pow using PyTorch (since pow is not available from tt_lib)
     py_pow_out = torch.pow(py_relu_out, py_tensor_exp)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_fill_rm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_fill_rm.py
@@ -38,7 +38,7 @@ def test_fill_rm(device):
         .to(device)
     )
     xtt = ttnn.fill_ones_rm(N, C, H, W, fillH, fillW, xt)
-    assert list(xtt.get_legacy_shape()) == [N, C, H, W]
+    assert list(xtt.shape.with_tile_padding()) == [N, C, H, W]
 
     tt_got_back = xtt.cpu().to_torch()
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
@@ -141,7 +141,7 @@ def run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device, 
         compute_kernel_config=compute_kernel_config,
     )
 
-    assert tt_param_out.get_legacy_shape() == list(model.weight.shape)
+    assert tt_param_out.shape.with_tile_padding() == list(model.weight.shape)
 
     param_result = tt_param_out.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
     exp_avg_result = tt_exp_avg_out.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
@@ -50,7 +50,7 @@ def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
     )
 
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_dev.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_dev.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -89,7 +89,7 @@ def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options
         dev_x, dim, None, strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -125,7 +125,7 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_opti
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -163,7 +163,7 @@ def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -206,7 +206,7 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, devic
         dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
@@ -248,7 +248,7 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kerne
         dev_y, dev_dy, dim, None, strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
@@ -288,7 +288,7 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_ke
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -329,7 +329,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, devic
         dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
@@ -366,7 +366,7 @@ def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, de
     else:
         tt_npu = ttnn.experimental.operations.primary.moreh_logsoftmax(dev_x, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -405,7 +405,7 @@ def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_t
     else:
         tt_npu = ttnn.experimental.operations.primary.moreh_logsoftmax_backward(dev_y, dev_dy, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py
@@ -167,7 +167,7 @@ def test_moreh_sgd(
         compute_kernel_config=compute_kernel_config,
     )
 
-    assert dev_param_in.get_legacy_shape() == list(model.weight.shape)
+    assert dev_param_in.shape.with_tile_padding() == list(model.weight.shape)
 
     # check param_out
     param_result = dev_param_out.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
@@ -304,7 +304,7 @@ def test_moreh_sgd_callback(
             compute_kernel_config=compute_kernel_config,
         )
 
-    assert dev_param_in.get_legacy_shape() == list(model.weight.shape)
+    assert dev_param_in.shape.with_tile_padding() == list(model.weight.shape)
 
     # check param_out
     param_result = dev_param_out.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -46,7 +46,7 @@ def test_softmax_for_dim_hw(shape_dim, compute_kernel_options, device):
     tt_cpu = torch.softmax(x, dim)
     tt_npu = ttnn.experimental.operations.primary.moreh_softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -86,7 +86,7 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, d
         dev_x, dim, None, strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -120,7 +120,7 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options
     tt_npu = ttnn.experimental.operations.primary.moreh_softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -156,7 +156,7 @@ def test_softmax_for_dim_nc(shape_dim, compute_kernel_options, device):
     tt_npu = ttnn.experimental.operations.primary.moreh_softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -199,7 +199,7 @@ def test_softmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
         dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -242,7 +242,7 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_op
         dev_y, dev_dy, dim, None, strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -282,7 +282,7 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kerne
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -323,7 +323,7 @@ def test_softmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
         dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -357,7 +357,7 @@ def test_softmax_callback(shape_dim_strategy, device):
     for i in range(2):
         tt_npu = ttnn.experimental.operations.primary.moreh_softmax(dev_x, dim, None, strategy)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -394,7 +394,7 @@ def test_softmax_backward_callback(shape_dim_strategy, device):
     for i in range(2):
         tt_npu = ttnn.experimental.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim, None, strategy)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -431,7 +431,7 @@ def test_softmax_optional_output_tensor(shape_dim, optional_output_tensor, devic
     else:
         tt_npu = ttnn.experimental.operations.primary.moreh_softmax(dev_x, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -470,7 +470,7 @@ def test_softmax_backward_optional_output_tensor(shape_dim, optional_output_tens
     else:
         tt_npu = ttnn.experimental.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
@@ -47,7 +47,7 @@ def test_softmin_for_dim_hw(shape_dim, compute_kernel_options, device):
     tt_cpu = F.softmin(x, dim)
     tt_npu = ttnn.experimental.operations.primary.moreh_softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -86,7 +86,7 @@ def test_softmin_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, d
         dev_x, dim, None, strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -120,7 +120,7 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options
     tt_npu = ttnn.experimental.operations.primary.moreh_softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -156,7 +156,7 @@ def test_softmin_for_dim_nc(shape_dim, compute_kernel_options, device):
     tt_npu = ttnn.experimental.operations.primary.moreh_softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -199,7 +199,7 @@ def test_softmin_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
         dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -241,7 +241,7 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_op
         dev_y, dev_dy, dim, None, strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -281,7 +281,7 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kerne
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -322,7 +322,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
         dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
     )
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -359,7 +359,7 @@ def test_softmin_optional_output_tensor(shape_dim, optional_output_tensor, devic
     else:
         tt_npu = ttnn.experimental.operations.primary.moreh_softmin(dev_x, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -398,7 +398,7 @@ def test_softmin_backward_optional_output_tensor(shape_dim, optional_output_tens
     else:
         tt_npu = ttnn.experimental.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads.py
@@ -31,7 +31,7 @@ def run_nlp_concat_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_con
     logger.debug(f"in0: {in0_t.memory_config().buffer_type} and {in0_t.get_dtype()}")
     logger.debug(f"out: {out.memory_config().buffer_type} and {out.get_dtype()}")
 
-    assert list(out.get_legacy_shape()) == [batch, 1, seq_len, num_heads * head_dim]
+    assert list(out.shape.with_tile_padding()) == [batch, 1, seq_len, num_heads * head_dim]
 
     pyt_got_back_rm_out = tt2torch_tensor(out)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
@@ -36,9 +36,9 @@ def run_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config
     logger.debug(f"k: {k.memory_config().buffer_type} and {k.get_dtype()}")
     logger.debug(f"v: {v.memory_config().buffer_type} and {v.get_dtype()}")
 
-    assert list(q.get_legacy_shape()) == [batch, 71, seq_len, 64]
-    assert list(k.get_legacy_shape()) == [batch, 1, seq_len, 64]
-    assert list(v.get_legacy_shape()) == [batch, 1, seq_len, 64]
+    assert list(q.shape.with_tile_padding()) == [batch, 71, seq_len, 64]
+    assert list(k.shape.with_tile_padding()) == [batch, 1, seq_len, 64]
+    assert list(v.shape.with_tile_padding()) == [batch, 1, seq_len, 64]
 
     pyt_got_back_rm_q = tt2torch_tensor(q)
     pyt_got_back_rm_k = tt2torch_tensor(k)
@@ -173,12 +173,12 @@ def run_nlp_create_qkv_heads_test(
     logger.debug(f"k: {k.memory_config().buffer_type} and {k.get_dtype()}")
     logger.debug(f"v: {v.memory_config().buffer_type} and {v.get_dtype()}")
 
-    assert list(q.get_legacy_shape()) == [batch, num_q_heads, seq_len, head_dim]
+    assert list(q.shape.with_tile_padding()) == [batch, num_q_heads, seq_len, head_dim]
     if transpose_k_heads:
-        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, head_dim, seq_len]
+        assert list(k.shape.with_tile_padding()) == [batch, num_kv_heads, head_dim, seq_len]
     else:
-        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, seq_len, head_dim]
-    assert list(v.get_legacy_shape()) == [batch, num_kv_heads, seq_len, head_dim]
+        assert list(k.shape.with_tile_padding()) == [batch, num_kv_heads, seq_len, head_dim]
+    assert list(v.shape.with_tile_padding()) == [batch, num_kv_heads, seq_len, head_dim]
 
     pyt_got_back_rm_q = tt2torch_tensor(q)
     pyt_got_back_rm_k = tt2torch_tensor(k)
@@ -372,9 +372,9 @@ def run_sharded_nlp_create_qkv_heads_test(
         memory_config=out_mem_config,
     )
 
-    assert list(q.get_legacy_shape()) == [seq_len, num_q_heads, batch, head_dim]
-    assert list(k.get_legacy_shape()) == [seq_len, num_kv_heads, batch, head_dim]
-    assert list(v.get_legacy_shape()) == [seq_len, num_kv_heads, batch, head_dim]
+    assert list(q.shape.with_tile_padding()) == [seq_len, num_q_heads, batch, head_dim]
+    assert list(k.shape.with_tile_padding()) == [seq_len, num_kv_heads, batch, head_dim]
+    assert list(v.shape.with_tile_padding()) == [seq_len, num_kv_heads, batch, head_dim]
 
     pyt_got_back_rm_q = tt2torch_tensor(q)
     pyt_got_back_rm_k = tt2torch_tensor(k)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
@@ -36,7 +36,7 @@ def test_pow_fractional_composite(device):
     pow_trunc_log = ttnn.multiply(ttnn.log(xt), yt_trunc)
     pow_frac = ttnn.exp(pow_trunc_log)
     xtt = ttnn.mul(ttnn.pow(xt, yt_floor), pow_frac)
-    assert list(xtt.get_legacy_shape()) == [N, C, H, W]
+    assert list(xtt.shape.with_tile_padding()) == [N, C, H, W]
     tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
     xtt_fp = ttnn.pow(xt, yt.item())

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshape.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshape.py
@@ -21,7 +21,7 @@ def test_tile_major_reshape(device):
 
     xtt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
     xtt = ttnn.reshape_on_device(xtt, 5, 3, 96, 64)
-    assert list(xtt.get_legacy_shape()) == [5, 3, 96, 64]
+    assert list(xtt.shape.with_tile_padding()) == [5, 3, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([5, 3, 96, 64])
@@ -29,7 +29,7 @@ def test_tile_major_reshape(device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, 64, 96)
-    assert list(xtt.get_legacy_shape()) == [3, 5, 64, 96]
+    assert list(xtt.shape.with_tile_padding()) == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -37,7 +37,7 @@ def test_tile_major_reshape(device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, -1, 5, 96, 64)
-    assert list(xtt.get_legacy_shape()) == [3, 5, 96, 64]
+    assert list(xtt.shape.with_tile_padding()) == [3, 5, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 96, 64])
@@ -45,7 +45,7 @@ def test_tile_major_reshape(device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, -1, 64, 96)
-    assert list(xtt.get_legacy_shape()) == [3, 5, 64, 96]
+    assert list(xtt.shape.with_tile_padding()) == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -53,7 +53,7 @@ def test_tile_major_reshape(device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, -1, 64)
-    assert list(xtt.get_legacy_shape()) == [3, 5, 96, 64]
+    assert list(xtt.shape.with_tile_padding()) == [3, 5, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 96, 64])
@@ -61,7 +61,7 @@ def test_tile_major_reshape(device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, 64, -1)
-    assert list(xtt.get_legacy_shape()) == [3, 5, 64, 96]
+    assert list(xtt.shape.with_tile_padding()) == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -69,7 +69,7 @@ def test_tile_major_reshape(device):
     assert eq
 
     xtt = ttnn.reshape_on_device(xtt, 3, 5, 32, -1)
-    assert list(xtt.get_legacy_shape()) == [3, 5, 32, 96 * 2]
+    assert list(xtt.shape.with_tile_padding()) == [3, 5, 32, 96 * 2]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x = x.reshape([3, 5, 32, 96 * 2])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
@@ -53,7 +53,7 @@ def test_rotary_embedding_prefill(W, Z, Y, X, cache_size, in_sharded, out_sharde
         out_mem_config = ttnn.MemoryConfig()
 
     xt = ttnn.Tensor(x, input_dtype)
-    if xt.get_legacy_shape()[-2] % 32 == 0 and xt.get_legacy_shape()[-1] % 32 == 0:
+    if xt.shape.with_tile_padding()[-2] % 32 == 0 and xt.shape.with_tile_padding()[-1] % 32 == 0:
         xt = xt.to(ttnn.TILE_LAYOUT)
     elif input_dtype == ttnn.bfloat8_b:
         pytest.skip()
@@ -61,7 +61,7 @@ def test_rotary_embedding_prefill(W, Z, Y, X, cache_size, in_sharded, out_sharde
     if in_sharded or out_sharded:
         if xt.get_layout() != ttnn.TILE_LAYOUT:
             pytest.skip("Sharding support required tile size")
-        num_blocks = xt.volume() // xt.get_legacy_shape()[-1] // 32
+        num_blocks = xt.volume() // xt.shape.with_tile_padding()[-1] // 32
         compute_grid_size = device.compute_with_storage_grid_size()
         for i in range(compute_grid_size.x * compute_grid_size.y, 0, -1):
             if num_blocks % i == 0:
@@ -75,7 +75,7 @@ def test_rotary_embedding_prefill(W, Z, Y, X, cache_size, in_sharded, out_sharde
                 shard_grid,
                 [
                     Ht * 32,
-                    xt.get_legacy_shape()[-1],
+                    xt.shape.with_tile_padding()[-1],
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
                 False,
@@ -126,7 +126,7 @@ def test_rotary_embedding_decode(
         out_mem_config = ttnn.MemoryConfig()
 
     xt = ttnn.Tensor(x, input_dtype)
-    if xt.get_legacy_shape()[-2] % 32 == 0 and xt.get_legacy_shape()[-1] % 32 == 0:
+    if xt.shape.with_tile_padding()[-2] % 32 == 0 and xt.shape.with_tile_padding()[-1] % 32 == 0:
         xt = xt.to(ttnn.TILE_LAYOUT)
     elif input_dtype == ttnn.bfloat8_b:
         pytest.skip()
@@ -134,7 +134,7 @@ def test_rotary_embedding_decode(
     if in_sharded or out_sharded:
         if xt.get_layout() != ttnn.TILE_LAYOUT:
             pytest.skip("Sharding support required tile size")
-        num_blocks = xt.volume() // xt.get_legacy_shape()[-1] // 32
+        num_blocks = xt.volume() // xt.shape.with_tile_padding()[-1] // 32
         compute_grid_size = device.compute_with_storage_grid_size()
         for i in range(compute_grid_size.x * compute_grid_size.y, 0, -1):
             if num_blocks % i == 0:
@@ -148,7 +148,7 @@ def test_rotary_embedding_decode(
                 shard_grid,
                 [
                     Ht * 32,
-                    xt.get_legacy_shape()[-1],
+                    xt.shape.with_tile_padding()[-1],
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
                 False,
@@ -199,7 +199,7 @@ def test_rotary_embedding_prefill_fp32(
         out_mem_config = ttnn.MemoryConfig()
 
     xt = ttnn.Tensor(x, input_dtype)
-    if xt.get_legacy_shape()[-2] % 32 == 0 and xt.get_legacy_shape()[-1] % 32 == 0:
+    if xt.shape.with_tile_padding()[-2] % 32 == 0 and xt.shape.with_tile_padding()[-1] % 32 == 0:
         xt = xt.to(ttnn.TILE_LAYOUT)
     elif input_dtype == ttnn.bfloat8_b:
         pytest.skip()
@@ -207,7 +207,7 @@ def test_rotary_embedding_prefill_fp32(
     if in_sharded or out_sharded:
         if xt.get_layout() != ttnn.TILE_LAYOUT:
             pytest.skip("Sharding support required tile size")
-        num_blocks = xt.volume() // xt.get_legacy_shape()[-1] // 32
+        num_blocks = xt.volume() // xt.shape.with_tile_padding()[-1] // 32
         compute_grid_size = device.compute_with_storage_grid_size()
         for i in range(compute_grid_size.x * compute_grid_size.y, 0, -1):
             if num_blocks % i == 0:
@@ -221,7 +221,7 @@ def test_rotary_embedding_prefill_fp32(
                 shard_grid,
                 [
                     Ht * 32,
-                    xt.get_legacy_shape()[-1],
+                    xt.shape.with_tile_padding()[-1],
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
                 False,
@@ -270,7 +270,7 @@ def test_rotary_embedding_decode_fp32(
         out_mem_config = ttnn.MemoryConfig()
 
     xt = ttnn.Tensor(x, input_dtype)
-    if xt.get_legacy_shape()[-2] % 32 == 0 and xt.get_legacy_shape()[-1] % 32 == 0:
+    if xt.shape.with_tile_padding()[-2] % 32 == 0 and xt.shape.with_tile_padding()[-1] % 32 == 0:
         xt = xt.to(ttnn.TILE_LAYOUT)
     elif input_dtype == ttnn.bfloat8_b:
         pytest.skip()
@@ -278,7 +278,7 @@ def test_rotary_embedding_decode_fp32(
     if in_sharded or out_sharded:
         if xt.get_layout() != ttnn.TILE_LAYOUT:
             pytest.skip("Sharding support required tile size")
-        num_blocks = xt.volume() // xt.get_legacy_shape()[-1] // 32
+        num_blocks = xt.volume() // xt.shape.with_tile_padding()[-1] // 32
         compute_grid_size = device.compute_with_storage_grid_size()
         for i in range(compute_grid_size.x * compute_grid_size.y, 0, -1):
             if num_blocks % i == 0:
@@ -292,7 +292,7 @@ def test_rotary_embedding_decode_fp32(
                 shard_grid,
                 [
                     Ht * 32,
-                    xt.get_legacy_shape()[-1],
+                    xt.shape.with_tile_padding()[-1],
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
                 False,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sfpu_chain.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sfpu_chain.py
@@ -37,7 +37,7 @@ def test_eltwise_unary_chain(device):
             ttnn.UnaryWithParam(ttnn.UnaryOpType.POWER, 2),
         ],
     )
-    assert list(xtt.get_legacy_shape()) == [N, C, H, W]
+    assert list(xtt.shape.with_tile_padding()) == [N, C, H, W]
 
     tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
@@ -82,7 +82,7 @@ def test_eltwise_binary_fused(device):
         yt,
         activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU), ttnn.UnaryWithParam(ttnn.UnaryOpType.POWER, 2)],
     )
-    assert list(xtt.get_legacy_shape()) == [N, C, H, W]
+    assert list(xtt.shape.with_tile_padding()) == [N, C, H, W]
 
     tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1475,8 +1475,8 @@ def test_sharded_untilize_padded_shard(in_sharded, out_sharded, dtype, device, f
             xt,
             grid_size,
             [
-                math.ceil((xt.get_legacy_shape()[-2] // 32) / grid_size[0]) * 32,
-                xt.get_legacy_shape()[-1] // grid_size[1],
+                math.ceil((xt.shape.with_tile_padding()[-2] // 32) / grid_size[0]) * 32,
+                xt.shape.with_tile_padding()[-1] // grid_size[1],
             ],
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             ttnn.ShardOrientation.COL_MAJOR,
@@ -1568,8 +1568,8 @@ def test_sharded_binary_padded_shard(
             xt,
             grid_size,
             [
-                math.ceil((xt.get_legacy_shape()[-2] // 32) / grid_size[0]) * 32,
-                xt.get_legacy_shape()[-1] // grid_size[1],
+                math.ceil((xt.shape.with_tile_padding()[-2] // 32) / grid_size[0]) * 32,
+                xt.shape.with_tile_padding()[-1] // grid_size[1],
             ],
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             ttnn.ShardOrientation.COL_MAJOR,
@@ -1578,8 +1578,8 @@ def test_sharded_binary_padded_shard(
             yt,
             grid_size,
             [
-                math.ceil((xt.get_legacy_shape()[-2] // 32) / grid_size[0]) * 32,
-                xt.get_legacy_shape()[-1] // grid_size[1],
+                math.ceil((xt.shape.with_tile_padding()[-2] // 32) / grid_size[0]) * 32,
+                xt.shape.with_tile_padding()[-1] // grid_size[1],
             ],
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             ttnn.ShardOrientation.COL_MAJOR,
@@ -1646,8 +1646,8 @@ def test_block_sharded_untilize_with_unpadding(in_sharded, out_sharded, dtype, d
             xt,
             grid_size,
             [
-                math.ceil((xt.get_legacy_shape()[-2] // 32) / grid_size[0]) * 32,
-                xt.get_legacy_shape()[-1] // grid_size[1],
+                math.ceil((xt.shape.with_tile_padding()[-2] // 32) / grid_size[0]) * 32,
+                xt.shape.with_tile_padding()[-1] // grid_size[1],
             ],
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
             ttnn.ShardOrientation.COL_MAJOR,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_rm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_rm.py
@@ -96,9 +96,7 @@ def test_split_rm(refshape_chunks_dim, in_mem_config, out_mem_config, device, dt
     for index, buff in enumerate(dev_buffers):
         logger.debug(f"buff{index} is on: {buff.memory_config().buffer_type}")
         assert list(buff.shape) == chunk_shape
-        tt_host_rm_buff = (
-            buff.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(buff.get_legacy_shape().without_padding())
-        )
+        tt_host_rm_buff = buff.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(buff.shape)
         pyt_got_back_rm_buff = tt_host_rm_buff.to_torch()
         pyt_buff_list.append(pyt_got_back_rm_buff)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
@@ -131,7 +131,7 @@ def test_split_tiled_w(dim, refshape, in_mem_config, out_mem_config, device, dty
     assert len(dev_buffers) == num_splits
     for index, buff in enumerate(dev_buffers):
         logger.debug(f"buff{index} is on: {buff.memory_config().buffer_type}")
-        assert list(buff.get_legacy_shape()) == chunk_shape
+        assert list(buff.shape.with_tile_padding()) == chunk_shape
         tt_host_rm_buff = buff.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
         pyt_got_back_rm_buff = tt_host_rm_buff.to_torch()
         pyt_buff_list.append(pyt_got_back_rm_buff)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
@@ -38,7 +38,7 @@ def run_tilize_matmul_test(M, K, N, device):
         device,
     )
     a_t = ttnn.tilize_with_zero_padding(a)
-    print("Shape of A_t - " + str(a_t.get_legacy_shape()))
+    print("Shape of A_t - " + str(a_t.shape.with_tile_padding()))
     b_t = ttnn.Tensor(
         tilize_to_list(B),
         b_shape,
@@ -46,9 +46,9 @@ def run_tilize_matmul_test(M, K, N, device):
         ttnn.TILE_LAYOUT,
         device,
     )
-    print("Shape of B_t - " + str(b_t.get_legacy_shape()))
+    print("Shape of B_t - " + str(b_t.shape.with_tile_padding()))
     t2 = ttnn.matmul(a_t, b_t)
-    assert list(t2.get_legacy_shape()) == output_shape
+    assert list(t2.shape.with_tile_padding()) == output_shape
     tt_host_rm = t2.cpu().to_torch()
     pyt_got_back = tt_host_rm.reshape(output_shape)
     # TODO: add support to remove padding in untilize

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_matmul.py
@@ -33,7 +33,7 @@ def run_tilize_matmul_test(M, K, N, device):
         device,
     )
     t2 = ttnn.matmul(a_t, b_t)
-    assert list(t2.get_legacy_shape()) == [1, 1, M, N]
+    assert list(t2.shape.with_tile_padding()) == [1, 1, M, N]
     tt_host_rm = t2.cpu().to_torch()
     pyt_got_back = tt_host_rm.reshape((1, 1, M, N))
     pyt_got_back_rm = untilize(pyt_got_back)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -40,7 +40,7 @@ def transpose(
 
     xt = xt.to(device, input_mem_config)
     xtt = ttnn.transpose(xt, dim0, dim1, memory_config=output_mem_config)
-    assert list(xtt.get_legacy_shape()) == output_shape
+    assert list(xtt.shape.with_tile_padding()) == output_shape
     transposed_ref = x.transpose(dim0, dim1)
 
     tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -44,8 +44,8 @@ class TestUpdateCache:
                 input_shard_spec = ttnn.ShardSpec(
                     shard_grid,
                     [
-                        xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                        xt.get_legacy_shape()[-1],
+                        xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                        xt.shape.with_tile_padding()[-1],
                     ],
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -112,8 +112,8 @@ class TestUpdateCache:
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [
-                    xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                    xt.get_legacy_shape()[-1],
+                    xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                    xt.shape.with_tile_padding()[-1],
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
                 False,
@@ -179,8 +179,8 @@ class TestUpdateCacheFP32:
                 input_shard_spec = ttnn.ShardSpec(
                     shard_grid,
                     [
-                        xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                        xt.get_legacy_shape()[-1],
+                        xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                        xt.shape.with_tile_padding()[-1],
                     ],
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -245,8 +245,8 @@ class TestUpdateCacheFP32:
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [
-                    xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                    xt.get_legacy_shape()[-1],
+                    xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                    xt.shape.with_tile_padding()[-1],
                 ],
                 ttnn.ShardOrientation.ROW_MAJOR,
                 False,

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -1112,7 +1112,7 @@ def threshold(x):
 
 
 def reshape(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
     ttnn.reshape(x, [shape[-4], shape[-3], shape[-1], shape[-2]])
 
 
@@ -1149,7 +1149,7 @@ def tilize(x):
 
 
 def tilize_with_val_padding(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
 
     output_tensor_shape = [shape[-4], shape[-3], shape[-2] + 32, shape[-1] + 32]
 
@@ -1157,7 +1157,7 @@ def tilize_with_val_padding(x):
 
 
 def untilize_with_unpadding(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
 
     unpadded_shape_end = [
         shape[0] - 1,
@@ -1170,7 +1170,7 @@ def untilize_with_unpadding(x):
 
 
 def pad(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
 
     padding = [
         (0, 0),
@@ -1183,7 +1183,7 @@ def pad(x):
 
 
 def ttnn_slice(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
 
     output_tensor_end = (
         shape[0],
@@ -1204,7 +1204,9 @@ def arange(x):
 
 
 def full(x):
-    ttnn.full(shape=x.get_legacy_shape(), fill_value=2, dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
+    ttnn.full(
+        shape=x.shape.with_tile_padding(), fill_value=2, dtype=x.get_dtype(), layout=x.get_layout(), device=x.device()
+    )
 
 
 def full_like(x):
@@ -1212,15 +1214,15 @@ def full_like(x):
 
 
 def ones(x):
-    ttnn.ones(shape=x.get_legacy_shape(), dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
+    ttnn.ones(shape=x.shape.with_tile_padding(), dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
 
 
 def zeros(x):
-    ttnn.zeros(shape=x.get_legacy_shape(), dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
+    ttnn.zeros(shape=x.shape.with_tile_padding(), dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
 
 
 def empty(x):
-    ttnn.empty(shape=x.get_legacy_shape(), dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
+    ttnn.empty(shape=x.shape.with_tile_padding(), dtype=x.get_dtype(), layout=x.get_layout(), device=x.device())
 
 
 def sum_dim_0(x):
@@ -1292,7 +1294,7 @@ def rsqrt_slow(x):
 
 
 def fill_rm(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
 
     ttnn.fill_rm(
         N=shape[0],
@@ -1308,7 +1310,7 @@ def fill_rm(x):
 
 
 def fill_ones_rm(x):
-    shape = x.get_legacy_shape()
+    shape = x.shape.with_tile_padding()
 
     ttnn.fill_ones_rm(N=shape[0], C=shape[1], H=shape[2], W=shape[3], hOnes=shape[2] - 32, wOnes=shape[3] - 32, any=x)
 

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -244,7 +244,7 @@ def test_post_allgather_layernorm(
 
     # shard to 1 core
     tt_stats_sharded_config = ttnn.create_sharded_memory_config(
-        shape=(1, 1, 32, tt_device_stats.get_legacy_shape()[-1]),
+        shape=(1, 1, 32, tt_device_stats.shape.with_tile_padding()[-1]),
         core_grid=ttnn.CoreGrid(y=1, x=1),
         strategy=ttnn.ShardStrategy.WIDTH,
     )
@@ -321,7 +321,7 @@ def test_simulated_distributed_layernorm(
     tt_global_stats = ttnn.concat(tt_stats_list, -1)
     # shard to 1 core
     tt_stats_sharded_config = ttnn.create_sharded_memory_config(
-        shape=(1, 1, 32, tt_global_stats.get_legacy_shape()[-1]),
+        shape=(1, 1, 32, tt_global_stats.shape.with_tile_padding()[-1]),
         core_grid=ttnn.CoreGrid(y=1, x=1),
         strategy=ttnn.ShardStrategy.WIDTH,
     )

--- a/tests/ttnn/unit_tests/operations/test_moe.py
+++ b/tests/ttnn/unit_tests/operations/test_moe.py
@@ -42,7 +42,7 @@ def run_moe_test(N, C, H, W, k, E, e, dtype, device):
     for i in range(3):
         weights_1SB1 = ttnn.moe(ttnn_input, ttnn_expert_mask, ttnn_topE_mask, k)
 
-        assert list(weights_1SB1.get_legacy_shape()) == [N, C, H, k]
+        assert list(weights_1SB1.shape.with_tile_padding()) == [N, C, H, k]
 
         ttnn_weights_1SB1 = ttnn.to_torch(weights_1SB1)
 

--- a/tests/ttnn/unit_tests/operations/test_moreh_adam.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_adam.py
@@ -111,7 +111,7 @@ def test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_
         compute_kernel_config=compute_kernel_config,
     )
 
-    assert dev_param.get_legacy_shape() == list(model.weight.shape)
+    assert dev_param.shape.with_tile_padding() == ttnn.Shape(model.weight.shape)
 
     param_result = dev_param_out.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
     exp_avg_result = dev_exp_avg_out.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
@@ -74,7 +74,7 @@ def test_getitem_RAW_MJOR_one_index(shape_index_dim, dtype, index_size, device):
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, [dev_idx], [index_dim])
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to_torch()
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
@@ -136,7 +136,7 @@ def test_getitem_RAW_MAJOR_two_indices(shape_index_dims, dtype, index_size, devi
         tt_cpu = x[:, :, indices[0], indices[1]]
     tt_npu = ttnn.operations.moreh.getitem(dev_x, dev_indices, index_dims)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to_torch()
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
@@ -196,7 +196,7 @@ def test_getitem_RAW_MAJOR_three_indices(shape_index_dims, dtype, index_size, de
         tt_cpu = x[:, indices[0], indices[1], indices[2]]
     tt_npu = ttnn.operations.moreh.getitem(dev_x, dev_indices, index_dims)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to_torch()
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -48,7 +48,7 @@ def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_dev.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_dev.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -87,7 +87,7 @@ def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options
         dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -121,7 +121,7 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_opti
     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -157,7 +157,7 @@ def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -198,7 +198,7 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, devic
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
@@ -240,7 +240,7 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kerne
         dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
@@ -278,7 +278,7 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_ke
     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.1
@@ -317,7 +317,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, devic
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
@@ -354,7 +354,7 @@ def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, de
     else:
         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -393,7 +393,7 @@ def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_t
     else:
         tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
@@ -46,7 +46,7 @@ def test_softmax_for_dim_hw(shape_dim, compute_kernel_options, device):
     tt_cpu = torch.softmax(x, dim)
     tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -84,7 +84,7 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, d
     )
     tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -118,7 +118,7 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options
     tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -154,7 +154,7 @@ def test_softmax_for_dim_nc(shape_dim, compute_kernel_options, device):
     tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -195,7 +195,7 @@ def test_softmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -238,7 +238,7 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_op
         dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -276,7 +276,7 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kerne
     tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -315,7 +315,7 @@ def test_softmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -349,7 +349,7 @@ def test_softmax_callback(shape_dim_strategy, device):
     for i in range(2):
         tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, strategy=strategy)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -386,7 +386,7 @@ def test_softmax_backward_callback(shape_dim_strategy, device):
     for i in range(2):
         tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, strategy=strategy)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -423,7 +423,7 @@ def test_softmax_optional_output_tensor(shape_dim, optional_output_tensor, devic
     else:
         tt_npu = ttnn.operations.moreh.softmax(dev_x, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -462,7 +462,7 @@ def test_softmax_backward_optional_output_tensor(shape_dim, optional_output_tens
     else:
         tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
@@ -47,7 +47,7 @@ def test_softmin_for_dim_hw(shape_dim, compute_kernel_options, device):
     tt_cpu = F.softmin(x, dim)
     tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -84,7 +84,7 @@ def test_softmin_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, d
     )
     tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -118,7 +118,7 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options
     tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -154,7 +154,7 @@ def test_softmin_for_dim_nc(shape_dim, compute_kernel_options, device):
     tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -195,7 +195,7 @@ def test_softmin_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -237,7 +237,7 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_op
         dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
     )
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -275,7 +275,7 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kerne
     tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -314,7 +314,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -351,7 +351,7 @@ def test_softmin_optional_output_tensor(shape_dim, optional_output_tensor, devic
     else:
         tt_npu = ttnn.operations.moreh.softmin(dev_x, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05
@@ -390,7 +390,7 @@ def test_softmin_backward_optional_output_tensor(shape_dim, optional_output_tens
     else:
         tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim)
 
-    assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.05

--- a/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
@@ -41,8 +41,8 @@ def run_test_update_cache_decode(
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
-            xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-            xt.get_legacy_shape()[-1],
+            xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+            xt.shape.with_tile_padding()[-1],
         ],
         ttnn.ShardOrientation.ROW_MAJOR,
         False,
@@ -151,8 +151,8 @@ def test_update_cache_decode(
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
-                xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                xt.get_legacy_shape()[-1],
+                xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                xt.shape.with_tile_padding()[-1],
             ],
             ttnn.ShardOrientation.ROW_MAJOR,
             False,
@@ -234,8 +234,8 @@ def test_update_cache_decode_program_cache(
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
-                xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                xt.get_legacy_shape()[-1],
+                xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                xt.shape.with_tile_padding()[-1],
             ],
             ttnn.ShardOrientation.ROW_MAJOR,
             False,
@@ -276,8 +276,8 @@ def run_test_tensor_index_update_cache_decode(
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
-            xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-            xt.get_legacy_shape()[-1],
+            xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+            xt.shape.with_tile_padding()[-1],
         ],
         ttnn.ShardOrientation.ROW_MAJOR,
         False,
@@ -414,8 +414,8 @@ def run_test_paged_update_cache_decode(
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
-            xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-            xt.get_legacy_shape()[-1],
+            xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+            xt.shape.with_tile_padding()[-1],
         ],
         ttnn.ShardOrientation.ROW_MAJOR,
         False,
@@ -543,8 +543,8 @@ def test_paged_update_cache_decode_program_caching(
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
-                xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
-                xt.get_legacy_shape()[-1],
+                xt.volume() // xt.shape.with_tile_padding()[-1] // num_cores,
+                xt.shape.with_tile_padding()[-1],
             ],
             ttnn.ShardOrientation.ROW_MAJOR,
             False,

--- a/tests/ttnn/unit_tests/operations/test_silu.py
+++ b/tests/ttnn/unit_tests/operations/test_silu.py
@@ -49,8 +49,8 @@ def run_elt_silu_relu(
     interleaved_mem_config = ttnn.L1_MEMORY_CONFIG
     input_tensor = ttnn.to_memory_config(input_tensor, interleaved_mem_config)
     # input_shape = [1, 1, _nearest_y(batch_size * input_height * input_width, 32), input_channels]
-    input_2d_height = input_tensor.get_legacy_shape()[2]
-    input_2d_width = input_tensor.get_legacy_shape()[3]
+    input_2d_height = input_tensor.shape.with_tile_padding()[2]
+    input_2d_width = input_tensor.shape.with_tile_padding()[3]
     logger.debug(f"input_2d_height={input_2d_height} and input_2d_width={input_2d_width}")
 
     ## input shard

--- a/tests/ttnn/unit_tests/operations/test_ssm_1d_sum_reduce.py
+++ b/tests/ttnn/unit_tests/operations/test_ssm_1d_sum_reduce.py
@@ -22,7 +22,7 @@ def run_ssm_1d_sum_reduce(H: int, W: int, latent_size: int, dtype, in_mem_config
     x = ttnn.Tensor(x, dtype).to(ttnn.TILE_LAYOUT).to(device, in_mem_config)
     actual = ttnn.experimental.hc_sum_reduce(x, memory_config=out_mem_config, dtype=dtype)
 
-    assert list(actual.get_legacy_shape()) == [1, 1, H, W // latent_size]
+    assert list(actual.shape.with_tile_padding()) == [1, 1, H, W // latent_size]
     assert actual.dtype == dtype
 
     actual = tt2torch_tensor(actual)

--- a/tests/ttnn/unit_tests/operations/test_ssm_prefix_scan.py
+++ b/tests/ttnn/unit_tests/operations/test_ssm_prefix_scan.py
@@ -56,7 +56,7 @@ def run_ssm_prefix_scan(L: int, E: int, N: int, num_cores: int, dtype, device):
     h_prev = ttnn.Tensor(h_prev, ttnn.bfloat16).to(ttnn.ROW_MAJOR_LAYOUT).to(device, h_memory_config)
 
     actual = ttnn.experimental.prefix_scan(a, bx, h_prev, memory_config=memory_config, dtype=dtype)
-    assert list(actual.get_legacy_shape()) == list(expected.shape)
+    assert list(actual.shape.with_tile_padding()) == list(expected.shape)
     assert actual.dtype == dtype
 
     actual = tt2torch_tensor(actual)

--- a/tests/ttnn/unit_tests/operations/test_ssm_repeat_and_interleave_eltwise_mul.py
+++ b/tests/ttnn/unit_tests/operations/test_ssm_repeat_and_interleave_eltwise_mul.py
@@ -31,7 +31,7 @@ def run_ssm_eltwise_mul_test(batch_size, in0_W, in1_W, dtype, in0_mem_config, in
         tt_input_tensor_B, tt_input_tensor_X, memory_config=out_mem_config, dtype=dtype
     )
 
-    assert list(tt_out.get_legacy_shape()) == [1, 1, batch_size, latent_size * hidden_size]
+    assert list(tt_out.shape.with_tile_padding()) == [1, 1, batch_size, latent_size * hidden_size]
 
     out = tt2torch_tensor(tt_out)
 

--- a/tests/ttnn/unit_tests/operations/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/test_topk.py
@@ -23,8 +23,8 @@ def run_topk_test(N, C, H, W, k, dtype, device):
     ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
     ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True)
 
-    assert list(ttnn_topk_values.get_legacy_shape()) == [N, C, H, k]
-    assert list(ttnn_topk_indices.get_legacy_shape()) == [N, C, H, k]
+    assert list(ttnn_topk_values.shape.with_tile_padding()) == [N, C, H, k]
+    assert list(ttnn_topk_indices.shape.with_tile_padding()) == [N, C, H, k]
 
     ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
     ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1406,17 +1406,6 @@ void pytensor_module(py::module &m_tensor) {
 
         )doc")
         .def(
-            "get_legacy_shape",
-            [](const Tensor &self) { return self.get_legacy_shape(); },
-            R"doc(
-            Get the shape of the tensor as Shape class.
-
-            .. code-block:: python
-
-                shape = tt_tensor.get_legacy_shape()
-
-        )doc")
-        .def(
             "volume", [](const Tensor &self) { return self.volume(); }, R"doc(
             Get the volume of the tensor.
 

--- a/ttnn/tt_lib/fallback_ops/conversion_wrapper.py
+++ b/ttnn/tt_lib/fallback_ops/conversion_wrapper.py
@@ -22,7 +22,7 @@ def check_log_pytorch_warning(arg):
 def custom_tensor_print_handler(tensor_cls):
     def custom_tt_tensor_to_str_fn(tensor):
         # We just report that this was a tt tensor and its shape as detailed information is already reported in other columns
-        return f"ttnn.Tensor({'_'.join(map(str, tensor.get_legacy_shape()))})"
+        return f"ttnn.Tensor({'_'.join(map(str, tensor.shape.with_tile_padding()))})"
 
     def custom_pt_tensor_to_str_fn(tensor):
         return f"torch.Tensor({'|'.join(['_'.join(map(str, tensor.shape)), str(tensor.layout), str(tensor.dtype), str(tensor.device)])})"
@@ -77,7 +77,7 @@ def convert_pt_tensor_to_tt_tensor(pt_tensor, output_format):
 
     if output_format["layout"] == ttnn.TILE_LAYOUT:
         if (
-            tt_tensor.get_legacy_shape()[2] % 32 == 0 and tt_tensor.get_legacy_shape()[3] % 32 == 0
+            tt_tensor.shape.with_tile_padding()[2] % 32 == 0 and tt_tensor.shape.with_tile_padding()[3] % 32 == 0
         ):  # Restore tile layout only if legal or else leave as RM
             tt_tensor = tt_tensor.to(ttnn.TILE_LAYOUT)
     else:
@@ -89,7 +89,7 @@ def convert_pt_tensor_to_tt_tensor(pt_tensor, output_format):
         if (
             tt_tensor.get_layout() == ttnn.TILE_LAYOUT
             or tt_tensor.get_layout() == ttnn.ROW_MAJOR_LAYOUT
-            and tt_tensor.get_legacy_shape()[3] % 2 == 0
+            and tt_tensor.shape.with_tile_padding()[3] % 2 == 0
         ):
             tt_tensor = tt_tensor.to(output_format["device"])
     return tt_tensor

--- a/ttnn/tt_lib/fused_ops/add_and_norm.py
+++ b/ttnn/tt_lib/fused_ops/add_and_norm.py
@@ -15,7 +15,7 @@ def AddAndNorm(gamma: ttnn.Tensor, beta: ttnn.Tensor, epsilon, H, W, device):
 
     def add_and_norm_(activationa, activationb):
         a_plus_b = ttnn.add(activationa, activationb)
-        H = activationa.get_legacy_shape()[2]
+        H = activationa.shape.with_tile_padding()[2]
         lnorm_a_plus_b = layernorm(a_plus_b, overrideH=H)
         return lnorm_a_plus_b
 

--- a/ttnn/tt_lib/fused_ops/layernorm.py
+++ b/ttnn/tt_lib/fused_ops/layernorm.py
@@ -89,10 +89,10 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
     # 1D variant
     # TODO(AP): merge with 2d? refactor.
     def layernorm_1d_(x, overrideH=None, refx=None, refgamma=None, refbeta=None):
-        N = x.get_legacy_shape()[0]
-        C = x.get_legacy_shape()[1]
-        H = x.get_legacy_shape()[2]
-        W = x.get_legacy_shape()[3]
+        N = x.shape.with_tile_padding()[0]
+        C = x.shape.with_tile_padding()[1]
+        H = x.shape.with_tile_padding()[2]
+        W = x.shape.with_tile_padding()[3]
 
         H_ = 1
         if overrideH is not None:
@@ -132,10 +132,10 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
             return x_gamma
 
     def layernorm_2d_(x):
-        N = x.get_legacy_shape()[0]
-        C = x.get_legacy_shape()[1]
-        H = x.get_legacy_shape()[2]
-        W = x.get_legacy_shape()[3]
+        N = x.shape.with_tile_padding()[0]
+        C = x.shape.with_tile_padding()[1]
+        H = x.shape.with_tile_padding()[2]
+        W = x.shape.with_tile_padding()[3]
 
         # first compute the mean (m)
         redW = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Need to remove `tt::tt_metal::LegacyShape` completely. This PR removes python usage of `get_legacy_shape`.

### What's changed
Remove python usage of `get_legacy_shape`.

### Checklist
- [x] Post commit CI passes
   - all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/11042335541
   - T3K frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11042393967
   - nightly fast dispatch (mostly passing; previous failures on main): https://github.com/tenstorrent/tt-metal/actions/runs/11042379744/job/30674984312
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml
- [x] New/Existing tests provide coverage for changes
