### PR TITLE
#0: Update cast in ncrisc BH init code

### DIFF
--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -39,7 +39,7 @@ void kernel_launch() {
 #endif
 #else
 #ifdef ARCH_BLACKHOLE
-    firmware_kernel_common_init((uint32_t)__kernel_init_local_l1_base);
+    firmware_kernel_common_init((void tt_l1_ptr *)__kernel_init_local_l1_base);
 #else
     firmware_kernel_common_init((void tt_l1_ptr *)(MEM_NCRISC_INIT_IRAM_L1_BASE + (uint32_t)__kernel_init_local_l1_base - MEM_NCRISC_IRAM_BASE));
 #endif


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
A [commit](https://github.com/tenstorrent/tt-metal/commit/6d78563fa8206c3331be9138915142de10fa3e85) seems to have broken something for BH with the following errors when trying to run a simple matmul python script:
```
/proj_sw/user_dev/bbradel/tt-metal/tt_metal/hw/firmware/src/ncrisck.cc: In function 'void kernel_launch()':
/proj_sw/user_dev/bbradel/tt-metal/tt_metal/hw/firmware/src/ncrisck.cc:42:33: error: invalid conversion from 'uint32_t' {aka 'long unsigned int'} to 'void*' [-fpermissive]
   42 |     firmware_kernel_common_init((uint32_t)__kernel_init_local_l1_base);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                 |
      |                                 uint32_t {aka long unsigned int}
In file included from /proj_sw/user_dev/bbradel/tt-metal/tt_metal/hw/firmware/src/ncrisck.cc:15:
/proj_sw/user_dev/bbradel/tt-metal/tt_metal/hw/inc/firmware_common.h:52:47: note:   initializing argument 1 of 'void firmware_kernel_common_init(void*)'
   52 | inline void firmware_kernel_common_init(void *init_local_l1_base) {
      |                                         ~~~~~~^~~~~~~~~~~~~~~~~~
                 Always | FATAL    | ncrisc build failed
                 Always | FATAL    | Failed to generate binaries for cq_prefetch TT_THROW @ ../tt_metal/jit_build/build.cpp:437: tt::exception
```


### What's changed
- change the cast for BH

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11112152917
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
