### PR TITLE
#13365: added program caching for page tensor for flash decode

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -753,6 +753,8 @@ def test_sdpa_decode_paged_attention(
         sharded_out=False,
     )
 
+    assert device.num_program_cache_entries() == 3
+
 
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
 @pytest.mark.parametrize(
@@ -896,6 +898,7 @@ def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, use_program_
             sharded_in=False,
             sharded_out=False,
             start_indices=start_indices,
+            cur_pos_tensor=True,
         )
         run_test_sdpa_decode_single_iter(
             device,
@@ -910,6 +913,7 @@ def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, use_program_
             sharded_in=True,
             sharded_out=False,
             start_indices=start_indices,
+            cur_pos_tensor=False,
         )
         run_test_sdpa_decode_single_iter(
             device,
@@ -924,6 +928,7 @@ def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, use_program_
             sharded_in=True,
             sharded_out=True,
             start_indices=start_indices,
+            cur_pos_tensor=False,
         )
         run_test_sdpa_decode_single_iter(
             device,
@@ -938,6 +943,7 @@ def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, use_program_
             sharded_in=False,
             sharded_out=True,
             start_indices=start_indices,
+            cur_pos_tensor=True,
         )
 
     assert device.num_program_cache_entries() == 4

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -42,17 +42,14 @@ void kernel_main() {
     constexpr bool is_q_sharded = get_compile_time_arg_val(6);
     constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(7);
     constexpr uint32_t k_chunk_size = get_compile_time_arg_val(8);
-    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(9);
-    constexpr uint32_t index_stick_size_B = get_compile_time_arg_val(10);
-    constexpr bool is_paged_attention = get_compile_time_arg_val(11) == 1;
-    constexpr uint32_t num_kv_heads = get_compile_time_arg_val(12);
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(13);
-    constexpr uint32_t log2_page_table_page_size = get_compile_time_arg_val(14);
-    constexpr uint32_t page_table_page_size = get_compile_time_arg_val(15);
-    constexpr uint32_t Bkv = get_compile_time_arg_val(16);
-    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(17);
-    constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(18);
-    constexpr uint32_t num_output_cores = get_compile_time_arg_val(19);
+    constexpr uint32_t index_stick_size_B = get_compile_time_arg_val(9);
+    constexpr bool is_paged_attention = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t num_kv_heads = get_compile_time_arg_val(11);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(12);
+    constexpr uint32_t Bkv = get_compile_time_arg_val(13);
+    constexpr uint32_t num_cores_per_head = get_compile_time_arg_val(14);
+    constexpr uint32_t num_heads_per_core = get_compile_time_arg_val(15);
+    constexpr uint32_t num_output_cores = get_compile_time_arg_val(16);
 
     uint32_t arg_idx = 0;
     const uint32_t q_addr  = get_arg_val<uint32_t>(arg_idx++);
@@ -60,6 +57,7 @@ void kernel_main() {
     const uint32_t v_addr  = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t pos_addr  = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t page_table_addr  = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t page_table_page_size = get_arg_val<uint32_t>(arg_idx++);
     const bool is_worker = get_arg_val<uint32_t>(arg_idx++) == 0;
     const bool is_output_core = get_arg_val<uint32_t>(arg_idx++) == 1;
     const uint32_t cur_head_group = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -156,10 +156,6 @@ operation::ProgramWithCallbacks ScaledDotProductAttentionDecode::create_program(
         scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.get_legacy_shape()[-1]));
     }
 
-    // TODO: get this from program_config
-    std::size_t q_chunk_size = program_config.has_value() ? program_config->q_chunk_size : 32;
-    std::size_t k_chunk_size = program_config.has_value() ? program_config->k_chunk_size : 32;
-
     return detail::sdpa_decode_multi_core(
         input_tensor_q,
         input_tensor_k,
@@ -183,8 +179,7 @@ operation::Hash ScaledDotProductAttentionDecode::compute_program_hash(const std:
         this->compute_kernel_config,
         this->k_chunk_size,
         this->paged_attention,
-        input_tensors,
-        optional_input_tensors);
+        input_tensors);
 }
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -97,6 +97,12 @@ ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
                                                                      : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     //uint32_t max_cur_pos = *std::max_element(cur_pos.begin(), cur_pos.end());
     uint32_t k_chunk_size = 512; //get_chunk_size(max_cur_pos + 1);
+    if (program_config.has_value() && program_config.value().k_chunk_size > 0) {
+        k_chunk_size = program_config.value().k_chunk_size;
+        // assert chunk size must be power of 2 and multiple of 32
+        TT_FATAL((k_chunk_size & (k_chunk_size - 1)) == 0, "User provided k_chunk_size must be power of 2, got: {}", k_chunk_size);
+        TT_FATAL(k_chunk_size % 32 == 0, "User provided k_chunk_size must be multiple of 32, got: {}", k_chunk_size);
+    }
 
     // get chunk size and then pass to sdpa decode as an attribute for prgm cache
     auto kernel_config_val = init_device_compute_kernel_config(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13365

### What's changed
Enabled Program Caching of Page Table Tensors in Paged SDPA Decode #13365

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11149419989
- [x] Single Chip Model: https://github.com/tenstorrent/tt-metal/actions/runs/11149441542
- [x] T3K model: https://github.com/tenstorrent/tt-metal/actions/runs/11149430961
- [x] galaxy model: https://github.com/tenstorrent/tt-metal/actions/runs/11149450074
