### PR TITLE
Optimize argmax bfloat16 comparison, saves llama 16us per token

### DIFF
--- a/tt_metal/hw/inc/bfloat16_utils.h
+++ b/tt_metal/hw/inc/bfloat16_utils.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+// Optimized function to compare two bfloat16 values using integer arithmetic
+bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
+    /*
+    bfloat16 format (16 bits total):
+    [Sign (1 bit)][Exponent (8 bits)][Mantissa (7 bits)]
+       bit 15         bits 14-7          bits 6-0
+
+    Comparison Logic:
+    - If signs differ:
+        - If bf16_a is positive (sign bit 0), it is greater.
+        - If bf16_a is negative (sign bit 1), it is not greater.
+    - If signs are the same:
+        - Positive numbers: higher bits mean greater value.
+        - Negative numbers: higher bits mean smaller value (reverse comparison).
+    */
+
+    // Check if signs are different
+    if ((bf16_a ^ bf16_b) & 0x8000) {
+        // Signs differ: if bf16_a is positive, it's greater
+        return (bf16_a & 0x8000) == 0;
+    }
+
+    // Signs are the same
+    if (bf16_a & 0x8000) {
+        // Both negative: reverse comparison
+        return bf16_a < bf16_b;
+    } else {
+        // Both positive: regular comparison
+        return bf16_a > bf16_b;
+    }
+}

--- a/tt_metal/hw/inc/utils/bfloat16.h
+++ b/tt_metal/hw/inc/utils/bfloat16.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2043 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
-#include "bfloat16_utils.h"
+#include "utils/bfloat16.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
@@ -8,48 +8,35 @@
 
 //#include "debug/dprint.h"
 
-// Function to compare two bfloat16 values using integer arithmetic
+// Optimized function to compare two bfloat16 values using integer arithmetic
 bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
-    // Extract signs
-    uint16_t sign_a = (bf16_a >> 15) & 0x1;
-    uint16_t sign_b = (bf16_b >> 15) & 0x1;
+    /*
+    bfloat16 format (16 bits total):
+    [Sign (1 bit)][Exponent (8 bits)][Mantissa (7 bits)]
+       bit 15         bits 14-7          bits 6-0
 
-    uint16_t exp_a = (bf16_a >> 7) & 0xFF;
-    uint16_t exp_b = (bf16_b >> 7) & 0xFF;
+    Comparison Logic:
+    - If signs differ:
+        - If bf16_a is positive (sign bit 0), it is greater.
+        - If bf16_a is negative (sign bit 1), it is not greater.
+    - If signs are the same:
+        - Positive numbers: higher bits mean greater value.
+        - Negative numbers: higher bits mean smaller value (reverse comparison).
+    */
 
-    uint16_t man_a = bf16_a & 0x7F;
-    uint16_t man_b = bf16_b & 0x7F;
-
-    // TODO: Investigate subnormal support
-    // uint16_t subnormal_a = (exp_a == 0x00);
-    // uint16_t subnormal_b = (exp_b == 0x00);
-
-    // DPRINT << HEX() << (bf16_a) << " > " << bf16_b << ENDL();
-    // DPRINT << HEX() << (sign_a) << " signs " << sign_b << ENDL();
-    // DPRINT << HEX() << (exp_a) << " exp " << exp_b << ENDL();
-    // DPRINT << HEX() << (man_a) << " man " << man_b << ENDL();
-
-    // If signs are different, the one without the sign bit is greater
-    if (sign_a != sign_b) {
-        // DPRINT << "sign_b > sign_a: " << (int)(sign_b > sign_a) << ENDL();
-        return sign_b > sign_a;
+    // Check if signs are different
+    if ((bf16_a ^ bf16_b) & 0x8000) {
+        // Signs differ: if bf16_a is positive, it's greater
+        return (bf16_a & 0x8000) == 0;
     }
 
-    // If signs are the same, compare the exponent and mantissa
-    if (sign_a == 0) { // Positive numbers
-        if(exp_a == exp_b) {
-            // DPRINT << "man_a > man_b: " << (int)(man_a > man_b) << ENDL();
-            return man_a > man_b;
-        }
-        // DPRINT << "exp_a > exp_b: " << (int)(exp_a > exp_b) << ENDL();
-        return exp_a > exp_b;
-    } else { // Negative numbers
-        if(exp_a == exp_b) {
-            // DPRINT << "man_a < man_b: " << (int)(man_a < man_b) << ENDL();
-            return man_a < man_b;
-        }
-        // DPRINT << "exp_a < exp_b: " << (int)(exp_a < exp_b) << ENDL();
-        return exp_a < exp_b;
+    // Signs are the same
+    if (bf16_a & 0x8000) {
+        // Both negative: reverse comparison
+        return bf16_a < bf16_b;
+    } else {
+        // Both positive: regular comparison
+        return bf16_a > bf16_b;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
@@ -5,40 +5,7 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
-
-//#include "debug/dprint.h"
-
-// Optimized function to compare two bfloat16 values using integer arithmetic
-bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
-    /*
-    bfloat16 format (16 bits total):
-    [Sign (1 bit)][Exponent (8 bits)][Mantissa (7 bits)]
-       bit 15         bits 14-7          bits 6-0
-
-    Comparison Logic:
-    - If signs differ:
-        - If bf16_a is positive (sign bit 0), it is greater.
-        - If bf16_a is negative (sign bit 1), it is not greater.
-    - If signs are the same:
-        - Positive numbers: higher bits mean greater value.
-        - Negative numbers: higher bits mean smaller value (reverse comparison).
-    */
-
-    // Check if signs are different
-    if ((bf16_a ^ bf16_b) & 0x8000) {
-        // Signs differ: if bf16_a is positive, it's greater
-        return (bf16_a & 0x8000) == 0;
-    }
-
-    // Signs are the same
-    if (bf16_a & 0x8000) {
-        // Both negative: reverse comparison
-        return bf16_a < bf16_b;
-    } else {
-        // Both positive: regular comparison
-        return bf16_a > bf16_b;
-    }
-}
+#include "bfloat16_utils.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
-#include "bfloat16_utils.h"
+#include "utils/bfloat16.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -8,48 +8,35 @@
 
 //#include "debug/dprint.h"
 
-// Function to compare two bfloat16 values using integer arithmetic
+// Optimized function to compare two bfloat16 values using integer arithmetic
 bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
-    // Extract signs
-    uint16_t sign_a = (bf16_a >> 15) & 0x1;
-    uint16_t sign_b = (bf16_b >> 15) & 0x1;
+    /*
+    bfloat16 format (16 bits total):
+    [Sign (1 bit)][Exponent (8 bits)][Mantissa (7 bits)]
+       bit 15         bits 14-7          bits 6-0
 
-    uint16_t exp_a = (bf16_a >> 7) & 0xFF;
-    uint16_t exp_b = (bf16_b >> 7) & 0xFF;
+    Comparison Logic:
+    - If signs differ:
+        - If bf16_a is positive (sign bit 0), it is greater.
+        - If bf16_a is negative (sign bit 1), it is not greater.
+    - If signs are the same:
+        - Positive numbers: higher bits mean greater value.
+        - Negative numbers: higher bits mean smaller value (reverse comparison).
+    */
 
-    uint16_t man_a = bf16_a & 0x7F;
-    uint16_t man_b = bf16_b & 0x7F;
-
-    // TODO: Investigate subnormal support
-    // uint16_t subnormal_a = (exp_a == 0x00);
-    // uint16_t subnormal_b = (exp_b == 0x00);
-
-    // DPRINT << HEX() << (bf16_a) << " > " << bf16_b << ENDL();
-    // DPRINT << HEX() << (sign_a) << " signs " << sign_b << ENDL();
-    // DPRINT << HEX() << (exp_a) << " exp " << exp_b << ENDL();
-    // DPRINT << HEX() << (man_a) << " man " << man_b << ENDL();
-
-    // If signs are different, the one without the sign bit is greater
-    if (sign_a != sign_b) {
-        // DPRINT << "sign_b > sign_a: " << (int)(sign_b > sign_a) << ENDL();
-        return sign_b > sign_a;
+    // Check if signs are different
+    if ((bf16_a ^ bf16_b) & 0x8000) {
+        // Signs differ: if bf16_a is positive, it's greater
+        return (bf16_a & 0x8000) == 0;
     }
 
-    // If signs are the same, compare the exponent and mantissa
-    if (sign_a == 0) { // Positive numbers
-        if(exp_a == exp_b) {
-            // DPRINT << "man_a > man_b: " << (int)(man_a > man_b) << ENDL();
-            return man_a > man_b;
-        }
-        // DPRINT << "exp_a > exp_b: " << (int)(exp_a > exp_b) << ENDL();
-        return exp_a > exp_b;
-    } else { // Negative numbers
-        if(exp_a == exp_b) {
-            // DPRINT << "man_a < man_b: " << (int)(man_a < man_b) << ENDL();
-            return man_a < man_b;
-        }
-        // DPRINT << "exp_a < exp_b: " << (int)(exp_a < exp_b) << ENDL();
-        return exp_a < exp_b;
+    // Signs are the same
+    if (bf16_a & 0x8000) {
+        // Both negative: reverse comparison
+        return bf16_a < bf16_b;
+    } else {
+        // Both positive: regular comparison
+        return bf16_a > bf16_b;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -5,40 +5,7 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
-
-//#include "debug/dprint.h"
-
-// Optimized function to compare two bfloat16 values using integer arithmetic
-bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {
-    /*
-    bfloat16 format (16 bits total):
-    [Sign (1 bit)][Exponent (8 bits)][Mantissa (7 bits)]
-       bit 15         bits 14-7          bits 6-0
-
-    Comparison Logic:
-    - If signs differ:
-        - If bf16_a is positive (sign bit 0), it is greater.
-        - If bf16_a is negative (sign bit 1), it is not greater.
-    - If signs are the same:
-        - Positive numbers: higher bits mean greater value.
-        - Negative numbers: higher bits mean smaller value (reverse comparison).
-    */
-
-    // Check if signs are different
-    if ((bf16_a ^ bf16_b) & 0x8000) {
-        // Signs differ: if bf16_a is positive, it's greater
-        return (bf16_a & 0x8000) == 0;
-    }
-
-    // Signs are the same
-    if (bf16_a & 0x8000) {
-        // Both negative: reverse comparison
-        return bf16_a < bf16_b;
-    } else {
-        // Both positive: regular comparison
-        return bf16_a > bf16_b;
-    }
-}
+#include "bfloat16_utils.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12328)

### Problem description
The bfloat16_greater function used by argmax uses a lot of unnecessary comparisons, bfloat16 is stored in sign/exponent/mantissa so once you've figured out if it's positive or negative you can just compare the uint16 representation directly and save a few cycles.

### What's changed
Rewrote bfloat16_greater to reduce the number of ops needed.
Saves llama 3.1 8b around 16k cycles per call.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11290560466) (unrelated-looking greyskull hang)
- [ ] Blackhole Post commit (n/a)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11290571545) (Mamba fails but is flaky and doesn't use ttnn.argmax anyway)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11290579333)
- [x] [Nightly fast dispatch](https://github.com/tenstorrent/tt-metal/actions/runs/11069942654) (Flaky Mamba fails but mamba doesn't use ttnn.argmax, random-looking t5 grayskull timeout)
- [ ] New/Existing tests provide coverage for changes (n/a)
