### PR TITLE
#13352: Add option to build programming examples to build_metal.sh

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -111,7 +111,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-tests"
+            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-tests --build-programming-examples"
             echo "${{ inputs.tracy }}"
             if [ "${{ inputs.tracy }}" = "true" ]; then
               build_command="$build_command --enable-profiler"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ if(ENABLE_TRACY)
     include(${PROJECT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
 
+option(BUILD_PROGRAMMING_EXAMPLES "Enables build of tt_metal programming examples" OFF)
 add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttnn)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,17 +65,35 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Set default values for variables/options
 set(UMD_HOME "${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd")
 
+############################################################################################################################
+# Project Options
+#   The following options and their defaults impact what artifacts get built
+############################################################################################################################
 option(WITH_PYTHON_BINDINGS "Enables build of python bindings" ON)
-message(STATUS "Build Python bindings: ${WITH_PYTHON_BINDINGS}")
-
 option(ENABLE_CODE_TIMERS "Enable code timers" OFF)
-
 option(ENABLE_TRACY "Enable Tracy Profiling" OFF)
-
 option(ENABLE_LIBCXX "Enable using libc++" ON)
-
-
 option(ENABLE_BUILD_TIME_TRACE "Enable build time trace (Clang only -ftime-trace)" OFF)
+option(BUILD_SHARED_LIBS "Create shared libraries" ON)
+option(ENABLE_ASAN "Enable build with AddressSanitizer" OFF)
+option(ENABLE_MSAN "Enable build with MemorySanitizer" OFF)
+option(ENABLE_TSAN "Enable build with ThreadSanitizer" OFF)
+option(ENABLE_UBSAN "Enable build with UndefinedBehaviorSanitizer" OFF)
+option(BUILD_PROGRAMMING_EXAMPLES "Enables build of tt_metal programming examples" OFF)
+option(TT_METAL_BUILD_TESTS "Enables build of tt_metal tests" OFF)
+option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
+
+message(STATUS "Build shared libs: ${BUILD_SHARED_LIBS}")
+message(STATUS "Build with ASAN: ${ENABLE_ASAN}")
+message(STATUS "Build with MSAN: ${ENABLE_MSAN}")
+message(STATUS "Build with TSAN: ${ENABLE_TSAN}")
+message(STATUS "Build with UBSAN: ${ENABLE_UBSAN}")
+message(STATUS "Build Python bindings: ${WITH_PYTHON_BINDINGS}")
+message(STATUS "Build Programming Examples: ${BUILD_PROGRAMMING_EXAMPLES}")
+message(STATUS "Build TT METAL Tests: ${TT_METAL_BUILD_TESTS}")
+message(STATUS "Build TTNN Tests: ${TTNN_BUILD_TESTS}")
+############################################################################################################################
+
 if(ENABLE_BUILD_TIME_TRACE)
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         message(STATUS "Adding compile option: -ftime-trace")
@@ -85,35 +103,18 @@ if(ENABLE_BUILD_TIME_TRACE)
     endif()
 endif()
 
-# Default to building everything as a shared lib
-option(BUILD_SHARED_LIBS "Create shared libraries" ON)
-message(STATUS "Build shared libs: ${BUILD_SHARED_LIBS}")
-
-option(ENABLE_ASAN "Enable build with AddressSanitizer" OFF)
-message(STATUS "Build with ASAN: ${ENABLE_ASAN}")
-
 set(SANITIZER_ENABLED ${ENABLE_ASAN})
-
-option(ENABLE_MSAN "Enable build with MemorySanitizer" OFF)
-message(STATUS "Build with MSAN: ${ENABLE_MSAN}")
-
 if(SANITIZER_ENABLED AND ENABLE_MSAN)
     message(FATAL_ERROR "Multiple sanitizers are not supported")
 elseif(ENABLE_MSAN)
     set(SANITIZER_ENABLED ${ENABLE_MSAN})
 endif()
 
-option(ENABLE_TSAN "Enable build with ThreadSanitizer" OFF)
-message(STATUS "Build with TSAN: ${ENABLE_TSAN}")
-
 if(SANITIZER_ENABLED AND ENABLE_TSAN)
     message(FATAL_ERROR "Multiple sanitizers are not supported")
 elseif(ENABLE_TSAN)
     set(SANITIZER_ENABLED ${ENABLE_TSAN})
 endif()
-
-option(ENABLE_UBSAN "Enable build with UndefinedBehaviorSanitizer" OFF)
-message(STATUS "Build with UBSAN: ${ENABLE_UBSAN}")
 
 if(SANITIZER_ENABLED AND ENABLE_UBSAN)
     message(FATAL_ERROR "Multiple sanitizers are not supported")
@@ -250,12 +251,9 @@ if(ENABLE_TRACY)
     include(${PROJECT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
 
-option(BUILD_PROGRAMMING_EXAMPLES "Enables build of tt_metal programming examples" OFF)
 add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttnn)
 
-option(TT_METAL_BUILD_TESTS "Enables build of tt_metal tests" OFF)
-option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
 if(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
     add_subdirectory(${PROJECT_SOURCE_DIR}/tests)
 endif(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -16,7 +16,11 @@ show_help() {
     echo "  -u, --enable-ubsan               Enable UndefinedBehaviorSanitizer."
     echo "  -p, --enable-profiler            Enable Tracy profiler."
     echo "  --install-prefix                 Where to install build artifacts."
-    echo "  --build-tests                    Build Testcases."
+    echo "  --build-tests                    Build All Testcases."
+    echo "  --build-ttnn-tests               Build ttnn Testcases."
+    echo "  --build-metal-tests              Build metal Testcases."
+    echo "  --build-umd-tests                Build umd Testcases."
+    echo "  --build-programming-examples     Build programming examples."
     echo "  --release                        Set the build type as Release."
     echo "  --development                    Set the build type as RelWithDebInfo."
     echo "  --debug                          Set the build type as Debug."
@@ -39,11 +43,15 @@ enable_ubsan="OFF"
 build_type="Release"
 enable_profiler="OFF"
 build_tests="OFF"
+build_ttnn_tests="OFF"
+build_metal_tests="OFF"
+build_umd_tests="OFF"
+build_programming_examples="OFF"
 
 declare -a cmake_args
 
 OPTIONS=h,e,c,t,a,m,s,u,b:,p
-LONGOPTIONS=help,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,release,development,debug,clean
+LONGOPTIONS=help,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,release,development,debug,clean
 
 # Parse the options
 PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTIONS --name "$0" -- "$@")
@@ -81,6 +89,14 @@ while true; do
             install_prefix="$2";shift;;
         --build-tests)
             build_tests="ON";;
+        --build-ttnn-tests)
+            build_ttnn_tests="ON";;
+        --build-metal-tests)
+            build_metal_tests="ON";;
+        --build-umd-tests)
+            build_umd_tests="ON";;
+        --build-programming-examples)
+            build_programming_examples="ON";;
         --release)
             build_type="Release";;
         --development)
@@ -180,6 +196,23 @@ if [ "$build_tests" = "ON" ]; then
     cmake_args+=("-DTTNN_BUILD_TESTS=ON")
     cmake_args+=("-DTT_UMD_BUILD_TESTS=ON")
 fi
+
+if [ "$build_metal_tests" = "ON" ]; then
+    cmake_args+=("-DTT_METAL_BUILD_TESTS=ON")
+fi
+
+if [ "$build_ttnn_tests" = "ON" ]; then
+    cmake_args+=("-DTTNN_BUILD_TESTS=ON")
+fi
+
+if [ "$build_tt_umd_tests" = "ON" ]; then
+    cmake_args+=("-DTT_UMD_BUILD_TESTS=ON")
+fi
+
+if [ "$build_programming_examples" = "ON" ]; then
+    cmake_args+=("-DBUILD_PROGRAMMING_EXAMPLES=ON")
+fi
+
 # Create and link the build directory
 mkdir -p $build_dir
 ln -nsf $build_dir build

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -52,8 +52,6 @@ foreach (TEST_SRC ${TT_METAL_TESTS_SRCS})
     list(APPEND METAL_TEST_TARGETS ${TEST})
 endforeach()
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal/programming_examples ${PROJECT_BINARY_DIR}/programming_examples)
-
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests_common)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests_fast_dispatch)

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -52,3 +52,8 @@ set_target_properties(tt_metal PROPERTIES
     INSTALL_RPATH "${PROJECT_BINARY_DIR}/lib"
     ADDITIONAL_CLEAN_FILES "${PROJECT_BINARY_DIR}/lib;${PROJECT_BINARY_DIR}/obj"
 )
+
+if(BUILD_PROGRAMMING_EXAMPLES)
+    add_subdirectory(programming_examples)
+endif(BUILD_PROGRAMMING_EXAMPLES)
+


### PR DESCRIPTION
### Ticket
#13352 

### Problem description
Currently the programming examples aren't built unless you build tests

### What's changed
Update build_metal.sh:
- Add option to build programming examples ONLY
- Add option to build tt metal tests ONLY
- Add option to build ttnn tests ONLY

Update CMakeLists.txt:
- Add CMake option to build programming examples ONLY
- Organize project options into singular block

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
