### PR TITLE
#13370: Introduce inline namespace v0

### DIFF
--- a/tt_metal/detail/reports/memory_reporter.hpp
+++ b/tt_metal/detail/reports/memory_reporter.hpp
@@ -9,9 +9,12 @@
 #include <fstream>
 #include <string>
 namespace tt::tt_metal {
+inline namespace v0 {
 
 class Program;
 class Device;
+
+}  // namespace v0
 namespace detail {
 
 /**
@@ -74,6 +77,5 @@ class MemoryReporter {
     std::ofstream program_detailed_memory_usage_report_;
 };
 
-}   // namespace detail
-
-}   // namespace tt::tt_metal
+}  // namespace detail
+}  // namespace tt::tt_metal

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -13,9 +13,11 @@
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 
 namespace tt::tt_metal {
+inline namespace v0 {
     class Program;
     class Buffer;
     class Device;
+}  // namespace v0
 
     namespace detail {
 
@@ -278,5 +280,5 @@ namespace tt::tt_metal {
         void AllocateBuffer(Buffer* buffer, bool bottom_up);
 
         void DeallocateBuffer(Buffer *buffer);
-    }
-}
+    }  // namespace detail
+}  // namespace tt::tt_metal

--- a/tt_metal/graph/graph_tracking.hpp
+++ b/tt_metal/graph/graph_tracking.hpp
@@ -13,8 +13,12 @@
 #include "tt_metal/impl/buffers/buffer.hpp"
 
 namespace tt::tt_metal {
+inline namespace v0 {
 
     class Program;
+
+}  // namespace v0
+
     class IGraphProcessor{
     public:
         enum class RunMode {

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -30,6 +30,7 @@ class CoreRangeSet;
 namespace tt {
 
 namespace tt_metal {
+inline namespace v0 {
 
 class Program;
 class Device;
@@ -657,6 +658,7 @@ bool EventQuery(const std::shared_ptr<Event> &event);
  */
 void Synchronize(Device *device, const std::optional<uint8_t> cq_id = std::nullopt);
 
+}  // namespace v0
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -22,11 +22,12 @@
 #include "tt_metal/tt_stl/reflection.hpp"
 #include "llrt/hal.hpp"
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal {
+inline namespace v0 {
 
 class Device;
+
+}  // namespace v0
 
 struct ShardSpec {
     /* The individual cores the shard grid is mapped to */
@@ -101,6 +102,8 @@ struct ShardSpecBuffer {
     }
 };
 
+inline namespace v0 {
+
 struct BufferConfig {
     Device *device;
     DeviceAddr size;       // Size in bytes
@@ -124,6 +127,8 @@ struct ShardedBufferConfig {
     bool allocate = true;
 };
 
+}  // namespace v0
+
 bool is_sharded(const TensorMemoryLayout &layout);
 
 struct BufferPageMapping {
@@ -139,6 +144,8 @@ struct BufferPageMapping {
     std::vector<uint32_t> host_page_to_local_shard_page_mapping_;
     std::vector<std::array<uint32_t, 2>> core_shard_shape_;
 };
+
+inline namespace v0 {
 
 class Buffer {
    public:
@@ -278,6 +285,8 @@ class Buffer {
     std::optional<bool> bottom_up_;
 };
 
+}  // namespace v0
+
 BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
 
 namespace detail {
@@ -310,6 +319,8 @@ class buffer_map_t {
 extern buffer_map_t BUFFER_MAP;
 }  // namespace detail
 
+inline namespace v0 {
+
 using HostDataType = std::variant<
     const std::shared_ptr<std::vector<uint8_t>>,
     const std::shared_ptr<std::vector<uint16_t>>,
@@ -319,9 +330,8 @@ using HostDataType = std::variant<
     const std::shared_ptr<std::vector<bfloat16>>,
     const void *>;
 
-}  // namespace tt_metal
-
-}  // namespace tt
+}  // namespace v0
+}  // namespace tt::tt_metal
 
 namespace tt::stl::json {
 template <>

--- a/tt_metal/impl/buffers/circular_buffer.hpp
+++ b/tt_metal/impl/buffers/circular_buffer.hpp
@@ -8,9 +8,8 @@
 #include "common/tt_backend_api_types.hpp"
 #include "tt_metal/impl/buffers/circular_buffer_types.hpp"
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal {
+inline namespace v0 {
 
 class CircularBuffer {
    public:
@@ -66,6 +65,5 @@ class CircularBuffer {
     // add a callback to invalidate circular buffer allocation
 };
 
-}  // namespace tt_metal
-
-}  // namespace tt
+}  // namespace v0
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -17,6 +17,7 @@
 #include "tt_metal/impl/tile/tile.hpp"
 
 namespace tt::tt_metal {
+inline namespace v0 {
 
 using CBHandle = uintptr_t;
 
@@ -151,4 +152,5 @@ class CircularBufferConfig {
     std::optional<uint32_t> max_size_ = std::nullopt;
 };
 
+}  // namespace v0
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -11,8 +11,10 @@
 namespace tt {
 
 namespace tt_metal {
+inline namespace v0 {
     class Device;
-}
+}  // namespace v0
+}  // namespace tt_metal
 
 /*
 @brief Attaches a device to be monitored by the print server. If no devices were present on the

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -23,14 +23,19 @@
 namespace tt {
 
 namespace tt_metal {
-
 // Fwd declares
 enum class BufferType;
+
+inline namespace v0 {
+
 class Buffer;
 class Program;
+class CommandQueue;
+
+}  // namespace v0
+
 class JitBuildEnv;
 class HWCommandQueue;
-class CommandQueue;
 class TraceBuffer;
 
 namespace detail {
@@ -53,6 +58,8 @@ static constexpr float  NAN_BH = NAN_WHB0;
 static constexpr float  INF_GS = 1.6948e38;
 static constexpr float  INF_WHB0 = 1.7014e+38;
 static constexpr float  INF_BH = INF_WHB0;
+
+inline namespace v0 {
 
 // A physical PCIexpress Tenstorrent device
 class Device {
@@ -333,6 +340,8 @@ class Device {
     void EnableAllocs();
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
 };
+
+}  // namespace v0
 
 inline HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord phys_core) const {
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -21,10 +21,14 @@
 #include "tt_metal/impl/trace/trace_buffer.hpp"
 
 namespace tt::tt_metal {
+inline namespace v0 {
 
+class CommandQueue;
 class Event;
 class Trace;
 using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
+
+}  // namespace v0
 
 // Only contains the types of commands which are enqueued onto the device
 enum class EnqueueCommandType {
@@ -47,7 +51,6 @@ enum class EnqueueCommandType {
 
 string EnqueueCommandTypeToString(EnqueueCommandType ctype);
 
-class CommandQueue;
 class CommandInterface;
 
 using WorkerQueue = LockFreeQueue<CommandInterface>;
@@ -591,8 +594,8 @@ class HWCommandQueue {
     friend void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event);
     friend void FinishImpl(CommandQueue& cq);
     friend void EnqueueRecordEvent(CommandQueue& cq, const std::shared_ptr<Event>& event);
-    friend class CommandQueue;
-    friend class Device;
+    friend CommandQueue;
+    friend Device;
 };
 
 // Common interface for all command queue types
@@ -609,6 +612,8 @@ struct CommandInterface {
     std::optional<std::shared_ptr<Event>> event;
     std::optional<uint32_t> trace_id;
 };
+
+inline namespace v0 {
 
 class CommandQueue {
     friend class Device;
@@ -696,6 +701,8 @@ class CommandQueue {
     inline static uint32_t num_async_cqs = 0;
     inline static uint32_t num_passthrough_cqs = 0;
 };
+
+}  // namespace v0
 
 // Primitives used to place host only operations on the SW Command Queue.
 // These are used in functions exposed through tt_metal.hpp or host_api.hpp

--- a/tt_metal/impl/event/event.hpp
+++ b/tt_metal/impl/event/event.hpp
@@ -8,8 +8,8 @@
 #include <thread>
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/logger.hpp"
-namespace tt::tt_metal
-{
+namespace tt::tt_metal {
+inline namespace v0 {
     class Device;
     struct Event
     {
@@ -31,4 +31,5 @@ namespace tt::tt_metal
             TT_ASSERT(cq_id != -1, "Event must have initialized cq_id");
         }
     };
-}
+}  // namespace v0
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -19,8 +19,12 @@
 namespace tt {
 
 namespace tt_metal {
+inline namespace v0 {
 
 class Device;
+
+}  // namespace v0
+
 constexpr uint32_t max_runtime_args = 256;
 constexpr uint32_t idle_eth_max_runtime_args = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE / sizeof(uint32_t);
 
@@ -46,6 +50,8 @@ struct KernelSource {
         return name;
     }
 };
+
+inline namespace v0 {
 
 class Kernel : public JitBuildSettings {
    public:
@@ -235,6 +241,8 @@ class ComputeKernel : public Kernel {
 
     std::string config_hash() const override;
 };
+
+}  // namespace v0
 
 std::ostream& operator<<(std::ostream& os, const DataMovementProcessor& processor);
 

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -19,13 +19,20 @@ namespace tt {
 namespace tt_metal {
 
 // Fwd declares
+inline namespace v0 {
+
 class Buffer;
 class Kernel;
 class CircularBuffer;
 class Device;
 class Program;
-class JitBuildOptions;
 class CircularBufferConfig;
+
+}  // namespace v0
+
+class EnqueueProgramCommand;
+class HWCommandQueue;
+class JitBuildOptions;
 namespace detail{
     void ValidateCircularBufferRegion(const Program &program, const Device *device);
     KernelHandle AddKernel (Program &program, std::shared_ptr<Kernel> kernel, const HalProgrammableCoreType core_type);
@@ -70,9 +77,9 @@ struct ProgramConfig {
     uint32_t cb_size;
 };
 
-class Program {
-    friend class KernelGroup;
+inline namespace v0 {
 
+class Program {
    public:
     Program();
 
@@ -254,10 +261,11 @@ class Program {
     bool runs_on_noc_unicast_only_cores();
     bool runs_on_noc_multicast_only_cores();
 
-    friend class HWCommandQueue;
-    friend class EnqueueProgramCommand;
+    friend HWCommandQueue;
+    friend EnqueueProgramCommand;
 };
 
+}  // namespace v0
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/trace/trace.hpp
+++ b/tt_metal/impl/trace/trace.hpp
@@ -15,6 +15,7 @@
 #include "tt_metal/impl/trace/trace_buffer.hpp"
 
 namespace tt::tt_metal {
+inline namespace v0 {
 
 class Trace {
    private:
@@ -31,4 +32,5 @@ class Trace {
     static std::shared_ptr<TraceBuffer> create_empty_trace_buffer();
 };
 
+}  // namespace v0
 }  // namespace tt::tt_metal

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -21,6 +21,7 @@
 namespace tt {
 
 namespace tt_metal {
+inline namespace v0 {
 
 void DumpDeviceProfileResults(Device* device, const Program& program) {
 #if defined(TRACY_ENABLE)
@@ -45,6 +46,8 @@ void DumpDeviceProfileResults(Device* device, const Program& program) {
     detail::DumpDeviceProfileResults(device, cores_in_program);
 #endif
 }
+
+}  // namespace v0
 
 namespace detail {
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -157,14 +157,14 @@ std::optional<uint32_t> get_semaphore_id(const Program &program, const CoreRange
     return semaphore_id;
 }
 
-inline void SetRuntimeArgs(
+inline void SetRuntimeArgsImpl(
     const Program &program, KernelHandle kernel_id, const CoreCoord &c, const std::vector<uint32_t> &runtime_args) {
     if (runtime_args.size() != 0) {
         detail::GetKernel(program, kernel_id)->set_runtime_args(c, runtime_args);
     }
 }
 
-inline void SetRuntimeArgs(
+inline void SetRuntimeArgsImpl(
     const Program &program,
     KernelHandle kernel_id,
     const CoreRange &core_range,
@@ -179,7 +179,7 @@ inline void SetRuntimeArgs(
     }
 }
 
-inline void SetRuntimeArgs(
+inline void SetRuntimeArgsImpl(
     const Program &program,
     KernelHandle kernel_id,
     const CoreRangeSet &core_range_set,
@@ -196,7 +196,7 @@ inline void SetRuntimeArgs(
     }
 }
 
-inline void SetRuntimeArgs(
+inline void SetRuntimeArgsImpl(
     CommandQueue &cq,
     const std::shared_ptr<Kernel> kernel,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
@@ -227,7 +227,7 @@ inline void SetRuntimeArgs(
         core_spec);
 }
 
-inline void SetRuntimeArgs(
+inline void SetRuntimeArgsImpl(
     CommandQueue &cq,
     const std::shared_ptr<Kernel> kernel,
     const std::vector<CoreCoord> &core_spec,
@@ -871,6 +871,8 @@ void DeallocateBuffer(Buffer *buffer) {
 
 }  // namespace detail
 
+inline namespace v0 {
+
 size_t GetNumAvailableDevices() {
     return tt::Cluster::instance().number_of_user_devices();
 }
@@ -1113,7 +1115,7 @@ void SetRuntimeArgs(
         not CommandQueue::async_mode_set(),
         "This variant of SetRuntimeArgs can only be called when Asynchronous SW Command Queues are disabled for Fast "
         "Dispatch.");
-    std::visit([&](auto &&core_spec) { SetRuntimeArgs(program, kernel_id, core_spec, runtime_args); }, core_spec);
+    std::visit([&](auto &&core_spec) { SetRuntimeArgsImpl(program, kernel_id, core_spec, runtime_args); }, core_spec);
 }
 
 void SetRuntimeArgs(
@@ -1141,7 +1143,7 @@ void SetRuntimeArgs(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
     std::shared_ptr<RuntimeArgs> runtime_args) {
     detail::DispatchStateCheck(not device->using_slow_dispatch());
-    SetRuntimeArgs(device->command_queue(), kernel, core_spec, runtime_args, false);
+    SetRuntimeArgsImpl(device->command_queue(), kernel, core_spec, runtime_args, false);
 }
 
 void SetRuntimeArgs(
@@ -1155,7 +1157,7 @@ void SetRuntimeArgs(
         core_spec.size(),
         runtime_args.size());
     detail::DispatchStateCheck(not device->using_slow_dispatch());
-    SetRuntimeArgs(device->command_queue(), kernel, core_spec, runtime_args, false);
+    SetRuntimeArgsImpl(device->command_queue(), kernel, core_spec, runtime_args, false);
 }
 
 void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args) {
@@ -1216,6 +1218,7 @@ void Synchronize(Device *device, const std::optional<uint8_t> cq_id) {
     }
 }
 
+}  // namespace v0
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
@@ -11,9 +11,12 @@
 namespace tt {
 namespace tt_metal {
 class Tensor;
+
+inline namespace v0 {
 class Device;
-} // namespace tt_metal
-} // namespace tt
+}  // namespace v0
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace ttnn {
 namespace ccl {

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.hpp
@@ -12,12 +12,14 @@
 
 namespace tt {
 namespace tt_metal {
+inline namespace v0 {
 
 // Forward declarations
 class Device;
 
-} // namespace tt_metal
-} // namespace tt
+}  // namespace v0
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace ttnn {
 namespace ccl {

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -7,11 +7,14 @@
 
 namespace tt::tt_metal {
 struct Tensor;
-class CommandQueue;
 struct MemoryConfig;
-class Device;
 class MeshDevice;
-}
+
+inline namespace v0 {
+class CommandQueue;
+class Device;
+}  // namespace v0
+}  // namespace tt::tt_metal
 
 namespace tt::tt_metal::tensor_ops {
 


### PR DESCRIPTION
### Ticket
#13370 

### Problem description
The intent is to introduce an inline namespace to help define the boundaries of the current api.  The idea is to wrap the existing api with namespace v0 and then subsequently introduce the namespace v1 for the new api.

### What's changed
inline namespace v0 was added under tt::tt_metal as applicable.

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11241795852)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
