### PR TITLE
#0: Bump trace region size to 20MB for T3K LLAMA2

### DIFF
--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -212,7 +212,7 @@ def run_test_LlamaModel_end_to_end(
     ),
     ids=["gen32", "gen128", "gen2k", "gen8k", "gen128k"],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 14227456}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 20000000}], indirect=True)
 def test_Llama_perf_host(
     generation_length,
     expected_compile_time,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
LLAMA 2 Trace Perf Test on T3K failing due to trace region being too small.

### What's changed
Bump trace region size to 20MB for T3K LLAMA2. Should resolve CI failure + provide factor of safety for future dispatch changes.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
