### PR TITLE
#0: TG Llama3-70b - fix frequent tests

### DIFF
--- a/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
@@ -12,8 +12,8 @@ from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.tg.llama3_70b.tt.llama_decoder_galaxy import TtLlamaDecoder_galaxy
 from models.demos.t3000.llama2_70b.reference.llama.llama.model import precompute_freqs_cis
 from models.utility_functions import skip_for_grayskull
+from models.demos.tg.llama3_70b.tt.llama_common import setup_llama_env
 from models.demos.t3000.llama2_70b.tt.llama_common import (
-    setup_llama_env,
     check_mesh_device,
     extract_pcc_from_log,
     generate_rot_emb,

--- a/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
@@ -12,10 +12,8 @@ from time import time
 import pytest
 from loguru import logger
 from models.utility_functions import skip_for_grayskull
-from models.demos.t3000.llama2_70b.tt.llama_common import (
-    setup_llama_env,
-    check_mesh_device,
-)
+from models.demos.t3000.llama2_70b.tt.llama_common import check_mesh_device
+from models.demos.tg.llama3_70b.tt.llama_common import setup_llama_env
 from models.demos.tg.llama3_70b.demo.demo import run_demo, construct_arg
 
 

--- a/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
@@ -10,8 +10,8 @@ import ttnn
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.tg.llama3_70b.tt.llama_mlp_galaxy import TtLlamaMLP_galaxy
 from models.utility_functions import skip_for_grayskull
+from models.demos.tg.llama3_70b.tt.llama_common import setup_llama_env
 from models.demos.t3000.llama2_70b.tt.llama_common import (
-    setup_llama_env,
     check_mesh_device,
     MAX_SEQ_LEN,
     BASE_URL,

--- a/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
@@ -5,7 +5,8 @@
 import pytest
 
 from models.utility_functions import skip_for_grayskull
-from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
+from models.demos.tg.llama3_70b.tt.llama_common import setup_llama_env
+from models.demos.t3000.llama2_70b.tt.llama_common import check_mesh_device
 from models.demos.tg.llama3_70b.tests.test_llama_model_galaxy import run_test_LlamaModel_inference
 
 

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -9,8 +9,8 @@ import ttnn
 
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.tg.llama3_70b.tt.llama_model_galaxy import TtLlamaModel_galaxy
+from models.demos.tg.llama3_70b.tt.llama_common import setup_llama_env
 from models.demos.t3000.llama2_70b.tt.llama_common import (
-    setup_llama_env,
     check_mesh_device,
     BASE_URL,
     should_skip_model_load,


### PR DESCRIPTION
Broken TG Llama3-70b frequent tests

### Problem description
setup_llama_env was linked to t3k implementation instead of TG

### What's changed
In all tests it's imported setup_llama_env from tg/llama_commoon.py

### Checklist
- [ ] Frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/11123357206
