### PR TITLE
#13457: optimize slice perf by shortcutting to 4D uint32_t variant

### DIFF
--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -617,8 +617,9 @@ class TtFalconAttentionDecode(nn.Module):
         # key and value layers will have kv_seq_len padded to nearest 32
         key_layer = ttnn.slice(
             layer_past[0],
-            [0, 0, 0, 0],
-            [batch, 1, nearest_32(layer_past_len + 1), self.head_dim],
+            starts=(0, 0, 0, 0),
+            ends=(batch, 1, nearest_32(layer_past_len + 1), self.head_dim),
+            steps=(1, 1, 1, 1),
             memory_config=self.model_config["K_CACHE_SLICE_OUTPUT_MEMCFG"],
         )
 
@@ -746,8 +747,9 @@ class TtFalconAttentionDecode(nn.Module):
 
         value_layer = ttnn.slice(
             layer_past[1],
-            [0, 0, 0, 0],
-            [batch, 1, nearest_32(layer_past_len + 1), self.head_dim],
+            starts=(0, 0, 0, 0),
+            ends=(batch, 1, nearest_32(layer_past_len + 1), self.head_dim),
+            steps=(1, 1, 1, 1),
             memory_config=self.model_config["V_CACHE_SLICE_OUTPUT_MEMCFG"],
         )
         if self.model_config["l1_sharded"]:
@@ -798,13 +800,14 @@ class TtFalconAttentionDecode(nn.Module):
             attn_output_shape = attn_output.shape.with_tile_padding()
             attn_output = ttnn.slice(
                 attn_output,
-                [0, 0, 0, 0],
-                [
+                starts=(0, 0, 0, 0),
+                ends=(
                     attn_output_shape[0],
                     self.num_heads,
                     attn_output_shape[2],
                     attn_output_shape[3],
-                ],
+                ),
+                steps=(1, 1, 1, 1),
                 memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
             )
         else:

--- a/models/demos/falcon7b_common/tt/falcon_mlp.py
+++ b/models/demos/falcon7b_common/tt/falcon_mlp.py
@@ -367,8 +367,9 @@ class TtFalconMLPDecode(nn.Module):
         if self.model_config["PREFILL_OPTIMIZED_MODE"] and self.prefill_seq_len in [1024, 2048]:
             hidden_states = ttnn.slice(
                 hidden_states,
-                [0, 0, 0, 0],
-                [1, 1, batch_size, self.hidden_size],
+                starts=(0, 0, 0, 0),
+                ends=(1, 1, batch_size, self.hidden_size),
+                steps=(1, 1, 1, 1),
                 memory_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
             )
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -1024,7 +1024,9 @@ class resnet50:
 
         if is_wormhole_b0() and self.batch_size == 16:
             xshape = x.shape
-            x = ttnn.slice(x, [0, 0, 0, 0], [xshape[0], xshape[1], xshape[2], xshape[3]])
+            x = ttnn.slice(
+                x, starts=(0, 0, 0, 0), ends=(xshape[0], xshape[1], xshape[2], xshape[3]), steps=(1, 1, 1, 1)
+            )
 
         layer4_module1_input_shape = ttnn.Shape(x.shape.with_tile_padding())
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
@@ -689,8 +689,9 @@ class resnet50:
         unpadded_shape = x.shape
         x = ttnn.slice(
             x,
-            (0, 0, 0, 0),
-            (unpadded_shape[0], unpadded_shape[1], unpadded_shape[2], unpadded_shape[3]),
+            starts=(0, 0, 0, 0),
+            ends=(unpadded_shape[0], unpadded_shape[1], unpadded_shape[2], unpadded_shape[3]),
+            steps=(1, 1, 1, 1),
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
 

--- a/tests/ttnn/unit_tests/operations/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/test_slice.py
@@ -507,7 +507,7 @@ def test_slice_output_tensor_rm(device):
     torch_output = torch_input[..., ::2, ::2]  # torch_output shape: [1, 3, 320, 320]
 
     pages_before = ttnn._ttnn.reports.get_buffer_pages()
-    ttnn.slice(ttnn_input, [0, 0, 0, 0], [1, 3, 320, 320], output_tensor=ttnn_output)
+    ttnn.slice(ttnn_input, starts=(0, 0, 0, 0), ends=(1, 3, 320, 320), steps=(1, 1, 1, 1), output_tensor=ttnn_output)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
 
     ttnn_output = ttnn.to_torch(ttnn_output)
@@ -525,9 +525,51 @@ def test_slice_output_tensor_tile(device):
     torch_output = torch_input[..., ::2, ::2]  # torch_output shape: [1, 3, 320, 320]
 
     pages_before = ttnn._ttnn.reports.get_buffer_pages()
-    ttnn.slice(ttnn_input, [0, 0, 0, 0], [1, 3, 320, 320], output_tensor=ttnn_output)
+    ttnn.slice(ttnn_input, starts=(0, 0, 0, 0), ends=(1, 3, 320, 320), steps=(1, 1, 1, 1), output_tensor=ttnn_output)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
 
     ttnn_output = ttnn.to_torch(ttnn_output)
 
+    assert_with_pcc(torch_output, ttnn_output, 0.99)
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_start, input_ends",
+    (
+        ((1, 1, 1, 256), (0, 0, 0, 0), (1, 1, 1, 255)),
+        ((1, 32, 32, 32), (0, 0, 0, 0), (1, 32, 32, 1)),
+        ((1, 32, 32, 64), (0, 0, 0, 0), (1, 32, 1, 32)),
+        ((1, 1, 64, 64), (0, 0, 0, 0), (1, 1, 1, 1)),
+    ),
+)
+@pytest.mark.parametrize(
+    "layout",
+    (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+)
+@pytest.mark.parametrize(
+    "memory_config",
+    (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
+)
+def test_ttnn_slice_optimized_shapes(input_shape, input_start, input_ends, layout, memory_config, device):
+    if layout == ttnn.TILE_LAYOUT:
+        torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.bfloat16, layout=layout)
+    else:
+        if (input_ends[-1] - input_start[-1]) % 2:
+            pytest.skip("Cannot slice the last dimension to 1 in row major layout")
+        torch_input = torch.randn(input_shape, dtype=torch.float32)
+        ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.float32, layout=layout)
+
+    torch_output = torch_input[
+        input_start[0] : input_ends[0],
+        input_start[1] : input_ends[1],
+        input_start[2] : input_ends[2],
+        input_start[3] : input_ends[3],
+    ]
+
+    ttnn_output = ttnn.slice(
+        ttnn_input, starts=input_start, ends=input_ends, steps=(1, 1, 1, 1), memory_config=memory_config
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_output, ttnn_output, 0.99)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
@@ -17,7 +17,7 @@ uint32_t get_tiled_start_offset(const Tensor &input_tensor, const Shape &slice_s
 struct SliceDeviceOperation {
     const tt::tt_metal::LegacyShape slice_start;
     const tt::tt_metal::LegacyShape slice_end;
-    const std::optional<tt::tt_metal::LegacyShape> step;
+    const tt::tt_metal::LegacyShape step;
     const MemoryConfig output_mem_config;
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
@@ -7,6 +7,6 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks slice_multi_core(const Tensor& a, Tensor& output, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end, const std::optional<tt::tt_metal::LegacyShape>& step);
+operation::ProgramWithCallbacks slice_multi_core(const Tensor& a, Tensor& output, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end, const tt::tt_metal::LegacyShape& step);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "ttnn/common/constants.hpp"
 #include "slice.hpp"
 #include "device/slice_op.hpp"
@@ -10,15 +9,16 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/copy/copy.hpp"
 
 
 namespace ttnn::operations::data_movement {
 namespace detail {
-    uint32_t wrap_index(int index, int size) {
+    static inline uint32_t wrap_index(int index, int size) {
         return index < 0 ? size + index : index;
     }
-    uint32_t round_up_to_multiple_of_32(uint32_t value) {
-        return value == 0 ? 32 : ((value + 31) & ~31);
+    static inline uint32_t round_up_to_multiple_of_32(uint32_t value) {
+        return value == 0 ? 32u : ((value + 31u) & ~31);
     }
 }
 
@@ -34,34 +34,22 @@ ttnn::Tensor SliceOperation::invoke(
 
     // Ensure start and end vectors have matching sizes and correct tensor rank
     uint32_t input_rank = input_tensor.get_shape().rank();
-    // Check if we can use the optimized version for uint32_t and 4D tensors
-    if (begins.size() == 4 && ends.size() == 4 && step.size() == 4 && input_rank == 4) [[likely]] {
-        // Convert vectors to arrays
-        std::array<uint32_t, 4> begins_array;
-        std::array<uint32_t, 4> ends_array;
-        std::array<uint32_t, 4> step_array;
-        if constexpr (std::is_same_v<T, uint32_t>) {
-            std::copy(begins.begin(), begins.end(), begins_array.begin());
-            std::copy(ends.begin(), ends.end(), ends_array.begin());
-            std::copy(step.begin(), step.end(), step_array.begin());
-            // Call the optimized version
-            return SliceOperation::invoke<uint32_t, 4>(
-                queue_id, input_tensor, begins_array, ends_array, step_array,
-                memory_config_arg, optional_output_tensor);
+    const auto &input_shape = input_tensor.get_shape();
+    bool no_step = std::ranges::all_of(step, [](uint32_t s) { return s == 1; });
+    bool starts_zero = std::ranges::all_of(begins, [](uint32_t s) { return s == 0; });
+    bool ends_max = true;
+    for (size_t i = 0; i < ends.size(); ++i) {
+        ends_max &= ends[i] == input_shape[i];
+        if (!ends_max) {
+            break;
         }
-        else {
-            if (begins[0] >= 0 && begins[1] >= 0 && begins[2] >= 0 && begins[3] >= 0 && ends[0] >= 0 && ends[1] >= 0 && ends[2] >= 0 && ends[3] >= 0) [[likely]] {
-                if (input_tensor.get_layout() == Layout::ROW_MAJOR || (input_tensor.get_layout() == Layout::TILE && (ends[2]%32 == 0) && (ends[3]%32 == 0))) [[likely]] {
-                    // Call the optimized version
-                    std::copy(begins.begin(), begins.end(), begins_array.begin());
-                    std::copy(ends.begin(), ends.end(), ends_array.begin());
-                    std::copy(step.begin(), step.end(), step_array.begin());
-                    return SliceOperation::invoke<uint32_t, 4>(
-                        queue_id, input_tensor, begins_array, ends_array, step_array,
-                        memory_config_arg, optional_output_tensor);
-                }
-            }
+    }
+    if (no_step && starts_zero && ends_max) {
+        if (input_tensor.storage_type() == StorageType::DEVICE) {
+            auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config_arg.value_or(input_tensor.memory_config());
+            return ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
         }
+        return input_tensor;
     }
 
     TT_FATAL(input_rank == begins.size(), "Input rank {} and begins {} must have the same size", input_rank, begins.size());
@@ -118,8 +106,12 @@ ttnn::Tensor SliceOperation::invoke(
     }
 
     // Early exit if slice is a no-op (ends = padding ends and step = 1 for all dimensions)
-    bool no_step = std::all_of(step.begin(), step.end(), [](int i) {return i == 1;});
     if (tt::tt_metal::LegacyShape(padded_shape) == input_tensor.get_legacy_shape() and no_step) {
+        if (input_tensor.storage_type() == StorageType::DEVICE) {
+            auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config_arg.value_or(input_tensor.memory_config());
+            auto res = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            return ttnn::reshape(res, output_shape);
+        }
         return ttnn::reshape(input_tensor, output_shape);
     }
 
@@ -163,13 +155,11 @@ ttnn::Tensor SliceOperation::invoke(
                    SliceDeviceOperation{
                     tt::tt_metal::LegacyShape(modified_begins),
                     tt::tt_metal::LegacyShape(padded_ends),
-                    no_step ? std::nullopt : std::optional<tt::tt_metal::LegacyShape>(tt::tt_metal::LegacyShape(modified_step)),
+                    modified_step,
                     memory_config},
                     {input_4d}, {}, {optional_output_tensor}, queue_id)
             .at(0);
-        res = ttnn::reshape(res, output_shape);
-        return res;
-
+        return ttnn::reshape(res, output_shape);
     }
 }
 template<typename T>
@@ -188,109 +178,100 @@ template<>
 ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
     uint8_t queue_id,
     const ttnn::Tensor& input_tensor,
-    const std::array<uint32_t, 4> &output_tensor_start,
-    const std::array<uint32_t, 4> &output_tensor_end,
+    const std::array<uint32_t, 4> &begins,
+    const std::array<uint32_t, 4> &ends,
     const std::array<uint32_t, 4> &step,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<Tensor>& optional_output_tensor) {
 
-    bool efficient_path = input_tensor.storage_type() == StorageType::DEVICE && !input_tensor.is_sharded();
-    for (int i = 0; i < 4; ++i) {
-        efficient_path &= (step[i] == 1) && (output_tensor_end[i] > output_tensor_start[i]);
-        if (!efficient_path) {
-            break;
+    const auto& padded_input_shape = input_tensor.get_shape().with_tile_padding();
+    TT_FATAL(padded_input_shape.rank() == 4, "Input tensor must have rank 4");
+
+    bool no_step = step[0] == 1 && step[1] == 1 && step[2] == 1 && step[3] == 1;
+    bool starts_zero = begins[0]==0 && begins[1]==0 && begins[2]==0 && begins[3]==0;
+    bool ends_max = ends[0]==padded_input_shape[0] && ends[1]==padded_input_shape[1] && ends[2]==padded_input_shape[2] && ends[3]==padded_input_shape[3];
+
+    if (no_step && starts_zero && ends_max) {
+        if (input_tensor.storage_type() == StorageType::DEVICE) {
+            auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config_arg.value_or(input_tensor.memory_config());
+            return ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
         }
-    }
-    if (efficient_path) {
-        return operation::run(
-            SliceDeviceOperation{
-                tt::tt_metal::LegacyShape(output_tensor_start),
-                tt::tt_metal::LegacyShape(output_tensor_end),
-                std::nullopt,
-                memory_config_arg.value_or(input_tensor.memory_config())},
-            {input_tensor}, {}, {optional_output_tensor}, queue_id)
-            .at(0);
+        return input_tensor;
     }
 
-    const auto& input_shape = input_tensor.get_legacy_shape();
-    std::array<uint32_t, 4> modified_begins;
-    std::array<uint32_t, 4> modified_ends;
-    std::array<uint32_t, 4> modified_step = step;
+    const bool tiled = input_tensor.get_layout() == Layout::TILE;
+    bool on_device = input_tensor.storage_type() == StorageType::DEVICE;
 
-    bool no_step = true;
-    bool empty = false;
     std::array<uint32_t, 4> actual_shape;
     std::array<uint32_t, 4> padded_shape;
-
+    const std::array<uint32_t, 4> padded_ends = tiled ? std::array<uint32_t, 4>({ends[0], ends[1], detail::round_up_to_multiple_of_32(ends[2]), detail::round_up_to_multiple_of_32(ends[3])}) : ends;
+    bool empty = false;
     for (int i = 0; i < 4; ++i) {
-        // No need for wrap_index since we're using uint32_t
-        modified_begins[i] = output_tensor_start[i];
-        modified_ends[i] = output_tensor_end[i];
-
-        TT_FATAL(modified_ends[i] >= modified_begins[i], "End {} must be greater than or equal to start {}", modified_ends[i], modified_begins[i]);
-
-        no_step &= (step[i] == 1);
-
-        uint32_t dim_size = (modified_ends[i] - modified_begins[i] + step[i] - 1) / step[i];
+        TT_FATAL(ends[i] >= begins[i], "End {} must be greater than or equal to start {}", ends[i], begins[i]);
+        uint32_t offset = step[i] - begins[i] - 1;
+        uint32_t dim_size = (ends[i] + offset) / step[i];
+        empty |= dim_size == 0;
         actual_shape[i] = dim_size;
-        padded_shape[i] = (i >= 2 && input_tensor.get_layout() == Layout::TILE) ? std::max(dim_size, 32u) : std::max(dim_size, 1u);
-
-        if (dim_size == 0) {
-            empty = true;
-        }
+        padded_shape[i]= std::max((padded_ends[i] + offset) / step[i], 1u);
     }
 
     ttnn::Shape output_shape(actual_shape, padded_shape);
 
     if (empty) {
-        TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Host tensor slice cannot return a scalar or empty tensor");
+        TT_FATAL(on_device, "Host tensor slice cannot return a scalar or empty tensor");
+        auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config_arg.value_or(input_tensor.memory_config());
         return ttnn::empty(output_shape, input_tensor.dtype(), input_tensor.layout(),
-            input_tensor.device(), memory_config_arg.value_or(input_tensor.memory_config()));
+            input_tensor.device(), memory_config);
     }
 
     // Early exit if slice is a no-op
-    if (tt::tt_metal::LegacyShape(padded_shape) == input_shape && no_step) {
-        return ttnn::reshape(input_tensor, output_shape);
+    if (ttnn::Shape(padded_shape) == padded_input_shape && no_step) {
+        if (input_tensor.storage_type() == StorageType::DEVICE) {
+            auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config_arg.value_or(input_tensor.memory_config());
+            auto res = ttnn::to_memory_config(input_tensor, memory_config, std::nullopt);
+            return ttnn::reshape(res, output_shape);
+        }
+        return ttnn::reshape(input_tensor, output_shape); // change to view
     }
 
-    if (input_tensor.storage_type() != StorageType::DEVICE) {
-        TT_FATAL(no_step, "Host tensor slice does not support strides");
-        if (input_tensor.get_legacy_shape() == actual_shape) {
-            return input_tensor;
-        } else {
-            auto input_4d_rm = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (Device *)nullptr);
-            auto output_4d =  input_4d_rm.unpad(tt::tt_metal::LegacyShape(modified_begins), tt::tt_metal::LegacyShape(modified_ends));
-            auto output_4d_rm = ttnn::to_layout(output_4d, input_tensor.get_layout(), std::nullopt, std::nullopt, (Device *)nullptr);
-            return ttnn::reshape(output_4d_rm, output_shape);
-        }
-    } else {
+    if (on_device) {
         auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config_arg.value_or(input_tensor.memory_config());
 
         // Check for in-place unpad optimization
-        if (input_tensor.is_sharded() && input_tensor.memory_config() == memory_config && input_shape.rank() > 1) {
+        if (input_tensor.is_sharded() && input_tensor.memory_config() == memory_config && padded_input_shape.rank() > 1) {
             TT_FATAL(no_step, "Sharded tensor slice implementation does not support striding");
             bool in_place_unpad = true;
             for (int i = 0; i < 2; ++i) {
-                in_place_unpad &= modified_begins[i] == 0 && modified_ends[i] == 1 && input_shape[i] == 1;
+                in_place_unpad &= begins[i] == 0 && ends[i] == 1 && padded_input_shape[i] == 1;
             }
-            in_place_unpad &= modified_begins[2] == 0 &&
-                              tt::div_up(modified_ends[2], input_tensor.shard_spec().value().shape[0]) ==
-                                  tt::div_up(input_shape[2], input_tensor.shard_spec().value().shape[0]);
-            in_place_unpad &= modified_begins[3] == 0 && modified_ends[3] == input_shape[3];
+            in_place_unpad &= begins[2] == 0 &&
+                                tt::div_up(ends[2], input_tensor.shard_spec().value().shape[0]) ==
+                                    tt::div_up(padded_input_shape[2], input_tensor.shard_spec().value().shape[0]);
+            in_place_unpad &= begins[3] == 0 && ends[3] == padded_input_shape[3];
             if (in_place_unpad) {
                 return ttnn::reshape(input_tensor, output_shape);
             }
         }
 
         auto res = operation::run(
-                   SliceDeviceOperation{
-                    tt::tt_metal::LegacyShape(modified_begins),
-                    tt::tt_metal::LegacyShape(modified_ends),
-                    no_step ? std::nullopt : std::optional<tt::tt_metal::LegacyShape>(tt::tt_metal::LegacyShape(modified_step)),
+                    SliceDeviceOperation{
+                    begins,
+                    padded_ends,
+                    step,
                     memory_config},
-                    {input_tensor}, {}, {optional_output_tensor}, queue_id)
-            .at(0);
-        return res.get_shape() != output_shape ? ttnn::reshape(res, output_shape) : res;
+                    {input_tensor}, {}, {optional_output_tensor}, queue_id)[0];
+        return ttnn::reshape(res, output_shape);
+    }
+
+    TT_FATAL(no_step, "Host tensor slice does not support strides");
+
+    if (input_tensor.get_legacy_shape() == actual_shape) {
+        return input_tensor;
+    } else {
+        auto input_4d_rm = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (Device *)nullptr);
+        auto output_4d =  input_4d_rm.unpad(tt::tt_metal::LegacyShape(begins), tt::tt_metal::LegacyShape(ends));
+        auto output_4d_rm = ttnn::to_layout(output_4d, input_tensor.get_layout(), std::nullopt, std::nullopt, (Device *)nullptr);
+        return ttnn::reshape(output_4d_rm, output_shape);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
@@ -59,7 +59,28 @@ void bind_slice(py::module& module) {
                 py::arg("input_tensor"),
                 py::arg("slice_start"),
                 py::arg("slice_end"),
-                py::arg("step") = std::nullopt, // should consider a better default value
+                py::arg("slice_step") = std::nullopt, // should consider a better default value
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt,
+                py::arg("output_tensor") = std::nullopt,
+                py::arg("queue_id") = 0,
+                },
+
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const std::array<uint32_t, 4> &begins,
+                const std::array<uint32_t, 4> &ends,
+                const std::array<uint32_t, 4> &step,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                const std::optional<Tensor>& optional_output_tensor,
+                uint8_t queue_id) {
+                    return self(queue_id, input_tensor, begins, ends, step, memory_config, optional_output_tensor);
+                },
+                py::arg("input_tensor"),
+                py::arg("starts"),
+                py::arg("ends"),
+                py::arg("steps"),
                 py::kw_only(),
                 py::arg("memory_config") = std::nullopt,
                 py::arg("output_tensor") = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -158,9 +158,9 @@ Tensor AutoFormat::format_output_tensor(
             // Output can be unpadded and layout supports the shape
             if ((formatted_output.get_layout() == Layout::TILE && AutoFormat::legal_tile_shape(shape)) ||
                 (formatted_output.get_layout() == Layout::ROW_MAJOR && AutoFormat::legal_rm_shape(shape))) {
-                auto begins = std::vector<uint32_t>({0, 0, 0, 0});
-                auto ends = std::vector<uint32_t>({shape[0], shape[1], shape[2], shape[3]});
-                auto step = std::vector<uint32_t>({1, 1, 1, 1});
+                auto begins = std::array<uint32_t, 4>({0, 0, 0, 0});
+                auto ends = std::array<uint32_t, 4>({shape[0], shape[1], shape[2], shape[3]});
+                auto step = std::array<uint32_t, 4>({1, 1, 1, 1});
 
                 formatted_output = ttnn::slice(
                     DefaultQueueId,
@@ -189,9 +189,9 @@ Tensor AutoFormat::format_output_tensor(
             } else if (
                 formatted_output.get_layout() == Layout::ROW_MAJOR && target_layout == Layout::TILE &&
                 AutoFormat::legal_tile_shape(shape)) {
-                auto begins = std::vector<uint32_t>({0, 0, 0, 0});
-                auto ends = std::vector<uint32_t>({shape[0], shape[1], shape[2], shape[3]});
-                auto step = std::vector<uint32_t>({1, 1, 1, 1});
+                auto begins = std::array<uint32_t, 4>({0, 0, 0, 0});
+                auto ends = std::array<uint32_t, 4>({shape[0], shape[1], shape[2], shape[3]});
+                auto step = std::array<uint32_t, 4>({1, 1, 1, 1});
                 formatted_output = ttnn::slice(
                     DefaultQueueId,
                     formatted_output,
@@ -214,9 +214,9 @@ Tensor AutoFormat::format_output_tensor(
             formatted_output = formatted_output.to(Layout::ROW_MAJOR);
             convert_layout = formatted_output.get_layout() != target_layout;
         }
-        auto begins = std::vector<uint32_t>({0, 0, 0, 0});
-        auto ends = std::vector<uint32_t>({shape[0], shape[1], shape[2], shape[3]});
-        auto step = std::vector<uint32_t>({1, 1, 1, 1});
+        auto begins = std::array<uint32_t, 4>({0, 0, 0, 0});
+        auto ends = std::array<uint32_t, 4>({shape[0], shape[1], shape[2], shape[3]});
+        auto step = std::array<uint32_t, 4>({1, 1, 1, 1});
         formatted_output =
             ttnn::slice(formatted_output, begins, ends, step, std::nullopt);
     }


### PR DESCRIPTION
### Ticket
#13457 

### Problem description
E2E model perf fix for one iteration of falcon caused another to decrease in perf due to increased overhead. To fix this I added an inplace optimization. Unfortunately, this caused a regression in sharded falcon as I forgot to move to L1. By the time I discovered this I added even more optimizations so they're rolled in ehre.

### What's changed
- overload the pybind to accept uint32_t 4D arrays that avoid costly wrap arounds and unsqueezes
- shortcut for when ends=input_shape, begins is all 0  and step is all 1
- use to_memory_config() before every return (stops the DRAM spillage oopsie)

### Summarize the changes made and its impact.

Device perf goes from 511 samples/s to 530 samples/s on falcon7b sharded with sequence length 2047

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11183083051
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11167834088
- [ ] Device performance regression CI testing passes (if applicable) (unet breaks this right now so I can't see this but I tested locally)
- [x] New/Existing tests provide coverage for changes
