### PR TITLE
TG Llama3-70b prefill frequent tests enabled

### DIFF
--- a/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
@@ -415,11 +415,11 @@ def run_test_LlamaAttention_inference(
     "batch, seq_len, pcc",
     [
         (32, 1, 0.9995),
-        #  (1, 256, 0.999)
+        (1, 256, 0.999),
     ],
     ids=[
         "decode",
-        #  "prefill"
+        "prefill",
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
@@ -396,11 +396,11 @@ def run_test_LlamaDecoder_inference(
     "batch, seq_len, pcc",
     [
         (32, 1, 0.995),
-        #  (1, 256, 0.995)
+        (1, 256, 0.995),
     ],
     ids=[
         "decode",
-        #  "prefill"
+        "prefill",
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
@@ -167,11 +167,11 @@ def run_test_LlamaMLP_inference(
     "batch, seq_len, pcc",
     [
         (32, 1, 0.9997),
-        #  (1, 256, 0.9995)
+        (1, 256, 0.9995),
     ],
     ids=[
         "decode",
-        #  "prefill"
+        "prefill",
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
@@ -27,11 +27,11 @@ from models.demos.tg.llama3_70b.tests.test_llama_model_galaxy import run_test_Ll
     "batch, seq_len",
     [
         (32, 1),
-        #  (1, 256)
+        (1, 256),
     ],
     ids=[
         "decode",
-        #  "prefill"
+        "prefill",
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -359,7 +359,7 @@ class TtLlamaModel_galaxy:
             epsilon=self.norm_eps,
             gamma=self.norm_sharded,
             mesh_device=self.mesh_device,
-            compute_kernel_config=self.LN_COMPUTE_KERNEL_CONFIG,
+            compute_kernel_config=self.core_model_config["LN_COMPUTE_KERNEL_CONFIG"],
         )
         # Slice out last padding_length(32) tokens in LM head to produce next token
         # TODO: Does not work for perplexity, or if we padded input to current sequence length

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -4,15 +4,15 @@ run_tg_tests() {
   # Add tests here
   echo "LOG_METAL: running run_tg_frequent_tests"
 
-  # pytest -n auto tests/ttnn/multichip_unit_tests/test_data_parallel_example_TG.py --timeout=900 ; fail+=$?
-  # pytest -n auto tests/ttnn/multichip_unit_tests/test_multidevice_TG.py --timeout=900 ; fail+=$?
-  # pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
+  pytest -n auto tests/ttnn/multichip_unit_tests/test_data_parallel_example_TG.py --timeout=900 ; fail+=$?
+  pytest -n auto tests/ttnn/multichip_unit_tests/test_multidevice_TG.py --timeout=900 ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py --timeout=300 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py --timeout=480 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py --timeout=600 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py --timeout=800 ; fail+=$?
-  # pytest -n auto models/demos/tg/resnet50/tests/test_resnet50_performant.py ; fail+=$?
-  # pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py --timeout=300 ; fail+=$?
+  pytest -n auto models/demos/tg/resnet50/tests/test_resnet50_performant.py ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py --timeout=300 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_frequent_tests failed"

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -4,15 +4,15 @@ run_tg_tests() {
   # Add tests here
   echo "LOG_METAL: running run_tg_frequent_tests"
 
-  pytest -n auto tests/ttnn/multichip_unit_tests/test_data_parallel_example_TG.py --timeout=900 ; fail+=$?
-  pytest -n auto tests/ttnn/multichip_unit_tests/test_multidevice_TG.py --timeout=900 ; fail+=$?
-  pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
+  # pytest -n auto tests/ttnn/multichip_unit_tests/test_data_parallel_example_TG.py --timeout=900 ; fail+=$?
+  # pytest -n auto tests/ttnn/multichip_unit_tests/test_multidevice_TG.py --timeout=900 ; fail+=$?
+  # pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py --timeout=300 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py --timeout=480 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py --timeout=600 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py --timeout=800 ; fail+=$?
-  pytest -n auto models/demos/tg/resnet50/tests/test_resnet50_performant.py ; fail+=$?
-  pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py --timeout=300 ; fail+=$?
+  # pytest -n auto models/demos/tg/resnet50/tests/test_resnet50_performant.py ; fail+=$?
+  # pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py --timeout=300 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tg_frequent_tests failed"


### PR DESCRIPTION
### Problem description
Enable TG Llama3-70b prefill frequent CI tests.

### What's changed
Prefill tests are uncommented and now are run as part of frequent CI tests

### Checklist
- [x] TG Frequent CI tests: https://github.com/tenstorrent/tt-metal/actions/runs/11178228548
