### PR TITLE
Remove profiler core flat id look up

### DIFF
--- a/tt_metal/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/profiler_common.h
@@ -41,6 +41,7 @@ namespace kernel_profiler{
         NOC_X,
         NOC_Y,
         FLAT_ID,
+        CORE_COUNT_PER_DRAM,
         DROPPED_ZONES,
         PROFILER_DONE,
     };

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -76,7 +76,6 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-    uint16_t core_flat_id __attribute__((used));
 }
 #endif
 

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -21,7 +21,6 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-    uint16_t core_flat_id __attribute__((used));
 }
 #endif
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -57,7 +57,6 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-    uint16_t core_flat_id __attribute__((used));
 }
 #endif
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -45,7 +45,6 @@ namespace kernel_profiler {
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-    uint16_t core_flat_id __attribute__((used));
 }
 #endif
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2911,9 +2911,7 @@ void Device::generate_device_headers(const std::string &path) const
         dram_noc_coord_per_bank,
         dram_offsets_per_bank,
         l1_noc_coord_per_bank,
-        l1_offset_per_bank,
-        soc_d.profiler_ceiled_core_count_perf_dram_bank,
-        soc_d.physical_routing_to_profiler_flat_id
+        l1_offset_per_bank
     );
 }
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -581,7 +581,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "#if defined(PROFILE_KERNEL) && (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || "
           "defined(COMPILE_FOR_ERISC))"
        << endl;
-    ss << "extern uint8_t noc_xy_to_profiler_flat_id[noc_size_x][noc_size_y];" << endl;
     ss << "extern uint16_t profiler_core_count_per_dram;" << endl;
     ss << "#endif" << endl;
 #endif
@@ -613,37 +612,11 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << endl;
 
 #if defined(TRACY_ENABLE)
-    /*
-     * This part is adding the 2D array for sharing the flat IDs soc descriptor has assigned to every NOC coordinate,
-     * and the ceiled number of cores per DRAM banks.
-     *
-     * The logic of flat ID assignment can be optimized to lower NOC traffic. With this design the heuristic can be
-     * implemented in host and device just does look up to the table.
-     *
-     * For DRAM banks in particular, integer division of flat_id/core_count_per_dram gives the dram bank id and the
-     * modulo is the offset.
-     * */
     ss << "#if defined(PROFILE_KERNEL) && (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || "
           "defined(COMPILE_FOR_ERISC))"
        << endl;
     ss << "uint16_t profiler_core_count_per_dram __attribute__((used)) = ";
     ss << core_count_per_dram << ";" << endl;
-    ss << endl;
-
-    ss << "uint8_t noc_xy_to_profiler_flat_id[noc_size_x][noc_size_y] __attribute__((used)) = {" << endl;
-    for (unsigned int x = 0; x < grid_size.x; x++) {
-        ss << "    {" << endl;
-        for (unsigned int y = 0; y < grid_size.y; y++) {
-            CoreCoord core = {x, y};
-            if (profiler_flat_id_map.find(core) == profiler_flat_id_map.end()) {
-                ss << "        " << 255 << "," << endl;
-            } else {
-                ss << "        " << profiler_flat_id_map.at(core) << "," << endl;
-            }
-        }
-        ss << "    }," << endl;
-    }
-    ss << "};" << endl;
     ss << endl;
     ss << "#endif" << endl;
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -524,9 +524,7 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     std::vector<CoreCoord>& dram_bank_map,
     std::vector<int32_t>& dram_bank_offset_map,
     std::vector<CoreCoord>& l1_bank_map,
-    std::vector<int32_t>& l1_bank_offset_map,
-    int core_count_per_dram,
-    const std::map<CoreCoord, int32_t>& profiler_flat_id_map) {
+    std::vector<int32_t>& l1_bank_offset_map) {
     stringstream ss;
     bool is_dram_pow2 = ceil(log2(dram_bank_map.size())) == log2(dram_bank_map.size());
     bool is_l1_pow2 = ceil(log2(l1_bank_map.size())) == log2(l1_bank_map.size());
@@ -577,13 +575,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];" << endl;
     ss << "extern uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];" << endl;
     ss << "extern int32_t bank_to_l1_offset[NUM_L1_BANKS];" << endl;
-#if defined(TRACY_ENABLE)
-    ss << "#if defined(PROFILE_KERNEL) && (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || "
-          "defined(COMPILE_FOR_ERISC))"
-       << endl;
-    ss << "extern uint16_t profiler_core_count_per_dram;" << endl;
-    ss << "#endif" << endl;
-#endif
 
     ss << endl;
     ss << "#else // !KERNEL_BUILD (FW_BUILD)" << endl;
@@ -610,17 +601,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     }
     ss << "};" << endl;
     ss << endl;
-
-#if defined(TRACY_ENABLE)
-    ss << "#if defined(PROFILE_KERNEL) && (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || "
-          "defined(COMPILE_FOR_ERISC))"
-       << endl;
-    ss << "uint16_t profiler_core_count_per_dram __attribute__((used)) = ";
-    ss << core_count_per_dram << ";" << endl;
-    ss << endl;
-    ss << "#endif" << endl;
-
-#endif
 
     ss << "uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used)) = {" << endl;
     for (unsigned int noc = 0; noc < 2; noc++) {
@@ -654,17 +634,13 @@ void jit_build_genfiles_bank_to_noc_coord_descriptor(
     std::vector<CoreCoord>& dram_bank_map,
     std::vector<int32_t>& dram_bank_offset_map,
     std::vector<CoreCoord>& l1_bank_map,
-    std::vector<int32_t>& l1_bank_offset_map,
-    int core_count_per_dram,
-    const std::map<CoreCoord, int32_t>& profiler_flat_id_map) {
+    std::vector<int32_t>& l1_bank_offset_map) {
     string output_string = generate_bank_to_noc_coord_descriptor_string(
         grid_size,
         dram_bank_map,
         dram_bank_offset_map,
         l1_bank_map,
-        l1_bank_offset_map,
-        core_count_per_dram,
-        profiler_flat_id_map);
+        l1_bank_offset_map);
 
     fs::create_directories(path + "/brisc");
     ofstream file_stream_br(path + "/brisc/generated_bank_to_noc_coord_mapping.h");

--- a/tt_metal/jit_build/genfiles.hpp
+++ b/tt_metal/jit_build/genfiles.hpp
@@ -27,9 +27,7 @@ void jit_build_genfiles_bank_to_noc_coord_descriptor(
     std::vector<CoreCoord>& dram_bank_map,
     std::vector<int32_t>& dram_bank_offset_map,
     std::vector<CoreCoord>& l1_bank_map,
-    std::vector<int32_t>& l1_bank_offset_map,
-    int core_count_per_dram,
-    const std::map<CoreCoord, int32_t>& profiler_flat_id_map);
+    std::vector<int32_t>& l1_bank_offset_map);
 
 void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& options);
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -187,11 +187,12 @@ namespace kernel_profiler{
         if (profiler_control_buffer[PROFILER_DONE] == 1){
             return;
         }
-        uint32_t pageSize =
-            PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * profiler_core_count_per_dram;
-
         while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
         uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
+        uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
+
+        uint32_t pageSize =
+            PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * profiler_core_count_per_dram;
 
         for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID ++)
 	{
@@ -267,6 +268,7 @@ namespace kernel_profiler{
 
         while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
         uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
+        uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
 
         profiler_data_buffer[myRiscID][ID_LH] = ((core_flat_id & 0xFF) << 3) | myRiscID;
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -50,13 +50,10 @@ namespace kernel_profiler{
 
 #if defined(COMPILE_FOR_BRISC)
     constexpr uint32_t myRiscID = 0;
-    extern uint16_t core_flat_id;
 #elif defined(COMPILE_FOR_ERISC)
     constexpr uint32_t myRiscID = 0;
-    extern uint16_t core_flat_id;
 #elif defined(COMPILE_FOR_NCRISC)
     constexpr uint32_t myRiscID = 1;
-    extern uint16_t core_flat_id;
 #elif COMPILE_FOR_TRISC == 0
     constexpr uint32_t myRiscID = 2;
 #elif COMPILE_FOR_TRISC == 1
@@ -92,21 +89,16 @@ namespace kernel_profiler{
 
         if (runCounter == 0)
         {
-            core_flat_id = noc_xy_to_profiler_flat_id[my_x[0]][my_y[0]];
-
             for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID ++)
             {
                 for (uint32_t i = ID_HH; i < GUARANTEED_MARKER_1_H; i ++)
                 {
                     profiler_data_buffer[riscID][i] = 0;
                 }
-
-                profiler_data_buffer[riscID][ID_LH] = ((core_flat_id & 0xFF) << 3) | riscID;
             }
 
             profiler_control_buffer[NOC_X] = my_x[0];
             profiler_control_buffer[NOC_Y] = my_y[0];
-            profiler_control_buffer[FLAT_ID] = core_flat_id;
         }
 
         for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID ++)
@@ -199,10 +191,11 @@ namespace kernel_profiler{
             PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * profiler_core_count_per_dram;
 
         while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
-        uint32_t dram_profiler_address = profiler_control_buffer[DRAM_PROFILER_ADDRESS];
+        uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
 
         for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID ++)
 	{
+            profiler_data_buffer[riscID][ID_LH] = ((core_flat_id & 0xFF) << 3) | riscID;
             int hostIndex = riscID;
             int deviceIndex = kernel_profiler::DEVICE_BUFFER_END_INDEX_BR_ER + riscID;
 	    if (profiler_control_buffer[deviceIndex])
@@ -244,7 +237,7 @@ namespace kernel_profiler{
 
                 if (do_noc){
 		    const InterleavedAddrGen<true> s = {
-			.bank_base_address = dram_profiler_address,
+			.bank_base_address = profiler_control_buffer[DRAM_PROFILER_ADDRESS],
 			.page_size = pageSize
 		    };
 
@@ -271,14 +264,17 @@ namespace kernel_profiler{
         SrcLocNameToHash("PROFILER-NOC-QUICK-SEND");
         mark_time_at_index_inlined(wIndex, hash);
         wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
-        core_flat_id = noc_xy_to_profiler_flat_id[my_x[0]][my_y[0]];
+
+        while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
+        uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
+
+        profiler_data_buffer[myRiscID][ID_LH] = ((core_flat_id & 0xFF) << 3) | myRiscID;
 
         uint32_t dram_offset =
             (core_flat_id % profiler_core_count_per_dram) * MAX_RISCV_PER_CORE * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
             (HOST_BUFFER_END_INDEX_BR_ER + myRiscID) * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
             profiler_control_buffer[HOST_BUFFER_END_INDEX_BR_ER + myRiscID] * sizeof(uint32_t);
 
-        while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
         const InterleavedAddrGen<true> s = {
             .bank_base_address = profiler_control_buffer[DRAM_PROFILER_ADDRESS],
             .page_size = PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MAX_RISCV_PER_CORE * profiler_core_count_per_dram

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -62,6 +62,8 @@ void setControlBuffer(uint32_t device_id, std::vector<uint32_t>& control_buffer)
 #if defined(TRACY_ENABLE)
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device_id);
 
+    control_buffer[kernel_profiler::CORE_COUNT_PER_DRAM] = soc_d.profiler_ceiled_core_count_perf_dram_bank;
+
     auto ethCores = soc_d.get_physical_ethernet_cores() ;
     for (auto &core : soc_d.physical_routing_to_profiler_flat_id)
     {

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -78,6 +78,7 @@ void setControlBuffer(uint32_t device_id, std::vector<uint32_t>& control_buffer)
             profiler_msg = hal.get_dev_addr<profiler_msg_t *>(HalProgrammableCoreType::ACTIVE_ETH, HalMemAddrType::PROFILER);
         }
 
+        control_buffer[kernel_profiler::FLAT_ID] = core.second;
         tt::llrt::write_hex_vec_to_core(
             device_id,
             core.first,


### PR DESCRIPTION
### Ticket
#6748 

### Problem description
Lookup table on global space is taking up too much space. 

### What's changed
Host individually assigns core flat ID and core count per DRAM on each core's L1.  

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11148495766
- [x] Device performance regression CI testing passes https://github.com/tenstorrent/tt-metal/actions/runs/11148504268/job/30985828115
- [x] uBenchmark https://github.com/tenstorrent/tt-metal/actions/runs/11148508069
- [x] T3K profiler https://github.com/tenstorrent/tt-metal/actions/runs/11148500506
