### PR TITLE
#0: Dispatch_s + Launch Message Ring Buffer Bugfixes

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -340,7 +340,7 @@ int main() {
     l1_to_local_mem_copy((uint*)__ldm_data_start, (uint tt_l1_ptr*)MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH, num_words);
 
     mailboxes->launch_msg_rd_ptr = 0; // Initialize the rdptr to 0
-
+    noc_index = 0;
     risc_init();
     device_setup();
     noc_init();
@@ -370,6 +370,9 @@ int main() {
             if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
                 // Set the rd_ptr on workers to specified value
                 mailboxes->launch_msg_rd_ptr = 0;
+                // Querying the noc_index is safe here, since the RUN_MSG_RESET_READ_PTR go signal is currently guaranteed
+                // to only be seen after a RUN_MSG_GO signal, which will set the noc_index to a valid value.
+                // For future proofing, the noc_index value is initialized to 0, to ensure an invalid NOC txn is not issued.
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
                     NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -70,17 +70,18 @@ uint32_t firmware_config_init(tt_l1_ptr mailboxes_t* const mailboxes, uint32_t c
 
     // TODO: check the asm for this loop to be sure loads are scheduled ok
     uint32_t kernel_config_base[ProgrammableCoreType::COUNT];
+    launch_msg_t* launch_msg_address = &(mailboxes->launch[mailboxes->launch_msg_rd_ptr]);
 #pragma GCC unroll ProgrammableCoreType::COUNT
     for (uint32_t index = 0; index < ProgrammableCoreType::COUNT; index++) {
         kernel_config_base[index] =
-            mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.kernel_config_base[index];
+            launch_msg_address->kernel_config.kernel_config_base[index];
         sem_l1_base[index] = (uint32_t tt_l1_ptr *)(kernel_config_base[index] +
-            mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.sem_offset[index]);
+            launch_msg_address->kernel_config.sem_offset[index]);
     }
     rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base[core_type_index] +
-        mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.mem_map[dispatch_class].rta_offset);
+        launch_msg_address->kernel_config.mem_map[dispatch_class].rta_offset);
     crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base[core_type_index] +
-        mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.mem_map[dispatch_class].crta_offset);
+        launch_msg_address->kernel_config.mem_map[dispatch_class].crta_offset);
 
     return kernel_config_base[core_type_index];
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2397,6 +2397,8 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
     this->initialize_cluster();
     this->initialize_allocator(l1_small_size, trace_region_size, l1_bank_remap);
     this->initialize_build();
+    // Reset the launch_message ring buffer state seen on host, since its reset on device, each time FW is initialized
+    this->worker_launch_message_buffer_state.reset();
     // For minimal setup, don't initialize FW, watcher, dprint. They won't work if we're attaching to a hung chip.
     if (minimal)
         return true;

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -283,6 +283,7 @@ class Device {
     WorkExecutor work_executor;
     uint32_t worker_thread_core;
     std::unique_ptr<SystemMemoryManager> sysmem_manager_;
+    LaunchMessageRingBufferState worker_launch_message_buffer_state;
     uint8_t num_hw_cqs_;
 
     std::vector<std::unique_ptr<Program>> command_queue_programs;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -532,8 +532,6 @@ class HWCommandQueue {
     volatile uint32_t num_completed_completion_q_reads;  // completion queue reader thread increments this after reading
                                                          // an entry out of the completion queue
     detail::CompletionReaderQueue issued_completion_q_reads;
-    uint32_t multicast_cores_launch_message_wptr = 0;
-    uint32_t unicast_cores_launch_message_wptr = 0;
     // These values are used to reset the host side launch message wptr after a trace is captured
     // Trace capture is a fully host side operation, but it modifies the state of the wptrs above
     // To ensure that host and device are not out of sync, we reset the wptrs to their original values

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -749,3 +749,39 @@ class SystemMemoryManager {
     WorkerConfigBufferMgr& get_config_buffer_mgr() { return config_buffer_mgr; }
 
 };
+
+struct LaunchMessageRingBufferState {
+    public:
+    void inc_mcast_wptr(uint32_t inc_val) {
+        this->multicast_cores_launch_message_wptr = (this->multicast_cores_launch_message_wptr + inc_val) & (launch_msg_buffer_num_entries - 1);
+    }
+
+    void inc_unicast_wptr(uint32_t inc_val) {
+        this->unicast_cores_launch_message_wptr = (this->unicast_cores_launch_message_wptr + inc_val) & (launch_msg_buffer_num_entries - 1);
+    }
+
+    void set_mcast_wptr(uint32_t val) {
+        this->multicast_cores_launch_message_wptr = val & (launch_msg_buffer_num_entries - 1);
+    }
+
+    void set_unicast_wptr(uint32_t val) {
+        this->unicast_cores_launch_message_wptr = val & (launch_msg_buffer_num_entries - 1);
+    }
+
+    uint32_t get_mcast_wptr() {
+        return this->multicast_cores_launch_message_wptr;
+    }
+
+    uint32_t get_unicast_wptr() {
+        return this->unicast_cores_launch_message_wptr;
+    }
+
+    void reset() {
+        this->multicast_cores_launch_message_wptr = 0;
+        this->unicast_cores_launch_message_wptr = 0;
+    }
+
+    private:
+    uint32_t multicast_cores_launch_message_wptr = 0;
+    uint32_t unicast_cores_launch_message_wptr = 0;
+};

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -368,7 +368,8 @@ class DeviceCommand {
         }
     }
     void add_dispatch_set_unicast_only_cores(const std::vector<uint32_t>& noc_encodings, DispatcherSelect dispatcher_type) {
-        TT_ASSERT(noc_encodings.size());
+        // noc_encodings are only populated if the device has active ethernet links. For devices such as Grayskull and N150, which
+        // don't have active ethernet links, this is essentially a NOP (command with empty payload).
         this->add_prefetch_relay_inline(true, sizeof(CQDispatchCmd) + noc_encodings.size() * sizeof(uint32_t), dispatcher_type);
         auto initialize_set_unicast_only_cores_cmd = [&] (CQDispatchCmd *set_unicast_only_cores_cmd) {
             *set_unicast_only_cores_cmd = {};


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Few bugs got exposed with recent dispatch_s changes with local testing + testing with different build modes.

### What's changed
  - Remove assert in `add_dispatch_set_unicast_only_cores`, requiring the num_cores > 0. This was causing debug build to fail for Grayskull and N150 devices, since an empty list is passed to this function, which asserts, since these devices don't have active eth cores
  - `Device` class owns the `launch_message_ring_buffer` state, instead of the `HWCommandQueue` class. This is required, since workers track a global launch message buffer state, instead of a state per CQ. Original changes could have host and device state to go out of sync if the same test ran workloads on multiple CQs. Exposed when we tried increasing the launch_message buffer size to 8 entries.
  - Initialize noc_index to 0 in `brisc.cc`: future proofing, for cases where a NOC txn is issued before a RUN_MSG_GO signal is seen. This is not the case today, but is the safe thing to do.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
