### PR TITLE
#13531: Update ttnn.clip, Support for ttnn.clamp_min, ttnn.clamp_max

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -165,16 +165,32 @@ def test_unary_composite_clamp_max_ttnn(input_shapes, max, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_clip_ttnn(input_shapes, device):
+@pytest.mark.parametrize(
+    "min, max",
+    [
+        (-10, 10),
+        (1, -1),
+        (0, 0),
+        (-1.0, None),
+        (None, 1.0),
+        (None, None),
+        (-0.5, None),
+        (None, -0.5),
+        (-10.0, 10.0),
+    ],
+)
+def test_unary_composite_clip_ttnn(input_shapes, min, max, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-    min = -10
-    max = 10
-    output_tensor = ttnn.clip(input_tensor1, min, max)
-    golden_function = ttnn.get_golden_function(ttnn.clip)
-    golden_tensor = golden_function(in_data1, min, max)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    if min is None and max is None:
+        with pytest.raises(RuntimeError, match="Only one of 'min' or 'max' can be None. Please provide one value"):
+            ttnn.clip(input_tensor1, min=min, max=max)
+        assert True
+    else:
+        output_tensor = ttnn.clip(input_tensor1, min=min, max=max)
+        golden_function = ttnn.get_golden_function(ttnn.clip)
+        golden_tensor = golden_function(in_data1, min=min, max=max)
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -93,16 +93,32 @@ def test_unary_composite_cbrt_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_clamp_ttnn(input_shapes, device):
+@pytest.mark.parametrize(
+    "min, max",
+    [
+        (-10, 10),
+        (1, -1),
+        (0, 0),
+        (-1.0, None),
+        (None, 1.0),
+        (None, None),
+        (-0.5, None),
+        (None, -0.5),
+        (-10.0, 10.0),
+    ],
+)
+def test_unary_composite_clamp_ttnn(input_shapes, min, max, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-    min = -10
-    max = 10
-    output_tensor = ttnn.clamp(input_tensor1, min, max)
-    golden_function = ttnn.get_golden_function(ttnn.clamp)
-    golden_tensor = golden_function(in_data1, min, max)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    if min is None and max is None:
+        with pytest.raises(RuntimeError, match="Only one of 'min' or 'max' can be None. Please provide one value"):
+            ttnn.clamp(input_tensor1, min=min, max=max)
+        assert True
+    else:
+        output_tensor = ttnn.clamp(input_tensor1, min=min, max=max)
+        golden_function = ttnn.get_golden_function(ttnn.clamp)
+        golden_tensor = golden_function(in_data1, min=min, max=max)
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -129,6 +129,42 @@ def test_unary_composite_clamp_ttnn(input_shapes, min, max, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
+@pytest.mark.parametrize("min", (-1.0, 1.0, 0.0, -0.5, -10.0, 10.0))
+def test_unary_composite_clamp_min_ttnn(input_shapes, min, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    output_tensor = ttnn.clamp_min(input_tensor1, min)
+    golden_function = ttnn.get_golden_function(ttnn.clamp_min)
+    golden_tensor = golden_function(in_data1, min=min)
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("max", (-1.0, 1.0, 0.0, -0.5, -10.0, 10.0))
+def test_unary_composite_clamp_max_ttnn(input_shapes, max, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    output_tensor = ttnn.clamp_max(input_tensor1, max)
+    golden_function = ttnn.get_golden_function(ttnn.clamp_max)
+    golden_tensor = golden_function(in_data1, max=max)
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
 def test_unary_composite_clip_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     min = -10

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -477,7 +477,7 @@ Tensor _clip(const Tensor& a, float low, float high, const std::optional<MemoryC
 }
 
 // clamp
-Tensor _clamp(const Tensor& a, float low, float high, const std::optional<MemoryConfig>& output_mem_config) {
+Tensor ExecuteUnaryCompositeClamp::invoke(const Tensor& a, float low, float high, const std::optional<MemoryConfig>& output_mem_config) {
     return _clip(a, low, high, output_mem_config);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -497,6 +497,11 @@ Tensor ExecuteUnaryCompositeClamp::invoke(const Tensor& a, std::optional<float> 
     }
 }
 
+// clamp_min
+Tensor ExecuteUnaryCompositeClampMin::invoke(const Tensor& a, float min, const std::optional<MemoryConfig>& output_mem_config) {
+    return ExecuteUnaryCompositeClamp::invoke(a, min, std::nullopt, output_mem_config);
+}
+
 // hardtanh
 Tensor _hardtanh(
     const Tensor& a, float low /* = -1.0f */, float high /* = +1.0f */, const std::optional<MemoryConfig>& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -502,6 +502,11 @@ Tensor ExecuteUnaryCompositeClampMin::invoke(const Tensor& a, float min, const s
     return ExecuteUnaryCompositeClamp::invoke(a, min, std::nullopt, output_mem_config);
 }
 
+// clamp_max
+Tensor ExecuteUnaryCompositeClampMax::invoke(const Tensor& a, float max, const std::optional<MemoryConfig>& output_mem_config) {
+    return ExecuteUnaryCompositeClamp::invoke(a, std::nullopt, max, output_mem_config);
+}
+
 // hardtanh
 Tensor _hardtanh(
     const Tensor& a, float low /* = -1.0f */, float high /* = +1.0f */, const std::optional<MemoryConfig>& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -464,16 +464,8 @@ Tensor _hardswish(const Tensor& a, float value_1, float value_2, const std::opti
 // Function Clip
 // use clip y = min( max( x, min_value), max_value) by broadcast
 // Ref: https://pytorch.org/docs/stable/generated/torch.clamp.html#torch.clamp
-Tensor _clip(const Tensor& a, float low, float high, const std::optional<MemoryConfig>& output_mem_config) {
-    auto output_memory_config = output_mem_config.value_or(a.memory_config());
-    const Tensor h_const = full_like(a, high);
-    Tensor a_max = ttnn::minimum(a, h_const, output_memory_config);
-    if (low == 0.0f) {
-        return ttnn::relu(a_max, output_memory_config);
-    } else {
-        const Tensor l_const = full_like(a, low);
-        return ttnn::maximum(a_max, l_const, output_memory_config);
-    }
+Tensor ExecuteUnaryCompositeClip::invoke(const Tensor& a, std::optional<float> min, std::optional<float> max, const std::optional<MemoryConfig>& output_mem_config) {
+    return ExecuteUnaryCompositeClamp::invoke(a, min, max, output_mem_config);
 }
 
 // clamp
@@ -511,7 +503,7 @@ Tensor ExecuteUnaryCompositeClampMax::invoke(const Tensor& a, float max, const s
 Tensor _hardtanh(
     const Tensor& a, float low /* = -1.0f */, float high /* = +1.0f */, const std::optional<MemoryConfig>& output_mem_config) {
         auto output_memory_config = output_mem_config.value_or(a.memory_config());
-    return _clip(a, low, high, output_memory_config);
+    return ExecuteUnaryCompositeClamp::invoke(a, low, high, output_memory_config);
 }
 
 // Theano defines this differently...

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -37,7 +37,6 @@ enum class UnaryCompositeOpType {
     HARDSWISH,
     HARDSIGMOID,
     HARDTANH,
-    CLIP,
     SELU,
     THRESHOLD,
     GLU,
@@ -84,7 +83,6 @@ Tensor _rad2deg(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _hardswish(const Tensor&, float scale =  1.0f/6.0f, float shift = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _hardsigmoid(const Tensor&, float scale =  1.0f/6.0f, float shift = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _hardtanh(const Tensor&, float min = -1, float max = 1, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-Tensor _clip(const Tensor&, float, float, const std::optional<MemoryConfig>& );
 Tensor _selu(const Tensor&, float scale = 1.0507, float alpha = 1.67326, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _threshold(const Tensor&, float, float, const std::optional<MemoryConfig>& );
 Tensor _glu(const Tensor&, int32_t, const std::optional<MemoryConfig>& );
@@ -268,13 +266,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::HARDTANH> {
     static Tensor handle(const Tensor& t1, float low, float high, const std::optional<MemoryConfig>& mem_cfg ) {
         return _hardtanh(t1, low, high, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::CLIP> {
-    static Tensor handle(const Tensor& t1, float low, float high, const std::optional<MemoryConfig>& mem_cfg ) {
-        return _clip(t1, low, high, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -38,7 +38,6 @@ enum class UnaryCompositeOpType {
     HARDSIGMOID,
     HARDTANH,
     CLIP,
-    CLAMP,
     SELU,
     THRESHOLD,
     GLU,
@@ -86,7 +85,6 @@ Tensor _hardswish(const Tensor&, float scale =  1.0f/6.0f, float shift = 0.5f, c
 Tensor _hardsigmoid(const Tensor&, float scale =  1.0f/6.0f, float shift = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _hardtanh(const Tensor&, float min = -1, float max = 1, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _clip(const Tensor&, float, float, const std::optional<MemoryConfig>& );
-Tensor _clamp(const Tensor&, float, float, const std::optional<MemoryConfig>& );
 Tensor _selu(const Tensor&, float scale = 1.0507, float alpha = 1.67326, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _threshold(const Tensor&, float, float, const std::optional<MemoryConfig>& );
 Tensor _glu(const Tensor&, int32_t, const std::optional<MemoryConfig>& );
@@ -277,13 +275,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::CLIP> {
     static Tensor handle(const Tensor& t1, float low, float high, const std::optional<MemoryConfig>& mem_cfg ) {
         return _clip(t1, low, high, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::CLAMP> {
-    static Tensor handle(const Tensor& t1, float low, float high, const std::optional<MemoryConfig>& mem_cfg ) {
-        return _clamp(t1, low, high, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -123,6 +123,13 @@ struct ExecuteUnaryCompositeClamp {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
+struct ExecuteUnaryCompositeClampMin {
+    static Tensor invoke(
+        const Tensor &input_tensor,
+        float min,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
 template <UnaryCompositeOpType unary_comp_op_type>
 struct ExecuteUnaryCompositeOpWithInt {
 
@@ -274,6 +281,9 @@ constexpr auto clip = ttnn::register_operation_with_auto_launch_op<
 constexpr auto clamp = ttnn::register_operation_with_auto_launch_op<
     "ttnn::clamp",
     operations::unary::ExecuteUnaryCompositeClamp>();
+constexpr auto clamp_min = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::clamp_min",
+    operations::unary::ExecuteUnaryCompositeClampMin>();
 constexpr auto selu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::selu",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::SELU>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -115,6 +115,14 @@ struct ExecuteUnaryCompositeOpWithFloats {
         }
 };
 
+struct ExecuteUnaryCompositeClamp {
+    static Tensor invoke(
+        const Tensor &input_tensor,
+        float param1,
+        float param2,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
 template <UnaryCompositeOpType unary_comp_op_type>
 struct ExecuteUnaryCompositeOpWithInt {
 
@@ -265,7 +273,7 @@ constexpr auto clip = ttnn::register_operation_with_auto_launch_op<
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::CLIP>>();
 constexpr auto clamp = ttnn::register_operation_with_auto_launch_op<
     "ttnn::clamp",
-    operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::CLAMP>>();
+    operations::unary::ExecuteUnaryCompositeClamp>();
 constexpr auto selu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::selu",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::SELU>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -118,8 +118,8 @@ struct ExecuteUnaryCompositeOpWithFloats {
 struct ExecuteUnaryCompositeClamp {
     static Tensor invoke(
         const Tensor &input_tensor,
-        float param1,
-        float param2,
+        std::optional<float> min = std::nullopt,
+        std::optional<float> max = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -130,6 +130,13 @@ struct ExecuteUnaryCompositeClampMin {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
+struct ExecuteUnaryCompositeClampMax {
+    static Tensor invoke(
+        const Tensor &input_tensor,
+        float max,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
 template <UnaryCompositeOpType unary_comp_op_type>
 struct ExecuteUnaryCompositeOpWithInt {
 
@@ -284,6 +291,9 @@ constexpr auto clamp = ttnn::register_operation_with_auto_launch_op<
 constexpr auto clamp_min = ttnn::register_operation_with_auto_launch_op<
     "ttnn::clamp_min",
     operations::unary::ExecuteUnaryCompositeClampMin>();
+constexpr auto clamp_max = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::clamp_max",
+    operations::unary::ExecuteUnaryCompositeClampMax>();
 constexpr auto selu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::selu",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::SELU>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -137,6 +137,14 @@ struct ExecuteUnaryCompositeClampMax {
         const std::optional<MemoryConfig> &memory_config = std::nullopt);
 };
 
+struct ExecuteUnaryCompositeClip {
+    static Tensor invoke(
+        const Tensor &input_tensor,
+        std::optional<float> min = std::nullopt,
+        std::optional<float> max = std::nullopt,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
 template <UnaryCompositeOpType unary_comp_op_type>
 struct ExecuteUnaryCompositeOpWithInt {
 
@@ -284,7 +292,7 @@ constexpr auto hardtanh = ttnn::register_operation_with_auto_launch_op<
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::HARDTANH>>();
 constexpr auto clip = ttnn::register_operation_with_auto_launch_op<
     "ttnn::clip",
-    operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::CLIP>>();
+    operations::unary::ExecuteUnaryCompositeClip>();
 constexpr auto clamp = ttnn::register_operation_with_auto_launch_op<
     "ttnn::clamp",
     operations::unary::ExecuteUnaryCompositeClamp>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1627,12 +1627,12 @@ void py_module(py::module& module) {
         "min", "min value", -1.0f,
         "max", "max value", 1.0f,
         R"doc(Performs hardtanh function on :attr:`input_tensor`, :attr:`min`, :attr:`max`.)doc");
-    detail::bind_unary_composite_floats(
+    detail::bind_unary_composite_optional_floats_with_default(
         module,
         ttnn::clip,
-        "low", "Low value",
-        "high", "High value",
-        R"doc(Performs clip function on :attr:`input_tensor`, :attr:`low`, :attr:`high`.)doc");
+        "min", "Minimum value", std::nullopt,
+        "max", "Maximum value", std::nullopt,
+        R"doc(Performs clip function on :attr:`input_tensor`, :attr:`min`, :attr:`max`. Only one of 'min' or 'max' value can be None.)doc");
     detail::bind_unary_composite_optional_floats_with_default(
         module,
         ttnn::clamp,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -24,6 +24,56 @@ namespace unary {
 namespace detail {
 
 template <typename unary_operation_t>
+void bind_unary_composite_optional_floats_with_default(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, std::optional<float> parameter_a_value, const std::string& parameter_name_b, const std::string& parameter_b_doc, std::optional<float> parameter_b_value, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc(
+        {8}
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+
+        Keyword args:
+            {2} (float): {3}. Defaults to `{4}`.
+            {5} (float): {6}. Defaults to `{7}`.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Example:
+            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> output = {1}(tensor, {2} = {4}, {5} = {7})
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        parameter_name_a,
+        parameter_a_doc,
+        parameter_a_value,
+        parameter_name_b,
+        parameter_b_doc,
+        parameter_b_value,
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               std::optional<float> parameter_a,
+               std::optional<float> parameter_b,
+               const std::optional<MemoryConfig>& memory_config)  {
+                return self(input_tensor, parameter_a, parameter_b, memory_config);
+            },
+            py::arg("input_tensor"),
+            py::kw_only(),
+            py::arg(parameter_name_a.c_str()) = parameter_a_value,
+            py::arg(parameter_name_b.c_str()) = parameter_b_value,
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename unary_operation_t>
 void bind_unary_operation(py::module& module, const unary_operation_t& operation, const std::string& math, const std::string& info_doc = "" ) {
     auto doc = fmt::format(
         R"doc(
@@ -1583,12 +1633,12 @@ void py_module(py::module& module) {
         "low", "Low value",
         "high", "High value",
         R"doc(Performs clip function on :attr:`input_tensor`, :attr:`low`, :attr:`high`.)doc");
-    detail::bind_unary_composite_floats(
+    detail::bind_unary_composite_optional_floats_with_default(
         module,
         ttnn::clamp,
-        "low", "Low value",
-        "high", "High value",
-        R"doc(Performs clamp function on :attr:`input_tensor`, :attr:`low`, :attr:`high`.)doc");
+        "min", "Minimum value", std::nullopt,
+        "max", "Maximum value", std::nullopt,
+        R"doc(Performs clamp function on :attr:`input_tensor`, :attr:`min`, :attr:`max`. Only one of 'min' or 'max' value can be None.)doc");
     detail::bind_unary_composite_floats_with_default(
         module,
         ttnn::selu,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1133,7 +1133,7 @@ void bind_unary_composite_float(py::module& module, const unary_operation_t& ope
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
-            {2}
+            {2} (float): {3}.
 
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
@@ -1639,6 +1639,11 @@ void py_module(py::module& module) {
         "min", "Minimum value", std::nullopt,
         "max", "Maximum value", std::nullopt,
         R"doc(Performs clamp function on :attr:`input_tensor`, :attr:`min`, :attr:`max`. Only one of 'min' or 'max' value can be None.)doc");
+    detail::bind_unary_composite_float(
+        module,
+        ttnn::clamp_min,
+        "min", "Minimum value",
+        R"doc(Performs clamp min function on :attr:`input_tensor`, :attr:`min`)doc");
     detail::bind_unary_composite_floats_with_default(
         module,
         ttnn::selu,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1644,6 +1644,11 @@ void py_module(py::module& module) {
         ttnn::clamp_min,
         "min", "Minimum value",
         R"doc(Performs clamp min function on :attr:`input_tensor`, :attr:`min`)doc");
+    detail::bind_unary_composite_float(
+        module,
+        ttnn::clamp_max,
+        "max", "Maximum value",
+        R"doc(Performs clamp max function on :attr:`input_tensor`, :attr:`max`)doc");
     detail::bind_unary_composite_floats_with_default(
         module,
         ttnn::selu,

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -304,6 +304,15 @@ def _golden_function_clamp_min(input_tensor_a, min, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.clamp_min, golden_function=_golden_function_clamp_min)
 
 
+def _golden_function_clamp_max(input_tensor_a, max, *args, **kwargs):
+    import torch
+
+    return torch.clamp_max(input_tensor_a, max)
+
+
+ttnn.attach_golden_function(ttnn.clamp_max, golden_function=_golden_function_clamp_max)
+
+
 def _golden_function_clip(input_tensor_a, min, max, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -286,7 +286,7 @@ def _golden_function_polygamma(input_tensor_a, k, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.polygamma, golden_function=_golden_function_polygamma)
 
 
-def _golden_function_clamp(input_tensor_a, min, max, *args, **kwargs):
+def _golden_function_clamp(input_tensor_a, min=None, max=None, *args, **kwargs):
     import torch
 
     return torch.clamp(input=input_tensor_a, min=min, max=max)

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -289,10 +289,19 @@ ttnn.attach_golden_function(ttnn.polygamma, golden_function=_golden_function_pol
 def _golden_function_clamp(input_tensor_a, min=None, max=None, *args, **kwargs):
     import torch
 
-    return torch.clamp(input=input_tensor_a, min=min, max=max)
+    return torch.clamp(input_tensor_a, min=min, max=max)
 
 
 ttnn.attach_golden_function(ttnn.clamp, golden_function=_golden_function_clamp)
+
+
+def _golden_function_clamp_min(input_tensor_a, min, *args, **kwargs):
+    import torch
+
+    return torch.clamp_min(input_tensor_a, min)
+
+
+ttnn.attach_golden_function(ttnn.clamp_min, golden_function=_golden_function_clamp_min)
 
 
 def _golden_function_clip(input_tensor_a, min, max, *args, **kwargs):

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -313,7 +313,7 @@ def _golden_function_clamp_max(input_tensor_a, max, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.clamp_max, golden_function=_golden_function_clamp_max)
 
 
-def _golden_function_clip(input_tensor_a, min, max, *args, **kwargs):
+def _golden_function_clip(input_tensor_a, min=None, max=None, *args, **kwargs):
     import torch
 
     return torch.clip(input=input_tensor_a, min=min, max=max)


### PR DESCRIPTION
Ref Link : [Link](https://github.com/pytorch/pytorch/blob/a569a8ac4c1eaaf1c3f241b0c09a6ed072570a26/torch/_refs/__init__.py#L1903)

PyTorch Clamp_min : 
<img width="427" alt="Screenshot 2024-10-06 at 6 12 04 PM" src="https://github.com/user-attachments/assets/870c8d1f-15cd-4934-91d0-056daef8d7bf">

PyTorch Clamp_max : 
<img width="428" alt="Screenshot 2024-10-06 at 6 14 04 PM" src="https://github.com/user-attachments/assets/cddf1e7d-5731-4c6c-85f4-d23c8d22bf79">
