### PR TITLE
Not holding state for freshening profiler logs

### DIFF
--- a/tt_metal/tools/profiler/profiler.cpp
+++ b/tt_metal/tools/profiler/profiler.cpp
@@ -252,12 +252,11 @@ void DeviceProfiler::dumpResultToFile(
 
     firstTimestamp(timestamp);
 
-    if (new_log || !std::filesystem::exists(log_path))
+    if (!std::filesystem::exists(log_path))
     {
         log_file.open(log_path);
         log_file << "ARCH: " << get_string_lowercase(device_architecture) << ", CHIP_FREQ[MHz]: " << device_core_frequency << std::endl;
         log_file << "PCIe slot, core_x, core_y, RISC processor type, timer_id, time[cycles since reset], stat value, run ID, run host ID,  zone name, zone phase, source line, source file" << std::endl;
-        new_log = false;
     }
     else
     {
@@ -288,10 +287,14 @@ DeviceProfiler::DeviceProfiler(const bool new_logs)
 {
 #if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
-    new_log = new_logs;
     output_dir = std::filesystem::path(string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME));
     std::filesystem::create_directories(output_dir);
+    std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
 
+    if (new_logs)
+    {
+        std::filesystem::remove(log_path);
+    }
 #endif
 }
 
@@ -308,10 +311,11 @@ DeviceProfiler::~DeviceProfiler()
 }
 
 
-void DeviceProfiler::setNewLogFlag(bool new_log_flag)
+void DeviceProfiler::freshDeviceLog()
 {
 #if defined(TRACY_ENABLE)
-    new_log = new_log_flag;
+    std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
+    std::filesystem::remove(log_path);
 #endif
 }
 

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -29,10 +29,6 @@ namespace tt_metal {
 
 class DeviceProfiler {
     private:
-
-        // Recreate device side log file with header
-        bool new_log;
-
         // Device architecture
         tt::ARCH device_architecture;
 
@@ -108,8 +104,8 @@ class DeviceProfiler {
         // Device-core Syncdata
         std::map<CoreCoord, std::tuple<double,double,double>> device_core_sync_info;
 
-        //Set the device side file flag
-        void setNewLogFlag(bool new_log_flag);
+        //Freshen device logs
+        void freshDeviceLog();
 
         //Set the device architecture
         void setDeviceArchitecture(tt::ARCH device_arch);

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -488,7 +488,7 @@ void FreshProfilerDeviceLog(){
 #if defined(TRACY_ENABLE)
     for (auto& device_id : tt_metal_device_profiler_map)
     {
-        tt_metal_device_profiler_map.at(device_id.first).setNewLogFlag(true);
+        tt_metal_device_profiler_map.at(device_id.first).freshDeviceLog();
     }
 #endif
 }


### PR DESCRIPTION
### Ticket
#13323 

### Problem description
T3K profiling is broken because log generation was dependant on what device dumps first
 
### What's changed
Logs generation is not dependant on the order of device init or device dump calls

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11126954446/job/30918385064
- [x] Device performance regression CI testing passes  https://github.com/tenstorrent/tt-metal/actions/runs/11126973506/job/30919322054 (Same threshold failure as main)
- [x] T3K Profiler https://github.com/tenstorrent/tt-metal/actions/runs/11126357070
