### PR TITLE
#13026: Enable full dst synchronization scheme

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
@@ -16,6 +16,7 @@ struct CopyBlockMatmulPartialsConfig {
     uint32_t compute_ublock;
     uint32_t src0_cb_index;
     uint32_t ouput_cb_index;
+    bool dst_full_sync_en;
 };
 
 void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const CopyBlockMatmulPartialsConfig& test_config) {
@@ -81,7 +82,8 @@ void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const 
         program,
         "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
         core,
-        tt_metal::ComputeConfig{.compile_args = compute_kernel_args}
+        tt_metal::ComputeConfig{.dst_full_sync_en = test_config.dst_full_sync_en,
+                                .compile_args = compute_kernel_args}
     );
 
 
@@ -153,53 +155,65 @@ void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const 
 //
 ////////////////////////////////////////////////////////////////////////////
 TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR8W8C8) {
-    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
-        .single_tile_size = 2 * 1024,
-        .num_tiles = 8,
-        .reader_ublock = 8,
-        .writer_ublock = 8,
-        .compute_ublock = 8,
-        .src0_cb_index = 0,
-        .ouput_cb_index = 16
-    };
-    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    for (bool dst_full_sync_en : {true, false}) {
+        unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+            .single_tile_size = 2 * 1024,
+            .num_tiles = 8,
+            .reader_ublock = 8,
+            .writer_ublock = 8,
+            .compute_ublock = 8,
+            .src0_cb_index = 0,
+            .ouput_cb_index = 16,
+            .dst_full_sync_en = dst_full_sync_en
+        };
+        unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    }
 }
 
 TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR8W8C1) {
-    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
-        .single_tile_size = 2 * 1024,
-        .num_tiles = 8,
-        .reader_ublock = 8,
-        .writer_ublock = 8,
-        .compute_ublock = 1,
-        .src0_cb_index = 0,
-        .ouput_cb_index = 16
-    };
-    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    for (bool dst_full_sync_en : {true, false}) {
+        unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+            .single_tile_size = 2 * 1024,
+            .num_tiles = 8,
+            .reader_ublock = 8,
+            .writer_ublock = 8,
+            .compute_ublock = 1,
+            .src0_cb_index = 0,
+            .ouput_cb_index = 16,
+            .dst_full_sync_en = dst_full_sync_en
+        };
+        unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    }
 }
 
 TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR8W1C1) {
-    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
-        .single_tile_size = 2 * 1024,
-        .num_tiles = 8,
-        .reader_ublock = 8,
-        .writer_ublock = 1,
-        .compute_ublock = 1,
-        .src0_cb_index = 0,
-        .ouput_cb_index = 16
-    };
-    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    for (bool dst_full_sync_en : {true, false}) {
+        unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+            .single_tile_size = 2 * 1024,
+            .num_tiles = 8,
+            .reader_ublock = 8,
+            .writer_ublock = 1,
+            .compute_ublock = 1,
+            .src0_cb_index = 0,
+            .ouput_cb_index = 16,
+            .dst_full_sync_en = dst_full_sync_en
+        };
+        unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    }
 }
 
 TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR1W1C1) {
-    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
-        .single_tile_size = 2 * 1024,
-        .num_tiles = 1,
-        .reader_ublock = 1,
-        .writer_ublock = 1,
-        .compute_ublock = 1,
-        .src0_cb_index = 0,
-        .ouput_cb_index = 16
-    };
-    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    for (bool dst_full_sync_en : {true, false}) {
+        unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+            .single_tile_size = 2 * 1024,
+            .num_tiles = 1,
+            .reader_ublock = 1,
+            .writer_ublock = 1,
+            .compute_ublock = 1,
+            .src0_cb_index = 0,
+            .ouput_cb_index = 16,
+            .dst_full_sync_en = dst_full_sync_en
+        };
+        unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+    }
 }

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
@@ -52,6 +52,7 @@ struct ReduceConfig {
     std::vector<uint32_t> result_shape;
     bool math_only_reduce = false;
     bool fp32_dest_acc_en = false;
+    bool dst_full_sync_en = false;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
 
@@ -315,6 +316,7 @@ void run_single_core_reduce_program(tt_metal::Device* device, const ReduceConfig
         core,
         tt_metal::ComputeConfig{.math_fidelity = test_config.math_fidelity,
                                 .fp32_dest_acc_en = test_config.fp32_dest_acc_en,
+                                .dst_full_sync_en = test_config.dst_full_sync_en,
                                 .compile_args = compute_kernel_args,
                                 .defines = reduce_defines});
 
@@ -382,22 +384,25 @@ TEST_F(DeviceFixture, ComputeReduceH) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::H,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_h,
-                    .result_shape = result_shape,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid),
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::H,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_h,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid),
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -411,23 +416,26 @@ TEST_F(DeviceFixture, ComputeReduceW) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::W,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_w,
-                    .result_shape = result_shape,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid),
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::W,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_w,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid),
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -441,24 +449,27 @@ TEST_F(DeviceFixture, ComputeReduceHW) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                // Currently fp32 dest unsupported with reduce scalar
-                if (fp32_dest_acc_en) continue;
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::HW,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_hw,
-                    .result_shape = result_shape,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    // Currently fp32 dest unsupported with reduce scalar
+                    if (fp32_dest_acc_en) continue;
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::HW,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_hw,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -476,23 +487,26 @@ TEST_F(DeviceFixture, ComputeReduceHMathOnly) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::H,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_h,
-                    .result_shape = result_shape,
-                    .math_only_reduce = true,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::H,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_h,
+                        .result_shape = result_shape,
+                        .math_only_reduce = true,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -506,24 +520,27 @@ TEST_F(DeviceFixture, ComputeReduceWMathOnly) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::W,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_w,
-                    .result_shape = result_shape,
-                    .math_only_reduce = true,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::W,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_w,
+                        .result_shape = result_shape,
+                        .math_only_reduce = true,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -537,25 +554,28 @@ TEST_F(DeviceFixture, ComputeReduceHWMathOnly) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                // Currently fp32 dest unsupported with reduce scalar
-                if (fp32_dest_acc_en) continue;
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::HW,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_hw,
-                    .result_shape = result_shape,
-                    .math_only_reduce = true,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    // Currently fp32 dest unsupported with reduce scalar
+                    if (fp32_dest_acc_en) continue;
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::HW,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_hw,
+                        .result_shape = result_shape,
+                        .math_only_reduce = true,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -573,23 +593,26 @@ TEST_F(DeviceFixture, ComputeReduceHShortInit) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .short_init = true,
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::H,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_h,
-                    .result_shape = result_shape,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .short_init = true,
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::H,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_h,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -603,24 +626,27 @@ TEST_F(DeviceFixture, ComputeReduceWShortInit) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .short_init = true,
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::W,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_w,
-                    .result_shape = result_shape,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .short_init = true,
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::W,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_w,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }
@@ -634,25 +660,28 @@ TEST_F(DeviceFixture, ComputeReduceHWShortInit) {
         if (math_fid == 1) continue;
         for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                // Currently fp32 dest unsupported with reduce scalar
-                if (fp32_dest_acc_en) continue;
-                log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}", math_fid, reduce_type, fp32_dest_acc_en);
-                ReduceConfig test_config = {
-                    .short_init = true,
-                    .shape = shape,
-                    .reduce_dim = ReduceDim::HW,
-                    .reduce_type = ReduceType(reduce_type),
-                    .data_gen_rand_max = 10.0f,
-                    .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
-                    .data_gen_offset = -10.0f,
-                    .atol = 1e-2f,
-                    .rtol = 0.08f,
-                    .golden_function = unit_tests::compute::gold_reduce_hw,
-                    .result_shape = result_shape,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .math_fidelity = MathFidelity(math_fid)
-                };
-                run_single_core_reduce_program(this->devices_.at(0), test_config);
+                for (bool dst_full_sync_en : {true, false}) {
+                    // Currently fp32 dest unsupported with reduce scalar
+                    if (fp32_dest_acc_en) continue;
+                    log_info(LogTest, "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}", math_fid, reduce_type, fp32_dest_acc_en, dst_full_sync_en);
+                    ReduceConfig test_config = {
+                        .short_init = true,
+                        .shape = shape,
+                        .reduce_dim = ReduceDim::HW,
+                        .reduce_type = ReduceType(reduce_type),
+                        .data_gen_rand_max = 10.0f,
+                        .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                        .data_gen_offset = -10.0f,
+                        .atol = 1e-2f,
+                        .rtol = 0.08f,
+                        .golden_function = unit_tests::compute::gold_reduce_hw,
+                        .result_shape = result_shape,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_fidelity = MathFidelity(math_fid)
+                    };
+                    run_single_core_reduce_program(this->devices_.at(0), test_config);
+                }
             }
         }
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/common/chlkc_list.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/common/chlkc_list.h
@@ -14,6 +14,7 @@ using namespace ckernel;
 #ifdef UCK_CHLKC_MATH
 // clang-format off
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_math_approx_mode.h"
 #include "chlkc_math_fidelity.h"
 #include "chlkc_unpack_data_format.h"
@@ -24,6 +25,7 @@ using namespace ckernel;
 #ifdef UCK_CHLKC_PACK
 // clang-format off
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_pack_data_format.h"
 #include "chlkc_pack.cpp"
 // clang-format on
@@ -32,6 +34,7 @@ using namespace ckernel;
 #ifdef UCK_CHLKC_UNPACK
 // clang-format off
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_unpack_data_format.h"
 #include "chlkc_unpack.cpp"
 // clang-format on

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
@@ -54,7 +54,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest,
         is_fp32_dest_acc_en>(num_faces, dst_index, clear_fp32_dst_acc);
@@ -77,7 +77,7 @@ inline void llk_math_eltwise_binary(
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest,
         is_fp32_dest_acc_en>(num_faces, dst_index, clear_fp32_dst_acc);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -26,7 +26,7 @@ inline void llk_math_eltwise_binary_sfpu(
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
 
-    _llk_math_eltwise_binary_sfpu_<sfpu_op, APPROXIMATE, DstSync::SyncHalf>(
+    _llk_math_eltwise_binary_sfpu_<sfpu_op, APPROXIMATE, DST_SYNC_MODE>(
         face_r_dim, num_faces, dst_index_a, dst_index_b, vector_mode, param0, param1, param2, param3, param4, param5);
 }
 
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_init(
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32(
     const uint operand, uint dst_index_a, uint dst_index_b, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu<SfpuType::quant_int32, APPROXIMATE, DstSync::SyncHalf>(operand, dst_index_a, dst_index_b, vector_mode);
+    llk_math_eltwise_binary_sfpu<SfpuType::quant_int32, APPROXIMATE>(operand, dst_index_a, dst_index_b, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -50,7 +50,7 @@ inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point)
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32(
     const uint operand, uint dst_index_a, uint dst_index_b, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu<SfpuType::requant_int32, APPROXIMATE, DstSync::SyncHalf>(operand, dst_index_a, dst_index_b, vector_mode);
+    llk_math_eltwise_binary_sfpu<SfpuType::requant_int32, APPROXIMATE>(operand, dst_index_a, dst_index_b, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -61,7 +61,7 @@ inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_poin
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32(
     const uint operand, uint dst_index_a, uint dst_index_b, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu<SfpuType::dequant_int32, APPROXIMATE, DstSync::SyncHalf>(operand, dst_index_a, dst_index_b, vector_mode);
+    llk_math_eltwise_binary_sfpu<SfpuType::dequant_int32, APPROXIMATE>(operand, dst_index_a, dst_index_b, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -28,18 +28,18 @@ inline void llk_math_hw_configure_disaggregated() {
 
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
     WAYPOINT("MWDD");
 }
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_dest_section_done() {
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_pack_sync_init() {
-    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool mail2math = true, bool mail2pack = true>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -18,7 +18,7 @@ template <
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DstSync::SyncHalf, is_fp32_dest_acc_en, unpack_to_dest>(
+    _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DST_SYNC_MODE, is_fp32_dest_acc_en, unpack_to_dest>(
         dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
 }
 
@@ -34,7 +34,7 @@ inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint nti
         _llk_math_eltwise_unary_datacopy_<
             type,
             src_b_bcast_type,
-            DstSync::SyncHalf,
+            DST_SYNC_MODE,
             is_fp32_dest_acc_en,
             unpack_to_dest>(dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "chlkc_list.h"
 #include "circular_buffer.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -175,7 +176,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-    _llk_pack_<DstSync::SyncHalf, untilize, is_fp32_dest_acc_en>(
+    _llk_pack_<DST_SYNC_MODE, untilize, is_fp32_dest_acc_en>(
         tile_index,
         pack_tile_addr
     );
@@ -251,7 +252,7 @@ inline void llk_matmul_pack(
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-        _llk_pack_<DstSync::SyncHalf, untilize, is_fp32_dest_acc_en>(tile_index, pack_tile_addr);
+        _llk_pack_<DST_SYNC_MODE, untilize, is_fp32_dest_acc_en>(tile_index, pack_tile_addr);
     }
 }
 
@@ -271,7 +272,7 @@ inline void llk_packer_set_math_semaphore() {
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_pack_dest_section_done() {
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool untilize = false, bool diagonal = false>
@@ -280,7 +281,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor>(
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor>(
         face_r_dim,
         narrow_tile
     );
@@ -292,7 +293,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, is_fp32_dest_acc_en>(
+    _llk_pack_dest_init_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, is_fp32_dest_acc_en>(
         face_r_dim,
         narrow_tile
     );

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_params.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_params.h
@@ -13,7 +13,7 @@ inline void llk_math_eltwise_unary_sfpu_params(
     int vector_mode = (int)VectorMode::RC,
     ARGS&& ... args) {
 
-    _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(dst_index);
+    _llk_math_eltwise_unary_sfpu_start_<DST_SYNC_MODE>(dst_index);
 
     if (vector_mode == (int)VectorMode::R) {
         // Do a row vector, Face0 + Face1 -- first iteration (first row)

--- a/tt_metal/hw/ckernels/grayskull/metal/common/chlkc_list.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/common/chlkc_list.h
@@ -17,18 +17,21 @@ using namespace ckernel;
 #include "chlkc_math_fidelity.h"
 #include "chlkc_math_approx_mode.h"
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_math.cpp"
 #endif
 
 #ifdef UCK_CHLKC_PACK
 #include "chlkc_pack_data_format.h"
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_pack.cpp"
 #endif
 
 #ifdef UCK_CHLKC_UNPACK
 #include "chlkc_unpack_data_format.h"
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_unpack.cpp"
 #endif
 

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_binary_api.h
@@ -59,7 +59,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest,
         is_fp32_dest_acc_en>(num_faces, num_faces, dst_index, clear_fp32_dst_acc);
@@ -82,7 +82,7 @@ inline void llk_math_eltwise_binary(
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest,
         is_fp32_dest_acc_en>(num_faces, num_faces, dst_index, clear_fp32_dst_acc);

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_common_api.h
@@ -23,18 +23,18 @@ inline void llk_math_hw_configure_disaggregated() { /*Unused for GS*/ }
 
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
     WAYPOINT("MWDD");
 }
 
 template <bool is_fp32_dest_acc_en = false /*not used*/>
 inline void llk_math_dest_section_done() {
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool is_fp32_dest_acc_en = false /*not used*/>
 inline void llk_math_pack_sync_init() {
-    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool mail2math = true, bool mail2pack = true>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -17,7 +17,7 @@ template <
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0 /* unused */) {
 
-    _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DstSync::SyncHalf, is_fp32_dest_acc_en>(dst_index);
+    _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DST_SYNC_MODE, is_fp32_dest_acc_en>(dst_index);
 }
 
 template <DataCopyType type, BroadcastType src_b_bcast_type = BroadcastType::NONE,  bool is_fp32_dest_acc_en = false, bool unpack_to_dest = false>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -30,7 +30,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_log(uint dst_index, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu<SfpuType::log, APPROXIMATE, DstSync::SyncHalf>(dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu<SfpuType::log, APPROXIMATE>(dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -41,7 +41,7 @@ inline void llk_math_eltwise_unary_sfpu_log_init() {
 //abs
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu<SfpuType::abs, APPROXIMATE, DstSync::SyncHalf>(dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu<SfpuType::abs, APPROXIMATE>(dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -52,7 +52,7 @@ inline void llk_math_eltwise_unary_sfpu_abs_init() {
 //log with base
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_log_with_base(uint dst_index, uint base, int vector_mode = VectorMode::RC) {
-  llk_math_eltwise_unary_sfpu<SfpuType::log_with_base, APPROXIMATE, DstSync::SyncHalf>(dst_index, vector_mode, base);
+  llk_math_eltwise_unary_sfpu<SfpuType::log_with_base, APPROXIMATE>(dst_index, vector_mode, base);
 }
 
 template <bool APPROXIMATE>
@@ -62,7 +62,7 @@ inline void llk_math_eltwise_unary_sfpu_log_with_base_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu<SfpuType::tanh, APPROXIMATE, DstSync::SyncHalf>(dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu<SfpuType::tanh, APPROXIMATE>(dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -73,7 +73,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 inline void llk_math_eltwise_unary_sfpu_dropout(
     uint dst_index, int vector_mode, int integer_dropout, int scale_factor) {
     constexpr bool dont_care = false;
-    llk_math_eltwise_unary_sfpu<SfpuType::dropout, dont_care, DstSync::SyncHalf>(
+    llk_math_eltwise_unary_sfpu<SfpuType::dropout, dont_care>(
         dst_index, vector_mode, integer_dropout, scale_factor);
 }
 
@@ -86,7 +86,7 @@ inline void llk_math_eltwise_unary_sfpu_dropout_init(uint seed = 0) {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_max(uint dst_index, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu<SfpuType::max, APPROXIMATE, DstSync::SyncHalf>(dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu<SfpuType::max, APPROXIMATE>(dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -96,7 +96,7 @@ inline void llk_math_eltwise_unary_sfpu_max_init() {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_square(uint dst_index, int vector_mode = VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu<SfpuType::square, APPROXIMATE, DstSync::SyncHalf>(dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu<SfpuType::square, APPROXIMATE>(dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_pack_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_template.h"
@@ -112,7 +113,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-    _llk_pack_<out_of_order_output, DstSync::SyncHalf, untilize, is_fp32_dest_acc_en>(
+    _llk_pack_<out_of_order_output, DST_SYNC_MODE, untilize, is_fp32_dest_acc_en>(
         tile_index,
         pack_dst_format[output_id],
         pack_tile_addr
@@ -177,17 +178,17 @@ inline void llk_packer_set_math_semaphore() {
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_pack_dest_section_done() {
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool untilize = false, bool diagonal = false>
 inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_output = 16) {
-    _llk_init_packer_dest_offset_registers_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, untilize, diagonal>();
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, untilize, diagonal>();
 }
 
 template <bool untilize = false, bool is_fp32_dest_acc_en = false /*unused*/>
 inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
-    _llk_pack_dest_init_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, untilize, is_fp32_dest_acc_en>();
+    _llk_pack_dest_init_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, untilize, is_fp32_dest_acc_en>();
 }
 
 template <bool mail2math=true, bool mail2pack=true>
@@ -281,7 +282,7 @@ inline void llk_matmul_pack(const std::uint32_t start_tile_index, const std::uin
 
         std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-        _llk_pack_<out_of_order_output, DstSync::SyncHalf, untilize, is_fp32_dest_acc_en>(
+        _llk_pack_<out_of_order_output, DST_SYNC_MODE, untilize, is_fp32_dest_acc_en>(
             tile_index,
             pack_dst_format[output_id],
             pack_tile_addr

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
@@ -75,7 +75,7 @@ inline void llk_math_eltwise_unary_sfpu(
     uint param4 = 0,
     uint param5 = 0) {
 
-    _llk_math_eltwise_unary_sfpu_start_<DstSync::SyncHalf>(dst_index);
+    _llk_math_eltwise_unary_sfpu_start_<DST_SYNC_MODE>(dst_index);
     if (vector_mode == (int)VectorMode::R) {
         // Do a row vector, Face0 + Face1 -- first iteration
         const int ITERATIONS = 1;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h
@@ -18,6 +18,7 @@ using namespace ckernel;
 #include "chlkc_math_fidelity.h"
 #include "chlkc_math_approx_mode.h"
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_math.cpp"
 #endif
 
@@ -25,6 +26,7 @@ using namespace ckernel;
 #include "chlkc_pack_data_format.h"
 #include "chlkc_pack_tile_dims.h"
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_pack.cpp"
 #endif
 
@@ -32,6 +34,7 @@ using namespace ckernel;
 #include "chlkc_unpack_data_format.h"
 #include "chlkc_unpack_tile_dims.h"
 #include "chlkc_dst_accum_mode.h"
+#include "chlkc_dst_sync_mode.h"
 #include "chlkc_unpack.cpp"
 #endif
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
@@ -54,7 +54,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest,
         is_fp32_dest_acc_en>(num_faces, dst_index, clear_fp32_dst_acc);
@@ -77,7 +77,7 @@ inline void llk_math_eltwise_binary(
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest,
         is_fp32_dest_acc_en>(num_faces, dst_index, clear_fp32_dst_acc);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -26,7 +26,7 @@ inline void llk_math_eltwise_binary_sfpu(
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
 
-    _llk_math_eltwise_binary_sfpu_<sfpu_op, APPROXIMATE, DstSync::SyncHalf>(
+    _llk_math_eltwise_binary_sfpu_<sfpu_op, APPROXIMATE, DST_SYNC_MODE>(
         face_r_dim, num_faces, dst_index_a, dst_index_b, vector_mode, param0, param1, param2, param3, param4, param5);
 }
 
@@ -39,7 +39,7 @@ inline void llk_math_eltwise_binary_sfpu_init(
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_quant_int32(
     uint dst_index_a, uint dst_index_b, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu<SfpuType::quant_int32, APPROXIMATE, DstSync::SyncHalf>(dst_index_a, dst_index_b, vector_mode);
+    llk_math_eltwise_binary_sfpu<SfpuType::quant_int32, APPROXIMATE>(dst_index_a, dst_index_b, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -50,7 +50,7 @@ inline void llk_math_eltwise_binary_sfpu_quant_int32_init(const uint zero_point)
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_requant_int32(
     uint dst_index_a, uint dst_index_b, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu<SfpuType::requant_int32, APPROXIMATE, DstSync::SyncHalf>(dst_index_a, dst_index_b, vector_mode);
+    llk_math_eltwise_binary_sfpu<SfpuType::requant_int32, APPROXIMATE>(dst_index_a, dst_index_b, vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -61,7 +61,7 @@ inline void llk_math_eltwise_binary_sfpu_requant_int32_init(const uint zero_poin
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_dequant_int32(
     uint dst_index_a, uint dst_index_b, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_binary_sfpu<SfpuType::dequant_int32, APPROXIMATE, DstSync::SyncHalf>(dst_index_a, dst_index_b, vector_mode);
+    llk_math_eltwise_binary_sfpu<SfpuType::dequant_int32, APPROXIMATE>(dst_index_a, dst_index_b, vector_mode);
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -26,18 +26,18 @@ inline void llk_math_hw_configure_disaggregated() { /*Unused for WHB0*/ }
 
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
     WAYPOINT("MWDD");
 }
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_dest_section_done() {
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_pack_sync_init() {
-    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool mail2math = true, bool mail2pack = true>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -18,7 +18,7 @@ template <
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DstSync::SyncHalf, is_fp32_dest_acc_en, unpack_to_dest>(
+    _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DST_SYNC_MODE, is_fp32_dest_acc_en, unpack_to_dest>(
         dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
 }
 
@@ -31,7 +31,7 @@ inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint nti
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
-        _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DstSync::SyncHalf, is_fp32_dest_acc_en, unpack_to_dest>(
+        _llk_math_eltwise_unary_datacopy_<type, src_b_bcast_type, DST_SYNC_MODE, is_fp32_dest_acc_en, unpack_to_dest>(
             dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "chlkc_list.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_template.h"
@@ -171,7 +172,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-    _llk_pack_<DstSync::SyncHalf, untilize, is_fp32_dest_acc_en>(
+    _llk_pack_<DST_SYNC_MODE, untilize, is_fp32_dest_acc_en>(
         tile_index,
         pack_tile_addr
     );
@@ -230,7 +231,7 @@ inline void llk_matmul_pack(std::uint32_t start_tile_index, std::uint32_t output
     for (uint32_t tile_index=start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
-        _llk_pack_<DstSync::SyncHalf, untilize, is_fp32_dest_acc_en>(
+        _llk_pack_<DST_SYNC_MODE, untilize, is_fp32_dest_acc_en>(
             tile_index,
             pack_tile_addr
         );
@@ -253,7 +254,7 @@ inline void llk_packer_set_math_semaphore() {
 
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_pack_dest_section_done() {
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_pack_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
 template <bool untilize = false, bool diagonal = false>
@@ -262,7 +263,7 @@ inline void llk_init_packer_dest_offset_registers(const std::uint32_t pack_outpu
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_init_packer_dest_offset_registers_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, untilize, diagonal>(
+    _llk_init_packer_dest_offset_registers_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, untilize, diagonal>(
         face_r_dim,
         narrow_tile
     );
@@ -275,7 +276,7 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
-    _llk_pack_dest_init_<DstSync::SyncHalf, DstTileFaceLayout::RowMajor, untilize, is_fp32_dest_acc_en>(
+    _llk_pack_dest_init_<DST_SYNC_MODE, DstTileFaceLayout::RowMajor, untilize, is_fp32_dest_acc_en>(
         face_r_dim,
         narrow_tile
     );

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -159,10 +159,11 @@ std::string EthernetKernel::config_hash() const {
 
 std::string ComputeKernel::config_hash() const {
     return fmt::format(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         magic_enum::enum_name(this->config_.math_fidelity),
         this->config_.fp32_dest_acc_en,
-        this->config_.math_approx_mode);
+        this->config_.math_approx_mode,
+        this->config_.dst_full_sync_en);
 }
 
 std::string Kernel::compute_hash() const {
@@ -310,6 +311,7 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
     build_options.set_hlk_math_fidelity_all_cores(this->config_.math_fidelity);
     build_options.set_hlk_math_approx_mode_all_cores(this->config_.math_approx_mode);
     build_options.fp32_dest_acc_en = this->config_.fp32_dest_acc_en;
+    build_options.dst_full_sync_en = this->config_.dst_full_sync_en;
     build_options.unpack_to_dest_mode = this->config_.unpack_to_dest_mode;
     build_options.hlk_defines = this->defines_;
 }

--- a/tt_metal/impl/kernels/kernel_types.hpp
+++ b/tt_metal/impl/kernels/kernel_types.hpp
@@ -48,6 +48,7 @@ struct WriterDataMovementConfig : public DataMovementConfig {
 struct ComputeConfig {
     MathFidelity math_fidelity = MathFidelity::HiFi4;
     bool fp32_dest_acc_en = false;
+    bool dst_full_sync_en = false;
     std::vector<UnpackToDestMode> unpack_to_dest_mode;
     bool math_approx_mode = false;
     std::vector<uint32_t> compile_args;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -473,6 +473,22 @@ static void generate_dst_accum_mode_descriptor(JitBuildOptions& options) {
     file_stream.close();
 }
 
+static void generate_dst_sync_mode_descriptor(JitBuildOptions& options) {
+    string dst_sync_mode_descriptor = options.path + "chlkc_dst_sync_mode.h";
+
+    ofstream file_stream;
+
+    file_stream.open(dst_sync_mode_descriptor);
+
+    if (options.dst_full_sync_en) {
+        file_stream << "#define DST_SYNC_MODE DstSync::SyncFull" << endl;
+    } else {
+        file_stream << "#define DST_SYNC_MODE DstSync::SyncHalf" << endl;
+    }
+
+    file_stream.close();
+}
+
 static void generate_math_fidelity_descriptor(JitBuildOptions& options) {
     string math_fidelity_descriptor = options.path + "chlkc_math_fidelity.h";
     // assuming all cores within a op have the same desc
@@ -509,11 +525,13 @@ void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& opt
         std::thread tm( [&]() { generate_math_fidelity_descriptor(options); } );
         std::thread ta( [&]() { generate_math_approx_mode_descriptor(options); } );
         std::thread tf( [&]() { generate_dst_accum_mode_descriptor(options); } );
+        std::thread ts( [&]() { generate_dst_sync_mode_descriptor(options); } );
         td.join();
         tt.join();
         tm.join();
         ta.join();
         tf.join();
+        ts.join();
     } catch (std::runtime_error& ex) {
         std::cerr << "EXCEPTION FROM THREADING IN GENERATE_DESCRIPTORS: " << ex.what() << std::endl;
     }

--- a/tt_metal/jit_build/settings.hpp
+++ b/tt_metal/jit_build/settings.hpp
@@ -27,6 +27,8 @@ class JitBuildOptions {
     bool fp32_dest_acc_en;
     std::vector<UnpackToDestMode> unpack_to_dest_mode;
 
+    bool dst_full_sync_en;
+
     std::map<std::string, std::string> hlk_defines;  // preprocessor defines for HLK
     std::map<std::string, std::string> ncrisc_defines;
     std::map<std::string, std::string> brisc_defines;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
@@ -118,7 +118,7 @@ operation::ProgramWithCallbacks moreh_layernorm_impl(
          num_rows_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_outer);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     // This could be inefficient.

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp
@@ -82,7 +82,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_gamma_beta_grad_impl(
          num_cols_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_inner);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp
@@ -93,7 +93,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_input_grad_impl(
          num_rows_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_outer);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
@@ -173,7 +173,7 @@ operation::ProgramWithCallbacks moreh_matmul_multi_core(
         need_other_mask_h, need_other_mask_w,
         other_mask_h, other_mask_w);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
         split_work_to_cores(core_range, num_tiles);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -26,7 +26,7 @@ bool is_moreh_softmax_h_small_available(const Tensor &tensor, const ttnn::Device
     int32_t Ht = (h + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
     auto arch = tensor.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
@@ -69,7 +69,7 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
         split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -26,7 +26,7 @@ bool is_moreh_softmax_w_small_available(const Tensor &tensor, const ttnn::Device
     int32_t Wt = (w + TILE_WIDTH - 1) / TILE_WIDTH;
 
     auto arch = tensor.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
     auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
@@ -69,7 +69,7 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
         split_work_to_cores(core_range, num_tiles);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -38,7 +38,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -61,7 +61,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -62,7 +62,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
         split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
@@ -45,7 +45,7 @@ operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const 
     const bool do_mask_h {(origin_H % TILE_HEIGHT) != 0};
     const auto mask_h {do_mask_h ? origin_H % TILE_HEIGHT: TILE_HEIGHT};
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
@@ -224,7 +224,7 @@ operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const 
     // const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
     // const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
 
-    // auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    // auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     // log_debug(
     //     LogOp,
     //     "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
     const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
     const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_int_sum_nc_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_int_sum_nc_impl.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks moreh_sum_int_nc_impl(const Tensor &input, const
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile {input_shape[dim]};
     const auto num_output_tiles {output.volume() / TILE_HW};
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
     log_debug(LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
     log_debug(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_sum_nc_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/moreh_sum_nc_impl.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks moreh_sum_nc_impl(const Tensor &input, const Ten
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile = input_shape[dim];
     const auto num_output_tiles = output.volume() / TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
     log_debug(LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
     log_debug(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
@@ -44,7 +44,7 @@ operation::ProgramWithCallbacks moreh_sum_int_w_impl(const Tensor &input, const 
     const bool do_mask_w {(origin_W % TILE_WIDTH) != 0};
     const auto mask_w {do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH};
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
@@ -37,7 +37,7 @@ operation::ProgramWithCallbacks moreh_sum_w_impl(const Tensor &a, const Tensor &
     const bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
     const auto mask_w = do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
     log_debug(
         LogOp,
         "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
@@ -105,7 +105,7 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(
         }
     }
     const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
 
     for (auto i = 0; i < input_grad_rank; ++i) {

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -12,7 +12,8 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
     const MathFidelity default_fidelity,
     bool default_approx_mode,
     bool default_fp32_acc,
-    bool default_l1_acc) {
+    bool default_l1_acc,
+    bool default_dst_full_sync_en) {
 
     DeviceComputeKernelConfig defaultConfig;
     if (device_kernel_config.has_value()) {
@@ -24,19 +25,24 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
                     TT_ASSERT(arch == tt::ARCH::GRAYSKULL, "kernel config is not for graykull");
                     MathFidelity math_fidelity = compute_kernel_config.math_fidelity;
                     bool math_approx_mode = compute_kernel_config.math_approx_mode;
+                    bool dst_full_sync_en = compute_kernel_config.dst_full_sync_en;
                     defaultConfig = GrayskullComputeKernelConfig{
-                        .math_fidelity = math_fidelity, .math_approx_mode = math_approx_mode};
+                        .math_fidelity = math_fidelity,
+                        .math_approx_mode = math_approx_mode,
+                        .dst_full_sync_en = dst_full_sync_en};
                 } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
                     TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(arch), "kernel config is not for wormhole_b0 or blackhole");
                     MathFidelity math_fidelity = compute_kernel_config.math_fidelity;
                     bool math_approx_mode = compute_kernel_config.math_approx_mode;
                     bool fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                     bool packer_l1_acc = compute_kernel_config.packer_l1_acc;
+                    bool dst_full_sync_en = compute_kernel_config.dst_full_sync_en;
                     defaultConfig = WormholeComputeKernelConfig{
                         .math_fidelity = math_fidelity,
                         .math_approx_mode = math_approx_mode,
                         .fp32_dest_acc_en = fp32_dest_acc_en,
-                        .packer_l1_acc = packer_l1_acc};
+                        .packer_l1_acc = packer_l1_acc,
+                        .dst_full_sync_en = dst_full_sync_en};
                 } else {
                     TT_THROW("arch not supported");
                 }
@@ -52,7 +58,8 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
                 .math_fidelity = default_fidelity,
                 .math_approx_mode = default_approx_mode,
                 .fp32_dest_acc_en = default_fp32_acc,
-                .packer_l1_acc = default_l1_acc};
+                .packer_l1_acc = default_l1_acc,
+                .dst_full_sync_en = default_dst_full_sync_en};
         }
     }
 }
@@ -75,13 +82,14 @@ bool get_fp32_dest_acc_en(const std::optional<DeviceComputeKernelConfig>& comput
         compute_kernel_config.value());
 }
 
-std::tuple<MathFidelity, bool, bool, bool> get_compute_kernel_config_args(
+std::tuple<MathFidelity, bool, bool, bool, bool> get_compute_kernel_config_args(
     tt::ARCH arch, const DeviceComputeKernelConfig compute_kernel_config) {
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
     bool fp32_dest_acc_en;
     bool packer_l1_acc;
+    bool dst_full_sync_en;
 
     std::visit(
         [&](auto&& compute_kernel_config) {
@@ -92,19 +100,21 @@ std::tuple<MathFidelity, bool, bool, bool> get_compute_kernel_config_args(
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = false;
                 packer_l1_acc = false;
+                dst_full_sync_en = false;
             } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
                 TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(arch), "kernel config is not for wormhole_b0 or blackhole");
                 math_fidelity = compute_kernel_config.math_fidelity;
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
+                dst_full_sync_en = compute_kernel_config.dst_full_sync_en;
             } else {
                 TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
 
-    return std::make_tuple(math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc);
+    return std::make_tuple(math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -12,6 +12,7 @@ namespace ttnn {
 struct GrayskullComputeKernelConfig {
     MathFidelity math_fidelity = MathFidelity::LoFi;
     bool math_approx_mode = true;
+    bool dst_full_sync_en = false;
 };
 
 struct WormholeComputeKernelConfig {
@@ -19,6 +20,7 @@ struct WormholeComputeKernelConfig {
     bool math_approx_mode = true;
     bool fp32_dest_acc_en = false;
     bool packer_l1_acc = false;
+    bool dst_full_sync_en = false;
 };
 
 using BlackholeComputeKernelConfig = WormholeComputeKernelConfig;
@@ -31,10 +33,11 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
     const MathFidelity default_fidelity = MathFidelity::LoFi,
     bool default_approx_mode = true,
     bool default_fp32_acc = false,
-    bool default_l1_acc = false);
+    bool default_l1_acc = false,
+    bool default_dst_full_sync_en = false);
 
 bool get_fp32_dest_acc_en(const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 
-std::tuple<MathFidelity, bool, bool, bool> get_compute_kernel_config_args(tt::ARCH arch, const DeviceComputeKernelConfig compute_kernel_config);
+std::tuple<MathFidelity, bool, bool, bool, bool> get_compute_kernel_config_args(tt::ARCH arch, const DeviceComputeKernelConfig compute_kernel_config);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -60,7 +60,7 @@ operation::ProgramWithCallbacks reduce_nc_factory(const ttnn::Tensor &input, con
     const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile = input_shape[dim];
     const auto num_output_tiles = output.volume() / TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     // choose granularity as the largest factor of num_reduce_input_tile that is less than or equal to 8
     uint32_t input_granularity;
     for (input_granularity = 8; input_granularity > 1; --input_granularity) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -121,7 +121,10 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
         program,
         "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp",
         core_group_1,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_args_group_1});
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .dst_full_sync_en = true,
+            .compile_args = compute_args_group_1});
 
     if (!core_group_2.ranges().empty()) {
         vector<uint32_t> compute_args_group_2 = {
@@ -136,7 +139,10 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
             program,
             "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp",
             core_group_2,
-            tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_args_group_2});
+            tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity,
+                .dst_full_sync_en = true,
+                .compile_args = compute_args_group_2});
     }
 
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
@@ -54,7 +54,7 @@ MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::Program
         tt::tt_metal::split_work_to_cores(grid, num_tiles);
 
     auto arch = param_in.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -55,7 +55,7 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
         split_work_to_cores(grid, num_units);
 
     auto arch = param_in.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
@@ -41,7 +41,7 @@ MorehDotOperation::SingleCore::cached_program_t MorehDotOperation::SingleCore::c
 
     tt::tt_metal::Device* device = input_a.device();
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     const uint32_t in0_t = 2;   // a

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
@@ -112,7 +112,7 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
             tt::tt_metal::split_work_to_cores(grid, num_outer);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     // This could be inefficient.

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
@@ -87,7 +87,7 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
             tt::tt_metal::split_work_to_cores(grid, num_inner);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
@@ -82,7 +82,7 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
             tt::tt_metal::split_work_to_cores(grid, num_outer);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
@@ -49,8 +49,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
     auto grid = device->compute_with_storage_grid_size();
     auto arch = device->arch();
     const auto num_cores_y = grid.y;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
-        get_compute_kernel_config_args(arch, compute_kernel_config);
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
     const auto
         [num_cores_to_be_used,
          all_cores,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_single_core_program_factory.cpp
@@ -57,7 +57,7 @@ MorehBiasAddBackwardOperation::SingleCoreProgramFactory::create(
 
     Device* device = output_grad.device();
     auto arch = device->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -238,7 +238,7 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
         other_mask_h,
         other_mask_w);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
@@ -55,7 +55,7 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
         split_work_to_cores(core_range, units_to_divide);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -70,7 +70,7 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
         split_work_to_cores(core_range, units_to_divide);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
@@ -54,7 +54,7 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
         split_work_to_cores(core_range, units_to_divide);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     // create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -98,7 +98,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardFactory::create(
         }
     }
     const auto num_input_grad_tiles = input_grad.volume() / tt::constants::TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
@@ -49,7 +49,7 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
@@ -46,7 +46,7 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();
@@ -225,7 +225,7 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();
@@ -413,7 +413,7 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
@@ -43,7 +43,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();
@@ -219,7 +219,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();
@@ -393,7 +393,7 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -40,7 +40,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();
@@ -170,7 +170,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();
@@ -297,7 +297,7 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_h.cpp
@@ -47,7 +47,7 @@ MorehNormOperation::ProgramFactoryH::cached_program_t MorehNormOperation::Progra
     const auto num_cores_y = grid.y;
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, operation_attributes.compute_kernel_config);
 
     const auto

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_other.cpp
@@ -59,7 +59,7 @@ MorehNormOperation::ProgramFactoryOther::cached_program_t MorehNormOperation::Pr
     const auto num_cores_y = grid.y;
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, operation_attributes.compute_kernel_config);
 
     const auto

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_w.cpp
@@ -47,7 +47,7 @@ MorehNormOperation::ProgramFactoryW::cached_program_t MorehNormOperation::Progra
     const auto num_cores_y = grid.y;
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, operation_attributes.compute_kernel_config);
 
     const auto

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -91,7 +91,7 @@ MorehNormBackwardOperation::ProgramFactory::cached_program_t MorehNormBackwardOp
     }
 
     const auto num_input_grad_tiles = input_grad.volume() / tt::constants::TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(output_grad.device()->arch(), operation_attributes.compute_kernel_config);
 
     auto [floored_p, decimal, p_is_negative] = get_floored_p_and_decimal_and_p_is_negative(p);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
@@ -55,7 +55,7 @@ MorehSgdOperation::ProgramFactory::cached_program_t MorehSgdOperation::ProgramFa
         tt::tt_metal::split_work_to_cores(grid, units_to_divide);
 
     auto arch = param_in.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
@@ -13,7 +13,7 @@ bool is_moreh_softmax_w_small_available(const Tensor& tensor, const DeviceComput
     int32_t Wt = (w + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
 
     auto arch = tensor.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
@@ -43,7 +43,7 @@ bool is_moreh_softmax_h_small_available(const Tensor& tensor, const DeviceComput
     int32_t Ht = (h + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT;
 
     auto arch = tensor.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -37,7 +37,7 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_tiles);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -36,7 +36,7 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -37,7 +37,7 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -37,7 +37,7 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -37,7 +37,7 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -38,7 +38,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_tiles);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -38,7 +38,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -38,7 +38,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_cols_tiles);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -38,7 +38,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -38,7 +38,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
         tt::operations::primary::split_work_to_cores(core_range, num_kernel_rows);
 
     auto arch = input_grad.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(arch, compute_kernel_config);
 
     Program program = Program();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -41,7 +41,7 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
     const bool do_mask_h{(origin_H % tt::constants::TILE_HEIGHT) != 0};
     const auto mask_h{do_mask_h ? origin_H % tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT};
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
@@ -36,7 +36,7 @@ MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::Mor
         tt::operations::primary::extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile{input_shape[dim]};
     const auto num_output_tiles{output.volume() / tt::constants::TILE_HW};
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
     log_debug(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
@@ -43,7 +43,7 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
     const bool do_mask_w{(origin_W % tt::constants::TILE_WIDTH) != 0};
     const auto mask_w{do_mask_w ? origin_W % tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH};
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -41,7 +41,7 @@ MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSu
     const bool do_mask_h = (origin_H % tt::constants::TILE_HEIGHT) != 0;
     const auto mask_h = do_mask_h ? origin_H % tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
@@ -35,7 +35,7 @@ MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehS
         tt::operations::primary::extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
     const auto num_reduce_input_tile = input_shape[dim];
     const auto num_output_tiles = output.volume() / tt::constants::TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
     log_debug(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
@@ -40,7 +40,7 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
     const bool do_mask_w = (origin_W % tt::constants::TILE_WIDTH) != 0;
     const auto mask_w = do_mask_w ? origin_W % tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
     log_debug(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
@@ -101,7 +101,7 @@ MorehSumBackwardOperation::ProgramFactory::cached_program_t MorehSumBackwardOper
         }
     }
     const auto num_input_grad_tiles = input_grad.volume() / tt::constants::TILE_HW;
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
 
     for (auto i = 0; i < input_grad_rank; ++i) {

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -90,7 +90,7 @@ operation::ProgramWithCallbacks bilinear_multi_core(const Tensor &input, Tensor&
     uint32_t in_w = input.get_legacy_shape()[2];
     uint32_t out_w =output.get_legacy_shape()[2];
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
 
     auto shard_spec = input.shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -27,7 +27,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
     uint32_t Ht = H / TILE_HEIGHT;
     uint32_t HtWt = Ht * Wt;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
 
     tt_metal::Program program = tt_metal::CreateProgram();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -28,7 +28,7 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     uint32_t Wt = W / TILE_WIDTH;
     uint32_t Ht = H / TILE_HEIGHT;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
 
     tt_metal::Program program = tt_metal::CreateProgram();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -23,7 +23,7 @@ operation::ProgramWithCallbacks reduce_single_core_hw(
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     uint32_t HW = H * W;
 
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(a.device()->arch(), compute_kernel_config);
 
     uint32_t Wt = W / TILE_WIDTH;


### PR DESCRIPTION
### 13026
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/13026)

### Problem description
Generate a define to specify the DST sync mode.

### What's changed
All the api's use the value generated as a. define to call lower level apis with the destination register synchronization mode. 
Ideally we should remove all default values for synchronization mode and remove arguments from functions like release_dst() which are unused, but this will come as a subsequent PR.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
