### PR TITLE
Add an option to split dprint output by risc

### DIFF
--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -21,11 +21,12 @@ Note that the core coordinates are logical coordinates, so worker cores and ethe
 
 .. code-block::
 
-    export TT_METAL_DPRINT_CORES=0,0     # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
-    export TT_METAL_DPRINT_ETH_CORES=0,0 # optional, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
-    export TT_METAL_DPRINT_CHIPS=0       # optional, comma separated list of chips
-    export TT_METAL_DPRINT_RISCVS=BR     # optional, default is all RISCs.  Use a subset of BR,NC,TR0,TR1,TR2
-    export TT_METAL_DPRINT_FILE=log.txt  # optional, default is to print to the screen
+    export TT_METAL_DPRINT_CORES=0,0           # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
+    export TT_METAL_DPRINT_ETH_CORES=0,0       # optional, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
+    export TT_METAL_DPRINT_CHIPS=0             # optional, comma separated list of chips
+    export TT_METAL_DPRINT_RISCVS=BR           # optional, default is all RISCs.  Use a subset of BR,NC,TR0,TR1,TR2
+    export TT_METAL_DPRINT_FILE=log.txt        # optional, default is to print to the screen
+    export TT_METAL_DPRINT_ONE_FILE_PER_RISC=1 # optional, splits DPRINT data on a per-RISC basis into files under $TT_METAL_HOME/generated/dprint/. Overrides TT_METAL_DPRINT_FILE.
 
 To generate kernel debug prints on the device, include the ``debug/dprint.h`` header and use the APIs defined there.
 And example with the different features available is shown below:

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
@@ -17,7 +17,7 @@ using namespace tt::tt_metal;
 
 // Some machines will run this test on different physical cores, so wildcard the exact coordinates.
 const std::string golden_output =
-R"(DPRINT server timed out on core (*,*) riscv 4, waiting on a RAISE signal: 1
+R"(DPRINT server timed out on Device *, worker core (x=*,y=*), riscv 4, waiting on a RAISE signal: 1
 )";
 
 static void RunTest(DPrintFixture* fixture, Device* device) {

--- a/tt_metal/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/dprint_common.h
@@ -13,6 +13,18 @@
 #include <cstddef>
 #include <dev_msgs.h>
 
+// Used to index into the DPRINT buffers. Erisc is separate because it only has one buffer.
+enum DebugPrintHartIndex : unsigned int {
+    DPRINT_RISCV_INDEX_NC  = 0,
+    DPRINT_RISCV_INDEX_TR0 = 1,
+    DPRINT_RISCV_INDEX_TR1 = 2,
+    DPRINT_RISCV_INDEX_TR2 = 3,
+    DPRINT_RISCV_INDEX_BR  = 4,
+    DPRINT_RISCV_INDEX_ER  = 0,
+};
+#define DPRINT_NRISCVS 5
+#define DPRINT_NRISCVS_ETH 1
+
 #define DPRINT_TYPES                 \
     DPRINT_PREFIX(CSTR)              \
     DPRINT_PREFIX(ENDL)              \

--- a/tt_metal/hw/inc/debug/dprint_buffer.h
+++ b/tt_metal/hw/inc/debug/dprint_buffer.h
@@ -6,16 +6,6 @@
 
 #include <dev_msgs.h>
 
-// TODO: remove the HartFlags in dprint_server.hpp and drive from this
-enum DebugPrintHartIndex : unsigned int {
-    DPRINT_RISCV_INDEX_NC  = 0,
-    DPRINT_RISCV_INDEX_TR0 = 1,
-    DPRINT_RISCV_INDEX_TR1 = 2,
-    DPRINT_RISCV_INDEX_TR2 = 3,
-    DPRINT_RISCV_INDEX_BR  = 4,
-    DPRINT_RISCV_INDEX_ER  = 0,
-};
-
 // Returns the buffer address for current thread+core. Differs for NC/BR/ER/TR0-2.
 inline uint8_t* get_debug_print_buffer() {
     #if defined(COMPILE_FOR_NCRISC)

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -10,9 +10,6 @@
 
 namespace tt {
 
-constexpr int DPRINT_NRISCVS = 5;
-constexpr int DPRINT_NRISCVS_ETH = 1;
-
 namespace tt_metal {
     class Device;
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2202,6 +2202,10 @@ CoreCoord Device::physical_core_from_logical_core(const CoreCoord &logical_coord
     return soc_desc.get_physical_core_from_logical_core(logical_coord, core_type);
 }
 
+CoreCoord Device::physical_core_from_logical_core(const CoreDescriptor &logical_core) const {
+    return physical_core_from_logical_core(logical_core.coord, logical_core.type);
+}
+
 CoreType Device::core_type_from_physical_core(const CoreCoord &physical_coord) const {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
     if (soc_desc.physical_cores.find(physical_coord) == soc_desc.physical_cores.end())

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -101,6 +101,7 @@ class Device {
     CoreCoord dram_grid_size() const;
 
     CoreCoord physical_core_from_logical_core(const CoreCoord &logical_core, const CoreType &core_type) const;
+    CoreCoord physical_core_from_logical_core(const CoreDescriptor &logical_core) const;
     CoreType core_type_from_physical_core(const CoreCoord &physical_core) const;
 
     CoreCoord worker_core_from_logical_core(const CoreCoord &logical_core) const;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -200,6 +200,7 @@ void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature) {
     ParseFeatureChipIds(feature, feature_env_prefix + "_CHIPS");
     ParseFeatureRiscvMask(feature, feature_env_prefix + "_RISCVS");
     ParseFeatureFileName(feature, feature_env_prefix + "_FILE");
+    ParseFeatureOneFilePerRisc(feature, feature_env_prefix + "_ONE_FILE_PER_RISC");
 
     // Set feature enabled if the user asked for any feature cores
     feature_targets[feature].enabled = false;
@@ -337,6 +338,11 @@ void RunTimeOptions::ParseFeatureRiscvMask(RunTimeDebugFeatures feature, const s
 void RunTimeOptions::ParseFeatureFileName(RunTimeDebugFeatures feature, const std::string &env_var) {
     char *env_var_str = std::getenv(env_var.c_str());
     feature_targets[feature].file_name = (env_var_str != nullptr) ? std::string(env_var_str) : "";
+}
+
+void RunTimeOptions::ParseFeatureOneFilePerRisc(RunTimeDebugFeatures feature, const std::string &env_var) {
+    char *env_var_str = std::getenv(env_var.c_str());
+    feature_targets[feature].one_file_per_risc = (env_var_str != nullptr);
 }
 
 }  // namespace llrt

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -80,6 +80,7 @@ struct TargetSelection {
     bool all_chips = false;
     uint32_t riscv_mask = 0;
     std::string file_name;  // File name to write output to.
+    bool one_file_per_risc = false;
 };
 
 class RunTimeOptions {
@@ -207,6 +208,12 @@ class RunTimeOptions {
     inline void set_feature_file_name(RunTimeDebugFeatures feature, std::string file_name) {
         feature_targets[feature].file_name = file_name;
     }
+    inline bool get_feature_one_file_per_risc(RunTimeDebugFeatures feature) {
+        return feature_targets[feature].one_file_per_risc;
+    }
+    inline void set_feature_one_file_per_risc(RunTimeDebugFeatures feature, bool one_file_per_risc) {
+        feature_targets[feature].one_file_per_risc = one_file_per_risc;
+    }
     inline TargetSelection get_feature_targets(RunTimeDebugFeatures feature) { return feature_targets[feature]; }
     inline void set_feature_targets(RunTimeDebugFeatures feature, TargetSelection targets) {
         feature_targets[feature] = targets;
@@ -277,6 +284,7 @@ class RunTimeOptions {
     void ParseFeatureChipIds(RunTimeDebugFeatures feature, const std::string &env_var);
     void ParseFeatureRiscvMask(RunTimeDebugFeatures feature, const std::string &env_var);
     void ParseFeatureFileName(RunTimeDebugFeatures feature, const std::string &env_var);
+    void ParseFeatureOneFilePerRisc(RunTimeDebugFeatures feature, const std::string &env_var);
 
     // Helper function to parse watcher-specific environment variables.
     void ParseWatcherEnv();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13081)

### Problem description
Multi-device/multi-core/multi-risc applications all have dprint data dumped to the same place, it's hard to parse.

### What's changed
Add an env var, `TT_METAL_DPRINT_ONE_FILE_PER_RISC`, to separate dprint output on a per-risc basis. Data is placed in generated files under `$TT_METAL_HOME/generated/dprint` as shown:
<img width="2388" alt="image" src="https://github.com/user-attachments/assets/55de1cd0-cddb-49e9-a17f-8d35b6f16783">

Also update dprint server to use logical coords instead of physical (and use CoreDescriptor to simplify the code) to facilitate this change.

### Checklist
- [ ] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11042899735
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
