### PR TITLE
#0: fix mesh device fixture selection for test_distributed_layernorm

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py
@@ -142,23 +142,20 @@ inp_shapes = [
 ]
 inp_shape_ids = ["inp_shape0", "inp_shape1", "inp_shape2"]
 
-stats_dtypes = [(ttnn.bfloat16, ttnn.bfloat8_b)]
+stats_dtypes = [ttnn.bfloat16, ttnn.bfloat8_b]
 stats_dtypes_ids = ["BFLOAT16_stats", "BFLOAT8_B_stats"]
 
 dtypes = [ttnn.bfloat16, ttnn.bfloat8_b]
 dtype_ids = ["BFLOAT16_in", "BFLOAT8_B_in"]
 
-iterations = [2]
-iteration_ids = ["loops2"]
-
-rms_norm_parametrizations = ([True, False],)
-rms_norm_parametrization_ids = (["rmsnorm", "layernorm"],)
+rms_norm_parametrizations = [True, False]
+rms_norm_parametrization_ids = ["rmsnorm", "layernorm"]
 
 
 def test_distributed_layernorm_with_program_cache_and_checks(
-    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, mesh_device, use_program_cache
+    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, mesh_device, use_program_cache, iterations
 ):
-    if mesh_device.get_num_devices() != 8:
+    if mesh_device.get_num_devices() < n_devices:
         pytest.skip("Not T3000!")
 
     run_distributed_layernorm(inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, mesh_device, iterations=iterations)
@@ -170,7 +167,7 @@ def test_distributed_layernorm_with_program_cache_and_checks(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("iterations", iterations, ids=iteration_ids)
+@pytest.mark.parametrize("iterations", [2], ids=["loops2"])
 @pytest.mark.parametrize("dtype", dtypes, ids=dtype_ids)
 @pytest.mark.parametrize("stats_dtype", stats_dtypes, ids=stats_dtypes_ids)
 @pytest.mark.parametrize("inp_shape", inp_shapes, ids=inp_shape_ids)
@@ -180,20 +177,20 @@ def test_distributed_layernorm_with_program_cache(
     inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, t3k_mesh_device, use_program_cache
 ):
     test_distributed_layernorm_with_program_cache_and_checks(
-        inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, t3k_mesh_device, iterations=iterations
+        inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, t3k_mesh_device, use_program_cache, iterations=iterations
     )
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("iterations", iterations, ids=iteration_ids)
+@pytest.mark.parametrize("iterations", [2], ids=["loops2"])
 @pytest.mark.parametrize("dtype", dtypes, ids=dtype_ids)
 @pytest.mark.parametrize("stats_dtype", stats_dtypes, ids=stats_dtypes_ids)
 @pytest.mark.parametrize("inp_shape", inp_shapes, ids=inp_shape_ids)
 @pytest.mark.parametrize("n_devices", [4])
 @pytest.mark.parametrize("is_rmsnorm", rms_norm_parametrizations, ids=rms_norm_parametrization_ids)
-def test_distributed_layernorm_with_program_cache(
+def test_distributed_layernorm_with_program_cache_4chip(
     inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, pcie_mesh_device, use_program_cache
 ):
     test_distributed_layernorm_with_program_cache_and_checks(
-        inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, pcie_mesh_device, iterations=iterations
+        inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, pcie_mesh_device, use_program_cache, iterations=iterations
     )

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py
@@ -152,7 +152,7 @@ rms_norm_parametrizations = [True, False]
 rms_norm_parametrization_ids = ["rmsnorm", "layernorm"]
 
 
-def test_distributed_layernorm_with_program_cache_and_checks(
+def run_test_distributed_layernorm_with_program_cache_and_checks(
     inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, mesh_device, use_program_cache, iterations
 ):
     if mesh_device.get_num_devices() < n_devices:
@@ -176,7 +176,7 @@ def test_distributed_layernorm_with_program_cache_and_checks(
 def test_distributed_layernorm_with_program_cache(
     inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, t3k_mesh_device, use_program_cache
 ):
-    test_distributed_layernorm_with_program_cache_and_checks(
+    run_test_distributed_layernorm_with_program_cache_and_checks(
         inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, t3k_mesh_device, use_program_cache, iterations=iterations
     )
 
@@ -191,6 +191,6 @@ def test_distributed_layernorm_with_program_cache(
 def test_distributed_layernorm_with_program_cache_4chip(
     inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, pcie_mesh_device, use_program_cache
 ):
-    test_distributed_layernorm_with_program_cache_and_checks(
+    run_test_distributed_layernorm_with_program_cache_and_checks(
         inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, pcie_mesh_device, use_program_cache, iterations=iterations
     )

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm.py
@@ -66,7 +66,7 @@ def tt_distributed_layernorm(inp, gamma, beta, epsilon, is_rmsnorm, compute_kern
 
 
 def run_distributed_layernorm(
-    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, devices, fp32_enabled=False, iterations=1
+    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, mesh_device, fp32_enabled=False, iterations=1
 ):
     compute_kernel_config = ttnn.WormholeComputeKernelConfig(
         math_fidelity=ttnn.MathFidelity.HiFi4,  # Highest fidelity
@@ -94,7 +94,7 @@ def run_distributed_layernorm(
             ttnn.as_tensor(
                 inp_chunked[d],
                 dtype=dtype,
-                device=devices[d],
+                device=mesh_device.get_devices()[d],
                 layout=ttnn.TILE_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
@@ -106,7 +106,7 @@ def run_distributed_layernorm(
             ttnn.as_tensor(
                 gamma_chunked[d].reshape(1, 1, -1, 32),
                 dtype=ttnn.bfloat16,
-                device=devices[d],
+                device=mesh_device.get_devices()[d],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
@@ -118,7 +118,7 @@ def run_distributed_layernorm(
             ttnn.as_tensor(
                 beta_chunked[d].reshape(1, 1, -1, 32),
                 dtype=ttnn.bfloat16,
-                device=devices[d],
+                device=mesh_device.get_devices()[d],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
@@ -135,51 +135,65 @@ def run_distributed_layernorm(
     assert passing
 
 
-@skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize(
-    "iterations",
-    [2],
-    ids=["loops2"],
-)
-@pytest.mark.parametrize(
-    "dtype",
-    (ttnn.bfloat16, ttnn.bfloat8_b),
-    ids=["BFLOAT16_in", "BFLOAT8_B_in"],
-)
-@pytest.mark.parametrize(
-    "stats_dtype",
-    (ttnn.bfloat16, ttnn.bfloat8_b),
-    ids=["BFLOAT16_stats", "BFLOAT8_B_stats"],
-)
-@pytest.mark.parametrize(
-    "inp_shape",
-    [
-        (1, 1, 2048, 8192),
-        (1, 1, 128, 8192),
-        (2, 1, 128, 8192),
-    ],
-    ids=["inp_shape0", "inp_shape1", "inp_shape2"],
-)
-@pytest.mark.parametrize(
-    "n_devices",
-    [4, 8],
-)
-@pytest.mark.parametrize(
-    "is_rmsnorm",
-    [True, False],
-    ids=["rmsnorm", "layernorm"],
-)
-def test_distributed_layernorm_with_program_cache(
-    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, all_devices, use_program_cache
+inp_shapes = [
+    (1, 1, 2048, 8192),
+    (1, 1, 128, 8192),
+    (2, 1, 128, 8192),
+]
+inp_shape_ids = ["inp_shape0", "inp_shape1", "inp_shape2"]
+
+stats_dtypes = [(ttnn.bfloat16, ttnn.bfloat8_b)]
+stats_dtypes_ids = ["BFLOAT16_stats", "BFLOAT8_B_stats"]
+
+dtypes = [ttnn.bfloat16, ttnn.bfloat8_b]
+dtype_ids = ["BFLOAT16_in", "BFLOAT8_B_in"]
+
+iterations = [2]
+iteration_ids = ["loops2"]
+
+rms_norm_parametrizations = ([True, False],)
+rms_norm_parametrization_ids = (["rmsnorm", "layernorm"],)
+
+
+def test_distributed_layernorm_with_program_cache_and_checks(
+    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, mesh_device, use_program_cache
 ):
-    if len(all_devices) != 8:
+    if mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
-    devices = get_devices_for_t3000(all_devices, n_devices)
+    run_distributed_layernorm(inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, mesh_device, iterations=iterations)
 
-    run_distributed_layernorm(inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, devices, iterations=iterations)
-
-    for d in range(len(devices)):
-        assert devices[d].num_program_cache_entries() == 3, "Program cache should have only 3 entries, but has " + str(
-            devices[d].num_program_cache_entries()
+    for d in mesh_device.get_devices():
+        assert d.num_program_cache_entries() == 3, "Program cache should have only 3 entries, but has " + str(
+            d.num_program_cache_entries()
         )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("iterations", iterations, ids=iteration_ids)
+@pytest.mark.parametrize("dtype", dtypes, ids=dtype_ids)
+@pytest.mark.parametrize("stats_dtype", stats_dtypes, ids=stats_dtypes_ids)
+@pytest.mark.parametrize("inp_shape", inp_shapes, ids=inp_shape_ids)
+@pytest.mark.parametrize("n_devices", [8])
+@pytest.mark.parametrize("is_rmsnorm", rms_norm_parametrizations, ids=rms_norm_parametrization_ids)
+def test_distributed_layernorm_with_program_cache(
+    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, t3k_mesh_device, use_program_cache
+):
+    test_distributed_layernorm_with_program_cache_and_checks(
+        inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, t3k_mesh_device, iterations=iterations
+    )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("iterations", iterations, ids=iteration_ids)
+@pytest.mark.parametrize("dtype", dtypes, ids=dtype_ids)
+@pytest.mark.parametrize("stats_dtype", stats_dtypes, ids=stats_dtypes_ids)
+@pytest.mark.parametrize("inp_shape", inp_shapes, ids=inp_shape_ids)
+@pytest.mark.parametrize("n_devices", [4])
+@pytest.mark.parametrize("is_rmsnorm", rms_norm_parametrizations, ids=rms_norm_parametrization_ids)
+def test_distributed_layernorm_with_program_cache(
+    inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, iterations, pcie_mesh_device, use_program_cache
+):
+    test_distributed_layernorm_with_program_cache_and_checks(
+        inp_shape, n_devices, is_rmsnorm, dtype, stats_dtype, pcie_mesh_device, iterations=iterations
+    )


### PR DESCRIPTION
### Ticket
No issue opened - pipelines failing non-deterministically 

### Problem description
test distributed layernorm has not been updated to use the latest mesh device infrastructure and as such is susceptible to non-deterministic device ordering which can cause multi-chip ops to fail because they can't reason about chip connectivity anymore (device ordering contract violated)

### What's changed
Updated to use mesh devices

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11167296381
- [x] t3k frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11167293261
- [x] (not applicable) Blackhole Post commit (if applicable)
- [x] (not applicable) Model regression CI testing passes (if applicable)
- [x] (not applicable) Device performance regression CI testing passes (if applicable)
- [x] (not applicable) New/Existing tests provide coverage for changes
