### PR TITLE
#13285: Add arch tag for galaxy workflows that didn't have it because a) we should specify and b) we need it for data collection

### DIFF
--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -45,7 +45,7 @@ jobs:
           {
             name: "TG unit tests",
             arch: wormhole_b0,
-            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type unit_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-unit-tests-impl.yaml
+++ b/.github/workflows/tgg-unit-tests-impl.yaml
@@ -12,7 +12,7 @@ jobs:
           {
             name: "TGG unit tests",
             arch: wormhole_b0,
-            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tgg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type unit_tgg_device --dispatch-mode ""'
           },
         ]


### PR DESCRIPTION
 ### Ticket

#13285 

### Problem description

We didn't detect an `arch` from certain Galaxy workflows when collecting data. this is to fix that.

### What's changed

Add `arch-` in workflows that didn't have it.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
