### PR TITLE
#9370: removed ndpcc work around and debug code in sdpa decode and re-enabled CI

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -451,16 +451,16 @@ def run_test_sdpa_decode_single_iter(
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d, grid_size, single_iter, cur_pos_tensor",
     (
-        [32, 8, 1, 32768, 128, (8, 6), True, True],  # Llama2-70B
-        [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
+        # [32, 8, 1, 32768, 128, (8, 6), True, True],  # Llama2-70B
+        # [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
         [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
-        [4, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
+        # [4, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
         [32, 8, 1, 32768, 128, (8, 8), True, True],  # Mixtral8x7b
-        [32, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
-        [4, 32, 8, 32768, 128, (8, 8), True, False],  # llama 3.1 8b
+        # [32, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
+        # [4, 32, 8, 32768, 128, (8, 8), True, False],  # llama 3.1 8b
         [4, 32, 8, 32768, 128, (8, 8), True, True],  # llama 3.1 8b
-        [4, 32, 8, 32768, 128, (8, 8), False, False],  # llama 3.1 8b
-        [4, 16, 4, 32768, 128, (8, 8), False, False],  # llama 3.1 8b
+        # [4, 32, 8, 32768, 128, (8, 8), False, False],  # llama 3.1 8b
+        # [4, 16, 4, 32768, 128, (8, 8), False, False],  # llama 3.1 8b
     ),
 )
 def test_sdpa_decode(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode_gqa.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode_gqa.py
@@ -222,7 +222,6 @@ def run_test_sdpa_decode_single_iter(
 
 
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
-@pytest.mark.skip("Skipping due to potential nd pcc issue #9370")
 @pytest.mark.parametrize(
     "dtype, q_dtype",
     [
@@ -287,7 +286,6 @@ def test_sdpa_decode(
 
 
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
-@pytest.mark.skip("Skipping due to potential nd pcc issue #9370")
 @pytest.mark.parametrize(
     "dtype",
     [

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -16,7 +16,6 @@
 #include "compute_kernel_api/matmul.h"
 #include "compute_kernel_api/reduce.h"
 
-#include "debug/dprint.h"  // required in all kernels using DPRINT
 #include "../../rt_args_common.hpp"
 
 namespace NAMESPACE {
@@ -51,17 +50,12 @@ void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) 
     constexpr uint32_t dst_reg_1 = 1;
     cb_wait_front(in0, num_tiles);
     cb_wait_front(in1, num_tiles);
-    // DPRINT << "[C] R ckpt 1.5" << ENDL();
     cb_reserve_back(out_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
         acquire_dst(tt::DstMode::Half);
-        //DPRINT_MATH(DPRINT << "[C] R ckpt 1.51 math" << ENDL());
         copy_tile(in0, i, dst_reg_0);
-        //DPRINT_MATH(DPRINT << "[C] R ckpt 1.52 math" << ENDL());
         copy_tile(in1, i, dst_reg_1);
-        //DPRINT_MATH(DPRINT << "[C] R ckpt 1.53 math" << ENDL());
         max_tile(dst_reg_0, dst_reg_1);
-        //DPRINT_MATH(DPRINT << "[C] R ckpt 1.54 math" << ENDL());
         pack_tile(dst_reg_0, out_cb, i);
         release_dst(tt::DstMode::Half);
     }
@@ -99,10 +93,6 @@ void reduce_c() {
     }
 
     reduce_revert_delta<reduce_dim>(out_cb);
-
-    // UNPACK(TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC_RESET_ALL_BANKS);)
-    UNPACK(TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC_RESET_ALL_BANKS);)
-    UNPACK(tensix_sync());
 }
 
 void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
@@ -228,21 +218,12 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     }
 
     cb_pop_front(in1_cb, num_tiles);
-    UNPACK(tensix_sync());
 }
 
 void add_block_inplace2(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles consumed
-
-    // TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);  // wait for pack to finish
-    TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    // TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
-    // TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-    // TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
-    // TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD);
-
 
     add_tiles_init();
     cb_wait_front(in0_cb, num_tiles);
@@ -258,14 +239,6 @@ void add_block_inplace2(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     }
 
     cb_pop_front(in1_cb, num_tiles);
-    UNPACK(tensix_sync());
-
-    // TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::PACK);  // wait for pack to finish
-    // TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    // TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
-    // TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-    // TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD);
-    // TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD);
 }
 
 void add_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
@@ -306,51 +279,25 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
         cb_push_back(in0_cb, 1);
         release_dst(tt::DstMode::Half);
     }
-    UNPACK(tensix_sync());
 }
 
 void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: out_cb has num_tiles produced
     // Postcondition: in0_cb and in1_cb has num_tiles produced
-    // WAYPOINT("XCAE");
     sub_tiles_init();
-    // WAYPOINT("XCAF");
     exp_tile_init<true>();
-    // WAYPOINT("XCAG");
-    // DPRINT_MATH(DPRINT << "[C] R ckpt 2.1.1.0 math" << ENDL());
-    // DPRINT_PACK(DPRINT << "[C] R ckpt 2.1.1.0 pack" << ENDL());
-    // DPRINT_UNPACK(DPRINT << "[C] R ckpt 2.1.1.0 unpack" << ENDL());
     cb_wait_front(in0_cb, num_tiles);
-    // WAYPOINT("XCAH");
-    // DPRINT_MATH(DPRINT << "[C] R ckpt 2.1.1.1 math" << ENDL());
-    // DPRINT_PACK(DPRINT << "[C] R ckpt 2.1.1.1 pack" << ENDL());
-    // DPRINT_UNPACK(DPRINT << "[C] R ckpt 2.1.1.1 unpack" << ENDL());
     cb_wait_front(in1_cb, num_tiles);
-    // WAYPOINT("XCAI");
     cb_reserve_back(out_cb, num_tiles);
-    // WAYPOINT("XCAJ");
-
-    // DPRINT << "[C] R ckpt 2.1.1.2" << ENDL();
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-
         acquire_dst(tt::DstMode::Half);
-        // WAYPOINT("XCAK");
-
         sub_tiles(in0_cb, in1_cb, i, i, 0);
-        // WAYPOINT("XCAL");
-
         exp_tile<true>(0);
-        // WAYPOINT("XCAM");
-
         pack_tile(0, out_cb);
-        // WAYPOINT("XCAN");
-
         cb_push_back(out_cb, 1);
-        // WAYPOINT("XCAO");
         release_dst(tt::DstMode::Half);
-        // WAYPOINT("XCAP");
     }
 }
 
@@ -525,20 +472,13 @@ void MAIN {
     mm_init();
     cb_wait_front(cb_q_in, q_chunk_tiles);
 
-    // DPRINT << "[C] kvm " << k_chunk_start << " to " << k_chunk_end << ENDL();
-
-    // DPRINT << "[C] kvm " << ENDL();
     // loop while k_low < q_high
     for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
-
-        // DPRINT << "[Compute] Processing k_chunk " << k_chunk << ENDL();
 
         /* QK = Q_CHUNK @ K_CHUNK */
         unpack_reconfig_data_format(cb_q_in, cb_k_in); // DEBUG
         pack_reconfig_data_format(cb_qk_im);
         cb_matmul_blocks(cb_q_in, cb_k_in, cb_qk_im, Sq_chunk_t, Sk_chunk_t, DHt, qk_num_blocks, qk_in0_num_subblocks, qk_in1_num_subblocks, qk_in0_block_w, qk_subblock_h, qk_subblock_w, true /*transpose*/);
-
-        // DPRINT << "[C] D QK 1"<< ENDL();
 
         /* QK *= SCALE */
         mul_block_bcast_scalar_inplace(cb_qk_im, cb_scale_in, qk_chunk_tiles);
@@ -549,13 +489,10 @@ void MAIN {
             unpack_reconfig_data_format(cb_qk_im, cb_mask_in);
             add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
         }
-        // DPRINT << "[C] D QK 2"<< ENDL();
 
         unpack_reconfig_data_format(cb_qk_im, cb_identity_scale_in);
         pack_reconfig_data_format(cb_cur_max);
         reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_qk_im, cb_identity_scale_in, cb_cur_max, Sq_chunk_t, Sk_chunk_t>();
-
-        // DPRINT << "[C] S QK 3"<< ENDL();
 
         if (k_chunk > k_chunk_start) {
             unpack_reconfig_data_format(cb_cur_max, cb_prev_max);
@@ -566,8 +503,6 @@ void MAIN {
         unpack_reconfig_data_format(cb_qk_im, cb_cur_max);
         pack_reconfig_data_format(cb_qk_im);
         sub_exp_block_bcast_cols_inplace(cb_qk_im, cb_cur_max, Sq_chunk_t, Sk_chunk_t);
-
-        // DPRINT << "[C] D QK all"<< ENDL();
 
         /* cb_cur_sum = sum(cb_qk_im, dim=-1) */
         unpack_reconfig_data_format(cb_qk_im, cb_identity_scale_in);
@@ -580,8 +515,6 @@ void MAIN {
         cb_matmul_blocks(cb_qk_im, cb_v_in, cb_out_im, Sq_chunk_t, DHt, Sk_chunk_t, out_num_blocks, out_in0_num_subblocks, out_in1_num_subblocks, out_in0_block_w, out_subblock_h, out_subblock_w, false /*transpose*/);
         unpack_reconfig_data_format_srca(cb_out_im);
         cb_pop_front(cb_qk_im, qk_chunk_tiles);
-
-        // DPRINT << "[C] D QKV "<< ENDL();
 
         /* OUT_ACC += OUT_IM */
         if (k_chunk == k_chunk_start) {
@@ -614,41 +547,30 @@ void MAIN {
             add_block_inplace(cb_out_accumulate_im, cb_out_im, out_chunk_tiles);
         }
 
-        // DPRINT << "[C] D iter "<< ENDL();
-
         if (k_chunk < k_chunk_end - 1 || do_reduce) {
             // Set cb_prev_sum and cb_prev_max
             unpack_reconfig_data_format(cb_cur_max, cb_cur_max); // DEBUG
             pack_reconfig_data_format(cb_prev_max);
             copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
             copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
-            // DPRINT << "[C] D cpy " << ENDL();
 
         } else{
             // Write o, m, l into cb_out
             copy_block(cb_out_accumulate_im, cb_out_o, out_chunk_tiles);
             copy_block(cb_cur_max, cb_out_m, Sq_chunk_t);
             copy_block(cb_cur_sum, cb_out_l, Sq_chunk_t);
-            // DPRINT << "[C] D Worker cpy" << ENDL();
         }
     }
     cb_pop_front(cb_q_in, q_chunk_tiles);
-    // DPRINT << "[C] Done workers" << ENDL();
-
 
     // do reduction across intermediates from other cores if this is the reduction core
     if (do_reduce) {
-        //TODO: Implement reduction
         // cb_out_accumulate_im should contain o_1
         // cb_prev_max and cb_prev_sum should contain m_1 and l_1
 
-        // DPRINT << "[Compute] Start for reducer" << ENDL();
         if (k_chunk_end - k_chunk_start < k_num_chunks){
             // This indicates that there are computes done by other workers. Needs to wait for them and send to reducer's compute
             for (uint32_t i = 0; i < num_cores_to_wait ; i++) {
-
-                // DPRINT << "[C] Reduce Iter" << ENDL();
-
                 cb_wait_front(cb_out_o, q_chunk_tiles);  //o_2
                 cb_wait_front(cb_m_in, Sq_chunk_t);  //m_2
                 cb_wait_front(cb_l_in, Sq_chunk_t);  //l_2
@@ -656,32 +578,8 @@ void MAIN {
                 // unpack_reconfig_data_format(cb_q_in, cb_q_in); // DEBUG
                 // pack_reconfig_data_format(cb_out_accumulate_im_2);
                 copy_block(cb_out_o, cb_out_accumulate_im_2, q_chunk_tiles);
-                // copy_block(cb_m_in, cb_prev_max_2, Sq_chunk_t);
-                // pack_reconfig_data_format(cb_prev_sum_2);
                 copy_block(cb_l_in, cb_prev_sum_2, Sq_chunk_t);
-
-                // // DEBUG ONLY: remove these
-                // cb_pop_front(cb_out_accumulate_im_2, q_chunk_tiles);
-                // cb_pop_front(cb_prev_max_2, Sq_chunk_t);
-                // cb_pop_front(cb_prev_sum_2, Sq_chunk_t);
-
-                // DPRINT << "[C] R ckpt 1" << ENDL();
-
-                // m = torch.max(m_1, m_2)
-                // unpack_reconfig_data_format(cb_prev_max_2, cb_prev_max);
                 max_block(cb_m_in, cb_prev_max, cb_cur_max, Sq_chunk_t); // pushed, pushed, popped
-
-                // copy_block(cb_prev_max, cb_cur_max, Sq_chunk_t);
-                // DPRINT << "[C] R ckpt 1.1" << ENDL();
-                // cb_push_back(cb_prev_max, Sq_chunk_t);
-                // WAYPOINT("XCAA");
-                // DPRINT << "[C] R ckpt 1.2" << ENDL();
-                // max_block_inplace<cb_cur_max, cb_prev_max_2, Sq_chunk_t>(); // TODO: NEED TO FIX THIS
-
-                // DPRINT_MATH(DPRINT << "[C] R ckpt 2 math" << ENDL());
-                // DPRINT_PACK(DPRINT << "[C] R ckpt 2 pack" << ENDL());
-                // DPRINT_UNPACK(DPRINT << "[C] R ckpt 2 unpack" << ENDL());
-                // WAYPOINT("XCAB");
 
                 // l = torch.exp(m_2 - m) * l_2 + torch.exp(m_1 - m) * l_1
                 /// l1 = torch.exp(m_2 - m) * l_2
@@ -699,71 +597,24 @@ void MAIN {
                 // pack_reconfig_data_format(cb_cur_sum);
                 add_block(cb_prev_sum_2, cb_prev_sum, cb_cur_sum, Sq_chunk_t);
 
-                // DPRINT << "[C] R ckpt 3" << ENDL();
-
-                // O = torch.matmul(torch.eye(padded_num_heads) * torch.exp(m_2 - m), O_2) + torch.matmul(torch.eye(padded_num_heads) * torch.exp(m_1 - m), O_1)
-                /// O_1 = torch.matmul(torch.eye(padded_num_heads) * torch.exp(m_2 - m), O_2)
-                // unpack_reconfig_data_format(cb_out_accumulate_im_2, cb_exp_max_diff_2); // DEBUG
-                // pack_reconfig_data_format(cb_out_accumulate_im_2);
-                // UNPACK(TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK));
-                // UNPACK(TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK));
-                // unpack_reconfig_data_format_srca(cb_out_accumulate_im_2); // DEBUG
-                // UNPACK(TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG));
-                // // MATH(llk_math_reconfig_data_format_srca(cb_out_accumulate_im_2));
-                // // unpack_reconfig_data_format_srcb(cb_exp_max_diff_2); // DEBUG
-                // // UNPACK(tensix_sync());
-                // UNPACK(TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK));
-
-                // UNPACK(DPRINT << "cb_id " << cb_out_accumulate_im_2 << ": { "
-                // << "page_size: " << cb_interface[cb_out_accumulate_im_2].fifo_page_size << ", "
-                // << " }");
-                // UNPACK(DPRINT << "cb_id " << cb_prev_sum_2 << ": { "
-                // << "page_size: " << cb_interface[cb_prev_sum_2].fifo_page_size << ", "
-                // << " }");
-                // UNPACK(DPRINT << "cb_id " << cb_out_accumulate_im << ": { "
-                // << "page_size: " << cb_interface[cb_out_accumulate_im].fifo_page_size << ", "
-                // << " }");
-
-                // DPRINT << "[C] R ckpt 3.1" << ENDL();
-                /// O_2 = torch.matmul(torch.eye(padded_num_heads) * torch.exp(m_1 - m), O_1)
                 // unpack_reconfig_data_format(cb_out_accumulate_im, cb_exp_max_diff); // DEBUG
                 // pack_reconfig_data_format(cb_out_accumulate_im);
                 mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, DHt);
-                // cb_pop_front(cb_exp_max_diff, Sq_chunk_t);
-                add_tiles_init();  // work around to nd pcc issue
                 mul_block_bcast_cols_inplace(cb_out_accumulate_im_2, cb_exp_max_diff_2, Sq_chunk_t, DHt);
-                // cb_pop_front(cb_exp_max_diff_2, Sq_chunk_t);
-                // DPRINT << "[C] R ckpt 3.2" << ENDL();
-                /// O = O_1 + O_2
+
                 // unpack_reconfig_data_format(cb_out_accumulate_im, cb_out_accumulate_im_2);
                 // pack_reconfig_data_format(cb_out_accumulate_im);
                 add_block_inplace2(cb_out_accumulate_im, cb_out_accumulate_im_2, q_chunk_tiles);
-                // cb_pop_front(cb_out_accumulate_im_2, q_chunk_tiles);
-
-                // cb_pop_front(cb_out_accumulate_im, q_chunk_tiles);
-                // copy_block(cb_out_accumulate_im_2, cb_out_accumulate_im, q_chunk_tiles);
-
-                // unpack_reconfig_data_format(cb_cur_max, cb_cur_max); // DEBUG
-                // pack_reconfig_data_format(cb_cur_max);
-                // DPRINT << "[C] R ckpt 4" << ENDL();
 
                 // copy tiles
                 // unpack_reconfig_data_format(cb_cur_max, cb_cur_max); // DEBUG
                 // pack_reconfig_data_format(cb_prev_max);
                 cb_pop_front(cb_prev_max, Sq_chunk_t);
                 cb_pop_front(cb_m_in, Sq_chunk_t);
-                // DPRINT << "[C] R ckpt 5" << ENDL();
-                // cb_pop_front(cb_prev_sum, Sq_chunk_t);
                 copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
-                // DPRINT << "[C] R ckpt 6" << ENDL();
                 copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
-                // DPRINT << "[C] R ckpt 7" << ENDL();
-
-
             }
         }
-        // DPRINT << "[C] R Final" << ENDL();
-
         /* cb_cur_sum = 1.0 / cb_cur_sum */
         cb_push_back(cb_cur_sum, Sq_chunk_t);
 
@@ -782,8 +633,5 @@ void MAIN {
         cb_pop_front(cb_prev_max, Sq_chunk_t);
         cb_pop_front(cb_prev_sum, Sq_chunk_t);
     }
-
-    // DPRINT << "[C] Done" << ENDL();
-
 }
 }


### PR DESCRIPTION
### Ticket
#9370

### Problem description
ND pcc in sdpa decode.

### What's changed
The bug exposed an issue in LLK and a work around has been added in LLK, so no work around is needed in the kernel itself.

Changes:
- cleaned up code in kernel and removed dprint
- re-enabled sdpa decode tests in CI

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11112706698