### PR TITLE
Fix Yolo tests after updating weights shape in conv2d

### DIFF
--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_head.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_head.py
@@ -74,13 +74,13 @@ def test_head(device, reset_seeds, model_location_generator):
     result_3 = ttnn.to_torch(result_ttnn[2])
     ref1, ref2, ref3 = torch_model(torch_input_tensor[0], torch_input_tensor[1], torch_input_tensor[2])
 
-    result_1 = result_1.reshape(1, ref1.shape[2], ref1.shape[3], 256)
+    result_1 = result_1.reshape(1, ref1.shape[2], ref1.shape[3], 255)
     result_1 = result_1.permute(0, 3, 1, 2)
 
-    result_2 = result_2.reshape(1, ref2.shape[2], ref2.shape[3], 256)
+    result_2 = result_2.reshape(1, ref2.shape[2], ref2.shape[3], 255)
     result_2 = result_2.permute(0, 3, 1, 2)
 
-    result_3 = result_3.reshape(1, ref3.shape[2], ref3.shape[3], 256)
+    result_3 = result_3.reshape(1, ref3.shape[2], ref3.shape[3], 255)
     result_3 = result_3.permute(0, 3, 1, 2)
 
     # Output is sliced because ttnn.conv returns 256 channels instead of 255.

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py
@@ -49,13 +49,13 @@ def test_yolov4(device, reset_seeds, model_location_generator):
 
     ref1, ref2, ref3 = torch_model(torch_input)
 
-    result_1 = result_1.reshape(1, ref1.shape[2], ref1.shape[3], 256)
+    result_1 = result_1.reshape(1, ref1.shape[2], ref1.shape[3], 255)
     result_1 = result_1.permute(0, 3, 1, 2)
 
-    result_2 = result_2.reshape(1, ref2.shape[2], ref2.shape[3], 256)
+    result_2 = result_2.reshape(1, ref2.shape[2], ref2.shape[3], 255)
     result_2 = result_2.permute(0, 3, 1, 2)
 
-    result_3 = result_3.reshape(1, ref3.shape[2], ref3.shape[3], 256)
+    result_3 = result_3.reshape(1, ref3.shape[2], ref3.shape[3], 255)
     result_3 = result_3.permute(0, 3, 1, 2)
 
     # Output is sliced because ttnn.conv returns 256 channels instead of 255.


### PR DESCRIPTION
### Ticket
#13129 

### Problem description
Yolov4 Nightly tests fail



### Checklist
- [ ] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/11054885336 )
- [ ] Nightly CI [fixed yolo + no regression ](https://github.com/tenstorrent/tt-metal/actions/runs/11054888241)
