### PR TITLE
Add Sharded Support to Repeat

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -23,3 +23,43 @@ def test_repeat(device):
     output = ttnn.to_torch(output)
 
     assert_with_pcc(torch_result, output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_sharded_memory_config_args",
+    [
+        (
+            (1, 2, 128, 128),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        ),
+        (
+            (1, 2, 128, 128),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.WIDTH),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "repeat_shape",
+    [
+        (1, 2, 1, 1),
+        (1, 4, 1, 1),
+        (1, 1, 4, 1),
+        (4, 1, 1, 1),
+        (1, 1, 1, 4),
+    ],
+)
+def test_repeat_sharded(input_shape, input_sharded_memory_config_args, repeat_shape, device):
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    input_sharded_memory_config = ttnn.create_sharded_memory_config(input_shape, **input_sharded_memory_config_args)
+
+    torch_result = torch_input_tensor.repeat(repeat_shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_sharded_memory_config
+    )
+
+    output = ttnn.repeat(input_tensor, ttnn.Shape(repeat_shape))
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_result, output, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -7,6 +7,8 @@
 #include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp"
 #include "device/repeat_op.hpp"
 
 namespace ttnn::operations::data_movement {
@@ -18,12 +20,27 @@ ttnn::Tensor RepeatOperation::invoke(
     const Shape & repeat_dims,
     const std::optional<MemoryConfig>& memory_config_arg) {
 
+    ttnn::Tensor interleaved_input_tensor;
+
+
+    // Currently no native support for sharded tensors
+    // Converting to Interleaved before sending to device operation
+    if(input_tensor.is_sharded()) {
+        tt::log_warning(tt::LogOp, "Sharding is not natively supported, converting to interleaved before going to device, and then will shard output");
+        auto dram_memory_config = tt::tt_metal::MemoryConfig{.memory_layout=tt::tt_metal::TensorMemoryLayout::INTERLEAVED,.buffer_type=tt::tt_metal::BufferType::DRAM};
+        interleaved_input_tensor = ttnn::sharded_to_interleaved(queue_id, input_tensor, dram_memory_config, std::nullopt);
+    }
+    else {
+        interleaved_input_tensor = input_tensor;
+    }
+
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
         [repeat_dims, memory_config_arg] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) -> std::vector<Tensor> {
             auto& input_tensor = input_tensors.at(0);
             auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
             uint32_t input_rank = input_tensor.get_legacy_shape().rank();
+
             TT_FATAL(repeat_dims.rank() == input_rank, "Number of repeat dims must be equal to number of tensor dims");
             Tensor output = input_tensor;
             for (uint32_t dim = 0; dim < repeat_dims.size(); ++dim) {
@@ -39,8 +56,20 @@ ttnn::Tensor RepeatOperation::invoke(
                 output = operation::run_without_autoformat(RepeatDeviceOperation{dim, repeat_dims[dim], memory_config}, {output}).at(0);
             }
             return {output};
-        }, {input_tensor}, output_tensors);
-    return output_tensors.at(0);
+        }, {interleaved_input_tensor}, output_tensors);
+
+    // If input was originally sharded, we want to shard the output again.
+    if(input_tensor.is_sharded()) {
+        auto shard_spec = input_tensor.shard_spec().value();
+        for(uint32_t dim_idx = 0; dim_idx < repeat_dims.rank() - 1; dim_idx++) {
+            shard_spec.shape[0] *= repeat_dims[dim_idx];
+        }
+        shard_spec.shape[1] *= repeat_dims[repeat_dims.rank() - 1];
+        return ttnn::interleaved_to_sharded(queue_id, output_tensors.at(0), shard_spec.grid, shard_spec.shape, input_tensor.buffer()->buffer_layout(), shard_spec.orientation, std::nullopt);
+    }
+    else {
+        return output_tensors.at(0);
+    }
 
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/4005)

### Problem description
Repeat device operation asserts out when getting a sharded tensor

### What's changed
Adding a bypass path at the op level to convert sharded tensor to interleaved.
If big performance hit later we will need to investigate adding native support

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
