### PR TITLE
#11592: use the semaphore indices returned by CreateSemaphore

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -441,11 +441,13 @@ int main(int argc, char **argv) {
         gen_cmds(device, cmds, all_workers_g, device_data, dispatch_buffer_page_size_g);
         llrt::write_hex_vec_to_core(device->id(), phys_spoof_prefetch_core, cmds, l1_buf_base);
 
-        constexpr uint32_t dispatch_cb_sem = 0;
-        constexpr uint32_t prefetch_sync_sem = 1;
-        tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, dispatch_buffer_pages);
-        tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
-        tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, 0);
+        const uint32_t spoof_prefetch_core_sem_0_id = tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, dispatch_buffer_pages);
+        const uint32_t dispatch_core_sem_id = tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
+        TT_ASSERT(spoof_prefetch_core_sem_0_id == dispatch_core_sem_id);
+        const uint32_t dispatch_cb_sem = spoof_prefetch_core_sem_0_id;
+
+        const uint32_t spoof_prefetch_core_sem_1_id = tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, 0);
+        const uint32_t prefetch_sync_sem = spoof_prefetch_core_sem_1_id;
 
         std::vector<uint32_t> dispatch_compile_args =
             {l1_buf_base,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2227,7 +2227,6 @@ void configure_for_multi_chip(Device *device,
 
     const uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
     const uint32_t prefetch_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
-    // tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
     if (packetized_path_en_g) {
         // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
         // value only to update the rptr:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1578,8 +1578,8 @@ void configure_for_single_chip(Device *device,
     tt::llrt::write_hex_vec_to_core(device->id(), phys_dispatch_host_core, tmp, CQ_COMPLETION_READ_PTR);
     dirty_host_completion_buffer(host_hugepage_completion_buffer);
 
-    const uint32_t prefetch_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_core}, 0); // 0
-    const uint32_t prefetch_d_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0); // 0
+    const uint32_t prefetch_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
+    const uint32_t prefetch_d_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0);
     TT_ASSERT(prefetch_core_sem_0_id == prefetch_d_core_sem_0_id);
     if (packetized_path_en_g) {
         const uint32_t prefetch_relay_mux_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0); // unused
@@ -1590,7 +1590,7 @@ void configure_for_single_chip(Device *device,
     const uint32_t prefetch_sync_sem = prefetch_core_sem_0_id;
 
     const uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
-    const uint32_t prefetch_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages); // 1
+    const uint32_t prefetch_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
     if (packetized_path_en_g) {
         // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
         // value only to update the rptr:
@@ -1599,8 +1599,8 @@ void configure_for_single_chip(Device *device,
     }
     const uint32_t prefetch_downstream_cb_sem = prefetch_core_sem_1_id;
 
-    const uint32_t prefetch_d_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0); // 1
-    const uint32_t prefetch_d_core_sem_2_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, dispatch_buffer_pages); // 2
+    const uint32_t prefetch_d_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0);
+    const uint32_t prefetch_d_core_sem_2_id = tt_metal::CreateSemaphore(program, {prefetch_d_core}, dispatch_buffer_pages);
     if (packetized_path_en_g) {
         const uint32_t prefetch_relay_mux_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0);
         TT_ASSERT(prefetch_d_core_sem_1_id == prefetch_relay_mux_core_sem_1_id);
@@ -1608,25 +1608,25 @@ void configure_for_single_chip(Device *device,
     const uint32_t prefetch_d_upstream_cb_sem = prefetch_d_core_sem_1_id;
     const uint32_t prefetch_d_downstream_cb_sem = prefetch_d_core_sem_2_id;
 
-    const uint32_t dispatch_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_core}, 0); // 0
-    const uint32_t dispatch_relay_demux_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused 0
+    const uint32_t dispatch_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
+    const uint32_t dispatch_relay_demux_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
     TT_ASSERT(dispatch_core_sem_0_id == dispatch_relay_demux_core_sem_0_id);
     const uint32_t dispatch_sync_sem = dispatch_core_sem_0_id;
 
     const uint32_t dispatch_core_sem_1_id = tt_metal::CreateSemaphore(program, {dispatch_core}, 0); // 1
-    const uint32_t dispatch_relay_demux_core_sem_1_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused 1
+    const uint32_t dispatch_relay_demux_core_sem_1_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
     TT_ASSERT(dispatch_core_sem_1_id == dispatch_relay_demux_core_sem_1_id);
     const uint32_t dispatch_cb_sem = dispatch_core_sem_1_id;
 
-    const uint32_t dispatch_core_sem_2_id = tt_metal::CreateSemaphore(program, {dispatch_core}, dispatch_buffer_pages); // 2
+    const uint32_t dispatch_core_sem_2_id = tt_metal::CreateSemaphore(program, {dispatch_core}, dispatch_buffer_pages);
     // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
     // value only to update the rptr:
-    const uint32_t dispatch_relay_demux_core_sem_2_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // 2
+    const uint32_t dispatch_relay_demux_core_sem_2_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0);
     TT_ASSERT(dispatch_core_sem_2_id == dispatch_relay_demux_core_sem_2_id);
     const uint32_t dispatch_downstream_cb_sem = dispatch_core_sem_2_id;
 
-    const uint32_t dispatch_h_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0); // 0
-    const uint32_t dispatch_relay_mux_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_relay_mux_core}, 0); // 0
+    const uint32_t dispatch_h_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0);
+    const uint32_t dispatch_relay_mux_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_relay_mux_core}, 0);
     TT_ASSERT(dispatch_h_core_sem_0_id == dispatch_relay_mux_core_sem_0_id);
     const uint32_t dispatch_h_cb_sem = dispatch_h_core_sem_0_id;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2212,47 +2212,62 @@ void configure_for_multi_chip(Device *device,
     tt::llrt::write_hex_vec_to_core(device->id(), phys_dispatch_host_core, tmp, CQ_COMPLETION_READ_PTR);
     dirty_host_completion_buffer(host_hugepage_completion_buffer);
 
-    constexpr uint32_t prefetch_sync_sem = 0;
-
-    tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
-    tt_metal::CreateSemaphore(program_r, {prefetch_d_core}, 0);
+    const uint32_t prefetch_core_sem_0_id = tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
+    const uint32_t prefetch_d_core_sem_0_id = tt_metal::CreateSemaphore(program_r, {prefetch_d_core}, 0);
+    TT_ASSERT(prefetch_core_sem_0_id == prefetch_d_core_sem_0_id);
     if (packetized_path_en_g) {
-        tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0); // unused
-        tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0); // unused
+        const uint32_t prefetch_relay_mux_core_sem_0_id =
+            tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0);  // unused
+        const uint32_t prefetch_relay_demux_core_sem_0_id =
+            tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0);  // unused
+        TT_ASSERT(prefetch_relay_mux_core_sem_0_id == prefetch_relay_demux_core_sem_0_id);
+        TT_ASSERT(prefetch_relay_mux_core_sem_0_id == prefetch_core_sem_0_id);
     }
-    constexpr uint32_t prefetch_downstream_cb_sem = 1;
-    uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
-    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
-    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
+    const uint32_t prefetch_sync_sem = prefetch_core_sem_0_id;
+
+    const uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
+    const uint32_t prefetch_core_sem_1_id = tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
+    // tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
     if (packetized_path_en_g) {
         // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
         // value only to update the rptr:
-        tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0);
+        const uint32_t prefetch_relay_demux_core_sem_1_id = tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0);
+        TT_ASSERT(prefetch_core_sem_1_id == prefetch_relay_demux_core_sem_1_id);
     }
+    const uint32_t prefetch_downstream_cb_sem = prefetch_core_sem_1_id;
 
-    constexpr uint32_t prefetch_d_upstream_cb_sem = 1;
-    constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
+    const uint32_t prefetch_d_core_sem_1_id = tt_metal::CreateSemaphore(program_r, {prefetch_d_core}, 0);
+    const uint32_t prefetch_d_core_sem_2_id =
+        tt_metal::CreateSemaphore(program_r, {prefetch_d_core}, dispatch_buffer_pages);
     if (packetized_path_en_g) {
-        tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0);
+        const uint32_t prefetch_relay_mux_core_sem_1_id =
+            tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0);
+        TT_ASSERT(prefetch_d_core_sem_1_id == prefetch_relay_mux_core_sem_1_id);
     }
-    tt_metal::CreateSemaphore(program_r, {prefetch_d_core}, 0);
-    tt_metal::CreateSemaphore(program_r, {prefetch_d_core}, dispatch_buffer_pages);
+    const uint32_t prefetch_d_upstream_cb_sem = prefetch_d_core_sem_1_id;
+    const uint32_t prefetch_d_downstream_cb_sem = prefetch_d_core_sem_2_id;
 
-    constexpr uint32_t dispatch_sync_sem = 0;
-    constexpr uint32_t dispatch_cb_sem = 1;
-    constexpr uint32_t dispatch_downstream_cb_sem = 2;
-    tt_metal::CreateSemaphore(program_r, {dispatch_core}, 0);
-    tt_metal::CreateSemaphore(program_r, {dispatch_core}, 0);
-    tt_metal::CreateSemaphore(program_r, {dispatch_core}, dispatch_buffer_pages);
-    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
-    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
+    const uint32_t dispatch_core_sem_0_id = tt_metal::CreateSemaphore(program_r, {dispatch_core}, 0);
+    const uint32_t dispatch_relay_demux_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
+    TT_ASSERT(dispatch_core_sem_0_id == dispatch_relay_demux_core_sem_0_id);
+    const uint32_t dispatch_sync_sem = dispatch_core_sem_0_id;
+
+    const uint32_t dispatch_core_sem_1_id =tt_metal::CreateSemaphore(program_r, {dispatch_core}, 0);
+    const uint32_t dispatch_relay_demux_core_sem_1_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
+    TT_ASSERT(dispatch_core_sem_1_id == dispatch_relay_demux_core_sem_1_id);
+    const uint32_t dispatch_cb_sem = dispatch_core_sem_1_id;
+
+    const uint32_t dispatch_core_sem_2_id = tt_metal::CreateSemaphore(program_r, {dispatch_core}, dispatch_buffer_pages);
     // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
     // value only to update the rptr:
-    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0);
+    const uint32_t dispatch_relay_demux_core_sem_2_id = tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0);
+    TT_ASSERT(dispatch_core_sem_2_id == dispatch_relay_demux_core_sem_2_id);
+    const uint32_t dispatch_downstream_cb_sem = dispatch_core_sem_2_id;
 
-    constexpr uint32_t dispatch_h_cb_sem = 0;
-    tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0);
-    tt_metal::CreateSemaphore(program_r, {dispatch_relay_mux_core}, 0);
+    const uint32_t dispatch_h_core_sem_0_id = tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0);
+    const uint32_t dispatch_relay_mux_core_sem_0_id = tt_metal::CreateSemaphore(program_r, {dispatch_relay_mux_core}, 0);
+    TT_ASSERT(dispatch_h_core_sem_0_id == dispatch_relay_mux_core_sem_0_id);
+    const uint32_t dispatch_h_cb_sem = dispatch_h_core_sem_0_id;
 
     std::vector<uint32_t> prefetch_compile_args = {
         dispatch_buffer_base, // overridden below for prefetch_h

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1579,16 +1579,16 @@ void configure_for_single_chip(Device *device,
 
     constexpr uint32_t prefetch_sync_sem = 0;
 
-    tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
-    tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0);
+    tt_metal::CreateSemaphore(program, {prefetch_core}, 0); // 0
+    tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0); // 0
     if (packetized_path_en_g) {
         tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0); // unused
         tt_metal::CreateSemaphore(program, {prefetch_relay_demux_core}, 0); // unused
     }
     constexpr uint32_t prefetch_downstream_cb_sem = 1;
     uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
-    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
-    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
+    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages); // 1
+    // tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages); // 2
     if (packetized_path_en_g) {
         // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
         // value only to update the rptr:
@@ -1600,24 +1600,24 @@ void configure_for_single_chip(Device *device,
     if (packetized_path_en_g) {
         tt_metal::CreateSemaphore(program, {prefetch_relay_mux_core}, 0);
     }
-    tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0);
-    tt_metal::CreateSemaphore(program, {prefetch_d_core}, dispatch_buffer_pages);
+    tt_metal::CreateSemaphore(program, {prefetch_d_core}, 0); // 1
+    tt_metal::CreateSemaphore(program, {prefetch_d_core}, dispatch_buffer_pages); // 2
 
     constexpr uint32_t dispatch_sync_sem = 0;
     constexpr uint32_t dispatch_cb_sem = 1;
     constexpr uint32_t dispatch_downstream_cb_sem = 2;
-    tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
-    tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
-    tt_metal::CreateSemaphore(program, {dispatch_core}, dispatch_buffer_pages);
-    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
-    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused
+    tt_metal::CreateSemaphore(program, {dispatch_core}, 0); // 0
+    tt_metal::CreateSemaphore(program, {dispatch_core}, 0); // 1
+    tt_metal::CreateSemaphore(program, {dispatch_core}, dispatch_buffer_pages); // 2
+    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused 0
+    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // unused 1
     // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
     // value only to update the rptr:
-    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0);
+    tt_metal::CreateSemaphore(program, {dispatch_relay_demux_core}, 0); // 2
 
     constexpr uint32_t dispatch_h_cb_sem = 0;
-    tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0);
-    tt_metal::CreateSemaphore(program, {dispatch_relay_mux_core}, 0);
+    tt_metal::CreateSemaphore(program, {dispatch_h_core}, 0); // 0
+    tt_metal::CreateSemaphore(program, {dispatch_relay_mux_core}, 0); // 0
 
     std::vector<uint32_t> prefetch_compile_args = {
         dispatch_buffer_base, // overridden below for prefetch_h

--- a/tests/tt_metal/tt_metal/unit_tests/fast_dispatch_kernels/test_write_host.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/fast_dispatch_kernels/test_write_host.cpp
@@ -127,11 +127,14 @@ bool test_write_host(Device *device, uint32_t data_size, std::pair<uint32_t, uin
     tt::llrt::write_hex_vec_to_core(device->id(), phys_spoof_prefetch_core, dispatch_cmds, l1_buf_base);
     tt::Cluster::instance().l1_barrier(device->id());
 
-    constexpr uint32_t dispatch_cb_sem = 0;
-    constexpr uint32_t prefetch_sync_sem = 1;
-    tt::tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, dispatch_buffer_pages);
-    tt::tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
-    tt::tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, 0);
+    const uint32_t spoof_prefetch_core_sem_0_id =
+        tt::tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, dispatch_buffer_pages);
+    const uint32_t dispatch_core_sem_id = tt::tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
+    TT_ASSERT(spoof_prefetch_core_sem_0_id == dispatch_core_sem_id);
+    const uint32_t dispatch_cb_sem = spoof_prefetch_core_sem_0_id;
+
+    const uint32_t spoof_prefetch_core_sem_1_id = tt::tt_metal::CreateSemaphore(program, {spoof_prefetch_core}, 0);
+    const uint32_t prefetch_sync_sem = spoof_prefetch_core_sem_1_id;
 
     std::vector<uint32_t> dispatch_compile_args = {
         l1_buf_base,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1458,19 +1458,6 @@ void Device::compile_command_queue_programs() {
     std::string prefetch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
     std::string dispatch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
 
-    // TODO: These are semaphore IDs, remove these when CreateSemaphore returns ID rather than address
-    // constexpr uint32_t prefetch_sync_sem = 0;
-    // constexpr uint32_t prefetch_downstream_cb_sem = 1;
-    // constexpr uint32_t prefetch_sem = 1;
-    // constexpr uint32_t dispatch_sem = 0;
-    // constexpr uint32_t mux_sem = 0;
-    // constexpr uint32_t demux_sem = 0;
-
-    // constexpr uint32_t prefetch_d_sync_sem = 0;
-    // constexpr uint32_t prefetch_d_upstream_cb_sem = 1;
-    // constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
-    // constexpr uint32_t dispatch_downstream_cb_sem = 1;
-
     // TODO: this->hw_command_queues_[cq_id]->noc_index is also hardcoded to NOC_0 elsewhere, should have one definition and remove assertion
     constexpr NOC my_noc_index = NOC::NOC_0;
     constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
@@ -1504,9 +1491,9 @@ void Device::compile_command_queue_programs() {
             uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;
             uint32_t completion_queue_size = this->sysmem_manager_->get_completion_queue_size(cq_id);
 
-            const uint32_t prefetch_sync_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, 0, dispatch_core_type); // prefetch_sync_sem
-            const uint32_t prefetch_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(), dispatch_core_type); // prefetch_sem
-            const uint32_t dispatch_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_core, 0, dispatch_core_type); // dispatch_sem
+            const uint32_t prefetch_sync_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, 0, dispatch_core_type);
+            const uint32_t prefetch_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(), dispatch_core_type);
+            const uint32_t dispatch_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_core, 0, dispatch_core_type);
 
             std::vector<uint32_t> prefetch_compile_args = {
                 dispatch_constants::DISPATCH_BUFFER_BASE,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11592)

### What's changed
Modified calls to `CreateSemaphore` in `test_prefetcher.cpp`, `test_dispatcher.cpp`, `test_write_host.cpp` and `device.cpp` to use the indices returned.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
