### PR TITLE
#13454: Refactor API for MeshDevice::enable_async

### DIFF
--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -97,10 +97,8 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_mesh_device.get_devices()
-    for device in devices:
-        device.enable_async(async_mode)
-    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    t3k_mesh_device.enable_async(async_mode)
+    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -88,10 +88,8 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     input_shape = [batch, seq_len]
     model_config_str = f"{data_type}-{memcfg}"
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_mesh_device.get_devices()
-    for device in devices:
-        device.enable_async(async_mode)
-    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    t3k_mesh_device.enable_async(async_mode)
+    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 

--- a/models/demos/t3000/falcon40b/tests/test_demo.py
+++ b/models/demos/t3000/falcon40b/tests/test_demo.py
@@ -48,9 +48,7 @@ def test_demo(
     use_program_cache,
 ):
     input_file = "models/demos/t3000/falcon40b/demo/input_data.json"
-    # Enable async mode
-    for device in t3k_mesh_device.get_devices():
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     generated_text, measurements = run_falcon_demo_kv(
         user_input=input_file,

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -382,10 +382,8 @@ def test_perf_bare_metal(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_mesh_device.get_devices()
-    for device in devices:
-        device.enable_async(async_mode)
-    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    t3k_mesh_device.enable_async(async_mode)
+    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 

--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -457,9 +457,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
@@ -374,9 +374,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
@@ -413,9 +413,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/llama2_70b/demo/eval.py
+++ b/models/demos/t3000/llama2_70b/demo/eval.py
@@ -379,9 +379,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/llama2_70b/demo/eval_t3000.py
+++ b/models/demos/t3000/llama2_70b/demo/eval_t3000.py
@@ -186,9 +186,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
@@ -151,8 +151,9 @@ def test_LlamaModel_inference(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
+    t3k_mesh_device.enable_async(True)
+    for device_id in t3k_mesh_device.get_device_ids():
+        device = t3k_mesh_device.get_device(device_id)
         device.enable_program_cache()
 
     args = construct_arg(

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
@@ -314,10 +314,10 @@ def test_Llama_perf_host(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
+    t3k_mesh_device.enable_async(True)
     for i in t3k_mesh_device.get_device_ids():
         device = t3k_mesh_device.get_device(i)
         device.enable_program_cache()
-        device.enable_async(True)
     disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -234,9 +234,7 @@ def test_Llama_perf_host(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     disable_compilation_reports()
 

--- a/models/demos/t3000/llama3_70b/demo/demo.py
+++ b/models/demos/t3000/llama3_70b/demo/demo.py
@@ -100,9 +100,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -273,8 +273,7 @@ def test_mixtral8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, ins
     if is_ci_env and instruct_weights == True:
         pytest.skip("CI demo test only runs general weights to reduce CI pipeline load (both are supported)")
 
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     return run_mixtral_demo(
         user_input=input_prompts,

--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -509,8 +509,7 @@ def test_mixtral8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, ins
     else:
         batch_size = 32
 
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     return run_mixtral_demo(
         user_input=input_prompts,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -20,8 +20,7 @@ from models.utility_functions import (
 
 
 def test_mixtral_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
@@ -34,8 +34,7 @@ from models.utility_functions import (
 )
 @torch.no_grad()
 def test_mixtral_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -28,8 +28,7 @@ def test_mixtral_decoder_inference(t3k_mesh_device, use_program_cache, reset_see
     s: sequence length
     h: hidden size
     """
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
@@ -35,8 +35,7 @@ def test_mixtral_decoder_inference(t3k_mesh_device, use_program_cache, reset_see
     s: sequence length
     h: hidden size
     """
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -19,8 +19,7 @@ from models.utility_functions import (
 
 
 def test_mixtral_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     # Specify different dtypes for each feedForward weights
     dtypes = {

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py
@@ -28,8 +28,7 @@ from models.utility_functions import (
     ),
 )
 def test_mixtral_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     # Specify different dtypes for each feedForward weights
     dtypes = {

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -36,8 +36,7 @@ class Emb(torch.nn.Module):
     ),
 )
 def test_mixtral_model_inference(t3k_mesh_device, use_program_cache, reset_seeds, batch):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     valid_pcc = 0.97
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
@@ -45,8 +45,7 @@ def test_mixtral_model_inference_CI(t3k_mesh_device, use_program_cache, reset_se
     if is_ci_env:
         os.environ["MIXTRAL_REF_OUTPUT_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/prefill/"
 
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     n_layers = 32
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
@@ -21,8 +21,7 @@ from models.utility_functions import (
 
 
 def test_mixtral_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     iterations = 1

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
@@ -30,8 +30,7 @@ from models.utility_functions import (
     ),
 )
 def test_mixtral_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     iterations = 1

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -51,8 +51,7 @@ def test_mixtral_model_perf(
     reset_seeds,
     is_ci_env,
 ):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
@@ -168,8 +167,7 @@ def test_mixtral_model_with_prefill_perf(
     reset_seeds,
     is_ci_env,
 ):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
@@ -283,8 +283,7 @@ def test_mixtral_perplexity(
         llm_mode == "decode"
     ), "Only decode mode is supported for now"  # TODO Add prefill support when it reaches main
 
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     # Adjust the batch size based on the max prefill length
     if max_seq_len >= 16 * 1024:

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -20,8 +20,7 @@ from models.utility_functions import (
 
 
 def test_mixtral_rms_norm_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     dtype = ttnn.bfloat8_b
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
@@ -42,8 +42,7 @@ class Emb(torch.nn.Module):
 def test_mixtral_model_inference(
     t3k_mesh_device, use_program_cache, reset_seeds, iterations, expected_top1, expected_top5
 ):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     # TODO Currently topk test is supporting decode-only mode. Add prefill support.
 

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -444,9 +444,7 @@ def test_LlamaModel_demo(
 
     check_mesh_device(mesh_device, model_config)
 
-    for i in mesh_device.get_device_ids():
-        device = mesh_device.get_device(i)
-        device.enable_async(True)
+    mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
@@ -93,9 +93,7 @@ def test_llama3_tg_nightly_demo(
     check_mesh_device(mesh_device, model_config)
 
     # TODO: Renable when issue #11089 is resolved
-    for i in mesh_device.get_device_ids():
-        device = mesh_device.get_device(i)
-        device.enable_async(True)
+    mesh_device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -196,10 +196,10 @@ def test_Llama_perf_host(
     )
 
     check_mesh_device(mesh_device, model_config)
+    mesh_device.enable_async(True)
 
     for device in mesh_device.get_devices():
         device.enable_program_cache()
-        device.enable_async(True)
     disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py
@@ -81,8 +81,7 @@ def test_falcon_attention(
     torch_model,
     enable_async,
 ):
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
@@ -190,5 +189,4 @@ def test_falcon_attention(
         pytorch_layer_present[1].squeeze(1), tt_layer_present[1].to(pytorch_layer_present[1].dtype), expected_pcc
     )
 
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(False)
+    mesh_device.enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -80,8 +80,7 @@ def test_falcon_causal_lm(
     enable_async,
     num_loops,
 ):
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
@@ -247,8 +246,7 @@ def test_falcon_causal_lm(
 
     logger.info("Falcon CausalLM Passed!")
 
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(False)
+    mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -297,8 +295,8 @@ def test_t3k_falcon_causal_lm_with_trace(
     enable_async,
     num_loops,
 ):
+    t3k_mesh_device.enable_async(enable_async)
     for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(enable_async)
         t3k_mesh_device.get_device(device).enable_program_cache()
 
     torch.manual_seed(0)
@@ -509,5 +507,4 @@ def test_t3k_falcon_causal_lm_with_trace(
 
     logger.info("Falcon CausalLM Passed!")
 
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(False)
+    t3k_mesh_device.enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
@@ -81,8 +81,7 @@ def test_falcon_decoder(
     torch_model,
     enable_async,
 ):
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
@@ -185,5 +184,4 @@ def test_falcon_decoder(
         pytorch_layer_present[1].squeeze(1), tt_layer_present[1].to(pytorch_layer_present[1].dtype), expected_pcc
     )
 
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(False)
+    mesh_device.enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
@@ -71,8 +71,7 @@ def test_falcon_mlp(
     torch_model,
     enable_async,
 ):
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     torch.manual_seed(0)
 
@@ -112,5 +111,4 @@ def test_falcon_mlp(
     )
     logger.success(f"Passed: pcc: {pcc}, expected: {expected_pcc}")
 
-    for device in mesh_device.get_device_ids():
-        mesh_device.get_device(device).enable_async(False)
+    mesh_device.enable_async(False)

--- a/models/experimental/grok/tests/test_grok_attention.py
+++ b/models/experimental/grok/tests/test_grok_attention.py
@@ -25,8 +25,7 @@ from models.utility_functions import (
 
 
 def test_grok_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_decoder.py
+++ b/models/experimental/grok/tests/test_grok_decoder.py
@@ -28,8 +28,7 @@ def test_grok_decoder_inference(t3k_mesh_device, use_program_cache, reset_seeds)
     s: sequence length
     h: hidden size
     """
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     pcc = 0.98
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_embedding.py
+++ b/models/experimental/grok/tests/test_grok_embedding.py
@@ -32,8 +32,7 @@ class Emb(torch.nn.Module):
 
 
 def test_grok_embedding(device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device, dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_mlp.py
+++ b/models/experimental/grok/tests/test_grok_mlp.py
@@ -26,8 +26,7 @@ from models.utility_functions import (
 
 @pytest.mark.timeout(500)
 def test_grok_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     # Specify different dtypes for each feedForward weights
     dtypes = {
         "linear": ttnn.bfloat4_b,

--- a/models/experimental/grok/tests/test_grok_model.py
+++ b/models/experimental/grok/tests/test_grok_model.py
@@ -42,8 +42,7 @@ from models.experimental.grok.reference.configuration_grok1 import Grok1Config
     (1, 2, 10),
 )
 def test_grok_model_inference(t3k_mesh_device, use_program_cache, reset_seeds, iterations, n_layers, validation_type):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     pcc = 0.97
     dtype = ttnn.bfloat8_b
 

--- a/models/experimental/grok/tests/test_grok_moe.py
+++ b/models/experimental/grok/tests/test_grok_moe.py
@@ -27,8 +27,7 @@ from models.utility_functions import (
 
 @pytest.mark.timeout(600)
 def test_grok_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     pcc = 0.87  # real weights = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b

--- a/models/experimental/grok/tests/test_grok_perf.py
+++ b/models/experimental/grok/tests/test_grok_perf.py
@@ -48,8 +48,7 @@ def test_grok_model_perf(
     reset_seeds,
 ):
     dtype = ttnn.bfloat8_b
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=False)

--- a/models/experimental/grok/tests/test_grok_rms_norm.py
+++ b/models/experimental/grok/tests/test_grok_rms_norm.py
@@ -26,8 +26,7 @@ from models.utility_functions import (
 
 def test_grok_rms_norm_inference(t3k_mesh_device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
 
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")
     model_args.n_layers = 1
@@ -75,8 +74,7 @@ def test_grok_rms_norm_inference(t3k_mesh_device, use_program_cache, reset_seeds
 
 
 def test_grok_rms_norm_sharded_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_async(True)
+    t3k_mesh_device.enable_async(True)
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")

--- a/tests/sweep_framework/sweeps/ccl/line_all_gather.py
+++ b/tests/sweep_framework/sweeps/ccl/line_all_gather.py
@@ -94,8 +94,7 @@ def run(
     device,
 ) -> list:
     t3k_mesh_device = device
-    for device in t3k_mesh_device.get_devices():
-        device.enable_async(enable_async)
+    t3k_mesh_device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -138,8 +138,7 @@ def run_all_gather_impl(
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
     # Use Async mode based on test input config
-    for device in mesh_device.get_devices():
-        device.enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     if enable_async:
         logger.info(f"Using Async Mode for All Gather Op Dispatch")
@@ -1280,8 +1279,7 @@ def run_all_gather_sharded_t3k(
     if t3k_mesh_device.get_num_devices() < num_devices:
         pytest.skip("Not T3000!")
 
-    for d in t3k_mesh_device.get_devices():
-        d.enable_async(enable_async)
+    t3k_mesh_device.enable_async(enable_async)
 
     return run_all_gather_sharded(
         t3k_mesh_device,
@@ -1332,8 +1330,7 @@ def run_all_gather_sharded_n300(
     if mesh_device.get_num_devices() != 2:
         pytest.skip("Not N300!")
 
-    for device in mesh_device.get_devices():
-        device.enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     return run_all_gather_sharded(
         mesh_device,

--- a/tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py
@@ -62,8 +62,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
 ):
     if len(mesh_device.get_devices()) != 32:
         pytest.skip("Not TG!")
-    for device in mesh_device.get_devices():
-        device.enable_async(enable_async)
+    mesh_device.enable_async(enable_async)
 
     input_shape_per_chip = list(input_shape_per_all_gather)
     input_shape_per_chip[2 if cluster_axis == 0 else 3] //= num_devices_per_line

--- a/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
@@ -156,8 +156,7 @@ def run_line_all_gather_instances(
     if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
-    for device in t3k_mesh_device.get_devices():
-        device.enable_async(enable_async)
+    t3k_mesh_device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -107,8 +107,7 @@ def run_reduce_scatter_test(
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
 
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
+    t3k_mesh_device.enable_async(enable_async)
     if enable_async:
         logger.info(f"Using Async Mode for Reduce Scatter Op Dispatch")
 
@@ -339,8 +338,7 @@ def run_reduce_scatter_sharded_test(
 
     debug = False
 
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
+    t3k_mesh_device.enable_async(enable_async)
 
     # Generate input tensors
     input_shard_shape = list(output_shard_shape)

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -20,8 +20,8 @@ def test_multi_device_events(t3k_mesh_device, shape):
         pytest.skip("This test requires multiple devices")
 
     # Enable Program Cache and Async Mode
+    t3k_mesh_device.enable_async(True)
     for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(True)
         t3k_mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors.
@@ -85,5 +85,4 @@ def test_multi_device_events(t3k_mesh_device, shape):
         )
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(False)
+    t3k_mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -27,8 +27,8 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
         pytest.skip("This test requires multiple devices")
 
     # Trace requires program cache to be enabled
+    t3k_mesh_device.enable_async(enable_async)
     for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
         t3k_mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -124,8 +124,7 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
     # Release trace buffer once workload is complete
     ttnn.release_trace(t3k_mesh_device, tid)
 
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(False)
+    t3k_mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -142,8 +141,8 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
         pytest.skip("This test requires multiple devices")
 
     # Trace requires program cache to be enabled
+    t3k_mesh_device.enable_async(enable_async)
     for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
         t3k_mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -323,5 +322,4 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
     ttnn.release_trace(t3k_mesh_device, tid_1)
     ttnn.release_trace(t3k_mesh_device, tid_2)
 
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_async(False)
+    t3k_mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
@@ -26,8 +26,8 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     if mesh_device.get_num_devices() < 32:
         pytest.skip("Test is only valid on Galaxy")
     # Trace requires program cache to be enabled
+    mesh_device.enable_async(True)
     for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(enable_async)
         mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -111,8 +111,7 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     # Release trace buffer once workload is complete
     ttnn.release_trace(mesh_device, tid)
 
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(False)
+    mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -129,8 +128,8 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         pytest.skip("Test is only valid on Galaxy")
 
     # Trace requires program cache to be enabled
+    mesh_device.enable_async(True)
     for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(enable_async)
         mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -282,5 +281,4 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
     ttnn.release_trace(mesh_device, tid_1)
     ttnn.release_trace(mesh_device, tid_2)
 
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(False)
+    mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -26,8 +26,8 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     if mesh_device.get_num_devices() < 64:
         pytest.skip("Test is only valid on TGG")
     # Trace requires program cache to be enabled
+    mesh_device.enable_async(True)
     for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(enable_async)
         mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -110,9 +110,7 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
 
     # Release trace buffer once workload is complete
     ttnn.release_trace(mesh_device, tid)
-
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(False)
+    mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -129,8 +127,8 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
         pytest.skip("Test is only valid on TGG")
 
     # Trace requires program cache to be enabled
+    mesh_device.enable_async(True)
     for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(enable_async)
         mesh_device.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -282,5 +280,4 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
     ttnn.release_trace(mesh_device, tid_1)
     ttnn.release_trace(mesh_device, tid_2)
 
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_async(False)
+    mesh_device.enable_async(False)

--- a/tt_metal/impl/device/mesh_device.cpp
+++ b/tt_metal/impl/device/mesh_device.cpp
@@ -401,6 +401,12 @@ bool validate_worker_modes(const std::vector<Device*>& workers) {
     return worker_modes_match;
 }
 
+void MeshDevice::enable_async(bool enable) {
+    for (auto device : this->devices) {
+        device->enable_async(enable);
+    }
+}
+
 std::vector<int> get_t3k_physical_device_ids_ring() {
     auto& instance = SystemMesh::instance();
     auto num_devices = instance.get_num_devices();

--- a/tt_metal/impl/device/mesh_device.hpp
+++ b/tt_metal/impl/device/mesh_device.hpp
@@ -152,6 +152,7 @@ class MeshDevice : public std::enable_shared_from_this<MeshDevice> {
     CoreCoord dram_grid_size() const;
 
     tt::ARCH arch() const;
+    void enable_async(bool enable);
 
     void close_devices();
     std::shared_ptr<const MeshDeviceView> get_view() const;

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -103,6 +103,16 @@ void py_module(py::module& module) {
             Returns:
                 Arch: The arch of the first device in the device mesh.
         )doc")
+        .def(
+            "enable_async",
+            &MeshDevice::enable_async,
+            py::arg("enable"),
+            R"doc(
+                Enable or disable async mode across all devices in the mesh.
+
+                Args:
+                    enable (bool): True to enable async mode, False to disable it.
+        )doc")
         .def_property_readonly("shape", &MeshDevice::shape, R"doc(
             Get the shape of the device mesh.
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/13454)

### Problem description
- Refactor API usage toward the eventual goal of MeshDevice interoperability as a virtual device using same interface as a physical device. 

### What's changed
- MeshDevice::enable_async 
- APIs will get incrementally updated in successive PRs

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
