### PR TITLE
#0: Add TG ResNet-50 Demos with Traced and Eager Execution on 2 CQs

### DIFF
--- a/models/demos/tg/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/tg/resnet50/tests/test_perf_e2e_resnet50.py
@@ -76,3 +76,65 @@ def test_perf_trace(
         f"resnet50_trace_{mode}",
         model_location_generator,
     )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.model_perf_tg
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize(
+    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
+    ((16, True, 0.0391, 60),),
+    indirect=["enable_async_mode"],
+)
+def test_perf_2cqs(
+    mesh_device,
+    use_program_cache,
+    device_batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    enable_async_mode,
+    model_location_generator,
+):
+    mode = "async" if enable_async_mode else "sync"
+    run_perf_resnet(
+        device_batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        mesh_device,
+        f"resnet50_2cqs_{mode}",
+        model_location_generator,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.model_perf_tg
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1332224}], indirect=True
+)
+@pytest.mark.parametrize(
+    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
+    ((16, True, 0.0069, 60),),
+    indirect=["enable_async_mode"],
+)
+def test_perf_trace_2cqs(
+    mesh_device,
+    use_program_cache,
+    device_batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    enable_async_mode,
+    model_location_generator,
+):
+    mode = "async" if enable_async_mode else "sync"
+    run_perf_resnet(
+        device_batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        mesh_device,
+        f"resnet50_trace_2cqs_{mode}",
+        model_location_generator,
+    )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
 - 2 CQ Resnet 50 perf tests need to be added to TG pipelines, now that this feature is enabled.
 - Recent 2 CQ on TG PR reduced the number of prefetch queue entries across all systems, since 2 CQs on Galaxy needs a 
    smaller prefetch q. This should not be done for all systems, only for Galaxy.

### What's changed
  - Add 2 CQ TG Resnet perf tests.
  - Make the `prefetch_q_entries_` computation a function of the system
  -  Allow the static `dispatch_constants` object to be toggled during device init, based on the number of CQs. This was 
  blocking dynamically modifying CQs in a workload on TG

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
