### PR TITLE
#13454: API refactor for Mesh::enable_program_cache

### DIFF
--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -527,8 +527,7 @@ def run_falcon_demo_kv(
     if not perf_mode:
         print_output_prompts(generated_ids, tokenizer)
 
-    for device in devices:
-        device.disable_and_clear_program_cache()
+    mesh_device.disable_and_clear_program_cache()
 
     generated_text = tokenizer.batch_decode(generated_ids.tolist())
 

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -276,8 +276,7 @@ def test_falcon_prefill_end_to_end_determinism(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, "prefill", input_shape, num_devices)
-    devices = t3k_mesh_device.get_devices()
-    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
@@ -286,8 +285,7 @@ def test_falcon_prefill_end_to_end_determinism(
     )
 
     if enable_program_cache:
-        for device in devices:
-            device.enable_program_cache()
+        t3k_mesh_device.enable_program_cache()
 
     run_test_falcon_prefill_end_to_end_determinism(
         t3k_mesh_device,
@@ -304,5 +302,4 @@ def test_falcon_prefill_end_to_end_determinism(
     )
 
     if enable_program_cache:
-        for device in devices:
-            device.disable_and_clear_program_cache()
+        t3k_mesh_device.disable_and_clear_program_cache()

--- a/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
@@ -152,9 +152,7 @@ def test_LlamaModel_inference(
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
     t3k_mesh_device.enable_async(True)
-    for device_id in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(device_id)
-        device.enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
@@ -315,9 +315,7 @@ def test_Llama_perf_host(
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
     t3k_mesh_device.enable_async(True)
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
     disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(

--- a/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
@@ -147,9 +147,7 @@ def test_Llama_stress_test(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    for i in t3k_mesh_device.get_device_ids():
-        device = t3k_mesh_device.get_device(i)
-        device.enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
     disable_compilation_reports()
     run_test_LlamaModel_stress_test(
         devices,

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -197,9 +197,7 @@ def test_Llama_perf_host(
 
     check_mesh_device(mesh_device, model_config)
     mesh_device.enable_async(True)
-
-    for device in mesh_device.get_devices():
-        device.enable_program_cache()
+    mesh_device.enable_program_cache()
     disable_compilation_reports()
 
     run_test_LlamaModel_end_to_end(

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -296,8 +296,7 @@ def test_t3k_falcon_causal_lm_with_trace(
     num_loops,
 ):
     t3k_mesh_device.enable_async(enable_async)
-    for device in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device).enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
 
     torch.manual_seed(0)
     batch = device_batch_size * t3k_mesh_device.get_num_devices()

--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
@@ -105,9 +105,6 @@ def run(
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 
-    # for device in devices:
-    #    device.disable_and_clear_program_cache()
-
     input_tensor = torch.rand(input_shape).bfloat16()
 
     input_tensors = torch.chunk(input_tensor, num_devices, dim)

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -149,9 +149,8 @@ def test_multi_device_unary_binary_op_chain(pcie_mesh_device, program_cache, sha
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
     pcie_mesh_device.enable_async(True)
-    for device in pcie_mesh_device.get_device_ids():
-        if program_cache:
-            pcie_mesh_device.get_device(device).enable_program_cache()
+    if program_cache:
+        pcie_mesh_device.enable_program_cache()
 
     torch_silu = torch.nn.SiLU()
     for i in range(50):
@@ -190,9 +189,8 @@ def test_multi_device_data_parallel_op_chain(pcie_mesh_device, program_cache, in
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 
     pcie_mesh_device.enable_async(True)
-    for device in pcie_mesh_device.get_device_ids():
-        if program_cache:
-            pcie_mesh_device.get_device(device).enable_program_cache()
+    if program_cache:
+        pcie_mesh_device.enable_program_cache()
 
     torch_silu = torch.nn.SiLU()
     torch_mish = torch.nn.Mish()

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -21,8 +21,7 @@ def test_multi_device_events(t3k_mesh_device, shape):
 
     # Enable Program Cache and Async Mode
     t3k_mesh_device.enable_async(True)
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors.
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -28,8 +28,7 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
 
     # Trace requires program cache to be enabled
     t3k_mesh_device.enable_async(enable_async)
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)
@@ -142,8 +141,7 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
 
     # Trace requires program cache to be enabled
     t3k_mesh_device.enable_async(enable_async)
-    for device_id in t3k_mesh_device.get_device_ids():
-        t3k_mesh_device.get_device(device_id).enable_program_cache()
+    t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
@@ -27,8 +27,7 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
         pytest.skip("Test is only valid on Galaxy")
     # Trace requires program cache to be enabled
     mesh_device.enable_async(True)
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_program_cache()
+    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)
@@ -129,8 +128,7 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
 
     # Trace requires program cache to be enabled
     mesh_device.enable_async(True)
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_program_cache()
+    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -27,8 +27,7 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
         pytest.skip("Test is only valid on TGG")
     # Trace requires program cache to be enabled
     mesh_device.enable_async(True)
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_program_cache()
+    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)
@@ -128,8 +127,7 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
 
     # Trace requires program cache to be enabled
     mesh_device.enable_async(True)
-    for device_id in mesh_device.get_device_ids():
-        mesh_device.get_device(device_id).enable_program_cache()
+    mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, mesh_device)

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -408,6 +408,18 @@ void MeshDevice::enable_async(bool enable) {
     }
 }
 
+void MeshDevice::enable_program_cache() {
+    for (auto device : this->devices) {
+        device->enable_program_cache();
+    }
+}
+
+void MeshDevice::disable_and_clear_program_cache() {
+    for (auto device : this->devices) {
+        device->disable_and_clear_program_cache();
+    }
+}
+
 std::vector<int> get_t3k_physical_device_ids_ring() {
     auto& instance = SystemMesh::instance();
     auto num_devices = instance.get_num_devices();

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -153,6 +153,8 @@ class MeshDevice : public std::enable_shared_from_this<MeshDevice> {
 
     tt::ARCH arch() const;
     void enable_async(bool enable);
+    void enable_program_cache();
+    void disable_and_clear_program_cache();
 
     void close_devices();
     std::shared_ptr<const MeshDeviceView> get_view() const;

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -111,7 +111,19 @@ void py_module(py::module& module) {
 
                 Args:
                     enable (bool): True to enable async mode, False to disable it.
-        )doc")
+            )doc")
+        .def(
+            "enable_program_cache",
+            &MeshDevice::enable_program_cache,
+            R"doc(
+                Enable program cache across all devices in the mesh.
+            )doc")
+        .def(
+            "disable_and_clear_program_cache",
+            &MeshDevice::disable_and_clear_program_cache,
+            R"doc(
+                Disable program cache across all devices in the mesh.
+            )doc")
         .def_property_readonly("shape", &MeshDevice::shape, R"doc(
             Get the shape of the device mesh.
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/13454)

### Problem description
- Refactor API usage toward the eventual goal of MeshDevice interoperability as a virtual device using same interface as a physical device.

### What's changed
- Add method for MeshDevice::enable_program_cache(..), MeshDevice::disable_and_clear_program_cache(..)

### Checklist
- [x] Post commit CI passes: 
        - https://github.com/tenstorrent/tt-metal/actions/runs/11222590773 [PASSING]
        - https://github.com/tenstorrent/tt-metal/actions/runs/11240282963 [PASSING]
- [ ] Blackhole Post commit (if applicable) -> n/a
- [x] Model regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/11222589016
- [ ] Device performance regression CI testing passes (if applicable) -> n/a
- [x] New/Existing tests provide coverage for changes
