### PR TITLE
#13269: Revise moreh_norm, moreh_norm_backward operations

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp
@@ -75,3 +75,5 @@ namespace ttnn::prim {
 constexpr auto moreh_norm =
     ttnn::register_operation<"ttnn::prim::moreh_norm", ttnn::operations::moreh::moreh_norm::MorehNormOperation>();
 }
+
+#undef DEFINE_PROGRAM_FACTORY

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -288,6 +288,8 @@ void MorehNormBackwardOperation::ProgramFactory::override_runtime_arguments(
         {
             auto& runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
             runtime_args[0] = tensor_args.input.buffer()->address();
+            runtime_args[1] = tensor_args.output.buffer()->address();
+            runtime_args[2] = tensor_args.output_grad.buffer()->address();
         }
 
         // writer


### PR DESCRIPTION
### Ticket
Link to Github Issue: [#13269](https://github.com/tenstorrent/tt-metal/issues/13269)

### Problem description
Some conventions need to be revised in the TTNN operation. In this case, moreh_norm, moreh_norm_backward will be revised.

### What's Changed
Fixed bug on `MorehNormBackwardOperation::ProgramFactory::override_runtime_arguments`.
Fixed bug on `tt_norm(...)`

To improve test coverage, additional test cases were added:
- Added docstring.
- Added a test case for program cache; ensure that `override_runtime_arguments` works correctly on both forward and backward phase.
- The test cases have now increased to 101 cases.

### Checklist
- [X] Post commit CI passes:
+ [All post-commit tests #16776](https://github.com/tenstorrent/tt-metal/issues/13269)
+ [All post-commit tests #16777](https://github.com/tenstorrent/tt-metal/actions/runs/11101843674)
+ [All post-commit tests #16782](https://github.com/tenstorrent/tt-metal/actions/runs/11102637041)
+ [All post-commit tests #16791](https://github.com/tenstorrent/tt-metal/actions/runs/11104241914)
+ [All post-commit tests #16850](https://github.com/tenstorrent/tt-metal/actions/runs/11118558677)
- [X] Blackhole Post commit (if applicable): N/A
- [X] Model regression CI testing passes (if applicable): N/A
- [X] Device performance regression CI testing passes (if applicable): N/A
- [X] New/Existing tests provide coverage for changes: 101/101 test cases passed


| Test Name                                 | Number of Test Cases |
|-------------------------------------------|----------------------|
| test_moreh_norm                           | 64                   |
| test_moreh_norm_compute_kernel_options    | 6                    |
| test_moreh_norm_callback                  | 1                    |
| test_moreh_norm_backward                  | 23                   |
| test_moreh_norm_backward_compute_kernel_options | 6              |
| test_moreh_norm_backward_callback         | 1                    |
