### PR TITLE
#0: Reduce copy sweep to cover only bf16

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/copy/copy.py
+++ b/tests/sweep_framework/sweeps/data_movement/copy/copy.py
@@ -89,7 +89,7 @@ parameters = {
             [],
         ],
         "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
-        "dtype": [ttnn.bfloat16, ttnn.float32, ttnn.int32],
+        "dtype": [ttnn.bfloat16],
     }
 }
 


### PR DESCRIPTION
Removed currently extraneous input types from copy sweep for consistency with other torch2.0 sweeps.