### PR TITLE
#13172: Use lower python version and cache dependencies

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -142,11 +142,18 @@ jobs:
           touch 'generated/benchmark_data/measurement_2024-07-12T05:01:45+0000.csv'
           touch 'generated/benchmark_data/measurement_2024-07-12T04:59:14+0000.csv'
           touch 'generated/benchmark_data/measurement_2024-07-12T05:03:29+0000.csv'
-      - name: sdf
+      - uses: actions/setup-python@v5.0.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'infra/requirements-infra.txt'
+      - name: Install infra dependencies
+        run: pip install -r infra/requirements-infra.txt
+      - name: Create environment CSV test
         env:
           PYTHONPATH: ${{ github.workspace }}
           ARCH_NAME: grayskull
-        run: pip3 install loguru && python3 .github/scripts/data_analysis/create_benchmark_environment_csv.py
+        run: python3 .github/scripts/data_analysis/create_benchmark_environment_csv.py
       - name: Show files
         shell: bash
         run: find generated/benchmark_data -type f | xargs -n 1 -I {} bash -c 'echo {} && cat {}'


### PR DESCRIPTION
### Ticket

#13172

### Problem description

GitHub decided to hate us today for some reason, and now Python versions 3.12 or higher on GitHub-hosted runners enforce permissions on dependencies in their system Python.

### What's changed

Use python 3.10 or lower in data pipeline and cache dependencies.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
