### PR TITLE
#13128: Enhance build_metal.sh

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -111,8 +111,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
-            nice -n 19 cmake --build build --target tests
+            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} -DTT_METALLIUM_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
             nice -n 19 cmake --build build --target install
 
       - name: 'Tar files'

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -111,7 +111,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} -DTT_METALLIUM_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
+            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DCMAKE_INSTALL_PREFIX=build -DENABLE_TRACY=${{ inputs.tracy }} -DTT_METALLIUM_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
             nice -n 19 cmake --build build --target install
 
       - name: 'Tar files'

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -111,7 +111,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DCMAKE_INSTALL_PREFIX=build -DENABLE_TRACY=${{ inputs.tracy }} -DTT_METALLIUM_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
+            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DCMAKE_INSTALL_PREFIX=build -DENABLE_TRACY=${{ inputs.tracy }} -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
             nice -n 19 cmake --build build --target install
 
       - name: 'Tar files'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,8 +43,8 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja
-            nice -n 19 cmake --build build --target tests
+            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja -DTT_METALLIUM_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
+            nice -n 19 cmake --build build
 
       - name: Check disk space
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja -DTT_METALLIUM_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
+            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
             nice -n 19 cmake --build build
 
       - name: Check disk space

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -37,7 +37,7 @@ jobs:
           ./scripts/build_scripts/build_with_profiler_opt.sh
           ./create_venv.sh
       - name: Build tests
-        run: cmake --build build --target tests -- -j`nproc`
+        run: cmake --build build -- -j`nproc`
       - name: Run microbenchmark tests
         timeout-minutes: 90
         run: ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type microbenchmarks

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build UMD device and tests
         run: |
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
           cmake --build build --target umd_tests
       - name: Run UMD unit regression tests
         timeout-minutes: 10

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build UMD device and tests
         run: |
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
           cmake --build build --target umd_tests
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,10 +252,11 @@ endif()
 add_subdirectory(tt_metal)
 add_subdirectory(ttnn)
 
-option(TT_METALLIUM_BUILD_TESTS "Enables build of Tests" OFF)
-if(TT_METALLIUM_BUILD_TESTS)
+option(TT_METAL_BUILD_TESTS "Enables build of tt_metal tests" OFF)
+option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
+if(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
     add_subdirectory(tests)
-endif(TT_METALLIUM_BUILD_TESTS)
+endif(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
 
 ############################################################################################################################
 # Install targets for build artifacts and pybinds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,11 +122,10 @@ endif()
 unset(SANITIZER_ENABLED)
 
 include(GNUInstallDirs)
-set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}")
-set(CMAKE_INSTALL_LIBDIR "${PROJECT_BINARY_DIR}/lib")
-set(CMAKE_INSTALL_BINDIR "${PROJECT_BINARY_DIR}/tmp/bin")
-set(CMAKE_INSTALL_INCLUDEDIR "${PROJECT_BINARY_DIR}/tmp/include")
-set(CMAKE_INSTALL_DATAROOTDIR "${PROJECT_BINARY_DIR}/tmp/share")
+#FIX ME: Should not be changing these
+set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/tmp/bin")
+set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/tmp/include")
+set(CMAKE_INSTALL_DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/tmp/share")
 
 ############################################################################################################################
 # Find all required libraries to build
@@ -145,7 +144,7 @@ if (NOT NUMA_LIBRARY)
 endif()
 
 # Bring in UMD and all it's dependencies
-add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd)
+add_subdirectory(tt_metal/third_party/umd)
 
 ############################################################################################################################
 # Constructing interface libs for common compiler flags, header directories, and libraries
@@ -250,10 +249,13 @@ if(ENABLE_TRACY)
     include(${PROJECT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal)
-add_subdirectory(${PROJECT_SOURCE_DIR}/ttnn)
+add_subdirectory(tt_metal)
+add_subdirectory(ttnn)
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
+option(TT_METALLIUM_BUILD_TESTS "Enables build of Tests" OFF)
+if(TT_METALLIUM_BUILD_TESTS)
+    add_subdirectory(tests)
+endif(TT_METALLIUM_BUILD_TESTS)
 
 ############################################################################################################################
 # Install targets for build artifacts and pybinds
@@ -273,7 +275,7 @@ install(TARGETS ttnn
 )
 if(WITH_PYTHON_BINDINGS)
     # Install .so into src files for pybinds implementation
-    install(FILES ${PROJECT_BINARY_DIR}/lib/_ttnn.so
+    install(TARGETS ttnn
     DESTINATION ${PROJECT_SOURCE_DIR}/ttnn/ttnn
     COMPONENT tt_pybinds
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,13 +4,10 @@ include(GoogleTest)
 add_library(test_common_libs INTERFACE)
 target_link_libraries(test_common_libs INTERFACE pthread gtest gtest_main)
 
-
-option(TT_METAL_BUILD_TESTS "Enables build of tt_metal tests" OFF)
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
 endif(TT_METAL_BUILD_TESTS)
 
-option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
 if(TTNN_BUILD_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,9 +4,15 @@ include(GoogleTest)
 add_library(test_common_libs INTERFACE)
 target_link_libraries(test_common_libs INTERFACE pthread gtest gtest_main)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
 
-set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn unit_tests_ttnn_ccl test_multi_device galaxy_unit_tests_ttnn ttnn watcher_dump umd_tests)
-add_custom_target(tests DEPENDS ${TESTS_DEPENDS_LIST})
+option(TT_METAL_BUILD_TESTS "Enables build of tt_metal tests" OFF)
+if(TT_METAL_BUILD_TESTS)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
+endif(TT_METAL_BUILD_TESTS)
+
+option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
+if(TTNN_BUILD_TESTS)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
+endif(TTNN_BUILD_TESTS)
+

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_executable(watcher_dump ${CMAKE_CURRENT_SOURCE_DIR}/watcher_dump.cpp)
-target_link_libraries(watcher_dump PRIVATE test_metal_common_libs)
+target_link_libraries(watcher_dump PRIVATE tt_metal)
 target_include_directories(watcher_dump PRIVATE
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
### Ticket
#13128 

### Problem description
Currently, we build tt-metal, ttnn, and tt-umd unit tests, or we build no tests.
Additionally, our users have no control over where build artifacts are installed when building from source.

### What's changed
- Three new CMake options are defined
  - TT_METAL_BUILD_TESTS -> Do we want to build tt_metal tests?
  - TTNN_BUILD_TESTS -> Do we want to build ttnn tests?
  - TT_UMD_BUILD_TESTS -> Do we want to build umd unit tests?
    - This option needs to be consumed by tt-umd, and would require a push to that repo, and submodule update.
- CMAKE_INSTALL_PREFIX no longer tied to PROJECT_BINARY_DIR, give people freedom
- Enhancements to `build_metal.sh`
  - Allow customer to provide long options; i.e. `--help`
  - Allow customer to provide installation directory, default to build_dir
  - Allow customer to provide extra cmake options
  - Add --clean option
  - Add --debug, --release, --development as shortcuts to pick build type

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
