### PR TITLE
#13187: revise `moreh_mean` and `moreh_mean_backward`

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -221,6 +221,10 @@ Primary Operations
 
 .. autofunction:: tt_lib.operations.primary.moreh_logsoftmax_backward
 
+.. autofunction:: ttnn.operations.moreh.mean
+
+.. autofunction:: ttnn.operations.moreh.mean_backward
+
 .. autofunction:: tt_lib.operations.primary.moreh_groupnorm
 
 .. autofunction:: tt_lib.operations.primary.moreh_groupnorm_backward

--- a/tests/ttnn/unit_tests/operations/test_moreh_mean.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_mean.py
@@ -204,10 +204,15 @@ def test_moreh_mean_compute_kernel_options(input_shape_dim, compute_kernel_optio
 def test_moreh_mean_callback(input_shape_dim, device, use_program_cache):
     torch.manual_seed(2023)
 
-    for _ in range(2):
+    for i in range(2):
         run_moreh_mean(input_shape_dim, device, keepdim=True)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_npu(torch_dummy, device)
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
 
 
 @pytest.mark.parametrize(
@@ -272,10 +277,15 @@ def test_moreh_mean_backward_compute_kernel_options(input_shape_dim, compute_ker
 def test_moreh_mean_backward_callback(input_shape_dim, device, use_program_cache):
     torch.manual_seed(2023)
 
-    for _ in range(2):
+    for i in range(2):
         run_moreh_mean_backward(input_shape_dim, device, keepdim=True)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_npu(torch_dummy, device)
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
@@ -5,7 +5,7 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
@@ -18,13 +18,10 @@ void kernel_main() {
     const DataFormat data_format = get_dataformat(cb_id_out);
 
     const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr,
-        .page_size = tile_bytes,
-        .data_format = data_format
-    };
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
 
     uint32_t end_id = start_id + num_tiles;
-    for (uint32_t i = start_id; i < end_id; ++ i) {
+    for (uint32_t i = start_id; i < end_id; ++i) {
         cb_wait_front(cb_id_out, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
         noc_async_write_tile(i, s, l1_read_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
@@ -18,7 +18,7 @@ void MorehMeanOperation::validate_tensors(
         (operation_attributes.dim >= 0 && operation_attributes.dim <= 7),
         "Invalid dimension value: {}. Expected a value between 0 and 7.",
         operation_attributes.dim);
-    // TT_FATAL(operation_attributes.divisor.has_value() == false, "divisor not supported yet.");
+    TT_FATAL(operation_attributes.divisor.has_value() == false, "divisor not supported yet.");
 
     tt::operations::primary::check_tensor(input, "moreh_mean", "input", {DataType::BFLOAT16});
     tt::operations::primary::check_tensor(output, "moreh_mean", "output", {DataType::BFLOAT16});
@@ -117,14 +117,14 @@ std::tuple<MorehMeanOperation::operation_attributes_t, MorehMeanOperation::tenso
     const Tensor& input,
     const int64_t dim,
     const bool keepdim,
-    // const std::optional<uint32_t>& divisor,
+    const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     return {
         {dim,
          keepdim,
-         //  divisor,
+         divisor,
          memory_config.value_or(input.memory_config()),
          init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
         {input, output}};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
@@ -4,8 +4,6 @@
 
 #include "moreh_mean_device_operation.hpp"
 
-#include <iostream>
-
 #include "tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -20,7 +18,7 @@ void MorehMeanOperation::validate_tensors(
         (operation_attributes.dim >= 0 && operation_attributes.dim <= 7),
         "Invalid dimension value: {}. Expected a value between 0 and 7.",
         operation_attributes.dim);
-    TT_FATAL(operation_attributes.divisor.has_value() == false, "divisor not supported yet.");
+    // TT_FATAL(operation_attributes.divisor.has_value() == false, "divisor not supported yet.");
 
     tt::operations::primary::check_tensor(input, "moreh_mean", "input", {DataType::BFLOAT16});
     tt::operations::primary::check_tensor(output, "moreh_mean", "output", {DataType::BFLOAT16});
@@ -112,19 +110,23 @@ MorehMeanOperation::tensor_return_value_t MorehMeanOperation::create_output_tens
         tensor_args.input.get_dtype(),
         tensor_args.input.get_layout(),
         tensor_args.input.device(),
-        operation_attributes.output_memory_config);
+        operation_attributes.memory_config);
 }
 
 std::tuple<MorehMeanOperation::operation_attributes_t, MorehMeanOperation::tensor_args_t> MorehMeanOperation::invoke(
     const Tensor& input,
     const int64_t dim,
     const bool keepdim,
-    const std::optional<uint32_t>& divisor,
+    // const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
-    const std::optional<MemoryConfig>& output_memory_config,
+    const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     return {
-        {dim, keepdim, divisor, output_memory_config.value_or(input.memory_config()), compute_kernel_config},
+        {dim,
+         keepdim,
+         //  divisor,
+         memory_config.value_or(input.memory_config()),
+         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
         {input, output}};
 }
 }  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
@@ -17,7 +17,7 @@ struct MorehMeanOperation {
     struct operation_attributes_t {
         const int64_t dim;
         const bool keepdim;
-        // const std::optional<uint32_t> divisor;
+        const std::optional<uint32_t> divisor;
         // const CoreRange core_range;  // unused for now
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
@@ -108,7 +108,7 @@ struct MorehMeanOperation {
         const Tensor& input,
         const int64_t dim,
         const bool keepdim,
-        // const std::optional<uint32_t>& divisor,
+        const std::optional<uint32_t>& divisor,
         const std::optional<Tensor>& output,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
@@ -17,10 +17,10 @@ struct MorehMeanOperation {
     struct operation_attributes_t {
         const int64_t dim;
         const bool keepdim;
-        const std::optional<uint32_t> divisor;
+        // const std::optional<uint32_t> divisor;
         // const CoreRange core_range;  // unused for now
-        const MemoryConfig output_memory_config;
-        const std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        const MemoryConfig memory_config;
+        const DeviceComputeKernelConfig compute_kernel_config;
     };
     struct tensor_args_t {
         const Tensor& input;
@@ -108,9 +108,9 @@ struct MorehMeanOperation {
         const Tensor& input,
         const int64_t dim,
         const bool keepdim,
-        const std::optional<uint32_t>& divisor,
+        // const std::optional<uint32_t>& divisor,
         const std::optional<Tensor>& output,
-        const std::optional<MemoryConfig>& output_memory_config,
+        const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
@@ -18,7 +18,6 @@ struct MorehMeanOperation {
         const int64_t dim;
         const bool keepdim;
         const std::optional<uint32_t> divisor;
-        // const CoreRange core_range;  // unused for now
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
     };
@@ -43,13 +42,13 @@ struct MorehMeanOperation {
         static cached_program_t create(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
 
         static void override_runtime_arguments(
             cached_program_t& cached_program,
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
     };
 
     struct MorehMeanNCFactory {
@@ -65,13 +64,13 @@ struct MorehMeanOperation {
         static cached_program_t create(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
 
         static void override_runtime_arguments(
             cached_program_t& cached_program,
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
     };
 
     struct MorehMeanWFactory {
@@ -87,13 +86,13 @@ struct MorehMeanOperation {
         static cached_program_t create(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
 
         static void override_runtime_arguments(
             cached_program_t& cached_program,
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
     };
 
     using program_factory_t = std::variant<MorehMeanHFactory, MorehMeanNCFactory, MorehMeanWFactory>;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -99,10 +99,8 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
     std::vector<uint32_t> writer_compile_time_args;
     const auto reader_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_nc.cpp";
     const auto writer_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp";
-    const auto reader_kernel_id =
-        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
-    const auto writer_kernel_id =
-        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
+    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
@@ -166,10 +164,7 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
             program,
             writer_kernel_id,
             core,
-            {output.buffer()->address(),
-             units_per_core,
-             tile_offset,
-             static_cast<uint32_t>(is_dram(output))});
+            {output.buffer()->address(), units_per_core, tile_offset, static_cast<uint32_t>(is_dram(output))});
 
         tile_offset += units_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
@@ -16,13 +16,12 @@ namespace ttnn::operations::moreh::moreh_mean {
 MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::MorehMeanWFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    tensor_return_value_t& output) {
     using namespace tt;
     using namespace tt::tt_metal;
     using namespace tt::operations::primary;
 
     auto input = tensor_args.input;
-    auto output = output_tensor;
     auto compute_kernel_config =
         init_device_compute_kernel_config(input.device()->arch(), operation_attributes.compute_kernel_config);
     const auto shape = input.get_shape();
@@ -138,8 +137,6 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
         ComputeKernelConfig{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            // TODO(hyungsuk): change unpack_to_dest_mode from false to fp32_dest_acc_en after fix #10337
-            // .unpack_to_dest_mode = fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .math_approx_mode = math_approx_mode,
             .defines = compute_defines});
@@ -190,20 +187,20 @@ void MorehMeanOperation::MorehMeanWFactory::override_runtime_arguments(
     auto num_cores = cached_program.shared_variables.num_cores;
     auto core_h = cached_program.shared_variables.core_h;
 
-    auto src_buffer = tensor_args.input.buffer();
-    auto dst_buffer = tensor_return_value.buffer();
+    auto src_buffer_address = tensor_args.input.buffer()->address();
+    auto dst_buffer_address = tensor_return_value.buffer()->address();
 
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
 
         {
             auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
+            runtime_args[0] = src_buffer_address;
         }
 
         {
             auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
+            runtime_args[0] = dst_buffer_address;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
@@ -82,8 +82,7 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
     auto bfloat_scaler_value = *(new class bfloat16(scaler));
     auto packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(is_dram(input)), packed_scaler_value};
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(is_dram(input)), packed_scaler_value};
 
     std::vector<uint32_t> writer_compile_time_args = {
         static_cast<uint32_t>(CB::c_out0), static_cast<uint32_t>(is_dram(output))};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
@@ -12,7 +12,7 @@ Tensor MorehMean::invoke(
     const Tensor& input,
     const std::optional<std::variant<int64_t, std::vector<int64_t>>> dim,
     const bool keep_batch_dim,
-    // const std::optional<uint32_t>& divisor,
+    const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
@@ -23,11 +23,11 @@ Tensor MorehMean::invoke(
     for (uint32_t i = dims.size() - 1; i > 0; i--) {
         log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims[i], keep_batch_dim);
         auto temp_output = ttnn::prim::moreh_mean(
-            temp_input, dims[i], keep_batch_dim, std::nullopt, memory_config, compute_kernel_config);
+            temp_input, dims[i], keep_batch_dim, divisor, std::nullopt, memory_config, compute_kernel_config);
         temp_input = temp_output;
     }
     log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims.front(), keep_batch_dim);
     return ttnn::prim::moreh_mean(
-        temp_input, dims.front(), keep_batch_dim, output, memory_config, compute_kernel_config);
+        temp_input, dims.front(), keep_batch_dim, divisor, output, memory_config, compute_kernel_config);
 }
 }  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::moreh::moreh_mean {
 Tensor MorehMean::invoke(
     const Tensor& input,
     const std::optional<std::variant<int64_t, std::vector<int64_t>>> dim,
-    const bool keep_batch_dim,
+    const bool keepdim,
     const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
@@ -21,13 +21,13 @@ Tensor MorehMean::invoke(
 
     auto temp_input = input;
     for (uint32_t i = dims.size() - 1; i > 0; i--) {
-        log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims[i], keep_batch_dim);
+        log_debug(tt::LogOp, "{}:{} dim {} keepdim {}", __func__, __LINE__, dims[i], keepdim);
         auto temp_output = ttnn::prim::moreh_mean(
-            temp_input, dims[i], keep_batch_dim, divisor, std::nullopt, memory_config, compute_kernel_config);
+            temp_input, dims[i], keepdim, divisor, std::nullopt, memory_config, compute_kernel_config);
         temp_input = temp_output;
     }
-    log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims.front(), keep_batch_dim);
+    log_debug(tt::LogOp, "{}:{} dim {} keepdim {}", __func__, __LINE__, dims.front(), keepdim);
     return ttnn::prim::moreh_mean(
-        temp_input, dims.front(), keep_batch_dim, divisor, output, memory_config, compute_kernel_config);
+        temp_input, dims.front(), keepdim, divisor, output, memory_config, compute_kernel_config);
 }
 }  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.cpp
@@ -12,9 +12,9 @@ Tensor MorehMean::invoke(
     const Tensor& input,
     const std::optional<std::variant<int64_t, std::vector<int64_t>>> dim,
     const bool keep_batch_dim,
-    const std::optional<uint32_t>& divisor,
+    // const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
-    const std::optional<MemoryConfig>& output_memory_config,
+    const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     std::vector<int64_t> dims = tt::operations::primary::get_dim(dim, input.get_shape().rank());
     std::sort(dims.begin(), dims.end());
@@ -23,11 +23,11 @@ Tensor MorehMean::invoke(
     for (uint32_t i = dims.size() - 1; i > 0; i--) {
         log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims[i], keep_batch_dim);
         auto temp_output = ttnn::prim::moreh_mean(
-            temp_input, dims[i], keep_batch_dim, divisor, std::nullopt, output_memory_config, compute_kernel_config);
+            temp_input, dims[i], keep_batch_dim, std::nullopt, memory_config, compute_kernel_config);
         temp_input = temp_output;
     }
     log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims.front(), keep_batch_dim);
     return ttnn::prim::moreh_mean(
-        temp_input, dims.front(), keep_batch_dim, divisor, output, output_memory_config, compute_kernel_config);
+        temp_input, dims.front(), keep_batch_dim, output, memory_config, compute_kernel_config);
 }
-}  // namespace ttnn::operations::moreh::moreh_sum
+}  // namespace ttnn::operations::moreh::moreh_mean

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
@@ -10,7 +10,7 @@ struct MorehMean {
     static Tensor invoke(
         const Tensor& input,
         const std::optional<std::variant<int64_t, std::vector<int64_t>>> dims,
-        const bool keep_batch_dim,
+        const bool keepdim,
         const std::optional<uint32_t>& divisor,
         const std::optional<Tensor>& output,
         const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
@@ -11,13 +11,14 @@ struct MorehMean {
         const Tensor& input,
         const std::optional<std::variant<int64_t, std::vector<int64_t>>> dims,
         const bool keep_batch_dim,
-        const std::optional<uint32_t>& divisor,
+        // const std::optional<uint32_t>& divisor,
         const std::optional<Tensor>& output,
-        const std::optional<MemoryConfig>& output_memory_config,
+        const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_mean
 
 namespace ttnn {
-constexpr auto moreh_mean = ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_mean", ttnn::operations::moreh::moreh_mean::MorehMean>();
+constexpr auto moreh_mean =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_mean", ttnn::operations::moreh::moreh_mean::MorehMean>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
@@ -11,7 +11,7 @@ struct MorehMean {
         const Tensor& input,
         const std::optional<std::variant<int64_t, std::vector<int64_t>>> dims,
         const bool keep_batch_dim,
-        // const std::optional<uint32_t>& divisor,
+        const std::optional<uint32_t>& divisor,
         const std::optional<Tensor>& output,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean_pybind.cpp
@@ -18,7 +18,7 @@ void bind_moreh_mean_operation(py::module& module) {
             py::kw_only(),
             py::arg("dim"),
             py::arg("keepdim") = false,
-            // py::arg("divisor") = std::nullopt,
+            py::arg("divisor") = std::nullopt,
             py::arg("output") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean_pybind.cpp
@@ -18,7 +18,7 @@ void bind_moreh_mean_operation(py::module& module) {
             py::kw_only(),
             py::arg("dim"),
             py::arg("keepdim") = false,
-            py::arg("divisor") = std::nullopt,
+            // py::arg("divisor") = std::nullopt,
             py::arg("output") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_mean_backward_device_operation.hpp"
-#include <iostream>
 
 #include "tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -76,7 +75,7 @@ MorehMeanBackwardOperation::tensor_return_value_t MorehMeanBackwardOperation::cr
         output_grad.get_dtype(),
         Layout::TILE,
         output_grad.device(),
-        operation_attributes.output_memory_config);
+        operation_attributes.memory_config);
 }
 
 std::tuple<MorehMeanBackwardOperation::operation_attributes_t, MorehMeanBackwardOperation::tensor_args_t>
@@ -86,16 +85,14 @@ MorehMeanBackwardOperation::invoke(
     const bool keepdim,
     const std::optional<Shape>& input_grad_shape,
     const std::optional<Tensor>& input_grad,
-    const std::optional<MemoryConfig>& output_memory_config,
+    const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-
     return {
-        {
-            dims,
-            keepdim,
-            input_grad_shape,
-            output_memory_config.value_or(output_grad.memory_config()),
-            compute_kernel_config},
+        {dims,
+         keepdim,
+         input_grad_shape,
+         memory_config.value_or(output_grad.memory_config()),
+         init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
         {
             output_grad,
             input_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
@@ -19,7 +19,6 @@ struct MorehMeanBackwardOperation {
         const bool keepdim;
         const std::optional<Shape> input_grad_shape;
         const MemoryConfig memory_config;
-        // const CoreRange core_range; // unused for now
         const DeviceComputeKernelConfig compute_kernel_config;
     };
     struct tensor_args_t {
@@ -43,13 +42,13 @@ struct MorehMeanBackwardOperation {
         static cached_program_t create(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
 
         static void override_runtime_arguments(
             cached_program_t& cached_program,
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensor);
+            tensor_return_value_t& output);
     };
 
     using program_factory_t = std::variant<MorehMeanBackwardFactory>;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
@@ -18,9 +18,9 @@ struct MorehMeanBackwardOperation {
         const std::vector<int64_t> dims;
         const bool keepdim;
         const std::optional<Shape> input_grad_shape;
-        const MemoryConfig output_memory_config;
+        const MemoryConfig memory_config;
         // const CoreRange core_range; // unused for now
-        const std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        const DeviceComputeKernelConfig compute_kernel_config;
     };
     struct tensor_args_t {
         const Tensor& output_grad;
@@ -66,13 +66,14 @@ struct MorehMeanBackwardOperation {
         const bool keepdim,
         const std::optional<Shape>& input_grad_shape,
         const std::optional<Tensor>& input_grad,
-        const std::optional<MemoryConfig>& output_memory_config,
+        const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_mean_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_mean_backward =
-    ttnn::register_operation<"ttnn::prim::moreh_mean_backward", ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation>();
+constexpr auto moreh_mean_backward = ttnn::register_operation<
+    "ttnn::prim::moreh_mean_backward",
+    ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -219,26 +219,26 @@ void MorehMeanBackwardOperation::MorehMeanBackwardFactory::override_runtime_argu
     cached_program_t &cached_program,
     const operation_attributes_t &operation_attributes,
     const tensor_args_t &tensor_args,
-    tensor_return_value_t &output_tensor){
-        auto& program = cached_program.program;
-        auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-        auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-        auto num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
-        auto num_cores_y = cached_program.shared_variables.num_cores_y;
+    tensor_return_value_t &output_tensor) {
+    auto &program = cached_program.program;
+    auto &reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto &writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores_to_be_used = cached_program.shared_variables.num_cores_to_be_used;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
 
-        const auto *output_grad_buffer = tensor_args.output_grad.buffer();
-        const auto *input_grad_buffer = output_tensor.buffer();
-        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = output_grad_buffer->address();
-            }
+    const auto *output_grad_buffer = tensor_args.output_grad.buffer();
+    const auto *input_grad_buffer = output_tensor.buffer();
+    for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        {
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = output_grad_buffer->address();
+        }
 
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = input_grad_buffer->address();
-            }
+        {
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = input_grad_buffer->address();
         }
     }
+}
 }  // namespace ttnn::operations::moreh::moreh_mean_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_mean_backward.hpp"
-#include <iostream>
 
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp"
@@ -15,7 +14,7 @@ Tensor MorehMeanBackward::invoke(
     const bool keepdim,
     const std::optional<Shape>& input_grad_shape,
     const std::optional<Tensor>& input_grad,
-    const std::optional<MemoryConfig>& output_memory_config,
+    const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     auto output_grad_rank = output_grad.get_shape().rank();
     auto input_grad_rank = output_grad_rank;
@@ -31,6 +30,6 @@ Tensor MorehMeanBackward::invoke(
     }
     std::vector<int64_t> dims = tt::operations::primary::get_dim(dim, input_grad_rank);
     return ttnn::prim::moreh_mean_backward(
-        output_grad, dims, keepdim, input_grad_shape, input_grad, output_memory_config, compute_kernel_config);
+        output_grad, dims, keepdim, input_grad_shape, input_grad, memory_config, compute_kernel_config);
 }
 }  // namespace ttnn::operations::moreh::moreh_mean_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp
@@ -13,11 +13,13 @@ struct MorehMeanBackward {
         const bool keepdim,
         const std::optional<Shape>& input_grad_shape,
         const std::optional<Tensor>& input_grad,
-        const std::optional<MemoryConfig>& output_memory_config,
+        const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_mean_backward
 
 namespace ttnn {
-constexpr auto moreh_mean_backward = ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_mean_backward", ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackward>();
+constexpr auto moreh_mean_backward = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::moreh_mean_backward",
+    ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackward>();
 }


### PR DESCRIPTION
### Ticket
#13086 

### Problem description
Revise `moreh_mean` and `moreh_mean_backward` to match other `ttnn` ops

### What's changed
- Remove `optional`s from `operation_attribute_t`
- Move optional handing to primitive invocation call
- Use `register_operation_with_auto_launch_op` for composite
- Adding callback testing to Python unit tests
- Reformatting code with `clang-format`

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
