### PR TITLE
#0: update all-gather tests to remove all_devices test fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -249,6 +249,29 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
 
 @pytest.fixture(scope="function")
+def n300_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
+    import ttnn
+
+    if ttnn.get_num_devices() < 2:
+        pytest.skip()
+
+    mesh_device = ttnn.open_mesh_device(
+        ttnn.MeshShape(1, 2),
+        dispatch_core_type=get_dispatch_core_type(),
+        **device_params,
+    )
+
+    logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
+    yield mesh_device
+
+    for device in mesh_device.get_devices():
+        ttnn.DumpDeviceProfiler(device)
+
+    ttnn.close_mesh_device(mesh_device)
+    del mesh_device
+
+
+@pytest.fixture(scope="function")
 def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
     import ttnn
 

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -8,7 +8,7 @@ run_additional_T3000_test(){
     remove_default_log_locations
     mkdir -p $PROFILER_ARTIFACTS_DIR
 
-    ./tt_metal/tools/profiler/profile_this.py -c "'pytest tests/ttnn/unit_tests/operations/test_all_gather.py::test_all_gather_on_t3000_post_commit[silicon_arch_name=wormhole_b0-silicon_arch_wormhole_b0=True-mem_config=MemoryConfig\(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt\)-input_dtype=DataType.BFLOAT16-num_devices=8-num_links=1-input_shape=[8,\ 1,\ 33,\ 256]-dim=0-layout=Layout.ROW_MAJOR]'" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
+    ./tt_metal/tools/profiler/profile_this.py -c "'pytest tests/ttnn/unit_tests/operations/test_all_gather.py::test_all_gather_on_t3000_post_commit_for_profiler_regression'" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
     if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
     then

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -8,7 +8,7 @@ run_additional_T3000_test(){
     remove_default_log_locations
     mkdir -p $PROFILER_ARTIFACTS_DIR
 
-    ./tt_metal/tools/profiler/profile_this.py -c "'pytest tests/ttnn/unit_tests/operations/test_all_gather.py::test_all_gather_on_t3000_post_commit[mem_config=MemoryConfig\(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt\)-input_dtype=DataType.BFLOAT16-num_devices=8-num_links=1-input_shape=[8,\ 1,\ 33,\ 256]-dim=0-layout=Layout.ROW_MAJOR]'" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
+    ./tt_metal/tools/profiler/profile_this.py -c "'pytest tests/ttnn/unit_tests/operations/test_all_gather.py::test_all_gather_on_t3000_post_commit[silicon_arch_name=wormhole_b0-silicon_arch_wormhole_b0=True-mem_config=MemoryConfig\(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt\)-input_dtype=DataType.BFLOAT16-num_devices=8-num_links=1-input_shape=[8,\ 1,\ 33,\ 256]-dim=0-layout=Layout.ROW_MAJOR]'" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
     if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
     then

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -470,6 +470,53 @@ def test_all_gather_on_t3000_nightly_commit_looping_4chip_ring(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
+        (8, 1, [8, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+    ],
+)
+def test_all_gather_on_t3000_post_commit_for_profiler_regression(
+    t3k_mesh_device,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+):
+    run_all_gather_on_t3000_impl(
+        t3k_mesh_device,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=ttnn.all_gather,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
         (8, 1, [8, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -7,7 +7,7 @@ import pytest
 from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
-from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
+from models.utility_functions import skip_for_grayskull
 import itertools
 from ttnn import ShardTensorToMesh
 
@@ -68,7 +68,7 @@ def is_unsupported_case_n300(input_shape, dim, mem_config, num_devices, num_link
 
 
 def run_with_trace(
-    t3k_mesh_device,
+    mesh_device,
     devices,
     all_gather_operation,
     input_tensor_mesh,
@@ -89,12 +89,12 @@ def run_with_trace(
         num_workers=n_worker,
         num_buffers_per_channel=n_buffer,
     )
-    for d in devices:
+    for d in mesh_device.get_devices():
         ttnn.synchronize_device(d)
 
     # Capture trace
     logger.info("Capturing trace")
-    trace_id = ttnn.begin_trace_capture(t3k_mesh_device, cq_id=0)
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
     for i in range(num_iter):
         tt_out_tensor = all_gather_operation(
             input_tensor_mesh,
@@ -104,22 +104,22 @@ def run_with_trace(
             num_workers=n_worker,
             num_buffers_per_channel=n_buffer,
         )
-    ttnn.end_trace_capture(t3k_mesh_device, trace_id, cq_id=0)
-    for d in devices:
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    for d in mesh_device.get_devices():
         ttnn.synchronize_device(d)
 
     # Run the op
     logger.info("Starting Trace perf test...")
-    ttnn.execute_trace(t3k_mesh_device, trace_id, blocking=False)
-    ttnn.release_trace(t3k_mesh_device, trace_id)
-    for d in devices:
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    for d in mesh_device.get_devices():
         ttnn.synchronize_device(d)
 
     return tt_out_tensor
 
 
 def run_all_gather_impl(
-    all_devices,
+    mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -130,20 +130,19 @@ def run_all_gather_impl(
     use_program_cache,
     function_level_defaults,
     all_gather_operation,
-    devices,
     num_iters=1,
     enable_async=False,
 ):
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
     # Use Async mode based on test input config
-    for device in all_devices:
+    for device in mesh_device.get_devices():
         device.enable_async(enable_async)
+
     if enable_async:
         logger.info(f"Using Async Mode for All Gather Op Dispatch")
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
-
-    # for device in devices:
-    #    device.disable_and_clear_program_cache()
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
@@ -153,13 +152,13 @@ def run_all_gather_impl(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
     for i in range(num_iters):
         tt_out_tensor = all_gather_operation(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
 
-        for d in devices:
+        for d in mesh_device.get_devices():
             ttnn.synchronize_device(d)
         logger.info(f"Done iteration {i}")
 
@@ -175,7 +174,7 @@ def run_all_gather_impl(
 
 
 def run_all_gather_on_n300_impl(
-    all_devices,
+    mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -189,7 +188,7 @@ def run_all_gather_on_n300_impl(
     num_iters=1,
     enable_async=False,
 ):
-    if len(all_devices) != 2:
+    if mesh_device.get_num_devices() != 2:
         pytest.skip("Not N300!")
 
     (is_known_failure, message) = is_unsupported_case_n300(
@@ -199,7 +198,7 @@ def run_all_gather_on_n300_impl(
         pytest.skip(f"Skipping unsupported case {message}.")
 
     return run_all_gather_impl(
-        all_devices,
+        mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -209,15 +208,14 @@ def run_all_gather_on_n300_impl(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        all_gather_operation,
-        all_devices,
-        num_iters,
-        enable_async,
+        all_gather_operation=all_gather_operation,
+        num_iters=num_iters,
+        enable_async=enable_async,
     )
 
 
 def run_all_gather_on_t3000_impl(
-    all_devices,
+    mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -231,7 +229,7 @@ def run_all_gather_on_t3000_impl(
     num_iters=1,
     enable_async=False,
 ):
-    if len(all_devices) != 8:
+    if mesh_device.get_num_devices() < num_devices:
         pytest.skip("Not T3000!")
 
     (is_known_failure, message) = is_unsupported_case_t3k(
@@ -240,10 +238,8 @@ def run_all_gather_on_t3000_impl(
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
 
-    devices = get_devices_for_t3000(all_devices, num_devices)
-
     return run_all_gather_impl(
-        all_devices,
+        mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -253,15 +249,14 @@ def run_all_gather_on_t3000_impl(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        all_gather_operation,
-        devices,
-        num_iters,
-        enable_async,
+        all_gather_operation=all_gather_operation,
+        num_iters=num_iters,
+        enable_async=enable_async,
     )
 
 
 def run_all_gather_on_t3000_impl_tight_loop(
-    all_devices,
+    mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -276,7 +271,7 @@ def run_all_gather_on_t3000_impl_tight_loop(
     enable_async=False,
 ):
     run_all_gather_on_t3000_impl(
-        all_devices,
+        mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -286,9 +281,9 @@ def run_all_gather_on_t3000_impl_tight_loop(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        all_gather_operation,
-        num_iters,
-        enable_async,
+        all_gather_operation=all_gather_operation,
+        num_iters=num_iters,
+        enable_async=enable_async,
     )
 
 
@@ -321,10 +316,10 @@ def run_all_gather_on_t3000_impl_tight_loop(
         # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("num_iters", [1])  # restore to 500: https://github.com/tenstorrent/tt-metal/issues/9686
-@pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("num_iters", [1000])  # restore to 500: https://github.com/tenstorrent/tt-metal/issues/9686
+@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_on_t3000_post_commit_looping(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -338,7 +333,65 @@ def test_all_gather_on_t3000_post_commit_looping(
     enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
-        all_devices,
+        t3k_mesh_device,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=ttnn.all_gather,
+        num_iters=num_iters,
+        enable_async=enable_async,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
+        (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+        (8, 1, [8, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,        # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
+@pytest.mark.parametrize("enable_async", [True, False])
+def test_all_gather_on_t3000_nightly_commit_looping(
+    t3k_mesh_device,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+):
+    run_all_gather_on_t3000_impl_tight_loop(
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -360,12 +413,8 @@ def test_all_gather_on_t3000_post_commit_looping(
     "num_devices, num_links, input_shape, dim, layout",
     [
         (4, 2, [4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
-        (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
-        (8, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
         (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
         (4, 2, [4, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
-        (8, 1, [8, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
-        (8, 1, [1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
         (4, 2, [1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
     ],
 )
@@ -385,8 +434,8 @@ def test_all_gather_on_t3000_post_commit_looping(
 )
 @pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
 @pytest.mark.parametrize("enable_async", [True, False])
-def test_all_gather_on_t3000_nightly_commit_looping(
-    all_devices,
+def test_all_gather_on_t3000_nightly_commit_looping_4chip_ring(
+    pcie_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -400,7 +449,7 @@ def test_all_gather_on_t3000_nightly_commit_looping(
     enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
-        all_devices,
+        pcie_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -421,26 +470,19 @@ def test_all_gather_on_t3000_nightly_commit_looping(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (4, 2, [4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
         (8, 1, [8, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
         # Only for BFP8B
         # # ([1, 1, 640, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # MLP AllGather,  Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
         # (8, 1, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # (8, 1, [1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # Input, Selfout, Final AllGather,  Llama2, Falcon 40B decode mlp attn
         # (8, 1, [1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # (8, 1, [1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # Falcon 40B prefill
         # # 8 chips
@@ -476,7 +518,7 @@ def test_all_gather_on_t3000_nightly_commit_looping(
     ],
 )
 def test_all_gather_on_t3000_post_commit(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -488,7 +530,7 @@ def test_all_gather_on_t3000_post_commit(
     function_level_defaults,
 ):
     run_all_gather_on_t3000_impl(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -502,8 +544,38 @@ def test_all_gather_on_t3000_post_commit(
     )
 
 
-def run_line_all_gather(
-    t3k_mesh_device,
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
+        (4, 2, [4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/968
+        # (4, 2, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # # (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # # Input, Selfout, Final AllGather,  Llama2, Falcon 40B decode mlp attn
+        # (4, 2, [1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,          # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),  # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+def test_all_gather_on_t3000_post_commit_4chip_ring(
+    pcie_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -513,107 +585,20 @@ def run_line_all_gather(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
-    num_iters=1,
 ):
-    if t3k_mesh_device.get_num_devices() != 8:
-        pytest.skip("Not T3000!")
-
-    for device in t3k_mesh_device.get_devices():
-        device.enable_async(enable_async)
-
-    logger.info(f"Input shape: {input_shape}")
-    logger.info(f"dim: {dim}")
-
-    (is_known_failure, message) = is_unsupported_case_t3k(
-        input_shape, dim, mem_config, num_devices, num_links, input_dtype, layout
+    run_all_gather_on_t3000_impl(
+        pcie_mesh_device,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=ttnn.all_gather,
     )
-    if is_known_failure:
-        pytest.skip(f"Skipping unsupported case {message}.")
-
-    logger.info(f"Input shape: {input_shape}")
-    logger.info(f"dim: {dim}")
-
-    input_tensor = torch.rand(input_shape).bfloat16()
-
-    ttnn_tensor = ttnn.from_torch(input_tensor, mesh_mapper=ShardTensorToMesh(t3k_mesh_device, dim=dim))
-    input_tensor_mesh = ttnn.to_device(ttnn_tensor, t3k_mesh_device)
-
-    for i in range(num_iters):
-        tt_out_tensor = ttnn.line_all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
-
-        logger.info(f"Done iteration {i}")
-
-    for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-        if input_dtype == ttnn.bfloat16:
-            eq, output = comp_equal(tt_output_tensor, input_tensor)
-        else:
-            eq, output = comp_pcc(tt_output_tensor, input_tensor)
-        if not eq:
-            logger.error(f"output mismatch for tensor {i}")
-        assert eq, f"{i} FAILED: {output}"
-
-
-# This run function is deprecated and is only intended to be used by 2-link tests on t3k
-def run_line_all_gather_deprecated(
-    all_devices,
-    num_devices,
-    input_shape,
-    dim,
-    num_links,
-    input_dtype,
-    layout,
-    mem_config,
-    use_program_cache,
-    function_level_defaults,
-    enable_async,
-    num_iters=1,
-):
-    if len(all_devices) != 8:
-        pytest.skip("Not T3000!")
-
-    for device in all_devices:
-        device.enable_async(enable_async)
-
-    logger.info(f"Input shape: {input_shape}")
-    logger.info(f"dim: {dim}")
-
-    (is_known_failure, message) = is_unsupported_case_t3k(
-        input_shape, dim, mem_config, num_devices, num_links, input_dtype, layout
-    )
-    if is_known_failure:
-        pytest.skip(f"Skipping unsupported case {message}.")
-
-    devices = get_devices_for_t3000(all_devices, num_devices)
-
-    logger.info(f"Input shape: {input_shape}")
-    logger.info(f"dim: {dim}")
-
-    input_tensor = torch.rand(input_shape).bfloat16()
-
-    input_tensors = torch.chunk(input_tensor, num_devices, dim)
-    tt_input_tensors = []
-    for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
-
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-    for i in range(num_iters):
-        tt_out_tensor = ttnn.line_all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
-
-        for d in devices:
-            ttnn.synchronize_device(d)
-        logger.info(f"Done iteration {i}")
-
-    for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-        if input_dtype == ttnn.bfloat16:
-            eq, output = comp_equal(tt_output_tensor, input_tensor)
-        else:
-            eq, output = comp_pcc(tt_output_tensor, input_tensor)
-        if not eq:
-            logger.error(f"output mismatch for tensor {i}")
-        assert eq, f"{i} FAILED: {output}"
 
 
 # Enumerate the post-commit cases explicitly
@@ -666,7 +651,10 @@ def test_line_all_gather_on_t3000_post_commit(
     enable_async,
     num_iters=1,
 ):
-    run_line_all_gather(
+    if t3k_mesh_device.get_num_devices() < num_devices:
+        pytest.skip("Not T3000!")
+
+    run_all_gather_on_t3000_impl(
         t3k_mesh_device,
         num_devices,
         input_shape,
@@ -677,41 +665,43 @@ def test_line_all_gather_on_t3000_post_commit(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        enable_async,
-        num_iters,
+        all_gather_operation=ttnn.line_all_gather,
+        enable_async=enable_async,
+        num_iters=num_iters,
     )
 
 
+# Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (
-            4,
-            2,
-            [1, 4, 32, 3584],
-            1,
-            ttnn.TILE_LAYOUT,
-        ),  # test cases with num_links = 2 is currently not supported by new mesh fixture
+        # (4, 2, [1, 4, 32, 3584], 1, ttnn.TILE_LAYOUT),
+        (4, 2, [1, 4, 32, 3584], 1, ttnn.TILE_LAYOUT),
+        # (4, 1, [4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 1, [8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 1, [8, 5, 32, 384], 3, ttnn.TILE_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
         ttnn.bfloat16,
-        ttnn.bfloat8_b,
+        ttnn.bfloat8_b,  # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),  # https://github.com/tenstorrent/tt-metal/issues/9686
         # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("enable_async", [True, False])
-def test_line_all_gather_on_t3000_post_commit_two_link(
-    all_devices,
+def test_line_all_gather_on_t3000_post_commit_4chip_ring(
+    pcie_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -724,8 +714,11 @@ def test_line_all_gather_on_t3000_post_commit_two_link(
     enable_async,
     num_iters=1,
 ):
-    run_line_all_gather_deprecated(
-        all_devices,
+    if pcie_mesh_device.get_num_devices() < num_devices:
+        pytest.skip("Not T3000!")
+
+    run_all_gather_on_t3000_impl(
+        pcie_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -735,8 +728,9 @@ def test_line_all_gather_on_t3000_post_commit_two_link(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        enable_async,
-        num_iters,
+        all_gather_operation=ttnn.line_all_gather,
+        enable_async=enable_async,
+        num_iters=num_iters,
     )
 
 
@@ -787,7 +781,10 @@ def test_line_all_gather_on_t3000_nightly(
     enable_async,
     num_iters=1,
 ):
-    run_line_all_gather(
+    if t3k_mesh_device.get_num_devices() < num_devices:
+        pytest.skip("Not T3000!")
+
+    run_all_gather_on_t3000_impl(
         t3k_mesh_device,
         num_devices,
         input_shape,
@@ -798,9 +795,109 @@ def test_line_all_gather_on_t3000_nightly(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        enable_async,
-        num_iters,
+        all_gather_operations=ttnn.line_all_gather,
+        enable_async=enable_async,
+        num_iters=num_iters,
     )
+
+
+nightly_all_gather_shape_dim_layouts = [
+    ([4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
+    ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+    ([8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
+    ([8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 0, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 0, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 2, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 3, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 768], 3, ttnn.TILE_LAYOUT),
+    ([8, 8, 1024, 4096], 1, ttnn.TILE_LAYOUT),
+    ([8, 8, 2048, 4096], 1, ttnn.TILE_LAYOUT),
+    ([8, 8, 128, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 1024, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 2048, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+    # Only for BFP8B
+    # ([1, 1, 640, 32768], 3, ttnn.TILE_LAYOUT),
+    # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
+    # Mixtral 8x7B, functional bringup with expanded tensor getting allgathered
+    # Full shape for 8 chips
+    ([1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Input, Selfout, Final AllGather
+    ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
+    # Half shape for 4 chips, same per chip shape as 8 chips
+    ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
+    # Full shape for 8 chips
+    ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
+    # Half shape for running on 4 chips, same per chip shape as for 8 chips
+    ([1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Falcon 40B prefill
+    # 8 chips
+    ([1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # 4 chips, same per chip shape as 8 chips
+    ([1, 1, 2048, 4096], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Falcon 40B prefill
+    # 8 chips
+    ([1, 1, 2048, 32768], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # 4 chips, same per chip shape as 8 chips
+    ([1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Mixtral 8x7B, Min sequence length
+    # 8 chips
+    # ([1, 1, 32768, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 32768, 32768], 3, ttnn.TILE_LAYOUT),  # ultra slow?
+    # 4 chips, per chip shape same as 8 chips
+    # ([1, 1, 32768, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # ([1, 1, 32768, 16384], 3, ttnn.TILE_LAYOUT),
+    # Llama galaxy mlp weights stationary -> emulation of row/col reduce
+    ([1, 1, 128, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 128, 1024], 2, ttnn.TILE_LAYOUT),
+    # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY
+    # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY
+    ([1, 1, 128, 4096], 2, ttnn.ROW_MAJOR_LAYOUT),  #
+    ([1, 1, 128, 4096], 2, ttnn.TILE_LAYOUT),
+    # ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
+    # ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
+    ([1, 1, 8192, 32], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 8192, 32], 2, ttnn.TILE_LAYOUT),
+    ([1, 1, 1024, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 1024, 128], 3, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 16384, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 16384, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 32768, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 32768, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 4096, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # only for 4 chip
+    ([1, 1, 4096, 128], 3, ttnn.TILE_LAYOUT),  # only for 4 chip
+    ([1, 1, 128, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 128, 2048], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # only for 4 chip - ALREADY LISTED PREVIOUSLY
+    # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # only for 4 chip - ALREADY LISTED PREVIOUSLY
+    ([1, 1, 128, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 128, 8192], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 256, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 1024, 256], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 256, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 256, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+]
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
@@ -808,111 +905,10 @@ def test_line_all_gather_on_t3000_nightly(
     "num_devices, num_links",
     [
         (2, 1),
-        (4, 1),
-        (4, 2),
         (8, 1),
     ],
 )
-@pytest.mark.parametrize(
-    "input_shape, dim, layout",
-    [
-        ([4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
-        ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
-        ([8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
-        ([8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),
-        ([8, 8, 256, 384], 0, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 256, 384], 0, ttnn.TILE_LAYOUT),
-        ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),
-        ([8, 8, 256, 384], 2, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 256, 384], 2, ttnn.TILE_LAYOUT),
-        ([8, 8, 256, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 256, 384], 3, ttnn.TILE_LAYOUT),
-        ([8, 8, 256, 768], 3, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 256, 768], 3, ttnn.TILE_LAYOUT),
-        ([8, 8, 1024, 4096], 1, ttnn.TILE_LAYOUT),
-        ([8, 8, 2048, 4096], 1, ttnn.TILE_LAYOUT),
-        ([8, 8, 128, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 1024, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
-        ([8, 8, 2048, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
-        # Only for BFP8B
-        # ([1, 1, 640, 32768], 3, ttnn.TILE_LAYOUT),
-        # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
-        # Mixtral 8x7B, functional bringup with expanded tensor getting allgathered
-        # Full shape for 8 chips
-        ([1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # Input, Selfout, Final AllGather
-        ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
-        # Half shape for 4 chips, same per chip shape as 8 chips
-        ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
-        # Full shape for 8 chips
-        ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
-        # Half shape for running on 4 chips, same per chip shape as for 8 chips
-        ([1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # Falcon 40B prefill
-        # 8 chips
-        ([1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # 4 chips, same per chip shape as 8 chips
-        ([1, 1, 2048, 4096], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # Falcon 40B prefill
-        # 8 chips
-        ([1, 1, 2048, 32768], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # 4 chips, same per chip shape as 8 chips
-        ([1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 2048, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # Mixtral 8x7B, Min sequence length
-        # 8 chips
-        # ([1, 1, 32768, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 32768, 32768], 3, ttnn.TILE_LAYOUT),  # ultra slow?
-        # 4 chips, per chip shape same as 8 chips
-        # ([1, 1, 32768, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
-        # ([1, 1, 32768, 16384], 3, ttnn.TILE_LAYOUT),
-        # Llama galaxy mlp weights stationary -> emulation of row/col reduce
-        ([1, 1, 128, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 128, 1024], 2, ttnn.TILE_LAYOUT),
-        # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY
-        # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY
-        ([1, 1, 128, 4096], 2, ttnn.ROW_MAJOR_LAYOUT),  #
-        ([1, 1, 128, 4096], 2, ttnn.TILE_LAYOUT),
-        # ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
-        # ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
-        ([1, 1, 8192, 32], 2, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 8192, 32], 2, ttnn.TILE_LAYOUT),
-        ([1, 1, 1024, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 1024, 128], 3, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 16384, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 16384, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 32768, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 32768, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 4096, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # only for 4 chip
-        ([1, 1, 4096, 128], 3, ttnn.TILE_LAYOUT),  # only for 4 chip
-        ([1, 1, 128, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 128, 2048], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
-        # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # only for 4 chip - ALREADY LISTED PREVIOUSLY
-        # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # only for 4 chip - ALREADY LISTED PREVIOUSLY
-        ([1, 1, 128, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
-        ([1, 1, 128, 8192], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
-        ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
-        ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 256, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 1024, 256], 3, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 256, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),
-        ([1, 1, 256, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
-    ],
-)
+@pytest.mark.parametrize("input_shape, dim, layout", nightly_all_gather_shape_dim_layouts)
 @pytest.mark.parametrize(
     "input_dtype",
     [
@@ -928,7 +924,57 @@ def test_line_all_gather_on_t3000_nightly(
     ],
 )
 def test_all_gather_on_t3000_nightly(
-    all_devices,
+    mesh_device,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+):
+    run_all_gather_on_t3000_impl(
+        mesh_device,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=ttnn.all_gather,
+    )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (4, 2),
+        (4, 1),
+    ],
+)
+@pytest.mark.parametrize("input_shape, dim, layout", nightly_all_gather_shape_dim_layouts)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+def test_all_gather_on_t3000_nightly(
+    pcie_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -984,7 +1030,7 @@ def test_all_gather_on_t3000_nightly(
         pytest.xfail(reason="Known failure")
 
     run_all_gather_on_t3000_impl(
-        all_devices,
+        pcie_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -999,7 +1045,7 @@ def test_all_gather_on_t3000_nightly(
 
 
 def run_all_gather_sharded(
-    t3k_mesh_device,
+    mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1014,7 +1060,6 @@ def run_all_gather_sharded(
     use_program_cache,
     function_level_defaults,
     all_gather_operation,
-    devices,
     enable_async,
     n_worker=None,
     n_buffer=None,
@@ -1042,9 +1087,6 @@ def run_all_gather_sharded(
     unchunked_input_tensor = unchunked_input_tensor.bfloat16()
 
     input_tensors = torch.chunk(unchunked_input_tensor, num_devices, dim)
-
-    # num_cores =
-    # compute_grid_size = devices[0].compute_with_storage_grid_size()
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"unchunked_input_shape: {unchunked_input_shape}")
@@ -1095,15 +1137,18 @@ def run_all_gather_sharded(
     tt_input_tensors = []
 
     for i, t in enumerate(input_tensors):
-        tt_input_tensors_dups.append(ttnn.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
+        tt_input_tensors_dups.append(
+            ttnn.Tensor(t, input_dtype).to(tensor_layout).to(mesh_device.get_devices()[i], input_mem_config)
+        )
+        tt_input_tensors.append(
+            ttnn.Tensor(t, input_dtype).to(tensor_layout).to(mesh_device.get_devices()[i], input_mem_config)
+        )
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
 
     if trace_mode:
         tt_out_tensor = run_with_trace(
-            t3k_mesh_device,
-            devices,
+            mesh_device,
             all_gather_operation,
             input_tensor_mesh,
             dim,
@@ -1125,7 +1170,7 @@ def run_all_gather_sharded(
                 num_buffers_per_channel=n_buffer,
             )
         ## Wait for completion
-        for d in devices:
+        for d in mesh_device.get_devices():
             ttnn.synchronize_device(d)
 
     torch.set_printoptions(sci_mode=False)
@@ -1180,13 +1225,11 @@ def run_all_gather_sharded_t3k(
     num_iter=1,
     trace_mode=False,
 ):
-    if len(t3k_mesh_device.get_device_ids()) != 8:
+    if t3k_mesh_device.get_num_devices() < num_devices:
         pytest.skip("Not T3000!")
 
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
-
-    devices = [t3k_mesh_device.get_device(t3k_mesh_device.get_device_ids()[i]) for i in range(num_devices)]
+    for d in t3k_mesh_device.get_devices():
+        d.enable_async(enable_async)
 
     return run_all_gather_sharded(
         t3k_mesh_device,
@@ -1204,7 +1247,6 @@ def run_all_gather_sharded_t3k(
         use_program_cache,
         function_level_defaults,
         all_gather_operation,
-        devices,
         enable_async,
         n_worker,
         n_buffer,
@@ -1214,7 +1256,7 @@ def run_all_gather_sharded_t3k(
 
 
 def run_all_gather_sharded_n300(
-    all_devices,
+    mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1235,14 +1277,14 @@ def run_all_gather_sharded_n300(
     num_iter=1,
     trace_mode=False,
 ):
-    if len(all_devices) != 2:
+    if mesh_device.get_num_devices() != 2:
         pytest.skip("Not N300!")
 
-    for device in all_devices:
+    for device in mesh_device.get_devices():
         device.enable_async(enable_async)
 
     return run_all_gather_sharded(
-        all_devices,
+        mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,
@@ -1257,7 +1299,6 @@ def run_all_gather_sharded_n300(
         use_program_cache,
         function_level_defaults,
         all_gather_operation,
-        all_devices,
         enable_async,
         n_worker,
         n_buffer,

--- a/tests/ttnn/unit_tests/operations/test_all_gather_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_N300_post_commit.py
@@ -17,9 +17,22 @@ from tests.ttnn.unit_tests.operations.test_all_gather import (
 # Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "num_devices, num_links, input_shape, dim, layout",
+    "num_devices, num_links, output_shape, dim, layout",
     [
         (2, 1, [1, 1, 64, 16384], 3, ttnn.TILE_LAYOUT),
+        (2, 1, [8, 5, 32, 768], 3, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 1, 32, 736], 3, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 1, 32, 704], 3, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 1, 64, 704], 3, ttnn.TILE_LAYOUT),
+        (2, 1, [1, 1, 32, 736], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [1, 1, 32, 704], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [1, 1, 64, 704], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [4, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [8, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [8, 5, 13, 768], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (2, 1, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
@@ -37,9 +50,9 @@ from tests.ttnn.unit_tests.operations.test_all_gather import (
 @pytest.mark.parametrize("num_iters", [1])
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_on_n300_post_commit(
-    all_devices,
+    n300_mesh_device,
     num_devices,
-    input_shape,
+    output_shape,
     dim,
     num_links,
     input_dtype,
@@ -51,9 +64,9 @@ def test_all_gather_on_n300_post_commit(
     enable_async,
 ):
     run_all_gather_on_n300_impl(
-        all_devices,
+        n300_mesh_device,
         num_devices,
-        input_shape,
+        output_shape,
         dim,
         num_links,
         input_dtype,
@@ -89,15 +102,20 @@ def test_all_gather_on_n300_post_commit(
     "input_shape, input_shard_shape,shard_grid",
     (
         (
-            (1, 1, 512, 2048),
+            (1, 1, 128, 8192),
             (128, 256),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (
+            (1, 1, 32, 1792),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
         ),
     ),
 )
 @pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_sharded_n300_post_commit(
-    all_devices,
+    n300_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -114,7 +132,7 @@ def test_all_gather_sharded_n300_post_commit(
     enable_async,
 ):
     run_all_gather_sharded_n300(
-        all_devices,
+        n300_mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,

--- a/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
@@ -10,8 +10,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
 from tests.ttnn.unit_tests.operations.test_all_gather import (
     is_unsupported_case,
-    run_line_all_gather,
-    run_line_all_gather_deprecated,
+    run_all_gather_on_t3000_impl,
 )
 from ttnn import ShardTensorToMesh
 
@@ -63,7 +62,7 @@ def test_line_all_gather_on_t3000_nightly(
     enable_async,
     num_iters=1,
 ):
-    run_line_all_gather(
+    run_all_gather_on_t3000_impl(
         t3k_mesh_device,
         num_devices,
         input_shape,
@@ -74,8 +73,9 @@ def test_line_all_gather_on_t3000_nightly(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        enable_async,
-        num_iters,
+        all_gather_function=ttnn.line_all_gather,
+        enable_async=enable_async,
+        num_iters=num_iters,
     )
 
 
@@ -108,7 +108,7 @@ def test_line_all_gather_on_t3000_nightly(
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly_two_link(
-    all_devices,
+    pcie_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -121,8 +121,8 @@ def test_line_all_gather_on_t3000_nightly_two_link(
     enable_async,
     num_iters=1,
 ):
-    run_line_all_gather_deprecated(
-        all_devices,
+    run_all_gather_on_t3000_impl(
+        pcie_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -132,8 +132,9 @@ def test_line_all_gather_on_t3000_nightly_two_link(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        enable_async,
-        num_iters,
+        all_gather_operation=ttnn.line_all_gather,
+        num_iters=num_iters,
+        enable_async=enable_async,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
@@ -73,7 +73,7 @@ def test_line_all_gather_on_t3000_nightly(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        all_gather_function=ttnn.line_all_gather,
+        all_gather_operation=ttnn.line_all_gather,
         enable_async=enable_async,
         num_iters=num_iters,
     )

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -215,7 +215,7 @@ template <typename T, template <typename> typename BufferType>
 inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     TT_FATAL(
         (shape[-2] % tile.get_tile_shape()[0] == 0 && shape[-1] % tile.get_tile_shape()[1] == 0),
-        "Unsupported shape for tensor conversion");
+        "Unsupported shape for tensor conversion from row-major to tile layout. The tensor shape height and width must be a multiple of tile height ({}) and width ({}), but the provided shape is {}", tile.get_tile_shape()[0], tile.get_tile_shape()[1], shape);
 
     auto tile_shape = std::vector<uint32_t>{ tile.get_tile_shape()[0], tile.get_tile_shape()[1] };
     auto face_shape = std::vector<uint32_t>{ tile.get_face_shape()[0], tile.get_face_shape()[1] };


### PR DESCRIPTION
closes https://github.com/tenstorrent/tt-metal/issues/13261

### Ticket
https://github.com/tenstorrent/tt-metal/issues/13261

### Problem description
As in pipelines like this, the all_devices device fixture is not adequate for ensuring correct device order for assembling CCL operations: https://github.com/tenstorrent/tt-metal/actions/runs/11095906860/job/30825284694

### What's changed
Updated all-gather tests to use correct test fixtures where they weren't.

In particular, 4-chip ring tests that are expected to run on the inner 4-chip ring of the t3000 were updated to use the pcie_mesh_device fixture to ensure that the first 4 chips in the list are those devices in the inner ring.

Additional changes along with the above:
- Removed some redundant `run_all_gather` type test functions to merge into a singla test function
- Added additional n300 all-gather test cases
- Improve error messaging
- Added n300 device fixture

### Checklist
- [x] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/11100888372
- [x] tg frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11099230912
  - all-gather tests all passing 
- [x] t3k nightly, frequent, unit: https://github.com/tenstorrent/tt-metal/actions/runs/11099234503
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
