### PR TITLE
#13315: Revise moreh_bmm, moreh_bmm_backward operations

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -11,126 +11,214 @@ import ttnn
 from tests.ttnn.unit_tests.operations.test_moreh_matmul import get_tensors
 from models.utility_functions import comp_allclose_and_pcc
 
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
+    to_npu,
 )
 
 
-@pytest.mark.parametrize(
-    "shape",
-    (
-        # batch, m, k, n
-        [1, 31, 639, 31],
-        [5, 95, 415, 65],
-        [10, 191, 447, 159],
-    ),
-)
-@pytest.mark.parametrize("has_output", [False, True])
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
+def run_moreh_bmm(shape, optional_output, compute_kernel_options, device):
+    """
+    Function to test Batched Matrix Multiplication (BMM) using PyTorch and TTNN backends.
+
+    Args:
+        shape (list): Shape of the input tensors [batch, m, k, n].
+        optional_output (bool): Flag indicating if output tensor should be preallocated.
+        compute_kernel_options: Configuration options for the compute kernel.
+        device: The device on which to run the operations.
+    """
     input_shape = [shape[0], shape[1], shape[2]]
     mat2_shape = [shape[0], shape[2], shape[3]]
     output_shape = [shape[0], shape[1], shape[3]]
-
-    # get tensors
-    tt_input, tt_mat2, tt_output, _, _, _, input, mat2, _ = get_tensors(
-        input_shape, mat2_shape, output_shape, False, False, False, device
-    )
-
+    (
+        ttnn_input,
+        ttnn_mat2,
+        ttnn_output,
+        _,
+        _,
+        _,
+        input,
+        mat2,
+        _,
+    ) = get_tensors(input_shape, mat2_shape, output_shape, False, False, False, device)
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
-    # tt bmm
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output = (
+    # Perform PyTorch BMM
+    output = torch.bmm(input, mat2)
+
+    # Perform TTNN BMM
+    ttnn_output = (
         ttnn.operations.moreh.bmm(
-            tt_input, tt_mat2, output=tt_output if has_output else None, compute_kernel_config=compute_kernel_config
+            ttnn_input,
+            ttnn_mat2,
+            output=ttnn_output if optional_output else None,
+            compute_kernel_config=compute_kernel_config,
         )
         .cpu()
-        .to(cpu_layout)
+        .to(ttnn.ROW_MAJOR_LAYOUT)
         .unpad_from_tile(output_shape)
         .to_torch()
     )
 
-    # torch bmm
-    output = torch.bmm(input, mat2)
-
-    # test for equivalance
-    passing, output_pcc = comp_allclose_and_pcc(output, tt_output, pcc=0.999)
+    # Compare results for equivalence
+    passing, output_pcc = comp_allclose_and_pcc(output, ttnn_output, pcc=0.999)
     logger.debug(f"Out passing={passing}")
     logger.debug(f"Output pcc={output_pcc}")
-
     assert passing
 
 
-@pytest.mark.parametrize(
-    "shape",
-    (
-        # batch, m, k, n
-        [1, 32, 32, 32],
-        [3, 31, 31, 31],
-        [7, 511, 313, 765],
-    ),
-)
-@pytest.mark.parametrize(
-    "requires_grad",
-    (
-        (True, False),
-        (False, True),
-        (True, True),
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device):
+def run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device):
+    """
+    Function to test the backward pass of Batched Matrix Multiplication (BMM) using PyTorch and TTNN backends.
+
+    Args:
+        shape (list): Shape of the input tensors [batch, m, k, n].
+        requires_grad (tuple): Flags indicating whether gradients are required for input and mat2.
+        compute_kernel_options: Configuration options for the compute kernel.
+        device: The device on which to run the operations.
+    """
     require_input_grad, require_mat2_grad = requires_grad
     input_shape = [shape[0], shape[1], shape[2]]
     mat2_shape = [shape[0], shape[2], shape[3]]
     output_shape = [shape[0], shape[1], shape[3]]
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    # get tensors
     (
-        tt_input,
-        tt_mat2,
+        ttnn_input,
+        ttnn_mat2,
         _,
-        tt_output_grad,
-        tt_input_grad,
-        tt_mat2_grad,
+        ttnn_output_grad,
+        ttnn_input_grad,
+        ttnn_mat2_grad,
         input,
         mat2,
         output_grad,
     ) = get_tensors(input_shape, mat2_shape, output_shape, require_input_grad, require_mat2_grad, False, device)
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
-    # tt bmm fwd, bwd
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    ttnn.operations.moreh.bmm_backward(
-        tt_output_grad,
-        tt_input,
-        mat2=tt_mat2,
-        are_required_outputs=(require_input_grad, require_mat2_grad),
-        input_grad=tt_input_grad if require_input_grad else None,
-        mat2_grad=tt_mat2_grad if require_mat2_grad else None,
-        compute_kernel_config=compute_kernel_config,
-    )
-
-    # torch bmm fwd, bwd
+    # Perform PyTorch BMM (backward)
     output = torch.bmm(input.requires_grad_(require_input_grad), mat2.requires_grad_(require_mat2_grad))
     output.backward(output_grad)
 
-    # test for equivalance
+    # Perform TTNN BMM (backward)
+    ttnn_input_grad, ttnn_mat2_grad = ttnn.operations.moreh.bmm_backward(
+        ttnn_output_grad,
+        ttnn_input,
+        mat2=ttnn_mat2,
+        are_required_outputs=(require_input_grad, require_mat2_grad),
+        input_grad=ttnn_input_grad if require_input_grad else None,
+        mat2_grad=ttnn_mat2_grad if require_mat2_grad else None,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    # Compare results for equivalence
     rtol = atol = 0.1
     if require_input_grad:
-        ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
-        passing, output_pcc = comp_allclose_and_pcc(input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
+        ttnn_cpu_input_grad = ttnn_input_grad.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(input_shape).to_torch()
+        passing, output_pcc = comp_allclose_and_pcc(input.grad, ttnn_cpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
         logger.debug(f"input_grad passing={passing}")
         logger.debug(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_mat2_grad:
-        ttcpu_mat2_grad = tt_mat2_grad.cpu().to(cpu_layout).unpad_from_tile(mat2_shape).to_torch()
-        passing, output_pcc = comp_allclose_and_pcc(mat2.grad, ttcpu_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
+        ttnn_cpu_mat2_grad = ttnn_mat2_grad.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(mat2_shape).to_torch()
+        passing, output_pcc = comp_allclose_and_pcc(mat2.grad, ttnn_cpu_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
         logger.debug(f"mat2_grad passing={passing}")
         logger.debug(f"mat2_grad pcc={output_pcc}")
         assert passing
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 31, 639, 31],
+        [5, 95, 415, 65],
+        [10, 191, 447, 159],
+    ],
+)
+@pytest.mark.parametrize("optional_output", [False, True])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm(shape, optional_output, compute_kernel_options, device):
+    """
+    PyTest wrapper for running BMM tests with multiple configurations.
+    """
+    torch.manual_seed(2024)
+    run_moreh_bmm(shape, optional_output, compute_kernel_options, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[10, 191, 447, 159]],
+)
+@pytest.mark.parametrize("optional_output", [False, True])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm_callback(shape, optional_output, compute_kernel_options, device, use_program_cache):
+    """
+    PyTest wrapper for running BMM tests with multiple configurations.
+    AssertionError: If the number of program cache entries differs between runs with the same settings.
+    """
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
+        run_moreh_bmm(shape, optional_output, compute_kernel_options, device)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_npu(torch_dummy, device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 32, 32, 32],
+        [3, 31, 31, 31],
+        [7, 511, 313, 765],
+    ],
+)
+@pytest.mark.parametrize(
+    "requires_grad",
+    [
+        [True, False],
+        [False, True],
+        [True, True],
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device):
+    """
+    PyTest wrapper for running BMM backward tests with multiple configurations.
+    """
+    torch.manual_seed(2024)
+    run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[7, 511, 313, 765]],
+)
+@pytest.mark.parametrize(
+    "requires_grad",
+    [
+        [True, False],
+        [False, True],
+        [True, True],
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm_backward_callback(shape, requires_grad, compute_kernel_options, device, use_program_cache):
+    """
+    PyTest wrapper for running BMM backward tests with multiple configurations.
+    AssertionError: If the number of program cache entries differs between runs with the same settings.
+    """
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
+        run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_npu(torch_dummy, device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.cpp
@@ -7,7 +7,7 @@
 #include "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp"
 
 namespace ttnn::operations::moreh::moreh_bmm {
-Tensor MorehBmm::invoke(
+Tensor MorehBMM::invoke(
     const Tensor& input,
     const Tensor& mat2,
     const std::optional<Tensor>& output,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.hpp
@@ -8,7 +8,7 @@
 #include "ttnn/decorators.hpp"
 
 namespace ttnn::operations::moreh::moreh_bmm {
-struct MorehBmm {
+struct MorehBMM {
     static Tensor invoke(
         const Tensor& input,
         const Tensor& mat2,
@@ -20,5 +20,5 @@ struct MorehBmm {
 
 namespace ttnn {
 constexpr auto moreh_bmm =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_bmm", ttnn::operations::moreh::moreh_bmm::MorehBmm>();
+    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_bmm", ttnn::operations::moreh::moreh_bmm::MorehBMM>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.cpp
@@ -7,7 +7,7 @@
 #include "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp"
 
 namespace ttnn::operations::moreh::moreh_bmm_backward {
-std::vector<std::optional<Tensor>> MorehBmmBackward::invoke(
+std::vector<std::optional<Tensor>> MorehBMMBackward::invoke(
     const Tensor& output_grad,
     const Tensor& input,
     const Tensor& mat2,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.hpp
@@ -8,7 +8,7 @@
 #include "ttnn/decorators.hpp"
 
 namespace ttnn::operations::moreh::moreh_bmm_backward {
-struct MorehBmmBackward {
+struct MorehBMMBackward {
     static std::vector<std::optional<Tensor>> invoke(
         const Tensor& output_grad,
         const Tensor& input,
@@ -24,5 +24,5 @@ struct MorehBmmBackward {
 
 namespace ttnn {
 constexpr auto moreh_bmm_backward = ttnn::
-    register_operation<"ttnn::moreh_bmm_backward", ttnn::operations::moreh::moreh_bmm_backward::MorehBmmBackward>();
+    register_operation<"ttnn::moreh_bmm_backward", ttnn::operations::moreh::moreh_bmm_backward::MorehBMMBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.cpp
@@ -12,7 +12,7 @@ void bind_moreh_bmm_backward_operation(py::module& module) {
     bind_registered_operation(
         module,
         ttnn::moreh_bmm_backward,
-        "Moreh Bmm Backward Operation",
+        "Moreh BMM Backward Operation",
         ttnn::pybind_arguments_t{
             py::arg("output_grad"),
             py::arg("input"),


### PR DESCRIPTION
### Ticket
Link to Github Issue: [#13315](https://github.com/tenstorrent/tt-metal/issues/13315)

### Problem description
Some conventions need to be revised in the TTNN operation. In this case, moreh_bmm, moreh_bmm_backward will be revised.

### What's changed
To improve test coverage, additional test cases were added:
- Added docstring.
- Added a test case for program cache; ensure that override_runtime_arguments works correctly on both forward and backward phase.
- The test cases have now increased to 40 cases.

### Checklist
- [x] Post commit CI passes:
+ [All post-commit tests #16870](https://github.com/tenstorrent/tt-metal/actions/runs/11123374538)
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] Device performance regression CI testing passes (if applicable): N/A
- [x] New/Existing tests provide coverage for changes: 40/40 test cases passed

| Test Type                        | Count |
|-----------------------------------|-------|
| test_moreh_bmm                    | 12    |
| test_moreh_bmm_callback           | 4     |
| test_moreh_bmm_backward           | 18    |
| test_moreh_bmm_backward_callback  | 6     |
