### PR TITLE
#0: fix CCL nightly and frequent test reqression suites

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -229,13 +229,13 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
     except (ValueError, AttributeError):
         num_pcie_devices_requested = len(device_ids)
 
+    if num_pcie_devices_requested != 4:
+        pytest.skip("Only 4 PCIe devices are supported for testing")
+
     request.node.pci_ids = device_ids[:num_pcie_devices_requested]
 
     mesh_device = ttnn.open_mesh_device(
-        ttnn.MeshShape(1, num_pcie_devices_requested),
-        dispatch_core_type=get_dispatch_core_type(),
-        **device_params,
-        physical_device_ids=device_ids[:num_pcie_devices_requested],
+        ttnn.MeshShape(2, 2), dispatch_core_type=get_dispatch_core_type(), **device_params, offset=(0, 1)
     )
 
     logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
@@ -278,6 +278,7 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
     if ttnn.get_num_devices() < 8:
         pytest.skip()
 
+    request.node.pci_ids = ttnn.get_pcie_device_ids()
     mesh_device = ttnn.open_mesh_device(
         ttnn.MeshShape(2, 4),
         dispatch_core_type=get_dispatch_core_type(),


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
 fix CCL nightly and frequent test reqression suites

### What's changed
- fixture requires annotating PCIE device IDs to reset the devices when timeout happens
- change `pcie_mesh_device` fixture to rely on `offset` instead of `physical_device_ids` because the device id enumeration can cause `physical_device_ids` to not necessarily be ordered in a ring.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
