### PR TITLE
#0: integrate distributed sharded layernrm with llama-tg

### DIFF
--- a/models/demos/tg/llama3_70b/tt/llama_common.py
+++ b/models/demos/tg/llama3_70b/tt/llama_common.py
@@ -148,7 +148,65 @@ def setup_llama_env(llama_version="llama3", max_batch_size=32, max_context_len=4
     return model_config, ckpt_dir, tokenizer_path, cache_path
 
 
-def tt_sharded_distributed_rmsnorm(mesh_device, inp, epsilon, gamma):
+def tt_distributed_rmsnorm(inp, epsilon, gamma, mesh_device, compute_kernel_config):
+    # Run distributed rmsnorm part 1
+    tt_stats = ttnn.rms_norm_pre_all_gather(inp, compute_kernel_config=compute_kernel_config, dtype=ttnn.bfloat16)
+
+    padded_shape = (1, 1, inp.shape[-2], 32)
+    tt_stats = ttnn.reshape(tt_stats, ttnn.Shape(padded_shape, padded_shape))  # TODO: Figure out why we need this
+    tt_stats = tt_all_gather(
+        tt_stats,
+        mesh_device=mesh_device,
+        dim=3,
+        cluster_axis=1,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Run distributed rmsnorm part 2
+    tt_out = ttnn.rms_norm_post_all_gather(
+        inp, tt_stats, epsilon=epsilon, weight=gamma, compute_kernel_config=compute_kernel_config
+    )
+
+    tt_stats.deallocate(True)
+
+    return tt_out
+
+
+# def tt_sharded_distributed_rmsnorm(
+#     inp, epsilon, gamma, mesh_device, ln_sharded_input_memcfg, ln_sharded_progcfg, ln_sharded_stats_memcfg
+# ):
+#     inp = ttnn.to_memory_config(inp, memory_config=ln_sharded_input_memcfg)
+
+#     # Run distributed rmsnorm part 1
+#     tt_stats = ttnn.rms_norm_pre_all_gather(inp, program_config=ln_sharded_progcfg)
+
+#     # All gather stats
+#     tt_stats = ttnn.line_all_gather(
+#         tt_stats,
+#         3,
+#         num_links=1,
+#         cluster_axis=1,
+#         mesh_device=mesh_device,
+#         memory_config=ln_sharded_stats_memcfg,
+#     )
+
+#     # Run distributed rmsnorm part 2
+#     tt_out = ttnn.rms_norm_post_all_gather(
+#         inp,
+#         epsilon=epsilon,
+#         weight=gamma,
+#         program_config=ln_sharded_progcfg,
+#         stats=tt_stats,
+#     )
+#     tt_stats.deallocate(True)
+
+#     return tt_out
+
+
+def tt_sharded_distributed_rmsnorm(
+    inp, epsilon, gamma, mesh_device, ln_sharded_input_memcfg, ln_sharded_progcfg, ln_sharded_stats_memcfg
+):
     core_grid = (4, 8)
     num_cores = core_grid[0] * core_grid[1]
     input_sharded_memory_config = ttnn.create_sharded_memory_config(
@@ -187,4 +245,3 @@ def tt_sharded_distributed_rmsnorm(mesh_device, inp, epsilon, gamma):
     )
     tt_stats.deallocate(True)
     return tt_out
-

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -23,6 +23,7 @@ from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,
     tt_all_gather,
     tt_sharded_distributed_rmsnorm,
+    tt_distributed_rmsnorm,
 )
 
 
@@ -297,36 +298,6 @@ class TtLlamaModel_galaxy:
         else:
             raise ValueError(f"Unknown llm_mode: {mode}")
 
-    def tt_distributed_rmsnorm(self, inp, epsilon, gamma):
-        # Run distributed rmsnorm part 1
-        tt_stats = ttnn.rms_norm_pre_all_gather(
-            inp, compute_kernel_config=self.core_model_config["LN_COMPUTE_KERNEL_CONFIG"], dtype=ttnn.bfloat16
-        )
-
-        padded_shape = (1, 1, inp.shape[-2], 32)
-        tt_stats = ttnn.reshape(tt_stats, ttnn.Shape(padded_shape, padded_shape))  # TODO: Figure out why we need this
-        tt_stats = tt_all_gather(
-            tt_stats,
-            mesh_device=self.mesh_device,
-            dim=3,
-            cluster_axis=1,
-            num_links=1,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        # Run distributed rmsnorm part 2
-        tt_out = ttnn.rms_norm_post_all_gather(
-            inp,
-            tt_stats,
-            epsilon=epsilon,
-            weight=gamma,
-            compute_kernel_config=self.core_model_config["LN_COMPUTE_KERNEL_CONFIG"],
-        )
-
-        tt_stats.deallocate(True)
-
-        return tt_out
-
     def decode_forward(
         self,
         xs: List[ttnn.Tensor],
@@ -339,10 +310,13 @@ class TtLlamaModel_galaxy:
             xs = layer(xs, rot_mats, start_pos, attn_masks, mode="decode")  # xs is fractured
 
         norm_out = tt_sharded_distributed_rmsnorm(
-            self.mesh_device,
             xs,
             epsilon=self.norm_eps,
             gamma=self.norm_sharded,
+            mesh_device=self.mesh_device,
+            ln_sharded_input_memcfg=self.core_model_config["LN_SHARDED_INPUT_MEMCFG"],
+            ln_sharded_progcfg=self.core_model_config["LN_SHARDED_PROGCFG"],
+            ln_sharded_stats_memcfg=self.core_model_config["LN_SHARDED_STATS_MEMCFG"],
         )
 
         norm_out = ttnn.to_memory_config(norm_out, memory_config=self.core_model_config["LM_HEAD_ACT_MEMCFG"])
@@ -380,10 +354,12 @@ class TtLlamaModel_galaxy:
         for id, layer in enumerate(self.layers):
             xs = layer(xs, rot_mats, start_pos, attn_masks, user_id, mode="prefill")
 
-        norm_out = self.tt_distributed_rmsnorm(
+        norm_out = tt_distributed_rmsnorm(
             xs,
             epsilon=self.norm_eps,
             gamma=self.norm_sharded,
+            mesh_device=self.mesh_device,
+            compute_kernel_config=self.LN_COMPUTE_KERNEL_CONFIG,
         )
         # Slice out last padding_length(32) tokens in LM head to produce next token
         # TODO: Does not work for perplexity, or if we padded input to current sequence length

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -22,6 +22,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,
     tt_all_gather,
+    tt_sharded_distributed_rmsnorm,
 )
 
 
@@ -337,10 +338,9 @@ class TtLlamaModel_galaxy:
         for layer in self.layers:
             xs = layer(xs, rot_mats, start_pos, attn_masks, mode="decode")  # xs is fractured
 
-        xs_interleaved = ttnn.to_memory_config(xs, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-        norm_out = self.tt_distributed_rmsnorm(
-            xs_interleaved,
+        norm_out = tt_sharded_distributed_rmsnorm(
+            self.mesh_device,
+            xs,
             epsilon=self.norm_eps,
             gamma=self.norm_sharded,
         )

--- a/models/demos/tg/llama3_70b/tt/model_config.py
+++ b/models/demos/tg/llama3_70b/tt/model_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -411,36 +411,28 @@ def set_decoder_config(model_config):
         packer_l1_acc=False,
     )
 
-    decode_config["LN_PROGCFG"] = ttnn.LayerNormShardedMultiCoreProgramConfig(
-        compute_with_storage_grid_size=[8, 4],
-        subblock_w=8,
-        block_h=32 // 32,
-        block_w=8,
+    # Sharded LN config
+    core_grid_ln = (4, 8)
+    num_cores_ln = core_grid_ln[0] * core_grid_ln[1]
+    hidden_size_per_device_distributed_ln = model_config["HIDDEN_SIZE"] // model_config["CLUSTER_SHAPE"][0]
+    decode_config["LN_SHARDED_INPUT_MEMCFG"] = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 32, hidden_size_per_device_distributed_ln),
+        core_grid=ttnn.CoreGrid(y=core_grid_ln[0], x=core_grid_ln[1]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+    decode_config["LN_SHARDED_PROGCFG"] = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(core_grid_ln[1], core_grid_ln[0]),
+        subblock_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
+        block_h=1,
+        block_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
         inplace=False,
     )
-
-    shard_spec_32_cores_grid = ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(
-                ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(7, 3),
-            ),
-        }
+    decode_config["LN_SHARDED_STATS_MEMCFG"] = ttnn.create_sharded_memory_config(
+        shape=[1, 1, 32, 32 * model_config["CLUSTER_SHAPE"][0]],
+        core_grid=ttnn.CoreGrid(y=1, x=1),
+        strategy=ttnn.ShardStrategy.WIDTH,
     )
 
-    decode_config["LN_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(
-            shard_spec_32_cores_grid,
-            [
-                32,
-                8192 // 32,
-            ],
-            ttnn.ShardOrientation.ROW_MAJOR,
-            False,
-        ),
-    )
     decode_config["ATTN_ACT_MEMCFG"] = ttnn.create_sharded_memory_config(
         shape=(32, 2048 // 32),
         core_grid=ttnn.CoreGrid(y=4, x=8),
@@ -465,6 +457,29 @@ def set_decoder_config(model_config):
 
 def set_core_model_config(model_config, cluster_shape):
     decode_config = {}
+
+    # Sharded LN config
+    core_grid_ln = (4, 8)
+    num_cores_ln = core_grid_ln[0] * core_grid_ln[1]
+    hidden_size_per_device_distributed_ln = model_config_entries["hidden_size"] // cluster_shape[0]
+    decode_config["LN_SHARDED_INPUT_MEMCFG"] = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 32, hidden_size_per_device_distributed_ln),
+        core_grid=ttnn.CoreGrid(y=core_grid_ln[0], x=core_grid_ln[1]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+    decode_config["LN_SHARDED_PROGCFG"] = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(core_grid_ln[1], core_grid_ln[0]),
+        subblock_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
+        block_h=1,
+        block_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
+        inplace=False,
+    )
+    decode_config["LN_SHARDED_STATS_MEMCFG"] = ttnn.create_sharded_memory_config(
+        shape=[1, 1, 32, 32 * model_config["CLUSTER_SHAPE"][0]],
+        core_grid=ttnn.CoreGrid(y=1, x=1),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+
     decode_config["LN_COMPUTE_KERNEL_CONFIG"] = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi2,
         math_approx_mode=False,


### PR DESCRIPTION
### Problem description
Replaced interleaved distributed layernorm with their sharded version in llama-tg.
### Perf and Accuracy
 Demo output is accurate after the changes. 
 e2e perf improved from `1.3 t/s/u `->` 1.6 t/s/u`
```
2024-09-27 20:26:05.805 | INFO     | models.demos.tg.llama3_70b.demo.demo:run_decode:273 - Loop 175 user 31: <|begin_of_text|>Counting in binary: 0000, 0001, 0010, 0011, 0100, 0101, 0110, 0│
111, 1000, 1001, 1010, 1011, 1100, 1101, 1110, 1111, 10000, 10001, 10010, 10011, 10100, 10101, 10110, 10111, 11000, 11001, 11010, 11011, 11100, 11101, 11110, 11111, 100000, 100001, 100010, │
100011, 100100, 100101, 100110, 100111, 101000, 101001, 101                                                                                                                                  │
                                                                                                                                                                                             │
2024-09-27 20:26:05.805 | INFO     | models.demos.tg.llama3_70b.demo.demo:latency_printout:311 - Overall throughput: 19.7 ms @ 50.7 tokens/s                                                 │
2024-09-27 20:26:05.805 | INFO     | models.demos.tg.llama3_70b.demo.demo:latency_printout:312 - Tokens per second per user: 1.6 tokens/s/u                                                  │
2024-09-27 20:26:05.805 | INFO     | models.demos.tg.llama3_70b.demo.demo:latency_printout:313 - User latency: 630.6 ms @ 1.6 tokens/s  
```

### What's changed
* Added tt_sharded_distributed_rmsnorm() in llama_common.py
* Replaced following interleaved version
   1. attn layernorm
   2. mlp layernorm
   3. final layernorm

### Checklist
- [x] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/11080935934
- [x] TG Frequent https://github.com/tenstorrent/tt-metal/actions/runs/11140866990