### PR TITLE
#7404: softplus operation passes on WH

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import ttnn
+import traceback
+
+from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from models.utility_functions import skip_for_grayskull
+
+
+def run_eltwise_softplus_tests(
+    input_shape,
+    dtype,
+    dlayout,
+    in_mem_config,
+    output_mem_config,
+    beta,
+    threshold,
+    data_seed,
+    device,
+):
+    torch.manual_seed(data_seed)
+    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100)
+
+    try:
+        # get ref result
+        ref_value = torch.nn.functional.softplus(x, beta=beta, threshold=threshold)
+
+        x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
+        tt_result = ttnn.softplus(x, beta=beta, threshold=threshold, memory_config=output_mem_config)
+
+        tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)
+
+    except Exception as e:
+        logger.warning(f"Test execution crashed: {e}")
+        print(traceback.format_exc())
+        raise e
+
+    assert len(tt_result.shape) == len(ref_value.shape)
+    assert tt_result.shape == ref_value.shape
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+    logger.debug(success)
+
+    assert success
+
+
+test_sweep_args = [
+    (
+        [(6, 6, 192, 224)],
+        [ttnn.bfloat16],
+        [ttnn.TILE_LAYOUT],
+        [ttnn.DRAM_MEMORY_CONFIG],
+        ttnn.L1_MEMORY_CONFIG,
+        0.0,
+        28.125,
+        19042500,
+    ),
+]
+
+
+@skip_for_grayskull("Softplus is not available in Grayskull")
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed",
+    (test_sweep_args),
+)
+def test_eltwise_softplus(
+    input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed, device
+):
+    run_eltwise_softplus_tests(
+        input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed, device
+    )


### PR DESCRIPTION
### Ticket
Link to Github Issue #7404

### Problem description
softplus operation passes on WH 

### What's changed
Added unit test to test the case mentioned in #7404
The test mentioned in the above issue is passing 

<img width="1512" alt="Screenshot 2024-10-01 at 1 11 34 PM" src="https://github.com/user-attachments/assets/3d1d1f00-fd60-400a-bdeb-f6b759386337">

<img width="1512" alt="Screenshot 2024-10-01 at 1 11 43 PM" src="https://github.com/user-attachments/assets/bedeb000-b2b9-4820-8ce8-66f7948b12a1">

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11165401837
https://github.com/tenstorrent/tt-metal/actions/runs/11253231316
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
