### PR TITLE
Error out with a clear message on a missing submodule.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 cmake_policy(VERSION 3.16)
 
+# Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
+if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
+    message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")
+endif()
+
 ############################################
 # Project setup
 ############################################


### PR DESCRIPTION
Many people (including myself) don't think to pull submodules when cloning a repo.  The subsequent (not clear) error is unnecessary friction.

Now we detect this situation and give a clear instruction to unblock the user so they can move forward.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
