### PR TITLE
Support generating perf report for C++ binaries

### DIFF
--- a/scripts/tools_setup_common.sh
+++ b/scripts/tools_setup_common.sh
@@ -10,6 +10,9 @@ fi
 PROFILER_SCRIPTS_ROOT=$TT_METAL_HOME/tt_metal/tools/profiler
 PROFILER_TEST_SCRIPTS_ROOT=$TT_METAL_HOME/tests/tt_metal/tools/profiler
 PROFILER_ARTIFACTS_DIR=$TT_METAL_HOME/generated/profiler
+if [[ "$TT_METAL_PROFILER_DIR" ]]; then
+    PROFILER_ARTIFACTS_DIR=$TT_METAL_PROFILER_DIR
+fi
 PROFILER_OUTPUT_DIR=$PROFILER_ARTIFACTS_DIR/reports
 
 remove_default_log_locations(){

--- a/tt_metal/tools/profiler/common.hpp
+++ b/tt_metal/tools/profiler/common.hpp
@@ -14,7 +14,24 @@ namespace tt_metal {
 constexpr std::string_view PROFILER_RUNTIME_ROOT_DIR = "generated/profiler/";
 constexpr std::string_view PROFILER_LOGS_DIR_NAME = ".logs/";
 
-inline std::string PROFILER_ZONE_SRC_LOCATIONS_LOG = string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME) + "zone_src_locations.log";
+
+inline std::string get_profiler_artifacts_dir()
+{
+    std::string artifactDir = string(PROFILER_RUNTIME_ROOT_DIR);
+    const auto PROFILER_ARTIFACTS_DIR = std::getenv("TT_METAL_PROFILER_DIR");
+    if (PROFILER_ARTIFACTS_DIR != nullptr)
+    {
+        artifactDir = string(PROFILER_ARTIFACTS_DIR) + "/";
+    }
+    return artifactDir;
+}
+
+inline std::string get_profiler_logs_dir()
+{
+    return get_profiler_artifacts_dir() + string(PROFILER_LOGS_DIR_NAME);
+}
+
+inline std::string PROFILER_ZONE_SRC_LOCATIONS_LOG =  get_profiler_logs_dir() + "zone_src_locations.log";
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/tools/profiler/common.py
+++ b/tt_metal/tools/profiler/common.py
@@ -20,12 +20,11 @@ PROFILER_HOST_DEVICE_SYNC_INFO = "sync_device_info.csv"
 
 PROFILER_SCRIPTS_ROOT = TT_METAL_HOME / "tt_metal/tools/profiler"
 PROFILER_ARTIFACTS_DIR = TT_METAL_HOME / "generated/profiler"
+if "TT_METAL_PROFILER_DIR" in ENVS.keys():
+    PROFILER_ARTIFACTS_DIR = Path(ENVS["TT_METAL_PROFILER_DIR"])
+
 
 PROFILER_BIN_DIR = TT_METAL_HOME / "build/tools/profiler/bin"
-PROFILER_LOGS_DIR = PROFILER_ARTIFACTS_DIR / ".logs"
-PROFILER_OUTPUT_DIR = PROFILER_ARTIFACTS_DIR / "reports"
-PROFILER_OPS_LOGS_DIR = PROFILER_LOGS_DIR / "ops"
-PROFILER_LOG_LOCATIONS_RECORD = PROFILER_LOGS_DIR / ".locations.log"
 
 TRACY_OPS_TIMES_FILE_NAME = "tracy_ops_times.csv"
 TRACY_OPS_DATA_FILE_NAME = "tracy_ops_data.csv"
@@ -34,6 +33,18 @@ TRACY_FILE_NAME = "tracy_profile_log_host.tracy"
 
 TRACY_CAPTURE_TOOL = "capture-release"
 TRACY_CSVEXPROT_TOOL = "csvexport-release"
+
+
+def generate_logs_folder(outFolder):
+    return outFolder / ".logs"
+
+
+def generate_reports_folder(outFolder):
+    return outFolder / "reports"
+
+
+PROFILER_LOGS_DIR = generate_logs_folder(PROFILER_ARTIFACTS_DIR)
+PROFILER_OUTPUT_DIR = generate_reports_folder(PROFILER_ARTIFACTS_DIR)
 
 
 def rm(path):
@@ -47,22 +58,3 @@ def rm(path):
 
 def clear_profiler_runtime_artifacts():
     rm(PROFILER_ARTIFACTS_DIR)
-
-
-def get_log_locations():
-    logLocations = set()
-    deviceLogLocations = set()
-    if os.path.isfile(PROFILER_LOG_LOCATIONS_RECORD):
-        with open(PROFILER_LOG_LOCATIONS_RECORD, "r") as recordFile:
-            for line in recordFile.readlines():
-                logLocation = line.strip()
-                if os.path.isdir(f"{logLocation}") or os.path.isdir(f"{TT_METAL_HOME}/{logLocation}"):
-                    logLocations.add(logLocation)
-                    tmpSplit = logLocation.rsplit("_", 1)
-                    if tmpSplit[-1] == "device":
-                        deviceLogLocations.add(tmpSplit[0])
-    for logLocation in deviceLogLocations:
-        if logLocation in logLocations:
-            logLocations.remove(f"{logLocation}_device")
-
-    return list(logLocations)

--- a/tt_metal/tools/profiler/process_model_log.py
+++ b/tt_metal/tools/profiler/process_model_log.py
@@ -7,12 +7,17 @@ import subprocess
 from pathlib import Path
 import pandas as pd
 
-from tt_metal.tools.profiler.common import PROFILER_OUTPUT_DIR, PROFILER_SCRIPTS_ROOT
+from tt_metal.tools.profiler.common import PROFILER_ARTIFACTS_DIR, PROFILER_SCRIPTS_ROOT, generate_reports_folder
+
+
+def get_profiler_folder(output_logs_subdir):
+    return PROFILER_ARTIFACTS_DIR / output_logs_subdir
 
 
 def get_latest_ops_log_filename(output_logs_subdir):
-    runDate = sorted(os.listdir(PROFILER_OUTPUT_DIR / output_logs_subdir))[-1]
-    filename = PROFILER_OUTPUT_DIR / output_logs_subdir / runDate / f"ops_perf_results_{runDate}.csv"
+    output_report_dir = generate_reports_folder(get_profiler_folder(output_logs_subdir))
+    runDate = sorted(os.listdir(output_report_dir))[-1]
+    filename = output_report_dir / runDate / f"ops_perf_results_{runDate}.csv"
     return filename
 
 
@@ -40,8 +45,8 @@ def post_process_ops_log(output_logs_subdir, columns, sum_vals=True, op_name="",
 
 
 def run_device_profiler(command, output_logs_subdir):
-    output_logs_dir = PROFILER_OUTPUT_DIR / output_logs_subdir
-    profiler_cmd = f"python -m tracy -p -r -o {output_logs_dir} -t 5000 -m {command}"
+    output_profiler_dir = get_profiler_folder(output_logs_subdir)
+    profiler_cmd = f"python -m tracy -p -r -o {output_profiler_dir} -t 5000 -m {command}"
     subprocess.run([profiler_cmd], shell=True, check=True)
 
 

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -20,14 +20,15 @@ from loguru import logger
 from tt_metal.tools.profiler.process_device_log import import_log_run_stats
 import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
 from tt_metal.tools.profiler.common import (
-    PROFILER_LOGS_DIR,
-    PROFILER_OPS_LOGS_DIR,
     PROFILER_DEVICE_SIDE_LOG,
     PROFILER_HOST_SIDE_LOG,
+    PROFILER_ARTIFACTS_DIR,
     PROFILER_OUTPUT_DIR,
     TRACY_FILE_NAME,
     TRACY_OPS_TIMES_FILE_NAME,
     TRACY_OPS_DATA_FILE_NAME,
+    generate_logs_folder,
+    generate_reports_folder,
 )
 
 yaml.SafeDumper.ignore_aliases = lambda *args: True
@@ -77,15 +78,15 @@ def csv_header_format(header):
     return header.replace("_", " ").upper()
 
 
-def import_tracy_op_logs():
+def import_tracy_op_logs(logFolder):
     logger.info(f"Importing ops logs")
     ops = {}
     signposts = {}
     signpostsCount = 0
     cached_ops = {}
 
-    tracyOpTimesLog = os.path.join(PROFILER_LOGS_DIR, TRACY_OPS_TIMES_FILE_NAME)
-    tracyOpDataLog = os.path.join(PROFILER_LOGS_DIR, TRACY_OPS_DATA_FILE_NAME)
+    tracyOpTimesLog = os.path.join(logFolder, TRACY_OPS_TIMES_FILE_NAME)
+    tracyOpDataLog = os.path.join(logFolder, TRACY_OPS_DATA_FILE_NAME)
 
     if not os.path.isfile(tracyOpTimesLog) or not os.path.isfile(tracyOpDataLog):
         return ops, signposts
@@ -190,10 +191,10 @@ def device_log_ops_compare(op):
 
 
 # Append device data to device ops and return the list of mapped device op ref list
-def append_device_data(ops, deviceLogFolder):
+def append_device_data(ops, logFolder):
     deviceOps = get_device_op_data(ops)
     logger.info(f"Appending device data")
-    deviceTimesLog = os.path.join(deviceLogFolder, PROFILER_DEVICE_SIDE_LOG)
+    deviceTimesLog = os.path.join(logFolder, PROFILER_DEVICE_SIDE_LOG)
     if os.path.isfile(deviceTimesLog):
         setup = device_post_proc_config.default_setup()
         setup.deviceInputLog = deviceTimesLog
@@ -231,7 +232,7 @@ def append_device_data(ops, deviceLogFolder):
                         if "run_host_id" in timeID.keys():
                             assert (
                                 timeID["run_host_id"] == deviceOp["global_call_count"]
-                            ), f"op id {timeID['run_host_id']} reproted by device is not matching assigned op id {deviceOp['global_call_count']}"
+                            ), f"op id {timeID['run_host_id']} reproted by device {device} is not matching assigned op id {deviceOp['global_call_count']}"
                         if core not in cores:
                             cores.add(core)
                 deviceOp["core_usage"] = {"count": len(cores), "cores": [str(core) for core in cores]}
@@ -245,9 +246,9 @@ def append_device_data(ops, deviceLogFolder):
 
 
 def get_device_data_generate_report(
-    deviceLogFolder, outputFolder, date, nameAppend, export_csv=True, cleanup_device_log=False
+    logFolder, outputFolder, date, nameAppend, export_csv=True, cleanup_device_log=False
 ):
-    deviceTimesLog = os.path.join(deviceLogFolder, PROFILER_DEVICE_SIDE_LOG)
+    deviceTimesLog = os.path.join(logFolder, PROFILER_DEVICE_SIDE_LOG)
     devicePreOpTime = {}
     deviceOps = {}
     i = 0
@@ -273,8 +274,8 @@ def get_device_data_generate_report(
         allOpsCSVPath = os.path.join(outFolder, f"{name}.csv")
         logger.info(f"Copying runtime artifacts")
         os.system(f"rm -rf {outFolder}; mkdir -p {outFolder}")
-        if os.path.isfile(f"{PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG}"):
-            os.system(f"cp {PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG} {outFolder}")
+        if os.path.isfile(f"{logFolder / PROFILER_DEVICE_SIDE_LOG}"):
+            os.system(f"cp {logFolder / PROFILER_DEVICE_SIDE_LOG} {outFolder}")
 
     if os.path.isfile(deviceTimesLog):
         logger.info(f"Getting device only ops data")
@@ -346,7 +347,7 @@ def get_device_data_generate_report(
     return rowDicts
 
 
-def generate_reports(ops, deviceOps, signposts, outputFolder, date, nameAppend):
+def generate_reports(ops, deviceOps, signposts, logFolder, outputFolder, date, nameAppend):
     logger.info(f"OPs' perf analysis is finished! Generating reports ...")
     outFolder = PROFILER_OUTPUT_DIR
     if outputFolder:
@@ -367,10 +368,10 @@ def generate_reports(ops, deviceOps, signposts, outputFolder, date, nameAppend):
 
     logger.info(f"Copying runtime artifacts")
     os.system(f"rm -rf {outFolder}; mkdir -p {outFolder}")
-    if os.path.isfile(f"{PROFILER_LOGS_DIR / TRACY_FILE_NAME}"):
-        os.system(f"cp {PROFILER_LOGS_DIR / TRACY_FILE_NAME} {outFolder}")
-    if os.path.isfile(f"{PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG}"):
-        os.system(f"cp {PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG} {outFolder}")
+    if os.path.isfile(f"{logFolder / TRACY_FILE_NAME}"):
+        os.system(f"cp {logFolder / TRACY_FILE_NAME} {outFolder}")
+    if os.path.isfile(f"{logFolder / PROFILER_DEVICE_SIDE_LOG}"):
+        os.system(f"cp {logFolder / PROFILER_DEVICE_SIDE_LOG} {outFolder}")
 
     # logger.info(f"Generating OPs yaml")
     # allOpsYAMLPath = os.path.join(outFolder, f"{name}_all_ops.yaml")
@@ -566,14 +567,19 @@ def generate_reports(ops, deviceOps, signposts, outputFolder, date, nameAppend):
 
 
 def process_ops(output_folder, name_append, date):
-    ops, signposts = import_tracy_op_logs()
+    if not output_folder:
+        output_folder = PROFILER_ARTIFACTS_DIR
+    logFolder = generate_logs_folder(output_folder)
+    reportFolder = generate_reports_folder(output_folder)
+
+    ops, signposts = import_tracy_op_logs(logFolder)
 
     if ops:
-        deviceOps = append_device_data(ops, PROFILER_LOGS_DIR)
-        generate_reports(ops, deviceOps, signposts, output_folder, date, name_append)
+        deviceOps = append_device_data(ops, logFolder)
+        generate_reports(ops, deviceOps, signposts, logFolder, reportFolder, date, name_append)
 
     else:
-        deviceOps = get_device_data_generate_report(PROFILER_LOGS_DIR, output_folder, date, name_append)
+        deviceOps = get_device_data_generate_report(logFolder, reportFolder, date, name_append)
 
 
 @click.command()
@@ -581,6 +587,8 @@ def process_ops(output_folder, name_append, date):
 @click.option("-n", "--name-append", type=str, help="Name to be appended to default csv name")
 @click.option("--date", default=False, is_flag=True, help="Append date to output files")
 def main(output_folder, name_append, date):
+    if output_folder:
+        output_folder = Path(output_folder)
     process_ops(output_folder, name_append, date)
 
 

--- a/tt_metal/tools/profiler/profiler.cpp
+++ b/tt_metal/tools/profiler/profiler.cpp
@@ -287,7 +287,7 @@ DeviceProfiler::DeviceProfiler(const bool new_logs)
 {
 #if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
-    output_dir = std::filesystem::path(string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME));
+    output_dir = std::filesystem::path(get_profiler_logs_dir());
     std::filesystem::create_directories(output_dir);
     std::filesystem::path log_path = output_dir / DEVICE_SIDE_LOG;
 

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -124,7 +124,7 @@ void syncDeviceHost(Device *device, CoreCoord logical_core, std::shared_ptr<tt_m
     constexpr bool force_slow_dispatch = true;
     LaunchProgram(device, sync_program, wait_for_all_cores_done, force_slow_dispatch);
 
-    std::filesystem::path output_dir = std::filesystem::path(string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME));
+    std::filesystem::path output_dir = std::filesystem::path(get_profiler_logs_dir());
     std::filesystem::path log_path = output_dir / "sync_device_info.csv";
     std::ofstream log_file;
 

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+
 from tracy import *
 
 
@@ -20,7 +22,7 @@ def main():
         "--no-device", dest="device", action="store_false", help="Do not include device data", default=True
     )
     parser.add_option(
-        "-o", "--output-folder", action="store", help="Artifact output folder", type="string", dest="output_folder"
+        "-o", "--output-folder", action="store", help="Profiler artifacts folder", type="string", dest="output_folder"
     )
     parser.add_option(
         "-n",
@@ -64,8 +66,16 @@ def main():
     (options, args) = parser.parse_args()
     sys.argv[:] = args
 
+    outputFolderEnvStr = "TT_METAL_PROFILER_DIR"
+    outputFolder = PROFILER_ARTIFACTS_DIR
+    if options.output_folder:
+        logger.info(f"Setting profiler artifacts folder to {options.output_folder}")
+        Path(options.output_folder).mkdir(parents=True, exist_ok=True)
+        os.environ["TT_METAL_PROFILER_DIR"] = options.output_folder
+        outputFolder = Path(options.output_folder)
+
     if options.processLogsOnly:
-        generate_report("generated/profiler/.log/", "", None)
+        generate_report(generate_logs_folder(outputFolder), "", None)
         sys.exit(0)
 
     if options.port:
@@ -87,9 +97,10 @@ def main():
                 logger.error("No available port found")
                 sys.exit(1)
             logger.info(f"Using port {port}")
-            doReport, captureProcess = run_report_setup(options.verbose, port)
+            doReport, captureProcess = run_report_setup(options.verbose, outputFolder, port)
 
         if not doReport:
+            code = None
             if options.module:
                 import runpy
 
@@ -99,18 +110,24 @@ def main():
                     "modname": args[0],
                 }
             else:
-                progname = args[0]
-                sys.path.insert(0, os.path.dirname(progname))
-                with io.open_code(progname) as fp:
-                    code = compile(fp.read(), progname, "exec")
-                spec = importlib.machinery.ModuleSpec(name="__main__", loader=None, origin=progname)
-                globs = {
-                    "__spec__": spec,
-                    "__file__": spec.origin,
-                    "__name__": spec.name,
-                    "__package__": None,
-                    "__cached__": None,
-                }
+                trySystem = False
+                try:
+                    progname = args[0]
+                    sys.path.insert(0, os.path.dirname(progname))
+                    with io.open_code(progname) as fp:
+                        code = compile(fp.read(), progname, "exec")
+                    spec = importlib.machinery.ModuleSpec(name="__main__", loader=None, origin=progname)
+                    globs = {
+                        "__spec__": spec,
+                        "__file__": spec.origin,
+                        "__name__": spec.name,
+                        "__package__": None,
+                        "__cached__": None,
+                    }
+                except ValueError as exc:
+                    trySystem = True
+                if trySystem:
+                    subprocess.run(progname, shell=True, check=True)
 
             if options.partial:
                 tracy_state.doPartial = True
@@ -119,7 +136,8 @@ def main():
                 tracy_state.doLine = True
 
             try:
-                runctx(code, globs, None, options.partial)
+                if code:
+                    runctx(code, globs, None, options.partial)
             except BrokenPipeError as exc:
                 # Prevent "Exception ignored" during interpreter shutdown.
                 sys.stdout = None
@@ -158,7 +176,7 @@ def main():
 
             try:
                 captureProcess.communicate(timeout=15)
-                generate_report(options.output_folder, options.name_append, options.child_functions)
+                generate_report(outputFolder, options.name_append, options.child_functions)
             except subprocess.TimeoutExpired as e:
                 captureProcess.terminate()
                 captureProcess.communicate()


### PR DESCRIPTION
### Ticket
#13386 

### Problem description
C++ files could not generated op reports and TT_METAL_HOME was used for profiler's artifacts dir

### What's changed
Generate perf reports for C++ binaries with `python -m tracy -r -v {path to bin}`
    - If this is a ttnn run, the same ops report csv will be generated
    - If this is tt-metal run, device data will be gathered in a device
      only csv

Collect all profiler artifacts in any location regardless of where
`TT_METAL_HOME` is set to with  `python -m tracy -o {out dir} -r -v {path to bin}`

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11237170086
- [x] T3K profiler https://github.com/tenstorrent/tt-metal/actions/runs/11237172933
- [x] Device perf https://github.com/tenstorrent/tt-metal/actions/runs/11236896996
- [x] uBenchmark https://github.com/tenstorrent/tt-metal/actions/runs/11219220899
