### PR TITLE
Implement a heuristic to select best sharding scheme for conv input0 (activations) tensor

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -639,6 +639,8 @@ class resnet50:
             width=self.conv1_output_width,
             in_channels=self.conv1_input_channels,
             out_channels=self.conv1_output_channels,
+            kernel_size=[self.conv1_kernel_size[0], self.conv1_kernel_size[1]],
+            stride=[self.conv1_stride[0], self.conv1_stride[1]],
         )
 
     def __del__(self):

--- a/tests/ttnn/unit_tests/operations/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv1d.py
@@ -45,6 +45,7 @@ def run_conv(
     deallocate_activation=True,
     debug=False,
     groups=1,
+    auto_shard=False,
 ):
     # has_bias = False
     has_bias = False
@@ -78,13 +79,17 @@ def run_conv(
 
     tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
 
+    shard_layout = (
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED if use_1d_systolic_array else ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    )
+    if auto_shard:
+        shard_layout = None
+
     conv_config = ttnn.Conv1dConfig(
         dtype=output_dtype,
         weights_dtype=weights_dtype,
         math_fidelity=math_fidelity,
-        shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-        if use_1d_systolic_array
-        else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        shard_layout=shard_layout,
         input_channels_alignment=(16 if use_shallow_conv_variant else 32),
         deallocate_activation=deallocate_activation,
         fp32_dest_acc_enabled=fp32_accum,
@@ -214,6 +219,7 @@ def test_conv1d_mamba(
         padded_input_channels=None,
         output_layout=output_layout,
         groups=groups,
+        auto_shard=True,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -6,12 +6,13 @@
 #include <sys/types.h>
 #include <cstdint>
 
+#include "impl/buffers/buffer_constants.hpp"
 #include "ttnn/operations/pool/downsample/device/downsample_op.hpp"
 #include "tt_metal/detail/reports/memory_reporter.hpp"
-#include "ttnn/operations/core/to_dtype/to_dtype_op.hpp"
 #include "tt_metal/common/work_split.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 using namespace tt;
 namespace ttnn {
@@ -313,16 +314,63 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
         .out_subblock_w_ntiles = out_subblock_w_ntiles};
 }
 
-template<typename T>
+// Implements a heuristic for selecting shard layout based on the input tensors shapes
+// and stride.
+static TensorMemoryLayout select_shard_layout(
+    uint32_t batch_size,
+    uint32_t height,
+    uint32_t width,
+    uint32_t in_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride) {
+    // ToDo: enhance shard layout selection logic to check
+    // which sharding scheme maximizes core count (and consequently available L1 space)
+
+    TensorMemoryLayout shard_layout;
+
+    // 1d convs support only height sharding
+    bool is_conv1d = width == 1 && kernel_size[1] == 1;
+    // block and width sharding support very few configurations of kernel size and stride
+    // which are encoded below.
+    bool is_width_or_block_sharding_valid =
+        (kernel_size[0] == 3 && kernel_size[1] == 3 && (stride[0] == 1 || stride[0] == 2)) ||
+        (kernel_size[0] == 1 && kernel_size[1] == 1 && stride[0] == 2);
+
+    if (is_conv1d || !is_width_or_block_sharding_valid) {
+        log_debug(LogOp, "Conv which can only be supported by TensorMemoryLayout::HEIGHT_SHARDED");
+        shard_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    } else {
+        float nhw = height * width * batch_size;
+        float ratio = nhw / in_channels;
+        log_debug(LogOp, "NHW: {}, C: {}, ratio: {}", nhw, in_channels, ratio);
+
+        if (ratio > 8.0f) {
+            shard_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+            log_debug(LogOp, "Shard layout: TensorMemoryLayout::HEIGHT_SHARDED");
+        } else if (ratio < 0.4f) {
+            shard_layout = TensorMemoryLayout::WIDTH_SHARDED;
+            log_debug(LogOp, "Shard layout: TensorMemoryLayout::WIDTH_SHARDED");
+        } else {
+            log_debug(LogOp, "Shard layout: TensorMemoryLayout::BLOCK_SHARDED");
+            shard_layout = TensorMemoryLayout::BLOCK_SHARDED;
+        }
+    }
+
+    return shard_layout;
+}
+
+template <typename T>
 std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config(
-    T * device,
+    T* device,
     const ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels) {
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride) {
     ttnn::Tensor input_tensor = input_tensor_;  // tensor to return
     bool input_tensor_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_);
     bool needs_shard_or_reshard = false;
@@ -330,6 +378,13 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
         TT_ASSERT(
             false,
             "Incorrect config provided: reshard_if_not_optimal and override_sharding_config cannot both be set.");
+    }
+
+    TensorMemoryLayout shard_layout;
+    if (conv_config.shard_layout.has_value()) {
+        shard_layout = conv_config.shard_layout.value();
+    } else {
+        shard_layout = select_shard_layout(batch_size, height, width, in_channels, kernel_size, stride);
     }
     ParallelConfig input_tensor_parallel_config;
     if (!input_tensor_on_device) {
@@ -357,15 +412,16 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
                 needs_shard_or_reshard = true;
             }
             if (conv_config.override_sharding_config) {
-                TT_FATAL(conv_config.core_grid.has_value(), "Error");
+                TT_FATAL(conv_config.core_grid.has_value(), "If override_sharding_config is set, core_grid must be set as well.");
+                TT_FATAL(conv_config.shard_layout.has_value(), "If override_sharding_config is set, shard_layout must be set as well.");
                 if (conv_config.core_grid.value() != input_shard_grid) {
                     needs_shard_or_reshard = true;
                 }
-                if(conv_config.shard_layout!=input_shard_scheme) {
+                if(shard_layout!=input_shard_scheme) {
                     needs_shard_or_reshard = true;
                 }
                 bool input_transpose_shards = input_shard_orientation == ShardOrientation::COL_MAJOR;
-                if (conv_config.shard_layout == TensorMemoryLayout::BLOCK_SHARDED && conv_config.transpose_shards != input_transpose_shards) {
+                if (shard_layout == TensorMemoryLayout::BLOCK_SHARDED && conv_config.transpose_shards != input_transpose_shards) {
                     needs_shard_or_reshard = true;
                 }
             }
@@ -376,23 +432,17 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
         auto block_shard_orientation =
             conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
         const ParallelConfig& optimal_parallel_config = determine_parallel_config(
-            conv_config.shard_layout,
-            batch_size,
-            in_channels,
-            height,
-            width,
-            out_channels,
-            device,
-            block_shard_orientation);
+            shard_layout, batch_size, in_channels, height, width, out_channels, device, block_shard_orientation);
 
         if (conv_config.override_sharding_config) {
             TT_FATAL(conv_config.core_grid.has_value(), "Error");
             // override parallel config
-            auto shard_orientation =
-                conv_config.shard_layout==TensorMemoryLayout::BLOCK_SHARDED ? block_shard_orientation:  ShardOrientation::ROW_MAJOR;
+            auto shard_orientation = shard_layout == TensorMemoryLayout::BLOCK_SHARDED
+                                         ? block_shard_orientation
+                                         : ShardOrientation::ROW_MAJOR;
             parallel_config = {
                 .grid = conv_config.core_grid.value(),
-                .shard_scheme = conv_config.shard_layout,
+                .shard_scheme = shard_layout,
                 .shard_orientation = shard_orientation};
         } else {
             parallel_config = optimal_parallel_config;
@@ -405,7 +455,7 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
         uint32_t input_num_cores_nhw = get_num_cores_nhw_from_parallel_config(parallel_config);
         // TT_ASSERT(input_tensor.get_legacy_shape() == input_tensor.get_shape());
         uint32_t tensor_height = input_tensor.get_shape()[0] * input_tensor.get_shape()[1] * input_tensor.get_shape()[2];
-        uint32_t input_tensor_height_snapped_to_tile = (conv_config.shard_layout == TensorMemoryLayout::WIDTH_SHARDED)? tensor_height : tt::round_up(tensor_height, input_num_cores_nhw * 32);
+        uint32_t input_tensor_height_snapped_to_tile = (shard_layout == TensorMemoryLayout::WIDTH_SHARDED)? tensor_height : tt::round_up(tensor_height, input_num_cores_nhw * 32);
         TT_ASSERT(input_tensor_height_snapped_to_tile >= tensor_height);
         uint32_t tensor_width = input_tensor.get_shape()[3];
         uint32_t input_tensor_width_snapped_to_channels_alignment =
@@ -429,20 +479,24 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
     }
 }
 
-template<typename T>
+template <typename T>
 std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_if_required(
-    T * device,
+    T* device,
     const ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels) {
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride) {
     ttnn::Tensor input_tensor = input_tensor_;  // tensor to return
     bool input_tensor_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_);
 
-    auto [input_padded_shape, input_tensor_sharded_memory_config, needs_shard_or_reshard] = get_conv_padded_input_shape_and_mem_config(device, input_tensor_, conv_config, batch_size, height, width, in_channels, out_channels);
+    auto [input_padded_shape, input_tensor_sharded_memory_config, needs_shard_or_reshard] =
+        get_conv_padded_input_shape_and_mem_config(
+            device, input_tensor_, conv_config, batch_size, height, width, in_channels, out_channels, kernel_size, stride);
     ParallelConfig parallel_config = {
         .grid = input_tensor_sharded_memory_config.shard_spec.value().grid,
         .shard_scheme = input_tensor_sharded_memory_config.memory_layout,
@@ -676,7 +730,7 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
     uint32_t output_height = ((input_height - kernel_size[0] - ((kernel_size[0] - 1 ) * (dilation[0] - 1)) + 2 * padding[0]) / stride[0]) + 1;
     uint32_t output_width = ((input_width - kernel_size[1] - ((kernel_size[0] - 1 ) * (dilation[0] - 1)) + 2 * padding[1]) / stride[1]) + 1;
     auto [input_tensor_post_tm, parallel_config, tensor_manipulated] = shard_or_reshard_tensor_if_required(
-        device, input_tensor, conv_config, batch_size, output_height, output_width, in_channels, out_channels);
+        device, input_tensor, conv_config, batch_size, output_height, output_width, in_channels, out_channels, kernel_size, stride);
     if (tensor_manipulated) {
         if (conv_config.deallocate_activation) {
             ttnn::Tensor input_tensor_ = input_tensor;  // TODO: allow in place modification of inputs to the op
@@ -910,14 +964,16 @@ template ParallelConfig determine_parallel_config<MeshDevice>(
     bool is_out_tiled);
 
 template std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config<Device>(
-    Device * device,
+    Device* device,
     const ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels);
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride);
 
 template std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config<MeshDevice>(
     MeshDevice * device,
@@ -927,17 +983,21 @@ template std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels);
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride);
 
 template std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_if_required<Device>(
-    Device * device,
+    Device* device,
     const ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels);
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride);
 
 template std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_if_required<MeshDevice>(
     MeshDevice * device,
@@ -947,7 +1007,9 @@ template std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels);
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride);
 
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device<Device>(
     const ttnn::Tensor& weight_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -40,7 +40,7 @@ struct Conv2dConfig {
     uint32_t act_block_w_div = 1; //Amount by which the maximum possible act_block_width is divided. Max act_block_w = (in_channels * window_w * window_h)/total_num_cores;
     bool reshard_if_not_optimal = false; // if true, override_sharding_config should not be set to true
     bool override_sharding_config = false; // if true, reshard_if_not_optimal should not be set to true
-    TensorMemoryLayout shard_layout = TensorMemoryLayout::HEIGHT_SHARDED; // used only if override_sharding_config is true
+    std::optional<TensorMemoryLayout> shard_layout;
     std::optional<CoreRangeSet> core_grid = std::nullopt; // used only if override_sharding_config is true
     bool transpose_shards = true; // used only if override_sharding_config is true and if height sharding is false
     Layout output_layout = Layout::TILE;
@@ -134,7 +134,9 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels);
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride);
 
 template<typename T>
 std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, bool> shard_or_reshard_tensor_if_required(
@@ -145,7 +147,9 @@ std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, bool> shard_or_reshard_
     uint32_t height,
     uint32_t width,
     uint32_t in_channels,
-    uint32_t out_channels);
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride);
 
 void validate_weight_and_bias_tensors(const ttnn::Tensor& weight_tensor, std::optional<const ttnn::Tensor>& bias_tensor);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -117,16 +117,18 @@ void py_bind_conv2d(py::module& module) {
 
     module.def(
         "get_conv_padded_input_shape_and_mem_config",
-        [](ttnn::Device * device,
-            const ttnn::Tensor& input_tensor,
-            const Conv2dConfig& conv_config,
-            uint32_t batch_size,
-            uint32_t height,
-            uint32_t width,
-            uint32_t in_channels,
-            uint32_t out_channels) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
+        [](ttnn::Device* device,
+           const ttnn::Tensor& input_tensor,
+           const Conv2dConfig& conv_config,
+           uint32_t batch_size,
+           uint32_t height,
+           uint32_t width,
+           uint32_t in_channels,
+           uint32_t out_channels,
+           std::array<uint32_t, 2> kernel_size,
+           std::array<uint32_t, 2> stride) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
             return ttnn::operations::conv::conv2d::get_conv_padded_input_shape_and_mem_config<ttnn::Device>(
-                device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels);
+                device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels, kernel_size, stride);
         },
         py::kw_only(),
         py::arg("device"),
@@ -136,20 +138,24 @@ void py_bind_conv2d(py::module& module) {
         py::arg("height"),
         py::arg("width"),
         py::arg("in_channels"),
-        py::arg("out_channels"));
+        py::arg("out_channels"),
+        py::arg("kernel_size"),
+        py::arg("stride"));
 
     module.def(
         "get_conv_padded_input_shape_and_mem_config",
-        [](MeshDevice * device,
-            const ttnn::Tensor& input_tensor,
-            const Conv2dConfig& conv_config,
-            uint32_t batch_size,
-            uint32_t height,
-            uint32_t width,
-            uint32_t in_channels,
-            uint32_t out_channels) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
+        [](MeshDevice* device,
+           const ttnn::Tensor& input_tensor,
+           const Conv2dConfig& conv_config,
+           uint32_t batch_size,
+           uint32_t height,
+           uint32_t width,
+           uint32_t in_channels,
+           uint32_t out_channels,
+           std::array<uint32_t, 2> kernel_size,
+           std::array<uint32_t, 2> stride) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
             return ttnn::operations::conv::conv2d::get_conv_padded_input_shape_and_mem_config<MeshDevice>(
-                device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels);
+                device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels, kernel_size, stride);
         },
         py::kw_only(),
         py::arg("device"),
@@ -159,7 +165,9 @@ void py_bind_conv2d(py::module& module) {
         py::arg("height"),
         py::arg("width"),
         py::arg("in_channels"),
-        py::arg("out_channels"));
+        py::arg("out_channels"),
+        py::arg("kernel_size"),
+        py::arg("stride"));
 
     module.def(
         "convert_conv_weight_tensor_to_tiled_layout",
@@ -186,7 +194,7 @@ void py_bind_conv2d(py::module& module) {
 
     auto py_conv_config = py::class_<Conv2dConfig>(module, "Conv2dConfig");
     py_conv_config.def(
-            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, uint32_t, bool, bool, TensorMemoryLayout, std::optional<CoreRangeSet>, bool, Layout, bool, bool, bool>(),
+            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, uint32_t, bool, bool, std::optional<TensorMemoryLayout>, std::optional<CoreRangeSet>, bool, Layout, bool, bool, bool>(),
             py::kw_only(),
             py::arg("math_fidelity") = MathFidelity::HiFi4,
             py::arg("dtype") = DataType::BFLOAT16,
@@ -202,7 +210,7 @@ void py_bind_conv2d(py::module& module) {
             py::arg("act_block_w_div") = 1,
             py::arg("reshard_if_not_optimal") = false,
             py::arg("override_sharding_config") = false,
-            py::arg("shard_layout") = TensorMemoryLayout::HEIGHT_SHARDED,
+            py::arg("shard_layout") = std::nullopt,
             py::arg("core_grid") = std::nullopt,
             py::arg("transpose_shards") = true,
             py::arg("output_layout") = Layout::TILE,


### PR DESCRIPTION
Conv2d requires (internally) a sharded tensor for in0(activations).
Currently if user passes in interleaved tensor  and shard_layout is not provided as part of the Conv2dConfig, op will default to height sharding. And conv will trigger an op to convert input tensor to height sharded tensor.

This isn't always the best heuristic. This change introduces a logic to select the best sharding layout based on the input tensor shape, in order to increase core count and consequently increase L1 space op can use, and reduce number of out-of-memory errors. There is still no guarantee that op will fit in L1 space, but we can observe high success rate in tests coming out of pytorch2 ttnn integration.

This heuristic is not the most optimal one and we will keep iterating on it as well, but given that it resolve a lot torch tests cases we want to prioritize getting it in.

This change is also a BREAKING CHANGE, as it changes the default behavior of Conv2d when user passes in interlaved tensor for in0(activations). This doesn't seem to affect our models given that they already provided sharded tensors as inputs, but it does affect some of our tests.

In case users wants to pass in interleaved tensor, and manually pick sharding layout, user has to set shard_layout in Conv2dConfig, which now defaults to std::nullopt instead of HEIGHT_SHARDED.

To test this change a variant with auto shard selection has been added to most of tests/ttnn/unit_tests/operations/test_new_conv2d.py. Some tests are skipped (like stable diffusion tests) as this change has exposed few issues with conv WIDTH_SHARDED codepath that we need to address.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13541)

### Checklist
- [x] Post commit CI passes -  https://github.com/tenstorrent/tt-metal/actions/runs/11234012162
- [x] Model regression CI testing passes (if applicable) -  https://github.com/tenstorrent/tt-metal/actions/runs/11233215136 (fails with same margin as on main)
- [x] (Single-card) Device perf regressions - https://github.com/tenstorrent/tt-metal/actions/runs/11233218302
- [x] New/Existing tests provide coverage for changes
