### PR TITLE
#13128: Add cmake options to control what tests get built

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -111,8 +111,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
-            nice -n 19 cmake --build build --target tests
+            nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
             nice -n 19 cmake --build build --target install
 
       - name: 'Tar files'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,8 +43,8 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja
-            nice -n 19 cmake --build build --target tests
+            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
+            nice -n 19 cmake --build build
 
       - name: Check disk space
         run: |

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -37,7 +37,7 @@ jobs:
           ./scripts/build_scripts/build_with_profiler_opt.sh
           ./create_venv.sh
       - name: Build tests
-        run: cmake --build build --target tests -- -j`nproc`
+        run: cmake --build build -- -j`nproc`
       - name: Run microbenchmark tests
         timeout-minutes: 90
         run: ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type microbenchmarks

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build UMD device and tests
         run: |
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
           cmake --build build --target umd_tests
       - name: Run UMD unit regression tests
         timeout-minutes: 10

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build UMD device and tests
         run: |
-          cmake -B build -G Ninja
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
           cmake --build build --target umd_tests
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,11 @@ endif()
 add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttnn)
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
+option(TT_METAL_BUILD_TESTS "Enables build of tt_metal tests" OFF)
+option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
+if(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
+endif(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
 
 ############################################################################################################################
 # Install targets for build artifacts and pybinds
@@ -273,7 +277,7 @@ install(TARGETS ttnn
 )
 if(WITH_PYTHON_BINDINGS)
     # Install .so into src files for pybinds implementation
-    install(FILES ${PROJECT_BINARY_DIR}/lib/_ttnn.so
+    install(TARGETS ttnn
     DESTINATION ${PROJECT_SOURCE_DIR}/ttnn/ttnn
     COMPONENT tt_pybinds
     )

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -167,12 +167,11 @@ ln -nsf $build_dir build
 
 # Prepare cmake arguments
 # -DCXX_INCLUDE_WHAT_YOU_USE=include-what-you-use
-cmake_args="$cmake_args -B $build_dir -G Ninja -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_EXPORT_COMPILE_COMMANDS=$export_compile_commands"
+cmake_args="$cmake_args -B $build_dir -G Ninja -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_EXPORT_COMPILE_COMMANDS=$export_compile_commands -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON"
 
 # Configure cmake
 cmake $cmake_args
 
 # Build libraries and cpp tests
 echo "Building libraries and cpp tests"
-cmake --build $build_dir --target tests      # <- Can also just run `ninja tests -C build`
 cmake --build $build_dir --target install    # <- This is a general cmake way, can also just run `ninja install -C build`

--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -11,7 +11,7 @@ if [[ -z "$ARCH_NAME" ]]; then
     exit 1
 fi
 
-cmake -B build -G Ninja -DENABLE_TRACY=ON
+cmake -B build -G Ninja -DENABLE_TRACY=ON -DTT_METAL_BUILD_TESTS -DTTNN_BUILD_TESTS=ON
 
 if [[ $1 == "NO_CLEAN" ]]; then
     cmake --build build

--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -11,7 +11,7 @@ if [[ -z "$ARCH_NAME" ]]; then
     exit 1
 fi
 
-cmake -B build -G Ninja -DENABLE_TRACY=ON -DTT_METAL_BUILD_TESTS -DTTNN_BUILD_TESTS=ON
+cmake -B build -G Ninja -DENABLE_TRACY=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON
 
 if [[ $1 == "NO_CLEAN" ]]; then
     cmake --build build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,9 +4,12 @@ include(GoogleTest)
 add_library(test_common_libs INTERFACE)
 target_link_libraries(test_common_libs INTERFACE pthread gtest gtest_main)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
+if(TT_METAL_BUILD_TESTS)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
+endif(TT_METAL_BUILD_TESTS)
 
-set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn unit_tests_ttnn_ccl test_multi_device galaxy_unit_tests_ttnn ttnn watcher_dump umd_tests)
-add_custom_target(tests DEPENDS ${TESTS_DEPENDS_LIST})
+if(TTNN_BUILD_TESTS)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
+endif(TTNN_BUILD_TESTS)
+

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -10,6 +10,7 @@
 
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/hostdevcommon/dprint_common.h"
 #include "debug/dprint_buffer.h"
 #include "llrt/hal.hpp"
 

--- a/tt_metal/hw/inc/debug/dprint_buffer.h
+++ b/tt_metal/hw/inc/debug/dprint_buffer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "tt_metal/hostdevcommon/dprint_common.h"
 #include <dev_msgs.h>
 
 // Returns the buffer address for current thread+core. Differs for NC/BR/ER/TR0-2.

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_executable(watcher_dump ${CMAKE_CURRENT_SOURCE_DIR}/watcher_dump.cpp)
-target_link_libraries(watcher_dump PRIVATE test_metal_common_libs)
+target_link_libraries(watcher_dump PRIVATE tt_metal)
 target_include_directories(watcher_dump PRIVATE
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
### Ticket
Closes #13128 

### Problem description
Today, we either build no tests, or we build all tests.
Some tests like umd tests require ARCH_NAME to be set.
For future work, we need more configurability.

### What's changed
New CMake options are required to build the test suites we have.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
