### PR TITLE
#0: Remove unnecessary ProgramDeleter

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -27,10 +27,6 @@ namespace tt {
 
 namespace tt_metal {
 
-void ::detail::ProgramDeleter::operator()(Program *p) {
-    delete p;
-}
-
 Device::Device(
     chip_id_t device_id, const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap, bool minimal, uint32_t worker_core) :
     id_(device_id), worker_thread_core(worker_core), work_executor(worker_core, device_id) {
@@ -1455,8 +1451,8 @@ void Device::setup_tunnel_for_remote_devices() {
 
 void Device::compile_command_queue_programs() {
     ZoneScoped;
-    std::unique_ptr<Program, detail::ProgramDeleter> command_queue_program_ptr(new Program);
-    std::unique_ptr<Program, detail::ProgramDeleter> mmio_command_queue_program_ptr(new Program);
+    auto command_queue_program_ptr = std::make_unique<Program>();
+    auto mmio_command_queue_program_ptr = std::make_unique<Program>();
 
     std::string prefetch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
     std::string dispatch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -34,13 +34,6 @@ class HWCommandQueue;
 class CommandQueue;
 
 namespace detail {
-// TODO(agrebenisan): Need device to hold onto command queue programs,
-// but the Program type is incomplete by this point. I can have
-// a unique_ptr of incomplete type as long as I override the default
-// delete function.
-struct ProgramDeleter {
-    void operator()(Program* p);
-};
 
 class TraceDescriptor;
 
@@ -296,7 +289,7 @@ class Device {
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
     uint8_t num_hw_cqs_;
 
-    vector<std::unique_ptr<Program, tt::tt_metal::detail::ProgramDeleter>> command_queue_programs;
+    std::vector<std::unique_ptr<Program>> command_queue_programs;
     bool using_fast_dispatch;
     program_cache::detail::ProgramCache program_cache;
 


### PR DESCRIPTION
### Problem description
The Device implementation code uses the unnecessary `ProgramDeleter` class that can be removed.

### Checklist
- [ ] Post commit CI passes
