### PR TITLE
Llama 3.1 8b DRAM-shard the LM head, 23.1 t/s/u

### DIFF
--- a/models/demos/wormhole/llama31_8b/demo/demo_trace.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_trace.py
@@ -26,6 +26,9 @@ from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import T
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 
+from models.perf.benchmarking_utils import BenchmarkProfiler
+from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
+
 
 # load from json, return as a list
 def load_inputs(user_input, batch):
@@ -136,10 +139,18 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
     # We disregard any warmup iteration for profiling, in favour of just measuring compile time on the first iteration
     N_warmup_iter = {"inference_prefill": 0, "inference_decode": 0}
 
+    # Start profiler
+    logger.info(f"Start profiler")
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
+
+    logger.info(f"Reading inputs...")
+    profiler.start("loading_inputs")
     if len(user_input) == 1:
         input_prompts = user_input * batch_size
     else:
         input_prompts = load_inputs(user_input, batch_size)
+    profiler.end("loading_inputs")
 
     # Generate the batched prompts (rotate the inputs between the users, for each batch)
     # If batch_size == 1, the same prompt is repeated for each batch
@@ -154,6 +165,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
     model_args.n_layers = 32
 
     logger.info("Loading weights...")
+    profiler.start("weight_loading")
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
     state_dict = {
         k: v
@@ -163,10 +175,12 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             or k in ["tok_embeddings.weight", "norm.weight", "output.weight"]
         )
     }
+    profiler.end("weight_loading")
     logger.info("Loading weights finished!")
 
     # Load TTNN Llama3.1 model
     logger.info("Loading weights to device...")
+    profiler.start("loading_weights_to_device")
     tt_model = TtTransformer(
         args=model_args,
         device=device,
@@ -185,11 +199,15 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
     embd = HostEmbedding(model_args)
     embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
 
+    profiler.end("loading_weights_to_device")
     logger.info("Finished loading weights to device. Starting inference...")
+
     max_generated_tokens = 120  # Maximum number of tokens to generate per user
     num_tokens_generated_decode = []
+
     for batch_idx, input_prompts in enumerate(batch_prompts):
         logger.info(f"Processing batch {batch_idx}")
+        profiler.start(f"preprocess_prefill_inputs", iteration=batch_idx)
         # Preprocess initial prompt inputs
         (
             input_tokens_prefill_pt,
@@ -204,6 +222,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             max_generated_tokens,
         )
         pt_prefill_input = [embd(input_tokens_prefill_pt[b]).view(1, prefill_lens[b], -1) for b in range(batch_size)]
+        profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
         # set kv cache to zeros if not first batch, to avoid context leaking
         if batch_idx != 0:
@@ -213,6 +232,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
                 v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
 
         logger.info(f"Starting prefill...")
+        profiler.start(f"prepare_rot_mat_for_prefill", iteration=batch_idx)
 
         head_dim = model_args.dim // model_args.n_heads
         transformation_mat_torch = get_rot_transformation_mat(head_dim)
@@ -223,12 +243,17 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             device=device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
+        profiler.end(f"prepare_rot_mat_for_prefill", iteration=batch_idx)
 
         # First user is used for compile time
         num_users_generated_prefill = batch_size - 1 if batch_size > 1 else 1  # First user is used for compile time
 
         pt_out = []
+
+        profiler.start(f"inference_prefill", iteration=batch_idx)
         for batch_id in range(batch_size):
+            if batch_id == 0:  # First user prefill also accounts for compile time
+                profiler.start(f"compile_prefill", iteration=batch_idx)
             prefill_seq_len = prefill_lens[batch_id]
             rot_mats_prefill = get_prefill_rot_mat(
                 model_args.head_dim, model_args.max_seq_len, device, seq_len=prefill_seq_len
@@ -253,10 +278,43 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             )
             pt_out.append(ttnn.to_torch(tt_out)[0, 0, (decoding_pos[batch_id] - 1) % 32, :])
             ttnn.deallocate(tt_out)
-            ttnn.synchronize_device(device)
+            if batch_id == 0:  # First user prefill also accounts for compile time
+                profiler.end(f"compile_prefill", iteration=batch_idx)
+
+        # Do another prefill run if batch_size == 1, to correctly measure inference prefill time
+        if batch_size == 1:
+            for batch_id in range(batch_size):
+                prefill_seq_len = prefill_lens[batch_id]
+                rot_mats_prefill = get_prefill_rot_mat(
+                    model_args.head_dim, model_args.max_seq_len, device, seq_len=prefill_seq_len
+                )
+                if decoding_pos[batch_id] < prefill_seq_len:
+                    pt_prefill_input[batch_id][
+                        :, decoding_pos[batch_id] :, :
+                    ] = 0  # Zero out the tokens after the prefill length
+
+                prefill_input = prepare_inputs_ttnn_prefill(
+                    pt_prefill_input[batch_id],
+                    device,
+                )
+                tt_out = tt_model(
+                    prefill_input,
+                    None,  # Current position
+                    rot_mats_prefill,
+                    transformation_mats,
+                    user_id=batch_id,
+                    mode="prefill",
+                    get_last_token=((decoding_pos[batch_id] - 1) // 32) * 32,
+                )
+                pt_out.append(ttnn.to_torch(tt_out)[0, 0, (decoding_pos[batch_id] - 1) % 32, :])
+                ttnn.deallocate(tt_out)
+
+        ttnn.synchronize_device(device)
+        profiler.end(f"inference_prefill", iteration=batch_idx)
         logger.info(f"Prefill finished!")
 
         # Preparing first decode token
+        profiler.start(f"prepare_first_decode_token_{batch_idx}")
         pt_out_batched = torch.stack(pt_out, dim=-2)
         pt_out_batched = torch.argmax(pt_out_batched, dim=-1)
         tt_out_tok = ttnn.from_torch(
@@ -264,6 +322,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             device=device,
             dtype=ttnn.uint32,
         )
+        profiler.end(f"prepare_first_decode_token_{batch_idx}")
 
         # Keep track of generated outputs to print out every iteration
         all_outputs = [encoded_prompts[b][:prefill_seq_len] for b in range(batch_size)]
@@ -275,12 +334,15 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
 
         logger.info("Starting decode...")
 
+        profiler.start(f"get_single_rot_mat_decode_{batch_idx}")
         current_rot_mat, rot_matrix = get_single_rot_mat(
             model_args.head_dim,
             device,
             start_pos=decoding_pos[0] - 2,
         )
+        profiler.end(f"get_single_rot_mat_decode_{batch_idx}")
 
+        profiler.start(f"compile_trace_{batch_idx}")
         # Create trace events
         op_event = ttnn.create_event(device)
         write_event = ttnn.create_event(device)
@@ -298,6 +360,8 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
         current_rot_mat = ttnn.copy(new_rot_mat, current_rot_mat)
         ttnn.plus_one(current_pos)
 
+        profiler.end(f"compile_trace_{batch_idx}")
+        profiler.start(f"capture_trace_{batch_idx}")
         # Capture Trace
         trace_id = ttnn.begin_trace_capture(device, cq_id=0)
 
@@ -312,6 +376,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
         ttnn.plus_one(current_pos)
 
         ttnn.end_trace_capture(device, trace_id, cq_id=0)
+        profiler.end(f"capture_trace_{batch_idx}")
 
         # Reset the decoding position for the proper run of the model
         current_pos_reset = ttnn.from_torch(torch.tensor(decoding_pos, dtype=torch.int32), dtype=ttnn.int32)
@@ -328,9 +393,13 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
         iteration = 0
         users_decoding = True  # reset to handle next batch
 
+        profiler.start(f"inference_decode", iteration=batch_idx)
         ttnn.record_event(1, write_event)
 
         while users_decoding:
+            if iteration == 0:  # First iteration also accounts for compile time
+                profiler.start(f"compile_decode", iteration=batch_idx)
+
             iteration_time_start = time()
             # Execute trace
             ttnn.wait_for_event(0, write_event)
@@ -357,6 +426,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             iteration_time = time() - iteration_time_start
             tokens_per_second_per_user = 1 / iteration_time
 
+            profiler.start(f"log_printing_iter_{iteration}", iteration=batch_idx)
             # Print out generated outputs for each user at the end of every iteration
             if not is_ci_env:
                 if len(user_input) == 1:
@@ -373,6 +443,11 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             logger.info(
                 f"Iteration {iteration}: {1000*iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
             )
+            profiler.end(f"log_printing_iter_{iteration}", iteration=batch_idx)
+
+            if iteration == 0:  # First iteration also accounts for compile time
+                profiler.end(f"compile_decode", iteration=batch_idx)
+
             iteration += 1
 
             # Reset rotation matrix every 100 iterations
@@ -389,11 +464,12 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
                 users_decoding = False
 
             if not users_decoding:
+                profiler.start(f"log_saving_file", iteration=batch_idx)
                 with open(output_filename, "a") as f:
                     for i, (output, prompt) in enumerate(zip(all_outputs, input_prompts)):
                         text = tokenizer.decode(output)
                         if instruct_mode:
-                            split_text = text.split("[/INST]", 1)
+                            split_text = text.split("<|start_header_id|>assistant<|end_header_id|>", 1)
                         else:
                             split_text = text.split(prompt, 1)
                         if len(split_text) > 1:
@@ -408,13 +484,92 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
                             logger.info(
                                 f"\nbatch: {batch_idx} user: {i}\nprompt: {prompt} \noutput:\n{text_after_prompt}\n"
                             )
+                profiler.end(f"log_saving_file", iteration=batch_idx)
 
         num_tokens_generated_decode.append(
             iteration - 1
         )  # Save the number of tokens generated for each batch (excluding the first token which is used for compile time)
 
+        profiler.end(f"inference_decode", iteration=batch_idx)
         # Release trace
         ttnn.release_trace(device, trace_id)
+
+    # Finish profiling at the end of all batches
+    profiler.end("run")
+
+    # Benchmark metrics for batch 0
+    compile_prefill_time = profiler.get_duration("compile_prefill")
+    compile_decode_time = profiler.get_duration("compile_decode")
+    inference_prefill_time = profiler.get_duration("inference_prefill")
+    inference_decode_time = profiler.get_duration("inference_decode")
+    log_printing_time = sum(profiler.get_duration(f"log_printing_iter_{i}") for i in range(max_generated_tokens))
+    log_saving_file_time = profiler.get_duration(f"log_saving_file")
+
+    # Correct the inference decode time to remove the time spent on compile (1st iteration) and log_printing (at the end of every iteration)
+    inference_decode_time = inference_decode_time - compile_decode_time - log_printing_time - log_saving_file_time
+    # Correct the inference prefill time to remove the time spent on compile (1st iteration)
+    inference_prefill_time = inference_prefill_time - compile_prefill_time
+
+    prefill_time_to_first = inference_prefill_time / num_users_generated_prefill
+
+    measurements = {
+        # Required measurements
+        "compile_prefill": compile_prefill_time,
+        "compile_decode": compile_decode_time,
+        "inference_prefill": inference_prefill_time,
+        "inference_decode": inference_decode_time,
+        "prefill_time_to_token": prefill_time_to_first,
+        "prefill_t/s": num_users_generated_prefill / inference_prefill_time * prefill_seq_len,  # tokens/s
+        "decode_t/s/u": num_tokens_generated_decode[0] / inference_decode_time,  # tokens/s
+        "decode_t/s": num_tokens_generated_decode[0] / inference_decode_time * batch_size,  # tokens/s/user
+        # Optional measurements
+        "loading_inputs": profiler.get_duration("loading_inputs"),
+        "weight_loading": profiler.get_duration("weight_loading"),
+        "preprocess_prefill_inputs": profiler.get_duration("preprocess_prefill_inputs"),
+        "loading_weights_to_device": profiler.get_duration("loading_weights_to_device"),
+        "prepare_rot_mat_for_prefill": profiler.get_duration("prepare_rot_mat_for_prefill"),
+        "compile_trace": profiler.get_duration("compile_trace_0"),
+        "capture_trace": profiler.get_duration("capture_trace_0"),
+        "Total compile time": compile_prefill_time + compile_decode_time,
+        "Full demo runtime": profiler.get_duration("run"),
+    }
+
+    # Print some of the perf metrics as well
+    logger.info("---")
+    logger.info(f"Performance metrics for batch 0")
+    logger.info(f"Prefill compile time: {round(measurements['compile_prefill'], 4)}s")
+    logger.info(f"Decode compile time: {round(measurements['compile_decode'], 4)}s")
+    logger.info(f"Prefill inference time per user: {round(inference_prefill_time/num_users_generated_prefill, 4)}s")
+    logger.info(
+        f"Total Decode inference time ({max_generated_tokens-1} iterations): {round(measurements['inference_decode'], 4)}s"
+    )
+    logger.info(
+        f"Average Decode inference time per user: {round(inference_decode_time / num_tokens_generated_decode[0], 4)}s"
+    )
+    logger.info("---")
+    logger.info(f"Time to first token: {round(measurements['prefill_time_to_token']* 1000, 4)}ms")
+    logger.info(f"Average tokens/sec/user: {round(measurements['decode_t/s/u'], 2)}")
+
+    target_prefill_ts = 5000  # TODO update target
+    target_decode_ts = 1056
+    decode_tsu = 23
+    targets = {"prefill_t/s": target_prefill_ts, "decode_t/s": target_decode_ts, "decode_t/s/u": decode_tsu}
+
+    # Save benchmark data for CI dashboard
+    if is_ci_env and is_n300:
+        benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, targets)
+        benchmark_data.prep_csvs(
+            profiler,
+            run_type=f"demo_trace",
+            ml_model_name="Llama3.1-8B",
+            ml_model_type="llm",
+            num_layers=model_args.n_layers,
+            batch_size=batch_size,
+            input_sequence_length=prefill_seq_len,
+            output_sequence_length=1,
+            # config_params=,
+            # precision=,
+        )
 
 
 @pytest.mark.parametrize(

--- a/models/demos/wormhole/llama31_8b/demo/demo_trace.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_trace.py
@@ -432,7 +432,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
         "instruct_weights-3_batch",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 7815168, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 7860224, "num_command_queues": 2}], indirect=True)
 def test_llama_demo(
     device, use_program_cache, input_prompts, instruct_weights, is_ci_env, is_single_card_n300, num_batches
 ):

--- a/models/demos/wormhole/llama31_8b/demo/demo_trace.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_trace.py
@@ -125,9 +125,9 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
 
     # Set Llama flags for CI
     if is_ci_env and instruct_mode:  # Update paths for instruct mode, otherwise use default paths for general weights
-        os.environ["LLAMA_CKPT_DIR"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
-        os.environ["LLAMA_TOKENIZER_PATH"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
-        os.environ["LLAMA_CACHE_PATH"] = "/proj_sw/user_dev/hf_data/llama/Meta-Llama-3.1-8B-Instruct/"
+        os.environ["LLAMA_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/"
+        os.environ["LLAMA_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/"
+        os.environ["LLAMA_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/"
     # This module requires the env paths above for CI runs
     from models.demos.wormhole.llama31_8b.tt.model_config import TtModelArgs
 

--- a/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
@@ -527,7 +527,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
 
     target_prefill_ts = 5000  # TODO update target
     target_decode_ts = 1056
-    decode_tsu = 33
+    decode_tsu = 23
     targets = {"prefill_t/s": target_prefill_ts, "decode_t/s": target_decode_ts, "decode_t/s/u": decode_tsu}
 
     # Save benchmark data for CI dashboard

--- a/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
@@ -525,8 +525,8 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
     logger.info(f"Time to first token: {round(measurements['prefill_time_to_token']* 1000, 4)}ms")
     logger.info(f"Average tokens/sec/user: {round(measurements['decode_t/s/u'], 2)}")
 
-    target_prefill_ts = 5000  # TODO update target
-    target_decode_ts = 1056
+    target_prefill_ts = 1050  # TODO update target
+    target_decode_ts = 23 * batch_size
     decode_tsu = 23
     targets = {"prefill_t/s": target_prefill_ts, "decode_t/s": target_decode_ts, "decode_t/s/u": decode_tsu}
 

--- a/models/demos/wormhole/llama31_8b/tests/test_llama_model.py
+++ b/models/demos/wormhole/llama31_8b/tests/test_llama_model.py
@@ -133,6 +133,8 @@ def test_llama_model_inference(device, weights, layers, use_program_cache, reset
             ttnn.to_torch(tt_out).permute(2, 1, 0, 3).squeeze(1)[: model_args.max_batch_size, :, :]
         )  # [seq, batch, hidden_dim]
 
+        ttnn.deallocate(tt_out)
+
         # Update rotation matrix for next iteration
         current_rot_mat = ttnn.linear(rot_matrix, current_rot_mat)
 

--- a/models/demos/wormhole/llama31_8b/tests/test_llama_perf.py
+++ b/models/demos/wormhole/llama31_8b/tests/test_llama_perf.py
@@ -30,8 +30,8 @@ if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs
 @pytest.mark.parametrize(
     "kv_cache_len, expected_compile_time, expected_inference_time",
     (
-        (32, 6, 0.09),
-        (128, 6, 0.09),
+        # (32, 6, 0.09),
+        # (128, 6, 0.09),
         (1024, 11, 0.09),
     ),
 )
@@ -43,7 +43,7 @@ def test_llama_model_perf(
     model_args = TtModelArgs(device)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
-    model_args.n_layers = 32
+    model_args.n_layers = 1
     # Clear global profiler state before starting measurements
     profiler.clear()
 

--- a/models/demos/wormhole/llama31_8b/tests/test_llama_perf.py
+++ b/models/demos/wormhole/llama31_8b/tests/test_llama_perf.py
@@ -30,8 +30,8 @@ if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs
 @pytest.mark.parametrize(
     "kv_cache_len, expected_compile_time, expected_inference_time",
     (
-        # (32, 6, 0.09),
-        # (128, 6, 0.09),
+        (32, 6, 0.09),
+        (128, 6, 0.09),
         (1024, 11, 0.09),
     ),
 )
@@ -43,7 +43,7 @@ def test_llama_model_perf(
     model_args = TtModelArgs(device)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
-    model_args.n_layers = 1
+    model_args.n_layers = 32
     # Clear global profiler state before starting measurements
     profiler.clear()
 

--- a/models/demos/wormhole/llama31_8b/tt/llama_model.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_model.py
@@ -56,50 +56,12 @@ class TtTransformer(nn.Module):
             weight_key="norm",
         )
 
-        # Helper function to create output memory config
-        def create_output_mem_config(size):
-            padded_size = math.ceil(size / (32 * 12)) * (32 * 12)
-            shard_spec = ttnn.ShardSpec(
-                args.dram_weight_grid, (4096, padded_size // 12), ttnn.ShardOrientation.ROW_MAJOR, False
-            )
-            return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
-
-        # Split the output weight
-        split_size = self.vocab_size // 2
-        output_weight = state_dict["output.weight"].permute(1, 0)
-        output_weight_1 = output_weight[:, :split_size]
-        output_weight_2 = output_weight[:, split_size:]
-
-        # Create ttnn tensors for split weights
-        self.output_weight_1 = ttnn.as_tensor(
-            output_weight_1,
+        self.lm_head = LMHead(
+            args=args,
             device=device,
-            memory_config=create_output_mem_config(split_size),
-            layout=ttnn.TILE_LAYOUT,
             dtype=dtype,
-            cache_file_name=None if args.dummy_weights else weight_cache_path / "output_sharded_1",
-        )
-        self.output_weight_2 = ttnn.as_tensor(
-            output_weight_2,
-            device=device,
-            memory_config=create_output_mem_config(split_size),
-            layout=ttnn.TILE_LAYOUT,
-            dtype=dtype,
-            cache_file_name=None if args.dummy_weights else weight_cache_path / "output_sharded_2",
-        )
-
-        self.compute_kernel_config_output = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,  # Save as much L1 as possible
-            packer_l1_acc=True,
-        )
-
-        self.program_config_output = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
-            in0_block_w=1,
-            per_core_M=1,
-            per_core_N=32,  # vocab_size / 2 / tile_size / core_count
-            fused_activation=None,
+            state_dict=state_dict,
+            weight_cache_path=weight_cache_path,
         )
 
     def forward(
@@ -118,37 +80,95 @@ class TtTransformer(nn.Module):
         if mode == "prefill" and get_last_token == -1:
             return x
 
-        # Slicing the tensor to the nearest celing/floor multiples of 32 for the prefill_len, to get the last token
+        # Slicing the tensor to the nearest ceiling/floor multiples of 32 for the prefill_len, to get the last token
         if get_last_token != -1:
             x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, 4096))
 
         x = self.norm(x)
+        output = self.lm_head(x)
 
-        x = ttnn.interleaved_to_sharded(x, self.model_config["SHARDED_MLP_DECODE_INPUT_MEMCFG"])
+        return output
 
-        # Split linear operation
-        output_1 = ttnn.linear(
-            x,
-            self.output_weight_1,
-            compute_kernel_config=self.compute_kernel_config_output,
-            program_config=self.program_config_output,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=ttnn.bfloat8_b,
+
+class LMHead(nn.Module):
+    def __init__(
+        self,
+        args,
+        device,
+        dtype,
+        state_dict,
+        weight_cache_path,
+    ):
+        super().__init__()
+        self.args = args
+        self.device = device
+        self.dtype = dtype
+        self.vocab_size = args.vocab_size
+        self.num_splits = 4  # 2 splits hangs after a few iterations, 1 split doesn't fit into L1
+
+        split_size = self.vocab_size // self.num_splits
+
+        # Helper function to create output memory config
+        def create_output_mem_config(size):
+            padded_size = math.ceil(size / (32 * 12)) * (32 * 12)
+            shard_spec = ttnn.ShardSpec(
+                args.dram_weight_grid, (4096, padded_size // 12), ttnn.ShardOrientation.ROW_MAJOR, False
+            )
+            return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+        # Split the output weight
+        output_weight = state_dict["output.weight"].permute(1, 0)
+        self.output_weights = []
+        for i in range(self.num_splits):
+            start = i * split_size
+            end = (i + 1) * split_size
+            weight_part = output_weight[:, start:end]
+            self.output_weights.append(
+                ttnn.as_tensor(
+                    weight_part,
+                    device=device,
+                    memory_config=create_output_mem_config(split_size),
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=dtype,
+                    cache_file_name=None if args.dummy_weights else weight_cache_path / f"output_sharded_{i+1}",
+                )
+            )
+
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
         )
-        output_1 = ttnn.sharded_to_interleaved(output_1, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-        output_2 = ttnn.linear(
-            x,
-            self.output_weight_2,
-            compute_kernel_config=self.compute_kernel_config_output,
-            program_config=self.program_config_output,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=ttnn.bfloat8_b,
+        # Calculate per_core_N based on the number of splits
+        tile_size = 32
+        core_count = 64  # Assuming 8x8 core grid
+        per_core_N = -(-split_size // (tile_size * core_count))  # Ceiling division
+
+        self.program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+            in0_block_w=2,
+            per_core_M=1,
+            per_core_N=per_core_N,
+            fused_activation=None,
         )
 
-        output_2 = ttnn.sharded_to_interleaved(output_2, memory_config=ttnn.L1_MEMORY_CONFIG)
+    def forward(self, x: ttnn.Tensor):
+        x = ttnn.interleaved_to_sharded(x, self.args.get_model_config()["SHARDED_MLP_DECODE_INPUT_MEMCFG"])
+
+        outputs = []
+        for weight in self.output_weights:
+            output = ttnn.linear(
+                x,
+                weight,
+                compute_kernel_config=self.compute_kernel_config,
+                program_config=self.program_config,
+                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                dtype=ttnn.bfloat8_b,
+            )
+            outputs.append(ttnn.sharded_to_interleaved(output, memory_config=ttnn.L1_MEMORY_CONFIG))
 
         # Concatenate the outputs
-        output = ttnn.concat([output_1, output_2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
+        output = ttnn.concat(outputs, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         return output

--- a/models/demos/wormhole/llama31_8b/tt/llama_model.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_model.py
@@ -110,7 +110,7 @@ class LMHead(nn.Module):
 
         # Helper function to create output memory config
         def create_output_mem_config(size):
-            padded_size = math.ceil(size / (32 * 12)) * (32 * 12)
+            padded_size = math.ceil(size / (32 * 12)) * (32 * 12)  # Tile size (32) * dram cores (12)
             shard_spec = ttnn.ShardSpec(
                 args.dram_weight_grid, (4096, padded_size // 12), ttnn.ShardOrientation.ROW_MAJOR, False
             )

--- a/models/demos/wormhole/llama31_8b/tt/llama_model.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_model.py
@@ -56,24 +56,36 @@ class TtTransformer(nn.Module):
             weight_key="norm",
         )
 
-        # output_weight: 4096 x 128256: width-sharded on 12 banks
-        output_shard_shape = (
-            4096,
-            128256 // 12,
-        )
-        output_shard_spec = ttnn.ShardSpec(
-            args.dram_weight_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False
-        )
-        output_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, output_shard_spec
-        )
-        self.output_weight = ttnn.as_tensor(
-            state_dict["output.weight"].permute(1, 0),
+        # Helper function to create output memory config
+        def create_output_mem_config(size):
+            padded_size = math.ceil(size / (32 * 12)) * (32 * 12)
+            shard_spec = ttnn.ShardSpec(
+                args.dram_weight_grid, (4096, padded_size // 12), ttnn.ShardOrientation.ROW_MAJOR, False
+            )
+            return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+        # Split the output weight
+        split_size = self.vocab_size // 2
+        output_weight = state_dict["output.weight"].permute(1, 0)
+        output_weight_1 = output_weight[:, :split_size]
+        output_weight_2 = output_weight[:, split_size:]
+
+        # Create ttnn tensors for split weights
+        self.output_weight_1 = ttnn.as_tensor(
+            output_weight_1,
             device=device,
-            memory_config=output_mem_config,
+            memory_config=create_output_mem_config(split_size),
             layout=ttnn.TILE_LAYOUT,
             dtype=dtype,
-            cache_file_name=None if args.dummy_weights else weight_cache_path / "output_sharded",
+            cache_file_name=None if args.dummy_weights else weight_cache_path / "output_sharded_1",
+        )
+        self.output_weight_2 = ttnn.as_tensor(
+            output_weight_2,
+            device=device,
+            memory_config=create_output_mem_config(split_size),
+            layout=ttnn.TILE_LAYOUT,
+            dtype=dtype,
+            cache_file_name=None if args.dummy_weights else weight_cache_path / "output_sharded_2",
         )
 
         self.compute_kernel_config_output = ttnn.WormholeComputeKernelConfig(
@@ -81,6 +93,13 @@ class TtTransformer(nn.Module):
             math_approx_mode=False,
             fp32_dest_acc_en=False,  # Save as much L1 as possible
             packer_l1_acc=True,
+        )
+
+        self.program_config_output = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+            in0_block_w=1,
+            per_core_M=1,
+            per_core_N=32,  # vocab_size / 2 / tile_size / core_count
+            fused_activation=None,
         )
 
     def forward(
@@ -106,15 +125,30 @@ class TtTransformer(nn.Module):
         x = self.norm(x)
 
         x = ttnn.interleaved_to_sharded(x, self.model_config["SHARDED_MLP_DECODE_INPUT_MEMCFG"])
-        output = ttnn.linear(
+
+        # Split linear operation
+        output_1 = ttnn.linear(
             x,
-            self.output_weight,
+            self.output_weight_1,
             compute_kernel_config=self.compute_kernel_config_output,
-            program_config=self.model_config["OUTPUT_MM_PROGCFG"],
+            program_config=self.program_config_output,
             memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.dtype,
+            dtype=ttnn.bfloat8_b,
+        )
+        output_1 = ttnn.sharded_to_interleaved(output_1, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        output_2 = ttnn.linear(
+            x,
+            self.output_weight_2,
+            compute_kernel_config=self.compute_kernel_config_output,
+            program_config=self.program_config_output,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            dtype=ttnn.bfloat8_b,
         )
 
-        ttnn.deallocate(x)
+        output_2 = ttnn.sharded_to_interleaved(output_2, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        # Concatenate the outputs
+        output = ttnn.concat([output_1, output_2], dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         return output

--- a/models/demos/wormhole/llama31_8b/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b/tt/model_config.py
@@ -311,10 +311,10 @@ class TtModelArgs:
 
             # Update OUTPUT_MM_PROGCFG for DECODE (DRAM-sharded)
             self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
-                # Grid size = [4, 8]
-                in0_block_w=4,  # K(4096) / TILE_WIDTH(32) / Grid_Size(32)
+                # Grid size = [8, 8]
+                in0_block_w=2,  # K(4096) / TILE_WIDTH(32) / Grid_Size(64)
                 per_core_M=1,  # M(32) / TILE_HEIGHT(32)
-                per_core_N=126,  # N(128256) / TILE_WIDTH(32) / Grid_Size(32)
+                per_core_N=32,  # N(128256 / 2) / TILE_WIDTH(32) / Grid_Size(64)
                 fused_activation=None,
             )
 

--- a/models/demos/wormhole/llama31_8b/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b/tt/model_config.py
@@ -309,15 +309,6 @@ class TtModelArgs:
                 fuse_batch=seq_len <= 2048,
             )
 
-            # Update OUTPUT_MM_PROGCFG for DECODE (DRAM-sharded)
-            self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
-                # Grid size = [8, 8]
-                in0_block_w=2,  # K(4096) / TILE_WIDTH(32) / Grid_Size(64)
-                per_core_M=1,  # M(32) / TILE_HEIGHT(32)
-                per_core_N=32,  # N(128256 / 2) / TILE_WIDTH(32) / Grid_Size(64)
-                fused_activation=None,
-            )
-
             self.model_config["KV_PREFILL_MEM_CFG"] = lambda seq_len: ttnn.create_sharded_memory_config(
                 (seq_len // 8, self.head_dim),
                 ttnn.CoreGrid(y=8, x=8),

--- a/models/demos/wormhole/llama31_8b_N300/demo/demo.py
+++ b/models/demos/wormhole/llama31_8b_N300/demo/demo.py
@@ -451,7 +451,7 @@ def run_llama_demo_n300(user_input, batch_size, device_mesh, instruct_mode, is_c
         "instruct_weights-3_batch",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 5451776, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 5487616, "num_command_queues": 2}], indirect=True)
 def test_llama_demo(mesh_device, use_program_cache, input_prompts, instruct_weights, is_ci_env, num_batches):
     if is_ci_env and instruct_weights == False:
         pytest.skip("CI demo test only runs instruct weights to reduce CI pipeline load (both are supported)")

--- a/models/demos/wormhole/llama31_8b_N300/demo/demo.py
+++ b/models/demos/wormhole/llama31_8b_N300/demo/demo.py
@@ -451,7 +451,7 @@ def run_llama_demo_n300(user_input, batch_size, device_mesh, instruct_mode, is_c
         "instruct_weights-3_batch",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 5438464, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 5451776, "num_command_queues": 2}], indirect=True)
 def test_llama_demo(mesh_device, use_program_cache, input_prompts, instruct_weights, is_ci_env, num_batches):
     if is_ci_env and instruct_weights == False:
         pytest.skip("CI demo test only runs instruct weights to reduce CI pipeline load (both are supported)")

--- a/models/demos/wormhole/llama31_8b_N300/tt/llama_model.py
+++ b/models/demos/wormhole/llama31_8b_N300/tt/llama_model.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import math
 import ttnn
 import torch
 import torch.nn as nn
@@ -55,14 +56,12 @@ class TtTransformer(nn.Module):
             weight_key="norm",
         )
 
-        self.output_weight = ttnn.as_tensor(
-            state_dict["output.weight"].permute(1, 0),
-            device=device_mesh,
-            mesh_mapper=ttnn.ShardTensorToMesh(device_mesh, dim=-1),
-            layout=ttnn.TILE_LAYOUT,
+        self.lm_head = LMHead(
+            args=args,
+            device_mesh=device_mesh,
             dtype=dtype,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            cache_file_name=None if args.dummy_weights else weight_cache_path / "output.weight",
+            state_dict=state_dict,
+            weight_cache_path=weight_cache_path,
         )
 
     def forward(
@@ -81,21 +80,104 @@ class TtTransformer(nn.Module):
         if mode == "prefill" and get_last_token == -1:
             return x
 
-        # Slicing the tensor to the nearest celing/floor multiples of 32 for the prefill_len, to get the last token
+        # Slicing the tensor to the nearest ceiling/floor multiples of 32 for the prefill_len, to get the last token
         if get_last_token != -1:
             x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, 4096))
 
         x = self.norm(x)
-
-        output = ttnn.linear(
-            x,
-            self.output_weight,
-            compute_kernel_config=self.args.compute_kernel_config_hifi4,
-            program_config=self.model_config["OUTPUT_MM_PROGCFG"],
-            memory_config=self.model_config["OUTPUT_MM_MEMCFG"],
-            dtype=self.dtype,
-        )
+        output = self.lm_head(x)
 
         ttnn.deallocate(x)
+
+        return output
+
+
+class LMHead(nn.Module):
+    def __init__(
+        self,
+        args,
+        device_mesh,
+        dtype,
+        state_dict,
+        weight_cache_path,
+    ):
+        super().__init__()
+        self.args = args
+        self.device_mesh = device_mesh
+        self.dtype = dtype
+        self.vocab_size = args.vocab_size
+        self.num_splits = 2
+
+        split_size = self.vocab_size // self.num_splits
+        split_size_per_device = math.ceil((split_size // device_mesh.get_num_devices()) / (32 * 12)) * (
+            32 * 12
+        )  # Padded - Tile size (32) * dram cores (12)
+
+        # Helper function to create output memory config
+        def create_output_mem_config(size, num_devices):
+            padded_size = math.ceil((size // num_devices) / (32 * 12)) * (32 * 12)  # Tile size (32) * dram cores (12)
+            shard_spec = ttnn.ShardSpec(
+                args.dram_weight_grid, (4096, padded_size // 12), ttnn.ShardOrientation.ROW_MAJOR, False
+            )
+            return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+        # Split the output weight
+        output_weight = state_dict["output.weight"].permute(1, 0)
+        self.output_weights = []
+        for i in range(self.num_splits):
+            start = i * split_size
+            end = (i + 1) * split_size
+            weight_part = output_weight[:, start:end]
+            self.output_weights.append(
+                ttnn.as_tensor(
+                    weight_part,
+                    device=device_mesh,
+                    mesh_mapper=ttnn.ShardTensorToMesh(device_mesh, dim=-1),
+                    layout=ttnn.TILE_LAYOUT,
+                    dtype=dtype,
+                    memory_config=create_output_mem_config(split_size, num_devices=device_mesh.get_num_devices()),
+                    cache_file_name=None
+                    if args.dummy_weights
+                    else weight_cache_path / f"output_lm_head_{self.num_splits}split_shard_{i}",
+                )
+            )
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+
+        # Calculate per_core_N based on the number of splits
+        tile_size = 32
+        core_count = 64  # Assuming 8x8 core grid
+        # TODO Miguel, this per_core_N doesn't work for 1 device!
+        # per_core_N = -(-split_size // (tile_size * core_count))  # Ceiling division
+        per_core_N = -(-split_size_per_device // (tile_size * core_count))  # Ceiling division
+        self.program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+            in0_block_w=2,  # 4096 (dim) // 32 (tile) // 64 cores
+            per_core_M=1,
+            per_core_N=per_core_N,
+            fused_activation=None,
+        )
+        # breakpoint()
+
+    def forward(self, x: ttnn.Tensor):
+        x = ttnn.interleaved_to_sharded(x, self.args.get_model_config()["SHARDED_MLP_DECODE_INPUT_MEMCFG"])
+
+        outputs = []
+        for weight in self.output_weights:
+            output = ttnn.linear(
+                x,
+                weight,
+                compute_kernel_config=self.compute_kernel_config,
+                program_config=self.program_config,
+                memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                dtype=ttnn.bfloat8_b,
+            )
+            outputs.append(ttnn.sharded_to_interleaved(output, memory_config=ttnn.L1_MEMORY_CONFIG))
+        # breakpoint()
+        # Concatenate the outputs
+        output = ttnn.concat(outputs, dim=-1, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         return output

--- a/models/demos/wormhole/llama31_8b_N300/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b_N300/tt/model_config.py
@@ -259,6 +259,14 @@ class TtModelArgs:
                 ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
             )
+            self.model_config["LM_HEAD_INPUT_MEMCFG"] = ttnn.create_sharded_memory_config(
+                (32, 4096 // 64),  # Shard shape: [32, 128] -> 1 shard per core
+                ttnn.CoreGrid(y=8, x=8),
+                ttnn.ShardStrategy.WIDTH,
+                ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
             #     x = [32, 4096]
             # W1/W3 = [4096, 14336/2(devices)]
             self.model_config[

--- a/models/demos/wormhole/llama31_8b_N300/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b_N300/tt/model_config.py
@@ -308,31 +308,6 @@ class TtModelArgs:
                 fuse_batch=seq_len <= 2048,
             )
 
-            if self.di_dt_workaround:
-                self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                    compute_with_storage_grid_size=(7, 8),
-                    in0_block_w=1,
-                    per_core_M=1,
-                    per_core_N=36,  # vocab size = 128k/2(devices) = 20048 tiles. 4004//56cores = 36
-                    out_subblock_h=1,
-                    out_subblock_w=1,
-                    fuse_batch=True,
-                    fused_activation=None,
-                    mcast_in0=True,
-                )
-            else:
-                self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                    compute_with_storage_grid_size=(8, 8),
-                    in0_block_w=2,
-                    out_subblock_h=1,
-                    out_subblock_w=4,
-                    per_core_M=1,
-                    per_core_N=36,  # vocab size = 128k/2(devices) = 20048 tiles. 4004//56cores = 36
-                    fuse_batch=True,
-                    fused_activation=None,
-                    mcast_in0=True,
-                )
-
             self.model_config["KV_PREFILL_MEM_CFG"] = lambda seq_len: ttnn.create_sharded_memory_config(
                 (seq_len // 16, self.head_dim),
                 ttnn.CoreGrid(y=8, x=8),

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -75,6 +75,9 @@ run_n300_perf_tests(){
   # Falcon7b (perf verification for 128/1024/2048 seq lens and output token verification)
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py; fail+=$?
 
+  # llama3.1-8B trace mode
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/llama31_8b/demo/demo_trace.py --timeout 600; fail+=$?
+
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12328)

### Problem description
The LM head was only getting ~160 GB/s but DRAM-sharding it was skipped because the size was too large to fit into L1. 

### What's changed
- Split the LM head into four chunks and use DRAM-sharded kernels to run them sequentially, then concat the results. Sounds crazy, still faster!
- Add a split LM Head to the N300 code as well. Improvement of 0.4 tok/s/u.
- Add demo trace to perf dashboard so we can track the model that reaches the target of 23+ tok/s/u 🔥 

### Checklist
- [x] [Nightly fast dispatch](https://github.com/tenstorrent/tt-metal/actions/runs/11163413873)
- [x] [demos (now with demo trace included](https://github.com/tenstorrent/tt-metal/actions/runs/11175929448)
- [x] [Model Perf](https://github.com/tenstorrent/tt-metal/actions/runs/11166308041)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11165948020)
