### PR TITLE
#13143: Add documentation for core, set_printoptions ops

### DIFF
--- a/ttnn/cpp/pybind11/core.hpp
+++ b/ttnn/cpp/pybind11/core.hpp
@@ -42,7 +42,10 @@ void py_module(py::module& module) {
         Returns:
             `None`: modifies print options.
 
+        Examples:
+            >>> ttnn.set_printoptions(profile="short")
         )doc");
+
     module.def("dump_stack_trace_on_segfault", &ttnn::core::dump_stack_trace_on_segfault);
 }
 

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -151,7 +151,8 @@ void py_module(py::module& module) {
                 >>> device = ttnn.open_device(0)
                 >>> tensor = ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16))
                 >>> device_tensor = ttnn.to_device(tensor=tensor, device=device)
-                >>> host_tensor = ttnn.from_device(device_tensor)
+                >>> # non-blocking mode
+                >>> host_tensor = ttnn.from_device(tensor=device_tensor, blocking=False)
         )doc");
 
     module.def("deallocate", &ttnn::operations::core::deallocate, py::arg("tensor"), py::arg("force") = true,
@@ -170,7 +171,7 @@ void py_module(py::module& module) {
             >>> device = ttnn.open_device(device_id=device_id)
             >>> tensor = ttnn.to_device(ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16)), device)
             >>> tensor = ttnn.to_layout(tensor, layout=ttnn.TILE_LAYOUT)
-            >>> ttnn.deallocate(tensor)
+            >>> ttnn.deallocate(tensor=tensor, force=False)
     )doc");
 
     module.def(
@@ -358,7 +359,7 @@ void py_module(py::module& module) {
             >>> tensor = ttnn.to_device(ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16)), device)
             >>> tensor = ttnn.to_layout(tensor, layout=ttnn.TILE_LAYOUT)
             >>> print(tensor[0,0,:3])
-            Tensor([ 1.42188, -1.25, -0.398438], dtype=bfloat16)
+            Tensor([1.42188, -1.25, -0.398438], dtype=bfloat16)
         )doc",
         ttnn::pybind_overload_t{
             [](const std::decay_t<decltype(ttnn::to_layout)> self,

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -182,12 +182,13 @@ def from_torch(
     Converts the `torch.Tensor` tensor into a `ttnn.Tensor`.
 
     Args:
-        tensor (torch.Tensor): The input tensor.
-        dtype (ttnn.DataType, optional): The desired `ttnn` data type. Defaults to `None`.
+        tensor (torch.Tensor): the input tensor.
+        dtype (ttnn.DataType, optional): the desired `ttnn` data type. Defaults to `None`.
 
     Keyword Args:
-        layout (ttnn.Layout, optional): The desired `ttnn` layout. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
-        device (ttnn.Device, optional): The desired `ttnn` device. Defaults to `None`.
+        tile (ttnn.Tile, optional): the desired tiling configuration for the tensor. Defaults to `None`.
+        layout (ttnn.Layout, optional): the desired `ttnn` layout. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
+        device (ttnn.Device, optional): the desired `ttnn` device. Defaults to `None`.
         memory_config (ttnn.MemoryConfig, optional): The desired `ttnn` memory configuration. Defaults to `None`.
         mesh_mapper (ttnn.TensorToMesh, optional): The desired `ttnn` mesh mapper. Defaults to `None`.
 
@@ -274,7 +275,7 @@ def to_torch(
     Converts the `ttnn.Tensor` tensor into a `torch.Tensor`.
 
     Args:
-        tensor (ttnn.Tensor): The `ttnn.Tensor` to be converted to `torch.Tensor`.
+        tensor (ttnn.Tensor): the input tensor.
 
     Keyword Args:
         torch_rank (int, optional): Desired rank of the `torch.Tensor`. Defaults to `None`.
@@ -449,13 +450,17 @@ def load_tensor(file_name: Union[str, pathlib.Path], *, device: ttnn.Device = No
     Load tensor from a file.
 
     Args:
-        file_name (str | pathlib.Path): The file name.
+        file_name (str | pathlib.Path): the file name.
 
     Keyword Args:
-        device (ttnn.Device, optional): The device. Defaults to `None`.
+        device (ttnn.Device, optional): the device. Defaults to `None`.
 
     Returns:
-        ttnn.Tensor: The loaded tensor.
+        ttnn.Tensor: the loaded tensor.
+
+    Example:
+        >>> device = ttnn.open_device(0)
+        >>> tensor = ttnn.load_tensor(file_name=str(tensor.bin), device=device)
     """
     file_name = pathlib.Path(file_name)
     if not file_name.exists():
@@ -472,8 +477,15 @@ def dump_tensor(file_name: Union[str, pathlib.Path], tensor: ttnn.Tensor, distri
 
     Args:
         file_name (str | pathlib.Path): The file name.
-        tensor (ttnn.Tensor): The tensor.
+        tensor (ttnn.Tensor): the tensor to be dumped.
         distribute (Dict[str, str], optional): The distributed strategy. Only applicable to multi-device tensors. Defaults to `None`.
+
+    Returns:
+        `None`: tensor saved to a specified file.
+
+    Example:
+        >>> tensor = ttnn.ones([2, 3], bfloat16, ttnn.ROW_MAJOR_LAYOUT)
+        >>> dump_tensor(file_name=str(tensor.bin), tensor=tensor)
     """
     if distribute is None:
         distribute = dict()
@@ -495,10 +507,10 @@ def as_tensor(
     use_device_tilizer: bool = False,
 ) -> ttnn.Tensor:
     """
-    Converts the `torch.Tensor` :attr:`tensor` into a `ttnn.Tensor`.
+    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`.
 
     Args:
-        tensor (torch.Tensor): Input tensor
+        tensor (torch.Tensor): the input tensor.
         dtype (ttnn.DataType, optional): The `ttnn` data type.
 
     Keyword args:
@@ -508,7 +520,7 @@ def as_tensor(
         cache_file_name (str | pathlib.Path, optional): The cache file name. Defaults to `None`.
         preprocess (Callable[[ttnn.Tensor], ttnn.Tensor], optional): The function to preprocess the tensor before serializing/converting to ttnn. Defaults to `None`.
         mesh_mapper (ttnn.TensorToMesh, optional): The TensorToMesh to define the mapping from torch to multi-device. Defaults to `None`.
-        use_device_tilizer (bool): The flag that toggles whether to use host vs. device tilizer. Defaults to `False`.
+        use_device_tilizer (bool, optional): The flag that toggles whether to use host vs. device tilizer. Defaults to `False`.
 
             - For Grayskull, the on-device tilizer will truncate mantissa bits for bfp* formats.
             - For Wormhole, the on-device tilizer will raise a runtime error (RTE) for bfp8 but will truncate for bfp4/2 formats.
@@ -519,8 +531,8 @@ def as_tensor(
     Examples:
         >>> tensor = ttnn.as_tensor(torch.randn((2,3)), dtype=ttnn.bfloat16)
         >>> print(tensor)
-        Tensor([ [1.375, -1.30469, -0.714844],
-            [-0.761719, 0.53125, -0.652344]], dtype=bfloat16 )
+        Tensor([[1.375, -1.30469, -0.714844],
+            [-0.761719, 0.53125, -0.652344]], dtype=bfloat16)
     """
 
     dtype_name = dtype.name if dtype is not None else "None"

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -198,7 +198,7 @@ def from_torch(
     Example:
         >>> tensor = ttnn.from_torch(torch.randn((2,3)), dtype=ttnn.bfloat16)
         >>> print(tensor)
-        Tensor([ [1.375, -1.30469, -0.714844],
+        Tensor([[1.375, -1.30469, -0.714844],
             [-0.761719, 0.53125, -0.652344]], dtype=bfloat16)
     """
 


### PR DESCRIPTION
### Ticket
Link to Github Issue: #13143

### What's changed
- Updated description according to PyTorch Reference
- Added examples to ops
- Fixed additional bugs

### List of Ops

- [x] ttnn.as_tensor
- [x] ttnn.from_torch
- [x] ttnn.to_torch
- [x] ttnn.to_device
- [x] ttnn.from_device
- [x] ttnn.to_layout
- [x] ttnn.dump_tensor
- [x] ttnn.load_tensor
- [x] ttnn.deallocate
- [x] ttnn.reallocate
- [x] ttnn.to_memory_config
- [x] ttnn.set_printoptions

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11072314301) - PASSED