### PR TITLE
#0: Move remote chip event synchronization to dispatch core

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -73,7 +73,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
                 ttnn::record_event(device->command_queue(1), workload_event);
                 ttnn::wait_for_event(device->command_queue(0), workload_event);
 
-                ttnn::read_buffer(1, output_tensor, {readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data});
+                ttnn::read_buffer(0, output_tensor, {readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data});
 
                 for (int j = 0; j < 3 * 2048 * 2048; j++) {
                     ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1521,12 +1521,6 @@ void EnqueueRecordEventCommand::process() {
             sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) + dispatch_constants::EVENT_PADDED_SIZE,
             pcie_alignment);  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_LINEAR_HOST + event ID
 
-    if (not device->is_mmio_capable()) {
-        cmd_sequence_sizeB +=
-            CQ_PREFETCH_CMD_BARE_MIN_SIZE *
-            num_hw_cqs;  // CQ_DISPATCH_REMOTE_WRITE (number of writes = number of prefetch_h cores on this CQ)
-    }
-
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);
 
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
@@ -1564,18 +1558,6 @@ void EnqueueRecordEventCommand::process() {
         event_payloads,
         packed_write_max_unicast_sub_cmds);
 
-    if (not device->is_mmio_capable()) {
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            tt_cxy_pair prefetch_location =
-                dispatch_core_manager::instance().prefetcher_core(this->device->id(), channel, cq_id);
-            CoreCoord prefetch_physical_core = get_physical_core_coordinate(prefetch_location, core_type);
-            command_sequence.add_dispatch_write_remote(
-                this->event_id,
-                this->device->get_noc_unicast_encoding(this->noc_index, prefetch_physical_core),
-                address);
-        }
-    }
-
     bool flush_prefetch = true;
     command_sequence.add_dispatch_write_host<true>(
         flush_prefetch, dispatch_constants::EVENT_PADDED_SIZE, true, event_payload.data());
@@ -1606,18 +1588,15 @@ EnqueueWaitForEventCommand::EnqueueWaitForEventCommand(
 
 void EnqueueWaitForEventCommand::process() {
     uint32_t cmd_sequence_sizeB = CQ_PREFETCH_CMD_BARE_MIN_SIZE;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
-                                                                  // or CQ_PREFETCH_CMD_WAIT_FOR_EVENT
 
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);
 
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
     uint32_t last_completed_event_address =
         sync_event.cq_id == 0 ? CQ0_COMPLETION_LAST_EVENT : CQ1_COMPLETION_LAST_EVENT;
-    if (this->device->is_mmio_capable()) {
-        command_sequence.add_dispatch_wait(false, last_completed_event_address, sync_event.event_id, this->clear_count);
-    } else {
-        command_sequence.add_prefetch_wait_for_event(sync_event.event_id, last_completed_event_address);
-    }
+
+    command_sequence.add_dispatch_wait(false, last_completed_event_address, sync_event.event_id, this->clear_count);
+
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->command_queue_id);
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -27,8 +27,7 @@ enum CQPrefetchCmdId : uint8_t {
     CQ_PREFETCH_CMD_EXEC_BUF_END = 7,         // finish executing commands from a buffer (return), payload like relay_inline
     CQ_PREFETCH_CMD_STALL = 8,                // drain pipe through dispatcher
     CQ_PREFETCH_CMD_DEBUG = 9,                // log waypoint data to watcher, checksum
-    CQ_PREFETCH_CMD_WAIT_FOR_EVENT = 10,      // wait_for_event: stall until dispatcher signals event completion
-    CQ_PREFETCH_CMD_TERMINATE = 11,           // quit
+    CQ_PREFETCH_CMD_TERMINATE = 10,           // quit
     CQ_PREFETCH_CMD_MAX_COUNT,                // for checking legal IDs
 };
 
@@ -47,9 +46,8 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_DEBUG = 10,             // log waypoint data to watcher, checksum
     CQ_DISPATCH_CMD_DELAY = 11,             // insert delay (for testing)
     CQ_DISPATCH_CMD_EXEC_BUF_END = 12,      // dispatch_d notify prefetch_h that exec_buf has completed
-    CQ_DISPATCH_CMD_REMOTE_WRITE = 13,      // dispatch_d issues write to address on L-Chip through dispatch_h
-    CQ_DISPATCH_CMD_SET_WRITE_OFFSET = 14,  // set the offset to add to all non-host destination addresses (relocation)
-    CQ_DISPATCH_CMD_TERMINATE = 15,         // quit
+    CQ_DISPATCH_CMD_SET_WRITE_OFFSET = 13,  // set the offset to add to all non-host destination addresses (relocation)
+    CQ_DISPATCH_CMD_TERMINATE = 14,         // quit
     CQ_DISPATCH_CMD_MAX_COUNT,              // for checking legal IDs
 };
 
@@ -115,13 +113,6 @@ struct CQPrefetchRelayInlineCmd {
     uint32_t stride;          // explicit stride saves a few insns on device
 } __attribute__((packed));
 
-struct CQPrefetchWaitForEventCmd {
-    uint8_t pad1;
-    uint16_t pad2;
-    uint32_t sync_event;
-    uint32_t sync_event_addr;
-} __attribute__((packed));
-
 struct CQPrefetchExecBufCmd {
     uint8_t pad1;
     uint16_t pad2;
@@ -138,7 +129,6 @@ struct CQPrefetchCmd {
         CQPrefetchRelayPagedPackedCmd relay_paged_packed;
         CQPrefetchRelayInlineCmd relay_inline;
         CQPrefetchExecBufCmd exec_buf;
-        CQPrefetchWaitForEventCmd event_wait;
         CQGenericDebugCmd debug;
     } __attribute__((packed));
 };
@@ -241,18 +231,6 @@ struct CQDispatchDelayCmd {
     uint32_t delay;
 } __attribute__((packed));
 
-// When dispatch_d gets this command, it will be
-// forwarded to dispatch_h, which will write data
-// to local noc_xy_addr at offset addr. The data
-// is currently a uint32_t field, which is inlined in
-// the command.
-struct CQDispatchRemoteWriteCmd {
-    uint32_t data;
-    uint32_t noc_xy_addr;
-    uint32_t addr;
-} __attribute__((packed));
-
-
 struct CQDispatchSetWriteOffsetCmd {
     uint8_t pad1;
     uint16_t pad2;
@@ -270,7 +248,6 @@ struct CQDispatchCmd {
         CQDispatchWritePagedCmd write_paged;
         CQDispatchWritePackedCmd write_packed;
         CQDispatchWritePackedLargeCmd write_packed_large;
-        CQDispatchRemoteWriteCmd write_from_remote;
         CQDispatchWaitCmd wait;
         CQGenericDebugCmd debug;
         CQDispatchDelayCmd delay;

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -183,7 +183,6 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream 
             case CQ_DISPATCH_CMD_GO: break;
             case CQ_DISPATCH_CMD_SINK: break;
             case CQ_DISPATCH_CMD_EXEC_BUF_END: break;
-            case CQ_DISPATCH_CMD_REMOTE_WRITE: break;
             case CQ_DISPATCH_CMD_TERMINATE: break;
             case CQ_DISPATCH_CMD_SET_WRITE_OFFSET: break;
             default: TT_THROW("Unrecognized dispatch command: {}", cmd_id); break;
@@ -248,13 +247,6 @@ uint32_t dump_prefetch_cmd(CQPrefetchCmd *cmd, uint32_t cmd_addr, std::ofstream 
                     val(cmd->debug.size),
                     val(cmd->debug.stride));
                 stride = cmd->debug.stride;
-                break;
-            case CQ_PREFETCH_CMD_WAIT_FOR_EVENT:
-                iq_file << fmt::format(
-                    " (sync_event={:#08x}, sync_event_addr={:#08x})",
-                    val(cmd->event_wait.sync_event),
-                    val(cmd->event_wait.sync_event_addr));
-                stride = CQ_PREFETCH_CMD_BARE_MIN_SIZE + sizeof(CQPrefetchHToPrefetchDHeader);
                 break;
             // These commands don't have any additional data to dump.
             case CQ_PREFETCH_CMD_ILLEGAL: break;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Previous R-Chip implementation would require event syncs to be processed on `prefetch_h`, since tunneler did not have VCs and a latent deadlock
- This lead to additional complexity and independent event sync mechanisms for L and R chips + worse perf on remote devices with 2 CQs

### What's changed
- With VCs in place, we can perform event synchronization on `dispatch_d` -> more performant, since prefetcher can keep buffering commands while `dispatch_d` is waiting

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
