### PR TITLE
#13144: Add documentation for tensor creation ops, matmul ops

### DIFF
--- a/ttnn/cpp/pybind11/operations/creation.hpp
+++ b/ttnn/cpp/pybind11/operations/creation.hpp
@@ -40,8 +40,8 @@ void bind_full_operation(py::module& module, const creation_operation_t& operati
         Example:
             >>> filled_tensor = ttnn.full(shape=[2, 3], fill_value=7.0, dtype=ttnn.bfloat16)
             >>> print(filled_tensor)
-            ttnn.Tensor([[[[ 7.0,  7.0,  7.0],
-                            [ 7.0,  7.0,  7.0]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[[[7.0,  7.0,  7.0],
+                            [7.0,  7.0,  7.0]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 
@@ -161,8 +161,8 @@ void bind_full_like_operation(py::module& module, const creation_operation_t& op
             >>> tensor = ttnn.zeros(shape=(2, 3), dtype=ttnn.bfloat16)
             >>> filled_tensor = ttnn.fill_like(tensor, fill_value=5.0, dtype=ttnn.bfloat16)
             >>> print(filled_tensor)
-            ttnn.Tensor([[[[ 5.0,  5.0,  5.0],
-                            [ 5.0,  5.0,  5.0]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[[[5.0,  5.0,  5.0],
+                            [5.0,  5.0,  5.0]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 
@@ -286,7 +286,7 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
         Example:
             >>> tensor = ttnn.arange(start=0, end=10, step=2, dtype=ttnn.float32)
             >>> print(tensor)
-            ttnn.Tensor([[[[ 0.00000,  2.00000,  ...,  8.00000,  0.00000]]]], shape=Shape([1, 1, 1, 6]), dtype=DataType::FLOAT32, layout=Layout::ROW_MAJOR)
+            ttnn.Tensor([[[[0.00000,  2.00000,  ...,  8.00000,  0.00000]]]], shape=Shape([1, 1, 1, 6]), dtype=DataType::FLOAT32, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 

--- a/ttnn/cpp/pybind11/operations/creation.hpp
+++ b/ttnn/cpp/pybind11/operations/creation.hpp
@@ -22,18 +22,26 @@ template <typename creation_operation_t>
 void bind_full_operation(py::module& module, const creation_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
-        Creates a tensor of the specified shape and fills it with the specified value.
+        Creates a tensor of the specified shape and fills it with the specified scalar value.
 
         Args:
             shape (ttnn.Shape): The shape of the tensor.
             fill_value (float): The value to fill the tensor with.
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
             layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to None.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to None.
+            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
-            ttnn.Tensor: A filled tensor.
+            ttnn.Tensor: A filled tensor of specified shape and value.
+
+        Example:
+            >>> filled_tensor = ttnn.full(shape=[2, 3], fill_value=7.0, dtype=ttnn.bfloat16)
+            >>> print(filled_tensor)
+            ttnn.Tensor([[[[ 7.0,  7.0,  7.0],
+                            [ 7.0,  7.0,  7.0]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 
@@ -84,22 +92,31 @@ void bind_full_operation(py::module& module, const creation_operation_t& operati
 }
 
 template <typename creation_operation_t>
-void bind_full_operation_with_hard_coded_value(py::module& module, const creation_operation_t& operation) {
+void bind_full_operation_with_hard_coded_value(py::module& module, const creation_operation_t& operation, const std::string& value_string) {
     auto doc = fmt::format(
         R"doc(
-        Creates a tensor with the specified shape and fills it with the value of {0}.
+        Creates a tensor with the specified shape and fills it with the value of {1}.
 
         Args:
             shape (ttnn.Shape): The shape of the tensor.
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
             layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to None.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to None.
+            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
 
         Returns:
-            ttnn.Tensor: A filled tensor.
+            ttnn.Tensor: A tensor filled with {1}.
+
+        Example:
+            >>> tensor = ttnn.{0}(shape=[1, 2, 2, 2], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+            >>> print(tensor)
+            ttnn.Tensor([[[[{1}, {1}],
+                            [{1}, {1}]],
+                            [[{1}, {1}],
+                            [{1}, {1}]]]]], shape=Shape([1, 2, 2, 2]), dtype=DataType::BFLOAT16, layout=Layout::TILE_LAYOUT)
         )doc",
-        operation.base_name());
+        operation.base_name(),
+        value_string);
 
     bind_registered_operation(
         module,
@@ -125,18 +142,27 @@ template <typename creation_operation_t>
 void bind_full_like_operation(py::module& module, const creation_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
-        Creates a tensor of the same shape as the input tensor and fills it with the specified value.
+        Creates a tensor of the same shape as the input tensor and fills it with the specified scalar value. The data type, layout, device, and memory configuration of the resulting tensor can be specified.
 
         Args:
             tensor (ttnn.Tensor): The tensor to use as a template for the shape of the new tensor.
-            fill_value (float): The value to fill the tensor with.
+            fill_value (float | int): The value to fill the tensor with.
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
             layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to None.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to None.
+            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
             ttnn.Tensor: A filled tensor.
+
+        Example:
+            >>> tensor = ttnn.zeros(shape=(2, 3), dtype=ttnn.bfloat16)
+            >>> filled_tensor = ttnn.fill_like(tensor, fill_value=5.0, dtype=ttnn.bfloat16)
+            >>> print(filled_tensor)
+            ttnn.Tensor([[[[ 5.0,  5.0,  5.0],
+                            [ 5.0,  5.0,  5.0]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
         )doc",
         operation.base_name());
 
@@ -187,22 +213,34 @@ void bind_full_like_operation(py::module& module, const creation_operation_t& op
 }
 
 template <typename creation_operation_t>
-void bind_full_like_operation_with_hard_coded_value(py::module& module, const creation_operation_t& operation) {
+void bind_full_like_operation_with_hard_coded_value(py::module& module, const creation_operation_t& operation, const std::string& value_string) {
     auto doc = fmt::format(
         R"doc(
-        Creates a tensor of the same shape as the input tensor and fills it with the value of {0}.
+        Creates a tensor of the same shape as the input tensor and fills it with the value of {1}. The data type, layout, device, and memory configuration of the resulting tensor can be specified.
 
         Args:
             tensor (ttnn.Tensor): The tensor to use as a template for the shape of the new tensor.
             dtype (ttnn.DataType, optional): The data type of the tensor. Defaults to `None`.
             layout (ttnn.Layout, optional): The layout of the tensor. Defaults to `None`.
-            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to None.
-            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to None.
+            device (ttnn.Device, optional): The device on which the tensor will be allocated. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration of the tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
-            ttnn.Tensor: A filled tensor.
+            ttnn.Tensor: A tensor filled with {1}.
+
+        Example:
+            >>> tensor = ttnn.{0}(ttnn.from_torch(torch.randn(1, 2, 2, 2), ttnn.bfloat16, ttnn.TILE_LAYOUT)
+            >>> output_tensor = ttnn.{0}(tensor=input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+            >>> print(output_tensor)
+            ttnn.Tensor([[[[{1}, {1}],
+                            [{1}, {1}]],
+                            [[{1}, {1}],
+                            [{1}, {1}]]]]], shape=Shape([1, 2, 2, 2]), dtype=DataType::BFLOAT16, layout=Layout::TILE_LAYOUT)
         )doc",
-        operation.base_name());
+        operation.base_name(),
+        value_string);
 
     bind_registered_operation(
         module,
@@ -276,7 +314,24 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
 
 void bind_empty_operation(py::module& module) {
     auto doc = fmt::format(
-        R"doc({0}(shape: List[int], dtype: ttnn.DataType, layout: ttnn.Layout, device: ttnn.Device, memory_config: ttnn.MemoryConfig)doc",
+        R"doc(
+        Creates a device tensor with uninitialized values of the specified shape, data type, layout, and memory configuration.
+
+        Args:
+            shape (List[int]): The shape of the tensor to be created.
+            dtype (ttnn.DataType, optional): The tensor data type. Defaults to `ttnn.bfloat16`.
+            layout (ttnn.Layout, optional): The tensor layout. Defaults to `ttnn.ROW_MAJOR`.
+            device (ttnn.Device): The device where the tensor will be allocated.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
+
+        Returns:
+            ttnn.Tensor: The output uninitialized tensor.
+
+        Example:
+            >>> tensor = ttnn.empty(shape=[2, 3], device=device)
+            >>> print(tensor)
+            ttnn.Tensor([[[[0.9, 0.21, 0.5], [0.67, 0.11, 0.30]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::TILE)
+        )doc",
         ttnn::empty.base_name());
 
     using EmptyType = decltype(ttnn::empty);
@@ -296,13 +351,33 @@ void bind_empty_operation(py::module& module) {
             py::arg("shape"),
             py::arg("dtype") = DataType::BFLOAT16,
             py::arg("layout") = Layout::ROW_MAJOR,
-            py::arg("device") = nullptr,
+            py::arg("device"),
             py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG});
 }
 
 void bind_empty_like_operation(py::module& module) {
     auto doc = fmt::format(
-        R"doc({0}(tensor: ttnn.Tensor, dtype: Optional[ttnn.DataType] = None, layout: Optional[ttnn.Layout] = None, device: Optional[ttnn.Device] = None, memory_config: Optional[ttnn.MemoryConfig] = None)doc",
+        R"doc(
+        Creates a new tensor with the same shape as the given `reference`, but without initializing its values. The data type, layout, device, and memory configuration of the new tensor can be specified.
+
+        Args:
+            reference (ttnn.Tensor): The reference tensor whose shape will be used for the output tensor.
+
+        Keyword Args:
+            dtype (ttnn.DataType, optional): The desired data type of the output tensor. Defaults to `ttnn.bfloat16`.
+            layout (ttnn.Layout, optional): The desired layout of the output tensor. Defaults to `ttnn.ROW_MAJOR`.
+            device (ttnn.Device, optional): The device where the output tensor will be allocated. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): The memory configuration for the operation. Defaults to `ttnn.DRAM_MEMORY_CONFIG`.
+
+        Returns:
+            ttnn.Tensor: The output uninitialized tensor with the same shape as the reference tensor.
+
+        Example:
+            >>> reference = ttnn.from_torch(torch.randn(2, 3), dtype=ttnn.bfloat16)
+            >>> tensor = ttnn.empty_like(reference, dtype=ttnn.float32)
+            >>> print(tensor)
+            ttnn.Tensor([[[[0.87, 0.45, 0.22], [0.60, 0.75, 0.25]]]], shape=Shape([2, 3]), dtype=DataType::BFLOAT16, layout=Layout::ROW_MAJOR)
+        )doc",
         ttnn::empty_like.base_name());
 
     using EmptyLikeType = decltype(ttnn::empty_like);
@@ -331,12 +406,12 @@ void bind_empty_like_operation(py::module& module) {
 
 void py_module(py::module& module) {
     detail::bind_full_operation(module, ttnn::full);
-    detail::bind_full_operation_with_hard_coded_value(module, ttnn::zeros);
-    detail::bind_full_operation_with_hard_coded_value(module, ttnn::ones);
+    detail::bind_full_operation_with_hard_coded_value(module, ttnn::zeros, "0.0");
+    detail::bind_full_operation_with_hard_coded_value(module, ttnn::ones, "1.0");
 
     detail::bind_full_like_operation(module, ttnn::full_like);
-    detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::zeros_like);
-    detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::ones_like);
+    detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::zeros_like, "0.0");
+    detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::ones_like, "1.0");
 
     detail::bind_arange_operation(module, ttnn::arange);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -81,7 +81,7 @@ void bind_primitive_binary_operation(py::module& module, const binary_operation_
 
 
 template <typename binary_operation_t>
-void bind_binary_operation(py::module& module, const binary_operation_t& operation, const std::string& description, const std::string& math, const std::string& info=". ") {
+void bind_binary_operation(py::module& module, const binary_operation_t& operation, const std::string& description, const std::string& math, const std::string& info=". ", const std::string& note=" ") {
     auto doc = fmt::format(
         R"doc(
         {2}
@@ -106,7 +106,7 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
         Supports broadcasting.
 
         Note:
-            {4}
+            {5}
 
         Example:
 
@@ -118,7 +118,8 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
         operation.python_fully_qualified_name(),
         description,
         math,
-        info);
+        info,
+        note);
 
     bind_registered_operation(
         module,
@@ -803,7 +804,7 @@ void py_module(py::module& module) {
         module,
         ttnn::logical_and,
         R"doc(Compute logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
-        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i \& \mathrm{{input\_tensor\_b}}_i))doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i \& \mathrm{{input\_tensor\_b}}_i))doc",". ",
 
         R"doc(Supported dtypes, layouts, and ranks:
         +----------------------------+---------------------------------+-------------------+
@@ -817,7 +818,7 @@ void py_module(py::module& module) {
         module,
         ttnn::logical_or,
         R"doc(Compute logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
-        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i | \mathrm{{input\_tensor\_b}}_i))doc",
+        R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor\_a}}_i | \mathrm{{input\_tensor\_b}}_i))doc",". ",
 
         R"doc(Supported dtypes, layouts, and ranks:
         +----------------------------+---------------------------------+-------------------+

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -158,12 +158,12 @@ void py_module(py::module& module) {
         If the input tensors have more than two dimensions, the additional, front,
         dimensions may be used for batched matrix multiply.
         These front dimensions may also be referred to as batch dimensions.
-        E.g. a tensor with dimensions :math:`(a \\times b \\times c \\times d)`
-        has batch dimensions a and b.
+        E.g. a tensor with dimensions (`a` x `b` x `c` x `d`)
+        has batch dimensions `a` and `b`.
         The following are the allowed possibilities for batch dimensions.
         Examples below show concrete operations and tensor sizes.
 
-        - If all batch dimensions are all of size 1, then there is no batched operation.
+        - If all batch dimensions are of size 1, then there is no batched operation.
 
         - If both inputs have batch dimensions that are not all of size 1, then the
           batch dimensions of both inputs should be the same. If the dimensions are
@@ -172,7 +172,7 @@ void py_module(py::module& module) {
 
         - If the first input has batch dimensions that are not all of size 1, and the
           second input has no batch dimensions or has batch dimensions all of size 1,
-          then the second input is broadcast to align appropriately with the first
+          then the second input is broadcasted to align appropriately with the first
           input.
 
         - Matrix multiplication will not work if the first input has batch
@@ -191,22 +191,22 @@ void py_module(py::module& module) {
           These exceptions are for the following scenarios related to batch
           dimensions:
 
-              - The two batch dimensions are swapped. E.g. the first input has :math:`(j \\times 1)`
-                and the second input has :math:`(1 \\times j)`
-                or the first input has :math:`(1 \\times j)` and the second input has
-                :math:`(j \\times 1)`
-              - When a batch dimension is implicitly extended then the two patch dimensions are swapped.
-                E.g.  :math:`(j \\times 1)` and :math:`(j)` which is treated as
-                :math:`(j \\times 1)` and :math:`(1 \\times j)`
+              - The two batch dimensions are swapped. E.g. the first input has (`j` x `1`)
+                and the second input has (`1` x `j`)
+                or the first input has (`1` x `j`) and the second input has
+                (`j` x `1`)
+              - When a batch dimension is implicitly extended, the two patch dimensions are swapped.
+                E.g.  (`j` x `1`) and (`j`) which is treated as
+                (`j` x `1`) and (`1` x `j`)
 
-        - In order to leverage sharded matmul implementations we can shard both input_tensor_a and input_tensor_b. The sharding strategy used will be according
-          to the sharding strategy on the respective tensor. A sharded 1D matmul can be either HEIGHT or WIDTH sharded, 2D matmuls can be block sharded.
+        - In order to leverage sharded matmul implementations we can shard both `input_tensor_a` and `input_tensor_b`. The sharding strategy used will be according
+          to the sharding strategy on the respective tensor. A sharded 1D matmul can be either HEIGHT or WIDTH sharded, 2D matmuls can be BLOCK sharded.
 
           Note: the broadcasting logic only looks at the batch dimensions when determining if the inputs
           are broadcastable, and not the matrix dimensions. For example, if :attr:`input_tensor_a` is a
-          :math:`(j \\times 1 \\times n\_size \\times m\_size)` tensor and :attr:`input_tensor_b` is a :math:`(k\_size \\times m\_size \\times p)`
+          (`j` x `1` x `n_size` x `m_size`) tensor and :attr:`input_tensor_b` is a (`k_size` x `m_size` x `p`)
           tensor, these inputs are valid for broadcasting even though the final two dimensions (i.e. the
-          matrix dimensions) are different. The operation will return a :math:`(j \\times k\_size \\times n\_size \\times p)` tensor.
+          matrix dimensions) are different. The operation will return a (`j` x `k_size` x `n_size` x `p`) tensor.
 
         - Note: there are various additional constraints related to specific program
           configs chosen. Please look at the error messages carefully and fix
@@ -217,12 +217,15 @@ void py_module(py::module& module) {
             input_tensor_b (ttnn.Tensor): the second tensor to be multiplied. Needs to be on the device.
 
         Keyword Args:
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
             memory_config(ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using ttnn.DRAM_MEMORY_CONFIG.
             dtype (ttnn.DataType): the data type of the output tensor. Defaults to `None`.
-            core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             program_config (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to `None`.
             activation (str, optional): the activation function to be applied. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -319,12 +322,15 @@ void py_module(py::module& module) {
 
         Keyword Args:
             bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
             dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
-            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
             activation (str, optional): the activation function to be applied. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.


### PR DESCRIPTION
### Ticket
Link to Github Issue: #13144

### What's changed
- Updated description according to PyTorch Reference
- Added examples to ops
- Fixed additional bugs

### List of Ops
- [x] ttnn.arange
- [x] ttnn.empty
- [x] ttnn.empty_like
- [x] ttnn.zeros
- [x] ttnn.zeros_like
- [x] ttnn.ones
- [x] ttnn.ones_like
- [x] ttnn.full
- [x] ttnn.full_like
- [x] ttnn.matmul
- [x] ttnn.linear

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11051499233) - PASSED