### PR TITLE
#13142: Add documentation for device ops, memory config

### DIFF
--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -56,25 +56,7 @@ void ttnn_device(py::module& module) {
                 <ttnn._ttnn.device.Device object at 0x7fbac5bfc1b0>
         )doc");
 
-    module.def(
-        "close_device",
-        &ttnn::close_device,
-        py::arg("device"),
-        R"doc(
-            Close the specified device.
-
-            Args:
-                device (ttnn.Device): the device to be closed.
-
-            Returns:
-                `None`: the device is closed.
-
-            Example:
-                >>> device_id = 0
-                >>> device = ttnn.open_device(device_id = device_id)
-                >>> success = ttnn.close_device(device)
-                Closing device 0
-        )doc");
+    module.def("close_device", &ttnn::close_device, py::arg("device"));
 
     module.def("enable_program_cache", &ttnn::enable_program_cache, py::arg("device"));
 
@@ -239,9 +221,9 @@ void device_module(py::module& m_device) {
                 This functionality is planned for deprecation in the future.
 
             Example:
-                device_id = 0
-                device = ttnn.open_device(device_id = device_id)
-                ttnn.SetDefaultDevice(device)
+                >>> device_id = 0
+                >>> device = ttnn.open_device(device_id = device_id)
+                >>> ttnn.SetDefaultDevice(device)
         )doc");
 
     m_device.def("GetDefaultDevice", &ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice,
@@ -255,7 +237,7 @@ void device_module(py::module& m_device) {
                 This functionality is planned for deprecation in the future.
 
             Example:
-                device = ttnn.GetDefaultDevice()
+                >>> device = ttnn.GetDefaultDevice()
         )doc");
 
     m_device.def(
@@ -349,7 +331,7 @@ void device_module(py::module& m_device) {
             This functionality is planned for deprecation in the future.
 
         Example:
-            padded_shape = ttnn.pad_to_tile_shape(unpadded_shape=[1, 2, 2, 2], pad_c=False, pad_n=False, pad_h=True, pad_w=True)
+            >>> padded_shape = ttnn.pad_to_tile_shape(unpadded_shape=[1, 2, 2, 2], pad_c=False, pad_n=False, pad_h=True, pad_w=True)
 
         )doc");
 
@@ -411,7 +393,7 @@ void device_module(py::module& m_device) {
                     cq_id (int, optional): The command queue ID to synchronize. Defaults to `None`.
 
                 Returns:
-                `None`: The op ensures that all operations are completed.
+                    `None`: The op ensures that all operations are completed.
 
                 Example:
                     >>> device_id = 0

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -98,11 +98,15 @@ def create_sharded_memory_config(
         halo (bool, optional): if the shards have overlapping values. Defaults to `False`.
         use_height_and_width_as_shard_shape (bool, optional): if True, the height and width of the tensor will be used as the shard shape. Defaults to `False`. If is False, the shard shape will be calculated based on the core_grid and the tensor shape where tensor shape is seen as [math.prod(dims), width]
 
-    Example:
-        >>> tensor = ttnn.create_sharded_memory_config((5, 8), (320,64), ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.ROW_MAJOR, False)
+    Returns:
+        ttnn.MemoryConfig: the MemoryConfig object.
 
     Note:
         Currently sharding only supports L1 tensors.
+
+    Example:
+        >>> tensor = ttnn.create_sharded_memory_config((5, 8), (320,64), ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.ROW_MAJOR, False)
+
     """
 
     if not isinstance(shape, (list, tuple, ttnn.Shape)):

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -33,6 +33,16 @@ def close_device(device: "ttnn.device.Device"):
 
     Args:
         device (ttnn.device.Device): The device to close.
+
+    Returns:
+        `None`: the device is closed.
+
+    Example:
+        >>> device_id = 0
+        >>> device = ttnn.open_device(device_id = device_id)
+        >>> success = ttnn.close_device(device)
+        Closing device 0
+
     """
     synchronize_device(device)
     ttnn._ttnn.device.close_device(device)
@@ -103,11 +113,11 @@ def manage_device(device_id: int) -> "ttnn.device.Device":
         ttnn.device.Device: the opened device. The device will be closed automatically when the block is exited, even if an error occurs.
 
     Example:
-        with manage_device(device_id=0) as device:
-            # Perform operations with the device
-            tensor = ttnn.zeros((2, 3), device=device)
-            print(tensor)
-            ttnn.Tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        >>> with manage_device(device_id=0) as device:
+            >>> # Perform operations with the device
+            >>> tensor = ttnn.zeros((2, 3), device=device)
+            >>> print(tensor)
+        ttnn.Tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
     """
     device = open_device(device_id=device_id)
     try:

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -99,8 +99,15 @@ def manage_device(device_id: int) -> "ttnn.device.Device":
     Args:
         device_id (int): The device ID to open.
 
-    Yields:
-        ttnn.device.Device: The opened device
+    Returns:
+        ttnn.device.Device: the opened device. The device will be closed automatically when the block is exited, even if an error occurs.
+
+    Example:
+        with manage_device(device_id=0) as device:
+            # Perform operations with the device
+            tensor = ttnn.zeros((2, 3), device=device)
+            print(tensor)
+            ttnn.Tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
     """
     device = open_device(device_id=device_id)
     try:


### PR DESCRIPTION
### Ticket
Link to Github Issue: #13142

### What's changed
- Updated description according to PyTorch Reference
- Added examples to ops
- Fixed additional bugs

### List of Ops
- [x] ttnn.open_device
- [x] ttnn.close_device
- [x] ttnn.manage_device
- [x] ttnn.synchronize_device
- [x] ttnn.SetDefaultDevice
- [x] ttnn.GetDefaultDevice
- [x] ttnn.format_input_tensor
- [x] ttnn.format_output_tensor
- [x] ttnn.pad_to_tile_shape
- [x] ttnn.create_sharded_memory_config

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11065481365) - PASSED