### PR TITLE
Fix gen_shapes in sweep_framework/utils.py

### DIFF
--- a/tests/sweep_framework/utils.py
+++ b/tests/sweep_framework/utils.py
@@ -60,7 +60,7 @@ def gen_shapes(start_shape, end_shape, interval, num_samples="all"):
 
     else:
         samples_id = 0
-
+        TIMEOUT = 5
         while samples_id < num_samples:
             shape = []
 
@@ -68,11 +68,8 @@ def gen_shapes(start_shape, end_shape, interval, num_samples="all"):
                 x = random.randint(start_shape[i], end_shape[i])
                 shape.append(align_to_interval(x, start_shape[i], interval[i]))
 
-            if shape in shapes:
-                pass
-            else:
-                samples_id += 1
-                shapes.append(shape)
+            samples_id += 1
+            shapes.append(shape)
 
     return shapes
 


### PR DESCRIPTION
### Problem description
If the interval in gen_shape function is too high (or the range between start_shape and end_shape is too low), it could cause hangs in vector generation.

### What's changed
Modified gen_shape function

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
