### PR TITLE
#10016: jit_build: link substitutes, tdma_xmov, noc

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -54,7 +54,7 @@ elseif("$ENV{ARCH_NAME}" STREQUAL "blackhole")
     set(ALIAS_ARCH_NAME "blackhole")
 endif()
 
-set(GPP_FLAGS ${GPP_FLAGS} -std=c++17 -flto -ffast-math -fno-use-cxa-atexit -fno-exceptions -Wall -Werror -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function)
+set(GPP_FLAGS ${GPP_FLAGS} -std=c++17 -flto -ffast-math -fno-use-cxa-atexit -fno-exceptions -Wall -Werror -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function -Os -fno-tree-loop-distribute-patterns)
 
 set(HW_LIB_DIR ${PROJECT_SOURCE_DIR}/runtime/hw/lib)
 set(GPP_CMD ${PROJECT_SOURCE_DIR}/tt_metal/third_party/sfpi/compiler/bin/riscv32-unknown-elf-g++)

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -13,7 +13,6 @@
 #include "ckernel_structs.h"
 #include "stream_io_map.h"
 #include "c_tensix_core.h"
-#include "tdma_xmov.h"
 #include "noc_nonblocking_api.h"
 #include "firmware_common.h"
 #include "tools/profiler/kernel_profiler.hpp"

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -172,6 +172,9 @@ void JitBuildState::finish_init() {
     // Append hw build objects compiled offline
     std::string build_dir = llrt::OptionsG.get_root_dir() + "runtime/hw/lib/";
     if (this->is_fw_) {
+        if (this->target_name_ == "brisc") {
+            this->link_objs_ += build_dir + "tdma_xmov.o ";
+        }
         if (this->target_name_ != "erisc") {
             this->link_objs_ += build_dir + "tmu-crt0.o ";
         }
@@ -182,6 +185,10 @@ void JitBuildState::finish_init() {
     } else {
         this->link_objs_ += build_dir + "tmu-crt0k.o ";
     }
+    if (this->target_name_ == "brisc" or this->target_name_ == "idle_erisc") {
+        this->link_objs_ += build_dir + "noc.o ";
+    }
+    this->link_objs_ += build_dir + "substitutes.o ";
 
     // Note the preceding slash which defies convention as this gets appended to
     // the kernel name used as a path which doesn't have a slash
@@ -204,9 +211,6 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
     uint32_t l1_cache_disable_mask =
         tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
 
-    // TODO(pgk): build these once at init into built/libs!
-    this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
-
     this->lflags_ = env_.lflags_ + "-Os ";
 
     switch (this->core_id_) {
@@ -217,9 +221,6 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
             if ((l1_cache_disable_mask & tt::llrt::DebugHartFlags::RISCV_BR) == tt::llrt::DebugHartFlags::RISCV_BR) {
                 this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
             }
-
-            this->srcs_.push_back("tt_metal/hw/firmware/src/tdma_xmov.c");
-            this->srcs_.push_back("tt_metal/hw/firmware/src/" + env_.aliased_arch_name_ + "/noc.c");
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/brisc.cc");
             } else {
@@ -287,7 +288,6 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, int which, bool is_fw) 
                       "tt_metal/third_party/sfpi/include " + "-I" + env_.root_ + "tt_metal/hw/firmware/src " + "-I" +
                       env_.root_ + "tt_metal/third_party/tt_llk_" + env.arch_name_ + "/llk_lib ";
 
-    this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
     if (this->is_fw_) {
         this->srcs_.push_back("tt_metal/hw/firmware/src/trisc.cc");
     } else {
@@ -378,7 +378,6 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
 
             this->includes_ += "-I " + env_.root_ + "tt_metal/hw/inc/ethernet ";
 
-            this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/erisc.cc");
             } else {
@@ -412,9 +411,6 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
 
             this->includes_ += "-I " + env_.root_ + "tt_metal/hw/firmware/src ";
 
-            // TODO(pgk): build these once at init into built/libs!
-            this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
-            this->srcs_.push_back("tt_metal/hw/firmware/src/" + env_.aliased_arch_name_ + "/noc.c");
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/idle_erisc.cc");
             } else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10016)
### Problem description
This was a previously reverted commit, due to program dispatch perf regressions. 

### What's changed
Added program dispatch perf test to CI. Fixed the perf issue, i.e. compiling `substitutes.cpp` with `-Os` instead of `-O3`.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
