### PR TITLE
Tweak UNet parameters to increase device performance

### DIFF
--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -7,6 +7,8 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+UNET_FULL_MODEL_PCC = 0.9916
+
 
 def is_n300_with_eth_dispatch_cores(mesh_device) -> bool:
     all_devices_using_full_grid = all(
@@ -24,16 +26,18 @@ def is_t3k_with_eth_dispatch_cores(mesh_device) -> bool:
 
 def verify_with_pcc(torch_tensor, ttnn_tensor, pcc):
     _, computed_pcc = assert_with_pcc(torch_tensor, ttnn_tensor, pcc)
-    logger.info(f"PCC check was successful ({computed_pcc:.4f} > {pcc:.4f})")
+    logger.info(f"PCC check was successful ({computed_pcc:.5f} > {pcc:.5f})")
     if (computed_pcc - pcc) / pcc > 0.0025:
         logger.warning(
-            f"Computed PCC ({computed_pcc:.4f}) was higher than the expected PCC ({pcc:.4f}) - consider updating the expected PCC value"
+            f"Computed PCC ({computed_pcc:.5f}) was higher than the expected PCC ({pcc:.5f}) - consider updating the expected PCC value"
         )
 
 
 def check_pcc_conv(torch_tensor, ttnn_tensor, pcc=0.999, mesh_composer=None):
     B, C, H, W = torch_tensor.shape
-    ttnn_tensor = ttnn.to_torch(ttnn_tensor, mesh_composer=mesh_composer).reshape(B, H, W, C).permute(0, 3, 1, 2)
+    ttnn_tensor = (
+        ttnn.to_torch(ttnn_tensor, mesh_composer=mesh_composer).reshape(B, H, W, -1).permute(0, 3, 1, 2)[:, :C, :, :]
+    )
     verify_with_pcc(torch_tensor, ttnn_tensor, pcc)
 
 

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -115,5 +115,5 @@ def test_unet_downblock_multi_device(
 
     assert len(ttnn_output.devices()) == 2, "Expected output tensor to be sharded across 2 devices"
     assert len(ttnn_residual.devices()) == 2, "Expected residual output tensor to be sharded across 2 devices"
-    check_pcc_conv(torch_residual, ttnn_residual, mesh_composer=output_mesh_composer)
-    check_pcc_pool(torch_output, ttnn_output, mesh_composer=output_mesh_composer)
+    check_pcc_conv(torch_residual, ttnn_residual, pcc=0.999, mesh_composer=output_mesh_composer)
+    check_pcc_pool(torch_output, ttnn_output, pcc=0.999, mesh_composer=output_mesh_composer)

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -11,7 +11,7 @@ from models.experimental.functional_unet.tt.model_preprocessing import (
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
 from models.experimental.functional_unet.tt import unet_shallow_ttnn
-from models.experimental.functional_unet.tests.common import check_pcc_conv
+from models.experimental.functional_unet.tests.common import check_pcc_conv, UNET_FULL_MODEL_PCC
 
 
 @pytest.mark.parametrize("batch", [2])
@@ -27,4 +27,4 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
     torch_output_tensor = model(torch_input)
     output_tensor = ttnn_model(ttnn_input)
 
-    check_pcc_conv(torch_output_tensor, output_tensor, 0.97)
+    check_pcc_conv(torch_output_tensor, output_tensor, UNET_FULL_MODEL_PCC)

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -17,6 +17,7 @@ from models.experimental.functional_unet.tests.common import (
     check_pcc_conv,
     is_n300_with_eth_dispatch_cores,
     is_t3k_with_eth_dispatch_cores,
+    UNET_FULL_MODEL_PCC,
 )
 
 
@@ -51,4 +52,4 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     torch_output_tensor = model(torch_input)
     output_tensor = ttnn_model(ttnn_input)
 
-    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.97)
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=UNET_FULL_MODEL_PCC)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -19,6 +19,7 @@ from models.experimental.functional_unet.tests.common import (
     check_pcc_conv,
     is_n300_with_eth_dispatch_cores,
     is_t3k_with_eth_dispatch_cores,
+    UNET_FULL_MODEL_PCC,
 )
 
 from models.perf.perf_utils import prep_perf_report
@@ -33,19 +34,19 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((2, 1, 755.0),),
+    ((2, 1, 773.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
-    inference_time_key = "AVG DEVICE FW SAMPLES/S"
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
     post_processed_results = run_device_perf(
         command, subdir="unet_shallow", num_iterations=1, cols=cols, batch_size=batch
     )
     expected_perf_cols = {inference_time_key: expected_device_perf_fps}
     expected_results = check_device_perf(
-        post_processed_results, margin=0.02, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+        post_processed_results, margin=0.01, expected_perf_cols=expected_perf_cols, assert_on_fail=True
     )
     prep_device_perf_report(
         model_name=f"unet-shallow_batch-{batch}_groups-{groups}",
@@ -127,7 +128,7 @@ def test_unet_perf_e2e(
     logger.info(f"Running sanity check against reference model output")
     B, C, H, W = torch_output_tensor.shape
     ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.97)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, UNET_FULL_MODEL_PCC)
 
 
 @skip_for_grayskull("UNet not currently supported on GS")
@@ -219,4 +220,4 @@ def test_unet_data_parallel_perf_e2e(
     )
 
     logger.info(f"Running sanity check against reference model output")
-    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.97)
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=UNET_FULL_MODEL_PCC)

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -20,6 +20,7 @@ from models.experimental.functional_unet.tests.common import (
     check_pcc_conv,
     is_n300_with_eth_dispatch_cores,
     is_t3k_with_eth_dispatch_cores,
+    UNET_FULL_MODEL_PCC,
 )
 
 from models.utility_functions import skip_for_grayskull, divup
@@ -75,7 +76,7 @@ def test_unet_trace(
     logger.info(f"Average model performance={iterations * batch / (end-start) : .2f} fps")
 
     logger.info(f"Running sanity check against reference model output")
-    check_pcc_conv(torch_output_tensor, outputs[-1], 0.97)
+    check_pcc_conv(torch_output_tensor, outputs[-1], UNET_FULL_MODEL_PCC)
 
 
 @skip_for_grayskull("UNet not currently supported on GS")
@@ -182,7 +183,7 @@ def test_unet_trace_2cq(
     ttnn.DumpDeviceProfiler(device)
 
     logger.info(f"Running sanity check against reference model output")
-    check_pcc_conv(torch_output_tensor, outputs[-1], 0.97)
+    check_pcc_conv(torch_output_tensor, outputs[-1], UNET_FULL_MODEL_PCC)
 
     ttnn.release_trace(device, tid)
 
@@ -313,6 +314,6 @@ def test_unet_trace_2cq_multi_device(
     logger.info(f"Average model performance={iterations * total_batch / (end-start) : .2f} fps")
 
     logger.info(f"Running sanity check against reference model output")
-    check_pcc_conv(torch_output_tensor, outputs[-1], 0.97, mesh_composer=output_mesh_composer)
+    check_pcc_conv(torch_output_tensor, outputs[-1], UNET_FULL_MODEL_PCC, mesh_composer=output_mesh_composer)
 
     ttnn.release_trace(mesh_device, tid)

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -147,4 +147,4 @@ def test_unet_upblock_multi_device(
     ttnn_output = getattr(ttnn_model, block_name)(ttnn_input, ttnn_residual)
 
     assert len(ttnn_output.devices()) == 2, "Expected output tensor to be sharded across 2 devices"
-    check_pcc_conv(torch_output, ttnn_output, mesh_composer=output_mesh_composer, pcc=0.998)
+    check_pcc_conv(torch_output, ttnn_output, pcc=0.999, mesh_composer=output_mesh_composer)

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -63,20 +63,20 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
         "num_cores_nhw": 55,
     }
 
-    parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c1["use_split_reader"] = True
     parameters.c1["use_activation_double_buffer"] = True
     parameters.c1["input_channels_alignment"] = 16
 
-    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c1_2["use_split_reader"] = True
     parameters.c1_2["use_activation_double_buffer"] = True
 
-    parameters.c2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 6 * 32}
+    parameters.c2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c2["use_split_reader"] = True
     parameters.c2["use_activation_double_buffer"] = True
 
-    parameters.c2_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 6 * 32}
+    parameters.c2_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c2_2["use_activation_double_buffer"] = True
     parameters.c2_2["use_split_reader"] = True
     parameters.c2_2["use_activation_double_buffer"] = True
@@ -115,27 +115,24 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
     parameters.c6_3["use_split_reader"] = True
     parameters.c6_3["use_activation_double_buffer"] = True
 
-    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c7["use_activation_double_buffer"] = True
     parameters.c7["use_split_reader"] = True
     parameters.c7["input_channels_alignment"] = 16
-
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
     parameters.c7_2["use_activation_double_buffer"] = True
-
     parameters.c7_3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_3["use_split_reader"] = True
     parameters.c7_3["use_activation_double_buffer"] = True
 
-    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
-    parameters.c8["use_activation_double_buffer"] = True
+    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c8["use_split_reader"] = True
-
-    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c8["use_activation_double_buffer"] = True
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True
-    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c8_3["use_activation_double_buffer"] = True
     parameters.c8_3["use_split_reader"] = True
 


### PR DESCRIPTION
### What's changed
- Tweak UNet convolution parameters to increase device performance (measured on N300) to 765 fps
- Removing explicit activation blocking on some convolutions (`c2`, `c2_2`) improves PCC from 0.97 to 0.99. This is possibly a bug in convolution (FYI @mywoodstock)

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)