### PR TITLE
#13398: Dataparallel suppport for MNIST model

### DIFF
--- a/models/demos/wormhole/mnist/README.md
+++ b/models/demos/wormhole/mnist/README.md
@@ -1,0 +1,32 @@
+# MNIST
+
+## Platforms
+
+WH N150, WH N300
+
+## Introduction
+
+The MNIST model uses only fully connected linear layers to classify handwritten digits from the MNIST dataset. Despite the absence of convolutional layers, the model efficiently processes the 28x28 pixel images by flattening them into a 1D vector and passing them through multiple linear layers to predict the corresponding digit (0-9). This approach demonstrates how even simpler architectures can be applied for image classification tasks.
+
+### Batch size: 4
+
+Batch Size determines the number of input sequences processed simultaneously during training or inference, impacting computational efficiency and memory usage. It's recommended to set the batch_size to 4
+
+## How to Run
+
+To run the demo for digit classification using the MNIST model, follow these instructions:
+
+-  Use the following command to run the MNIST model.
+  ```
+  pytest models/demos/wormhole/mnist/demo/demo.py::test_demo_dataset
+  ```
+
+## Inputs
+
+The demo receives inputs from respective dataset MNIST.
+
+## Additional Information
+
+If you encounter issues when running the model, ensure that device has support for all required operations.
+
+### Owner: [sabira-mcw](https://github.com/sabira-mcw)

--- a/models/demos/wormhole/mnist/README.md
+++ b/models/demos/wormhole/mnist/README.md
@@ -8,9 +8,9 @@ WH N150, WH N300
 
 The MNIST model uses only fully connected linear layers to classify handwritten digits from the MNIST dataset. Despite the absence of convolutional layers, the model efficiently processes the 28x28 pixel images by flattening them into a 1D vector and passing them through multiple linear layers to predict the corresponding digit (0-9). This approach demonstrates how even simpler architectures can be applied for image classification tasks.
 
-### Batch size: 512
+### Batch size: 128
 
-Batch Size determines the number of input sequences processed simultaneously during training or inference, impacting computational efficiency and memory usage. It's recommended to set the batch_size to 512
+Batch Size determines the number of input sequences processed simultaneously during training or inference, impacting computational efficiency and memory usage. It's recommended to set the batch_size to 128
 
 ## How to Run
 
@@ -28,5 +28,3 @@ The demo receives inputs from respective dataset MNIST.
 ## Additional Information
 
 If you encounter issues when running the model, ensure that device has support for all required operations.
-
-### Owner: [sabira-mcw](https://github.com/sabira-mcw)

--- a/models/demos/wormhole/mnist/README.md
+++ b/models/demos/wormhole/mnist/README.md
@@ -8,9 +8,9 @@ WH N150, WH N300
 
 The MNIST model uses only fully connected linear layers to classify handwritten digits from the MNIST dataset. Despite the absence of convolutional layers, the model efficiently processes the 28x28 pixel images by flattening them into a 1D vector and passing them through multiple linear layers to predict the corresponding digit (0-9). This approach demonstrates how even simpler architectures can be applied for image classification tasks.
 
-### Batch size: 4
+### Batch size: 512
 
-Batch Size determines the number of input sequences processed simultaneously during training or inference, impacting computational efficiency and memory usage. It's recommended to set the batch_size to 4
+Batch Size determines the number of input sequences processed simultaneously during training or inference, impacting computational efficiency and memory usage. It's recommended to set the batch_size to 512
 
 ## How to Run
 

--- a/models/demos/wormhole/mnist/demo/demo.py
+++ b/models/demos/wormhole/mnist/demo/demo.py
@@ -68,7 +68,7 @@ def run_demo_dataset(batch_size, iterations, model_location_generator, mesh_devi
 
 
 @skip_for_grayskull()
-@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("batch_size", [512])
 @pytest.mark.parametrize("iterations", [1])
 def test_demo_dataset(
     batch_size,

--- a/models/demos/wormhole/mnist/demo/demo.py
+++ b/models/demos/wormhole/mnist/demo/demo.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from torchvision import transforms, datasets
+from loguru import logger
+
+from torch.utils.data import DataLoader
+from models.demos.wormhole.mnist.reference.mnist import MnistModel
+from models.demos.wormhole.mnist.tt import tt_mnist
+
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull
+
+
+def run_demo_dataset(batch_size, iterations, model_location_generator, mesh_device):
+    # Data preprocessing/loading
+    transform = transforms.Compose([transforms.ToTensor()])
+    test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
+
+    state_dict = torch.load(model_location_generator("mnist_model.pt", model_subdir="mnist"))
+    model = MnistModel(state_dict)
+    model = model.eval()
+
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+    with ttnn.distribute(ttnn.ReplicateTensorToMesh(mesh_device)):
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: model,
+            device=mesh_device,
+        )
+
+    correct = 0
+    for iters in range(iterations):
+        dataloader = DataLoader(test_dataset, batch_size=batch_size)
+        x, labels = next(iter(dataloader))
+        dataset_predictions = []
+        ttnn_predictions = []
+        dataset_ttnn_correct = 0
+        x = ttnn.from_torch(x, dtype=ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper, device=mesh_device)
+        tt_output = tt_mnist.mnist(mesh_device, batch_size, x, parameters)
+        tt_output = ttnn.to_torch(tt_output, mesh_composer=output_mesh_composer)
+        predicted_probabilities = torch.nn.functional.softmax(tt_output, dim=1)
+        _, predicted_label = torch.max(predicted_probabilities, 1)
+        tt_output = tt_output
+        for i in range(batch_size):
+            dataset_predictions.append(labels[i])
+            ttnn_predictions.append(predicted_label[i])
+            logger.info(f"Iter: {iters} Sample {i}:")
+            logger.info(f"Expected Label: {dataset_predictions[i]}")
+            logger.info(f"Predicted Label: {ttnn_predictions[i]}")
+
+            if dataset_predictions[i] == ttnn_predictions[i]:
+                dataset_ttnn_correct += 1
+                correct += 1
+
+        dataset_ttnn_accuracy = dataset_ttnn_correct / (batch_size)
+        logger.info(
+            f"MNIST Inference Accuracy for iter {iters} of {batch_size} input samples : {dataset_ttnn_accuracy}"
+        )
+
+    accuracy = correct / (batch_size * iterations)
+    logger.info(f"MNIST Inference Accuracy for {batch_size}x{iterations} Samples : {accuracy}")
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("iterations", [1])
+def test_demo_dataset(
+    batch_size,
+    iterations,
+    model_location_generator,
+    mesh_device,
+):
+    return run_demo_dataset(
+        batch_size=batch_size,
+        iterations=iterations,
+        model_location_generator=model_location_generator,
+        mesh_device=mesh_device,
+    )

--- a/models/demos/wormhole/mnist/reference/mnist.py
+++ b/models/demos/wormhole/mnist/reference/mnist.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+
+class MnistModel(torch.nn.Module):
+    def __init__(self, state_dict):
+        super().__init__()
+
+        self.fc1 = torch.nn.Linear(784, 120)
+        self.fc2 = torch.nn.Linear(120, 84)
+        self.fc3 = torch.nn.Linear(84, 10)
+
+        self.load_state_dict(state_dict)
+
+    def forward(self, x):
+        x = x.view(x.shape[0], -1)
+
+        x = self.fc1(x)
+        x = torch.nn.functional.relu(x)
+
+        x = self.fc2(x)
+        x = torch.nn.functional.relu(x)
+
+        x = self.fc3(x)
+        x = torch.nn.functional.relu(x)
+
+        return torch.nn.functional.softmax(x)

--- a/models/demos/wormhole/mnist/tests/test_perf_mnist.py
+++ b/models/demos/wormhole/mnist/tests/test_perf_mnist.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import time
+import pytest
+import torch
+from loguru import logger
+from torchvision import transforms, datasets
+from models.perf.perf_utils import prep_perf_report
+from models.demos.wormhole.mnist.tt import tt_mnist
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.demos.wormhole.mnist.reference.mnist import MnistModel
+from torch.utils.data import DataLoader
+from torchvision import transforms, datasets
+from models.utility_functions import (
+    enable_persistent_kernel_cache,
+    disable_persistent_kernel_cache,
+)
+from models.utility_functions import is_grayskull, is_wormhole_b0, skip_for_grayskull
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+
+transform = transforms.Compose([transforms.ToTensor()])
+test_dataset = datasets.MNIST(root="./data", train=False, transform=None, download=True)
+
+
+@skip_for_grayskull()
+def get_expected_times(tt_mnist):
+    if is_wormhole_b0():
+        return {
+            tt_mnist: (7.71, 0.0105),
+        }[tt_mnist]
+
+
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+@pytest.mark.parametrize(
+    "batch_size",
+    [32],
+)
+@pytest.mark.parametrize(
+    "tt_mnist",
+    [tt_mnist],
+)
+def test_performance_mnist(mesh_device, batch_size, tt_mnist, model_location_generator):
+    state_dict = torch.load(model_location_generator("mnist_model.pt", model_subdir="mnist"))
+    model = MnistModel(state_dict)
+    model = model.eval()
+    disable_persistent_kernel_cache()
+    transform = transforms.Compose([transforms.ToTensor()])
+    test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
+    dataloader = DataLoader(test_dataset, batch_size=batch_size)
+    x, labels = next(iter(dataloader))
+
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+    with ttnn.distribute(ttnn.ReplicateTensorToMesh(mesh_device)):
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: model,
+            device=mesh_device,
+        )
+
+    x = ttnn.from_torch(x, dtype=ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper, device=mesh_device)
+    durations = []
+
+    for _ in range(2):
+        start = time.time()
+
+        ttnn_output = tt_mnist.mnist(mesh_device, batch_size, x, parameters)
+        end = time.time()
+        durations.append(end - start)
+        # enable_persistent_kernel_cache()
+
+    inference_and_compile_time, *inference_times = durations
+    average_inference_time = sum(inference_times) / len(inference_times)
+    expected_compile_time, expected_inference_time = get_expected_times(tt_mnist)
+
+    prep_perf_report(
+        model_name="MNIST",
+        batch_size=batch_size,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=average_inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="",
+        inference_time_cpu=0.0,
+    )
+
+    logger.info(f"Compile time: {inference_and_compile_time - average_inference_time}")
+    logger.info(f"Inference time: {average_inference_time}")
+    logger.info(f"Inference times: {inference_times}")
+    logger.info(f"Sample(s) per second: {1 / average_inference_time * batch_size}")
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "batch_size, expected_perf",
+    [
+        [32, 143288.92],
+    ],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_perf_device_bare_metal(batch_size, expected_perf):
+    subdir = "ttnn_mnist"
+    num_iterations = 1
+    margin = 0.03
+
+    command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_perf}
+
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols)
+    prep_device_perf_report(
+        model_name=f"tt_mnist{batch_size}",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )

--- a/models/demos/wormhole/mnist/tests/test_perf_mnist.py
+++ b/models/demos/wormhole/mnist/tests/test_perf_mnist.py
@@ -29,7 +29,7 @@ test_dataset = datasets.MNIST(root="./data", train=False, transform=None, downlo
 def get_expected_times(tt_mnist):
     if is_wormhole_b0():
         return {
-            tt_mnist: (7.71, 0.0105),
+            tt_mnist: (10.460, 0.0139),
         }[tt_mnist]
 
 
@@ -37,7 +37,7 @@ def get_expected_times(tt_mnist):
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "batch_size",
-    [32],
+    [512],
 )
 @pytest.mark.parametrize(
     "tt_mnist",
@@ -98,7 +98,7 @@ def test_performance_mnist(mesh_device, batch_size, tt_mnist, model_location_gen
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [32, 143288.92],
+        [512, 2899420.682],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/wormhole/mnist/tests/test_perf_mnist_wh.py
+++ b/models/demos/wormhole/mnist/tests/test_perf_mnist_wh.py
@@ -8,10 +8,9 @@ import pytest
 import torch
 from loguru import logger
 from torchvision import transforms, datasets
+
 from models.perf.perf_utils import prep_perf_report
-from models.demos.wormhole.mnist.tt import tt_mnist
 from ttnn.model_preprocessing import preprocess_model_parameters
-from models.demos.wormhole.mnist.reference.mnist import MnistModel
 from torch.utils.data import DataLoader
 from torchvision import transforms, datasets
 from models.utility_functions import (
@@ -21,6 +20,9 @@ from models.utility_functions import (
 from models.utility_functions import is_grayskull, is_wormhole_b0, skip_for_grayskull
 from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
 
+from models.demos.wormhole.mnist.reference.mnist import MnistModel
+from models.demos.wormhole.mnist.tt import tt_mnist
+
 transform = transforms.Compose([transforms.ToTensor()])
 test_dataset = datasets.MNIST(root="./data", train=False, transform=None, download=True)
 
@@ -29,7 +31,7 @@ test_dataset = datasets.MNIST(root="./data", train=False, transform=None, downlo
 def get_expected_times(tt_mnist):
     if is_wormhole_b0():
         return {
-            tt_mnist: (10.460, 0.0139),
+            tt_mnist: (6.35, 0.00817),
         }[tt_mnist]
 
 
@@ -37,7 +39,7 @@ def get_expected_times(tt_mnist):
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "batch_size",
-    [512],
+    [128],
 )
 @pytest.mark.parametrize(
     "tt_mnist",
@@ -48,11 +50,12 @@ def test_performance_mnist(mesh_device, batch_size, tt_mnist, model_location_gen
     model = MnistModel(state_dict)
     model = model.eval()
     disable_persistent_kernel_cache()
+    mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
+    batch_size = (2 * batch_size) if mesh_device_flag else batch_size
     transform = transforms.Compose([transforms.ToTensor()])
     test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
     dataloader = DataLoader(test_dataset, batch_size=batch_size)
     x, labels = next(iter(dataloader))
-
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
@@ -71,34 +74,38 @@ def test_performance_mnist(mesh_device, batch_size, tt_mnist, model_location_gen
         ttnn_output = tt_mnist.mnist(mesh_device, batch_size, x, parameters)
         end = time.time()
         durations.append(end - start)
-        # enable_persistent_kernel_cache()
+        enable_persistent_kernel_cache()
 
     inference_and_compile_time, *inference_times = durations
-    average_inference_time = sum(inference_times) / len(inference_times)
+    inference_time = sum(inference_times) / len(inference_times)
     expected_compile_time, expected_inference_time = get_expected_times(tt_mnist)
 
     prep_perf_report(
         model_name="MNIST",
         batch_size=batch_size,
         inference_and_compile_time=inference_and_compile_time,
-        inference_time=average_inference_time,
+        inference_time=inference_time,
         expected_compile_time=expected_compile_time,
         expected_inference_time=expected_inference_time,
         comments="",
         inference_time_cpu=0.0,
     )
 
-    logger.info(f"Compile time: {inference_and_compile_time - average_inference_time}")
-    logger.info(f"Inference time: {average_inference_time}")
+    logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
+    logger.info(f"Inference time: {inference_time}")
     logger.info(f"Inference times: {inference_times}")
-    logger.info(f"Sample(s) per second: {1 / average_inference_time * batch_size}")
+    logger.info(f"Sample(s) per second: {1 / inference_time * batch_size}")
+    assert (
+        inference_time < expected_inference_time
+    ), f"Expected inference time: {expected_inference_time} Actual inference time: {inference_time}"
+    logger.info("Exit MNIST perf test")
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [512, 2899420.682],
+        [128, 1520045.60],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
@@ -107,14 +114,16 @@ def test_perf_device_bare_metal(batch_size, expected_perf):
     num_iterations = 1
     margin = 0.03
 
-    command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py"
+    command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist_wh.py"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
     expected_perf_cols = {inference_time_key: expected_perf}
-
+    mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
+    batch_size = (2 * batch_size) if mesh_device_flag else batch_size
     post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
-    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
+
     prep_device_perf_report(
         model_name=f"tt_mnist{batch_size}",
         batch_size=batch_size,

--- a/models/demos/wormhole/mnist/tt/tt_mnist.py
+++ b/models/demos/wormhole/mnist/tt/tt_mnist.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+
+
+def mnist(mesh_device, batch_size, x, parameters):
+    x = ttnn.reshape(x, (x.shape[0], -1))
+
+    x = ttnn.from_device(x)
+    x = ttnn.to_device(x, device=mesh_device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)
+
+    x = ttnn.linear(
+        x, parameters.fc1.weight, bias=parameters.fc1.bias, memory_config=ttnn.L1_MEMORY_CONFIG, activation="relu"
+    )
+
+    x = ttnn.linear(
+        x, parameters.fc2.weight, bias=parameters.fc2.bias, memory_config=ttnn.L1_MEMORY_CONFIG, activation="relu"
+    )
+
+    x = ttnn.linear(
+        x, parameters.fc3.weight, bias=parameters.fc3.bias, memory_config=ttnn.L1_MEMORY_CONFIG, activation="relu"
+    )
+
+    x = ttnn.softmax(x)
+    return x

--- a/models/demos/wormhole/mnist/tt/tt_mnist.py
+++ b/models/demos/wormhole/mnist/tt/tt_mnist.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-import torch
 
 
 def mnist(mesh_device, batch_size, x, parameters):

--- a/models/demos/wormhole/mnist/tt/tt_mnist.py
+++ b/models/demos/wormhole/mnist/tt/tt_mnist.py
@@ -12,17 +12,52 @@ def mnist(mesh_device, batch_size, x, parameters):
     x = ttnn.to_device(x, device=mesh_device, memory_config=ttnn.L1_MEMORY_CONFIG)
     x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT)
 
-    x = ttnn.linear(
-        x, parameters.fc1.weight, bias=parameters.fc1.bias, memory_config=ttnn.L1_MEMORY_CONFIG, activation="relu"
+    memory_config = ttnn.create_sharded_memory_config(
+        x.shape,
+        core_grid=ttnn.CoreGrid(y=mesh_device.core_grid.y, x=mesh_device.core_grid.x),
+        strategy=ttnn.ShardStrategy.BLOCK,
+        # orientation=ttnn.ShardOrientation.TILE,
     )
 
     x = ttnn.linear(
-        x, parameters.fc2.weight, bias=parameters.fc2.bias, memory_config=ttnn.L1_MEMORY_CONFIG, activation="relu"
+        x,
+        parameters.fc1.weight,
+        bias=parameters.fc1.bias,
+        memory_config=memory_config,
+        activation="relu",
+        core_grid=mesh_device.core_grid,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+        ),
     )
 
     x = ttnn.linear(
-        x, parameters.fc3.weight, bias=parameters.fc3.bias, memory_config=ttnn.L1_MEMORY_CONFIG, activation="relu"
+        x,
+        parameters.fc2.weight,
+        bias=parameters.fc2.bias,
+        memory_config=memory_config,
+        activation="relu",
+        core_grid=mesh_device.core_grid,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+        ),
     )
+
+    x = ttnn.linear(
+        x,
+        parameters.fc3.weight,
+        bias=parameters.fc3.bias,
+        memory_config=memory_config,
+        activation="relu",
+        core_grid=mesh_device.core_grid,
+        compute_kernel_config=ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+        ),
+    )
+
+    if x.is_sharded():
+        x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
 
     x = ttnn.softmax(x)
+
     return x

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -120,6 +120,7 @@ run_device_perf_models() {
     fi
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
+
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests/test_unet_perf.py -m $test_marker

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -23,6 +23,8 @@ run_perf_models_other() {
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/test_perf_yolo.py -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests/test_perf_distilbert.py -m $test_marker
+
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mnist/tests/test_perf_mnist.py -m $test_marker
     fi
 
     env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker
@@ -133,6 +135,8 @@ run_device_perf_models() {
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/yolov4/tests/ -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/distilbert/tests -m $test_marker
+        
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yam pytets models/demos/wormhole/mnist/tests/test_perf_mnist.py::test_performance_mnist -m $test_marker
     fi
 
     ## Merge all the generated reports

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -44,6 +44,9 @@ run_common_func_tests() {
   # Resnet
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/demo/demo.py; fail+=$?
 
+  #MNIST
+  pytest --disable-warnings models/demos/wormhole/mnist/demo/demo.py --timeout 600; fail+=$?
+
   # Distilbert
   pytest --disable-warnings models/demos/distilbert/demo/demo.py --timeout 600; fail+=$?
 

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -62,6 +62,8 @@ run_common_func_tests() {
   #RoBERTa
   pytest --disable-warnings models/demos/roberta/demo/demo.py --timeout 600; fail+=$?
 
+  #MNIST
+  pytest --disable-warnings models/demos/wormhole/mnist/demo/demo.py --timeout 600; fail+=$?
   return $fail
 }
 
@@ -96,6 +98,8 @@ run_n300_func_tests() {
   fail=0;
 
   run_common_func_tests; fail+=$?
+
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/experimental/functional_mnist/demo/demo.py; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     exit 1

--- a/tests/ttnn/integration_tests/mnist/test_mnist_wh.py
+++ b/tests/ttnn/integration_tests/mnist/test_mnist_wh.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import ttnn
+import pytest
+from torch.utils.data import DataLoader
+from torchvision import transforms, datasets
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull
+
+from models.demos.wormhole.mnist.reference.mnist import MnistModel
+from models.demos.wormhole.mnist.tt import tt_mnist
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "batch_size",
+    [128],
+)
+def test_mnist(mesh_device, reset_seeds, batch_size, model_location_generator):
+    state_dict = torch.load(model_location_generator("mnist_model.pt", model_subdir="mnist"))
+    model = MnistModel(state_dict)
+    model = model.eval()
+    transform = transforms.Compose([transforms.ToTensor()])
+    test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
+    mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
+    batch_size = (2 * batch_size) if mesh_device_flag else batch_size
+    dataloader = DataLoader(test_dataset, batch_size=batch_size)
+    x, labels = next(iter(dataloader))
+    torch_output = model(x)
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+
+    with ttnn.distribute(ttnn.ReplicateTensorToMesh(mesh_device)):
+        parameters = preprocess_model_parameters(initialize_model=lambda: model, device=mesh_device)
+    x = ttnn.from_torch(x, dtype=ttnn.bfloat16, mesh_mapper=inputs_mesh_mapper, device=mesh_device)
+    tt_output = tt_mnist.mnist(mesh_device, batch_size, x, parameters)
+    tt_output = ttnn.to_torch(tt_output, mesh_composer=output_mesh_composer)
+
+    assert_with_pcc(torch_output, tt_output, 0.999)


### PR DESCRIPTION
### Ticket
[Link to the GitHub Issue](https://github.com/tenstorrent/tt-metal/issues/13398)

### Problem description
Data Parallel implementation for MNIST model- WIP.

### What's changed
The MNIST model is configured to run on either N150 or N300, depending on the available machine.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
