### PR TITLE
#11168: Fix ttnn.repeat for padded tiled tensors.

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -188,6 +188,7 @@ on:
           - data_movement.fill.fill_pytorch2
           - data_movement.index_select.index_select_pytorch2
           - data_movement.split.split_with_sizes_pytorch2
+          - data_movement.repeat.repeat
   schedule:
     - cron: "0 21 * * *" # This cron schedule runs the workflow at 9:00pm UTC nightly
 

--- a/tests/sweep_framework/sweeps/data_movement/repeat/repeat.py
+++ b/tests/sweep_framework/sweeps/data_movement/repeat/repeat.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import random
+import ttnn
+import sys
+
+from typing import Optional, Tuple
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+from functools import reduce
+
+TIMEOUT = 15
+
+dtypes = [ttnn.bfloat16]
+shapes = [(1, 2, 4, 4), (1, 1, 1, 1)] + [(1, 2, 2 * j, 4 * j) for j in range(2, 12)]
+repeat_specs = [(2, 2, 2, 2), (1, 2, 1, 1)] + [(1, 3, 2 * j, 4 * j) for j in range(2, 12)]
+
+parameters = {
+    "nightly": {
+        "shape": shapes,
+        "repeat_shape": repeat_specs,
+        "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+        "dtype": dtypes,
+    }
+}
+
+
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        if test_vector["dtype"] == ttnn.bfloat8_b:
+            return True, "bfloat8_b not supported with ROW_MAJOR_LAYOUT"
+        if test_vector["dtype"] == ttnn.bfloat16 and len(test_vector["shape"]) > 1 and test_vector["shape"][-1] < 2:
+            return True, "bfloat16 in ROW_MAJOR_LAYOUT not supported with inner dim < 2"
+    return False, None
+
+
+def run(
+    shape,
+    repeat_shape,
+    layout,
+    dtype,
+    *,
+    device,
+):
+    torch_dtype = {
+        ttnn.bfloat16: torch.bfloat16,
+        ttnn.float32: torch.float32,
+        ttnn.int32: torch.int32,
+    }[dtype]
+
+    mul = lambda x, y: x * y
+    torch_input_tensor = torch.arange(0, reduce(mul, shape, 1), dtype=torch_dtype).reshape(shape)
+
+    torch_result = torch_input_tensor.repeat(repeat_shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+
+    start_time = start_measuring_time()
+    tt_result = ttnn.repeat(input_tensor, ttnn.Shape(repeat_shape))
+    e2e_perf = stop_measuring_time(start_time)
+    tt_result = tt_result.cpu().to_torch()
+
+    assert (
+        tt_result.shape == torch_result.shape
+    ), f"TT result shape {tt_result.shape} does not match torch shape {torch_result.shape}"
+
+    return [check_with_pcc(torch_result, tt_result, 0.999), e2e_perf]

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -8,26 +8,24 @@ import torch
 
 import ttnn
 
+from models.utility_functions import comp_pcc
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from functools import reduce
+
+dtypes = [torch.bfloat16]
+shapes = [(1, 2, 4, 4), (1, 1, 1, 1)] + [(1, 2, 2 * j, 4 * j) for j in range(2, 12)]
+repeat_specs = [(2, 2, 2, 2), (1, 2, 1, 1)]
 
 
-def test_repeat(device):
-    torch_input_tensor = torch.randn((1, 2, 4, 4), dtype=torch.bfloat16)
-    repeat_shape = (1, 2, 1, 1)
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("shape", shapes)
+@pytest.mark.parametrize("repeat_shape", repeat_specs)
+def test_repeat(device, dtype, shape, repeat_shape):
+    if dtype == torch.bfloat16 and shape[-1] < 2 and repeat_shape[-1] < 2:
+        pytest.skip("bfloat16 needs 4 byte inner dim on the output.")
 
-    torch_result = torch_input_tensor.repeat(repeat_shape)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-
-    output = ttnn.repeat(input_tensor, ttnn.Shape(repeat_shape))
-    output = ttnn.to_torch(output)
-
-    assert_with_pcc(torch_result, output, 0.9999)
-
-
-def test_repeat_with_tile_padding(device):
-    torch_input_tensor = torch.randn((1, 1, 1, 1), dtype=torch.bfloat16)
-    repeat_shape = (2, 2, 2, 2)
+    mul = lambda x, y: x * y
+    torch_input_tensor = torch.arange(0, reduce(mul, shape, 1), dtype=dtype).reshape(shape)
 
     torch_result = torch_input_tensor.repeat(repeat_shape)
 
@@ -40,4 +38,4 @@ def test_repeat_with_tile_padding(device):
         output.shape == torch_result.shape
     ), f"Output shape {output.shape} does not match torch shape {torch_result.shape}"
 
-    assert_with_pcc(torch_result, output, 0.9999), f"Output {output} does not match torch output {torch_result}"
+    assert_with_pcc(torch_result, output, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -13,14 +13,16 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from functools import reduce
 
 dtypes = [torch.bfloat16]
-shapes = [(1, 2, 4, 4), (1, 1, 1, 1)] + [(1, 2, 2 * j, 4 * j) for j in range(2, 12)]
-repeat_specs = [(2, 2, 2, 2), (1, 2, 1, 1)]
+shapes = [(1, 2, 4, 4), (1, 1, 1, 1)]
+repeat_specs = [(1, 2, 1, 1), (2, 2, 2, 2)]
+
+shape_and_repeat_specs = list(zip(shapes, repeat_specs))
 
 
 @pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("shape", shapes)
-@pytest.mark.parametrize("repeat_shape", repeat_specs)
-def test_repeat(device, dtype, shape, repeat_shape):
+@pytest.mark.parametrize("shape_and_repeat_spec", shape_and_repeat_specs)
+def test_repeat(device, dtype, shape_and_repeat_spec):
+    shape, repeat_shape = shape_and_repeat_spec
     if dtype == torch.bfloat16 and shape[-1] < 2 and repeat_shape[-1] < 2:
         pytest.skip("bfloat16 needs 4 byte inner dim on the output.")
 

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -23,3 +23,21 @@ def test_repeat(device):
     output = ttnn.to_torch(output)
 
     assert_with_pcc(torch_result, output, 0.9999)
+
+
+def test_repeat_with_tile_padding(device):
+    torch_input_tensor = torch.randn((1, 1, 1, 1), dtype=torch.bfloat16)
+    repeat_shape = (2, 2, 2, 2)
+
+    torch_result = torch_input_tensor.repeat(repeat_shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.repeat(input_tensor, ttnn.Shape(repeat_shape))
+    output = ttnn.to_torch(output)
+
+    assert (
+        output.shape == torch_result.shape
+    ), f"Output shape {output.shape} does not match torch shape {torch_result.shape}"
+
+    assert_with_pcc(torch_result, output, 0.9999), f"Output {output} does not match torch output {torch_result}"

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -73,7 +73,7 @@ ttnn::Tensor RepeatOperation::invoke(
             auto rm_output = ttnn::untilize(output_tensors[0]);
             auto sliced_output = ttnn::slice(rm_output, zero_indices, end_indices, step, input_tensor.memory_config(), std::nullopt);
 
-            if (sliced_output.get_padded_shape().volume() % tt::constants::TILE_HW != 0) {
+            if (sliced_output.get_padded_shape().volume() % tt::constants::TILE_HW == 0) {
                 // slice preserved tile padding for us, so we can just tilize now.
                 return ttnn::tilize(sliced_output, input_tensor.memory_config());
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -8,6 +8,9 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"
 #include "device/repeat_op.hpp"
+#include "ttnn/operations/data_movement/untilize/untilize.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
 
 namespace ttnn::operations::data_movement {
 
@@ -18,10 +21,18 @@ ttnn::Tensor RepeatOperation::invoke(
     const Shape & repeat_dims,
     const std::optional<MemoryConfig>& memory_config_arg) {
 
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    // special path for handling padded tiled tensors that are naively repeated
+    // *with padding* in the current implementation
+    std::optional<Tensor> formatted_input_tensor = std::nullopt;
+    if (input_tensor.get_layout() != Layout::ROW_MAJOR
+        && input_tensor.get_legacy_shape().without_padding() != input_tensor.get_legacy_shape()) {
+        formatted_input_tensor = ttnn::untilize(input_tensor);
+    }
+
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({formatted_input_tensor.has_value() ? *formatted_input_tensor : input_tensor}))};
     operation::launch_op(
         [repeat_dims, memory_config_arg] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) -> std::vector<Tensor> {
-            auto& input_tensor = input_tensors.at(0);
+            auto& input_tensor = input_tensors[0];
             auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
             uint32_t input_rank = input_tensor.get_legacy_shape().rank();
             TT_FATAL(repeat_dims.rank() == input_rank, "Number of repeat dims must be equal to number of tensor dims");
@@ -36,11 +47,26 @@ ttnn::Tensor RepeatOperation::invoke(
                         (input_tensor.get_legacy_shape()[dim] * input_tensor.element_size()) % input_tensor.buffer()->alignment() == 0,
                         "Current repeat implementation requires aligned last dim when repeating on last dim");
                 }
-                output = operation::run_without_autoformat(RepeatDeviceOperation{dim, repeat_dims[dim], memory_config}, {output}).at(0);
+                auto outputs = operation::run_without_autoformat(RepeatDeviceOperation{dim, repeat_dims[dim], memory_config}, {output});
+                TT_FATAL(outputs.size() == 1, "ttnn.repeat: expected 1 output tensor from run_without_autoformat, but got {}", outputs.size());
+                output = outputs[0];
             }
             return {output};
-        }, {input_tensor}, output_tensors);
-    return output_tensors.at(0);
+        }, {formatted_input_tensor.has_value() ? *formatted_input_tensor : input_tensor}, output_tensors);
+    TT_FATAL(output_tensors.size() == 1, "ttnn.repeat: expected 1 output tensor, but got {}", output_tensors.size());
+    if (formatted_input_tensor.has_value()) {
+        auto zero_indices = std::vector<uint32_t>(input_tensor.get_legacy_shape().rank(), 0);
+        std::vector<uint32_t> end_indices(repeat_dims.size());
+        for (uint32_t i = 0; i < repeat_dims.size(); ++i) {
+            end_indices[i] = repeat_dims[i] * input_tensor.get_legacy_shape().without_padding()[i];
+        }
+        auto step = std::vector<uint32_t>(input_tensor.get_legacy_shape().rank(), 1);
+        auto sliced_output = ttnn::slice(output_tensors[0], zero_indices, end_indices, step, input_tensor.memory_config(), std::nullopt);
+        auto padded_to_tile = sliced_output.cpu().pad_to_tile(0.0).to(input_tensor.device(), input_tensor.memory_config());
+        auto tiled_output = ttnn::tilize(padded_to_tile);
+        return tiled_output;
+    }
+    return output_tensors[0];
 
 }
 


### PR DESCRIPTION
### Ticket
#11168 

### Problem description
The current implemenation of ttnn.repeat doesn't handle tiled tensors with padding correctly; in this case, we had a [1,1,1,1] tensor padded to [1,1,1[32],1[32]] repeated 2x, which resulted in a [2,2,33,33] tensor.


### What's changed
This commit adds some pre/post-repeat massaging to get a result of the correct shape and adds a unit test to check its correctness for the shape in the ticket.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11189916974)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
