### PR TITLE
#13145: Temporarily revert Resnet on Galaxy to use slower config for first conv to avoid hangs

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -581,7 +581,11 @@ class resnet50:
             reshard_if_not_optimal=False,
         )
         if whb0_and_b16:
-            self.conv1_config.act_block_h_override = 256
+            # Issue #13145: Temp workaround for Galaxy to avoid hangs
+            if type(device) == ttnn.MeshDevice and device.get_num_devices() > 8:
+                self.conv1_config.act_block_h_override = 64
+            else:
+                self.conv1_config.act_block_h_override = 256
 
         self.conv1_kernel_size = (4, 4)
         self.conv1_stride = (1, 1)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13145

### Problem description
Resnet on Galaxy hangs after first conv optimization.

### What's changed
Temporarily revert optimization for Galaxy to enable CI.

### Checklist
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
