### PR TITLE
Add initial (very limited) support for line reduce scatter

### DIFF
--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -3,8 +3,10 @@ add_library(test_eager_common_libs INTERFACE)
 target_link_libraries(test_eager_common_libs INTERFACE test_common_libs)
 
 set(TT_EAGER_TESTS_OPS
+    ops/ccl/test_ccl_commands.cpp
     ops/ccl/test_ccl_helpers.cpp
     ops/ccl/test_ccl_tensor_slicers.cpp
+    ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
     ops/test_average_pool.cpp
     ops/test_eltwise_binary_op.cpp
     ops/test_eltwise_unary_op.cpp

--- a/tests/tt_eager/ops/ccl/test_ccl_commands.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_commands.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_eager/ops/ccl/test_ccl_commands.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_commands.cpp
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+
+#include "gtest/gtest.h"
+
+#include <limits>
+#include <numeric>
+#include <ranges>
+
+using ttnn::ccl::Shape4D;
+using ttnn::ccl::cmd::tensor_shape_command_arg_t;
+using ttnn::ccl::cmd::tensor_slice_shape_command_arg_t;
+using ttnn::ccl::cmd::tensor_slice_offset_command_arg_t;
+using ttnn::ccl::cmd::worker_start_offset_command_arg_t;
+using ttnn::ccl::cmd::worker_pages_command_arg_t;
+using ttnn::ccl::cmd::full_tensor_command_arg_t;
+using ttnn::ccl::cmd::CclCommandTensor;
+
+const Shape4D<uint32_t> uninitialized_test_shape = {
+    std::numeric_limits<uint32_t>::max(),
+    std::numeric_limits<uint32_t>::max(),
+    std::numeric_limits<uint32_t>::max(),
+    std::numeric_limits<uint32_t>::max()};
+
+// tensor shape
+TEST(CclCommandArgGenerator, PackTensorShapeArg) {
+    constexpr std::size_t size_in_words = tensor_shape_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    std::array<uint32_t, size_in_words> args;
+    std::ranges::fill(args, std::numeric_limits<uint32_t>::max());
+    Shape4D<uint32_t> test_shape = {1,2,3,4};
+    tensor_shape_command_arg_t::pack_to(args.data(), test_shape);
+    ASSERT_EQ(args[0], 1);
+    ASSERT_EQ(args[1], 2);
+    ASSERT_EQ(args[2], 3);
+    ASSERT_EQ(args[3], 4);
+}
+
+TEST(CclCommandArgGenerator, UnpackTensorShapeArg) {
+    constexpr std::size_t size_in_words = tensor_shape_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    std::array<uint32_t, tensor_shape_command_arg_t::size_in_words()> args = {1,2,3,4};
+    Shape4D<uint32_t> test_shape = uninitialized_test_shape;
+    tensor_shape_command_arg_t::unpack(args.data(), test_shape);
+
+    ASSERT_EQ(test_shape.w, 1);
+    ASSERT_EQ(test_shape.z, 2);
+    ASSERT_EQ(test_shape.y, 3);
+    ASSERT_EQ(test_shape.x, 4);
+}
+
+// tensor slice
+TEST(CclCommandArgGenerator, PackTensorSliceShapeArg) {
+    std::array<uint32_t, tensor_slice_shape_command_arg_t::size_in_words()> args;
+    std::ranges::fill(args, std::numeric_limits<uint32_t>::max());
+    constexpr std::size_t size_in_words = tensor_slice_shape_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    Shape4D<uint32_t> test_shape = {1,2,3,4};
+    tensor_slice_shape_command_arg_t::pack_to(args.data(), test_shape);
+    ASSERT_EQ(args[0], 1);
+    ASSERT_EQ(args[1], 2);
+    ASSERT_EQ(args[2], 3);
+    ASSERT_EQ(args[3], 4);
+}
+
+TEST(CclCommandArgGenerator, UnpackTensorSliceShapeArg) {
+    std::array<uint32_t, tensor_slice_shape_command_arg_t::size_in_words()> args = {1,2,3,4};
+    constexpr std::size_t size_in_words = tensor_slice_shape_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    Shape4D<uint32_t> test_shape = uninitialized_test_shape;
+    tensor_slice_shape_command_arg_t::unpack(args.data(), test_shape);
+    ASSERT_EQ(test_shape.w, 1);
+    ASSERT_EQ(test_shape.z, 2);
+    ASSERT_EQ(test_shape.y, 3);
+    ASSERT_EQ(test_shape.x, 4);
+}
+
+// tensor slice offset
+TEST(CclCommandArgGenerator, PackTensorSliceOffsetArg) {
+    std::array<uint32_t, tensor_slice_offset_command_arg_t::size_in_words()> args;
+    std::ranges::fill(args, std::numeric_limits<uint32_t>::max());
+    constexpr std::size_t size_in_words = tensor_slice_offset_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    Shape4D<uint32_t> test_shape = {1,2,3,4};
+    tensor_slice_offset_command_arg_t::pack_to(args.data(), test_shape);
+    ASSERT_EQ(args[0], 1);
+    ASSERT_EQ(args[1], 2);
+    ASSERT_EQ(args[2], 3);
+    ASSERT_EQ(args[3], 4);
+}
+
+TEST(CclCommandArgGenerator, UnpackTensorSliceOffsetArg) {
+    std::array<uint32_t, tensor_slice_offset_command_arg_t::size_in_words()> args = {1,2,3,4};
+    constexpr std::size_t size_in_words = tensor_slice_offset_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    Shape4D<uint32_t> test_shape = uninitialized_test_shape;
+    tensor_slice_offset_command_arg_t::unpack(args.data(), test_shape);
+    ASSERT_EQ(test_shape.w, 1);
+    ASSERT_EQ(test_shape.z, 2);
+    ASSERT_EQ(test_shape.y, 3);
+    ASSERT_EQ(test_shape.x, 4);
+}
+
+// worker start offset in slice
+TEST(CclCommandArgGenerator, PackWorkerStartOffsetInSliceArg) {
+    std::array<uint32_t, worker_start_offset_command_arg_t::size_in_words()> args;
+    std::ranges::fill(args, std::numeric_limits<uint32_t>::max());
+    constexpr std::size_t size_in_words = worker_start_offset_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    Shape4D<uint32_t> test_shape = {1,2,3,4};
+    worker_start_offset_command_arg_t::pack_to(args.data(), test_shape);
+    ASSERT_EQ(args[0], 1);
+    ASSERT_EQ(args[1], 2);
+    ASSERT_EQ(args[2], 3);
+    ASSERT_EQ(args[3], 4);
+}
+
+TEST(CclCommandArgGenerator, UnpackWorkerStartOffsetInSliceArg) {
+    std::array<uint32_t, worker_start_offset_command_arg_t::size_in_words()> args = {1,2,3,4};
+    constexpr std::size_t size_in_words = worker_start_offset_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 4);
+    Shape4D<uint32_t> test_shape = uninitialized_test_shape;
+    worker_start_offset_command_arg_t::unpack(args.data(), test_shape);
+    ASSERT_EQ(test_shape.w, 1);
+    ASSERT_EQ(test_shape.z, 2);
+    ASSERT_EQ(test_shape.y, 3);
+    ASSERT_EQ(test_shape.x, 4);
+}
+
+// worker pages per slice
+TEST(CclCommandArgGenerator, PackWorkerPagesPerSliceArg) {
+    std::array<uint32_t, worker_pages_command_arg_t::size_in_words()> args;
+    std::ranges::fill(args, std::numeric_limits<uint32_t>::max());
+    constexpr std::size_t size_in_words = worker_pages_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 1);
+    uint32_t test_value = 1;
+    worker_pages_command_arg_t::pack_to(args.data(), test_value);
+    ASSERT_EQ(args[0], 1);
+}
+
+TEST(CclCommandArgGenerator, UnpackWorkerPagesPerSliceArg) {
+    std::array<uint32_t, worker_pages_command_arg_t::size_in_words()> args = {1};
+    constexpr std::size_t size_in_words = worker_pages_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 1);
+    uint32_t test_value = 0;
+    worker_pages_command_arg_t::unpack(args.data(), test_value);
+    ASSERT_EQ(test_value, 1);
+}
+
+// full tensor
+TEST(CclCommandArgGenerator, PackFullTensorArg) {
+    constexpr std::size_t size_in_words = full_tensor_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 17);
+    std::array<uint32_t, full_tensor_command_arg_t::size_in_words()> args;
+    std::ranges::fill(args, std::numeric_limits<uint32_t>::max());
+
+    CclCommandTensor test_tensor = {
+        {0,1,2,3},
+        {4,5,6,7},
+        {8,9,10,11},
+        {12,13,14,15},
+        16
+    };
+    full_tensor_command_arg_t::pack_to(args.data(), test_tensor);
+    for (std::size_t i = 0; i < size_in_words; i++) {
+        ASSERT_EQ(args[i], i);
+    }
+}
+
+TEST(CclCommandArgGenerator, UnpackFullTensorArg) {
+    constexpr std::size_t size_in_words = full_tensor_command_arg_t::size_in_words();
+    ASSERT_EQ(size_in_words, 17);
+    std::array<uint32_t, full_tensor_command_arg_t::size_in_words()> args;
+    std::iota(args.begin(), args.end(), 0);
+
+    full_tensor_command_arg_t::field_type test_tensor = {
+        {std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max()},
+        {std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max()},
+        {std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max()},
+        {std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max(),std::numeric_limits<uint32_t>::max()},
+        std::numeric_limits<uint32_t>::max()
+    };
+    full_tensor_command_arg_t::unpack(args.data(), test_tensor);
+    ASSERT_EQ(test_tensor.tensor_shape.w, 0);
+    ASSERT_EQ(test_tensor.tensor_shape.z, 1);
+    ASSERT_EQ(test_tensor.tensor_shape.y, 2);
+    ASSERT_EQ(test_tensor.tensor_shape.x, 3);
+    ASSERT_EQ(test_tensor.tensor_slice_shape.w, 4);
+    ASSERT_EQ(test_tensor.tensor_slice_shape.z, 5);
+    ASSERT_EQ(test_tensor.tensor_slice_shape.y, 6);
+    ASSERT_EQ(test_tensor.tensor_slice_shape.x, 7);
+    ASSERT_EQ(test_tensor.tensor_slice_offset.w, 8);
+    ASSERT_EQ(test_tensor.tensor_slice_offset.z, 9);
+    ASSERT_EQ(test_tensor.tensor_slice_offset.y, 10);
+    ASSERT_EQ(test_tensor.tensor_slice_offset.x, 11);
+    ASSERT_EQ(test_tensor.worker_start_offset_in_slice.w, 12);
+    ASSERT_EQ(test_tensor.worker_start_offset_in_slice.z, 13);
+    ASSERT_EQ(test_tensor.worker_start_offset_in_slice.y, 14);
+    ASSERT_EQ(test_tensor.worker_start_offset_in_slice.x, 15);
+    ASSERT_EQ(test_tensor.worker_pages_per_slice, 16);
+}

--- a/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
@@ -1,0 +1,92 @@
+#include "gtest/gtest.h"
+
+#include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+
+#include <vector>
+#include <cstdint>
+
+using ttnn::ccl::cmd::CclCommandArg;
+using ttnn::ccl::cmd::CclCommandArgCode;
+using ttnn::ccl::cmd::CclCommandHeader;
+using ttnn::ccl::cmd::CclCommandCode;
+using ttnn::ccl::generate_slice_sequence_on_dim;
+using shape4d = ttnn::ccl::Shape4D<uint32_t>;
+TEST(LineReduceScatter, EmitCclSendSliceSequenceCommands_8Slices_1x1x32x2048Tensor_Dim3_Slice0to7)
+{
+    const std::size_t num_slices = 8;
+    const std::int64_t start_slice_index = 0;
+    const std::int64_t end_slice_index_exclusive = 8;
+    // const tt_xy_pair tensor_shape(2048, 32);
+    const tt_xy_pair tensor_shape(64, 1);
+    const tt_xy_pair worker_slice_shape(16, 1);
+    const std::size_t scatter_dim = 3;
+    const std::size_t worker_index = 0;
+    auto const& slices = generate_slice_sequence_on_dim(
+        tensor_shape,
+        worker_slice_shape,
+        scatter_dim,
+        num_slices,
+        start_slice_index,
+        end_slice_index_exclusive,
+        worker_index
+    );
+
+    std::vector<uint32_t> args;
+    ASSERT_EQ(slices.size(), 8);
+    ttnn::ccl::reduce_scatter_detail::emit_ccl_send_slice_sequence_commands(slices, args);
+
+    const std::size_t args_per_command_header = 1;
+    const std::size_t args_per_command_arg_header = 1;
+
+    const std::size_t args_per_full_tensor_field = CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::size_in_words();
+    const std::size_t args_per_full_tensor_slice_command = args_per_command_header + args_per_command_arg_header + args_per_full_tensor_field;
+
+    const std::size_t args_per_shape_field = CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::size_in_words();
+    const std::size_t args_per_member_update = args_per_command_header + args_per_command_arg_header + args_per_shape_field;
+    const std::size_t num_commands_with_single_field_update = num_slices - 1;
+
+    ASSERT_EQ(args.size(), num_commands_with_single_field_update * args_per_member_update + args_per_full_tensor_slice_command);
+
+    shape4d expected_tensor_slice_shape = shape4d(1, 1, 1, 8);
+
+    log_info(tt::LogOp, "Commands");
+    for (std::size_t i = 0; i < args.size(); i++) {
+        log_info(tt::LogOp, "arg {}: {}", i, args[i]);
+    }
+
+
+    { // Validate the first command
+        std::size_t cmd_start_offset = 0;
+        CclCommandHeader cmd_hdr = CclCommandHeader::from_uint32(args[cmd_start_offset]);
+        CclCommandCode cmd_code = cmd_hdr.code;
+        auto arg_count = cmd_hdr.arg_count;
+        ASSERT_EQ(cmd_code, CclCommandCode::STREAM_TENSOR_TO_EDM);
+        ASSERT_EQ(arg_count, 1);
+
+        std::size_t arg_start_offset = cmd_start_offset + args_per_command_header;
+        std::size_t fields_start = arg_start_offset + args_per_command_arg_header;
+        std::size_t arg_offset = fields_start;
+        ASSERT_EQ(args[arg_offset++], 1);
+        ASSERT_EQ(args[arg_offset++], 1);
+        ASSERT_EQ(args[arg_offset++], tensor_shape.y);
+        ASSERT_EQ(args[arg_offset++], tensor_shape.x);
+
+        ASSERT_EQ(args[arg_offset++], expected_tensor_slice_shape.w);
+        ASSERT_EQ(args[arg_offset++], expected_tensor_slice_shape.z);
+        ASSERT_EQ(args[arg_offset++], expected_tensor_slice_shape.y);
+        ASSERT_EQ(args[arg_offset++], expected_tensor_slice_shape.x);
+
+
+    }
+
+    // Validate the rest of the commands
+    {
+
+    }
+
+
+}

--- a/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "gtest/gtest.h"
 
 #include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp"

--- a/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_reduce_scatter_host_helpers.cpp
@@ -20,7 +20,6 @@ TEST(LineReduceScatter, EmitCclSendSliceSequenceCommands_8Slices_1x1x32x2048Tens
     const std::size_t num_slices = 8;
     const std::int64_t start_slice_index = 0;
     const std::int64_t end_slice_index_exclusive = 8;
-    // const tt_xy_pair tensor_shape(2048, 32);
     const tt_xy_pair tensor_shape(64, 1);
     const tt_xy_pair worker_slice_shape(16, 1);
     const std::size_t scatter_dim = 3;
@@ -82,11 +81,5 @@ TEST(LineReduceScatter, EmitCclSendSliceSequenceCommands_8Slices_1x1x32x2048Tens
 
 
     }
-
-    // Validate the rest of the commands
-    {
-
-    }
-
 
 }

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -178,6 +178,7 @@ def run_reduce_scatter_test(
                                     logger.error(
                                         f"mismatch at {w}, {z}, {y}, {x}: {tt_output_tensor[w, z, y, x]} != {golden_output_tensors[i][w, z, y, x]}"
                                     )
+
         else:
             logger.info(f"output match for tensor {i}")
     assert not mismatch, f"{i} FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -120,7 +120,6 @@ def run_reduce_scatter_test(
     numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
     input_tensors = [
         torch.rand(canonical_input_shape).bfloat16() if not debug else torch.ones(canonical_input_shape).bfloat16()
-        # torch.rand(canonical_input_shape).bfloat16() if not debug else torch.zeros(canonical_input_shape).bfloat16()
         for _ in range(num_devices)
     ]
 
@@ -179,19 +178,6 @@ def run_reduce_scatter_test(
                                     logger.error(
                                         f"mismatch at {w}, {z}, {y}, {x}: {tt_output_tensor[w, z, y, x]} != {golden_output_tensors[i][w, z, y, x]}"
                                     )
-                        # for y in range(0, tt_output_tensor.shape[2], 32):
-                        #     for x in range(0, tt_output_tensor.shape[3], 32):
-                        #         # xx = 0
-                        #         # yy = 0
-                        #         for yy in range(32):
-                        #             for xx in range(32):
-                        #                 if (
-                        #                     tt_output_tensor[w, z, y + yy, x + xx]
-                        #                     != golden_output_tensors[i][w, z, y + yy, x + xx]
-                        #                 ):
-                        #                     logger.error(
-                        #                         f"mismatch at {w}, {z}, {y+yy}, {x+xx}: {tt_output_tensor[w, z, y+yy, x+xx]} != {golden_output_tensors[i][w, z, y+yy, x+xx]}"
-                        #                     )
         else:
             logger.info(f"output match for tensor {i}")
     assert not mismatch, f"{i} FAILED: {output}"
@@ -213,7 +199,7 @@ def run_reduce_scatter_test(
         ([1, 1, 32, 32 * 8], 3, ttnn.TILE_LAYOUT),
         ([1, 8, 1024, 1024], 3, ttnn.TILE_LAYOUT),
         ([1, 4, 2048, 1024], 3, ttnn.TILE_LAYOUT),
-        # # # # Has worker slice size warning - defaults to 1x1
+        # # # Has worker slice size warning - defaults to 1x1
         ([1, 1, 128, 8192], 3, ttnn.TILE_LAYOUT),
     ],
 )
@@ -270,34 +256,25 @@ def test_ring_reduce_scatter_post_commit(
 @pytest.mark.parametrize(
     "num_devices, num_links",
     [
-        # (4, 1),
         (8, 1),
     ],
 )
 @pytest.mark.parametrize(
     "per_chip_output_shape, scatter_dim, layout",
     [
-        # ([1, 1, 32, 32 * 2], 3, ttnn.TILE_LAYOUT),
         ([1, 1, 32, 32 * 8], 3, ttnn.TILE_LAYOUT),
-        # Fals with 5th chip not reduceing some of its final tiles with the counter-clockwise direction
-        # ([1, 2, 256, 32 * 8], 3, ttnn.TILE_LAYOUT),  # Input tensor is (16*32) x (64*32) = 8 * input tensor shape
-        # ([1, 8, 1024, 1024], 3, ttnn.TILE_LAYOUT),
-        # ([1, 4, 2048, 1024], 3, ttnn.TILE_LAYOUT),
-        # ([1, 1, 128, 8192], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
         ttnn.bfloat16,
-        # ttnn.bfloat8_b, # passes
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
-        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -99,7 +99,7 @@ def run_reduce_scatter_test(
     if len(t3k_mesh_device.get_device_ids()) != 8:
         pytest.skip("Not T3000!")
 
-    debug = True
+    debug = False
 
     (is_known_failure, message) = is_unsupported_case(
         per_chip_output_shape, scatter_dim, math_op, mem_config, num_devices, num_links, input_dtype, layout

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -207,7 +207,7 @@ def run_reduce_scatter_test(
     "input_dtype",
     [
         ttnn.bfloat16,
-        # ttnn.bfloat8_b,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -20,6 +20,8 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/common/uops/ccl_command.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
@@ -28,6 +30,8 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -498,7 +498,6 @@ FORCE_INLINE void read_wrapped_chunk_from_output_tensor(
         local_l1_read_addr += page_size * contig_pages;
     }
     noc_async_read_barrier();
-
     cb_push_back(cb_id, num_pages);
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -434,12 +434,12 @@ template <typename AddrGen>
 FORCE_INLINE void read_wrapped_chunk_from_output_tensor(
     uint32_t& curr_page_idx,
     uint32_t& offset_into_worker_slice,
-     ttnn::ccl::coord_t& offset_worker_slice,
-    const  ttnn::ccl::coord_t& worker_slice_shape,
+    const ttnn::ccl::coord_t& offset_worker_slice,
+    const ttnn::ccl::coord_t& worker_slice_shape,
 
     // In tiles for tile layout
-    const  ttnn::ccl::coord_t& tensor_shape,
-    const  ttnn::ccl::coord_t& tensor_slice_shape,
+    const ttnn::ccl::coord_t& tensor_shape,
+    const ttnn::ccl::coord_t& tensor_slice_shape,
     const uint32_t cb_id,
     const AddrGen& s,
     const uint32_t num_pages,
@@ -498,6 +498,7 @@ FORCE_INLINE void read_wrapped_chunk_from_output_tensor(
         local_l1_read_addr += page_size * contig_pages;
     }
     noc_async_read_barrier();
+
     cb_push_back(cb_id, num_pages);
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -17,8 +17,12 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+
 #include <sstream>
 #include <type_traits>
+#include <ranges>
 
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 
@@ -196,8 +200,8 @@ static bool shard_grid_is_transposed(Tensor const& t) {
 }
 
 static void emit_sharded_tensor_kernel_ct_args(Device *d, Tensor const& tensor, std::vector<uint32_t> &args, std::size_t pages_per_shard_y, std::size_t pages_per_shard_x) {
-    auto const& new_args = ShardedAddrGenArgBuilder::emit_ct_args(tensor);
-    std::copy(std::begin(new_args), std::end(new_args), std::back_inserter(args));
+    std::ranges::copy(std::vector<uint32_t>{static_cast<uint32_t>(tensor.memory_config().memory_layout)}, std::back_inserter(args));
+    std::ranges::copy(ShardedAddrGenArgBuilder::emit_ct_args(tensor), std::back_inserter(args));
 };
 
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -17,7 +17,6 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
-
 #include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 
 #include <sstream>

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -372,7 +372,6 @@ std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::compute_worker_slice_offs
     return worker_slice_offsets;
 }
 
-// Not specific to reduce scatter - we can start to commonize this somewhere.
 static std::vector<tt_xy_pair> compute_worker_slice_offsets_for_wrapped_tensor_slicer(
     std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
     std::vector<tt_xy_pair> worker_slice_offsets;
@@ -739,7 +738,7 @@ std::vector<TensorSlice> generate_slice_sequence_on_dim(
     auto dim_start_offset = start_slice_index * slice_size_on_dim;
     TensorSlice::ords_t tensor_slice_offset = fracture_dim == 0 ? tt_xy_pair{0, dim_start_offset} : tt_xy_pair{dim_start_offset, 0};
 
-    bool forward_direction = start_slice_index > end_slice_index_exclusive; // REMOVE - ONLY HERE FOR DEBUG
+    bool forward_direction = start_slice_index > end_slice_index_exclusive; // only for debug
     auto incr = start_slice_index < end_slice_index_exclusive ? 1 : -1;
     if (forward_direction) {
         log_trace(tt::LogOp, "slice_size_on_dim {}", slice_size_on_dim);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -67,6 +67,14 @@ RingTopology::RingTopology(
     }
 }
 
+bool RingTopology::is_first_device_in_line(bool in_clockwise_direction) const {
+    return this->is_linear && ((in_clockwise_direction && this->ring_index == 0) ||
+                               (!in_clockwise_direction && this->ring_index == this->ring_size - 1));
+}
+bool RingTopology::is_last_device_in_line(bool in_clockwise_direction) const {
+    return this->is_linear && ((in_clockwise_direction && this->ring_index == this->ring_size - 1) ||
+                               (!in_clockwise_direction && this->ring_index == 0));
+}
 
 CclOpTensorConfig::CclOpTensorConfig(Tensor const& tensor) :
     buffer_start_address(tensor.buffer()->address()),
@@ -99,111 +107,8 @@ std::unique_ptr<CclOpTensorConfig> CclOpTensorConfig::build_all_gather_tensor_co
     }
 }
 
-static std::pair<tt_xy_pair, tt_xy_pair> shard_grid_from_shard_spec(const ShardSpec& shard_spec) {
-    auto const& core_range = shard_spec.grid.bounding_box();
-    log_trace(tt::LogOp, "SHARD CORE_RANGE: start_x:{} start_y:{} end_x:{} end_y:{}", core_range.start_coord.x, core_range.start_coord.y, core_range.end_coord.x, core_range.end_coord.y);
-    log_trace(tt::LogOp, "grid_size: {}", shard_spec.grid.num_cores());
 
-    return {core_range.start_coord, core_range.end_coord};
-}
 
-std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(Tensor const& t) {
-    std::vector<uint32_t> args;
-    TT_ASSERT(t.is_sharded());
-    auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
-    auto const& [shard_grid_start, shard_grid_end] = shard_grid_from_shard_spec(t.shard_spec().value());
-    bool shard_grid_transposed = shard_grid_is_transposed(t);
-    TT_FATAL(
-        t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
-        "Unsupported memory layout {}.", t.memory_config().memory_layout
-    );
-    args.push_back(static_cast<uint32_t>(t.memory_config().memory_layout));
-    // shard_grid_height (cores)
-    args.push_back(shard_grid_end.y - shard_grid_start.y + 1);
-    // shard_grid_width (cores)
-    args.push_back(shard_grid_end.x - shard_grid_start.x + 1);
-    // shard_grid_start_y
-    args.push_back(shard_grid_start.y);
-    // shard_grid_start_x
-    args.push_back(shard_grid_start.x);
-    // pages_per_shard_y
-    args.push_back(pages_per_shard_y);
-    // pages_per_shard_x
-    args.push_back(pages_per_shard_x);
-    // transposed grid
-    args.push_back(static_cast<uint32_t>(shard_grid_transposed));
-
-    return args;
-}
-
-bool ShardedAddrGenArgBuilder::shard_grid_is_transposed(Tensor const& t) {
-    TT_FATAL(
-        t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
-        "Unsupported memory layout {}.", t.memory_config().memory_layout
-    );
-    bool shard_grid_transposed =
-        ((t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
-          t.shard_spec()->orientation == ShardOrientation::ROW_MAJOR) ||
-         ((t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
-           t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) &&
-          t.shard_spec()->orientation == ShardOrientation::COL_MAJOR));
-    return shard_grid_transposed;
-}
-
-void ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(Tensor const& t, std::string const& prefix) {
-
-    auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
-    auto const& [shard_grid_start, shard_grid_end] = shard_grid_from_shard_spec(t.shard_spec().value());
-    bool shard_grid_transposed = shard_grid_is_transposed(t);
-
-    TT_ASSERT(pages_per_shard_y > 0);
-    TT_ASSERT(pages_per_shard_x > 0);
-    log_trace(tt::LogOp, "\t{}_shard_grid_height: {}", prefix,   shard_grid_end.y - shard_grid_start.y + 1);
-    log_trace(tt::LogOp, "\t{}_shard_grid_width: {}", prefix,    shard_grid_end.x - shard_grid_start.x + 1);
-    log_trace(tt::LogOp, "\t{}_shard_grid_start_y: {}", prefix,  shard_grid_start.y);
-    log_trace(tt::LogOp, "\t{}_shard_grid_start_x: {}", prefix,  shard_grid_start.x);
-    log_trace(tt::LogOp, "\t{}_pages_per_shard_y: {}", prefix,     pages_per_shard_y);
-    log_trace(tt::LogOp, "\t{}_pages_per_shard_x: {}", prefix,     pages_per_shard_x);
-    log_trace(tt::LogOp, "\t{}_transposed_grid: {}", prefix,     static_cast<uint32_t>(shard_grid_transposed));
-}
-
-// non-transposed - always row-major layout
-// vec<logical row -> noc row>, vec<logicacal col -> noc col>
-static std::pair<std::vector<uint32_t>,std::vector<uint32_t>> shard_noc_cores_from_shard_spec(Device const* d, const ShardSpec& shard_spec) {
-    TT_ASSERT(d != nullptr);
-    auto const& core_range = shard_spec.grid.bounding_box();
-    std::vector<uint32_t> logical_to_noc_row_map;
-    std::vector<uint32_t> logical_to_noc_col_map;
-    for (uint32_t y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-        CoreCoord noc_core = d->physical_core_from_logical_core(CoreCoord(0, y), CoreType::WORKER);
-        logical_to_noc_row_map.push_back(noc_core.y);
-    }
-    for (uint32_t x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-        CoreCoord noc_core = d->physical_core_from_logical_core(CoreCoord(x, 0), CoreType::WORKER);
-        logical_to_noc_col_map.push_back(noc_core.x);
-    }
-
-    return {logical_to_noc_row_map, logical_to_noc_col_map};
-}
-
-std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(Device const* d, Tensor const& t) {
-    std::vector<uint32_t> args;
-    auto const& [row_map, col_map] = shard_noc_cores_from_shard_spec(d, t.shard_spec().value());
-    args.push_back(row_map.size());
-    for (uint32_t i = 0; i < row_map.size(); i++) {
-        args.push_back(row_map.at(i));
-    }
-    args.push_back(col_map.size());
-    for (uint32_t i = 0; i < col_map.size(); i++) {
-        args.push_back(col_map.at(i));
-    }
-
-    return args;
-}
 
 void generate_edm_kernels_for_ring_or_linear_topology(
    tt::tt_metal::Program& program,
@@ -467,7 +372,8 @@ std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::compute_worker_slice_offs
     return worker_slice_offsets;
 }
 
-std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(
+// Not specific to reduce scatter - we can start to commonize this somewhere.
+static std::vector<tt_xy_pair> compute_worker_slice_offsets_for_wrapped_tensor_slicer(
     std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
     std::vector<tt_xy_pair> worker_slice_offsets;
     worker_slice_offsets.reserve(worker_slice_shapes.size());
@@ -489,6 +395,11 @@ std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::compute_worker_sli
 
     TT_ASSERT(worker_slice_offsets.size() == worker_slice_shapes.size());
     return worker_slice_offsets;
+}
+
+std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(
+    std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
+        return compute_worker_slice_offsets_for_wrapped_tensor_slicer(worker_slice_shapes, tensor_slice_shape);
 }
 
 template <class DERIVED_SLICER_T>
@@ -797,6 +708,92 @@ std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::create_worker_slic
     return worker_slice_shapes;
 }
 
+
+/*
+ * @brief: Given a tensor shape, evenly break it into pieces along a given dimension and generate the slices accordingly.
+ * This can be fed into a CCL Send command generator
+ */
+std::vector<TensorSlice> generate_slice_sequence_on_dim(
+    TensorSlice::ords_t tensor_shape,
+    TensorSlice::ords_t worker_slice_shape,
+    std::size_t fracture_dim,
+    std::size_t num_slices,
+    std::int64_t start_slice_index,
+    std::int64_t end_slice_index_exclusive,
+    std::size_t worker_index
+) {
+    static_assert(std::is_same_v<TensorSlice::ords_t, tt_xy_pair>, "generate_slice_sequence_on_dim not yet implemented for type not of tt_xy_pair");
+    TT_ASSERT(fracture_dim == 3);
+    // We don't support 4D shapes in the CCL kernels yet, which are needed for proper reduction/concatenation in some cases
+    // so for now we subtract the outer dims from the fracture_dim since we only support 2D at the moment.
+    fracture_dim -= 2;
+
+    TT_ASSERT(worker_slice_shape.y == 1);
+
+    std::vector<TensorSlice> slices;
+    auto dim_size = fracture_dim == 1 ? tensor_shape.x : tensor_shape.y;
+    TT_ASSERT(dim_size % num_slices == 0);
+    auto slice_size_on_dim = dim_size / num_slices;
+    auto slice_shape = fracture_dim == 0 ? tt_xy_pair{tensor_shape.x, slice_size_on_dim} : tt_xy_pair{slice_size_on_dim, tensor_shape.y};
+
+    auto dim_start_offset = start_slice_index * slice_size_on_dim;
+    TensorSlice::ords_t tensor_slice_offset = fracture_dim == 0 ? tt_xy_pair{0, dim_start_offset} : tt_xy_pair{dim_start_offset, 0};
+
+    bool forward_direction = start_slice_index > end_slice_index_exclusive; // REMOVE - ONLY HERE FOR DEBUG
+    auto incr = start_slice_index < end_slice_index_exclusive ? 1 : -1;
+    if (forward_direction) {
+        log_trace(tt::LogOp, "slice_size_on_dim {}", slice_size_on_dim);
+        log_trace(tt::LogOp, "worker_index {}", worker_index);
+    }
+
+    auto worker_slice_start_offset = fracture_dim == 0 ? TensorSlice::ords_t{0, worker_index * worker_slice_shape.y} : TensorSlice::ords_t{worker_index * worker_slice_shape.x, 0};
+
+    auto generate_slice = [forward_direction,incr, &slices, &tensor_shape, &slice_shape, &worker_slice_shape, tensor_slice_offset, &worker_slice_start_offset, fracture_dim, dim_start_offset, slice_size_on_dim](std::int64_t i){
+        auto tensor_slice_offset_adjusted = tensor_slice_offset;
+        if (fracture_dim == 0) {
+            tensor_slice_offset_adjusted.y = slice_size_on_dim * i;
+        } else {
+            tensor_slice_offset_adjusted.x = slice_size_on_dim * i;
+        }
+        TT_ASSERT(tensor_shape.x > 0, "Invalid tensor shape. x = 0 but it must be > 0");
+        TT_ASSERT(tensor_shape.y > 0, "Invalid tensor shape. y = 0 but it must be > 0");
+        TT_ASSERT(slice_shape.x > 0, "Invalid tensor slice shape. x = 0 but it must be > 0");
+        TT_ASSERT(slice_shape.y > 0, "Invalid tensor slice shape. x = 0 but it must be > 0");
+        TT_ASSERT(tensor_slice_offset_adjusted.x < tensor_shape.x, "Invalid tensor slice offset. x = {} but it must be < tensor shape x={}. slice_offset: (y={},x={}), tensor_shape: (y={},x={}). slice_size_on_dim: {}, i: {}", tensor_slice_offset_adjusted.x, tensor_shape.x, tensor_slice_offset_adjusted.y, tensor_slice_offset_adjusted.x, tensor_shape.y, tensor_shape.x, slice_size_on_dim, i);
+        TT_ASSERT(tensor_slice_offset_adjusted.y < tensor_shape.y, "Invalid tensor slice offset. y = {} but it must be < tensor shape y={}. slice_offset: (y={},x={}), tensor_shape: (y={},x={}). slice_size_on_dim: {}, i: {}", tensor_slice_offset_adjusted.y, tensor_shape.y, tensor_slice_offset_adjusted.y, tensor_slice_offset_adjusted.x, tensor_shape.y, tensor_shape.x, slice_size_on_dim, i);
+        TT_ASSERT(worker_slice_shape.x > 0, "Invalid worker slice shape. x = 0 but it must be > 0");
+        TT_ASSERT(worker_slice_shape.y > 0, "Invalid worker slice shape. y = 0 but it must be > 0");
+
+        auto const& tensor_slice = TensorSlice(tensor_shape, slice_shape, tensor_slice_offset_adjusted, worker_slice_shape, worker_slice_start_offset, fracture_dim);
+        if (forward_direction) {
+        log_trace(
+            tt::LogOp,
+            "generate_slice ({}):\n\ttensor_shape: (y={},x={})\n\ttensor_slice_shape: (y={},x={})\n\ttensor_slice_offset_adjusted: (y={},x={})\n\tslice_start_shape: (y={},x={})\n\tworker relative slice_start_offset: (y={},x={})\n\tfracture_dim: {}\n\tdim_start_offset: {}\n\tslice_size_on_dim: {}\n",
+            i,
+            tensor_slice.tensor_shape.y,
+            tensor_slice.tensor_shape.x,
+            tensor_slice.tensor_slice_shape.y,
+            tensor_slice.tensor_slice_shape.x,
+            tensor_slice.tensor_slice_offset.y,
+            tensor_slice.tensor_slice_offset.x,
+            tensor_slice.worker_slice_shape.y,
+            tensor_slice.worker_slice_shape.x,
+            tensor_slice.worker_slice_offset.y,
+            tensor_slice.worker_slice_offset.x,
+            fracture_dim,
+            dim_start_offset,
+            slice_size_on_dim);
+        }
+
+        slices.push_back(tensor_slice);
+    };
+
+    for (int i = start_slice_index; i != end_slice_index_exclusive; i += incr) {
+        generate_slice(i);
+    }
+
+    return slices;
+}
 
 }  // namespace ccl
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -9,6 +9,7 @@
 
 #include "common/constants.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/common/types/ccl_types.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/program/program.hpp"
@@ -27,6 +28,9 @@ struct RingTopology {
         uint32_t num_links,
         uint32_t ring_size,
         uint32_t ring_index);
+
+    bool is_first_device_in_line(bool in_clockwise_direction) const;
+    bool is_last_device_in_line(bool in_clockwise_direction) const;
 
     const Device *device;
 
@@ -189,10 +193,34 @@ struct LegacyCclTensorSlicer {
     bool is_sharded;
 };
 
+
+struct TensorSlice {
+    using ords_t = tt_xy_pair;//Shape4D<uint32_t>;
+    ords_t tensor_shape;
+    ords_t tensor_slice_shape;
+    ords_t tensor_slice_offset;
+    ords_t worker_slice_shape;
+    ords_t worker_slice_offset;
+    std::size_t dim;
+};
+
+// Workers iterate over tensor slices in a sequence along a
+// single, specified dimension. Workers iterator over the tensor
+// slice in wrapped mode
+std::vector<TensorSlice> generate_slice_sequence_on_dim(
+    TensorSlice::ords_t tensor_shape,
+    TensorSlice::ords_t worker_slice_shape,
+    std::size_t fracture_dim,
+    std::size_t num_slices,
+    std::int64_t start_slice_index,
+    std::int64_t end_slice_index,
+    std::size_t worker_index
+);
+
 // Uniform Tensor Worker Slice
 struct InterleavedTensorWorkerSlice {
     InterleavedTensorWorkerSlice(
-        tt_xy_pair const& tensor_shape,  // Don't _really_ need this
+        tt_xy_pair const& tensor_shape,
         tt_xy_pair const& tensor_slice_shape,
         tt_xy_pair const& worker_slice_shape,
         tt_xy_pair const& worker_slice_offset,
@@ -204,6 +232,7 @@ struct InterleavedTensorWorkerSlice {
         worker_slice_is_wrapped(worker_slice_is_wrapped) {}
 
     // Could probably be solved in some closed form
+
     std::size_t compute_num_worker_slice_iterations(std::size_t num_workers) const {
         auto slice_offset = coord_t(worker_slice_offset.x, worker_slice_offset.y);
         auto const& slice_shape = coord_t(worker_slice_shape.x, worker_slice_shape.y);
@@ -245,11 +274,13 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
         uint32_t half_cb_n_pages);
 
     ccl::InterleavedTensorWorkerSlice get_worker_slice(std::size_t global_worker_index, bool wrapped) {
+        TT_ASSERT(global_worker_index < this->worker_slice_shapes.size(), "Invalid worker index {} in `worker_slice_shapes` of size {}", global_worker_index, worker_slice_shapes.size());
+        TT_ASSERT(global_worker_index < this->worker_slice_offsets.size(), "Invalid worker index {} in `worker_slice_offsets` of size {}", global_worker_index, worker_slice_offsets.size());
         return ccl::InterleavedTensorWorkerSlice(
             this->flattened_tensor_shape,
             this->tensor_slice_shape,
-            this->worker_slice_shapes.at(global_worker_index),
-            this->worker_slice_offsets.at(global_worker_index),
+            this->worker_slice_shapes[global_worker_index],
+            this->worker_slice_offsets[global_worker_index],
             wrapped);
     }
 
@@ -260,7 +291,8 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
 
    public:
     std::vector<tt_xy_pair> get_worker_slice_shapes() const { return this->worker_slice_shapes; }
-    uint32_t get_worker_slice_size_bytes(int worker_index) {
+    uint32_t get_worker_slice_size_bytes(std::size_t worker_index) {
+        TT_ASSERT(this->worker_slice_shapes.size() > worker_index, "Invalid worker index {} in `worker_slice_shapes` of size {}", worker_index, worker_slice_shapes.size());
         auto worker_slice_shape = this->worker_slice_shapes.at(worker_index);
         return worker_slice_shape.x * worker_slice_shape.y * this->input_page_size;
     }
@@ -426,14 +458,6 @@ class InterleavedRingAllGatherTensorSlicer : public LegacyCclTensorSlicer {
         this->input_start_page_idx += num_pages /*pages_per_worker*/;
     }
 };
-
-struct ShardedAddrGenArgBuilder {
-    static bool shard_grid_is_transposed(Tensor const& t);
-    static std::vector<uint32_t> emit_ct_args(Tensor const& t);
-    static std::vector<uint32_t> emit_rt_args(Device const* d, Tensor const& t);
-    static void log_sharded_tensor_kernel_args(Tensor const& t, std::string const& prefix);
-};
-
 
 
 KernelHandle generate_edm_kernel(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -195,7 +195,7 @@ struct LegacyCclTensorSlicer {
 
 
 struct TensorSlice {
-    using ords_t = tt_xy_pair;//Shape4D<uint32_t>;
+    using ords_t = tt_xy_pair;
     ords_t tensor_shape;
     ords_t tensor_slice_shape;
     ords_t tensor_slice_offset;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -7,12 +7,11 @@
 #include "eth_l1_address_map.h"
 #include "ttnn/cpp/ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include <limits>
 
 namespace ttnn {
 namespace ccl {
-
-enum Topology { Ring = 0, Linear = 1, Meash = 2 };
 
 struct EriscDatamoverConfig {
     static constexpr std::size_t total_l1_buffer_space =
@@ -197,6 +196,8 @@ class EriscDatamoverBuilder {
         log_trace(tt::LogOp, "\tbuffer_address: {}", local_buffer_addresses.at(channel));
         log_trace(tt::LogOp, "\tsemaphore_address: {}", local_semaphore_addresses.at(channel));
         log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
+        TT_ASSERT(local_buffer_addresses.size() > channel);
+        TT_ASSERT(local_semaphore_addresses.size() > channel);
 
         return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
     }
@@ -225,6 +226,8 @@ class EriscDatamoverBuilder {
         log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
         log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
         log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+        TT_ASSERT(local_buffer_addresses.size() > channel);
+        TT_ASSERT(local_semaphore_addresses.size() > channel);
         return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace ttnn {
+namespace ccl {
+
+enum Topology { Ring = 0, Linear = 1, Mesh = 2 };
+
+};  // namespace ccl
+};  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "impl/buffers/buffer_constants.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+// #include "ttnn/tensor/types.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command_device.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_device.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
+#include "debug/dprint.h"
+#include <type_traits>
+#include <cstdint>
+
+using ttnn::ccl::coord_t;
+// For the future
+using address_t = uint32_t;
+
+
+
+using ttnn::ccl::Shape4D;
+using tt::tt_metal::TensorMemoryLayout;
+
+std::size_t get_flat_index_from_shape(const Shape4D<uint32_t> &shape, const Shape4D<uint32_t> &index) {
+    std::size_t offset = index.x;
+    std::size_t inner_volume = shape.x;
+    offset += index.y * inner_volume;
+    inner_volume *= shape.y;
+    offset += index.z * inner_volume;
+    inner_volume *= shape.z;
+    offset += index.w * inner_volume;
+    return offset;
+}
+
+
+namespace tt {
+namespace tt_metal {
+// TODO: Include directly from tt_metal or ttnn
+enum class Layout { ROW_MAJOR = 0, TILE = 1, INVALID = 2 };
+
+// TODO: move from `buffer.hpp` into a commmon location
+enum class BufferType {
+    DRAM,
+    L1,
+    SYSTEM_MEMORY,
+    L1_SMALL,
+    TRACE,
+};
+}
+}
+
+using tt::tt_metal::BufferType;
+using tt::tt_metal::Layout;
+
+/// TODO: This is *mostly* duplicate (but updated and closer to the intended deisng) to
+///       similar logic from worker_interleaved_ring_reduce_scatter_reader.cpp
+///       -> BEFORE MERGE, DEPRECATE THAT ONE AND REPLACE WITH THIS ONE
+template <TensorMemoryLayout tensor_layout, tt::tt_metal::BufferType buffer_type, tt::tt_metal::Layout page_layout>
+struct source_tensor_addrgen {
+    static constexpr char name[] = "Uninitialized";
+};
+template <tt::tt_metal::BufferType buffer_type, tt::tt_metal::Layout page_layout>
+struct source_tensor_addrgen<TensorMemoryLayout::INTERLEAVED, buffer_type, page_layout> {
+    static constexpr bool is_dram = buffer_type == tt::tt_metal::BufferType::DRAM;
+    static constexpr char name[] = "InterleavedAddrGen(default)";
+    using type = InterleavedAddrGen<is_dram>;
+};
+template <tt::tt_metal::BufferType buffer_type>
+struct source_tensor_addrgen<TensorMemoryLayout::INTERLEAVED, buffer_type, tt::tt_metal::Layout::TILE> {
+    static constexpr bool is_dram = buffer_type == tt::tt_metal::BufferType::DRAM;
+    static constexpr char name[] = "InterleavedAddrGen(Tile)";
+    using type = InterleavedAddrGenFast<is_dram>;
+};
+template <tt::tt_metal::BufferType buffer_type, tt::tt_metal::Layout page_layout>
+struct source_tensor_addrgen<TensorMemoryLayout::WIDTH_SHARDED, buffer_type, page_layout> {
+    static constexpr char name[] = "WidthSharded";
+    using type = tt::tt_metal::address_generators::DefaultWidthShardedAddressGenerator;
+};
+template <tt::tt_metal::BufferType buffer_type, tt::tt_metal::Layout page_layout>
+struct source_tensor_addrgen<TensorMemoryLayout::HEIGHT_SHARDED, buffer_type, page_layout> {
+    static constexpr char name[] = "HeightSharded";
+    using type = tt::tt_metal::address_generators::DefaultHeightShardedAddressGenerator;
+};
+template <tt::tt_metal::BufferType buffer_type, tt::tt_metal::Layout page_layout>
+struct source_tensor_addrgen<TensorMemoryLayout::BLOCK_SHARDED, buffer_type, page_layout> {
+    static constexpr char name[] = "BlockSharded";
+    using type = tt::tt_metal::address_generators::DefaultBlockShardedAddressGenerator;
+};
+
+
+constexpr bool is_sharded_tensor_layout(tt::tt_metal::TensorMemoryLayout tensor_layout) {
+    return tensor_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED ||
+           tensor_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
+           tensor_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED;
+}
+
+// reader code
+template <typename T>
+constexpr Shape4D<T> build_wrapped_row_tensor_slice(T n_pages) {
+    return Shape4D<T>{1, 1, 1, n_pages};
+}
+
+//tt::tt_metal::Layout from ttnn/cpp/ttnn/tensor/types.hpp
+template <tt::tt_metal::TensorMemoryLayout tensor_layout, tt::tt_metal::BufferType buffer_type, tt::tt_metal::Layout page_layout>
+auto build_source_address_generator(std::size_t &arg_idx, address_t tensor_address, std::size_t page_size, uint32_t cb_id_in0) -> typename source_tensor_addrgen<tensor_layout, buffer_type, page_layout>::type {
+    constexpr bool is_sharded = is_sharded_tensor_layout(tensor_layout);
+    constexpr bool is_interleaved = tensor_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
+    constexpr bool is_tile_page_layout = page_layout == tt::tt_metal::Layout::TILE;
+    constexpr bool is_row_major_layout = page_layout == tt::tt_metal::Layout::ROW_MAJOR;
+    static_assert(is_sharded || is_interleaved, "Only sharded and interleaved tensor layouts are supported but the unified address generator. A tensor layout not matching TensorMemoryLayout::WIDTH_SHARDED, TensorMemoryLayout::HEIGHT_SHARDED, TensorMemoryLayout::BLOCK_SHARDED, or TensorMemoryLayout::INTERLEAVED was specified.");
+
+    using addrgen_type = typename source_tensor_addrgen<tensor_layout, buffer_type, page_layout>::type;
+
+    if constexpr (is_row_major_layout) {
+        if constexpr (is_interleaved) {
+            return addrgen_type{
+                .bank_base_address = tensor_address, .page_size = page_size};
+        } else if constexpr (is_sharded) {
+            return tt::tt_metal::address_generators::build_sharded_addr_gen<tensor_layout>(
+                tt::tt_metal::address_generators::HarvestedWormholeWorkerToNocLookup(
+                    0,//output_shard_grid_nrows,
+                    0,//output_shard_grid_row_map,
+                    0,//output_shard_grid_ncols,
+                    0),//output_shard_grid_col_map),
+                tt::tt_metal::address_generators::DeviceShardSpecTypeGetter<tensor_layout>::type(
+                    0,//output_tensor_shard_pages_per_shard_y,
+                    0,//output_tensor_shard_pages_per_shard_x,
+                    0,//output_tensor_shard_grid_height,
+                    0,//output_tensor_shard_grid_width,
+                    0,//output_tensor_shard_grid_start_y_logical,
+                    0,//output_tensor_shard_grid_start_x_logical,
+                    0//output_tensor_shard_grid_transposed
+                ),
+                page_size,
+                tensor_address
+            );
+            ASSERT(false); // unimplemented and untested
+        }
+    } else if constexpr (is_tile_page_layout) {
+        if constexpr (is_interleaved) {
+            return addrgen_type{
+                .bank_base_address = tensor_address, .page_size = page_size, .data_format = get_dataformat(cb_id_in0)};
+        } else if constexpr (is_sharded) {
+            ASSERT(false);//"Sharded support has not been added to ccl_send yet");
+            return tt::tt_metal::address_generators::build_sharded_addr_gen<tensor_layout>(
+                tt::tt_metal::address_generators::HarvestedWormholeWorkerToNocLookup(
+                    0,//output_shard_grid_nrows,
+                    0,//output_shard_grid_row_map,
+                    0,//output_shard_grid_ncols,
+                    0),//output_shard_grid_col_map),
+                tt::tt_metal::address_generators::DeviceShardSpecTypeGetter<tensor_layout>::type(
+                    0,//output_tensor_shard_pages_per_shard_y,
+                    0,//output_tensor_shard_pages_per_shard_x,
+                    0,//output_tensor_shard_grid_height,
+                    0,//output_tensor_shard_grid_width,
+                    0,//output_tensor_shard_grid_start_y_logical,
+                    0,//output_tensor_shard_grid_start_x_logical,
+                    0//output_tensor_shard_grid_transposed
+                ),
+                page_size,
+                tensor_address
+            );
+        }
+    }
+}
+
+/*
+* CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time) dispatch
+* implementations depending on those invocation parameters.
+*/
+void kernel_main() {
+    std::size_t arg_idx = 0;
+    using shape_t = Shape4D<uint32_t>;
+
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    constexpr TensorMemoryLayout tensor_layout = static_cast<TensorMemoryLayout>(get_compile_time_arg_val(0));
+    constexpr BufferType buffer_type = static_cast<BufferType>(get_compile_time_arg_val(1));
+    constexpr Layout page_layout = static_cast<Layout>(get_compile_time_arg_val(2));
+    constexpr ttnn::ccl::EriscDataMoverTerminationMode termination_mode = static_cast<ttnn::ccl::EriscDataMoverTerminationMode>(get_compile_time_arg_val(3));
+    constexpr uint32_t cb_id = get_compile_time_arg_val(4);
+
+    // Load the input tensor spec
+    address_t tensor_address = get_arg_val<address_t>(arg_idx++);
+    address_t num_commands = get_arg_val<address_t>(arg_idx++);
+
+    // EDM Interface Parameters
+    const ttnn::ccl::WorkerEdmInterfaceArgs edm_args = ttnn::ccl::build_from_args<ttnn::ccl::WorkerEdmInterfaceArgs>(arg_idx);
+    // static_assert(tt_metal::is_compile_time_evaluated(edm_args.num_buffers_per_channel), "Number of buffers per channel was expected to resolve as compile time variable.");
+
+
+    // Assuming whole page transmissions (which is the only mode we support at the moment)
+    // -> however, wanted to call it out here to make it clear that we need to pull this
+    //    out when we start enabling other modes
+    const uint32_t packet_size_in_pages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t page_size = get_arg_val<uint32_t>(arg_idx++);
+    auto tensor_addrgen = build_source_address_generator<tensor_layout, buffer_type, page_layout>(arg_idx, tensor_address, page_size, tt::CB::c_in0);
+    volatile uint32_t* my_edm_worker_semaphore_ptr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
+
+    // For now we only support single EDM connection
+    ccl::edm::WorkerToEdmSender<termination_mode> sender(
+        ttnn::ccl::WorkerXY(edm_args.edm_noc_x, edm_args.edm_noc_y),
+        edm_args.edm_buffer_base_address,
+        edm_args.num_buffers_per_channel,
+        edm_args.edm_semaphore_address,
+        packet_size_in_pages * page_size,
+        my_edm_worker_semaphore_ptr);
+
+    ttnn::ccl::cmd::CclCommandTensor command_tensor;
+
+    for (std::size_t i = 0; i < num_commands; ++i) {
+        // Generalized would be to get the command header info and then dispatch accordingly - if the command type is singular
+        //
+        // TODO: Turn this into a command iterator that initializes itself with the current arg_idx and then after that,
+        //       the arg_idx never needs to be accessed again
+        std::size_t old_arg_idx = arg_idx;
+        ttnn::ccl::cmd::update_command_tensor(arg_idx, command_tensor);
+        std::size_t new_arg_idx = arg_idx;
+
+        {
+            DPRINT << "cmd[" << (uint32_t)i << "]:\n";
+            DPRINT << "\ttensor_slice_shape.w: " << (uint32_t)command_tensor.tensor_slice_shape.w << "\n";
+            DPRINT << "\ttensor_slice_shape.z: " << (uint32_t)command_tensor.tensor_slice_shape.z << "\n";
+            DPRINT << "\ttensor_slice_shape.y: " << (uint32_t)command_tensor.tensor_slice_shape.y << "\n";
+            DPRINT << "\ttensor_slice_shape.x: " << (uint32_t)command_tensor.tensor_slice_shape.x << "\n";
+            DPRINT << "\ttensor_slice_offset.w: " << (uint32_t)command_tensor.tensor_slice_offset.w << "\n";
+            DPRINT << "\ttensor_slice_offset.z: " << (uint32_t)command_tensor.tensor_slice_offset.z << "\n";
+            DPRINT << "\ttensor_slice_offset.y: " << (uint32_t)command_tensor.tensor_slice_offset.y << "\n";
+            DPRINT << "\ttensor_slice_offset.x: " << (uint32_t)command_tensor.tensor_slice_offset.x << "\n";
+            DPRINT << "\tworker_start_offset_in_slice.w: " << (uint32_t)command_tensor.worker_start_offset_in_slice.w << "\n";
+            DPRINT << "\tworker_start_offset_in_slice.z: " << (uint32_t)command_tensor.worker_start_offset_in_slice.z << "\n";
+            DPRINT << "\tworker_start_offset_in_slice.y: " << (uint32_t)command_tensor.worker_start_offset_in_slice.y << "\n";
+            DPRINT << "\tworker_start_offset_in_slice.x: " << (uint32_t)command_tensor.worker_start_offset_in_slice.x << "\n";
+            DPRINT << "\tworker_pages_per_slice: " << (uint32_t)command_tensor.worker_pages_per_slice << "\n";
+            ASSERT(ccl_command.worker_pages_per_slice > 0);
+
+            // CURRENTLY ONLY SUPPORTS WRAPPED TENSOR ITERATION COMMANDS
+            // Implemented really inefficiently for now - in the future we can do more efficient packing and also change
+            // the tensor read API to require the information in a more efficient way (less intermediate calculations)
+            // const shape_t tensor_slice_start_offset = ttnn::ccl::build_from_args<shape_t>(arg_idx); // Should be RT
+            shape_t valid_worker_slice_shape = build_wrapped_row_tensor_slice(command_tensor.worker_pages_per_slice); // Parametrizable by ct arg
+
+            shape_t const& global_offset = command_tensor.tensor_slice_offset + command_tensor.worker_start_offset_in_slice;
+            uint32_t curr_tile_id = get_flat_index_from_shape(command_tensor.tensor_shape, global_offset);
+
+            uint32_t offset_into_worker_slice = 0;
+            bool last_page_of_worker = false;
+            for (uint32_t p = 0; p < command_tensor.worker_pages_per_slice; p += packet_size_in_pages) {
+                uint32_t n_pages = std::min(packet_size_in_pages, command_tensor.worker_pages_per_slice - p);
+                ASSERT(ccl_command.worker_start_offset_in_slice.w == 1);
+                ASSERT(ccl_command.worker_start_offset_in_slice.z == 1);
+                ASSERT(valid_worker_slice_shape.w == 1);
+                ASSERT(valid_worker_slice_shape.z == 1);
+                ASSERT(command_tensor.tensor_shape.w == 1);
+                ASSERT(command_tensor.tensor_shape.z == 1);
+                ASSERT(ccl_command.tensor_slice_shape.w == 1);
+                ASSERT(ccl_command.tensor_slice_shape.z == 1);
+
+                read_wrapped_chunk_from_output_tensor(
+                    curr_tile_id,
+                    offset_into_worker_slice,
+                    ttnn::ccl::coord_t(command_tensor.worker_start_offset_in_slice.x, command_tensor.worker_start_offset_in_slice.y), // Offset into tensor slice
+                    ttnn::ccl::coord_t(valid_worker_slice_shape.x, valid_worker_slice_shape.y),
+                    // In tiles for tile layout
+                    ttnn::ccl::coord_t(command_tensor.tensor_shape.x, command_tensor.tensor_shape.y),
+                    ttnn::ccl::coord_t(command_tensor.tensor_slice_shape.x, command_tensor.tensor_slice_shape.y),
+                    cb_id,
+                    tensor_addrgen,
+                    n_pages,
+                    page_size,
+                    last_page_of_worker);
+
+                // Not optimal (doesn't overlap read/write) - but good for functional
+                // bringup
+                cb_wait_front(cb_id, n_pages);
+                uint32_t l1_read_addr = get_read_ptr(cb_id);
+
+                sender.wait_for_empty_write_slot();
+                sender.send_payload_blocking(cb_id, n_pages, page_size);
+            }
+        }
+    }
+    ////////////////////////////////////////////////////////////////////////////////////
+
+    sender.close();
+}

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/*
+ *    ------   ATTENTION  ATTENTION  ATTENTION  ATTENTION  ATTENTION   ------
+ * This file is intended to be useable across both host and device code. Therefore.
+ *
+ * DO NOT include any headers that are not host/device agnostic.
+ * DO NOT use any types that do not have fixed sizes across host and device.
+ * e.g. int32_t -> good (always 32 bits), int -> bad (size depends on platform)
+ */
+
+#include <cstdint>
+#include <cstddef>
+
+namespace ttnn {
+namespace ccl {
+
+using address_t = uint32_t;
+
+
+template <typename T>
+struct Shape4D {
+    T w;
+    T z;
+    T y;
+    T x;
+
+    Shape4D() = default;
+    Shape4D(T w, T z, T y, T x): w(w), z(z), y(y), x(x) {}
+    Shape4D(Shape4D const& rhs) = default;
+
+    Shape4D<T> operator+(const Shape4D<T> &rhs) const {
+        return {w + rhs.w, z + rhs.z, y + rhs.y, x + rhs.x};
+    }
+
+    bool operator==(const Shape4D<T> &rhs) const {
+        return w == rhs.w && z == rhs.z && y == rhs.y && x == rhs.x;
+    }
+
+    constexpr std::size_t volume() const {
+        return w * z * y * x;
+    }
+};
+
+struct WorkerEdmInterfaceArgs {
+    const uint32_t edm_noc_x;
+    const uint32_t edm_noc_y;
+    const address_t edm_buffer_base_address;
+    const address_t edm_semaphore_address;
+    const uint32_t num_buffers_per_channel;
+};
+
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+#include "impl/buffers/buffer_constants.hpp"
+#include "ttnn/cpp/ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "tt_metal/impl/device/device.hpp"
+
+namespace ttnn {
+namespace ccl {
+
+
+args_list_t emit_runtime_args(WorkerEdmInterfaceArgs const& edm_interface_args) {
+    return {
+        edm_interface_args.edm_noc_x,
+        edm_interface_args.edm_noc_y,
+        reinterpret_cast<uint32_t>(edm_interface_args.edm_buffer_base_address),
+        reinterpret_cast<uint32_t>(edm_interface_args.edm_semaphore_address),
+        edm_interface_args.num_buffers_per_channel
+    };
+}
+
+args_list_t emit_compile_time(WorkerEdmInterfaceArgs const& edm_interface_args) {
+    return {};
+}
+
+
+args_list_t emit_address_generator_runtime_args(tt::tt_metal::Device const* const d, tt::tt_metal::Tensor const& t) {
+    args_list_t args;
+    switch (t.buffer()->buffer_layout()) {
+        case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
+        case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED:
+        case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED:
+            return ShardedAddrGenArgBuilder::emit_rt_args(d, t);
+        break;
+
+        case tt::tt_metal::TensorMemoryLayout::INTERLEAVED:
+            TT_ASSERT(t.buffer()->page_size() != 1024);
+            // For now we won't emit args for interleaved here... assume these are passed in elsewhere
+            // This is during some transitionary period
+            return {};
+
+        break;
+
+        case tt::tt_metal::TensorMemoryLayout::SINGLE_BANK:
+        default:
+            TT_ASSERT(false, "Tried emitting address generator args for an unsupported type{}. Consider adding the missing support or using a supported tensor memory layout (width sharded, height sharded, block sharded, interleaved", t.buffer()->buffer_layout());
+            return {};
+    };
+}
+
+args_list_t emit_address_generator_compile_time_args(tt::tt_metal::Tensor const& t) {
+        switch (t.buffer()->buffer_layout()) {
+        case tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
+        case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED:
+        case tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED:
+            return ShardedAddrGenArgBuilder::emit_ct_args(t);
+        break;
+
+        case tt::tt_metal::TensorMemoryLayout::INTERLEAVED:
+            return {};
+        break;
+
+        case tt::tt_metal::TensorMemoryLayout::SINGLE_BANK:
+        default:
+            TT_ASSERT(false, "Tried emitting address generator args for an unsupported type{}. Consider adding the missing support or using a supported tensor memory layout (width sharded, height sharded, block sharded, interleaved", t.buffer()->buffer_layout());
+            return {};
+    }
+    TT_ASSERT(false);
+}
+
+static std::pair<tt_xy_pair, tt_xy_pair> shard_grid_from_shard_spec(const ShardSpec& shard_spec) {
+    auto const& core_range = shard_spec.grid.bounding_box();
+    log_trace(tt::LogOp, "SHARD CORE_RANGE: start_x:{} start_y:{} end_x:{} end_y:{}", core_range.start_coord.x, core_range.start_coord.y, core_range.end_coord.x, core_range.end_coord.y);
+    log_trace(tt::LogOp, "grid_size: {}", shard_spec.grid.num_cores());
+
+    return {core_range.start_coord, core_range.end_coord};
+}
+
+// non-transposed - always row-major layout
+// vec<logical row -> noc row>, vec<logicacal col -> noc col>
+static std::pair<std::vector<uint32_t>,std::vector<uint32_t>> shard_noc_cores_from_shard_spec(Device const* d, const ShardSpec& shard_spec) {
+    TT_ASSERT(d != nullptr);
+    auto const& core_range = shard_spec.grid.bounding_box();
+    std::vector<uint32_t> logical_to_noc_row_map;
+    std::vector<uint32_t> logical_to_noc_col_map;
+    for (uint32_t y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+        CoreCoord noc_core = d->physical_core_from_logical_core(CoreCoord(0, y), CoreType::WORKER);
+        logical_to_noc_row_map.push_back(noc_core.y);
+    }
+    for (uint32_t x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+        CoreCoord noc_core = d->physical_core_from_logical_core(CoreCoord(x, 0), CoreType::WORKER);
+        logical_to_noc_col_map.push_back(noc_core.x);
+    }
+
+    return {logical_to_noc_row_map, logical_to_noc_col_map};
+}
+
+std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(Device const* d, Tensor const& t) {
+    std::vector<uint32_t> args;
+    auto const& [row_map, col_map] = shard_noc_cores_from_shard_spec(d, t.shard_spec().value());
+    args.push_back(row_map.size());
+    for (uint32_t i = 0; i < row_map.size(); i++) {
+        args.push_back(row_map.at(i));
+    }
+    args.push_back(col_map.size());
+    for (uint32_t i = 0; i < col_map.size(); i++) {
+        args.push_back(col_map.at(i));
+    }
+
+    return args;
+}
+
+std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(Tensor const& t) {
+    std::vector<uint32_t> args;
+    TT_ASSERT(t.is_sharded());
+    auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
+    auto const& [shard_grid_start, shard_grid_end] = shard_grid_from_shard_spec(t.shard_spec().value());
+    bool shard_grid_transposed = shard_grid_is_transposed(t);
+    TT_FATAL(
+        t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
+        t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+    "ShardedAddrGenArgBuilder::emit_ct_args was invoked with a tensor containing an unsupported (Sharded) Tensor Memory Layout: {}", t.memory_config().memory_layout);
+    // shard_grid_height (cores)
+    args.push_back(shard_grid_end.y - shard_grid_start.y + 1);
+    // shard_grid_width (cores)
+    args.push_back(shard_grid_end.x - shard_grid_start.x + 1);
+    // shard_grid_start_y
+    args.push_back(shard_grid_start.y);
+    // shard_grid_start_x
+    args.push_back(shard_grid_start.x);
+    // pages_per_shard_y
+    args.push_back(pages_per_shard_y);
+    // pages_per_shard_x
+    args.push_back(pages_per_shard_x);
+    // transposed grid
+    args.push_back(static_cast<uint32_t>(shard_grid_transposed));
+
+    return args;
+}
+
+bool ShardedAddrGenArgBuilder::shard_grid_is_transposed(Tensor const& t) {
+    TT_FATAL(
+        t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
+        t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
+        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+    "ShardedAddrGenArgBuilder::emit_ct_args was invoked with a tensor containing an unsupported (Sharded) Tensor Memory Layout: {}", t.memory_config().memory_layout);
+    bool shard_grid_transposed =
+        ((t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&
+          t.shard_spec()->orientation == ShardOrientation::ROW_MAJOR) ||
+         ((t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
+           t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) &&
+          t.shard_spec()->orientation == ShardOrientation::COL_MAJOR));
+    return shard_grid_transposed;
+}
+
+void ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(Tensor const& t, std::string const& prefix) {
+
+    auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
+    auto const& [shard_grid_start, shard_grid_end] = shard_grid_from_shard_spec(t.shard_spec().value());
+    bool shard_grid_transposed = shard_grid_is_transposed(t);
+
+    TT_ASSERT(pages_per_shard_y > 0);
+    TT_ASSERT(pages_per_shard_x > 0);
+    log_trace(tt::LogOp, "\t{}_shard_grid_height: {}", prefix,   shard_grid_end.y - shard_grid_start.y + 1);
+    log_trace(tt::LogOp, "\t{}_shard_grid_width: {}", prefix,    shard_grid_end.x - shard_grid_start.x + 1);
+    log_trace(tt::LogOp, "\t{}_shard_grid_start_y: {}", prefix,  shard_grid_start.y);
+    log_trace(tt::LogOp, "\t{}_shard_grid_start_x: {}", prefix,  shard_grid_start.x);
+    log_trace(tt::LogOp, "\t{}_pages_per_shard_y: {}", prefix,     pages_per_shard_y);
+    log_trace(tt::LogOp, "\t{}_pages_per_shard_x: {}", prefix,     pages_per_shard_x);
+    log_trace(tt::LogOp, "\t{}_transposed_grid: {}", prefix,     static_cast<uint32_t>(shard_grid_transposed));
+}
+
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+
+#include <vector>
+#include <string>
+
+namespace tt {
+namespace tt_metal {
+class Tensor;
+class Device;
+} // namespace tt_metal
+} // namespace tt
+
+namespace ttnn {
+namespace ccl {
+
+using args_list_t = std::vector<uint32_t>;
+
+args_list_t emit_runtime_args(WorkerEdmInterfaceArgs const& edm_interface_args);
+args_list_t emit_compile_time(WorkerEdmInterfaceArgs const& edm_interface_args);
+args_list_t log_runtime_args(WorkerEdmInterfaceArgs const& edm_interface_args, std::string_view const& prefix);
+args_list_t log_compile_time(WorkerEdmInterfaceArgs const& edm_interface_args, std::string_view const& prefix);
+
+template <typename T>
+args_list_t emit_runtime_args(T const& args);
+template <typename T>
+args_list_t emit_compile_time(T const& args);
+
+
+////////////
+// Shape 4D
+template<typename T>
+args_list_t emit_runtime_args(Shape4D<T> const& shape) {
+    return {
+        shape.w,
+        shape.z,
+        shape.y,
+        shape.x
+    };
+}
+
+template<typename T>
+args_list_t emit_compile_time(Shape4D<T> const& shape) {
+    return {};
+}
+
+
+
+args_list_t emit_address_generator_runtime_args(tt::tt_metal::Device const* const d, tt::tt_metal::Tensor const& tensor);
+args_list_t emit_address_generator_compile_time_args(tt::tt_metal::Tensor const& tensor);
+
+struct ShardedAddrGenArgBuilder {
+    static bool shard_grid_is_transposed(tt::tt_metal::Tensor const& t);
+    static std::vector<uint32_t> emit_ct_args(tt::tt_metal::Tensor const& t);
+    static std::vector<uint32_t> emit_rt_args(tt::tt_metal::Device const* d, tt::tt_metal::Tensor const& t);
+    static void log_sharded_tensor_kernel_args(tt::tt_metal::Tensor const& t, std::string const& prefix);
+};
+
+
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_device.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_device.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+
+
+namespace ttnn {
+namespace ccl {
+
+template <>
+auto build_from_args<WorkerEdmInterfaceArgs>(std::size_t &rt_arg_idx) -> WorkerEdmInterfaceArgs{
+    static_assert(sizeof(address_t) <= sizeof(uint32_t), "Address type is too large for this function.");
+    return WorkerEdmInterfaceArgs{
+        get_arg_val<uint32_t>(rt_arg_idx++),
+        get_arg_val<uint32_t>(rt_arg_idx++),
+        reinterpret_cast<address_t>(get_arg_val<uint32_t>(rt_arg_idx++)),
+        reinterpret_cast<address_t>(get_arg_val<uint32_t>(rt_arg_idx++)),
+        get_arg_val<uint32_t>(rt_arg_idx++)
+    };
+}
+
+template <>
+constexpr std::size_t ct_args_consumed<WorkerEdmInterfaceArgs>() {
+    return 0;
+}
+
+} // namespace ttnn
+} // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+
+namespace ttnn {
+namespace ccl {
+namespace cmd {
+
+void pack_field_without_header(ttnn::ccl::cmd::args_elem_t* args, ttnn::ccl::Shape4D<uint32_t> const& out) {
+    std::size_t i = 0;
+    args[i++] = out.w;
+    args[i++] = out.z;
+    args[i++] = out.y;
+    args[i++] = out.x;
+}
+
+
+}  // namespace cmd
+}  // namespace ccl
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types.hpp"
+
+namespace ttnn {
+namespace ccl {
+namespace cmd {
+
+constexpr std::size_t round_up(std::size_t a, std::size_t multiple) {
+    return ((a + multiple - 1) / multiple) * multiple;
+}
+
+enum class CclCommandArgCode : uint8_t {
+    // If operating on a per page granularity
+    SET_TENSOR_SHAPE_IN_PAGES = 0,
+    SET_TENSOR_SLICE_SHAPE_IN_PAGES,
+    SET_TENSOR_SLICE_OFFSET_IN_PAGES,
+    SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES,
+    SET_WORKER_PAGES_PER_SLICE,
+    SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES
+};
+
+struct CclCommandTensor {
+    Shape4D<uint32_t> tensor_shape;
+    Shape4D<uint32_t> tensor_slice_shape;
+    Shape4D<uint32_t> tensor_slice_offset;
+    Shape4D<uint32_t> worker_start_offset_in_slice;
+    uint32_t worker_pages_per_slice;
+};
+
+template <CclCommandArgCode code>  struct command_arg_field                                         {  using type = std::nullptr_t; };
+template <> struct command_arg_field<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>                  {  using type = Shape4D<uint32_t>; };
+template <> struct command_arg_field<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>            {  using type = Shape4D<uint32_t>; };
+template <> struct command_arg_field<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>           {  using type = Shape4D<uint32_t>; };
+template <> struct command_arg_field<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>  {  using type = Shape4D<uint32_t>; };
+template <> struct command_arg_field<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>                 {  using type = uint32_t; };
+template <> struct command_arg_field<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>        {  using type = CclCommandTensor; };
+
+
+template <CclCommandArgCode T>
+struct CclCommandArg {
+
+};
+
+
+using args_elem_t = uint32_t;
+template <typename T, CclCommandArgCode CODE>
+struct CclCommandArgBase {
+    // Let the user override
+    using field_type = typename command_arg_field<CODE>::type;  // Ensure T::type is accessible
+    static constexpr std::size_t size_in_words() { return (sizeof(T) + sizeof(uint32_t) - 1) / sizeof(uint32_t); }
+
+    static void pack_to(args_elem_t* args, CclCommandTensor const& command_tensor) { T::pack_to(args, command_tensor); }
+    static void pack_to(args_elem_t* args, T const& arg) { T::pack_to(args, arg); }
+    void pack_to(args_elem_t* args) const { static_cast<T const*>(this)->pack_to(args, this->value); }
+
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) { T::unpack(args, out); }
+    static void unpack(volatile args_elem_t const* args, T& out) { T::unpack(args, out); }
+    void unpack(volatile args_elem_t const* args) { static_cast<T const*>(this)->unpack(args, &this->value); }
+
+    field_type value;
+};
+
+// Note that we choose to reinterpret our pointers as volatile so that in the future we can add streaming
+// of additional commands from some backing memory (e.g. dram or L1), potentially by another core, without
+// having to track down this code and add volatile casts later (which would be a potentially tricky bug to
+// root cause).
+inline void unpack_field_without_header(volatile args_elem_t const* args, Shape4D<uint32_t>& out) {
+    std::size_t i = 0;
+    out.w = args[i++];
+    out.z = args[i++];
+    out.y = args[i++];
+    out.x = args[i++];
+}
+void pack_field_without_header(args_elem_t* args, Shape4D<uint32_t> const& out);
+
+template <>
+struct CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES> : public CclCommandArgBase<CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>, CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES> {
+
+    static void pack_to(args_elem_t* args, CclCommandTensor const& out) {
+        pack_field_without_header(&args[0], out.tensor_shape);
+    }
+    static void pack_to(args_elem_t* args, field_type const& out) { pack_field_without_header(&args[0], out); }
+    void pack_to(args_elem_t* args) { pack_field_without_header(&args[0], this->value); }
+
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) {
+        unpack_field_without_header(&args[0], out.tensor_shape);
+    }
+    static void unpack(volatile args_elem_t const* args, field_type& out) { unpack_field_without_header(&args[0], out); }
+    void unpack(volatile args_elem_t const* args) { unpack_field_without_header(&args[0], this->value); }
+};
+
+template <>
+struct CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES> : public CclCommandArgBase<CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>, CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES> {
+
+    static void pack_to(args_elem_t* args, CclCommandTensor const& out) {
+        pack_field_without_header(&args[0], out.tensor_slice_shape);
+    }
+    static void pack_to(args_elem_t* args, field_type const& out) { pack_field_without_header(&args[0], out); }
+    void pack_to(args_elem_t* args) { pack_field_without_header(&args[0], this->value); }
+
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) {
+        unpack_field_without_header(args, out.tensor_slice_shape);
+    }
+    static void unpack(volatile args_elem_t const* args, field_type& out) { unpack_field_without_header(args, out); }
+    void unpack(volatile args_elem_t const* args) { unpack_field_without_header(args, this->value); }
+};
+
+template <>
+struct CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES> : public CclCommandArgBase<CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>, CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES> {
+    using type = Shape4D<uint32_t>;
+
+    static void pack_to(args_elem_t* args, CclCommandTensor const& out) {
+        pack_field_without_header(args, out.tensor_slice_offset);
+    }
+    static void pack_to(args_elem_t* args, field_type const& out) { pack_field_without_header(args, out); }
+    void pack_to(args_elem_t* args) { pack_field_without_header(args, this->value); }
+
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) {
+        unpack_field_without_header(args, out.tensor_slice_offset);
+    }
+    static void unpack(volatile args_elem_t const* args, field_type& out) { unpack_field_without_header(args, out); }
+    void unpack(volatile args_elem_t const* args) { unpack_field_without_header(args, this->value); }
+};
+
+template <>
+struct CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES> : public CclCommandArgBase<CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>, CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES> {
+    using type = Shape4D<uint32_t>;
+
+    static void pack_to(args_elem_t* args, CclCommandTensor const& out) {
+        pack_field_without_header(args, out.worker_start_offset_in_slice);
+    }
+    static void pack_to(args_elem_t* args, field_type const& out) { pack_field_without_header(args, out); }
+    void pack_to(args_elem_t* args) { pack_field_without_header(args, this->value); }
+
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) {
+        unpack_field_without_header(args, out.worker_start_offset_in_slice);
+    }
+    static void unpack(volatile args_elem_t const* args, field_type& out) { unpack_field_without_header(args, out); }
+    void unpack(volatile args_elem_t const* args) { unpack_field_without_header(args, this->value); }
+};
+
+template <>
+struct CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE> : public CclCommandArgBase<CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>, CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE> {
+    using type = uint32_t;
+
+    static void pack_to(args_elem_t* args, CclCommandTensor const& out) { args[0] = out.worker_pages_per_slice; }
+    static void pack_to(args_elem_t* args, field_type const& out) { args[0] = out; }
+    void pack_to(args_elem_t* args) const { args[0] = this->value; }
+
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) { out.worker_pages_per_slice = args[0]; }
+    static void unpack(volatile args_elem_t const* args, field_type& out) { out = args[0]; }
+    void unpack(volatile args_elem_t const* args) { this->value = args[0]; }
+};
+
+template <>
+struct CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>
+    : public CclCommandArgBase<CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>, CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES> {
+    using type = CclCommandTensor;
+
+    // considering making this some generator type that implements operator[]
+    // so I can have tests that make sure I don't go OoB so I can make sure `size_in_words`
+    // is correct
+    static void pack_to(args_elem_t* args, field_type const& command_tensor) {
+        std::size_t i = 0;
+
+        CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::pack_to(&args[i], command_tensor.tensor_shape);
+        i += CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::pack_to(&args[i], command_tensor.tensor_slice_shape);
+        i += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::pack_to(&args[i], command_tensor.tensor_slice_offset);
+        i += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::pack_to(&args[i], command_tensor.worker_start_offset_in_slice);
+        i += CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::pack_to(&args[i], command_tensor.worker_pages_per_slice);
+        i += CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::size_in_words();
+    }
+
+    void pack_to(args_elem_t* args) const {
+        CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::pack_to(args, this->value);
+    }
+
+    // TODO: when kernels get c++20, use std::span
+    static void unpack(volatile args_elem_t const* args, CclCommandTensor& out) {
+        std::size_t i = 0;
+        CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::unpack(&args[i], out.tensor_shape);
+        i += CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::unpack(&args[i], out.tensor_slice_shape);
+        i += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::unpack(&args[i], out.tensor_slice_offset);
+        i += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::unpack(&args[i], out.worker_start_offset_in_slice);
+        i += CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::size_in_words();
+
+        CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::unpack(&args[i], out.worker_pages_per_slice);
+        i += CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::size_in_words();
+    }
+
+    void unpack(volatile args_elem_t const* args) {
+        CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::unpack(args, this->value);
+    }
+};
+
+
+// Convenience type aliases
+using tensor_shape_command_arg_t = CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>;
+using tensor_slice_shape_command_arg_t = CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>;
+using tensor_slice_offset_command_arg_t = CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>;
+using worker_start_offset_command_arg_t = CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>;
+using worker_pages_command_arg_t = CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>;
+using full_tensor_command_arg_t = CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>;
+
+// A command is composed of one or more arguments
+// This enum specifies the high level command
+// Future commands are to be added and will enable
+// functionalilty such as synchronizing
+enum class CclCommandCode : uint8_t {
+    STREAM_TENSOR_TO_EDM = 0,
+    STREAM_EDM_TO_TENSOR
+};
+
+struct CclCommandHeader {
+    CclCommandCode code;
+
+    // For the time being we have a dedicated arg_count because we assume
+    // we may save args/tensor info from previous command. Up to command sequence
+    // generator to make sure any fields/args not explicitly listed are correct from prior command
+    uint8_t arg_count : 4;
+    uint8_t reserved1;
+    uint8_t reserved2;
+
+    static CclCommandHeader from_uint32(uint32_t const& cmd_header) {
+        CclCommandHeader decoded;
+        decoded.code = static_cast<CclCommandCode>(cmd_header & 0xFF);
+        decoded.arg_count = (cmd_header >> 8) & 0xF;
+        return decoded;
+    }
+
+    static uint32_t to_uint32(CclCommandHeader const& cmd_header) {
+        uint32_t encoded = 0;
+        encoded = (uint8_t)(cmd_header.code);
+        encoded = encoded | (cmd_header.arg_count << 8);
+        return encoded;
+    }
+    uint32_t to_uint32() const {
+        return *reinterpret_cast<uint32_t const*>(this);
+    }
+};
+static_assert(sizeof(CclCommandHeader) == sizeof(uint32_t));
+
+
+}  // namespace cmd
+}  // namespace ccl
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command_device.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command_device.hpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp"
+
+#include "debug/dprint.h"
+
+#include <cstdint>
+#include <type_traits>
+
+namespace ttnn {
+namespace ccl {
+
+
+template<typename T>
+auto build_from_args(std::size_t &rt_arg_idx) -> T {
+    static_assert(!std::is_same<T, T>::value, "This base template cannot be instantiated. Please provide a specialization.");
+}
+template<typename T>
+constexpr std::size_t ct_args_consumed(std::size_t ct_arg_offset, std::size_t &rt_arg_idx) {
+    static_assert(!std::is_same<T, T>::value, "This base template cannot be instantiated. Please provide a specialization.");
+    return 0;
+}
+template<typename T>
+constexpr std::size_t ct_args_consumed() {
+    static_assert(!std::is_same<T, T>::value, "This base template cannot be instantiated. Please provide a specialization.");
+    return 0;
+}
+
+template <>
+auto build_from_args<Shape4D<uint32_t>>(std::size_t &rt_arg_idx) -> Shape4D<uint32_t> {
+    // static_assert(sizeof(Shape4D<uint32_t>) <= sizeof(uint32_t), "Shape4D doesn't support types larger than 4B.");
+    auto w = get_arg_val<uint32_t>(rt_arg_idx++);
+    auto z = get_arg_val<uint32_t>(rt_arg_idx++);
+    auto y = get_arg_val<uint32_t>(rt_arg_idx++);
+    auto x = get_arg_val<uint32_t>(rt_arg_idx++);
+
+    return Shape4D<uint32_t>{w, z, y, x};
+}
+
+namespace cmd {
+
+void update_command_tensor(std::size_t &arg_idx, CclCommandTensor &cmd_tensor) {
+    auto cmd = CclCommandHeader::from_uint32(get_arg_val<uint32_t>(arg_idx++));
+    DPRINT << "CMD (code=" << (uint32_t)cmd.code << ", arg_count=" << (uint32_t)cmd.arg_count << ")\n";
+
+    for (std::size_t i = 0; i < cmd.arg_count; i++) {
+
+        // Note that we choose to reinterpret our pointers as volatile so that in the future we can add streaming
+        // of additional commands from some backing memory (e.g. dram or L1), potentially by another core, without
+        // having to track down this code and add volatile casts later (which would be a potentially tricky bug to
+        // root cause).
+        switch (static_cast<CclCommandArgCode>(get_arg_val<uint32_t>(arg_idx++))) {
+            case CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES:
+                CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::unpack(reinterpret_cast<volatile uint32_t*>(get_arg_addr(arg_idx)), cmd_tensor.tensor_shape);
+                DPRINT << "Updating tensor shape: (w=" << (uint32_t)cmd_tensor.tensor_shape.w << ", z=" << (uint32_t)cmd_tensor.tensor_shape.z << ", y=" << (uint32_t)cmd_tensor.tensor_shape.y << ", x=" << (uint32_t)cmd_tensor.tensor_shape.x << ")\n";
+                arg_idx += CclCommandArg<CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::size_in_words();
+                break;
+            case CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES:
+                CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::unpack(reinterpret_cast<volatile uint32_t*>(get_arg_addr(arg_idx)), cmd_tensor.tensor_slice_shape);
+                DPRINT << "Updating tensor slice shape: (w=" << (uint32_t)cmd_tensor.tensor_slice_shape.w << ", z=" << (uint32_t)cmd_tensor.tensor_slice_shape.z << ", y=" << (uint32_t)cmd_tensor.tensor_slice_shape.y << ", x=" << (uint32_t)cmd_tensor.tensor_slice_shape.x << ")\n";
+                arg_idx += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::size_in_words();
+                break;
+            case CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES:
+                CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::unpack(
+                    reinterpret_cast<volatile uint32_t *>(get_arg_addr(arg_idx)), cmd_tensor.tensor_slice_offset);
+                // DPRINT << "Updating tensor slice offset: (w=" << (uint32_t)cmd_tensor.tensor_slice_offset.w
+                //        << ", z=" << (uint32_t)cmd_tensor.tensor_slice_offset.z
+                //        << ", y=" << (uint32_t)cmd_tensor.tensor_slice_offset.y
+                //        << ", x=" << (uint32_t)cmd_tensor.tensor_slice_offset.x << ")\n";
+                arg_idx += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::size_in_words();
+                break;
+            case CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES:
+                CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::unpack(reinterpret_cast<volatile uint32_t*>(get_arg_addr(arg_idx)), cmd_tensor.worker_start_offset_in_slice);
+                DPRINT << "Updating worker start offset in slice: (w=" << (uint32_t)cmd_tensor.worker_start_offset_in_slice.w << ", z=" << (uint32_t)cmd_tensor.worker_start_offset_in_slice.z << ", y=" << (uint32_t)cmd_tensor.worker_start_offset_in_slice.y << ", x=" << (uint32_t)cmd_tensor.worker_start_offset_in_slice.x << ")\n";
+                arg_idx += CclCommandArg<CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::size_in_words();
+                break;
+            case CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE:
+                CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::unpack(reinterpret_cast<volatile uint32_t*>(get_arg_addr(arg_idx)), cmd_tensor.worker_pages_per_slice);
+                DPRINT << "Updating worker pages per slice: " << (uint32_t)cmd_tensor.worker_pages_per_slice << "\n";
+                arg_idx += CclCommandArg<CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::size_in_words();
+                break;
+            case CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES:
+                CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::unpack(reinterpret_cast<volatile uint32_t*>(get_arg_addr(arg_idx)), cmd_tensor);
+                DPRINT << "Updating full tensor slice spec: (tensor_shape: w=" << (uint32_t)cmd_tensor.tensor_shape.w << ", z=" << (uint32_t)cmd_tensor.tensor_shape.z << ", y=" << (uint32_t)cmd_tensor.tensor_shape.y << ", x=" << (uint32_t)cmd_tensor.tensor_shape.x << ")\n";
+                arg_idx += CclCommandArg<CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::size_in_words();
+                break;
+            default:
+                ASSERT(false);
+        };
+    }
+
+}
+
+} // namespace cmd
+
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command_device.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command_device.hpp
@@ -32,7 +32,6 @@ constexpr std::size_t ct_args_consumed() {
 
 template <>
 auto build_from_args<Shape4D<uint32_t>>(std::size_t &rt_arg_idx) -> Shape4D<uint32_t> {
-    // static_assert(sizeof(Shape4D<uint32_t>) <= sizeof(uint32_t), "Shape4D doesn't support types larger than 4B.");
     auto w = get_arg_val<uint32_t>(rt_arg_idx++);
     auto z = get_arg_val<uint32_t>(rt_arg_idx++);
     auto y = get_arg_val<uint32_t>(rt_arg_idx++);
@@ -67,10 +66,6 @@ void update_command_tensor(std::size_t &arg_idx, CclCommandTensor &cmd_tensor) {
             case CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES:
                 CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::unpack(
                     reinterpret_cast<volatile uint32_t *>(get_arg_addr(arg_idx)), cmd_tensor.tensor_slice_offset);
-                // DPRINT << "Updating tensor slice offset: (w=" << (uint32_t)cmd_tensor.tensor_slice_offset.w
-                //        << ", z=" << (uint32_t)cmd_tensor.tensor_slice_offset.z
-                //        << ", y=" << (uint32_t)cmd_tensor.tensor_slice_offset.y
-                //        << ", x=" << (uint32_t)cmd_tensor.tensor_slice_offset.x << ")\n";
                 arg_idx += CclCommandArg<CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::size_in_words();
                 break;
             case CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES:

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp
@@ -129,6 +129,7 @@ struct WorkerToEdmSender{
     template<ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
         uint64_t buffer_address = this->edm_buffer_addr + (this->buffer_index * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
+        ASSERT(num_pages * page_size <= this->buffer_size_bytes);
         send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address);
         noc_semaphore_inc(edm_semaphore_addr, 1);
         this->buffer_index = (this->buffer_index == this->last_buffer_index) ? 0 : this->buffer_index + 1;

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
@@ -14,7 +14,7 @@ using ttnn::ccl::WorkerXY;
 
 namespace ttnn {
 namespace ccl {
-static FORCE_INLINE coord_t coord_from_args(uint32_t& arg_idx) {
+static FORCE_INLINE coord_t coord_from_args(std::size_t& arg_idx) {
     uint32_t x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t y = get_arg_val<uint32_t>(arg_idx++);
     return coord_t(x, y);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -102,7 +102,6 @@ static void add_worker_config_to_edm_builders(
         std::size_t global_worker_idx = c + num_channels_per_edm * link;
         log_trace(tt::LogOp, "get_worker_slice_size_bytes");
         std::size_t worker_tensor_slice_index = !is_linear ? global_worker_idx : (c % (num_channels_per_edm / 2)) + ((num_channels_per_edm / 2) * link);
-        // std::size_t worker_tensor_slice_index = !is_linear ? global_worker_idx : (c / 2) + (num_channels_per_edm / 2) * link;
 
         bool is_in_clockwise_direction = worker_attrs.direction == Direction::CLOCKWISE;
 
@@ -184,9 +183,7 @@ static std::tuple<KernelHandle, KernelHandle, KernelHandle, std::optional<Kernel
         }
     }
 
-    static std::string const& receiver_kernel_path = //topology_config.is_linear ?
-        // "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_line_reduce_scatter_reader.cpp" :
-        "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp";
+    static std::string const& receiver_kernel_path = "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp";
     static std::string const& forward_sender_kernel_path = "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp";
     static std::string const& line_start_sender_kernel_path = "ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send.cpp";
     static std::string const& reduce_kernel_path = "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp";
@@ -288,7 +285,6 @@ static void set_reduce_scatter_worker_rt(
             worker_arg_builder.generate_reduce_op_kernel_rt_args(worker_attributes, topology_config.ring_size));
     }
 
-    // if (!topology_config.is_last_device_in_line(is_in_clockwise_direction))
     {
         ttnn::ccl::WorkerXY edm_noc_coord = ttnn::ccl::WorkerXY(0,0);
         uint32_t edm_core_semaphore_address = 0;
@@ -788,9 +784,6 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
             log_trace(tt::LogOp, "------ Worker: {} (global ID={})", worker, global_worker_index);
 
             std::size_t worker_tensor_slice_index = get_worker_index_in_slice(topology_config, global_worker_index, worker, num_edm_channels_per_link, link);
-                // !topology_config.is_linear ?
-                //     global_worker_index :
-                //     (worker % (num_edm_channels_per_link / 2)) + ((num_edm_channels_per_link / 2) * link);
             auto const& worker_slice = tensor_slicer.get_worker_slice(worker_tensor_slice_index);
             auto worker_arg_builder = ReduceScatterWorkerArgBuilder(
                 device,
@@ -804,7 +797,6 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
                 receiver_worker_partial_ready_semaphore_id,
                 num_buffers_per_channel);
 
-            // log_trace(tt::LogOp, "worker_cores.at(global_worker_index): {}", worker_cores.at(global_worker_index));
             set_reduce_scatter_worker_rt(
                 program,
                 device,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -4,10 +4,9 @@
 ///
 
 #include "common/core_coord.h"
-#include "eth_l1_address_map.h"
 #include "impl/buffers/buffer.hpp"
-#include "impl/kernels/data_types.hpp"
-#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -17,10 +16,13 @@
 
 #include "ttnn/operations/eltwise/binary/common/binary_op_types.hpp"
 #include "ttnn/operations/eltwise/binary/common/binary_op_utils.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp"
 
 // Includes that need to be moved to CCL datastructures header
 #include <vector>
 #include <algorithm>
+#include <limits>
+#include <ranges>
 
 using namespace tt::constants;
 
@@ -40,302 +42,21 @@ namespace ttnn {
 
 namespace ccl {
 namespace reduce_scatter_detail {
-struct WorkerTransferInfo {
-    WorkerTransferInfo(
-        std::vector<uint32_t> pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers) :
-        pages_per_full_chunk_per_worker(pages_per_full_chunk_per_worker),
-        num_links(num_links),
-        num_workers(num_workers) {}
 
-    uint32_t get_num_pages_per_full_chunk(uint32_t link, uint32_t worker_idx) const {
-        return pages_per_full_chunk_per_worker.at(link * num_workers + worker_idx);
-    }
 
-    std::vector<uint32_t> pages_per_full_chunk_per_worker;
-    uint32_t num_links;
-    uint32_t num_workers;
-};
+
 
 static std::size_t decide_number_of_edm_channels(
    ttnn::ccl::CCLOpConfig const& ccl_op_config, std::size_t max_num_workers, bool enable_bidirectional) {
-    return std::min<std::size_t>(max_num_workers, enable_bidirectional ? 8 : 4);
+    bool is_linear_topology = ccl_op_config.get_topology() == ttnn::ccl::Topology::Linear;
+    TT_ASSERT(!is_linear_topology || max_num_workers > 1);
+    if (is_linear_topology) {
+        // Workers must be evenly divided for line reduce scatter
+        max_num_workers = tt::round_down(max_num_workers, 2);
+    }
+    return std::min<std::size_t>(max_num_workers, enable_bidirectional || is_linear_topology ? 8 : 4);
 }
 
-struct ReduceScatterWorkerArgBuilder {
-    ReduceScatterWorkerArgBuilder(
-        Device const* device,
-        ttnn::ccl::CCLOpConfig const& op_config,
-        ttnn::ccl::RingTopology const& topology_config,
-        ttnn::ccl::InterleavedTensorWorkerSlice const& worker_input_slice,
-        WorkerTransferInfo const& worker_transfer_info,
-        uint32_t cb_num_pages_per_packet,
-        uint32_t worker_sender_semaphore_id,
-        uint32_t worker_receiver_semaphore_id,
-        uint32_t num_buffers_per_channel) :
-        device(device),
-        op_config(op_config),
-        topology_config(topology_config),
-        worker_input_slice(worker_input_slice),
-        worker_transfer_info(worker_transfer_info),
-        cb_num_pages_per_packet(cb_num_pages_per_packet),
-        worker_sender_semaphore_id(worker_sender_semaphore_id),
-        worker_receiver_semaphore_id(worker_receiver_semaphore_id),
-        num_buffers_per_channel(num_buffers_per_channel) {
-    }
-
-    uint32_t get_total_num_math_pages(uint32_t link, uint32_t worker_idx) const {
-        // This algorithm assumes that the worker slices are sized such that they start at the same x offsets for each
-        // new row they slice into (as they stride through the tensor)
-        std::size_t num_slice_iterations =
-            worker_input_slice.compute_num_worker_slice_iterations(worker_transfer_info.num_workers);
-        std::size_t worker_slice_num_pages =
-            worker_input_slice.worker_slice_shape.x * worker_input_slice.worker_slice_shape.y;
-        std::size_t pages_per_full_chunk = worker_transfer_info.get_num_pages_per_full_chunk(link, worker_idx);
-        std::size_t num_filler_pages_per_slice = pages_per_full_chunk - (worker_slice_num_pages % pages_per_full_chunk);
-        uint32_t total_num_math_pages = (worker_input_slice.get_worker_slice_num_pages() + num_filler_pages_per_slice) *
-                                     num_slice_iterations * (topology_config.ring_size - 1);
-        return total_num_math_pages;
-    }
-
-    std::vector<uint32_t> generate_reduce_op_kernel_ct_args() const {
-        log_trace(tt::LogOp, "Reduce Scatter Worker CT Args: None");
-        return {};
-    }
-
-    std::vector<uint32_t> generate_reduce_op_kernel_rt_args(
-        uint32_t link, uint32_t worker_index, uint32_t ring_size) const {
-        log_trace(tt::LogOp, "generate_reduce_op_kernel_rt_args");
-
-        uint32_t total_num_math_pages = get_total_num_math_pages(link, worker_index);
-
-        auto const& args = std::vector<uint32_t>{total_num_math_pages, 1, 0};
-
-        std::size_t i = 0;
-        log_trace(tt::LogOp, "Reduce Scatter Worker RT Args:");
-        log_trace(tt::LogOp, "\tblock_size: {}", args.at(i++));
-        log_trace(tt::LogOp, "\ttotal_num_math_pages: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tacc_to_dst: {}", args.at(i++));
-
-        return args;
-    }
-
-    std::vector<uint32_t> generate_receiver_kernel_ct_args() const {
-        auto const& local_input_tensor = this->op_config.get_input_tensor(0);
-        auto args = std::vector<uint32_t>{
-            static_cast<uint32_t>(this->op_config.is_input_sharded() ? 1 : 0),
-            static_cast<uint32_t>(this->op_config.get_input_tensor(0).memory_config().buffer_type == BufferType::DRAM ? 1 : 0),
-            static_cast<uint32_t>(this->num_buffers_per_channel)};
-
-        std::size_t i = 0;
-        log_trace(tt::LogOp, "Reduce Scatter Receiver Worker CT Args:");
-        log_trace(tt::LogOp, "\tis_sharded: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tsrc_is_dram: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tnum_buffers_per_channel: {}", args.at(i++));
-        TT_ASSERT(args.size() == i, "Missed some args");
-
-        if (local_input_tensor.is_sharded()) {
-            auto const& shard_ct_args = ShardedAddrGenArgBuilder::emit_ct_args(local_input_tensor);
-            std::copy(shard_ct_args.begin(), shard_ct_args.end(), std::back_inserter(args));
-        } else {
-            args.push_back(static_cast<uint32_t>(local_input_tensor.memory_config().memory_layout));
-        }
-        return args;
-    }
-
-    std::vector<uint32_t> generate_receiver_kernel_rt_args(
-       ttnn::ccl::WorkerXY edm_core,
-        uint32_t edm_core_semaphore_address,
-        uint32_t edm_core_buffer_address,
-        uint32_t link,
-        uint32_t worker_index,
-        bool is_in_clockwise_direction) const {
-        TT_ASSERT(edm_core_semaphore_address > 0);
-        TT_ASSERT(edm_core_buffer_address > 0);
-        auto const& local_input_tensor = this->op_config.get_input_tensor(0);
-        uint32_t starting_ring_index =
-            is_in_clockwise_direction ? (this->topology_config.ring_index == 0 ? this->topology_config.ring_size - 1
-                                                                               : this->topology_config.ring_index - 1)
-                                      : (this->topology_config.ring_index == this->topology_config.ring_size - 1
-                                             ? 0
-                                             : this->topology_config.ring_index + 1);
-        uint32_t total_num_math_pages = get_total_num_math_pages(link, worker_index);
-        auto args = std::vector<uint32_t>{
-            static_cast<uint32_t>(local_input_tensor.buffer()->address()),
-            static_cast<uint32_t>(this->topology_config.ring_size),  // num_transfers
-            static_cast<uint32_t>(this->worker_transfer_info.get_num_pages_per_full_chunk(link, worker_index)),
-            static_cast<uint32_t>(this->op_config.get_page_size()),
-            static_cast<uint32_t>(starting_ring_index),
-            static_cast<uint32_t>(this->topology_config.ring_size),
-            static_cast<uint32_t>(this->worker_receiver_semaphore_id),
-            static_cast<uint32_t>(is_in_clockwise_direction ? 1 : 0),
-            static_cast<uint32_t>(this->cb_num_pages_per_packet),
-            static_cast<uint32_t>(edm_core.x),
-            static_cast<uint32_t>(edm_core.y),
-            static_cast<uint32_t>(edm_core_semaphore_address),
-            static_cast<uint32_t>(edm_core_buffer_address),
-
-            static_cast<uint32_t>(worker_transfer_info.num_workers),
-
-            static_cast<uint32_t>(this->worker_input_slice.tensor_shape.x),
-            static_cast<uint32_t>(this->worker_input_slice.tensor_shape.y),
-
-            static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.x),
-            static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.y),
-
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.x),
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.y),
-
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.x),
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.y),
-
-            total_num_math_pages};
-
-        std::size_t i = 0;
-        log_trace(tt::LogOp, "Reduce Scatter Receiver Worker RT Args:");
-        log_trace(tt::LogOp, "\tsrc_addr: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tnum_transfers: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tfull_chunk_num_pages: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tpage_size: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tmy_ring_idx: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tring_size: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tsem_addr: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tis_clockwise_direction: {}", args.at(i++));
-        log_trace(tt::LogOp, "\thalf_cb_n_pages: {}", args.at(i++));
-
-        log_trace(tt::LogOp, "\tedm_core_noc0_core_x: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tedm_core_noc0_core_y: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tedm_core_semaphore_address: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tedm_core_buffer_address: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tnum_concurrent_workers: {}", args.at(i++));
-
-        log_trace(tt::LogOp, "\tinput_tensor_shape.x={}", args.at(i++));
-        log_trace(tt::LogOp, "\tinput_tensor_shape.y={}", args.at(i++));
-        log_trace(tt::LogOp, "\ttensor_slice_shape.x={}", args.at(i++));
-        log_trace(tt::LogOp, "\ttensor_slice_shape.y={}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_shape.x={}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_shape.y={}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_offset.x={}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_offset.y={}", args.at(i++));
-        log_trace(tt::LogOp, "\ttotal_num_math_pages={}", args.at(i++));
-
-        TT_ASSERT(args.size() == i, "Missed some args");
-
-
-        if (local_input_tensor.is_sharded()) {
-            auto const& shard_rt_args = ShardedAddrGenArgBuilder::emit_rt_args(device, local_input_tensor);
-            std::copy(shard_rt_args.begin(), shard_rt_args.end(), std::back_inserter(args));
-        }
-        return args;
-    }
-
-    std::vector<uint32_t> generate_sender_kernel_ct_args() const {
-        auto const& local_output_tensor = this->op_config.get_output_tensor(0);
-        auto args = std::vector<uint32_t>{
-            static_cast<uint32_t>(this->op_config.is_input_sharded() ? 1 : 0),
-            static_cast<uint32_t>(this->op_config.get_output_tensor(0).memory_config().buffer_type == BufferType::DRAM ? 1 : 0),
-            static_cast<uint32_t>(this->num_buffers_per_channel)};
-
-        std::size_t i = 0;
-        log_trace(tt::LogOp, "Reduce Scatter Sender Worker CT Args:");
-        log_trace(tt::LogOp, "\tis_sharded: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tdst_is_dram: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tnum_buffers_per_channel: {}", args.at(i++));
-        TT_ASSERT(args.size() == i, "Missed some args");
-
-        if (local_output_tensor.is_sharded()) {
-            auto const& shard_ct_args = ShardedAddrGenArgBuilder::emit_ct_args(local_output_tensor);
-            std::copy(shard_ct_args.begin(), shard_ct_args.end(), std::back_inserter(args));
-        } else {
-            args.push_back(static_cast<uint32_t>(local_output_tensor.memory_config().memory_layout));
-        }
-        return args;
-    }
-
-    std::vector<uint32_t> generate_sender_kernel_rt_args(
-        ttnn::ccl::WorkerXY edm_core,
-        uint32_t edm_core_semaphore_address,
-        uint32_t edm_core_buffer_address,
-        uint32_t link,
-        uint32_t worker_index,
-        bool is_clockwise) const {
-        TT_ASSERT(edm_core_semaphore_address > 0);
-        TT_ASSERT(edm_core_buffer_address > 0);
-        auto const& local_output_tensor = this->op_config.get_output_tensor(0);
-        uint32_t total_num_math_pages = get_total_num_math_pages(link, worker_index);
-        auto args = std::vector<uint32_t>{
-            static_cast<uint32_t>(local_output_tensor.buffer()->address()),
-            static_cast<uint32_t>(edm_core_buffer_address),
-            static_cast<uint32_t>(edm_core_semaphore_address),
-            static_cast<uint32_t>(edm_core.x),
-            static_cast<uint32_t>(edm_core.y),
-            static_cast<uint32_t>(this->topology_config.ring_size - 1),  // num_transfers),
-
-            static_cast<uint32_t>(this->op_config.get_page_size()),
-            static_cast<uint32_t>(this->worker_transfer_info.get_num_pages_per_full_chunk(link, worker_index)),
-
-            static_cast<uint32_t>(this->worker_sender_semaphore_id),
-            static_cast<uint32_t>(this->cb_num_pages_per_packet),
-
-            static_cast<uint32_t>(worker_transfer_info.num_workers),
-
-            // For sender side, all worker slice info is the same except for the tensor shape
-            // and for sender side specifically, there is only one tensor_slice_shape for the output
-            // tensor (as opposed to `ring_size` tensor_slice_shapes for the input tensor), so we can
-            // directly use it as the output tensor shape
-            static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.x),
-            static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.y),
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.x),
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.y),
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.x),
-            static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.y),
-
-            total_num_math_pages};
-
-        std::size_t i = 0;
-        log_trace(tt::LogOp, "Reduce Scatter Sender Worker RT Args:");
-        log_trace(tt::LogOp, "\tdst_addr: {}", args.at(i++));
-        log_trace(tt::LogOp, "\teth_sender_l1_base_addr: {}", args.at(i++));
-        log_trace(tt::LogOp, "\teth_sender_l1_sem_addr: {}", args.at(i++));
-        log_trace(tt::LogOp, "\teth_sender_noc_x: {}", args.at(i++));
-        log_trace(tt::LogOp, "\teth_sender_noc_y: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tnum_transfers: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tpage_size: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tfull_chunk_num_pages: {}", args.at(i++));
-        log_trace(tt::LogOp, "\twriter_send_sem_addr: {}", args.at(i++));
-        log_trace(tt::LogOp, "\thalf_cb_n_pages: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tnum_concurrent_workers: {}", args.at(i++));
-
-        log_trace(tt::LogOp, "\toutput_tensor_shape.x: {}", args.at(i++));
-        log_trace(tt::LogOp, "\toutput_tensor_shape.y: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_shape.x: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_shape.y: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_offset.x: {}", args.at(i++));
-        log_trace(tt::LogOp, "\tworker_slice_offset.y: {}", args.at(i++));
-
-        log_trace(tt::LogOp, "\ttotal_num_math_pages={}", args.at(i++));
-
-        TT_ASSERT(args.size() == i, "Missed some args");
-
-        if (local_output_tensor.is_sharded()) {
-            auto const& shard_rt_args = ShardedAddrGenArgBuilder::emit_rt_args(device, local_output_tensor);
-            std::copy(shard_rt_args.begin(), shard_rt_args.end(), std::back_inserter(args));
-        }
-        return args;
-    }
-
-    Device const*device;
-    ttnn::ccl::RingTopology const topology_config;
-    ttnn::ccl::CCLOpConfig const op_config;
-    ttnn::ccl::InterleavedTensorWorkerSlice const worker_input_slice;
-    WorkerTransferInfo const worker_transfer_info;
-    uint32_t cb_num_pages_per_packet;
-    uint32_t worker_sender_semaphore_id;
-    uint32_t worker_receiver_semaphore_id;
-    uint32_t num_buffers_per_channel;
-
-    bool src_is_dram;
-    bool dst_is_dram;
-};
 
 struct EdmInterfaceAddresses {
     std::unordered_map<int, uint32_t> worker_sender_edm_semaphore_addresses;
@@ -344,6 +65,7 @@ struct EdmInterfaceAddresses {
     std::unordered_map<int, uint32_t> worker_receiver_edm_buffer_addresses;
 };
 
+
 // Future work: split this up further:
 // 1) assign workers to EDM channel (with buffer sharing mode specified too)
 // 2) Compute the semaphore and buffer addresses (for each EDM channel and worker)
@@ -351,99 +73,133 @@ struct EdmInterfaceAddresses {
 static void add_worker_config_to_edm_builders(
     Device* device,
     RingReduceScatterWrappedTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
-    ccl::CCLOpConfig const& op_config,
-    std::vector<CoreCoord> const& worker_cores,
-    uint32_t num_channels_per_edm,
-    uint32_t num_buffers_per_channel,
+    std::vector<WorkerAttributes> const& all_worker_attributes,
+    std::size_t num_channels_per_edm,
+    std::size_t num_buffers_per_channel,
 
     std::vector<ttnn::ccl::EriscDatamoverBuilder>& clockwise_edm_builders,
     std::vector<ttnn::ccl::EriscDatamoverBuilder>& counter_clockwise_edm_builders,
 
-    uint32_t worker_sender_semaphore_id,
-    uint32_t worker_receiver_semaphore_id,
-    uint32_t link,
-    uint32_t ring_size,
-    std::function<bool(uint32_t)> is_buffer_in_clockwise_direction_fn,
+    ttnn::ccl::RingTopology const& topology_config,
+    std::size_t link,
 
     EdmInterfaceAddresses& edm_interface_addresses) {
-    for (uint32_t c = 0; c < num_channels_per_edm; ++c) {
-        uint32_t global_worker_idx = c + num_channels_per_edm * link;
-        uint32_t num_workers_per_eth_buffer = 1;
+    bool is_linear = topology_config.is_linear;
+    for (std::size_t c = 0; c < num_channels_per_edm; ++c) {
+        std::size_t num_workers_per_eth_buffer = 1;
+        auto global_worker_index = get_global_worker_id(link, c, num_channels_per_edm);
+        TT_ASSERT(global_worker_index < all_worker_attributes.size());
+        WorkerAttributes const& worker_attrs = all_worker_attributes[global_worker_index];
 
         std::vector<ttnn::ccl::WorkerXY> sender_worker_coords;
         std::vector<ttnn::ccl::WorkerXY> receiver_worker_coords;
-        for (uint32_t w = c * num_workers_per_eth_buffer; w < (c + 1) * num_workers_per_eth_buffer; ++w) {
-            sender_worker_coords.push_back(ttnn::ccl::WorkerXY(
-                device->worker_core_from_logical_core(worker_cores.at(w)).x,
-                device->worker_core_from_logical_core(worker_cores.at(w)).y));
-            receiver_worker_coords.push_back(ttnn::ccl::WorkerXY(
-                device->worker_core_from_logical_core(worker_cores.at(w)).x,
-                device->worker_core_from_logical_core(worker_cores.at(w)).y));
-        }
+        auto const& worker_noc_coords = device->worker_core_from_logical_core(worker_attrs.location_logical);
+        sender_worker_coords.push_back(ttnn::ccl::WorkerXY(worker_noc_coords.x, worker_noc_coords.y));
+        receiver_worker_coords.push_back(ttnn::ccl::WorkerXY(worker_noc_coords.x, worker_noc_coords.y));
 
         // Get the maximum message size we'd like to use. Not the actual packet size
-        uint32_t expected_message_size_bytes = (num_buffers_per_channel == 1) ? tensor_slicer.get_worker_slice_size_bytes(global_worker_idx)
-                                                                           : clockwise_edm_builders.at(link).get_eth_buffer_size_bytes();
+        // If linear, then we want to reuse the slicer in both directions
+        std::size_t global_worker_idx = c + num_channels_per_edm * link;
+        log_trace(tt::LogOp, "get_worker_slice_size_bytes");
+        std::size_t worker_tensor_slice_index = !is_linear ? global_worker_idx : (c % (num_channels_per_edm / 2)) + ((num_channels_per_edm / 2) * link);
+        // std::size_t worker_tensor_slice_index = !is_linear ? global_worker_idx : (c / 2) + (num_channels_per_edm / 2) * link;
 
-        bool sender_enabled = true;  // (!is_linear || !is_last_chip_in_chain); // update for linear
+        bool is_in_clockwise_direction = worker_attrs.direction == Direction::CLOCKWISE;
+
+        // sender kernel enabled
+        bool sender_enabled = !is_linear || !topology_config.is_last_device_in_line(is_in_clockwise_direction);
         if (sender_enabled) {
-            auto& sender_edm_builder = is_buffer_in_clockwise_direction_fn(c) ? clockwise_edm_builders.at(link)
+            bool choose_clockwise_edm_builder = is_in_clockwise_direction;
+            log_trace(tt::LogOp, "Adding sender EDM channel to {} edm builder", choose_clockwise_edm_builder ? "clockwise" : "counter-clockwise");
+            auto& sender_edm_builder = choose_clockwise_edm_builder ? clockwise_edm_builders.at(link)
                                                                               : counter_clockwise_edm_builders.at(link);
-            log_trace(tt::LogOp, "Adding sender EDM channel");
+            std::size_t expected_message_size_bytes = (num_buffers_per_channel == 1) ? tensor_slicer.get_worker_slice_size_bytes(worker_tensor_slice_index)
+                                                                            : sender_edm_builder.get_eth_buffer_size_bytes();
+            TT_ASSERT(worker_attrs.send_to_edm_semaphore_id.has_value(), "Internal error");
             ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface const& sender_channel_buffer_info =
                 sender_edm_builder.add_sender_channel(
-                    worker_sender_semaphore_id,
-                    1,  // cw_edm_channel_num_messages_to_send_per_transfer.at(c) * (ring_size - 1),
+                    worker_attrs.send_to_edm_semaphore_id.value(),
+                    1,
                     sender_worker_coords,
                     expected_message_size_bytes);
             edm_interface_addresses.worker_sender_edm_semaphore_addresses.insert(
                 {global_worker_idx, sender_channel_buffer_info.eth_semaphore_l1_address});
             edm_interface_addresses.worker_sender_edm_buffer_addresses.insert(
                 {global_worker_idx, sender_channel_buffer_info.eth_buffer_l1_address});
+            log_trace(tt::LogOp, "EDM-IF SENDER: Ring Index: {}, sender {}, sem_addr: {}, buf_addr: {}", topology_config.ring_index, global_worker_idx, sender_channel_buffer_info.eth_semaphore_l1_address, sender_channel_buffer_info.eth_buffer_l1_address);
+            log_trace(tt::LogOp, "\tAdded");
         }
 
-        bool receiver_enabled = true;  //(!is_linear || !is_first_chip_in_chain);
+        // receiver kernel enabled
+        bool receiver_enabled = !is_linear || !topology_config.is_first_device_in_line(is_in_clockwise_direction);
         if (receiver_enabled) {
-            auto& receiver_edm_builder = is_buffer_in_clockwise_direction_fn(c)
-                                             ? counter_clockwise_edm_builders.at(link)
-                                             : clockwise_edm_builders.at(link);
-            log_trace(tt::LogOp, "Adding receiver EDM channel");
+            bool choose_counter_clockwise_edm_builder = is_in_clockwise_direction;
+            log_trace(tt::LogOp, "Adding receiver EDM channel to {} edm builder", choose_counter_clockwise_edm_builder ? "counter-clockwise" : "clockwise");
+            auto& receiver_edm_builder =
+                 is_in_clockwise_direction ? counter_clockwise_edm_builders.at(link) : clockwise_edm_builders.at(link);
+            std::size_t expected_message_size_bytes = (num_buffers_per_channel == 1) ? tensor_slicer.get_worker_slice_size_bytes(worker_tensor_slice_index)
+                                                                            : receiver_edm_builder.get_eth_buffer_size_bytes();
+            TT_ASSERT(worker_attrs.receive_from_edm_semaphore_id.has_value());
             ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface const& receiver_channel_buffer_info =
                 receiver_edm_builder.add_receiver_channel(
-                    worker_receiver_semaphore_id,
+                    worker_attrs.receive_from_edm_semaphore_id.value(),
                     // Since we are in worker signal EDM termination mode, we don't need to set the actual number of
                     // messages the EDM must forward as it will receive its finish signal from the worker instead
                     1,
                     receiver_worker_coords,
                     expected_message_size_bytes);
+
             edm_interface_addresses.worker_receiver_edm_semaphore_addresses.insert(
                 {global_worker_idx, receiver_channel_buffer_info.eth_semaphore_l1_address});
             edm_interface_addresses.worker_receiver_edm_buffer_addresses.insert(
                 {global_worker_idx, receiver_channel_buffer_info.eth_buffer_l1_address});
+            log_trace(tt::LogOp, "EDM-IF RECEIVER: Ring Index: {}, receiver {}, sem_addr: {}, buf_addr: {}", topology_config.ring_index, global_worker_idx, receiver_channel_buffer_info.eth_semaphore_l1_address, receiver_channel_buffer_info.eth_buffer_l1_address);
         }
+
+        TT_ASSERT(receiver_enabled || sender_enabled);
     }
 }
 
-static std::tuple<KernelHandle, KernelHandle, KernelHandle> build_reduce_scatter_worker_ct(
+static std::tuple<KernelHandle, KernelHandle, KernelHandle, std::optional<KernelHandle>> build_reduce_scatter_worker_ct(
     tt::tt_metal::Program& program,
+    ttnn::ccl::RingTopology const& topology_config,
     ttnn::ccl::CCLOpConfig const& op_config,
     ReduceScatterWorkerArgBuilder const& worker_arg_builder,
     CoreRangeSet const& worker_core_range,
+    // if line and at the end of the line we split the worker core range
+    // because we need to invoke separate kernels
+    std::optional<CoreRangeSet> const& split_worker_core_range,
     ttnn::operations::binary::BinaryOpType binary_math_op) {
+    log_trace(tt::LogOp, "build_reduce_scatter_worker_ct");
 
     auto const& worker_defines = op_config.emit_worker_defines();
     TT_ASSERT(worker_defines.size() > 0);
     for (auto const& [key, value] : worker_defines) {
         log_trace(tt::LogOp, "Worker Define: {} = {}", key, value);
     }
-    static std::string const& receiver_kernel_path =
+    if (split_worker_core_range.has_value()) {
+        log_trace(tt::LogOp, "second worker core list:");
+        for (const auto &core : corerange_to_cores(split_worker_core_range.value())) {
+            log_trace(tt::LogOp, "\tx={},y={}", core.x, core.y);
+        }
+    }
+
+    static std::string const& receiver_kernel_path = //topology_config.is_linear ?
+        // "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_line_reduce_scatter_reader.cpp" :
         "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp";
-    static std::string const& sender_kernel_path =
-        "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp";
-    static std::string const& reduce_kernel_path =
-        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp";
+    static std::string const& forward_sender_kernel_path = "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp";
+    static std::string const& line_start_sender_kernel_path = "ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send.cpp";
+    static std::string const& reduce_kernel_path = "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp";
+
+    // Need to be able to split up the workers so that on the end of the lines, some of the cores are for send/receive and
+    // others are for CCL send only
+    bool is_start_chip_in_line = topology_config.is_linear && (topology_config.ring_index == 0 || topology_config.ring_index == topology_config.ring_size - 1);
+
+    // If we we implementing a line, and are at the end of the line
+    bool worker_grid_split_in_half = is_start_chip_in_line;
 
     KernelHandle worker_receiver_kernel_id, worker_sender_kernel_id, worker_reduce_kernel_id;
+    std::optional<KernelHandle> line_start_sender_kernel_id;
 
     worker_receiver_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -453,7 +209,7 @@ static std::tuple<KernelHandle, KernelHandle, KernelHandle> build_reduce_scatter
 
     worker_sender_kernel_id = tt::tt_metal::CreateKernel(
         program,
-        sender_kernel_path,
+        forward_sender_kernel_path,
         worker_core_range,
         tt::tt_metal::WriterDataMovementConfig(worker_arg_builder.generate_sender_kernel_ct_args(), worker_defines));
 
@@ -472,7 +228,20 @@ static std::tuple<KernelHandle, KernelHandle, KernelHandle> build_reduce_scatter
             .compile_args = compute_kernel_args,
             .defines = eltwise_defines});
 
-    return {worker_receiver_kernel_id, worker_sender_kernel_id, worker_reduce_kernel_id};
+    if (is_start_chip_in_line) {
+        TT_ASSERT(split_worker_core_range.has_value(), "Internal Error. (line) Reduce scatter did not generate a smaller second worker grid to map the line start kernels onto");
+        log_trace(tt::LogOp, "Invoking CCL send kernel on split kernel core range");
+        for (auto const& core : corerange_to_cores(split_worker_core_range.value())) {
+            log_trace(tt::LogOp, "\tcore=(x={},y={})", core.x, core.y);
+        }
+        line_start_sender_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            line_start_sender_kernel_path,
+            split_worker_core_range.value(),
+            tt::tt_metal::WriterDataMovementConfig(worker_arg_builder.generate_line_start_sender_kernel_ct_args(), worker_defines));
+    }
+
+    return {worker_receiver_kernel_id, worker_sender_kernel_id, worker_reduce_kernel_id, line_start_sender_kernel_id};
 }
 
 static void set_reduce_scatter_worker_rt(
@@ -481,112 +250,156 @@ static void set_reduce_scatter_worker_rt(
     KernelHandle worker_receiver_kernel_id,
     KernelHandle worker_sender_kernel_id,
     KernelHandle worker_reduce_kernel_id,
+    std::optional<KernelHandle> optional_line_start_ccl_send_kernel,
     ttnn::ccl::RingTopology const& topology_config,
-    ttnn::ccl::CCLOpConfig const& op_config,
-    ReduceScatterWorkerArgBuilder const& worker_arg_builder,
+    ttnn::ccl::reduce_scatter_detail::ReduceScatterWorkerArgBuilder const& worker_arg_builder,
     std::vector<ttnn::ccl::EriscDatamoverBuilder>& cw_edm_builders,
     std::vector<ttnn::ccl::EriscDatamoverBuilder>& ccw_edm_builders,
     EdmInterfaceAddresses const& edm_interface_addresses,
-    CoreCoord const& worker_core,
-    uint32_t num_edm_channels,
-    uint32_t link,
-    uint32_t ring_size,
-    uint32_t worker_index,
-    ttnn::operations::binary::BinaryOpType binary_math_op,
-    std::function<bool(uint32_t)> is_buffer_in_clockwise_direction_fn) {
+    WorkerAttributes &worker_attributes,
+    std::size_t num_edm_channels,
+    std::size_t edm_num_buffers_per_channel,
+    ttnn::operations::binary::BinaryOpType binary_math_op) {
+    bool is_in_clockwise_direction = worker_attributes.direction == Direction::CLOCKWISE;
+    const std::size_t global_worker_index = get_global_worker_id(worker_attributes, num_edm_channels);
 
-    bool is_in_clockwise_direction = is_buffer_in_clockwise_direction_fn(worker_index);
-    uint32_t global_worker_index = link * num_edm_channels + worker_index;
+    if (!topology_config.is_first_device_in_line(is_in_clockwise_direction))
     {
-        CoreCoord const& receiver_edm = is_in_clockwise_direction ? topology_config.eth_receiver_cores.at(link)
-                                                                  : topology_config.eth_sender_cores.at(link);
-       ttnn::ccl::WorkerXY receiver_edm_noc_coord =ttnn::ccl::WorkerXY(
+        CoreCoord const& receiver_edm = is_in_clockwise_direction
+                                            ? topology_config.eth_receiver_cores.at(worker_attributes.link)
+                                            : topology_config.eth_sender_cores.at(worker_attributes.link);
+        ttnn::ccl::WorkerXY receiver_edm_noc_coord = ttnn::ccl::WorkerXY(
             device->ethernet_core_from_logical_core(receiver_edm).x,
             device->ethernet_core_from_logical_core(receiver_edm).y);
-        const uint32_t edm_core_semaphore_address =
-            is_in_clockwise_direction
-                ? edm_interface_addresses.worker_receiver_edm_semaphore_addresses.at(global_worker_index)
-                : edm_interface_addresses.worker_sender_edm_semaphore_addresses.at(global_worker_index);
-        const uint32_t edm_core_buffer_address =
-            is_in_clockwise_direction
-                ? edm_interface_addresses.worker_receiver_edm_buffer_addresses.at(global_worker_index)
-                : edm_interface_addresses.worker_sender_edm_buffer_addresses.at(global_worker_index);
+        const uint32_t edm_core_semaphore_address = edm_interface_addresses.worker_receiver_edm_semaphore_addresses.at(global_worker_index);
+        const uint32_t edm_core_buffer_address = edm_interface_addresses.worker_receiver_edm_buffer_addresses.at(global_worker_index);
 
         tt::tt_metal::SetRuntimeArgs(
             program,
             worker_receiver_kernel_id,
-            worker_core,
+            worker_attributes.location_logical,
             worker_arg_builder.generate_receiver_kernel_rt_args(
-                receiver_edm_noc_coord,
-                edm_core_semaphore_address,
-                edm_core_buffer_address,
-                link,
-                worker_index,
-                is_in_clockwise_direction));
-    }
+                receiver_edm_noc_coord, edm_core_semaphore_address, edm_core_buffer_address, worker_attributes));
 
-    {
         tt::tt_metal::SetRuntimeArgs(
             program,
             worker_reduce_kernel_id,
-            worker_core,
-            worker_arg_builder.generate_reduce_op_kernel_rt_args(link, worker_index, ring_size));
+            worker_attributes.location_logical,
+            worker_arg_builder.generate_reduce_op_kernel_rt_args(worker_attributes, topology_config.ring_size));
     }
 
+    // if (!topology_config.is_last_device_in_line(is_in_clockwise_direction))
     {
-        CoreCoord sender_edm = is_in_clockwise_direction ? topology_config.eth_sender_cores.at(link)
-                                                         : topology_config.eth_receiver_cores.at(link);
-       ttnn::ccl::WorkerXY const sender_edm_noc_coord =ttnn::ccl::WorkerXY(
-            device->ethernet_core_from_logical_core(sender_edm).x,
-            device->ethernet_core_from_logical_core(sender_edm).y);
-        TT_ASSERT(sender_edm_noc_coord.y == 0 || sender_edm_noc_coord.y == 6);
-        const uint32_t edm_core_semaphore_address =
-            is_in_clockwise_direction
-                ? edm_interface_addresses.worker_sender_edm_semaphore_addresses.at(global_worker_index)
-                : edm_interface_addresses.worker_receiver_edm_semaphore_addresses.at(global_worker_index);
-        const uint32_t edm_core_buffer_address =
-            is_in_clockwise_direction
-                ? edm_interface_addresses.worker_sender_edm_buffer_addresses.at(global_worker_index)
-                : edm_interface_addresses.worker_receiver_edm_buffer_addresses.at(global_worker_index);
+        ttnn::ccl::WorkerXY edm_noc_coord = ttnn::ccl::WorkerXY(0,0);
+        uint32_t edm_core_semaphore_address = 0;
+        uint32_t edm_core_buffer_address = 0;
 
+        // If we are at the end of a line, then the sender kernel does not forward anything to an EDM
+        if (!topology_config.is_last_device_in_line(is_in_clockwise_direction)) {
+            CoreCoord sender_edm = is_in_clockwise_direction ? topology_config.eth_sender_cores.at(worker_attributes.link)
+                                                            : topology_config.eth_receiver_cores.at(worker_attributes.link);
+            edm_noc_coord = ttnn::ccl::WorkerXY(
+                device->ethernet_core_from_logical_core(sender_edm).x, device->ethernet_core_from_logical_core(sender_edm).y);
+            TT_ASSERT(edm_noc_coord.y == 0 || edm_noc_coord.y == 6);
+            edm_core_semaphore_address = edm_interface_addresses.worker_sender_edm_semaphore_addresses.at(global_worker_index);
+            edm_core_buffer_address = edm_interface_addresses.worker_sender_edm_buffer_addresses.at(global_worker_index);
+        }
+
+        WorkerEdmInterfaceArgs edm_interface = {
+            edm_noc_coord.x,
+            edm_noc_coord.y,
+            edm_core_buffer_address,
+            edm_core_semaphore_address,
+            edm_num_buffers_per_channel};
+
+        bool use_line_start_kernel = topology_config.is_first_device_in_line(is_in_clockwise_direction);
+        if (use_line_start_kernel) {
+            log_trace(tt::LogOp, "Setting CCL send RT args");
+        }
+        auto const rt_args = use_line_start_kernel
+                                 ? worker_arg_builder.generate_line_start_sender_kernel_rt_args(
+                                       edm_interface, worker_arg_builder.scatter_dim, worker_attributes)
+                                 : worker_arg_builder.generate_sender_kernel_rt_args(edm_interface, worker_attributes);
+        TT_ASSERT(!use_line_start_kernel || optional_line_start_ccl_send_kernel.has_value());
+        auto sender_kernel_id = use_line_start_kernel ? optional_line_start_ccl_send_kernel.value(): worker_sender_kernel_id;
+
+        log_trace(tt::LogOp, "{} rt_args for sender kernel", rt_args.size());
         tt::tt_metal::SetRuntimeArgs(
             program,
-            worker_sender_kernel_id,
-            worker_core,
-            worker_arg_builder.generate_sender_kernel_rt_args(
-                sender_edm_noc_coord,
-                edm_core_semaphore_address,
-                edm_core_buffer_address,
-                link,
-                worker_index,
-                is_in_clockwise_direction));
+            sender_kernel_id,
+            worker_attributes.location_logical,
+            rt_args);
     }
 }
 
-static CoreRangeSet select_worker_cores(
-   ttnn::ccl::CCLOpConfig const& op_config, std::size_t num_links, std::size_t num_edm_channels) {
+/*
+ * Core range sets for line topology
+ */
+static std::pair<CoreRangeSet, std::optional<CoreRangeSet>> select_worker_cores_for_line_topology(ttnn::ccl::RingTopology const& topology_config, ttnn::ccl::CCLOpConfig const& op_config, std::size_t num_links, std::size_t num_edm_channels) {
+    static constexpr std::size_t num_directions_per_line = 2;
+
+    TT_ASSERT(num_edm_channels % 2 == 0, "For line topologies, we expect a multiple of 2 number of channels for the algorithm and worker kernels to work.");
+    const std::size_t workers_per_direction = num_edm_channels / num_directions_per_line;
+    auto const& lower_half_of_cores = CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(workers_per_direction - 1, num_links - 1))});
+    auto const& upper_half_of_cores = CoreRangeSet({CoreRange(CoreCoord(workers_per_direction, 0), CoreCoord(num_edm_channels - 1, num_links - 1))});
+    if (topology_config.ring_index == 0) {
+        log_trace(tt::LogOp, "Start of line, putting CCL send cores in lower half");
+        return {upper_half_of_cores, lower_half_of_cores};
+    } else if (topology_config.ring_index == topology_config.ring_size - 1) {
+        // Flip them for the other end because the send will be for the "second" core range set (conceptually, the other direction)
+        // of the line flows in the second half of all workers, for each chip.
+        log_trace(tt::LogOp, "End of line, putting CCL send cores in lower half");
+        return {lower_half_of_cores, upper_half_of_cores};
+    } else {
+        log_trace(tt::LogOp, "Middle of line - no CCL kernel");
+        return {CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(num_edm_channels - 1, num_links - 1))}), std::nullopt};
+    }
+}
+
+/*
+ * Returns 1 or 2 core range sets. Typically returns only one but in the case of a line reduce scatter where we are at the end of the line,
+ * then we must split the core range in half (and return 2), one for each direction where half the cores will invoke the ccl::send kernel
+ * to implement the start of the line and the others will invoke the typical reduce scatter worker kernels.
+ */
+static std::pair<CoreRangeSet, std::optional<CoreRangeSet>> select_worker_cores(
+    ttnn::ccl::RingTopology const& topology_config, ttnn::ccl::CCLOpConfig const& op_config, std::size_t num_links, std::size_t num_edm_channels) {
     switch (op_config.get_topology()) {
-        case ttnn::ccl::Topology::Linear:
-            return CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(num_edm_channels - 1, num_links - 1))});
+        case ttnn::ccl::Topology::Linear: {
+            auto const& core_ranges = select_worker_cores_for_line_topology(topology_config, op_config, num_links, num_edm_channels);
+            log_trace(tt::LogOp, "First core range");
+            for (const auto &core : corerange_to_cores(core_ranges.first)) {
+                log_trace(tt::LogOp, "\tx={},y={}", core.x, core.y);
+            }
+            if (core_ranges.second.has_value()) {
+                log_trace(tt::LogOp, "second worker core list:");
+                for (const auto &core : corerange_to_cores(core_ranges.second.value())) {
+                    log_trace(tt::LogOp, "\tx={},y={}", core.x, core.y);
+                }
+            }
+            return core_ranges;
+        }
+
         case ttnn::ccl::Topology::Ring:
-            return CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(num_edm_channels - 1, num_links - 1))});
-        default: TT_ASSERT(false, "Unsupported topology"); return CoreRangeSet({});
+            return {CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(num_edm_channels - 1, num_links - 1))}), std::nullopt};
+
+        default: TT_ASSERT(false, "Unsupported topology"); return {CoreRangeSet({}), std::nullopt};
     };
 }
 
 static WorkerTransferInfo compute_num_edm_messages_per_channel(
     ccl::CCLOpConfig const& op_config,
     RingReduceScatterWrappedTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
+    ttnn::ccl::RingTopology const& topology_config,
     std::vector<ttnn::ccl::EriscDatamoverBuilder> const& cw_per_link_edm_builders,
     std::vector<ttnn::ccl::EriscDatamoverBuilder> const& ccw_per_link_edm_builders,
-    std::size_t const num_edm_channels,
-    std::size_t const num_links,
-    std::size_t const ring_size) {
+    std::size_t const num_edm_channels
+    ) {
     uint32_t const page_size_in_bytes = op_config.get_page_size();
     TT_ASSERT(num_edm_channels > 0);
-    TT_ASSERT(num_links > 0);
+    TT_ASSERT(topology_config.num_links > 0);
     TT_ASSERT(page_size_in_bytes > 0);
     log_trace(tt::LogOp, "WorkerTransferInfo");
+    const std::size_t num_links = topology_config.num_links;
     std::size_t total_num_workers = num_edm_channels * num_links;
 
     auto get_iter_begin = [num_edm_channels](auto& vec, std::size_t link) -> auto {
@@ -608,7 +421,9 @@ static WorkerTransferInfo compute_num_edm_messages_per_channel(
     std::vector<uint32_t> num_pages_per_full_chunk(total_num_edm_channels * num_links, 0);
 
     for (std::size_t link = 0; link < num_links; link++) {
-        std::size_t edm_channel_size_in_bytes = cw_per_link_edm_builders.at(link).get_eth_buffer_size_bytes();
+        const auto& an_edm_builder = cw_per_link_edm_builders.size() > 0 ? cw_per_link_edm_builders.at(link) : ccw_per_link_edm_builders.at(link);
+        TT_ASSERT(cw_per_link_edm_builders.size() > 0 || topology_config.ring_index == topology_config.ring_size - 1, "Internal logic error");
+        std::size_t edm_channel_size_in_bytes = an_edm_builder.get_eth_buffer_size_bytes();
         std::size_t num_pages_per_edm_buffer = edm_channel_size_in_bytes / page_size_in_bytes;
         log_trace(
             tt::LogOp,
@@ -636,16 +451,27 @@ static WorkerTransferInfo compute_num_edm_messages_per_channel(
 }
 
 static uint32_t compute_maximum_worker_slice_in_bytes(
+    ttnn::ccl::Topology topology,
     uint32_t cb_src0_size_pages,
     uint32_t cb_dst0_size_pages,
     uint32_t cb_short_circuit_size_pages,
     std::size_t edm_channel_buffer_size,
     uint32_t page_size) {
-    return std::min(cb_short_circuit_size_pages, cb_src0_size_pages + cb_dst0_size_pages) * page_size +
-           edm_channel_buffer_size;
+    switch (topology) {
+        case ttnn::ccl::Topology::Linear:
+            // For linear topology, we only want one slice per worker so we don't
+            return std::numeric_limits<uint32_t>::max();
+
+        case ttnn::ccl::Topology::Ring:
+            return std::min(cb_short_circuit_size_pages, cb_src0_size_pages + cb_dst0_size_pages) * page_size +
+                   edm_channel_buffer_size;
+
+        default: TT_ASSERT(false, "Unsupported topology"); return 0;
+    };
 }
 
 static bool is_cb_buffering_sufficient_to_avoid_deadlock(
+    ttnn::ccl::Topology topology,
    ttnn::ccl::InterleavedTensorWorkerSlice const& worker_slice,
     uint32_t cb_src0_size_pages,
     uint32_t cb_dst0_size_pages,
@@ -656,7 +482,7 @@ static bool is_cb_buffering_sufficient_to_avoid_deadlock(
         tt::round_up(worker_slice.worker_slice_shape.x * worker_slice.worker_slice_shape.y, cb_src0_size_pages / 2);
     uint32_t worker_slice_size_bytes = worker_size_pages_rounded_up * page_size;
     uint32_t available_buffering_capacity = compute_maximum_worker_slice_in_bytes(
-        cb_src0_size_pages, cb_dst0_size_pages, cb_short_circuit_size_pages, edm_channel_buffer_size, page_size);
+        topology, cb_src0_size_pages, cb_dst0_size_pages, cb_short_circuit_size_pages, edm_channel_buffer_size, page_size);
     log_trace(tt::LogOp, "worker_slice.worker_slice_shape.x: {}", worker_slice.worker_slice_shape.x);
     log_trace(tt::LogOp, "worker_slice.worker_slice_shape.y: {}", worker_slice.worker_slice_shape.y);
     log_trace(tt::LogOp, "worker_slice_size_bytes: {}", worker_slice_size_bytes);
@@ -670,10 +496,20 @@ static bool is_cb_buffering_sufficient_to_avoid_deadlock(
     return available_buffering_capacity >= worker_slice_size_bytes;
 }
 
-static std::tuple<CBHandle, CBHandle, CBHandle, CBHandle> create_worker_circular_buffers(
+static std::tuple<
+    CBHandle,
+    CBHandle,
+    CBHandle,
+    CBHandle,
+    std::optional<CBHandle>,
+    std::optional<CBHandle>,
+    std::optional<CBHandle>,
+    std::optional<CBHandle>>
+create_worker_circular_buffers(
     Tensor const& input_tensor,
-   ttnn::ccl::CCLOpConfig const& op_config,
+    ttnn::ccl::CCLOpConfig const& op_config,
     CoreRangeSet const& worker_core_range,
+    std::optional<CoreRangeSet> const& second_worker_core_range,
     uint32_t worker_pages_per_transfer,
     tt::tt_metal::Program& program) {
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
@@ -685,6 +521,10 @@ static std::tuple<CBHandle, CBHandle, CBHandle, CBHandle> create_worker_circular
         tt::tt_metal::CircularBufferConfig(worker_pages_per_transfer * page_size_bytes, {{src0_cb_index, df}})
             .set_page_size(src0_cb_index, page_size_bytes);
     CBHandle cb_src0_workers = CreateCircularBuffer(program, worker_core_range, cb_src0_config);
+    std::optional<CBHandle> cb_src0_workers_2;
+    if (second_worker_core_range.has_value()) {
+        cb_src0_workers_2 = CreateCircularBuffer(program, second_worker_core_range.value(), cb_src0_config);
+    }
 
     // Input 1 CB
     uint32_t src1_cb_index = tt::CB::c_in1;
@@ -692,6 +532,10 @@ static std::tuple<CBHandle, CBHandle, CBHandle, CBHandle> create_worker_circular
         tt::tt_metal::CircularBufferConfig(worker_pages_per_transfer * page_size_bytes, {{src1_cb_index, df}})
             .set_page_size(src1_cb_index, page_size_bytes);
     CBHandle cb_src1_workers = CreateCircularBuffer(program, worker_core_range, cb_src1_config);
+    std::optional<CBHandle> cb_src1_workers_2;
+    if (second_worker_core_range.has_value()) {
+        cb_src1_workers_2 = CreateCircularBuffer(program, second_worker_core_range.value(), cb_src1_config);
+    }
 
     // Dataflow Writer Kernel input CB
     uint32_t cb_dst0_index = tt::CB::c_out0;
@@ -699,6 +543,10 @@ static std::tuple<CBHandle, CBHandle, CBHandle, CBHandle> create_worker_circular
         tt::tt_metal::CircularBufferConfig(worker_pages_per_transfer * page_size_bytes, {{cb_dst0_index, df}})
             .set_page_size(cb_dst0_index, page_size_bytes);
     CBHandle cb_dst0_sender_workers = CreateCircularBuffer(program, worker_core_range, cb_dst0_config);
+    std::optional<CBHandle> cb_dst0_sender_workers_2;
+    if (second_worker_core_range.has_value()) {
+        cb_dst0_sender_workers_2 = CreateCircularBuffer(program, second_worker_core_range.value(), cb_dst0_config);
+    }
 
     // From reader -> writer kernel (I think I need this because sharing the cb_dst0_sender_workers as output
     // of reader kernel (first output) and math kernel (all subsequent outputs) doesn't seem to work because
@@ -711,7 +559,21 @@ static std::tuple<CBHandle, CBHandle, CBHandle, CBHandle> create_worker_circular
     CBHandle cb_short_circuit_sender_workers =
         CreateCircularBuffer(program, worker_core_range, cb_short_circuit_config);
 
-    return {cb_src0_workers, cb_src1_workers, cb_dst0_sender_workers, cb_short_circuit_sender_workers};
+    std::optional<CBHandle> cb_short_circuit_sender_workers_2;
+    if (second_worker_core_range.has_value()) {
+        cb_short_circuit_sender_workers_2 =
+            CreateCircularBuffer(program, second_worker_core_range.value(), cb_short_circuit_config);
+    }
+
+    return {
+        cb_src0_workers,
+        cb_src1_workers,
+        cb_dst0_sender_workers,
+        cb_short_circuit_sender_workers,
+        cb_src0_workers_2,
+        cb_src1_workers_2,
+        cb_dst0_sender_workers_2,
+        cb_short_circuit_sender_workers_2};
 }
 
 operation::ProgramWithCallbacks reduce_scatter_with_workers(
@@ -748,14 +610,17 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
         ttnn::ccl::CclOpTensorConfig::build_all_gather_tensor_config(output_tensor);
     // // The input tensor is fractured by ring_size so we divi
     std::size_t input_tensor_n_elems_per_slice = input_tensor.volume() / ring_size;
-    uint32_t input_tensor_num_units_per_tensor_slice =
+    std::size_t input_tensor_num_units_per_tensor_slice =
         input_tensor_n_elems_per_slice / (tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT);
 
     TT_ASSERT(input_tensor_num_units_per_tensor_slice > 0);
-    uint32_t max_num_workers = std::min<std::size_t>(user_defined_num_workers.value_or(8), input_tensor_num_units_per_tensor_slice);
-    bool enable_bidirectional = true;
-    std::size_t num_edm_channels = decide_number_of_edm_channels(op_config, max_num_workers, enable_bidirectional);
-    log_trace(tt::LogOp, "num_edm_channels: {}", num_edm_channels);
+    constexpr bool enable_bidirectional = true;
+    uint32_t max_num_workers = std::min<std::size_t>(user_defined_num_workers.value_or(topology == Topology::Linear ? 2 : 8), input_tensor_num_units_per_tensor_slice);
+    if (topology == ttnn::ccl::Topology::Linear) {
+        max_num_workers = std::max<std::size_t>(max_num_workers, 2);
+    }
+    auto num_edm_channels_per_link = decide_number_of_edm_channels(op_config, max_num_workers, enable_bidirectional);
+    log_trace(tt::LogOp, "num_edm_channels_per_link: {}", num_edm_channels_per_link);
     auto edm_termination_mode = ttnn::ccl::EriscDataMoverTerminationMode::WORKER_INITIATED;
 
     std::size_t num_buffers_per_channel = 2;
@@ -764,53 +629,99 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
         num_buffers_per_channel = user_defined_num_buffers_per_channel.value();
     }
     auto const& edm_builder = create_erisc_datamover_builder(
-        num_edm_channels, op_config.get_page_size(), num_buffers_per_channel, buffer_sharing_mode, edm_termination_mode);
-    TT_ASSERT(num_edm_channels > 0);
+        num_edm_channels_per_link, op_config.get_page_size(), num_buffers_per_channel, buffer_sharing_mode, edm_termination_mode);
+    TT_ASSERT(num_edm_channels_per_link > 0);
 
-    Tensor const& local_chip_tensor = input_tensor;
-    Tensor const& local_chip_output_tensor = output_tensor;
+    const auto& device = input_tensor.device();
+    auto const& topology_config =
+       ttnn::ccl::RingTopology(device, topology, sender_device_id, receiver_device_id, num_links, ring_size, ring_index);
+    bool is_linear = topology_config.is_linear;
+    // For line reduce scatter we have special instantiation behaviour at the ends of the line, namely:
+    // The start of the line has no counter-clockwise EDM and the end has no clockwise EDM
+    std::size_t num_active_cw_edm_links = (!is_linear || (ring_index != ring_size - 1)) ? num_links : 0;
+    std::size_t num_active_ccw_edm_links = (!is_linear || (ring_index != 0)) ? num_links : 0;
+    log_trace(tt::LogOp, "ring_index: {}, num_active_cw_edm_links: {}, num_active_ccw_edm_links: {}", ring_index, num_active_cw_edm_links, num_active_ccw_edm_links);
+    std::vector<ttnn::ccl::EriscDatamoverBuilder> cw_per_link_edm_builders(num_active_cw_edm_links, edm_builder);
+    std::vector<ttnn::ccl::EriscDatamoverBuilder> ccw_per_link_edm_builders(num_active_ccw_edm_links, edm_builder);
+    TT_ASSERT(cw_per_link_edm_builders.size() > 0 ||  ccw_per_link_edm_builders.size() > 0, "Internal error. No EDMs were instantiated in reduce scatter.");
 
-    std::map<string, string> worker_defines;
-    std::vector<ttnn::ccl::EriscDatamoverBuilder> cw_per_link_edm_builders(num_links, edm_builder);
-    std::vector<ttnn::ccl::EriscDatamoverBuilder> ccw_per_link_edm_builders(num_links, edm_builder);
+    std::function<bool(uint32_t)> is_worker_in_clockwise_direction_fn = [is_linear, enable_bidirectional, num_edm_channels_per_link](std::size_t x) {
+                static constexpr std::size_t bidirectional_directions = 2;
+                return is_linear ? (x < (num_edm_channels_per_link / bidirectional_directions)):
+                    enable_bidirectional ? (x % bidirectional_directions == 0) : true;
+            };
+
+    auto const& [worker_core_range, second_worker_core_range] = select_worker_cores(topology_config, op_config, num_links, num_edm_channels_per_link);
+    auto const& worker_cores = corerange_to_cores(worker_core_range, std::nullopt, true);
+    std::optional<std::vector<CoreCoord>> second_worker_cores_list;
+    if (second_worker_core_range.has_value()) {
+        second_worker_cores_list = corerange_to_cores(second_worker_core_range.value(), std::nullopt, true);
+    }
 
     //////////////////
     tt::tt_metal::Program program{};
 
-    const auto& device = local_chip_tensor.device();
-
-    auto const& topology_config =
-       ttnn::ccl::RingTopology(device, topology, sender_device_id, receiver_device_id, num_links, ring_size, ring_index);
-
-    CoreRangeSet const& worker_core_range = select_worker_cores(op_config, num_links, num_edm_channels);
-    auto const& worker_cores = corerange_to_cores(worker_core_range, std::nullopt, true);
-
     // Semaphores && CBs
     auto worker_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range, 0);
     auto worker_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range, 0);
+    std::optional<uint32_t> worker_receiver_semaphore_id_second_core_range = std::nullopt;
+    std::optional<uint32_t> worker_sender_semaphore_id_second_core_range = std::nullopt;
+    std::optional<uint32_t> receiver_worker_partial_ready_semaphore_id = std::nullopt;
+    std::optional<uint32_t> receiver_worker_partial_ready_semaphore_id_second_core_range = std::nullopt;
+    if (second_worker_core_range.has_value()) {
+        worker_receiver_semaphore_id_second_core_range = tt::tt_metal::CreateSemaphore(program, second_worker_core_range.value(), 0);
+        worker_sender_semaphore_id_second_core_range = tt::tt_metal::CreateSemaphore(program, second_worker_core_range.value(), 0);
+    }
+    if (topology_config.is_linear) {
+        receiver_worker_partial_ready_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range, 0);
+        if (second_worker_core_range.has_value()) {
+            receiver_worker_partial_ready_semaphore_id_second_core_range = tt::tt_metal::CreateSemaphore(program, second_worker_core_range.value(), 0);
+        }
+    }
 
-    uint32_t cb_num_pages = std::min(input_tensor_num_units_per_tensor_slice,
-        (cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes() / op_config.get_page_size())) * 2;
+    std::vector<WorkerAttributes> all_worker_attributes = build_worker_attributes(
+        topology_config,
+        worker_cores,
+        second_worker_cores_list,
+
+        worker_sender_semaphore_id,
+        worker_receiver_semaphore_id,
+        worker_sender_semaphore_id_second_core_range,
+        worker_receiver_semaphore_id_second_core_range,
+
+        num_links,
+        num_edm_channels_per_link,
+        is_worker_in_clockwise_direction_fn);
+
+    const std::size_t edm_buffer_size_bytes = (cw_per_link_edm_builders.size() > 0 ? cw_per_link_edm_builders.at(0) : ccw_per_link_edm_builders.at(0)).get_eth_buffer_size_bytes();
+    uint32_t cb_num_pages = std::min(input_tensor_num_units_per_tensor_slice, (edm_buffer_size_bytes / op_config.get_page_size())) * 2;
     uint32_t cb_num_pages_per_packet = cb_num_pages / 2;
     log_trace(tt::LogOp, "cb_num_pages: {}", cb_num_pages);
-    auto const& [cb_src0_workers, cb_src1_workers, cb_dst0_sender_workers, cb_short_circuit_sender_workers] =
-        create_worker_circular_buffers(local_chip_tensor, op_config, worker_core_range, cb_num_pages, program);
+    auto const& [cb_src0_workers, cb_src1_workers, cb_dst0_sender_workers, cb_short_circuit_sender_workers, optional_cb_src0_workers_2, optional_cb_src1_workers_2, optional_cb_dst0_sender_workers_2, optional_cb_short_circuit_sender_workers_2] =
+        create_worker_circular_buffers(
+            input_tensor, op_config, worker_core_range, second_worker_core_range, cb_num_pages, program);
 
     uint32_t max_worker_slice_in_bytes = compute_maximum_worker_slice_in_bytes(
+        topology,
         cb_num_pages,
         cb_num_pages,
         cb_num_pages,
-        cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes(),
+        edm_buffer_size_bytes,
         op_config.get_page_size());
-    std::size_t num_workers = worker_cores.size();
-    TT_ASSERT(num_workers == num_edm_channels * num_links);
+    const std::size_t num_workers = all_worker_attributes.size();
+    TT_ASSERT(num_workers == num_edm_channels_per_link * num_links);
+    // For tensor slicer purposes, if we are working with a linear topology, then half of
+    // the workers will be for one direction of the line and the other half will be for
+    // the other. Therefore, for each tensor slice, only half of the total workers are available
+    // to work on it.
+    const std::size_t num_workers_per_slicer = topology_config.is_linear ? num_workers / 2 : num_workers;
     auto tensor_slicer = ttnn::ccl::RingReduceScatterWrappedTensorSlicer(
-        local_chip_tensor,
-        local_chip_output_tensor,
+        input_tensor,
+        output_tensor,
         scatter_split_dim,
         ring_index,
         ring_size,
-        num_workers,
+        num_workers_per_slicer,
         max_worker_slice_in_bytes,
         cb_num_pages / 2);
 
@@ -818,35 +729,26 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
     WorkerTransferInfo const& worker_transfer_info = compute_num_edm_messages_per_channel(
         op_config,
         tensor_slicer,
+        topology_config,
         cw_per_link_edm_builders,
         ccw_per_link_edm_builders,
-        num_edm_channels,
-        num_links,
-        ring_size);
+        num_edm_channels_per_link);
 
     // Configure the EDM builders
-    std::function<bool(uint32_t)> is_worker_in_clockwise_direction_fn = [enable_bidirectional, num_edm_channels](uint32_t x) {
-                static constexpr bool bidirectional_directions = 2;
-                return enable_bidirectional ? (x % bidirectional_directions == 0) : true;
-            };
     EdmInterfaceAddresses edm_interface_addresses;
     for (std::size_t link = 0; link < num_links; link++) {
         add_worker_config_to_edm_builders(
             device,
             tensor_slicer,
-            op_config,
-            worker_cores,
-            num_edm_channels,
+            all_worker_attributes,
+            num_edm_channels_per_link,
             num_buffers_per_channel,
 
             cw_per_link_edm_builders,
             ccw_per_link_edm_builders,
 
-            worker_sender_semaphore_id,
-            worker_receiver_semaphore_id,
+            topology_config,
             link,
-            ring_size,
-            is_worker_in_clockwise_direction_fn,
 
             edm_interface_addresses);
     }
@@ -859,67 +761,75 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
         topology_config,
         dummy_worker_slice,
         worker_transfer_info,
+        edm_termination_mode, // Can probably remove this once everything is working
+        scatter_split_dim,
         cb_num_pages_per_packet,
-        worker_sender_semaphore_id,
-        worker_receiver_semaphore_id,
+        receiver_worker_partial_ready_semaphore_id, // This one should go too but not sure how yet
         num_buffers_per_channel);
-    auto [worker_receiver_kernel_id, worker_sender_kernel_id, worker_reduce_kernel_id] = build_reduce_scatter_worker_ct(
+    auto [worker_receiver_kernel_id, worker_sender_kernel_id, worker_reduce_kernel_id, optional_line_start_ccl_send_kernel] = build_reduce_scatter_worker_ct(
         program,
+        topology_config,
         op_config,
         worker_arg_builder,
         worker_core_range,
+        second_worker_core_range,
         reduce_op);
+
+    // build the worker kernels
 
     // set worker kernels rt
     tt::tt_metal::ComputeConfig compute_config;
     for (std::size_t link = 0; link < num_links; link++) {
-        uint32_t global_worker_index = link * num_edm_channels;
         log_trace(tt::LogOp, "==============================================");
         log_trace(tt::LogOp, "------------------ Link: {} ------------------", link);
-        for (std::size_t worker = 0; worker < num_edm_channels; worker++) {
-            std::size_t global_worker_index = worker + link * num_edm_channels;
+        for (std::size_t worker = 0; worker < num_edm_channels_per_link; worker++) {
+            std::size_t global_worker_index = worker + link * num_edm_channels_per_link;
+
             log_trace(tt::LogOp, "------ Worker: {} (global ID={})", worker, global_worker_index);
 
-            auto const& worker_slice = tensor_slicer.get_worker_slice(global_worker_index);
+            std::size_t worker_tensor_slice_index = get_worker_index_in_slice(topology_config, global_worker_index, worker, num_edm_channels_per_link, link);
+                // !topology_config.is_linear ?
+                //     global_worker_index :
+                //     (worker % (num_edm_channels_per_link / 2)) + ((num_edm_channels_per_link / 2) * link);
+            auto const& worker_slice = tensor_slicer.get_worker_slice(worker_tensor_slice_index);
             auto worker_arg_builder = ReduceScatterWorkerArgBuilder(
                 device,
                 op_config,
                 topology_config,
                 worker_slice,
                 worker_transfer_info,
+                edm_termination_mode,
+                scatter_split_dim,
                 cb_num_pages_per_packet,
-                worker_sender_semaphore_id,
-                worker_receiver_semaphore_id,
+                receiver_worker_partial_ready_semaphore_id,
                 num_buffers_per_channel);
 
-            log_trace(tt::LogOp, "worker_cores.at(global_worker_index): {}", worker_cores.at(global_worker_index));
+            // log_trace(tt::LogOp, "worker_cores.at(global_worker_index): {}", worker_cores.at(global_worker_index));
             set_reduce_scatter_worker_rt(
                 program,
                 device,
                 worker_receiver_kernel_id,
                 worker_sender_kernel_id,
                 worker_reduce_kernel_id,
+                optional_line_start_ccl_send_kernel,
                 topology_config,
-                op_config,
                 worker_arg_builder,
                 cw_per_link_edm_builders,
                 ccw_per_link_edm_builders,
                 edm_interface_addresses,
-                worker_cores.at(global_worker_index),
-                num_edm_channels,
-                link,
-                ring_size,
-                worker,
-                reduce_op,
-                is_worker_in_clockwise_direction_fn);
+                all_worker_attributes.at(global_worker_index),
+                num_edm_channels_per_link,
+                num_buffers_per_channel,
+                reduce_op);
 
             TT_FATAL(is_cb_buffering_sufficient_to_avoid_deadlock(
-                worker_slice,
-                cb_num_pages,
-                cb_num_pages,
-                cb_num_pages,
-                cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes(),
-                op_config.get_page_size()), "Error");
+                    topology,
+                    worker_slice,
+                    cb_num_pages,
+                    cb_num_pages,
+                    cb_num_pages,
+                    edm_buffer_size_bytes,
+                    op_config.get_page_size()), "Internal error: reduce scatter implementation generated a program that will deadlock due to insufficient buffering based on the tensor slice sizes the op chose to use.");
         }
     }
 
@@ -933,7 +843,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
         receiver_device_id,
         sender_device_id);
 
-    uint32_t total_num_workers = worker_cores.size();
+    std::size_t total_num_workers = worker_cores.size();
     auto override_runtime_arguments_callback =
         [topology_config, worker_receiver_kernel_id, worker_sender_kernel_id, worker_cores, total_num_workers, ring_index](
             const void* operation,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
@@ -21,8 +21,9 @@ using ttnn::ccl::WorkerXY;
 using tt::tt_metal::TensorMemoryLayout;
 
 struct reduce_scatter_reader_common_args_t {
-    reduce_scatter_reader_common_args_t(uint32_t& arg_idx, DataFormat in0_df) :
-        src_addr(get_arg_val<uint32_t>(arg_idx++)),
+    reduce_scatter_reader_common_args_t(std::size_t& arg_idx, DataFormat in0_df) :
+        input_tensor_addr(get_arg_val<uint32_t>(arg_idx++)),
+        output_tensor_addr(get_arg_val<uint32_t>(arg_idx++)),
         num_transfers(get_arg_val<uint32_t>(arg_idx++)),
         full_chunk_num_pages(get_arg_val<uint32_t>(arg_idx++)),
         page_size(get_arg_val<uint32_t>(arg_idx++)),
@@ -44,15 +45,17 @@ struct reduce_scatter_reader_common_args_t {
         worker_slice_shape(ttnn::ccl::coord_from_args(arg_idx)),
         worker_slice_offset(ttnn::ccl::coord_from_args(arg_idx)),
         total_eltwise_kernel_num_pages(get_arg_val<uint32_t>(arg_idx++)),
+        requires_last_input_from_other_sender(get_arg_val<uint32_t>(arg_idx++)),
         in0_df(in0_df)
-         {
+        {
         ASSERT(full_chunk_num_pages > 0);
         ASSERT(page_size > 0);
         ASSERT(ring_size > 0);
         ASSERT(half_cb_n_pages > 0);
     }
 
-    const uint32_t src_addr;
+    const uint32_t input_tensor_addr;
+    const uint32_t output_tensor_addr;
     const uint32_t num_transfers;
     const uint32_t full_chunk_num_pages;
     const uint32_t page_size;
@@ -74,6 +77,7 @@ struct reduce_scatter_reader_common_args_t {
     coord_t worker_slice_shape;
     coord_t worker_slice_offset;
     uint32_t total_eltwise_kernel_num_pages;
+    bool requires_last_input_from_other_sender;
     DataFormat in0_df;
 };
 #ifdef ROW_MAJOR_LAYOUT
@@ -98,20 +102,42 @@ constexpr bool is_sharded = get_compile_time_arg_val(0) == 1;
 
 // Currently meaningless when `is_sharded=true`
 constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
-constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(2);
 static constexpr tt::tt_metal::TensorMemoryLayout input_tensor_memory_layout =
-    static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(3));
+    static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(2));
 
+constexpr bool dest_is_dram = get_compile_time_arg_val(3) == 1;
+static constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout =
+    static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(4));
+
+constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(5);
+/*
+ * Readback accumulation is a mode that may be enabled for line reductions. This
+ * option tells the worker that it must perform a second pass of the data and
+ * and emit to the output tensor again:
+ * The first pass would be a partial accumulated for a given direction (in a line reduce-scatter)
+ * and the second one would be to accumulate that  b
+ */
+constexpr bool is_line_reduce_scatter = get_compile_time_arg_val(6) != 0;
 // TODO: clean this up
 #ifdef SHARDED_MEM_LAYOUT
 static constexpr bool is_sharded_mode = true;
-static constexpr uint32_t input_tensor_shard_grid_height = get_compile_time_arg_val(4);
-static constexpr uint32_t input_tensor_shard_grid_width = get_compile_time_arg_val(5);
-static constexpr uint32_t input_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(6);
-static constexpr uint32_t input_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(7);
-static constexpr uint32_t input_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(8);
-static constexpr uint32_t input_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(9);
-static constexpr bool input_tensor_shard_grid_transposed = get_compile_time_arg_val(10) != 0;
+static constexpr uint32_t input_tensor_shard_grid_height = get_compile_time_arg_val(7);
+static constexpr uint32_t input_tensor_shard_grid_width = get_compile_time_arg_val(8);
+static constexpr uint32_t input_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(9);
+static constexpr uint32_t input_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(10);
+static constexpr uint32_t input_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(11);
+static constexpr uint32_t input_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(12);
+static constexpr bool input_tensor_shard_grid_transposed = get_compile_time_arg_val(13) != 0;
+
+
+static constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(14);
+static constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(15);
+static constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(16);
+static constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(17);
+static constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(18);
+static constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(19);
+static constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(20) != 0;
+
 #else
 static constexpr bool is_sharded_mode = false;
 static constexpr uint32_t input_tensor_shard_grid_height = 0;
@@ -121,21 +147,30 @@ static constexpr uint32_t input_tensor_shard_grid_start_x_logical = 0;
 static constexpr uint32_t input_tensor_shard_pages_per_shard_y = 0;
 static constexpr uint32_t input_tensor_shard_pages_per_shard_x = 0;
 static constexpr bool input_tensor_shard_grid_transposed = 0;
+
+static constexpr uint32_t output_tensor_shard_grid_height = 0;
+static constexpr uint32_t output_tensor_shard_grid_width = 0;
+static constexpr uint32_t output_tensor_shard_grid_start_y_logical = 0;
+static constexpr uint32_t output_tensor_shard_grid_start_x_logical = 0;
+static constexpr uint32_t output_tensor_shard_pages_per_shard_y = 0;
+static constexpr uint32_t output_tensor_shard_pages_per_shard_x = 0;
+static constexpr bool output_tensor_shard_grid_transposed = 0;
 #endif
 
 
-template <tt::tt_metal::TensorMemoryLayout input_tensor_memory_layout, bool src_is_dram>
-auto build_source_address_generator(uint32_t &arg_idx, reduce_scatter_reader_common_args_t const& args) -> typename source_tensor_addrgen<input_tensor_memory_layout, src_is_dram>::type {
-    if constexpr (input_tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
+
+template <tt::tt_metal::TensorMemoryLayout tensor_memory_layout, bool tensor_is_dram>
+auto build_source_address_generator(std::size_t &arg_idx, reduce_scatter_reader_common_args_t const& args, uint32_t tensor_base_addr) -> typename source_tensor_addrgen<input_tensor_memory_layout, src_is_dram>::type {
+    if constexpr (tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
         if constexpr (row_major_layout) {
-            return typename source_tensor_addrgen<input_tensor_memory_layout, src_is_dram>::type{args.src_addr, args.page_size};
+            return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type{tensor_base_addr, args.page_size};
         } else {
-            return typename source_tensor_addrgen<input_tensor_memory_layout, src_is_dram>::type{args.src_addr, args.page_size, args.in0_df};
+            return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type{tensor_base_addr, args.page_size, args.in0_df};
         }
     } else if constexpr (
-        input_tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
-        input_tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
-        input_tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+        tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
+        tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
         ASSERT(is_sharded_mode);
         uint32_t input_shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t* const input_shard_grid_row_map =
@@ -146,10 +181,10 @@ auto build_source_address_generator(uint32_t &arg_idx, reduce_scatter_reader_com
             reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
         arg_idx += input_shard_grid_ncols;
 
-        return typename source_tensor_addrgen<input_tensor_memory_layout, src_is_dram>::type(
+        return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type(
             tt::tt_metal::address_generators::HarvestedWormholeWorkerToNocLookup(
                 input_shard_grid_nrows, input_shard_grid_row_map, input_shard_grid_ncols, input_shard_grid_col_map),
-            typename tt::tt_metal::address_generators::DeviceShardSpecTypeGetter<input_tensor_memory_layout>::type(
+            typename tt::tt_metal::address_generators::DeviceShardSpecTypeGetter<tensor_memory_layout>::type(
                 input_tensor_shard_pages_per_shard_y,
                 input_tensor_shard_pages_per_shard_x,
                 input_tensor_shard_grid_height,
@@ -158,7 +193,7 @@ auto build_source_address_generator(uint32_t &arg_idx, reduce_scatter_reader_com
                 input_tensor_shard_grid_start_x_logical,
                 input_tensor_shard_grid_transposed),
             args.page_size,
-            args.src_addr);
+            tensor_base_addr);
     } else {
         ASSERT(false);
     }
@@ -209,19 +244,42 @@ advance_to_next_transfer_slice_result_t advance_to_next_transfer_slice(
     }
 }
 
+template <bool connected_to_producer>
+struct signal_receiver {
+    bool requires_last_input_from_other_sender;
+    volatile uint32_t * noc_semaphore_address;
+
+    FORCE_INLINE static signal_receiver build(bool requires_last_input_from_other_sender, std::size_t &arg_idx) {
+        if constexpr (connected_to_producer) {
+            return {requires_last_input_from_other_sender, reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)))};
+        } else {
+            return {requires_last_input_from_other_sender, 0};
+        }
+    }
+
+    FORCE_INLINE void wait_min(uint32_t count) const {
+        if constexpr (connected_to_producer) {
+            if (requires_last_input_from_other_sender) {
+                noc_semaphore_wait_min(noc_semaphore_address, count);
+            }
+        }
+    }
+};
+
+
 void kernel_main() {
-
-
-    uint32_t arg_idx = 0;
+    std::size_t arg_idx = 0;
 
     constexpr uint32_t to_dm_sender_short_circuit_cb = tt::CB::c_out1;
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
     constexpr uint32_t cb_id_in1 = tt::CB::c_in1;
     auto args = reduce_scatter_reader_common_args_t(arg_idx, get_dataformat(cb_id_in0));
+    auto output_partial_signal_ready_receiver = signal_receiver<is_line_reduce_scatter>::build(args.requires_last_input_from_other_sender, arg_idx);
 
-    auto s = build_source_address_generator<input_tensor_memory_layout, src_is_dram>(arg_idx, args);
+    auto s = build_source_address_generator<input_tensor_memory_layout, src_is_dram>(arg_idx, args, args.input_tensor_addr);
 
-    ASSERT(args.half_cb_n_pages >= args.full_chunk_num_pages);
+    auto d = build_source_address_generator<output_tensor_memory_layout, dest_is_dram>(arg_idx, args, args.output_tensor_addr);
+
 
     bool width_sliced = args.tensor_slice_shape.x <= args.input_tensor_shape.x;
 
@@ -236,7 +294,6 @@ void kernel_main() {
         args.edm_core_buffer_address,
         num_buffers_per_channel,
         args.edm_core_semaphore_address,
-        // (num_full_chunks > 0 ? args.full_chunk_num_pages : rem_num_pages) * args.page_size,
         args.full_chunk_num_pages * args.page_size,
         receiver_read_semaphore_addr_ptr);
 
@@ -244,6 +301,7 @@ void kernel_main() {
     // of the output data movement kernel - short-circuiting past the (reducer) math kernel
     // For tile => shape in tiles
     // For RM => shape in elements
+    std::size_t n_reads = 1;
     uint32_t start_ring_index = args.my_ring_idx;
     while (args.worker_slice_offset.x < args.tensor_slice_shape.x &&
            args.worker_slice_offset.y < args.tensor_slice_shape.y) {
@@ -264,6 +322,10 @@ void kernel_main() {
         const uint32_t starting_tile_id = curr_ring_slice_start_page_offset + worker_relative_start_offset_into_slice;
         uint32_t curr_tile_id = starting_tile_id;
 
+        const uint32_t worker_relative_start_offset_into_output_slice =
+            args.worker_slice_offset.x + (args.worker_slice_offset.y * args.tensor_slice_shape.x);
+        uint32_t output_curr_tile_id = worker_relative_start_offset_into_output_slice;
+
 
         // Set the valid_worker_slice_shape
         coord_t valid_worker_slice_shape = args.worker_slice_shape;
@@ -278,10 +340,16 @@ void kernel_main() {
         ASSERT(
             (args.num_transfers - 1) * worker_slice_n_pages + total_cb_pages_pushed_to_math <=
             args.total_eltwise_kernel_num_pages);
-        {
+
+        if constexpr (!is_line_reduce_scatter) {
+            // is_line_reduce_scatter enabled for linear only. In linear topology reduce scatter,
+            // only the first chip in the line will forward and input without producing a partial reduction
+            // output. Therefore we don't do this short-circuit when that mode is enabled
             uint32_t offset_into_worker_slice = 0;
             for (uint32_t p = 0; p < worker_slice_n_pages; p += args.full_chunk_num_pages) {
+
                 uint32_t n_pages = std::min(args.full_chunk_num_pages, worker_slice_n_pages - p);
+                ASSERT(args.half_cb_n_pages >= n_pages);
                 ASSERT(!last_page_of_worker);
                 read_wrapped_chunk_from_output_tensor(
                     curr_tile_id,
@@ -323,31 +391,68 @@ void kernel_main() {
 
             for (uint32_t p = 0; p < worker_slice_n_pages; p += args.full_chunk_num_pages) {
                 uint32_t n_pages = std::min(args.full_chunk_num_pages, worker_slice_n_pages - p);
+                ASSERT(args.half_cb_n_pages >= n_pages);
                 ASSERT(n_pages > 0);
                 // Fetch from input tensor
 
-                read_wrapped_chunk_from_output_tensor(
-                    curr_tile_id,
-                    offset_into_worker_slice,
-                    args.worker_slice_offset, // Offset into tensor slice
-                    valid_worker_slice_shape,
-                    // In tiles for tile layout
-                    args.input_tensor_shape,
-                    args.tensor_slice_shape,
-                    cb_id_in1,
-                    s,
-                    n_pages,
-                    args.page_size,
-                    last_page_of_worker);
+                // POTENTIALLY CONFUSING SEQUENCE AHEAD
+                // Please note that we are NOT reading from the tensor twice. We just distinguish between the case
+                // where our input is dependent on the other line direction and when it is not. In the former case,
+                // we are waiting for the other direction to complete its output, which typically will be equidistant
+                // from the very first read - in other words, we are likely to be waiting for a little bit of time.
+                // During that time, we may as well try reading from EDM first, as it is likely to be ready sooner.
+                bool read_from_output_tensor = is_line_reduce_scatter && last_transfer && output_partial_signal_ready_receiver.requires_last_input_from_other_sender;
+                if (!read_from_output_tensor) {
+                    read_wrapped_chunk_from_output_tensor(
+                        curr_tile_id,
+                        offset_into_worker_slice,
+                        args.worker_slice_offset, // Offset into tensor slice
+                        valid_worker_slice_shape,
+                        // In tiles for tile layout
+                        args.input_tensor_shape,
+                        args.tensor_slice_shape,
+                        cb_id_in1,
+                        s,
+                        n_pages,
+                        args.page_size,
+                        last_page_of_worker);
+                }
 
                 // Fetch from EDM
                 bool last_worker_message_to_edm = last_transfer && last_slice_of_worker && (p + n_pages >= worker_slice_n_pages);
-
                 reader.wait_for_payload_available();
                 reader.fetch_payload_blocking(cb_id_in0, n_pages, args.page_size, last_worker_message_to_edm);
 
+                if (read_from_output_tensor) {
+                    // The last transfer for the reader, when in line reduce-scatter mode
+                    // (i.e. when `is_line_reduce_scatter` is true), must fetch its
+                    // local tensor input from the output tensor because the other direction
+                    // of the line was designated be the first writer (of its partial result)
+                    // to the output tensor while this kernel instance was designated to be the
+                    // final accumulator
+                    if (output_partial_signal_ready_receiver.requires_last_input_from_other_sender) {
+                        output_partial_signal_ready_receiver.wait_min(n_reads++);
+                    }
+
+                    read_wrapped_chunk_from_output_tensor(
+                        output_curr_tile_id,//curr_tile_id,
+                        offset_into_worker_slice,
+                        args.worker_slice_offset, // Offset into tensor slice
+                        valid_worker_slice_shape,
+                        // In tiles for tile layout
+                        args.tensor_slice_shape, // output tensor shape
+                        args.tensor_slice_shape,
+                        cb_id_in1,
+                        d,
+                        n_pages,
+                        args.page_size,
+                        last_page_of_worker);
+                }
+
+
                 total_cb_pages_pushed_to_math += n_pages;
                 total_cb_pages_pushed += n_pages;
+
 
                 if (n_pages < args.half_cb_n_pages) {
                     uint32_t num_filler_pages = args.half_cb_n_pages - n_pages;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -22,6 +22,8 @@ void ReduceScatter::validate(const std::vector<Tensor>& input_tensors) const {
         TT_FATAL(
             t.get_legacy_shape()[this->scatter_dim] % this->ring_size == 0,
             "Reduce scatter input tensor shape on dim {} must be divisible by ring size", this->scatter_dim);
+
+        TT_FATAL(this->topology != ccl::Topology::Linear || !t.is_sharded(), "Sharded tensors are not supported for reduce scatter on a linear topology");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -3,14 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp"
-#include <cstdint>
-
-#include "ttnn/operations/reduction/generic/device/common.hpp"
-#include "ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "tt_metal/host_api.hpp"
 
-#include "ttnn/operations/eltwise/binary/binary.hpp"
-
+#include <cstdint>
 
 namespace ttnn {
 
@@ -29,7 +24,7 @@ void ReduceScatter::validate(const std::vector<Tensor>& input_tensors) const {
 
 std::vector<tt::tt_metal::LegacyShape> ReduceScatter::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     auto shape = input_tensors[0].get_legacy_shape();
-    TT_ASSERT(
+    TT_FATAL(
         shape[this->scatter_dim] % this->ring_size == 0,
         "The size of the scatter dimension must be a multiple of the ring size");
     shape[this->scatter_dim] /= this->ring_size;
@@ -91,7 +86,7 @@ Tensor reduce_scatter(
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            TT_ASSERT(input_tensors.size() >= 1, "Reduce scatter op expects an input tensor");
+            TT_FATAL(input_tensors.size() >= 1, "Reduce scatter op expects an input tensor but it received none");
             bool is_linear = topology == ttnn::ccl::Topology::Linear;
 
             const auto& input_tensor = input_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp"
+#include <cstdint>
 
 #include "ttnn/operations/reduction/generic/device/common.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp"
@@ -75,10 +76,10 @@ Tensor reduce_scatter(
     ttnn::operations::reduction::ReduceType math_op,
     const uint32_t num_links,
     const MemoryConfig& output_mem_config,
+    ttnn::ccl::Topology topology,
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel) {
     ttnn::operations::binary::BinaryOpType binary_op_type = convert_reduce_type_to_eltwise_type(math_op);
-    const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring;
     TT_FATAL(std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "This op is only supported for Fast Dispatch");
 
     auto devices = input_tensor.get_workers();
@@ -88,8 +89,8 @@ Tensor reduce_scatter(
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-
-            bool is_ring = topology ==ttnn::ccl::Topology::Ring;
+            TT_ASSERT(input_tensors.size() >= 1, "Reduce scatter op expects an input tensor");
+            bool is_linear = topology == ttnn::ccl::Topology::Linear;
 
             const auto& input_tensor = input_tensors.at(0);
             uint32_t num_devices = devices.size();
@@ -98,11 +99,16 @@ Tensor reduce_scatter(
             std::optional<chip_id_t> sender_device_id = std::nullopt; // Initialize sender device ID
             for (uint32_t i = 0; i < num_devices; ++i) {
                 if (devices.at(i) == input_tensor.device()) {
-                    bool is_last_chip_in_clockwise_direction = is_ring ? false : i == (input_tensors.size() - 1);
-                    bool is_last_chip_in_counter_clockwise_direction = is_ring ? false : i == 0;
+
+                    bool is_last_chip_in_clockwise_direction = is_linear && i == (num_devices - 1);
+                    bool is_last_chip_in_counter_clockwise_direction = is_linear && i == 0;
                     device_index = i;
-                    receiver_device_id = devices.at((i + 1) % num_devices)->id(); // Next device in the ring
-                    sender_device_id = devices.at((i + num_devices - 1) % num_devices)->id(); // Previous device in the ring
+                    receiver_device_id = is_last_chip_in_clockwise_direction ?
+                        std::nullopt :
+                        std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
+                    sender_device_id = is_last_chip_in_counter_clockwise_direction ?
+                        std::nullopt :
+                        std::optional<chip_id_t>(devices.at((i + num_devices - 1) % num_devices)->id());
                     break;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -60,7 +60,6 @@ namespace ccl{
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
     const std::optional<size_t> user_defined_num_workers = std::nullopt,
     const std::optional<size_t> user_defined_num_buffers_per_channel = std::nullopt);
-    // const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring);
 } // namespace ccl
 } // namespace operations
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -57,8 +57,10 @@ namespace ccl{
     ttnn::operations::reduction::ReduceType reduce_op = ttnn::operations::reduction::ReduceType::Sum,
     const uint32_t num_links = 1,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
     const std::optional<size_t> user_defined_num_workers = std::nullopt,
     const std::optional<size_t> user_defined_num_buffers_per_channel = std::nullopt);
+    // const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring);
 } // namespace ccl
 } // namespace operations
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp"
+// #include "ttnn/tensor/tensor.hpp"
+#include "tt_metal/common/base.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp"
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace ttnn {
+namespace ccl {
+
+
+namespace reduce_scatter_detail {
+
+WorkerTransferInfo::WorkerTransferInfo(
+    std::vector<uint32_t> pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers) :
+    pages_per_full_chunk_per_worker(pages_per_full_chunk_per_worker),
+    num_links(num_links),
+    num_workers(num_workers) {}
+
+uint32_t WorkerTransferInfo::get_num_pages_per_full_chunk(WorkerAttributes const& worker_attrs) const {
+    std::size_t index = worker_attrs.link * num_workers + worker_attrs.channel;
+    TT_ASSERT(index < pages_per_full_chunk_per_worker.size(), "Index {} out of bounds for pages_per_full_chunk_per_worker of size {}", index, pages_per_full_chunk_per_worker.size());
+    return pages_per_full_chunk_per_worker.at(index);
+}
+
+std::size_t get_global_worker_id(std::size_t link, std::size_t channel_id, std::size_t num_channels_per_link) {
+    return link * num_channels_per_link + channel_id;
+}
+std::size_t get_global_worker_id(WorkerAttributes const& attrs, std::size_t num_channels_per_link) {
+    return get_global_worker_id(attrs.link, attrs.channel, num_channels_per_link);
+}
+
+
+std::size_t get_worker_index_in_slice(ttnn::ccl::RingTopology const& tc, std::size_t global_worker_index, std::size_t worker_channel_id, std::size_t num_edm_channels_per_link, std::size_t link) {
+    std::size_t worker_tensor_slice_index = !tc.is_linear ?
+        global_worker_index :
+        (worker_channel_id % (num_edm_channels_per_link / 2)) + ((num_edm_channels_per_link / 2) * link);
+    return worker_tensor_slice_index;
+}
+
+/*
+ * For each live worker on this chip, we specify explicitly details for it:
+ * - which direction datapath it is in
+ * - its location
+ * - its associated worker (if it is a linear topology)
+ * - its relative worker index
+ */
+std::vector<WorkerAttributes> build_worker_attributes(
+    ttnn::ccl::RingTopology const& topology_config,
+    std::vector<CoreCoord> const& worker_cores_list,
+    std::optional<std::vector<CoreCoord>> const& second_worker_cores_list,
+
+    uint32_t worker_sender_semaphore_id,
+    uint32_t worker_receiver_semaphore_id,
+    std::optional<uint32_t> worker_sender_semaphore_id_second_core_range,
+    std::optional<uint32_t> worker_receiver_semaphore_id_second_core_range,
+
+    std::size_t num_links,
+    std::size_t num_channels_per_link,
+    std::function<bool(std::size_t)> is_buffer_in_clockwise_direction_fn) {
+
+    std::vector<WorkerAttributes> worker_attributes;
+
+    std::size_t workers_per_slice = num_channels_per_link / (topology_config.is_linear ? 2 : 1);
+
+    std::size_t worker_cores_idx = 0;
+    std::size_t second_worker_cores_idx = 0;
+
+    bool split_grids = second_worker_cores_list.has_value();
+    auto const first_workers_list = split_grids && topology_config.ring_index == 0 ?
+        second_worker_cores_list.value():
+        worker_cores_list;
+    auto const first_send_to_edm_sem_id = split_grids && topology_config.ring_index == 0 ?
+        worker_sender_semaphore_id_second_core_range :
+        worker_sender_semaphore_id;
+    auto const first_read_from_edm_sem_id = split_grids && topology_config.ring_index == 0 ?
+        worker_receiver_semaphore_id_second_core_range :
+        worker_receiver_semaphore_id;
+
+    std::optional<std::vector<CoreCoord>> second_workers_list =
+        !topology_config.is_linear || !split_grids || (split_grids && topology_config.ring_index == 0) ?
+            worker_cores_list :
+            second_worker_cores_list.value();
+    auto const second_send_to_edm_sem_id = !topology_config.is_linear || !split_grids || (split_grids && topology_config.ring_index == 0) ?
+        worker_sender_semaphore_id :
+        worker_sender_semaphore_id_second_core_range;
+    auto const second_read_from_edm_sem_id = !topology_config.is_linear || !split_grids || (split_grids && topology_config.ring_index == 0) ?
+        worker_receiver_semaphore_id :
+        worker_receiver_semaphore_id_second_core_range;
+
+    for (std::size_t l = 0; l < num_links; l++) {
+        for (std::size_t i = 0; i < workers_per_slice; i++) {
+            auto worker_id = get_global_worker_id(l, i, num_channels_per_link);
+            TT_ASSERT(worker_cores_idx < worker_cores_list.size());
+
+            worker_attributes.push_back(
+                {
+                    l,
+                    i,
+                    i,
+                    is_buffer_in_clockwise_direction_fn(worker_id) ? Direction::CLOCKWISE : Direction::COUNTER_CLOCKWISE,
+                    first_workers_list[worker_cores_idx],
+                    first_send_to_edm_sem_id,
+                    first_read_from_edm_sem_id
+                }
+            );
+            log_trace(tt::LogOp, "Worker {} direction= {}", i, worker_attributes.back().direction == Direction::CLOCKWISE ? "CLOCKWISE" : "COUNTER-CLOCKWISE");
+            worker_cores_idx++;
+        }
+        if (topology_config.is_linear) {
+            auto & second_vec_index = split_grids ? second_worker_cores_idx : worker_cores_idx;
+            for (std::size_t i = 0; i < workers_per_slice; i++) {
+                TT_ASSERT(second_vec_index < second_workers_list.value().size());
+                std::size_t my_logical_index = workers_per_slice + i;
+                std::size_t my_idx = worker_attributes.size();
+                worker_attributes.push_back(
+                    {
+                        l,
+                        my_logical_index,
+                        i,
+                        is_buffer_in_clockwise_direction_fn(my_logical_index) ?
+                            Direction::CLOCKWISE : Direction::COUNTER_CLOCKWISE,
+                        second_workers_list.value()[second_vec_index],
+                        second_send_to_edm_sem_id,
+                        second_read_from_edm_sem_id
+                    }
+                );
+                log_trace(tt::LogOp, "Worker {} direction= {}", my_logical_index, worker_attributes.back().direction == Direction::CLOCKWISE ? "CLOCKWISE" : "COUNTER-CLOCKWISE");
+                std::size_t associated_idx = my_idx - workers_per_slice;
+                worker_attributes[my_idx].associated_worker_index = associated_idx;
+                worker_attributes[my_idx].associated_worker_core_logical = worker_attributes[associated_idx].location_logical;
+                worker_attributes[associated_idx].associated_worker_index = my_idx;
+                worker_attributes[associated_idx].associated_worker_core_logical = worker_attributes[my_idx].location_logical;
+                second_vec_index++;
+            }
+        }
+    }
+
+    // Validate the worker attributes
+    for (const auto &wa : worker_attributes) {
+        TT_ASSERT(wa.send_to_edm_semaphore_id.has_value() || wa.receive_from_edm_semaphore_id.has_value(), "Internal error. Incorrectly setup worker attributes for reduce scatter");
+    }
+
+    // Log worker attributes
+    log_trace(tt::LogOp, "Worker Attributes:");
+    for (const auto &wa : worker_attributes) {
+        log_trace(tt::LogOp, "\tAttributes: link={}, index={}, core_logical=(x={},y={}), direction={}, associated_core=(x={},y={}), associated_index={}",
+            wa.link,
+            wa.channel,
+            wa.location_logical.x,
+            wa.location_logical.y,
+            wa.direction == Direction::CLOCKWISE ? "CLOCKWISE": "COUNTER-CLOCKWISE",
+            wa.associated_worker_core_logical.has_value() ? std::to_string(wa.associated_worker_core_logical.value().x) : "std::nullopt",
+            wa.associated_worker_core_logical.has_value() ? std::to_string(wa.associated_worker_core_logical.value().y) : "std::nullopt",
+            wa.associated_worker_index.has_value() ? std::to_string(wa.associated_worker_index.value()) : "std::nullopt"
+            );
+
+    }
+
+    TT_ASSERT(!topology_config.is_linear || std::ranges::all_of(worker_attributes, [](auto const& wa) { return wa.associated_worker_index.has_value() && wa.associated_worker_core_logical.has_value(); }));
+
+    return worker_attributes;
+}
+
+} // namespace reduce_scatter_detail
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
@@ -4,7 +4,6 @@
 
 
 #include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp"
-// #include "ttnn/tensor/tensor.hpp"
 #include "tt_metal/common/base.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp"
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
@@ -4,7 +4,7 @@
 
 
 #include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp"
-#include "tt_metal/common/base.hpp"
+// #include "tt_metal/common/base.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp"
 
 #include <cstdint>
@@ -18,7 +18,7 @@ namespace ccl {
 namespace reduce_scatter_detail {
 
 WorkerTransferInfo::WorkerTransferInfo(
-    std::vector<uint32_t> pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers) :
+    std::vector<uint32_t> const& pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers) :
     pages_per_full_chunk_per_worker(pages_per_full_chunk_per_worker),
     num_links(num_links),
     num_workers(num_workers) {}

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "common/core_coord.h"
+
+#include <cstdint>
+#include <vector>
+#include <optional>
+
+namespace ttnn {
+namespace ccl {
+
+class RingTopology;
+
+namespace reduce_scatter_detail {
+
+enum class Direction {
+    CLOCKWISE = 0,
+    RIGHT = 0,
+
+    COUNTER_CLOCKWISE = 1,
+    LEFT = 1,
+
+    UNASSIGNED
+};
+
+static_assert(Direction::CLOCKWISE == Direction::RIGHT, "Direction::CLOCKWISE == Direction::RIGHT not equal but expected to be for current design");
+static_assert(Direction::COUNTER_CLOCKWISE == Direction::LEFT, "Direction::COUNTER_CLOCKWISE == Direction::LEFT not equal but expected to be for current design");
+
+/*
+ * Contains various attributes about a given worker
+ */
+struct WorkerAttributes {
+    std::size_t link = std::numeric_limits<std::size_t>::max();
+    std::size_t channel = std::numeric_limits<std::size_t>::max();
+
+    // Workers cooperate to process the data in a given slice. This represents the index in that
+    // list of workers. Note that for line reduce scatter, we may have n workers but only n/2 of
+    // them will cooperate for a given slice (half will work on slices from one direction and the
+    // other half for the other direction)
+    std::size_t index_in_slice = std::numeric_limits<std::size_t>::max();
+    Direction direction = Direction::UNASSIGNED;
+    CoreCoord location_logical = {std::numeric_limits<std::size_t>::max(), std::numeric_limits<std::size_t>::max()};
+    std::optional<uint32_t> send_to_edm_semaphore_id = std::nullopt;
+    std::optional<uint32_t> receive_from_edm_semaphore_id = std::nullopt;
+    std::optional<std::size_t> associated_worker_index = std::nullopt;
+    std::optional<CoreCoord> associated_worker_core_logical = std::nullopt;
+};
+
+struct WorkerTransferInfo {
+    WorkerTransferInfo(
+        std::vector<uint32_t> pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers);
+
+    uint32_t get_num_pages_per_full_chunk(WorkerAttributes const& worker_attrs) const;
+
+    std::vector<uint32_t> pages_per_full_chunk_per_worker;
+    uint32_t num_links;
+    uint32_t num_workers;
+};
+
+std::size_t get_global_worker_id(std::size_t link, std::size_t channel_id, std::size_t num_channels_per_link);
+std::size_t get_global_worker_id(WorkerAttributes const& attrs, std::size_t num_channels_per_link);
+std::size_t get_worker_index_in_slice(ttnn::ccl::RingTopology const& tc, std::size_t global_worker_index, std::size_t worker_channel_id, std::size_t num_edm_channels_per_link, std::size_t link);
+
+std::vector<WorkerAttributes> build_worker_attributes(
+    ttnn::ccl::RingTopology const& topology_config,
+    std::vector<CoreCoord> const& worker_cores_list,
+    std::optional<std::vector<CoreCoord>> const& second_worker_cores_list,
+
+    uint32_t worker_sender_semaphore_id,
+    uint32_t worker_receiver_semaphore_id,
+    std::optional<uint32_t> worker_sender_semaphore_id_second_core_range,
+    std::optional<uint32_t> worker_receiver_semaphore_id_second_core_range,
+
+    std::size_t num_links,
+    std::size_t num_channels_per_link,
+    std::function<bool(std::size_t)> is_buffer_in_clockwise_direction_fn);
+
+} // namespace reduce_scatter_detail
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp
@@ -52,7 +52,7 @@ struct WorkerAttributes {
 
 struct WorkerTransferInfo {
     WorkerTransferInfo(
-        std::vector<uint32_t> pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers);
+        std::vector<uint32_t> const& pages_per_full_chunk_per_worker, uint32_t num_links, uint32_t num_workers);
 
     uint32_t get_num_pages_per_full_chunk(WorkerAttributes const& worker_attrs) const;
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -45,7 +45,6 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_reduce_op_kernel_c
     return {};
 }
 
-// TODO: expose for testing
 static bool worker_writer_must_send_sync_signal_to_other_line_direction(WorkerAttributes const& wa, ttnn::ccl::RingTopology const& tc) {
     // Doesn't actually matter which direction is the one waiting because it will be the same number of prior slices to forward
     // from either direction before reach the each (however, in practice, there may be slight differences that lead us to prefer
@@ -600,7 +599,6 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_line_start_sender_
     for (auto const& arg : edm_interface_args) {
         log_trace(tt::LogOp, "ccl_send arg[{}]: edm_interface_args[] {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
     }
-    // ttnn::ccl::log_runtime_args(edm_interface, "edm_interface");
 
     std::ranges::copy(std::vector<uint32_t>{this->worker_transfer_info.get_num_pages_per_full_chunk(worker_attrs)}, std::back_inserter(args));
     log_trace(tt::LogOp, "ccl_send arg[{}]: pages_per_packet {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include <iterator>
-#include <ranges>
 
 #include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp"
 #include "hostdevcommon/kernel_structs.h"

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -1,0 +1,644 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <iterator>
+#include <ranges>
+
+#include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp"
+#include "hostdevcommon/kernel_structs.h"
+#include "ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_command.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+
+namespace ttnn {
+namespace ccl {
+namespace reduce_scatter_detail {
+
+ReduceScatterWorkerArgBuilder::ReduceScatterWorkerArgBuilder (
+    Device const* device,
+    ttnn::ccl::CCLOpConfig const& op_config,
+    ttnn::ccl::RingTopology const& topology_config,
+    ttnn::ccl::InterleavedTensorWorkerSlice const& worker_input_slice,
+    WorkerTransferInfo const& worker_transfer_info,
+    ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode,
+    std::size_t scatter_dim,
+    std::size_t cb_num_pages_per_packet,
+    std::optional<uint32_t> receiver_worker_partial_ready_semaphore_id,
+    std::size_t num_buffers_per_channel
+    ) :
+    device(device),
+    op_config(op_config),
+    topology_config(topology_config),
+    worker_input_slice(worker_input_slice),
+    worker_transfer_info(worker_transfer_info),
+    edm_termination_mode(edm_termination_mode),
+    cb_num_pages_per_packet(cb_num_pages_per_packet),
+    num_buffers_per_channel(num_buffers_per_channel),
+    receiver_worker_partial_ready_semaphore_id(receiver_worker_partial_ready_semaphore_id),
+    scatter_dim(scatter_dim) {
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_reduce_op_kernel_ct_args() const {
+    log_trace(tt::LogOp, "Reduce Scatter Worker CT Args: None");
+    return {};
+}
+
+// TODO: expose for testing
+static bool worker_writer_must_send_sync_signal_to_other_line_direction(WorkerAttributes const& wa, ttnn::ccl::RingTopology const& tc) {
+    // Doesn't actually matter which direction is the one waiting because it will be the same number of prior slices to forward
+    // from either direction before reach the each (however, in practice, there may be slight differences that lead us to prefer
+    // one direction over the other)
+    bool is_in_clockwise_direction = wa.direction == Direction::CLOCKWISE;
+    return tc.is_linear && is_in_clockwise_direction;
+}
+
+static bool worker_reader_must_receive_sync_signal_from_other_line_direction(WorkerAttributes const& wa, ttnn::ccl::RingTopology const& tc) {
+    bool is_end_of_line = tc.is_last_device_in_line(wa.direction == Direction::CLOCKWISE);
+    return tc.is_linear && !worker_writer_must_send_sync_signal_to_other_line_direction(wa, tc) && !is_end_of_line;
+}
+
+static std::size_t compute_number_of_slices_to_forward_through_worker(WorkerAttributes const& wa, ttnn::ccl::RingTopology const& tc) {
+    std::size_t num_slices_to_forward_through_math = !tc.is_linear ? tc.ring_size - 1
+                                                     : (wa.direction == Direction::CLOCKWISE)
+                                                        //  ? (tc.ring_size - tc.ring_index + 1)
+                                                         ? (tc.ring_size - tc.ring_index)
+                                                         : tc.ring_index + 1;
+
+    return num_slices_to_forward_through_math;
+}
+
+std::size_t ReduceScatterWorkerArgBuilder::get_total_num_math_pages(WorkerAttributes const& wa) const {
+    // This algorithm assumes that the worker slices are sized such that they start at the same x offsets for each
+    // new row they slice into (as they stride through the tensor)
+    const std::size_t num_slice_iterations =
+        worker_input_slice.compute_num_worker_slice_iterations(worker_transfer_info.num_workers);
+    std::size_t num_slices_to_forward_through_math = compute_number_of_slices_to_forward_through_worker(wa, this->topology_config);
+
+    // We should be able to delete this by just properl;y accounting for the number of slices to forward
+
+    std::size_t worker_slice_num_pages =
+        worker_input_slice.worker_slice_shape.x * worker_input_slice.worker_slice_shape.y;
+    std::size_t pages_per_full_chunk = worker_transfer_info.get_num_pages_per_full_chunk(wa);
+    std::size_t num_filler_pages_per_slice = pages_per_full_chunk - (worker_slice_num_pages % pages_per_full_chunk);
+    const std::size_t worker_slice_num_pages_getter_val = worker_input_slice.get_worker_slice_num_pages();
+    std::size_t total_num_math_pages = (worker_slice_num_pages_getter_val + num_filler_pages_per_slice) *
+                                    num_slice_iterations * num_slices_to_forward_through_math;
+
+    log_trace(tt::LogOp, "ring_index: {}, pages_per_full_chunk: {}, num_filler_pages_per_slice: {}, worker_slice_num_pages: {}, worker_slice_num_pages_getter_val: {}, num_slice_iterations: {}, num_filler_pages_per_slice: {}, num_slices_to_forward_through_math: {}, total_num_math_pages: {}",
+        this->topology_config.ring_index,
+        pages_per_full_chunk,
+        num_filler_pages_per_slice,
+        worker_slice_num_pages,
+        worker_slice_num_pages_getter_val,
+        num_filler_pages_per_slice,
+        num_slice_iterations,
+        num_slices_to_forward_through_math,
+        total_num_math_pages);
+    return total_num_math_pages;
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_reduce_op_kernel_rt_args(
+    WorkerAttributes const& worker_attrs, std::size_t ring_size
+) const {
+    log_trace(tt::LogOp, "generate_reduce_op_kernel_rt_args");
+
+
+    uint32_t total_num_math_pages = get_total_num_math_pages(worker_attrs);
+    auto const& args = std::vector<uint32_t>{total_num_math_pages, 1, 0};
+
+    std::size_t i = 0;
+    log_trace(tt::LogOp, "Reduce Scatter Worker RT Args:");
+    log_trace(tt::LogOp, "\tblock_size: {}", args.at(i++));
+    log_trace(tt::LogOp, "\ttotal_num_math_pages: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tacc_to_dst: {}", args.at(i++));
+    TT_ASSERT(args.size() == i, "Missed some args");
+
+    return args;
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_receiver_kernel_ct_args() const {
+    auto const& local_input_tensor = this->op_config.get_input_tensor(0);
+    auto const& local_output_tensor = this->op_config.get_output_tensor(0);
+
+    auto args = std::vector<uint32_t>{
+        static_cast<uint32_t>(this->op_config.is_input_sharded() ? 1 : 0),
+        static_cast<uint32_t>(local_input_tensor.memory_config().buffer_type == BufferType::DRAM ? 1 : 0),
+        static_cast<uint32_t>(local_input_tensor.memory_config().memory_layout),
+
+        static_cast<uint32_t>(local_output_tensor.memory_config().buffer_type == BufferType::DRAM ? 1 : 0),
+        static_cast<uint32_t>(local_output_tensor.memory_config().memory_layout),
+
+        static_cast<uint32_t>(this->num_buffers_per_channel),
+        static_cast<uint32_t>(this->topology_config.is_linear)};
+
+    std::size_t i = 0;
+    log_trace(tt::LogOp, "Reduce Scatter Receiver Worker CT Args:");
+    log_trace(tt::LogOp, "\tis_sharded: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tsrc_is_dram: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tinput_tensor_memory_layout: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tdest_is_dram: {}", args.at(i++));
+    log_trace(tt::LogOp, "\toutput_tensor_memory_layout: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tnum_buffers_per_channel: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tis_linear: {}", args.at(i++));
+
+    TT_ASSERT(args.size() == i, "Missed some args");
+    if (local_input_tensor.is_sharded()) {
+        // TODO: rangeify
+        auto const& input_sharded_tensor_args = ShardedAddrGenArgBuilder::emit_ct_args(local_input_tensor);
+        std::copy(input_sharded_tensor_args.begin(), input_sharded_tensor_args.end(), std::back_inserter(args));
+        auto const& output_sharded_tensor_args = ShardedAddrGenArgBuilder::emit_ct_args(local_output_tensor);
+        std::copy(output_sharded_tensor_args.begin(), output_sharded_tensor_args.end(), std::back_inserter(args));
+
+        ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_input_tensor, "input");
+        ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_output_tensor, "output");
+    }
+
+    return args;
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_receiver_kernel_rt_args(
+    ttnn::ccl::WorkerXY const& edm_core,
+    uint32_t edm_core_semaphore_address,
+    uint32_t edm_core_buffer_address,
+    WorkerAttributes const& worker_attrs) const {
+    TT_ASSERT(edm_core_semaphore_address > 0);
+    TT_ASSERT(edm_core_buffer_address > 0);
+    auto const& local_input_tensor = this->op_config.get_input_tensor(0);
+    auto const& local_output_tensor = this->op_config.get_output_tensor(0);
+    bool is_in_clockwise_direction = worker_attrs.direction == Direction::CLOCKWISE;
+    uint32_t starting_ring_index =
+        !this->topology_config.is_linear
+            ? (is_in_clockwise_direction
+                   ? (this->topology_config.ring_index == 0 ? this->topology_config.ring_size - 1
+                                                            : this->topology_config.ring_index - 1)
+                   : (this->topology_config.ring_index == this->topology_config.ring_size - 1
+                          ? 0
+                          : this->topology_config.ring_index + 1))
+            : (is_in_clockwise_direction ? 0 : this->topology_config.ring_size - 1);
+    std::size_t line_reduce_scatter_start_transfer_offset = 1;
+    uint32_t num_transfers = !this->topology_config.is_linear
+                                 ? this->topology_config.ring_size
+                                 : is_in_clockwise_direction
+                                    ? ((this->topology_config.ring_size - this->topology_config.ring_index) + line_reduce_scatter_start_transfer_offset)
+                                    : this->topology_config.ring_index + 1 + line_reduce_scatter_start_transfer_offset;
+
+    uint32_t total_num_math_pages = get_total_num_math_pages(worker_attrs);
+    TT_ASSERT(worker_attrs.receive_from_edm_semaphore_id.has_value(), "Internal Error");
+    auto args = std::vector<uint32_t>{
+        static_cast<uint32_t>(local_input_tensor.buffer()->address()),
+        static_cast<uint32_t>(local_output_tensor.buffer()->address()),
+        static_cast<uint32_t>(num_transfers),
+        static_cast<uint32_t>(this->worker_transfer_info.get_num_pages_per_full_chunk(worker_attrs)),
+        static_cast<uint32_t>(this->op_config.get_page_size()),
+        static_cast<uint32_t>(starting_ring_index),
+        static_cast<uint32_t>(this->topology_config.ring_size),
+        static_cast<uint32_t>(worker_attrs.receive_from_edm_semaphore_id.value()),
+        static_cast<uint32_t>(is_in_clockwise_direction ? 1 : 0),
+        static_cast<uint32_t>(this->cb_num_pages_per_packet),
+        static_cast<uint32_t>(edm_core.x),
+        static_cast<uint32_t>(edm_core.y),
+        static_cast<uint32_t>(edm_core_semaphore_address),
+        static_cast<uint32_t>(edm_core_buffer_address),
+
+        static_cast<uint32_t>(worker_transfer_info.num_workers),
+
+        static_cast<uint32_t>(this->worker_input_slice.tensor_shape.x),
+        static_cast<uint32_t>(this->worker_input_slice.tensor_shape.y),
+
+        static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.x),
+        static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.y),
+
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.x),
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.y),
+
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.x),
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.y),
+
+        total_num_math_pages};
+
+    bool signal_reader_on_output_tensor_partial_writes = worker_reader_must_receive_sync_signal_from_other_line_direction(worker_attrs, this->topology_config);
+    args.push_back(static_cast<uint32_t>(signal_reader_on_output_tensor_partial_writes));
+    if (signal_reader_on_output_tensor_partial_writes) {
+        TT_ASSERT(receiver_worker_partial_ready_semaphore_id.has_value());
+        args.push_back(static_cast<uint32_t>(receiver_worker_partial_ready_semaphore_id.value()));
+    }
+
+    std::size_t i = 0;
+    log_trace(tt::LogOp, "Reduce Scatter Receiver Worker RT Args:");
+    log_trace(tt::LogOp, "\tinput_tensor_address: {}", args.at(i++));
+    log_trace(tt::LogOp, "\toutput_tensor_address: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tnum_transfers: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tfull_chunk_num_pages: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tpage_size: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tmy_ring_idx: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tring_size: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tsem_addr: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tis_clockwise_direction: {}", args.at(i++));
+    log_trace(tt::LogOp, "\thalf_cb_n_pages: {}", args.at(i++));
+
+    log_trace(tt::LogOp, "\tedm_core_noc0_core_x: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tedm_core_noc0_core_y: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tedm_core_semaphore_address: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tedm_core_buffer_address: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tnum_concurrent_workers: {}", args.at(i++));
+
+    log_trace(tt::LogOp, "\tinput_tensor_shape.x={}", args.at(i++));
+    log_trace(tt::LogOp, "\tinput_tensor_shape.y={}", args.at(i++));
+    log_trace(tt::LogOp, "\ttensor_slice_shape.x={}", args.at(i++));
+    log_trace(tt::LogOp, "\ttensor_slice_shape.y={}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_shape.x={}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_shape.y={}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_offset.x={}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_offset.y={}", args.at(i++));
+    log_trace(tt::LogOp, "\ttotal_num_math_pages={}", args.at(i++));
+    log_trace(tt::LogOp, "\tsignal_reader_on_output_tensor_partial_writes={}", args.at(i++));
+
+    if (signal_reader_on_output_tensor_partial_writes) {
+        log_trace(tt::LogOp, "\treceiver_worker_partial_ready_semaphore_id={}", args.at(i++));
+    }
+
+    TT_ASSERT(args.size() == i, "Missed some args");
+
+    if (local_input_tensor.is_sharded()) {
+        std::ranges::copy(ShardedAddrGenArgBuilder::emit_rt_args(device, local_input_tensor), std::back_inserter(args));
+        ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_input_tensor, "input");
+
+        if (this->topology_config.is_linear) {
+            std::ranges::copy(ShardedAddrGenArgBuilder::emit_rt_args(device, local_output_tensor), std::back_inserter(args));
+            ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_output_tensor, "output");
+        }
+    }
+
+    return args;
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_sender_kernel_ct_args() const {
+    auto const& local_output_tensor = this->op_config.get_output_tensor(0);
+
+    auto args = std::vector<uint32_t>{
+        static_cast<uint32_t>(
+            this->op_config.get_output_tensor(0).memory_config().buffer_type == BufferType::DRAM ? 1 : 0),
+        static_cast<uint32_t>(this->num_buffers_per_channel),
+        static_cast<uint32_t>(local_output_tensor.memory_config().memory_layout),
+        static_cast<uint32_t>(this->topology_config.is_linear)
+    };
+
+    std::size_t i = 0;
+    log_trace(tt::LogOp, "Reduce Scatter Sender Worker CT Args:");
+    log_trace(tt::LogOp, "\tdst_is_dram: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tnum_buffers_per_channel: {}", args.at(i++));
+    log_trace(tt::LogOp, "\ttensor_memory_layout: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tis_linear: {}", args.at(i++));
+    TT_ASSERT(args.size() == i, "Missed some args");
+
+    if (local_output_tensor.is_sharded()) {
+        auto const& shard_ct_args = ShardedAddrGenArgBuilder::emit_ct_args(local_output_tensor);
+        std::copy(shard_ct_args.begin(), shard_ct_args.end(), std::back_inserter(args));
+    }
+    return args;
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_sender_kernel_rt_args(
+    WorkerEdmInterfaceArgs const& edm_interface,
+    WorkerAttributes const& worker_attrs) const {
+
+    bool is_clockwise = worker_attrs.direction == Direction::CLOCKWISE;
+    // For the last device in a line reduce scatter, we don't care about EDM interface values for
+    // sender, otherwise we must have valid values
+    TT_ASSERT(topology_config.is_linear && topology_config.is_last_device_in_line(is_clockwise) || edm_interface.edm_semaphore_address > 0);
+    TT_ASSERT(topology_config.is_linear && topology_config.is_last_device_in_line(is_clockwise) || edm_interface.edm_buffer_base_address > 0);
+    auto const& local_output_tensor = this->op_config.get_output_tensor(0);
+
+    bool signal_reader_on_output_tensor_partial_writes = worker_writer_must_send_sync_signal_to_other_line_direction(worker_attrs, this->topology_config);
+
+    uint32_t total_num_math_pages = get_total_num_math_pages(worker_attrs);
+    log_trace(tt::LogOp, "reduce-scatter-sender num_math_pages: {}. ring_index: {}, direction: {}", total_num_math_pages, this->topology_config.ring_index, worker_attrs.direction == Direction::CLOCKWISE ? "CLOCKWISE" : "COUNTER-CLOCKIWSE");
+    TT_ASSERT(worker_attrs.send_to_edm_semaphore_id.has_value(), "Internal Error");
+    const std::size_t num_transfers = !this->topology_config.is_linear ? this->topology_config.ring_size - 1
+                                      : is_clockwise
+                                          ? (this->topology_config.ring_size - this->topology_config.ring_index) - 1
+                                          : this->topology_config.ring_index;
+
+    auto args = std::vector<uint32_t>{
+        static_cast<uint32_t>(local_output_tensor.buffer()->address()),
+        static_cast<uint32_t>(edm_interface.edm_buffer_base_address),
+        static_cast<uint32_t>(edm_interface.edm_semaphore_address),
+        static_cast<uint32_t>(edm_interface.edm_noc_x),
+        static_cast<uint32_t>(edm_interface.edm_noc_y),
+        static_cast<uint32_t>(num_transfers),
+
+        static_cast<uint32_t>(this->op_config.get_page_size()),
+        static_cast<uint32_t>(this->worker_transfer_info.get_num_pages_per_full_chunk(worker_attrs)),
+
+        static_cast<uint32_t>(worker_attrs.send_to_edm_semaphore_id.value()),
+        static_cast<uint32_t>(this->cb_num_pages_per_packet),
+
+        static_cast<uint32_t>(worker_transfer_info.num_workers),
+
+        // For sender side, all worker slice info is the same except for the tensor shape
+        // and for sender side specifically, there is only one tensor_slice_shape for the output
+        // tensor (as opposed to `ring_size` tensor_slice_shapes for the input tensor), so we can
+        // directly use it as the output tensor shape
+        static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.x),
+        static_cast<uint32_t>(this->worker_input_slice.tensor_slice_shape.y),
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.x),
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_shape.y),
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.x),
+        static_cast<uint32_t>(this->worker_input_slice.worker_slice_offset.y),
+
+        total_num_math_pages};
+    if (this->topology_config.is_linear) {
+        args.push_back(static_cast<uint32_t>(signal_reader_on_output_tensor_partial_writes));
+
+        if (signal_reader_on_output_tensor_partial_writes) {
+            TT_ASSERT(receiver_worker_partial_ready_semaphore_id.has_value());
+            auto associated_worker_core = worker_attrs.associated_worker_core_logical;
+            TT_ASSERT(associated_worker_core.has_value());
+            auto const& worker_core_xy = this->device->worker_core_from_logical_core(associated_worker_core.value());
+
+            args.push_back(static_cast<uint32_t>(worker_core_xy.x));
+            args.push_back(static_cast<uint32_t>(worker_core_xy.y));
+            args.push_back(static_cast<uint32_t>(receiver_worker_partial_ready_semaphore_id.value()));
+        }
+    }
+    TT_ASSERT(!(signal_reader_on_output_tensor_partial_writes && !this->topology_config.is_linear));
+
+    std::size_t i = 0;
+    log_trace(tt::LogOp, "Reduce Scatter Sender Worker RT Args (signal_reader_on_output_tensor_partial_writes={}):", signal_reader_on_output_tensor_partial_writes);
+    log_trace(tt::LogOp, "\tdst_addr: {}", args.at(i++));
+    log_trace(tt::LogOp, "\teth_sender_l1_base_addr: {}", args.at(i++));
+    log_trace(tt::LogOp, "\teth_sender_l1_sem_addr: {}", args.at(i++));
+    log_trace(tt::LogOp, "\teth_sender_noc_x: {}", args.at(i++));
+    log_trace(tt::LogOp, "\teth_sender_noc_y: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tnum_transfers: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tpage_size: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tfull_chunk_num_pages: {}", args.at(i++));
+    log_trace(tt::LogOp, "\twriter_send_sem_addr: {}", args.at(i++));
+    log_trace(tt::LogOp, "\thalf_cb_n_pages: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tnum_concurrent_workers: {}", args.at(i++));
+
+    log_trace(tt::LogOp, "\toutput_tensor_shape.x: {}", args.at(i++));
+    log_trace(tt::LogOp, "\toutput_tensor_shape.y: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_shape.x: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_shape.y: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_offset.x: {}", args.at(i++));
+    log_trace(tt::LogOp, "\tworker_slice_offset.y: {}", args.at(i++));
+
+    log_trace(tt::LogOp, "\ttotal_num_math_pages={}", args.at(i++));
+
+    if (this->topology_config.is_linear) {
+        log_trace(tt::LogOp, "\tsignal_reader_on_output_tensor_partial_writes={}", args.at(i++));
+
+        if (signal_reader_on_output_tensor_partial_writes) {
+            log_trace(tt::LogOp, "\teth_receiver_noc_x: {}", args.at(i++));
+            log_trace(tt::LogOp, "\teth_receiver_noc_y: {}", args.at(i++));
+            log_trace(tt::LogOp, "\teth_receiver_sem_addr: {}", args.at(i++));
+        }
+    }
+
+    TT_ASSERT(args.size() == i, "Missed some args");
+
+    if (local_output_tensor.is_sharded()) {
+        auto const& shard_rt_args = ShardedAddrGenArgBuilder::emit_rt_args(device, local_output_tensor);
+        std::copy(shard_rt_args.begin(), shard_rt_args.end(), std::back_inserter(args));
+
+        ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_output_tensor, "output");
+    }
+    return args;
+}
+
+
+static void convert_slices_to_ccl_commands() {
+
+}
+
+void emit_ccl_send_slice_sequence_commands(std::vector<TensorSlice> const& slices, std::vector<uint32_t>& args_out) {
+    for (std::size_t i = 0; i < slices.size(); i++) {
+        auto const& slice = slices[i];
+        // Copy the header
+        if (i == 0) {
+            const std::size_t args_index_old = args_out.size();
+            // push back Command Header
+            args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandHeader::to_uint32(
+                ttnn::ccl::cmd::CclCommandHeader{ttnn::ccl::cmd::CclCommandCode::STREAM_TENSOR_TO_EDM, 1})));
+
+            // push back arg 0 header
+            args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES));
+            auto const& ccl_command_tensor = ttnn::ccl::cmd::CclCommandTensor{
+                Shape4D<uint32_t>(1, 1, slice.tensor_shape.y, slice.tensor_shape.x),
+                Shape4D<uint32_t>(1, 1, slice.tensor_slice_shape.y, slice.tensor_slice_shape.x),
+                Shape4D<uint32_t>(0, 0, slice.tensor_slice_offset.y, slice.tensor_slice_offset.x),
+                Shape4D<uint32_t>(0, 0, slice.worker_slice_offset.y, slice.worker_slice_offset.x),
+                slice.worker_slice_shape.x * slice.worker_slice_shape.y};
+            const auto num_words_for_args = ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::size_in_words();
+            log_trace(tt::LogOp, "Emitting {} args for full tensor slice command", num_words_for_args);
+            args_out.resize(args_out.size() + num_words_for_args);
+            // push_back arg 0 payload
+            ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_FULL_TENSOR_SLICE_SPEC_IN_PAGES>::
+                pack_to(
+                    &args_out[args_out.size() - num_words_for_args],
+                    ccl_command_tensor
+                    );
+            const std::size_t args_index_new = args_out.size();
+
+            TT_ASSERT(i < slices.size(), "Internal Error");
+            std::stringstream ss; ss << "ccl_send command " << std::to_string(i) << " has " << args_index_new - args_index_old << " args:\n";
+            for (std::size_t j = args_index_old; j < args_index_new; j++) {
+                ss << "\targ " << j << ":" << args_out[j] << "\n";
+            }
+            log_trace(tt::LogOp, "{}", ss.str());
+            // We can reused cached values for the first slice
+        } else {
+            auto const& last_slice = slices[i - 1];
+            const std::size_t args_index_old = args_out.size();
+            auto header_index = args_out.size();
+            args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandHeader::to_uint32(
+                ttnn::ccl::cmd::CclCommandHeader{ttnn::ccl::cmd::CclCommandCode::STREAM_TENSOR_TO_EDM, 1})));
+            std::size_t num_args = 0;
+
+            // tensor shape
+            if (last_slice.tensor_shape != slice.tensor_shape) {
+                args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES));
+                auto num_words_for_args = ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::size_in_words();
+                log_trace(tt::LogOp, "Emitting {} args for tensor_shape field", num_words_for_args);
+                args_out.resize(args_out.size() + num_words_for_args);
+                ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SHAPE_IN_PAGES>::pack_to(
+                    &args_out[args_out.size() - num_words_for_args],
+                    Shape4D<uint32_t>(1, 1, slice.tensor_shape.y, slice.tensor_shape.x)
+                );
+                for (std::size_t j = args_out.size() - num_words_for_args; j < args_out.size(); j++) {
+                    log_trace(tt::LogOp, "\t{}", args_out[j]);
+                }
+
+                num_args++;
+            }
+
+            // tensor slice shape
+            if (last_slice.tensor_slice_shape != slice.tensor_slice_shape) {
+                args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES));
+                auto num_words_for_args = ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::size_in_words();
+                log_trace(tt::LogOp, "Emitting {} args for tensor_slice_shape field", num_words_for_args);
+                args_out.resize(args_out.size() + num_words_for_args);
+                ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SLICE_SHAPE_IN_PAGES>::pack_to(
+                    &args_out[args_out.size() - num_words_for_args],
+                    Shape4D<uint32_t>(1, 1, slice.tensor_slice_shape.y, slice.tensor_slice_shape.x)
+                );
+                for (std::size_t i = args_out.size() - num_words_for_args; i < args_out.size(); i++) {
+                    log_trace(tt::LogOp, "\t{}", args_out[i]);
+                }
+
+                num_args++;
+            }
+
+            // tensor slice offset
+            if (last_slice.tensor_slice_offset != slice.tensor_slice_offset) {
+                args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES));
+                auto num_words_for_args = ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::size_in_words();
+                log_trace(tt::LogOp, "Emitting {} args for tensor_slice_offset field", num_words_for_args);
+                args_out.resize(args_out.size() + num_words_for_args);
+                ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_TENSOR_SLICE_OFFSET_IN_PAGES>::pack_to(
+                    &args_out[args_out.size() - num_words_for_args],
+                    Shape4D<uint32_t>(0, 0, slice.tensor_slice_offset.y, slice.tensor_slice_offset.x)
+                );
+                for (std::size_t j = args_out.size() - num_words_for_args; j < args_out.size(); j++) {
+                    log_trace(tt::LogOp, "\t{}", args_out[j]);
+                }
+
+                num_args++;
+            }
+
+            // worker slice offset
+            if (last_slice.worker_slice_offset != slice.worker_slice_offset) {
+                args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES));
+                auto num_words_for_args = ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::size_in_words();
+                log_trace(tt::LogOp, "Emitting {} args for worker_slice_offset field", num_words_for_args);
+                args_out.resize(args_out.size() + num_words_for_args);
+                ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_WORKER_START_OFFSET_IN_SLICE_IN_PAGES>::pack_to(
+                    &args_out[args_out.size() - num_words_for_args],
+                    Shape4D<uint32_t>(0, 0, slice.worker_slice_offset.y, slice.worker_slice_offset.x)
+                );
+
+                for (std::size_t j = args_out.size() - num_words_for_args; j < args_out.size(); j++) {
+                    log_trace(tt::LogOp, "\t{}", args_out[j]);
+                }
+                num_args++;
+            }
+
+            // worker_pages_per_slice
+            if (last_slice.worker_slice_shape != slice.worker_slice_shape) {
+                args_out.push_back(static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE));
+                auto num_words_for_args = ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::size_in_words();
+                log_trace(tt::LogOp, "Emitting {} args for worker_pages_per_slice field", num_words_for_args);
+                args_out.resize(args_out.size() + num_words_for_args);
+                ttnn::ccl::cmd::CclCommandArg<ttnn::ccl::cmd::CclCommandArgCode::SET_WORKER_PAGES_PER_SLICE>::pack_to(
+                    &args_out[args_out.size() - num_words_for_args],
+                    slice.worker_slice_shape.y * slice.worker_slice_shape.x
+                );
+                for (std::size_t j = args_out.size() - num_words_for_args; j < args_out.size(); j++) {
+                    log_trace(tt::LogOp, "\t{}", args_out[j]);
+                }
+
+                num_args++;
+            }
+
+            args_out[header_index] = static_cast<uint32_t>(ttnn::ccl::cmd::CclCommandHeader::to_uint32(
+                ttnn::ccl::cmd::CclCommandHeader{ttnn::ccl::cmd::CclCommandCode::STREAM_TENSOR_TO_EDM, 1}));
+
+            std::size_t args_index_new = args_out.size();
+            std::stringstream ss; ss << "ccl_send command " << i << " has " << args_index_new - args_index_old << " args:\n";
+            for (std::size_t j = args_index_old; j < args_index_new; j++) {
+                ss << "\targ " << j << ":" << args_out[j] << "\n";
+            }
+            log_trace(tt::LogOp, "{}", ss.str());
+        }
+    }
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_line_start_sender_kernel_rt_args(
+    WorkerEdmInterfaceArgs const& edm_interface,
+    std::size_t scatter_dim,
+    WorkerAttributes const& worker_attrs) const
+{
+    const std::size_t num_commands_expected = this->topology_config.ring_size - 1;
+
+    auto const& tensor_shape = this->worker_input_slice.tensor_shape;
+    auto const& tensor_slice_shape = this->worker_input_slice.tensor_slice_shape;
+
+    auto num_slices = topology_config.ring_size;
+    auto start_slice_index = topology_config.ring_index == 0 ? topology_config.ring_size - 1 : 0;
+    std::int64_t end_slice_index_exclusive = topology_config.ring_index == 0 ? 0 : static_cast<std::int64_t>(topology_config.ring_size) - 1;
+
+    // Add the command args
+    auto const& slices = generate_slice_sequence_on_dim(
+        tensor_shape,
+        worker_input_slice.worker_slice_shape,
+        scatter_dim,
+        num_slices,
+        start_slice_index,
+        end_slice_index_exclusive,
+        worker_attrs.index_in_slice
+    );
+    TT_ASSERT(num_commands_expected == slices.size());
+
+    // If we are on device zero, we send n-1 chunks in ascending order
+    auto &input_tensor = this->op_config.get_input_tensor(0);
+    TT_ASSERT(input_tensor.get_legacy_shape().size() == 4, "Only 4D tensors are supported for reduce scatter");
+    ttnn::ccl::Shape4D<uint32_t> input_tensor_shape = {input_tensor.get_legacy_shape()[0], input_tensor.get_legacy_shape()[1],input_tensor.get_legacy_shape()[2],input_tensor.get_legacy_shape()[3]};
+
+    std::vector<uint32_t> args = {
+        static_cast<uint32_t>(input_tensor.buffer()->address()),
+        static_cast<uint32_t>(slices.size())
+    };
+    std::size_t logged_arg_idx = 0;
+    log_trace(tt::LogOp, "ccl_send arg[{}]: buffer_address = {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+    log_trace(tt::LogOp, "ccl_send arg[{}]: num_commands = {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+
+    auto const& edm_interface_args = ttnn::ccl::emit_runtime_args(edm_interface);
+    std::ranges::copy(edm_interface_args, std::back_inserter(args));
+    for (auto const& arg : edm_interface_args) {
+        log_trace(tt::LogOp, "ccl_send arg[{}]: edm_interface_args[] {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+    }
+    // ttnn::ccl::log_runtime_args(edm_interface, "edm_interface");
+
+    std::ranges::copy(std::vector<uint32_t>{this->worker_transfer_info.get_num_pages_per_full_chunk(worker_attrs)}, std::back_inserter(args));
+    log_trace(tt::LogOp, "ccl_send arg[{}]: pages_per_packet {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+
+    std::ranges::copy(std::vector<uint32_t>{this->op_config.get_page_size()}, std::back_inserter(args));
+    log_trace(tt::LogOp, "ccl_send arg[{}]: page_size {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+
+    auto const& addr_gen_rt_args = ttnn::ccl::emit_address_generator_runtime_args(this->device, input_tensor);
+    std::ranges::copy(addr_gen_rt_args, std::back_inserter(args));
+    for (auto const& arg : addr_gen_rt_args) {
+        log_trace(tt::LogOp, "ccl_send arg[{}]: addr_gen_rt_args[] {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+    }
+
+    TT_ASSERT(worker_attrs.send_to_edm_semaphore_id.has_value(), "Internal Error");
+    std::ranges::copy(std::vector<uint32_t>{worker_attrs.send_to_edm_semaphore_id.value()}, std::back_inserter(args));
+    log_trace(tt::LogOp, "ccl_send arg[{}]: semaphore_id {}", logged_arg_idx, args[logged_arg_idx]);logged_arg_idx++;
+
+    log_trace(tt::LogOp, "Generating {} ccl send commands", slices.size());
+    emit_ccl_send_slice_sequence_commands(slices, args);
+
+    log_trace(tt::LogOp, "Reduce Scatter Sender Worker has {} RT Args: {}", args.size(), args);
+
+    return args;
+}
+
+std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_line_start_sender_kernel_ct_args() const
+{
+    std::vector<uint32_t> args = {
+        static_cast<uint32_t>(this->op_config.get_input_tensor(0).memory_config().memory_layout), // tensor memory layout
+        static_cast<uint32_t>(this->op_config.get_input_tensor(0).buffer()->buffer_type()), // buffer type
+        static_cast<uint32_t>(this->op_config.get_input_tensor(0).layout()), // page layout
+        static_cast<uint32_t>(this->edm_termination_mode), // (EDM) termination mode
+        static_cast<uint32_t>(tt::CB::c_in0) // cb_id
+    };
+
+    return args;
+}
+
+} // namespace reduce_scatter_detail
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp"
+
+#include <cstdint>
+
+namespace tt {
+namespace tt_metal {
+
+// Forward declarations
+class Device;
+
+} // namespace tt_metal
+} // namespace tt
+
+namespace ttnn {
+namespace ccl {
+class WorkerEdmInterfaceArgs;
+
+namespace reduce_scatter_detail {
+
+void emit_ccl_send_slice_sequence_commands(std::vector<TensorSlice> const& slices, std::vector<uint32_t>& args_out);
+
+struct ReduceScatterWorkerArgBuilder {
+    ReduceScatterWorkerArgBuilder (
+        tt::tt_metal::Device const* device,
+        ttnn::ccl::CCLOpConfig const& op_config,
+        ttnn::ccl::RingTopology const& topology_config,
+        ttnn::ccl::InterleavedTensorWorkerSlice const& worker_input_slice,
+        WorkerTransferInfo const& worker_transfer_info,
+        ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode,
+        std::size_t scatter_dim,
+        std::size_t cb_num_pages_per_packet,
+        std::optional<uint32_t> receiver_worker_partial_ready_semaphore_id,
+        std::size_t num_buffers_per_channel
+        );
+
+    std::size_t get_total_num_math_pages(WorkerAttributes const& worker_attrs) const;
+
+    std::vector<uint32_t> generate_reduce_op_kernel_ct_args() const;
+
+    std::vector<uint32_t> generate_reduce_op_kernel_rt_args(WorkerAttributes const& worker_attrs, std::size_t ring_size) const;
+
+    std::vector<uint32_t> generate_receiver_kernel_ct_args() const;
+
+    std::vector<uint32_t> generate_receiver_kernel_rt_args(
+        ttnn::ccl::WorkerXY const& edm_core,
+        uint32_t edm_core_semaphore_address,
+        uint32_t edm_core_buffer_address,
+        WorkerAttributes const& worker_attrs) const;
+
+    std::vector<uint32_t> generate_sender_kernel_ct_args() const;
+
+    std::vector<uint32_t> generate_sender_kernel_rt_args(
+        WorkerEdmInterfaceArgs const& edm_interface,
+        WorkerAttributes const& worker_attrs) const;
+
+
+    std::vector<uint32_t> generate_line_start_sender_kernel_rt_args(
+        WorkerEdmInterfaceArgs const& edm_interface,
+        std::size_t scatter_dim,
+        WorkerAttributes const& worker_attrs) const;
+
+    std::vector<uint32_t> generate_line_start_sender_kernel_ct_args() const;
+
+    tt::tt_metal::Device const*device;
+    ttnn::ccl::RingTopology const topology_config;
+    ttnn::ccl::CCLOpConfig const op_config;
+    ttnn::ccl::InterleavedTensorWorkerSlice const worker_input_slice;
+    WorkerTransferInfo const worker_transfer_info;
+    ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode;
+    uint32_t cb_num_pages_per_packet;
+    uint32_t worker_sender_semaphore_id;
+    uint32_t worker_receiver_semaphore_id;
+    uint32_t num_buffers_per_channel;
+    std::optional<uint32_t> receiver_worker_partial_ready_semaphore_id;
+
+    std::size_t scatter_dim;
+    bool src_is_dram;
+    bool dst_is_dram;
+};
+
+} // namespace reduce_scatter_detail
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
@@ -14,11 +14,12 @@ ttnn::Tensor ExecuteReduceScatter::invoke(
     ttnn::operations::reduction::ReduceType math_op,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
+    ttnn::ccl::Topology topology,
     const std::optional<size_t> num_workers,
     const std::optional<size_t> num_buffers_per_channel) {
 
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
-    return ttnn::operations::ccl::reduce_scatter(input_tensor, scatter_dim, math_op, num_links, out_memory_config, num_workers, num_buffers_per_channel);
+    return ttnn::operations::ccl::reduce_scatter(input_tensor, scatter_dim, math_op, num_links, out_memory_config, topology, num_workers, num_buffers_per_channel);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp
@@ -8,6 +8,8 @@
 
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+
 namespace ttnn {
 namespace operations {
 namespace ccl {
@@ -19,6 +21,7 @@ struct ExecuteReduceScatter {
         ttnn::operations::reduction::ReduceType math_op,
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
         const std::optional<size_t> num_workers = std::nullopt,
         const std::optional<size_t> num_buffers_per_channel = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp"
 #include "ttnn/types.hpp"
 
@@ -30,9 +31,10 @@ void bind_reduce_scatter(pybind11::module& module, const ccl_operation_t& operat
                ttnn::operations::reduction::ReduceType math_op,
                const uint32_t num_links,
                const ttnn::MemoryConfig& memory_config,
+               ttnn::ccl::Topology topology,
                const std::optional<size_t> num_workers,
                const std::optional<size_t> num_buffers_per_channel) -> ttnn::Tensor {
-                return self(input_tensor, scatter_dim, math_op, num_links, memory_config, num_workers, num_buffers_per_channel);
+                return self(input_tensor, scatter_dim, math_op, num_links, memory_config, topology, num_workers, num_buffers_per_channel);
             },
             py::arg("input_tensor"),
             py::arg("scatter_dim"),
@@ -40,6 +42,7 @@ void bind_reduce_scatter(pybind11::module& module, const ccl_operation_t& operat
             py::kw_only(),
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring,
             py::arg("num_workers") = std::nullopt,
             py::arg("num_buffers_per_channel") = std::nullopt});
 }
@@ -52,7 +55,7 @@ void py_bind_reduce_scatter(pybind11::module& module) {
     detail::bind_reduce_scatter(
         module,
         ttnn::reduce_scatter,
-        R"doc(reduce_scatter(input_tensor: std::vector<ttnn.Tensor>, scatter_dim: int, math_op: ReduceType, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None, num_workers: int = None, num_buffers_per_channel: int = None) -> std::vector<ttnn.Tensor>
+        R"doc(reduce_scatter(input_tensor: std::vector<ttnn.Tensor>, scatter_dim: int, math_op: ReduceType, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None, topology: ttnn.ccl.Topology, num_workers: int = None, num_buffers_per_channel: int = None) -> std::vector<ttnn.Tensor>
 
         Performs an reduce_scatter operation on multi-device :attr:`input_tensor` across all devices.
 
@@ -63,6 +66,7 @@ void py_bind_reduce_scatter(pybind11::module& module) {
         Keyword Args:
             * :attr:`num_links` (int): Number of links to use for the all-gather operation.
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+            * :attr:`topology` (Optional[ttnn.ccl.topology]): The topology configuration to run the operation in. Valid options are Ring and Linear. Default = Ring
             * :attr:`num_workers` (int): Number of workers to use for the operation.
             * :attr:`num_buffers_per_channel` (int): Number of buffers per channel to use for the operation.
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp
@@ -5,11 +5,7 @@
 #pragma once
 
 #include "pybind11/pybind_fwd.hpp"
-#include <pybind11/pybind11.h>
-#include "ttnn/operations/ccl/ccl_host_types.hpp"
 
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
 namespace ttnn::operations::ccl {
 
 void py_bind_reduce_scatter(pybind11::module& module);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp
@@ -5,7 +5,11 @@
 #pragma once
 
 #include "pybind11/pybind_fwd.hpp"
+#include <pybind11/pybind11.h>
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
 
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
 namespace ttnn::operations::ccl {
 
 void py_bind_reduce_scatter(pybind11::module& module);

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -120,7 +120,7 @@ inline coord_t advance_wrapped_slice_row_major(
 inline void advance_worker_global_page_interleaved (
     uint32_t &curr_page_idx,
     uint32_t &offset_into_worker_slice, // local to the worker chunk
-    coord_t &offset_worker_slice, // local to the tensor slice
+    coord_t const& offset_worker_slice, // local to the tensor slice
 
     coord_t const &worker_slice_shape, // worker chunk shape
     coord_t const &tensor_slice_shape, // tensor slice shape (per device)


### PR DESCRIPTION
# Ticket
#11178 

# Problem description
We don't support line reduce scatter

# What's changed

This commit adds the initial support for reduce scatter. However, only a
few cases are functional. Future work will improve correctness across
more cases.

## Line Reduce Scatter Algorithm
The algorithm for line reduce scatter will send the minimal ammount of
data over each line and out of each chip. All diagrams are for an
example 4-chip line reduce scatter.

First the operation fractures each input tensor

```
Input Tensors ---------------
       |      |      |      |
       |      |      |      |
       v      v      v      v
      |-|    |-|    |-|    |-|
      | |    | |    | |    | |
      | |    | |    | |    | |
      | |    | |    | |    | |
      | |    | |    | |    | |
      | |    | |    | |    | |
      | |    | |    | |    | |
      | |    | |    | |    | |
      |-|    |-|    |-|    |-|

Chip   0      1      2      3

                 |
                 | Fracture
                 | Tensors
                 v

Input Tensors ---------------
       |      |      |      |
       |      |      |      |
       v      v      v      v
      |-|    |-|    |-|    |-|
      | |    | |    | |    | |
      |-|    |-|    |-|    |-|
      | |    | |    | |    | |
      |-|    |-|    |-|    |-|
      | |    | |    | |    | |
      |-|    |-|    |-|    |-|
      | |    | |    | |    | |
      |-|    |-|    |-|    |-|

Chip   0      1      2      3
```

With fracture tensors are reduced and collapsed to the diagonal across
the chips where the diagonal shows how the fractures spatially map to
the final outputs. For example, the first output is generated by
reducing the top chunk of each input tensor.

The reduction is performed by having each chip forward its input to its
neighbour. For chips that are not at the end of the line, they reduce
with their input and forward.

```
      |-|    |-|    |-|    |-|
      |#|<---| |<---| |<---| |
      |-|    |-|    |-|    |-|
      | |--->|#|<---| |<---| |
      |-|    |-|    |-|    |-|
      | |--->| |--->|#|<---| |
      |-|    |-|    |-|    |-|
      | |--->| |--->| |--->|#|
      |-|    |-|    |-|    |-|

Chip   0      1      2      3
```

However, note that each arrow from the diagram heading out of of a chip
in a given direction shares ethernet resources for all other arrows
heading in the same direction from that chip. This means there is
inherently serialization here. For that reason, we schedule the chunks
in some way.

The general scheduling strategy is to send the chunks that are furthest
from the final reduce output first and step through chunks that are
incrementally closer to the final output.

Each direction from a chip can be processed independently.

The diagram below is annotated with the "timesteps" when each chunk is
sent. Each timestep is marked relative to the chunk source.

```
      |-| t=0|-| t=0|-| t=0|-|
      |#|<---| |<---| |<---| |
      |-|t=2 |-| t=1|-| t=1|-|
      | |--->|#|<---| |<---| |
      |-|t=1 |-|t=1 |-| t=2|-|
      | |--->| |--->|#|<---| |
      |-|t=0 |-|t=0 |-|t=0 |-|
      | |--->| |--->| |--->|#|
      |-|    |-|    |-|    |-|

Chip   0      1      2      3
```

Finally, not that the final output requires a reduction from both
directions. Given that the two directions of the line are executing
completely indepdently, we require some sort of merge operation. At the
time of this commit, the merge strategy is to designate a master and
slave reducer direction. We arbitrarily choose the 'right' or
'clockwise' direction as the master.

The master direction will write its output to the output tensor but note
that this will only be a partial output. The slave direction will read
from the output tensor to merge with the data from producer chip. It
will read from the output tensor based on a credit passing from master
 (implemented via semaphores)

```
     -------Input Tensor
     |
     |
     |
     |
     |
     |      |---------|----------
     |----> |         |         |
            | Reader  | Sender  |---
  From EDM  | (master)| (master)|  |
 ---------> |         |         |  |
            |---------|---------|  |
                                   |
                                   |
        |------  Output Tensor <---|
        |                 ^
        |                 |---------
        |                          |
        |   |---------|----------  |
        --> |         |         |  |
            | Reader  | Sender  |--|
  From EDM  | (master)| (master)|
 ---------> |         |         |
            |---------|---------|
```

As a part of the line reduce scatter implementation, new CCL
componenst were added: ccl send and ccl command generators/readers.

The ccl_send (kernel) was used to implement the starting ends of the lines
(i.e. the first senders). Although the ccl_send provides more generic
send capabilities than line reduce scatter currently requires, it was
chosen because it is a basic building block also for future CCL
send/recv "operations" and higher level CCL programming models.

## CCL Send (Kernel)
The ccl_send kernel acts like an interpreter of CCL commands. CCL
commands are, so far, limited to be a send from tensor to EDM of a
tensor slice. The command specifies some information about the tensor
(shape, slice/view shape, view offset, etc.).

CCL send is capable of executing multiple commands back to back. In the
context of line reduce scatter, the ccl_send implements the separate
sends of the fractured chunks on the left and right ends of the line. To
do this for a line reduce scatter, we invoke n commands where n=#chips
in the line. Future commands will let an invoker specify this basic
pattern as a single command.

Looking at the third diagram that outlines the timesteps for each chunk,
for the left/right tensors, each timestep directly maps to a separate
ccl command.

## CCL Command Generators/Readers 
To facilitate command generation, initial components have been added to
let the host serialize commands for the the ccl_send kernel.
Correspondingly, command unpacking logic is also specified for each
command. This is used to help simplify command generation for the host.

Note that ccl_send as a standalone kernel and operation is experimental
and has several limitations:
- Slice reads currently constrained to page aligned slices
- Host command generation doesn't support proper 4D shape support
    (although the kernel side will internally represent shapes as 4D)
- Only one command is currently supported (send tensor slice to EDM)

# Future Work:
These are specific to line reduce scatter
1. Resolve correctness bugs (PCC) exposed by non-enabled test cases from ring and enable those tests in the test list
2. Enable sharding support
3. Drive towards minimum op completion requirements which will be the same effort as ring reduce scatter as the pieces that need changing there are common amongst the two (namely proper 4D shape representation on device side - today we only pass a flattened-to-2d shape)


Merging now to
1. Unblock (composite) implementation for all-reduce op 
2. Enable more incremental development of ccl-send-recv op
4. Avoid repeated conflicts due to rebase
 

# Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11043482824
  - https://github.com/tenstorrent/tt-metal/actions/runs/11086517124
- [x] t3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11043294192
- [x] t3000 model perf: https://github.com/tenstorrent/tt-metal/actions/runs/11043404805
  - Not completely green but neither is main. Seeing the same failures as on main and failures are unrelated to changes here. 
- [x] t3000 unit test: https://github.com/tenstorrent/tt-metal/actions/runs/11043407305
- [x] TG frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11043423582
- [x] Blackhole Post commit (if applicable)
- [x] New/Existing tests provide coverage for changes
