### PR TITLE
#11791: Implement Elf reading

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -194,7 +194,7 @@ void JitBuildState::finish_init() {
 
     // Note the preceding slash which defies convention as this gets appended to
     // the kernel name used as a path which doesn't have a slash
-    this->target_full_path_ = "/" + this->target_name_ + "/" + this->target_name_ + ".hex";
+    this->target_full_path_ = "/" + this->target_name_ + "/" + this->target_name_ + ".elf";
 }
 
 JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuiltStateConfig &build_config) :

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLRT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/rtoptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tlb_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_cluster.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tt_elffile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_hexfile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hal.cpp

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_elffile.hpp"
+
+#include "common/assert.hpp"
+// C
+#include <errno.h>
+// OS
+#include <elf.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// Verify some knowledge of, and compatibilty with, RiscV
+#ifndef EM_RISCV
+#error "Don't know RISCV elf details"
+#endif
+
+// Having the same endianness as RISCV makes things easier.
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error "Host must be little endian"
+#endif
+
+#ifdef PT_RISCV_ATTRIBUTES
+#warning "PT_RISCV_ATTRIBUTES available, remove workaround"
+#else
+// Missing from my elf.h
+#define PT_RISCV_ATTRIBUTES (PT_LOPROC + 3)
+enum {
+    Tag_RISCV_arch = 5,
+};
+#endif
+
+// Sadly the toolchain's usurped some machine numbers.  With any luck
+// this will go away at some point.
+#define EM_RISCV_GRAYSKULL 242
+#define EM_RISCV_WORMHOLE 0x5151
+#define EM_RISCV_BLACKHOLE 0x6151
+
+using namespace ll_api;
+
+class ElfFile::Impl {
+   private:
+    std::span<Elf32_Phdr const> phdrs_;
+    std::span<Elf32_Shdr const> shdrs_;
+    std::span<std::byte const> strtab_;
+    std::string const &path_;
+
+   private:
+    ElfFile &owner_;
+
+   public:
+    Impl(ElfFile &owner, std::string const &path) : owner_(owner), path_(path) {}
+    ~Impl() = default;
+
+   public:
+    void LoadImage();
+
+   private:
+    Elf32_Ehdr const &GetHeader() const { return *reinterpret_cast<Elf32_Ehdr const *>(GetContents().data()); }
+    std::span<Elf32_Phdr const> GetPhdrs() const { return phdrs_; }
+    std::span<Elf32_Shdr const> GetShdrs() const { return shdrs_; }
+    std::vector<Segment> &GetSegments() const { return owner_.segments_; }
+    std::span<std::byte> &GetContents() const { return owner_.contents_; }
+    std::span<std::byte> GetContents(Elf32_Phdr const &phdr) {
+        return GetContents().subspan(phdr.p_offset, phdr.p_filesz);
+    }
+    std::span<std::byte> GetContents(Elf32_Shdr const &shdr) {
+        return GetContents().subspan(shdr.sh_offset, shdr.sh_size);
+    }
+    char const *GetString(size_t offset) {
+        if (offset < strtab_.size())
+            return ByteOffset<char const>(strtab_.data(), offset);
+        else
+            return "*BADSTRING*";
+    }
+    char const *GetName(Elf32_Shdr const &shdr) { return GetString(shdr.sh_name); }
+
+   private:
+    template <typename T = std::byte>
+    static T *ByteOffset(std::byte *base, size_t offset = 0) {
+        return reinterpret_cast<T *>(base + offset);
+    }
+    template <typename T = std::byte>
+    static T const *ByteOffset(std::byte const *base, size_t offset = 0) {
+        return reinterpret_cast<T const *>(base + offset);
+    }
+};
+
+ElfFile::ElfFile(std::string const &path) {
+    int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    struct stat st;
+    void *buffer = MAP_FAILED;
+    if (fd >= 0 && fstat(fd, &st) >= 0)
+        buffer = mmap(nullptr, st.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (fd >= 0)
+        // It is acceptable to close a mapped file -- the mapping stays.
+        close(fd);
+    if (buffer == MAP_FAILED)
+        TT_THROW("{}: cannot map elf file into memory: {}", path, strerror(errno));
+
+    contents_ = std::span(reinterpret_cast<std::byte *>(buffer), st.st_size);
+
+    Impl impl(*this, path);
+
+    impl.LoadImage();
+}
+
+ElfFile::~ElfFile() {
+    if (!contents_.empty())
+        munmap(contents_.data(), contents_.size());
+}
+
+void ElfFile::Impl::LoadImage() {
+    auto &hdr = GetHeader();
+
+    // Make sure it's ELF
+    if (hdr.e_ident[EI_MAG0] != 0x7f || hdr.e_ident[EI_MAG1] != 'E' || hdr.e_ident[EI_MAG2] != 'L' ||
+        hdr.e_ident[EI_MAG3] != 'F')
+        TT_THROW("{}: no ELF magic found", path_);
+
+    // Of the expected address size, endianness and version
+    if (hdr.e_ident[EI_CLASS] != ELFCLASS32 || hdr.e_ident[EI_DATA] != ELFDATA2LSB ||
+        hdr.e_ident[EI_VERSION] != EV_CURRENT)
+        TT_THROW("{}: incompatible address size or endianness", path_);
+
+    if (hdr.e_type != ET_EXEC)
+        TT_THROW("{}: not an executable", path_);
+
+    if (hdr.e_machine != EM_RISCV
+        // Hopefully these can go way at some point.
+        && hdr.e_machine != EM_RISCV_GRAYSKULL && hdr.e_machine != EM_RISCV_WORMHOLE &&
+        hdr.e_machine != EM_RISCV_BLACKHOLE)
+        TT_THROW("{}: incompatible architecture {}", path_, hdr.e_machine);
+
+    if (!hdr.e_phoff || hdr.e_phoff & (sizeof(address_t) - 1) || hdr.e_phentsize != sizeof(Elf32_Phdr) ||
+        (hdr.e_phoff + hdr.e_phnum * sizeof(Elf32_Phdr) > GetContents().size()))
+        TT_THROW("{}: PHDRS are missing or malformed", path_);
+    phdrs_ = std::span(ByteOffset<Elf32_Phdr const>(GetContents().data(), hdr.e_phoff), hdr.e_phnum);
+    if (!hdr.e_shoff || hdr.e_shoff & (sizeof(address_t) - 1) || hdr.e_shentsize != sizeof(Elf32_Shdr) ||
+        (hdr.e_shoff + hdr.e_shnum * sizeof(Elf32_Shdr) > GetContents().size()))
+        TT_THROW("{}: sections are missing or malformed", path_);
+    shdrs_ = std::span(ByteOffset<Elf32_Shdr const>(GetContents().data(), hdr.e_shoff), hdr.e_shnum);
+    if (!hdr.e_shstrndx || hdr.e_shstrndx >= GetShdrs().size())
+        TT_THROW("{}: string table is missing or malformed", path_);
+    strtab_ = GetContents(GetShdrs()[hdr.e_shstrndx]);
+
+    // We care about the location of some sections.
+    for (auto const &section : GetShdrs())
+        if ((section.sh_flags & SHF_ALLOC || section.sh_type == SHT_RELA || section.sh_type == SHT_SYMTAB) &&
+                (section.sh_offset | section.sh_addr) & (sizeof(word_t) - 1) ||
+            section.sh_offset + section.sh_size > GetContents().size())
+            TT_THROW("{}: section {} is misaligned", path_, GetName(section));
+
+    GetSegments().reserve(hdr.e_phnum);
+    int textIx = -1;
+    for (auto const &phdr : GetPhdrs()) {
+        if (phdr.p_type == PT_RISCV_ATTRIBUTES)
+            // TODO: verify Arch is ok?
+            continue;
+        if (phdr.p_type != PT_LOAD)
+            continue;
+        if (!phdr.p_memsz)
+            // Have observed zero-sized segments, ignore them
+            continue;
+
+        // Require loadable segments to be nicely aligned
+        if ((phdr.p_offset | phdr.p_vaddr) & (sizeof(word_t) - 1))
+            TT_THROW("{}: loadable segment {} is misaligned", path_, unsigned(GetSegments().size()));
+
+        auto contents = GetContents(phdr);
+        // We require the entry point to be the start of the text segment,
+        // so use a simple comparison -- if the entry point is elsewhere
+        // we'll complain about lack of text segment.
+        if (hdr.e_entry == phdr.p_vaddr)
+            textIx = GetSegments().size();
+
+        // This word-size rounding up means the span can occupy some bytes
+        // outside the range of the original span, but those bytes will
+        // still be inside the span covering the whole file, so that's ok.
+        offset_t file_size = (phdr.p_filesz + sizeof(word_t) - 1) / sizeof(word_t);
+        offset_t mem_size = (phdr.p_memsz + sizeof(word_t) - 1) / sizeof(word_t);
+        GetSegments().emplace_back(
+            std::span(reinterpret_cast<word_t const *>(contents.data()), file_size),
+            phdr.p_vaddr / sizeof(word_t),
+            mem_size - file_size);
+    }
+    if (textIx < 0)
+        TT_THROW("{}: cannot find text segment", path_);
+    if (textIx > 0) {
+        auto &segments = GetSegments();
+        std::rotate(segments.begin(), std::next(segments.begin(), textIx), segments.end());
+    }
+}

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// C++
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+// An ELF executable loader
+// This is a replacement for tt_hexfile stuff.
+
+namespace ll_api {
+
+class ElfFile {
+   public:
+    // ELF32
+    using address_t = std::uint32_t;  // Address in memory
+    using offset_t = std::uint32_t;   // Offset within region
+    using word_t = std::uint32_t;     // Contents
+
+    struct Segment {
+        std::span<word_t const> contents;  // Non-owning span
+        address_t address = 0;             // word address or 0 for XIP
+        offset_t bss = 0;                  // words of BSS
+
+       public:
+        constexpr Segment(std::span<word_t const> contents, address_t addr, offset_t bss) :
+            contents(contents), address(addr), bss(bss) {}
+    };
+
+   public:
+    ElfFile(std::string const &path);
+    ~ElfFile();
+
+    // Uncopyable -- because of the owning buffer
+    ElfFile(ElfFile const &) = delete;
+    ElfFile operator=(ElfFile const &) = delete;
+
+    // Move constructable -- take ownership
+    ElfFile(ElfFile &&s) : contents_(std::move(s.contents_)), segments_(std::move(s.segments_)) {
+        s.contents_ = std::span<std::byte>();
+    }
+    ElfFile &operator=(ElfFile &&s) {
+        std::swap(contents_, s.contents_);
+        segments_ = std::move(s.segments_);
+        return *this;
+    }
+
+   public:
+    std::vector<Segment> const &GetSegments() const { return segments_; }
+
+   private:
+    class Impl;
+    std::span<std::byte> contents_;  // Owning buffer
+    std::vector<Segment> segments_;
+};
+
+}  // namespace ll_api


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11791

### Problem description
As a step towards XIP, we need to load the ELF file directly and avoid the HEX8 and HEX32 stuff

### What's changed
New elf loader object, invoked by tt_memory's constructor when the file suffix is not `.hex`.  The hex8/32 stuff remains, to be deleted in a later patch.

We may want to expose the Segments this elf loader has in the memory object itself -- avoid a bunch of copying and be explicit about start addresses rather than have to remember core<->textaddr mappings.


### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [NA] Model regression CI testing passes (if applicable)
- [NA] Device performance regression CI testing passes (if applicable)
- [YES] New/Existing tests provide coverage for changes
