### PR TITLE
#0: linker script firware/kernel boundary alignment

### DIFF
--- a/tt_metal/hw/toolchain/sections.ld
+++ b/tt_metal/hw/toolchain/sections.ld
@@ -15,19 +15,6 @@
 __firmware_start = DEFINED(__fw_export_end_text) ? __fw_export_end_text : ORIGIN(REGION_CODE);
 __ldm_start = DEFINED(__fw_export_ldm_end) ? __fw_export_ldm_end : ORIGIN(REGION_DATA);
 
-/*
-  Need a 32B separation between FW end and Kernel start on eriscs to
-    ensure kernel does not get cached into i$ because we cannot flush the i$.
-  FW must align to 32 byte boundary so Kernel begins aligned to meet noc
-    alignment constraints
-*/
-#if LD_TARGET == IERISC
-__padding = 31;
-__alignment = 32;
-#endif
-__padding = 0;
-__alignment = 16;
-
 OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
 	      "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
@@ -65,8 +52,7 @@ SECTIONS
     *(l1_data_noinit)
   } > REGION_CODE
 
-  . += __padding;
-  . = ALIGN(__alignment);
+  . = ALIGN(16);
 
   PROVIDE (__etext = .);
   PROVIDE (_etext = .);


### PR DESCRIPTION
### Ticket
NA

### Problem description
While looking at XIP support I noticed this fragment of linker script. There are three problems
1) The `#if` fragment setting __padding & __align is unconditionally overwritten, because the non ierisc path is not in a `#else` block. This kind of makes the following 2 points moot, but I mention them because maybe this is a latent bug?

2) the description of what is happening here is confusing and the behavior does not match 'needs 32bytes of padding'.  If the end address is `32m + n`, one will get 31 bytes of padding when `n == 1`.  (one gets 32 bytes when `n == 0` and `64-n` for all other values. What I think it's trying to achieve is that the firmware and kernel do not share a (32byte?) cache line, and for that a simple `ALIGN(32)` is sufficient.  Perhaps additional padding is needed because of inst buffer read ahead straying past the firmware into the next cache line? But in any case `we cannot flush the cache` seems just broken -- what's to stop a first kernel sitting in the cache after memory is overwritten by a second kernel?

3) setting global symbols `__align` and `__padding` is undesirable -- this is being processed by the C preprocessor, we can just use `#define`

### What's changed
Remove the ineffective code paths.

### Checklist
- [Yes ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ NA] Model regression CI testing passes (if applicable)
- [ NA] Device performance regression CI testing passes (if applicable)
- [ Yes] New/Existing tests provide coverage for changes
