### PR TITLE
Fix demo_trace and add on-device argmax to test_llama_perf

### DIFF
--- a/models/demos/wormhole/llama31_8b/demo/demo_trace.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_trace.py
@@ -124,10 +124,10 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
     output_filename = f"{output_directory}/demo_user_output_{timestamp}.txt"
 
     # Set Llama flags for CI
-    # if is_ci_env and instruct_mode:  # Update paths for instruct mode, otherwise use default paths for general weights
-    os.environ["LLAMA_CKPT_DIR"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
-    os.environ["LLAMA_TOKENIZER_PATH"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
-    os.environ["LLAMA_CACHE_PATH"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
+    if is_ci_env and instruct_mode:  # Update paths for instruct mode, otherwise use default paths for general weights
+        os.environ["LLAMA_CKPT_DIR"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
+        os.environ["LLAMA_TOKENIZER_PATH"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
+        os.environ["LLAMA_CACHE_PATH"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
     # This module requires the env paths above for CI runs
     from models.demos.wormhole.llama31_8b.tt.model_config import TtModelArgs
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12328)

### Problem description
demo_trace incorrectly ignores env vars and the perf test doesn't use on-device argmax

### What's changed
Fix the above issues

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11071400498) (random unrelated GS test times out)
- [ ] Blackhole Post commit (not applicable)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11071408653) (unrelated mamba perf check fails as on main)
- [x] [Nightly fast dispatch](https://github.com/tenstorrent/tt-metal/actions/runs/11071421247) (unrelated mamba, falcon and GS bert fails)
- [ ] New/Existing tests provide coverage for changes (not applicable)
