### PR TITLE
Mchiou/13011 dump firmware and system logs if ci jobs fail

### DIFF
--- a/.github/actions/generate-system-logs/action.yml
+++ b/.github/actions/generate-system-logs/action.yml
@@ -1,0 +1,32 @@
+name: ""
+description: "Generate system logs for hardware debugging"
+
+inputs:
+  run_args:
+    description: 'Commands to run in docker'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Get Runner Host Name
+      id: get_hostname
+      shell: bash
+      run: |
+        echo "HOSTNAME=$(hostname)" >> $GITHUB_ENV
+        echo "TIMESTAMP=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+    - name: Determine Docker Tag to use
+      shell: bash
+      run: |
+        rm -rf ~/run-log
+        mkdir -p ~/run-log/
+        sudo dmesg > ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_dmesg.log
+        sudo lspci > ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_lspci.log
+        sudo lshw > ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_lshw.log
+    - name: 'Tar files'
+      shell: bash
+      run: tar -cvf ~/run-log/sys_logs.tar ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_*
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_sys_logs
+        path: ~/run-log/${{ env.TIMESTAMP}}_sys_logs.tar

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -65,3 +65,6 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U0593J2RQRZ # Bill Teng
+      - name: Generate system logs on failure
+        uses: ./.github/actions/generate-system-logs
+        if: ${{ failure() }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -77,3 +77,6 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: U0593J2RQRZ # Bill Teng
+      - name: Generate system logs on failure
+        uses: ./.github/actions/generate-system-logs
+        if: ${{ failure() }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -85,3 +85,6 @@ jobs:
           path: |
             generated/test_reports/
           prefix: "test_reports_"
+      - name: Generate system logs on failure
+        uses: ./.github/actions/generate-system-logs
+        if: ${{ failure() }}


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/13011

### Problem description
Could for debugging if a system crashes possibly due to firmware/driver issues.

### What's changed
new GH Action which uploads artifacts which contains logs about tt-smi dumps, pci connections, etc on test failure

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
