### PR TITLE
#0: fix CCL nightly tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_nightly.py
@@ -19,7 +19,6 @@ import itertools
 @pytest.mark.parametrize(
     "num_devices, num_links",
     [
-        (4, 1),
         (8, 1),
     ],
 )
@@ -79,6 +78,84 @@ def test_reduce_scatter_nightly(
 ):
     run_reduce_scatter_test(
         t3k_mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        scatter_dim,
+        num_links,
+        math_op,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        num_iters=num_iters,
+        enable_async=enable_async,
+    )
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (4, 2),
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape, scatter_dim, layout",
+    [
+        ([1, 8, 1024, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 4, 1024, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 4, 2048, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 32], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 64], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 64, 64], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 128], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 256], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 512], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 2048], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 128, 1024], 3, ttnn.TILE_LAYOUT),
+        # Has worker slice size warning - defaults to 1x1
+        ([1, 1, 128, 8192], 3, ttnn.TILE_LAYOUT),
+        # Always fails with bfp8_b
+        ([1, 1, 2048, 1024], 3, ttnn.TILE_LAYOUT),
+        # Has worker slice size warning - defaults to 1x1
+        ([1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
+@pytest.mark.parametrize("enable_async", [True, False])
+def test_reduce_scatter_nightly(
+    pcie_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    scatter_dim,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    num_iters=1,
+):
+    run_reduce_scatter_test(
+        pcie_mesh_device,
         num_devices,
         per_chip_output_shape,
         scatter_dim,


### PR DESCRIPTION
### Ticket
#12986

### Problem description
There was a t3k nightly regression

### What's changed
Update 4chip reduce scatter tests to use pcie_device_mesh so that we will always target the inner 4-chips (ring) of the t3000.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11056879927
- [x] T3000 nightly: https://github.com/tenstorrent/tt-metal/actions/runs/11055279218
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
