### PR TITLE
#13537: Remove extra param in ttnn.bitwise_not

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_not.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/bitwise/bitwise_not.py
@@ -66,8 +66,6 @@ def run(
 
     torch_input_tensor_a = torch.full(size=input_shape, fill_value=-2147483647).to(torch.int32)
 
-    scalar = torch.randint(-100, 101, (1,)).item()
-
     torch_output_tensor = torch.bitwise_not(torch_input_tensor_a)
 
     input_tensor_a = ttnn.from_torch(
@@ -79,7 +77,7 @@ def run(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.bitwise_not(input_tensor_a, value=scalar, memory_config=output_memory_config)
+    result = ttnn.bitwise_not(input_tensor_a, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -889,7 +889,6 @@ def eltwise_bitwise_xor(
 def eltwise_bitwise_not(
     x,
     *args,
-    value,
     device,
     dtype,
     layout,
@@ -898,7 +897,7 @@ def eltwise_bitwise_not(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.bitwise_not(t0, value, memory_config=output_mem_config, queue_id=0)
+    t1 = ttnn.bitwise_not(t0, memory_config=output_mem_config, queue_id=0)
 
     return tt2torch_tensor(t1)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -404,3 +404,27 @@ def test_asin_fixed(device, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_acos_fixed(device, h, w):
     run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
+
+
+def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.full(size=(h, w), fill_value=fill_value).to(torch.int32)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn_function(input_tensor)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("fill_value", [-2147483647, 2147483648, 7534, 225, 97, 3])
+def test_bitwise_not(device, h, w, fill_value):
+    run_unary_test_bitwise_not(device, h, w, fill_value, ttnn.bitwise_not)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_not(const uint value) {
+inline void calculate_bitwise_not() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_not.h
@@ -18,9 +18,9 @@ inline void llk_math_eltwise_unary_sfpu_bitwise_not_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_bitwise_not(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_bitwise_not(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>
                                 (ckernel::sfpu::calculate_bitwise_not<APPROXIMATE>,
-                                dst_index, vector_mode, param0);
+                                dst_index, vector_mode);
 }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_not(const uint value) {
+inline void calculate_bitwise_not() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_not.h
@@ -18,9 +18,9 @@ inline void llk_math_eltwise_unary_sfpu_bitwise_not_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_bitwise_not(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+inline void llk_math_eltwise_unary_sfpu_bitwise_not(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>
                                 (ckernel::sfpu::calculate_bitwise_not<APPROXIMATE>,
-                                dst_index, vector_mode, param0);
+                                dst_index, vector_mode);
 }
 }

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_not.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_not.h
@@ -30,8 +30,8 @@ namespace ckernel {
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to modify the computation of  | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
-ALWI void bitwise_not_tile(uint32_t idst, uint32_t param0) {
-    MATH((llk_math_eltwise_unary_sfpu_bitwise_not<APPROX>(idst, param0)));
+ALWI void bitwise_not_tile(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_bitwise_not<APPROX>(idst)));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -118,10 +118,6 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             op_init_and_name = {
                 "bitwise_xor_tile_init();", fmt::format("bitwise_xor_tile({}, {}u);", idst, std::to_string((uint)param0))};
             break;
-        case UnaryOpType::BITWISE_NOT:
-            op_init_and_name = {
-                "bitwise_not_tile_init();", fmt::format("bitwise_not_tile({}, {}u);", idst, std::to_string((uint)param0))};
-            break;
         case UnaryOpType::BITWISE_AND:
             op_init_and_name = {
                 "bitwise_and_tile_init();", fmt::format("bitwise_and_tile({}, {}u);", idst, std::to_string((uint)param0))};
@@ -251,6 +247,10 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
 std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, std::string idst) {
     std::pair<std::string, std::string> op_init_and_name;
     switch (op_type) {
+        case UnaryOpType::BITWISE_NOT:
+            op_init_and_name = {
+                "bitwise_not_tile_init();", fmt::format("bitwise_not_tile({});", idst)};
+            break;
         case UnaryOpType::RECIP: op_init_and_name = {"recip_tile_init();", fmt::format("recip_tile({});", idst)}; break;
         case UnaryOpType::RELU: op_init_and_name = {"relu_tile_init();", fmt::format("relu_tile({});", idst)}; break;
         case UnaryOpType::SQRT: op_init_and_name = {"sqrt_tile_init();", fmt::format("sqrt_tile({});", idst)}; break;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -53,7 +53,6 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::UNARY_LT:
         case UnaryOpType::TYPECAST:
         case UnaryOpType::BITWISE_XOR:
-        case UnaryOpType::BITWISE_NOT:
         case UnaryOpType::BITWISE_AND:
         case UnaryOpType::BITWISE_OR:
         case UnaryOpType::RIGHT_SHIFT:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -120,6 +120,7 @@ template struct ExecuteUnary<UnaryOpType::TAN>;
 template struct ExecuteUnary<UnaryOpType::TANH>;
 template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;
 template struct ExecuteUnary<UnaryOpType::TILED_PROD>;
+template struct ExecuteUnary<UnaryOpType::BITWISE_NOT>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFastAndApproximateMode<unary_op_type>::invoke(
@@ -373,7 +374,6 @@ template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::RIGHT_SHIFT, int32
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_AND, int32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_OR, int32_t>;
 template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_XOR, int32_t>;
-template struct ExecuteUnaryWithIntegerParameter<UnaryOpType::BITWISE_NOT, int32_t>;
 
 
 template <UnaryOpType unary_op_type, typename T>

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -299,6 +299,7 @@ REGISTER_UNARY_OPERATION(square, SQUARE);
 REGISTER_UNARY_OPERATION(tan, TAN);
 REGISTER_UNARY_OPERATION(tanh, TANH);
 REGISTER_UNARY_OPERATION(tiled_prod, TILED_PROD);
+REGISTER_UNARY_OPERATION(bitwise_not, BITWISE_NOT);
 
 constexpr auto log_sigmoid = ttnn::register_operation_with_auto_launch_op<"ttnn::log_sigmoid", ttnn::operations::unary::ExecuteUnary<
     ttnn::operations::unary::UnaryOpType::SIGMOID,
@@ -331,7 +332,6 @@ REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(bitwise_right_shift, RIGHT_SHIFT
 REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(bitwise_and, BITWISE_AND, int32_t);
 REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(bitwise_or, BITWISE_OR, int32_t);
 REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(bitwise_xor, BITWISE_XOR, int32_t);
-REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(bitwise_not, BITWISE_NOT, int32_t);
 
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1403,6 +1403,7 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::tan, R"doc(\mathrm{{output\_tensor}}_i = tan(\mathrm{{input\_tensor}}_i))doc");
     detail::bind_unary_operation(module, ttnn::tanh, R"doc(\mathrm{{output\_tensor}}_i = tanh(\mathrm{{input\_tensor}}_i))doc");
     detail::bind_unary_operation(module, ttnn::log_sigmoid, R"doc(\mathrm{{output\_tensor}}_i = \verb|log_sigmoid|(\mathrm{{input\_tensor}}_i))doc");
+    detail::bind_unary_operation(module, ttnn::bitwise_not, R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_not|(\mathrm{{input\_tensor}}_i))doc", "Input tensor needs to be in the range [-2147483647, 2147483647], INT32 dtype. Support provided only for Wormhole_B0.");
 
     //  Unaries with fast_and_approximate_mode
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::exp,
@@ -1470,7 +1471,6 @@ void py_module(py::module& module) {
     detail::bind_unary_operation_with_integer_parameter(module, ttnn::bitwise_and, "value", "scalar value", "Input tensor needs to be positive, INT32 dtype. Support provided only for Wormhole_B0.");
     detail::bind_unary_operation_with_integer_parameter(module, ttnn::bitwise_or, "value", "scalar value", "Input tensor needs to be positive, INT32 dtype. Support provided only for Wormhole_B0.");
     detail::bind_unary_operation_with_integer_parameter(module, ttnn::bitwise_xor, "value", "scalar value", "Input tensor needs to be positive, INT32 dtype. Support provided only for Wormhole_B0.");
-    detail::bind_unary_operation_with_integer_parameter(module, ttnn::bitwise_not, "value", "scalar value", "Input tensor needs to be in the range [-2147483647, 2147483647], INT32 dtype. Support provided only for Wormhole_B0.");
 
 
     // Unary ops with dim parameter

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -412,10 +412,10 @@ def _golden_function_bitwise_xor(input_tensor_a, value, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.bitwise_xor, golden_function=_golden_function_bitwise_xor)
 
 
-def _golden_function_bitwise_not(input_tensor_a, value, *args, **kwargs):
+def _golden_function_bitwise_not(input_tensor_a, *args, **kwargs):
     import torch
 
-    return torch.bitwise_not(input_tensor_a, value)
+    return torch.bitwise_not(input_tensor_a)
 
 
 ttnn.attach_golden_function(ttnn.bitwise_not, golden_function=_golden_function_bitwise_not)


### PR DESCRIPTION
### Ticket
Link to Github Issue #13537 
also fixes #12901

### Problem description
`ttnn.bitwise_not` has an extra `int` param that needs to be removed from kernel and bindings.

### What's changed
`ttnn.bitwise_not` doesn't require an extra int param 
<img width="880" alt="image" src="https://github.com/user-attachments/assets/2e3dd674-b96e-4e4e-a1c5-b985b3e489e3">

the existing sweep passes like it did before.
<img width="1069" alt="image" src="https://github.com/user-attachments/assets/3df7240c-1c60-4b98-82c5-858e28909832">

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11237713541 
https://github.com/tenstorrent/tt-metal/actions/runs/11345022710
- [ ] Nightly FD https://github.com/tenstorrent/tt-metal/actions/runs/11345057847
- [x] ttnn sweeps https://github.com/tenstorrent/tt-metal/actions/runs/11237723067
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
