### PR TITLE
#13292: Skip mamba perplexity for now while we fix

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -155,7 +155,7 @@ jobs:
         run: tar -xvf ttm_wormhole_b0.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run frequent reg tests scripts
-        timeout-minutes: 50
+        timeout-minutes: 75
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME

--- a/models/demos/wormhole/mamba/tests/test_mamba_perplexity.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_perplexity.py
@@ -62,6 +62,7 @@ def calculate_perplexity(
         ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 32, 128, 64, 15.4, 0.44, 0.69),
     ),
 )
+@pytest.mark.skip(reason="#13292: Possible hang regression introduced")
 def test_mamba_reference_perplexity(
     model_version: MambaPretrainedModelName,
     mode: ModelMode,
@@ -126,6 +127,7 @@ def test_mamba_reference_perplexity(
 
 
 @pytest.mark.timeout(1200)
+@pytest.mark.skip(reason="#13292: Possible hang regression introduced")
 @skip_for_grayskull("Mamba not supported on Grayskull")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
#13292

### Problem description

Possible regression in mamba introduced. Skipping perplexity for now

### What's changed

Skipping while we try fixing on side

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
