### PR TITLE
Calulate core coords for dram sharded matmul (width sharded) on BH

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -4,7 +4,7 @@
 
 import pytest
 from loguru import logger
-from models.utility_functions import is_wormhole_b0, is_grayskull, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_grayskull, is_blackhole, skip_for_wormhole_b0
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 import torch
 import ttnn
@@ -69,7 +69,7 @@ def run_test_matmul_in1_dram_sharded(
     if is_grayskull() and (N == 4096 or K == 32768):
         pytest.skip("Skipping too large tensor test on Grayskull")
 
-    if is_grayskull():
+    if is_grayskull() or is_blackhole():
         N_padded = N
         num_banks = 8
     else:
@@ -191,7 +191,6 @@ def run_test_matmul_in1_dram_sharded(
     assert passing
 
 
-@skip_for_blackhole("Segfault on BH, see #12349")
 @pytest.mark.parametrize(
     "fidelity",
     [
@@ -297,7 +296,7 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     if is_grayskull() and (N == 4096 or K == 32768):
         pytest.skip("Skipping too large tensor test on Grayskull")
 
-    if is_grayskull():
+    if is_grayskull() or is_blackhole():
         N_padded = N
         num_banks = 8
     else:
@@ -397,7 +396,6 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     assert True
 
 
-@skip_for_blackhole("Segfaulting on BH, see #12349")
 @pytest.mark.parametrize(
     "fidelity",
     [
@@ -492,7 +490,7 @@ def test_matmul_2d_in1_dram_sharded(
     fuse_batch,
     function_level_defaults,
 ):
-    if is_grayskull():
+    if is_grayskull() or is_blackhole():
         N_padded = N
         num_banks = 8
     else:

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -344,7 +344,7 @@ void get_dram_reader_core_coords_blackhole(
         all_worker_cores_x_physical.push_back(core_phy.x);
     }
 
-    // get the harvested rows, we treat dram and eth cores as harvested as well
+    // get the harvested cols, we treat dram and eth cores as harvested as well
     std::vector<uint32_t> harvested_cols;
     for (int i = 0; i < full_grid_size_x; ++i) {
         auto x = i;
@@ -368,7 +368,7 @@ void get_dram_reader_core_coords_blackhole(
     for (auto& coord : adj_core_physical) {
         auto x = coord.x;
 
-        // if row is harvested, move core down by 1
+        // if col is harvested, move core right by 1
         while (std::find(harvested_cols.begin(), harvested_cols.end(), x) != harvested_cols.end() and x < (full_grid_size_x - 1)) {
             x += 1;
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -468,6 +468,8 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         get_dram_reader_core_coords_grayskull(device, all_worker_cores, all_worker_cores_ordered);
     } else if (device->arch() == tt::ARCH::BLACKHOLE) {
         get_dram_reader_core_coords_blackhole(device, all_worker_cores, all_worker_cores_ordered);
+    } else {
+        TT_THROW("Device not supported");
     }
 
     // dram banks

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -310,6 +310,92 @@ void get_dram_reader_core_coords_wormhole_b0(
     all_cores_ordered = adj_core_logical_realloc;
 }
 
+void get_dram_reader_core_coords_blackhole(
+    tt_metal::Device* device, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
+
+    // hardcoded for blackhole
+    uint32_t full_grid_size_x = 17;
+
+    // get all the logical coord
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    // get dram banks and coords
+    uint32_t num_banks = device->num_dram_channels();
+    uint32_t max_bank_id = num_banks - 1;
+    std::vector<CoreCoord> dram_coord_phy;
+    for (int i = 0; i < num_banks; ++i) {
+        dram_coord_phy.push_back(device->dram_core_from_dram_channel(i));
+    }
+
+    // get worker logical coords
+    std::vector<CoreCoord> all_worker_cores_logical;
+    for (int i = 0; i < num_cores_x; ++i) {
+        for (int j = 0; j < num_cores_y; ++j) {
+            all_worker_cores_logical.push_back(CoreCoord(i, j));
+        }
+    }
+
+    // get x coords of the workers
+    std::vector<uint32_t> all_worker_cores_x_physical;
+    for (int i = 0; i < num_cores_x; ++i) {
+        auto core_phy = device->worker_core_from_logical_core(CoreCoord(i, 0));
+        all_worker_cores_x_physical.push_back(core_phy.x);
+    }
+
+    // get the harvested rows, we treat dram and eth cores as harvested as well
+    std::vector<uint32_t> harvested_cols;
+    for (int i = 0; i < full_grid_size_x; ++i) {
+        auto x = i;
+
+        if (std::find(all_worker_cores_x_physical.begin(), all_worker_cores_x_physical.end(), x) ==
+            all_worker_cores_x_physical.end()) {
+            harvested_cols.push_back(x);
+        }
+    }
+
+    // get the ajacent cores of DRAM banks
+    std::vector<CoreCoord> adj_core_physical;
+    for (int i = 0; i < num_banks; ++i) {
+        auto dram_core = dram_coord_phy[i];
+        uint32_t adj_core_x = dram_core.x + 1;
+        uint32_t adj_core_y = dram_core.y;
+        adj_core_physical.push_back(CoreCoord(adj_core_x, adj_core_y));
+    }
+
+    // move worker if they are in the harvested cols
+    for (auto& coord : adj_core_physical) {
+        auto x = coord.x;
+
+        // if row is harvested, move core down by 1
+        while (std::find(harvested_cols.begin(), harvested_cols.end(), x) != harvested_cols.end() and x < (full_grid_size_x - 1)) {
+            x += 1;
+        }
+
+        coord.x = x;
+    }
+
+    // find the logical coord from physical coord
+    std::vector<CoreCoord> adj_core_logical_realloc;
+    for (int i = 0; i < adj_core_physical.size(); ++i) {
+        for (int j = 0; j < all_worker_cores_logical.size(); ++j) {
+            auto core = device->worker_core_from_logical_core(all_worker_cores_logical[j]);
+            if (adj_core_physical[i] == core) {
+                adj_core_logical_realloc.push_back(all_worker_cores_logical[j]);
+            }
+        }
+    }
+
+    // create sets
+    std::set<CoreRange> all_cores_set;
+    for (int i = 0; i < num_banks; ++i) {
+        all_cores_set.insert(CoreRange(adj_core_logical_realloc[i]));
+    }
+    all_cores = CoreRangeSet(all_cores_set);
+    all_cores_ordered = adj_core_logical_realloc;
+}
+
 void get_max_page_size_and_num_pages(uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
     uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
 
@@ -378,8 +464,10 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
 
     if (device->arch() == tt::ARCH::WORMHOLE_B0) {
         get_dram_reader_core_coords_wormhole_b0(device, all_worker_cores, all_worker_cores_ordered);
-    } else {
+    } else if (device->arch() == tt::ARCH::GRAYSKULL) {
         get_dram_reader_core_coords_grayskull(device, all_worker_cores, all_worker_cores_ordered);
+    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
+        get_dram_reader_core_coords_blackhole(device, all_worker_cores, all_worker_cores_ordered);
     }
 
     // dram banks


### PR DESCRIPTION
### Ticket
Make MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig work with BH #13487


### Problem description
the core coords for dram sharded matmul calculation was never implemented for BH, adding it now.

### What's changed
core coords calculation considering column harvesting on BH.

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/11186496989
- [x] Blackhole Post commit https://github.com/tenstorrent/tt-metal/actions/runs/11186503786
