### PR TITLE
#13447: Enable asynchronous TTNN Tensor and Op API calls from multiple app threads

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -48,7 +48,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     Tensor np_out_host = np_out.cpu();
     const bfloat16* golden_output = std::get<owned_buffer::Buffer<bfloat16>>(std::get<OwnedStorage>(np_out_host.get_storage()).buffer).begin();
     // Enable Asynchronous Execution and test ttnn runtime APIs
-    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+    device->enable_async(true);
     // Events for host - device synchronization
     auto write_event = std::make_shared<Event>();
     auto workload_event = std::make_shared<Event>();
@@ -94,7 +94,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
 
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
     Device* device = this->device_;
-    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+    device->enable_async(true);
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -150,7 +150,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeBufferDestructor) {
     // We must ensure that the deallocate step, which can run after the buffer has been destroyed
     // does not rely on stale buffer state, after the buffer has been destroyed on host
     Device* device = this->device_;
-    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+    device->enable_async(true);
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -25,7 +25,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiProducerLockBasedQueue) {
     // Test thread safety.
     Device* device = this->device_;
     // Enable async engine and set queue setting to lock_based
-    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+    device->enable_async(true);
     device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
 
     MemoryConfig mem_cfg = MemoryConfig{
@@ -101,7 +101,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiAppThreadSync) {
     // Use write_event to stall reader and read_event to stall writer.
     Device* device = this->device_;
     // Enable async engine and set queue setting to lock_based
-    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+    device->enable_async(true);
     device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
 
     MemoryConfig mem_cfg = MemoryConfig{

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -21,6 +21,8 @@ namespace tt::tt_metal {
 
         bool DispatchStateCheck( bool isFastDispatch);
 
+        bool InWorkerThread();
+
         std::map<chip_id_t, Device *> CreateDevices(
             // TODO: delete this in favour of DevicePool
             const std::vector<chip_id_t>& device_ids,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3239,6 +3239,15 @@ void Device::set_worker_mode(const WorkExecutorMode& mode) {
 void Device::enable_async(bool enable) {
     auto mode = enable ? WorkExecutorMode::ASYNCHRONOUS : WorkExecutorMode::SYNCHRONOUS;
     this->set_worker_mode(mode);
+    // If a worker thread is spawned for a device, register/track it in a runtime structure.
+    // If a worker thread is destroyed, remove it from the structure.
+    // This is required for checking if a call is made from an application thread or a worker thread.
+    // See InWorkerThread().
+    if (enable) {
+        tt::DevicePool::instance().register_worker_thread_for_device(this, this->work_executor.get_worker_thread_id());
+    } else {
+        tt::DevicePool::instance().unregister_worker_thread_for_device(this);
+    }
 }
 
 bool Device::using_slow_dispatch() const {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -313,11 +313,6 @@ class Device {
         return program_cache.num_entries();
     }
 
-    inline bool in_main_thread() {
-        // Detect if an instruction is being called in the main thread or worker thread
-        return (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->work_executor.get_parent_thread_id())
-                or get_worker_mode() == WorkExecutorMode::SYNCHRONOUS;
-    }
    uint32_t trace_buffers_size = 0;
    void update_dispatch_cores_for_multi_cq_eth_dispatch();
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -125,6 +125,10 @@ void DevicePool::initialize(
     _inst->trace_region_size = trace_region_size;
     _inst->num_hw_cqs = num_hw_cqs;
     _inst->l1_bank_remap = l1_bank_remap;
+    // Track the thread where the Device Pool was created. Certain functions
+    // modifying the state of this instance, for example those responsible for
+    // (un)registering worker threads, can only be called in the creation thread
+    _inst->device_pool_creation_thread_id = std::this_thread::get_id();
 
      // Never skip for TG Cluster
     bool skip = not tt::Cluster::instance().is_galaxy_cluster();
@@ -250,6 +254,32 @@ void DevicePool::add_devices_to_pool(std::vector<chip_id_t> device_ids) {
     }
 }
 
+void DevicePool::register_worker_thread_for_device(Device* device, std::thread::id worker_thread_id) {
+    TT_FATAL(std::this_thread::get_id() == this->device_pool_creation_thread_id, "Worker threads can only be registered in the thread where the Device(s) were created");
+    auto worker_thread_handle = this->device_to_worker_thread_id.find(device);
+    if (worker_thread_handle != this->device_to_worker_thread_id.end()) {
+        TT_FATAL(worker_thread_handle->second == worker_thread_id, "Cannot register more than one worker thread per device.");;
+    } else {
+        TT_FATAL(this->worker_thread_ids.find(worker_thread_id) == this->worker_thread_ids.end(), "Cannot register a single worker thread on multiple devices");
+    }
+
+    this->device_to_worker_thread_id.insert({device, worker_thread_id});
+    this->worker_thread_ids.insert(worker_thread_id);
+}
+
+void DevicePool::unregister_worker_thread_for_device(Device* device) {
+    TT_FATAL(std::this_thread::get_id() == this->device_pool_creation_thread_id, "Worker threads can only be unregistered in the thread where the Device(s) were created");
+    auto worker_thread_handle = this->device_to_worker_thread_id.find(device);
+    if (worker_thread_handle != this->device_to_worker_thread_id.end()) {
+        this->worker_thread_ids.erase(worker_thread_handle->second);
+        this->device_to_worker_thread_id.erase(device);
+    }
+}
+
+const std::unordered_set<std::thread::id>& DevicePool::get_worker_thread_ids() const {
+    return this->worker_thread_ids;
+}
+
 void DevicePool::init_firmware_on_active_devices() const {
     for (const auto& dev : this->get_all_active_devices()) {
         // For Galaxy init, we only need to loop over mmio devices
@@ -325,7 +355,7 @@ std::vector<Device*> DevicePool::get_all_active_devices() const {
     return user_devices;
 }
 
-bool DevicePool::close_device(chip_id_t device_id) const {
+bool DevicePool::close_device(chip_id_t device_id) {
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
     bool pass = true;
     const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
@@ -333,6 +363,9 @@ bool DevicePool::close_device(chip_id_t device_id) const {
          tt::Cluster::instance().get_devices_controlled_by_mmio_device(mmio_device_id)) {
         if (this->is_device_active(mmio_controlled_device_id)) {
             pass &= this->devices[mmio_controlled_device_id]->close();
+            // When a device is closed, its worker thread is joined. Stop tracking this
+            // worker thread.
+            this->unregister_worker_thread_for_device(this->devices[mmio_controlled_device_id].get());
         }
     }
     return pass;

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -24,6 +24,10 @@ class DevicePool {
         return *_inst;
     }
 
+    static bool is_instantiated() {
+        return (_inst != nullptr);
+    }
+
     static void initialize(
         std::vector<chip_id_t> device_ids,
         const uint8_t num_hw_cqs,
@@ -34,9 +38,11 @@ class DevicePool {
 
     Device *get_active_device(chip_id_t device_id) const;
     std::vector<Device *> get_all_active_devices() const;
-    bool close_device(chip_id_t device_id) const;
+    bool close_device(chip_id_t device_id);
     bool is_device_active(chip_id_t id) const;
-
+    void register_worker_thread_for_device(Device* device, std::thread::id worker_thread_id);
+    void unregister_worker_thread_for_device(Device* device);
+    const std::unordered_set<std::thread::id>& get_worker_thread_ids() const;
    private:
     ~DevicePool();
     DevicePool(
@@ -51,6 +57,12 @@ class DevicePool {
     std::vector<uint32_t> l1_bank_remap;
     std::mutex lock;
     std::vector<std::unique_ptr<Device>> devices;
+    // Used to track worker thread handles (1 worker thread created per device)
+    // when we need to check if a call is made from an application thread or a
+    // worker thread
+    std::unordered_map<Device*, std::thread::id> device_to_worker_thread_id;
+    std::unordered_set<std::thread::id> worker_thread_ids;
+    std::thread::id device_pool_creation_thread_id;
     bool skip_remote_devices;
     std::unordered_set<uint32_t> firmware_built_keys;
 

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -43,8 +43,8 @@ class LockFreeQueue {
 
     public:
         // Optional - Set these if the worker and parent thread state needs to be tracked
-        std::atomic<uint64_t> worker_thread_id = 0;
-        std::atomic<uint64_t> parent_thread_id = 0;
+        std::atomic<std::thread::id> worker_thread_id;
+        std::atomic<std::thread::id> parent_thread_id;
         LockFreeQueue()
         {
             // Initialize ring buffer for traversal. Each node points to the subsequent node, except for the last one, which points to the head.

--- a/ttnn/cpp/ttnn/run_operation_inl.hpp
+++ b/ttnn/cpp/ttnn/run_operation_inl.hpp
@@ -78,7 +78,7 @@ void launch_op(
     ZoneScopedN("LaunchOp");
     auto& workers = get_workers(output_tensors);
     std::size_t workers_size = workers.size();
-    if (not enable_autoformat_device and workers.empty() or not workers.at(0)->in_main_thread()) {
+    if (not enable_autoformat_device and workers.empty() or tt::tt_metal::detail::InWorkerThread()) {
         // Run in main thread or immediately in worker thread
         output_tensors = op_func(input_tensors, optional_input_tensors, optional_output_tensors);
         return;

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -16,6 +16,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "tt_metal/graph/graph_tracking.hpp"
 #include "ttnn/core.hpp"
@@ -27,6 +28,47 @@ using namespace tt::constants;
 namespace tt {
 
 namespace tt_metal {
+
+void Tensor::TensorAttributes::increment_main_thread_ref_count(Device *worker) {
+    if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and not tt::tt_metal::detail::InWorkerThread()) {
+        main_thread_ref_count++;
+        if (track_ref_count) {
+            tt::log_info(
+                "Inc Ref Count on tensor {}. Main Thread Ref Count: {}. Total Ref Count: {}.",
+                reinterpret_cast<uint64_t>(this),
+                main_thread_ref_count,
+                shared_from_this().use_count());
+        }
+    }
+}
+
+void Tensor::TensorAttributes::decrement_main_thread_ref_count(Device *worker) {
+    if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and not tt::tt_metal::detail::InWorkerThread()) {
+        main_thread_ref_count--;
+        if (track_ref_count) {
+            tt::log_info(
+                "Dec Ref Count on tensor {}. Main Thread Ref Count: {}. Total Ref Count: {}.",
+                reinterpret_cast<uint64_t>(this),
+                main_thread_ref_count,
+                shared_from_this().use_count());
+        }
+    }
+}
+
+uint32_t Tensor::TensorAttributes::record_main_thread_ref_count() { return main_thread_ref_count; }
+
+void Tensor::TensorAttributes::update_main_thread_ref_count(Device *worker, uint32_t ref_count) {
+    if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and not tt::tt_metal::detail::InWorkerThread()) {
+        if (track_ref_count) {
+            tt::log_info(
+                "Update Ref Count on tensor {}. Main Thread Ref Count: {}. Total Ref Count: {}.",
+                reinterpret_cast<uint64_t>(this),
+                main_thread_ref_count,
+                shared_from_this().use_count());
+        }
+        main_thread_ref_count = ref_count;
+    }
+}
 
 Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, Layout layout, const std::optional<Tile>& tile) :
     tensor_id{std::nullopt},
@@ -56,7 +98,7 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
                 this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
                 // This tensor is being created from scratch in a worker. Track this and allow it to be explicitly
                 // deallocated inside the worker (composite ops do this).
-                if (not this->workers.at(0)->in_main_thread()) {
+                if (tt::tt_metal::detail::InWorkerThread()) {
                     this->tensor_attributes->main_thread_tensor = false;
                 }
                 this->tensor_attributes->num_shards_to_be_populated = 1;
@@ -76,7 +118,7 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
                 this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
                 // This tensor is being created from scratch in a worker. Track this and allow it to be explicitly
                 // deallocated inside the worker (composite ops do this).
-                if (not this->workers.at(0)->in_main_thread()) {
+                if (tt::tt_metal::detail::InWorkerThread()) {
                     this->tensor_attributes->main_thread_tensor = false;
                 }
                 this->tensor_attributes->num_shards_to_be_populated = storage.num_buffers();
@@ -89,6 +131,86 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
         storage);
     this->tensor_attributes->num_workers_completed = this->tensor_attributes->num_shards_to_be_populated;
     this->tensor_attributes->metadata_populated = true;
+}
+
+Tensor::Tensor(
+    const std::vector<Device *>& workers,
+    uint32_t num_buffers,
+    std::optional<DistributedTensorConfig> distributed_tensor_config) :
+    tensor_id(std::nullopt),
+    tensor_attributes(std::make_shared<TensorAttributes>()),
+    workers(workers),
+    deallocate_through_destructor(false) {
+    // When creating a device tensor, specify workers.
+    // When creating a host tensor, specify num_buffers.
+    // If neither are specified, a dummy tensor is being created. Do nothing.
+    if (workers.size()) {
+        if (not tt::tt_metal::detail::InWorkerThread()) {
+            this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
+        } else {
+            // This tensor is being created from scratch in a worker. Track this and allow it to be explicitly
+            // deallocated inside the worker (composite ops do this).
+            this->tensor_attributes->main_thread_tensor = false;
+        }
+        if (workers.size() == 1) {
+            this->tensor_attributes->storage = DeviceStorage();
+        } else if (workers.size() > 1) {
+            this->tensor_attributes->storage = MultiDeviceStorage();
+            std::transform(
+                workers.cbegin(),
+                workers.cend(),
+                std::back_inserter(
+                    std::get<MultiDeviceStorage>(this->tensor_attributes->storage).ordered_device_ids),
+                [](const Device *worker) { return worker->id(); });
+        }
+        this->tensor_attributes->num_shards_to_be_populated = workers.size();
+    } else if (num_buffers) {
+        if (num_buffers == 1) {
+            this->tensor_attributes->storage = OwnedStorage();
+        } else {
+            this->tensor_attributes->storage = MultiDeviceHostStorage();
+            // Preallocate buffer and shape vector for MultiDeviceHostStorage
+            if (distributed_tensor_config.has_value()) {
+                std::get<MultiDeviceHostStorage>(this->tensor_attributes->storage).strategy =
+                    distributed_tensor_config.value();
+            }
+            std::get<MultiDeviceHostStorage>(this->tensor_attributes->storage).buffers =
+                std::vector<OwnedBuffer>(num_buffers, OwnedBuffer());
+            std::get<MultiDeviceHostStorage>(this->tensor_attributes->storage).shapes =
+                std::vector<tt::tt_metal::LegacyShape>(num_buffers, this->tensor_attributes->shape.value);
+        }
+        this->tensor_attributes->num_shards_to_be_populated = num_buffers;
+    }
+}
+
+Tensor &Tensor::operator=(const Tensor &other) {
+    // Don't self-assign
+    this->tensor_id = other.tensor_id;
+    if (this->tensor_attributes != other.tensor_attributes) {
+        // Update ref count for curr tensor_attr and deallocate if needed
+        perform_cleanup_for_async_mode();
+        this->workers = other.workers;
+        this->tensor_attributes = other.tensor_attributes;
+        this->deallocate_through_destructor = other.deallocate_through_destructor;
+        if (this->workers.size()) {
+            if (not tt::tt_metal::detail::InWorkerThread()) {
+                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
+            }
+        }
+    }
+    return *this;
+}
+
+Tensor::Tensor(const Tensor &other) :
+    tensor_id(other.tensor_id),
+    workers(other.workers),
+    tensor_attributes(other.tensor_attributes),
+    deallocate_through_destructor(other.deallocate_through_destructor) {
+    if (this->workers.size()) {
+        if (not tt::tt_metal::detail::InWorkerThread()) {
+            this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
+        }
+    }
 }
 
 Tensor::~Tensor() {
@@ -119,7 +241,7 @@ void Tensor::deallocate(bool force) {
                     if (not this->workers.at(0)->is_initialized()) {
                         return;
                     }
-                    if (this->workers.at(0)->in_main_thread() or not this->tensor_attributes->main_thread_tensor) {
+                    if ((not tt::tt_metal::detail::InWorkerThread()) or not this->tensor_attributes->main_thread_tensor) {
                         if (not this->tensor_attributes->main_thread_tensor) {
                             TT_ASSERT(
                                 not this->tensor_attributes->main_thread_ref_count,
@@ -187,7 +309,7 @@ void Tensor::deallocate(bool force) {
                     if (not this->workers.at(0)->is_initialized()) {
                         return;
                     }
-                    if (this->workers.at(0)->in_main_thread() or not this->tensor_attributes->main_thread_tensor) {
+                    if ((not tt::tt_metal::detail::InWorkerThread()) or not this->tensor_attributes->main_thread_tensor) {
                         // If owned by the main thread, deallocate this tensor only from the main thread. If owned by
                         // worker thread, allow deallocation in worker and use shared_ptr ref count, since this is a
                         // thread_local tensor
@@ -245,7 +367,7 @@ void Tensor::perform_cleanup_for_async_mode() {
     // or move assignment operator
     if (this->tensor_attributes) {
         // Object has tensor_attributes that will be reassigned
-        if (this->workers.size() and this->workers.at(0)->in_main_thread() and
+        if (this->workers.size() and (not tt::tt_metal::detail::InWorkerThread()) and
             this->workers.at(0)->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS) {
             // Operator called in main thread with async mode. Main thread Ref Count must be decremented.
             // This is the last tensor in the main thread holding these attributes. Deallocate the buffer

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -62,46 +62,13 @@ struct Tensor {
         // Update the main thread ref count with the recorded value after the tensor is pushed to the queue(s),
         // since pushing to the queue requires an extra datacopy in the main thread, that gets balanced by the
         // worker, however the worker cannot modify main_thread_ref_count.
-        void increment_main_thread_ref_count(Device *worker) {
-            if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and worker->in_main_thread()) {
-                main_thread_ref_count++;
-                if (track_ref_count) {
-                    tt::log_info(
-                        "Inc Ref Count on tensor {}. Main Thread Ref Count: {}. Total Ref Count: {}.",
-                        reinterpret_cast<uint64_t>(this),
-                        main_thread_ref_count,
-                        shared_from_this().use_count());
-                }
-            }
-        }
+        void increment_main_thread_ref_count(Device *worker);
 
-        void decrement_main_thread_ref_count(Device *worker) {
-            if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and worker->in_main_thread()) {
-                main_thread_ref_count--;
-                if (track_ref_count) {
-                    tt::log_info(
-                        "Dec Ref Count on tensor {}. Main Thread Ref Count: {}. Total Ref Count: {}.",
-                        reinterpret_cast<uint64_t>(this),
-                        main_thread_ref_count,
-                        shared_from_this().use_count());
-                }
-            }
-        }
+        void decrement_main_thread_ref_count(Device *worker);
 
-        uint32_t record_main_thread_ref_count() { return main_thread_ref_count; }
+        uint32_t record_main_thread_ref_count();
 
-        void update_main_thread_ref_count(Device *worker, uint32_t ref_count) {
-            if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and worker->in_main_thread()) {
-                if (track_ref_count) {
-                    tt::log_info(
-                        "Update Ref Count on tensor {}. Main Thread Ref Count: {}. Total Ref Count: {}.",
-                        reinterpret_cast<uint64_t>(this),
-                        main_thread_ref_count,
-                        shared_from_this().use_count());
-                }
-                main_thread_ref_count = ref_count;
-            }
-        }
+        void update_main_thread_ref_count(Device *worker, uint32_t ref_count);
     };
 
     std::optional<std::int64_t> tensor_id = std::nullopt;
@@ -128,90 +95,11 @@ struct Tensor {
     Tensor(
         const std::vector<Device *>& workers,
         uint32_t num_buffers = 0,
-        std::optional<DistributedTensorConfig> distributed_tensor_config = std::nullopt) :
-        tensor_id(std::nullopt),
-        tensor_attributes(std::make_shared<TensorAttributes>()),
-        workers(workers),
-        deallocate_through_destructor(false) {
-        // When creating a device tensor, specify workers.
-        // When creating a host tensor, specify num_buffers.
-        // If neither are specified, a dummy tensor is being created. Do nothing.
-        if (workers.size()) {
-            bool in_main_thread_based_on_first_worker = workers.at(0)->in_main_thread();
-            for (auto &worker : workers) {
-                bool in_main_thread_based_on_curr_worker = worker->in_main_thread();
-                TT_FATAL(
-                    in_main_thread_based_on_curr_worker == in_main_thread_based_on_first_worker,
-                    "in_main_thread() inconsistency found across worker threads. Some worker threads have incorrectly "
-                    "assigned main thread IDs.");
-            }
-            if (in_main_thread_based_on_first_worker) {
-                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
-            } else {
-                // This tensor is being created from scratch in a worker. Track this and allow it to be explicitly
-                // deallocated inside the worker (composite ops do this).
-                this->tensor_attributes->main_thread_tensor = false;
-            }
-            if (workers.size() == 1) {
-                this->tensor_attributes->storage = DeviceStorage();
-            } else if (workers.size() > 1) {
-                this->tensor_attributes->storage = MultiDeviceStorage();
-                std::transform(
-                    workers.cbegin(),
-                    workers.cend(),
-                    std::back_inserter(
-                        std::get<MultiDeviceStorage>(this->tensor_attributes->storage).ordered_device_ids),
-                    [](const Device *worker) { return worker->id(); });
-            }
-            this->tensor_attributes->num_shards_to_be_populated = workers.size();
-        } else if (num_buffers) {
-            if (num_buffers == 1) {
-                this->tensor_attributes->storage = OwnedStorage();
-            } else {
-                this->tensor_attributes->storage = MultiDeviceHostStorage();
-                // Preallocate buffer and shape vector for MultiDeviceHostStorage
-                if (distributed_tensor_config.has_value()) {
-                    std::get<MultiDeviceHostStorage>(this->tensor_attributes->storage).strategy =
-                        distributed_tensor_config.value();
-                }
-                std::get<MultiDeviceHostStorage>(this->tensor_attributes->storage).buffers =
-                    std::vector<OwnedBuffer>(num_buffers, OwnedBuffer());
-                std::get<MultiDeviceHostStorage>(this->tensor_attributes->storage).shapes =
-                    std::vector<tt::tt_metal::LegacyShape>(num_buffers, this->tensor_attributes->shape.value);
-            }
-            this->tensor_attributes->num_shards_to_be_populated = num_buffers;
-        }
-    }
+        std::optional<DistributedTensorConfig> distributed_tensor_config = std::nullopt);
 
-    Tensor(const Tensor &other) :
-        tensor_id(other.tensor_id),
-        workers(other.workers),
-        tensor_attributes(other.tensor_attributes),
-        deallocate_through_destructor(other.deallocate_through_destructor) {
-        if (this->workers.size()) {
-            if (this->workers.at(0)->in_main_thread()) {
-                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
-            }
-        }
-    }
+    Tensor(const Tensor &other);
 
-    Tensor &operator=(const Tensor &other) {
-        // Don't self-assign
-        this->tensor_id = other.tensor_id;
-        if (this->tensor_attributes != other.tensor_attributes) {
-            // Update ref count for curr tensor_attr and deallocate if needed
-            perform_cleanup_for_async_mode();
-            this->workers = other.workers;
-            this->tensor_attributes = other.tensor_attributes;
-            this->deallocate_through_destructor = other.deallocate_through_destructor;
-            if (this->workers.size()) {
-                if (this->workers.at(0)->in_main_thread()) {
-                    this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
-                }
-            }
-        }
-        return *this;
-    }
+    Tensor &operator=(const Tensor &other);
 
     Tensor(Tensor &&other) noexcept = default;
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13447)

### Problem description
- Asynchronous tensor and op APIs have different behaviour based on which thread they're called from. For example, when a tensor is copied in an app thread, internal reference counting is done for it. Conversely, if an op API is called from a worker thread, the op call isn't handed off to an async executor, but called JIT
- We previously assumed that TTNN would run in a single application thread. For applications such as VLLM, this assumption is not true

### What's changed
- Generalize the logic for determining if a call is made in a worker or application thread -> we no longer assume a single main thread, but track the worker thread handles instead. The calling thread is then compared against the worker handles instead of a single main thread id, allowing multiple application threads to safely interface with the worker threads
- This should unblock work on frameworks like VLLM that require a model being run from an app thread forked off the main thread.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
