### PR TITLE
#11307: Remove l1_buffer

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -41,15 +41,6 @@ inline void llk_unpack_reduce_hw_configure(
         within_face_16x16_transpose,
         unpA_num_faces,
         unpA_num_faces);
-
-    if constexpr (type != PoolType::MAX) {
-        union {
-            float f;
-            uint32_t u;
-        } f2u = {.f = const_mult};
-
-        for (uint i = 0; i < 16; i++) l1_buffer[i] = f2u.u;  // Load const into L1 buffer
-    }
 }
 
 template <

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_reduce_api.h
@@ -20,15 +20,6 @@ inline void llk_unpack_reduce_hw_configure(
         unpack_src_format[unpA_operand_id],
         unpack_dst_format[unpA_operand_id]
     );
-
-    if constexpr (type != PoolType::MAX) {
-        union {
-            float f;
-            uint32_t u;
-        } f2u = {.f = const_mult};
-
-        for (uint i = 0; i < 16; i++) l1_buffer[i] = f2u.u;  // Load const into L1 buffer
-    }
 }
 
 template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en=false /*not used*/, StochRndType stoch_rnd_mode = StochRndType::None /*not used*/>
@@ -74,9 +65,6 @@ inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpo
 
     cfg[THCON_SEC1_REG0_TileDescriptor_ADDR32] = tile_descriptor.val[0];
     cfg[THCON_SEC1_REG2_Out_data_format_ADDR32] = config.val[0];
-
-    cfg[THCON_SEC1_REG3_Base_address_ADDR32] = (((uint)l1_buffer) >> 4) - 1;        // Set l1 buffer address
-    cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = (((uint)l1_buffer) >> 4) - 1;  // Set l1 buffer address
 
     _llk_unpack_reduce_init_<type, dim>(within_face_16x16_transpose);
     WAYPOINT("UPRD");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -35,15 +35,6 @@ inline void llk_unpack_reduce_hw_configure(
         unpA_num_faces,
         unpA_num_faces
     );
-
-    if constexpr (type != PoolType::MAX) {
-        union {
-            float f;
-            uint32_t u;
-        } f2u = {.f = const_mult};
-
-        for (uint i = 0; i < 16; i++) l1_buffer[i] = f2u.u;  // Load const into L1 buffer
-    }
 }
 
 template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en=false, StochRndType stoch_rnd_mode = StochRndType::None>

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -54,9 +54,6 @@ volatile tt_l1_ptr uint8_t *const trisc_run =
 tt_l1_ptr mailboxes_t *const mailboxes = (tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE);
 }  // namespace ckernel
 
-volatile tt_l1_ptr uint32_t l1_buffer[16] __attribute__((section("l1_data"))) __attribute__((aligned(16)))
-__attribute__((used));
-
 #if !defined(UCK_CHLKC_MATH)
 uint32_t tt_l1_ptr *cb_l1_base __attribute__((used));
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
@@ -88,16 +85,6 @@ int main(int argc, char *argv[]) {
     // Initialize GPRs to all 0s
 #pragma GCC unroll 0
     for (int i = 0; i < 64; i++) regfile[i] = 0;
-
-    // Init L1 buffer with 1.0f (used for reduce max)
-    union {
-        float f;
-        uint32_t u;
-    } f2u = {.f = 1.0f};
-
-    // Save a little code space.  GCC fails to remove the loop variable so loop with a ptr
-#pragma GCC unroll 0
-    for (uint i = 0; i < 16; i++) l1_buffer[i] = f2u.u;  // Load const into L1 buffer
 
     reset_cfg_state_id();
 


### PR DESCRIPTION
Step towards removing l1_data sections

### Ticket
#11307 

### Problem description
l1_data is deprecated, removing its uses.  l1_buffer is set up for the llks, but is unused, removing

### What's changed
Removed the l1_buffer

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
