### PR TITLE
#13127: Update ttnn::Shape struct to maintain API parity with existing tt::tt_metal::LegacyShape usages

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -91,9 +91,6 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
     this->tensor_attributes->metadata_populated = true;
 }
 
-Tensor::Tensor(const Storage storage, const tt::tt_metal::LegacyShape shape, DataType dtype, Layout layout, const std::optional<Tile>& tile) :
-    Tensor(storage, ttnn::Shape{shape}, dtype, layout, tile) {}
-
 Tensor::~Tensor() {
     ZoneScoped;
     this->deallocate_through_destructor = true;

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -121,7 +121,6 @@ struct Tensor {
         deallocate_through_destructor(false) {}
 
     Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, Layout layout, const std::optional<Tile>& tile = std::nullopt);
-    Tensor(const Storage storage, const tt::tt_metal::LegacyShape shape, DataType dtype, Layout layout, const std::optional<Tile>& tile = std::nullopt);
 
     // Constructor to initialize unpopulated tensor with workers and storage specified. Use this when creating tensor
     // handles in async mode.

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -293,3 +293,12 @@ MemoryConfig load_memory_config(const std::string& file_name) {
 }  // namespace tt_metal
 
 }  // namespace tt
+
+namespace ttnn {
+namespace types {
+
+uint32_t Shape::operator[](std::int64_t index) const { return this->value.without_padding()[index]; }
+
+}  // namespace ttnn
+
+}  // namespace types

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -667,10 +667,12 @@ struct Shape {
     // It is used to flip the default value of operator[] to return the shape without padding
     tt::tt_metal::LegacyShape value;
 
-    explicit Shape(const tt::tt_metal::LegacyShape &shape) : value{shape} {}
+    Shape(const std::initializer_list<uint32_t> dimensions) : value{dimensions} {}
+
+    Shape(const tt::tt_metal::LegacyShape &shape) : value{shape} {}
 
     template <std::size_t Rank>
-    explicit Shape(const std::array<uint32_t, Rank> &shape) : value{shape} {}
+    Shape(const std::array<uint32_t, Rank> &shape) : value{shape} {}
 
     template <std::size_t Rank>
     explicit Shape(const std::array<uint32_t, Rank> &shape, const std::array<uint32_t, Rank> &shape_with_tile_padding) :
@@ -681,14 +683,24 @@ struct Shape {
         const std::array<uint32_t, Rank> &shape, const std::array<std::array<uint32_t, 2>, Rank> &tile_padding) :
         value{detail::compute_ttl_shape(shape, tile_padding)} {}
 
-    explicit Shape(const std::vector<uint32_t> &shape) : value{tt::tt_metal::LegacyShape{shape}} {}
+    Shape(const std::vector<uint32_t> &shape) : value{tt::tt_metal::LegacyShape{shape}} {}
 
     explicit Shape(const std::vector<uint32_t> &shape, const std::vector<uint32_t> &shape_with_tile_padding) :
         value{tt::tt_metal::LegacyShape{shape, shape_with_tile_padding}} {}
 
+    explicit Shape(const std::vector<uint32_t> &shape, const Padding &padding) :
+        value{tt::tt_metal::LegacyShape{shape, padding}} {}
+
+    explicit Shape(const Shape &shape, const Padding &padding) :
+        value{tt::tt_metal::LegacyShape{shape.value, padding}} {}
+
     const auto rank() const { return this->value.rank(); }
 
     const auto size() const { return this->rank(); }
+
+    const tt::tt_metal::Padding &padding() const { return this->value.padding(); }
+
+    const uint32_t get_normalized_index(std::int64_t index) const { return this->value.get_normalized_index(index); }
 
     Shape with_tile_padding() const {
         return Shape{tt::tt_metal::LegacyShape{this->value, tt::tt_metal::Padding{this->value.rank()}}};
@@ -722,7 +734,7 @@ struct Shape {
 
     bool operator!=(const Shape &other) const { return not(*this == other); }
 
-    const auto operator[](std::int64_t index) const { return this->value.without_padding()[index]; }
+    uint32_t operator[](std::int64_t index) const;
 
     const auto volume() const {
         auto rank = this->rank();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Remove `LegacyShape`.

### What's changed
- Constructor changes:
  * IMPORTANT: Remove tensor constructor with tt::tt_metal::LegacyShape
  * Make ttnn::Shape vector, array, and LegacyShape constructors non-explicit
  * Add initializer list for ttnn::Shape
  * Add ttnn::Shape constructor with Padding
  * Add ttnn::Shape constructor with shape and padding
- Method changes:
  * Make return type of operator[] non-const
  * Add padding() to ttnn::Shape
  * Add get_normalized_index() to ttnn::Shape
  * Add reference to LegacyShape begin() and end() operator


### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11167485847/job/31045016891
  - Failures seem unrelated.
  - Older commit with passing: https://github.com/tenstorrent/tt-metal/actions/runs/11166178041
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/11167488258
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
