### PR TITLE
Apply obvious fixes for issues identified during initial sweep run

### DIFF
--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
@@ -16,7 +16,7 @@ from tests.ttnn.unit_tests.operations.test_all_gather import is_unsupported_case
 from ttnn import ShardTensorToMesh
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
+TIMEOUT = 75
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -32,7 +32,7 @@ def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, in
     for i in input_shape:
         tensor_size_bytes *= i
     num_l1_banks = 64
-    if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
+    if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > (num_l1_banks * 256 * 1024):
         return True, "L1 buffer can't support large tensor sizes"
 
     # Check that each chip has a non-zero amount of data available


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
During an initial run through of the n300 allgather sweep tests, a handful of "obvious" errors were identified. This PR resolves those obvious issues

### What's changed
A few changes:
- Relaxed test case invalidation at pytest level that would be overly conservative and skip some cases because it thought they couldn't fit in L1/DRAM (even though they could)
- Updated timeout for sweeps as it was too long (after reset, device initialization seemed to take a while, often time leading to another timeout before the main test body was even enterred
- Fixed all-gather edm buffer sizing to support (much) larger pages.

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11170239688
- [ ] t3k pipelines: frequent, nightly, model-perf: https://github.com/tenstorrent/tt-metal/actions/runs/11170251637
- [ ] tg pipelines: https://github.com/tenstorrent/tt-metal/actions/runs/11170262941
- [x] N/A Blackhole Post commit (if applicable)
- [x] (above) Model regression CI testing passes (if applicable)
- [x] N/A Device performance regression CI testing passes (if applicable)
- [x] N/A New/Existing tests provide coverage for changes
