### PR TITLE
#13547: Removed unused arguments from release_dst and acquire_dst

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/acquire_dst.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/acquire_dst.rst
@@ -1,4 +1,4 @@
 acquire_dst
 ===========
 
-.. doxygenfunction:: acquire_dst(tt::DstMode mode)
+.. doxygenfunction:: acquire_dst()

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/release_dst.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/release_dst.rst
@@ -1,4 +1,4 @@
 release_dst
 ===========
 
-.. doxygenfunction:: release_dst(tt::DstMode mode)
+.. doxygenfunction:: release_dst()

--- a/tests/tt_eager/ops/kernel/eltwise_sfpu.cpp
+++ b/tests/tt_eager/ops/kernel/eltwise_sfpu.cpp
@@ -20,7 +20,7 @@ void MAIN {
            uint32_t block_index = 0;
            cb_reserve_back(tt::CB::c_out0, per_core_block_dim);
            uint32_t tile_index = 0;
-           acquire_dst(tt::DstMode::Half);
+           acquire_dst();
 
            // Pop tile after tile, copy to DST and pack
            cb_wait_front(tt::CB::c_in0, 1);
@@ -36,7 +36,7 @@ void MAIN {
 
            cb_pop_front(tt::CB::c_in0, 1);
 
-           release_dst(tt::DstMode::Half);
+           release_dst();
 
            cb_push_back(tt::CB::c_out0, per_core_block_dim);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -58,7 +58,7 @@ void MAIN {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         // Reconfigure input
@@ -99,7 +99,7 @@ void MAIN {
                                 pack_tile(i, mm_bias_intermediate_cb_id);
                             }
                             cb_push_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
-                            release_dst(tt::DstMode::Half);
+                            release_dst();
 
                             // Redundant wait since we know data was just pushed
                             cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
@@ -109,7 +109,7 @@ void MAIN {
                             unpack_reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                             // reconfigure packer df for out
                             pack_reconfig_data_format(out_cb_id);
-                            acquire_dst(tt::DstMode::Half);
+                            acquire_dst();
                             for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                                 uint32_t bcast_tile_idx = in1_index_subblock_offset;
                                 for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
@@ -158,7 +158,7 @@ void MAIN {
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -58,7 +58,7 @@ void MAIN {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         // Reconfigure input
@@ -98,7 +98,7 @@ void MAIN {
                                 pack_tile(i, mm_bias_intermediate_cb_id);
                             }
                             cb_push_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
-                            release_dst(tt::DstMode::Half);
+                            release_dst();
 
                             // Redundant wait since we know data was just pushed
                             cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
@@ -108,7 +108,7 @@ void MAIN {
                             unpack_reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                             // reconfigure packer df for out
                             pack_reconfig_data_format(out_cb_id);
-                            acquire_dst(tt::DstMode::Half);
+                            acquire_dst();
                             for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                                 uint32_t bcast_tile_idx = in1_index_subblock_offset;
                                 for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
@@ -150,7 +150,7 @@ void MAIN {
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/compute_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/compute_local_l1.cpp
@@ -16,14 +16,14 @@ void MAIN {
 
     for (uint32_t mt = 0; mt < sub_Mt; ++mt) {
         for (uint32_t nt = 0; nt < sub_Nt; ++nt) {
-            acquire_dst(tt::DstMode::Full);
+            acquire_dst();
             for (uint32_t kt = 0; kt < Kt; ++kt) {
                 matmul_tiles(tt::CB::c_in0, tt::CB::c_in1, mt * Kt + kt, nt * Kt + kt, 0, false);
             }
             cb_reserve_back(tt::CB::c_out0, onetile);
             pack_tile(0, tt::CB::c_out0);
             cb_push_back(tt::CB::c_out0, onetile);
-            release_dst(tt::DstMode::Full);
+            release_dst();
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_h.cpp
@@ -24,7 +24,7 @@ void MAIN {
 
         cb_reserve_back(tt::CB::c_out0, onetile);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         cb_wait_front(tt::CB::c_in0, onetile);
 
@@ -33,7 +33,7 @@ void MAIN {
 
         cb_pop_front(tt::CB::c_in0, onetile);
 
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, onetile);
         cb_pop_front(tt::CB::c_in1, onetile);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_hw.cpp
@@ -26,7 +26,7 @@ void MAIN {
         #endif
         cb_reserve_back(tt::CB::c_out0, onetile);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         cb_wait_front(tt::CB::c_in0, onetile);
 
@@ -37,7 +37,7 @@ void MAIN {
         #ifndef BCAST_SCALAR
         cb_pop_front(tt::CB::c_in1, onetile);
         #endif
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, onetile);
     } } }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_w.cpp
@@ -23,14 +23,14 @@ void MAIN {
 
             cb_reserve_back(tt::CB::c_out0, onetile);
 
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
 
             cb_wait_front(tt::CB::c_in0, onetile);
             BCAST_OP<BroadcastType::COL>(tt::CB::c_in0, tt::CB::c_in1, 0, 0, 0);
             pack_tile(0, tt::CB::c_out0);
             cb_pop_front(tt::CB::c_in0, onetile);
 
-            release_dst(tt::DstMode::Half);
+            release_dst();
 
             cb_push_back(tt::CB::c_out0, onetile);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
@@ -31,7 +31,7 @@ void MAIN {
     for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) // output tile of C
     for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C) // output tile index of C
     {
-        acquire_dst(tt::DstMode::Full);
+        acquire_dst();
         for (uint32_t kt = 0; kt < Kt; kt++) {
             cb_wait_front(tt::CB::c_in0, onetile);
             cb_wait_front(tt::CB::c_in1, onetile);
@@ -46,7 +46,7 @@ void MAIN {
         pack_tile(0, tt::CB::c_out0);
         cb_push_back(tt::CB::c_out0, onetile);
 
-        release_dst(tt::DstMode::Full);
+        release_dst();
     }
 
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm.cpp
@@ -41,7 +41,7 @@ void MAIN {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         copy_tile_to_dst_init_short();
@@ -91,7 +91,7 @@ void MAIN {
                         cb_push_back(tt::CB::c_intermed0, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -58,7 +58,7 @@ void MAIN {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         // Reconfigure input
@@ -98,7 +98,7 @@ void MAIN {
                                 pack_tile(i, mm_bias_intermediate_cb_id);
                             }
                             cb_push_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
-                            release_dst(tt::DstMode::Half);
+                            release_dst();
 
                             // Redundant wait since we know data was just pushed
                             cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
@@ -108,7 +108,7 @@ void MAIN {
                             unpack_reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                             // reconfigure packer df for out
                             pack_reconfig_data_format(out_cb_id);
-                            acquire_dst(tt::DstMode::Half);
+                            acquire_dst();
                             for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                                 uint32_t bcast_tile_idx = in1_index_subblock_offset;
                                 for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
@@ -150,7 +150,7 @@ void MAIN {
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_mixed_precision.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_mixed_precision.cpp
@@ -46,7 +46,7 @@ void MAIN {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         // Reconfigure input
@@ -98,7 +98,7 @@ void MAIN {
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -71,10 +71,10 @@ inline void tilize_in(
             for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
                 for (uint32_t w = 0; w < out_subblock_w; w++) {
                     uint32_t tile_index = block_offset + within_block_index + w;
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
                     copy_tile(interm_cb_id, tile_index, 0);
                     pack_tile(0, reblock_cb_id);
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                 }
                 block_offset += out_subblock_num_tiles;
             }
@@ -165,7 +165,7 @@ void MAIN {
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     int in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
-                        acquire_dst(tt::DstMode::Half);
+                        acquire_dst();
                         if (enable_reload) {
                             // Reconfigure input
                             copy_tile_to_dst_init_short_with_dt(in1_cb_id, matmul_partials_cb);
@@ -201,7 +201,7 @@ void MAIN {
                             if (last_out) {
                                 // first move the current result from dst to interim CB
                                 pack_matmul_subblock(out_for_bias_cb_id, out_subblock_num_tiles);
-                                release_dst(tt::DstMode::Half);
+                                release_dst();
                                 // reconfig unpacker df for src B
                                 // unpack_reconfig_data_format(out_for_bias_cb_id, bias_cb_id);
                                 // bcast add data from bias_cb_id
@@ -210,7 +210,7 @@ void MAIN {
                                 add_bcast_rows_init_short();
                                 // reconfig packer df for out
                                 // pack_reconfig_data_format(out_cb_id);
-                                acquire_dst(tt::DstMode::Half);
+                                acquire_dst();
                                 uint32_t i = 0;
                                 for (uint32_t h = 0; h < out_subblock_h; ++ h) {
                                     uint32_t bcast_tile_i = bias_block_offset + in1_index_subblock_offset;
@@ -244,7 +244,7 @@ void MAIN {
                                                         : out_cb_id)
                                                     : matmul_partials_cb;
                         pack_matmul_subblock(curr_matmul_out_cb, out_subblock_num_tiles);
-                        release_dst(tt::DstMode::Half);
+                        release_dst();
                         in1_index_subblock_offset += out_subblock_w;
                     } // for in1_num_subblocks
                     #ifndef FUSE_BIAS

--- a/tests/tt_metal/tt_metal/test_kernels/compute/broadcast.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/broadcast.cpp
@@ -19,7 +19,7 @@ void MAIN {
 
     cb_wait_front(tt::CB::c_in1, onetile);
     cb_reserve_back(tt::CB::c_out0, onetile);
-    acquire_dst(tt::DstMode::Half);
+    acquire_dst();
     cb_wait_front(tt::CB::c_in0, onetile);
 
     #ifndef BCAST_SPECIFIC
@@ -30,7 +30,7 @@ void MAIN {
     pack_tile(0, tt::CB::c_out0);
 
     cb_pop_front(tt::CB::c_in0, onetile);
-    release_dst(tt::DstMode::Half);
+    release_dst();
     cb_push_back(tt::CB::c_out0, onetile);
     cb_pop_front(tt::CB::c_in1, onetile);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
@@ -30,7 +30,7 @@ void MAIN {
         for(uint32_t wt = 0; wt < Wt; ++wt) {
             for(uint32_t ht = 0; ht < Ht; ++ht) {
                 cb_reserve_back(tt::CB::c_out0, onetile);
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
                 cb_wait_front(tt::CB::c_in0, onetile);
 
                 #ifndef ROWWISE
@@ -48,7 +48,7 @@ void MAIN {
                 pack_tile(0, tt::CB::c_out0);
 
                 cb_pop_front(tt::CB::c_in0, onetile);
-                release_dst(tt::DstMode::Half);
+                release_dst();
                 cb_push_back(tt::CB::c_out0, onetile);
             }
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dropout_sfpu.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dropout_sfpu.cpp
@@ -21,7 +21,7 @@ void MAIN {
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
         cb_reserve_back(tt::CB::c_out0, per_core_block_dim);
         for(uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
 
             // Pop tile after tile, copy to DST and pack
             cb_wait_front(tt::CB::c_in0, 1);
@@ -34,7 +34,7 @@ void MAIN {
 
             cb_pop_front(tt::CB::c_in0, 1);
 
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_push_back(tt::CB::c_out0, per_core_block_dim);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
@@ -15,7 +15,7 @@ void MAIN {
     unary_op_init_common(tt::CB::c_in0);
     for(uint32_t b=0;b<per_core_tile_cnt;++b)
     {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         // Pop tile after tile, copy to DST and pack
         cb_wait_front(tt::CB::c_in0, 1);
@@ -27,7 +27,7 @@ void MAIN {
         cb_pop_front(tt::CB::c_in0, 1);
         cb_push_back(tt::CB::c_out0, 1);
 
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block.cpp
@@ -12,7 +12,7 @@ void MAIN {
     constexpr uint32_t num_blocks = get_compile_time_arg_val(1);
 
     for(uint32_t block = 0; block < num_blocks; ++block) {
-       acquire_dst(tt::DstMode::Half);
+       acquire_dst();
 
        // Wait tiles on the input / copy to dst / pop from input
        cb_wait_front(tt::CB::c_in0, block_num_tiles);
@@ -28,7 +28,7 @@ void MAIN {
        }
        cb_push_back(tt::CB::c_out0, block_num_tiles);
 
-       release_dst(tt::DstMode::Half);
+       release_dst();
     }
 
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -28,7 +28,7 @@ void MAIN {
         // Wait for num_single_transfer tiles to be available in in_cb
         cb_wait_front(in_cb_id, num_single_transfer);
         // Acquire DEST reg for MATH/PACK
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         // Reserve out_cb space for num_single_transfer tiles
         cb_reserve_back(out_cb_id, num_single_transfer);
 
@@ -38,7 +38,7 @@ void MAIN {
         matmul_pack_tile(START_DST_TILE_ID, out_cb_id, num_single_transfer);
 
         // Release DEST reg marking compute/pack complete
-        release_dst(tt::DstMode::Half);
+        release_dst();
         // Move rd ptr from in_cb by num_single_transfer places
         cb_pop_front(in_cb_id, num_single_transfer);
         // Move wr prt from out_cb by num_single_transfer places

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_sfpi.cpp
@@ -15,7 +15,7 @@ void MAIN {
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
         cb_reserve_back(CB::c_out0, per_core_block_dim);
         for(uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-            acquire_dst(DstMode::Full);
+            acquire_dst();
 
             // Pop tile after tile, copy to DST and pack
             cb_wait_front(CB::c_in0, 1);
@@ -33,7 +33,7 @@ void MAIN {
 
             cb_pop_front(CB::c_in0, 1);
 
-            release_dst(DstMode::Full);
+            release_dst();
         }
         cb_push_back(CB::c_out0, per_core_block_dim);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -17,8 +17,8 @@
 #include "compute_kernel_api/layernorm.h"
 
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 
 namespace NAMESPACE {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp
@@ -20,7 +20,7 @@ void MAIN {
 
     mm_init();
 
-    acquire_dst(tt::DstMode::Full);
+    acquire_dst();
     for(uint32_t b=0;b<block_cnt;++b)
     {
         cb_wait_front(tt::CB::c_in0, in0_block_tile_cnt);
@@ -54,6 +54,6 @@ void MAIN {
 
     cb_push_back(tt::CB::c_out0, out_block_tile_cnt);
 
-    release_dst(tt::DstMode::Full);
+    release_dst();
 }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -72,7 +72,7 @@ void MAIN {
     );
 #endif
 
-    acquire_dst(tt::DstMode::Full);
+    acquire_dst();
     for(uint32_t b=0;b<block_cnt;++b)
     {
         cb_wait_front(tt::CB::c_in0, in0_block_tile_cnt);
@@ -102,6 +102,6 @@ void MAIN {
     }
     cb_push_back(tt::CB::c_out0, out_block_tile_cnt);
 
-    release_dst(tt::DstMode::Full);
+    release_dst();
 }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
@@ -52,10 +52,10 @@ inline void reblock_and_untilize(
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             for (uint32_t w = 0; w < out_subblock_w; w++) {
                 uint32_t tile_index = block_offset + within_block_index + w;
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
                 copy_tile(interm_cb_id, tile_index, 0);
                 pack_tile(0, reblock_cb_id);
-                release_dst(tt::DstMode::Half);
+                release_dst();
             }
             block_offset += out_subblock_num_tiles;
         }
@@ -156,7 +156,7 @@ void MAIN {
             int in1_index_subblock_offset = 0;
             for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
 
                 if (enable_reload) {
                     copy_tile_to_dst_init_short();
@@ -199,7 +199,7 @@ void MAIN {
                     pack_matmul_subblock(matmul_partials_cb, out_subblock_num_tiles);
                 }
 
-                release_dst(tt::DstMode::Half);
+                release_dst();
 
                 in1_index_subblock_offset += out_subblock_w;
             }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
@@ -50,10 +50,10 @@ inline void reblock_and_untilize(
         for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
             for (uint32_t w = 0; w < out_subblock_w; w++) {
                 uint32_t tile_index = block_offset + within_block_index + w;
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
                 copy_tile(interm_cb_id, tile_index, 0);
                 pack_tile(0, reblock_cb_id);
-                release_dst(tt::DstMode::Half);
+                release_dst();
             }
             block_offset += out_subblock_num_tiles;
         }
@@ -161,7 +161,7 @@ void MAIN {
                     int in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                        acquire_dst(tt::DstMode::Half);
+                        acquire_dst();
 
                         if (enable_reload) {
                             copy_tile_to_dst_init_short();
@@ -202,7 +202,7 @@ void MAIN {
                         } else {
                             pack_matmul_subblock(matmul_partials_cb, out_subblock_num_tiles);
                         }
-                        release_dst(tt::DstMode::Half);
+                        release_dst();
 
                         in1_index_subblock_offset += out_subblock_w;
                     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
@@ -39,7 +39,7 @@ void MAIN {
             int in1_index_subblock_offset = 0;
             for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
 
                 if (enable_reload) {
                     copy_tile_to_dst_init_short();
@@ -84,7 +84,7 @@ void MAIN {
                     cb_push_back(tt::CB::c_intermed0, out_subblock_num_tiles);
                 }
 
-                release_dst(tt::DstMode::Half);
+                release_dst();
                 in1_index_subblock_offset += out_subblock_w;
             }
             in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp
@@ -24,7 +24,7 @@ void MAIN {
     uint32_t with_bias = get_compile_time_arg_val(7);
 
 
-    acquire_dst(tt::DstMode::Full);
+    acquire_dst();
 
     mm_init();
     for(uint32_t b=0;b<block_cnt;++b)
@@ -61,9 +61,9 @@ void MAIN {
             pack_tile(i, tt::CB::c_intermed0);
         }
         cb_push_back(tt::CB::c_intermed0, out_block_tile_cnt);
-        release_dst(tt::DstMode::Full);
+        release_dst();
 
-        acquire_dst(tt::DstMode::Full);
+        acquire_dst();
 
         add_bcast_rows_init_short();
         cb_wait_front(tt::CB::c_intermed0, out_block_tile_cnt);
@@ -88,6 +88,6 @@ void MAIN {
     }
 
     cb_push_back(tt::CB::c_out0, out_block_tile_cnt);
-    release_dst(tt::DstMode::Full);
+    release_dst();
 }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
@@ -75,14 +75,14 @@ inline void reduce_h(uint32_t out_nelems,
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         uint32_t dst_i = 0; // TODO [AS]: Use more than one dst tile at a time
         for (uint32_t hw_i = 0; hw_i < in_ntiles_hw; ++hw_i) {
             uint32_t tile_i = base_tile_id + hw_i;
             reduce_tile(in_cb_id, in_scalar_cb_id, tile_i, 0, dst_i);
         }
         pack_tile(dst_i, out_cb_id);
-        release_dst(tt::DstMode::Half);
+        release_dst();
         base_tile_id += in_ntiles_hw;
     }
     reduce_revert_delta(out_cb_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
@@ -75,14 +75,14 @@ inline void reduce_h(uint32_t out_nelems,
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         uint32_t dst_i = 0; // TODO [AS]: Use more than one dst tile at a time
         for (uint32_t hw_i = 0; hw_i < in_ntiles_hw; ++hw_i) {
             uint32_t tile_i = base_tile_id + hw_i;
             reduce_tile(in_cb_id, in_scalar_cb_id, tile_i, 0, dst_i);
         }
         pack_tile(dst_i, out_cb_id);
-        release_dst(tt::DstMode::Half);
+        release_dst();
         base_tile_id += in_ntiles_hw;
     }
     reduce_revert_delta(out_cb_id);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -33,7 +33,7 @@ void MAIN {
         cb_reserve_back(cb_out0, ublock_size_tiles);
         cb_reserve_back(cb_out1, ublock_size_tiles);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         // ------------------------- Copy to DEST -----------------------------
 
@@ -97,7 +97,7 @@ void MAIN {
         pack_reconfig_l1_acc(false);
 
         matmul_pack_tile(START_DST_TILE_ID, cb_out1, ublock_size_tiles);
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_pop_front(cb_in0, ublock_size_tiles);
         cb_pop_front(cb_in1, ublock_size_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -31,7 +31,7 @@ void MAIN {
             // tiles are expected to be coming in in NCWH order (H-contiguous)
             // reducing in W means out[0][w] = sum(h=0..H-1, in[h][w])
             // in this case we just sequentially add to accumulator all the H-tiles in a column
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             for(uint32_t ht = 0; ht < Ht; ++ht) {
                 cb_wait_front(tt::CB::c_in0, onetile);
 #if (MATH_ONLY == 1)
@@ -48,7 +48,7 @@ void MAIN {
             cb_reserve_back(tt::CB::c_out0, onetile);
             pack_tile(reduce_dst_idx, tt::CB::c_out0);
             cb_push_back(tt::CB::c_out0, onetile);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
 #ifdef SHORT_INIT

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -27,7 +27,7 @@ void MAIN {
 
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for(uint32_t ht = 0; ht < Ht; ++ht) {
             // tiles are expected to be coming in in NCHW order (W-contiguous)
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
@@ -48,7 +48,7 @@ void MAIN {
         cb_reserve_back(tt::CB::c_out0, onetile);
         pack_tile(reduce_dst_idx, tt::CB::c_out0);
         cb_push_back(tt::CB::c_out0, onetile);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 #ifdef SHORT_INIT
     reduce_revert_delta(tt::CB::c_out0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -31,7 +31,7 @@ void MAIN {
             // tiles are expected to be coming in in NCHW order (W-contiguous)
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
             // in this case we just sequentially add to accumulator all the W-tiles in a row
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             for(uint32_t wt = 0; wt < Wt; ++wt) {
                 cb_wait_front(tt::CB::c_in0, onetile);
 #if (MATH_ONLY == 1)
@@ -48,7 +48,7 @@ void MAIN {
             cb_reserve_back(tt::CB::c_out0, onetile);
             pack_tile(reduce_dst_idx, tt::CB::c_out0);
             cb_push_back(tt::CB::c_out0, onetile);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
 #ifdef SHORT_INIT

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -16,8 +16,8 @@
 #include "compute_kernel_api/layernorm.h"
 
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 
 namespace NAMESPACE {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
@@ -10,8 +10,8 @@
 #include "compute_kernel_api/tilize.h"
 #include "compute_kernel_api/untilize.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles, uint32_t in1_idx) {
     // Multiply input by cos

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -13,8 +13,8 @@
 #include "compute_kernel_api/softmax.h"
 #include "compute_kernel_api/reduce.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 // for scale+mask+softmax:
 // bcast HW (mul by 1 tile)  example: (  [2,1,1024,64] * [1,1,32,32]  )

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
@@ -37,7 +37,7 @@ void MAIN {
     for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C) // output tile index of C
     {
         for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             for (uint32_t kt = 0; kt < Kt; kt++) {
                 if (tile_row_id == 0) {
                     cb_wait_front(tt::CB::c_in0, kt+1);
@@ -51,7 +51,7 @@ void MAIN {
 
             cb_reserve_back(cb_intermed0, onetile);
             pack_tile(0, cb_intermed0);
-            release_dst(tt::DstMode::Half);
+            release_dst();
             cb_push_back(cb_intermed0, onetile);
 
             // untilize tile and write to CB::c_intermed1

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
@@ -26,10 +26,10 @@ void MAIN {
         cb_wait_front(tt::CB::c_in0, 1);
         cb_reserve_back(tt::CB::c_out0, 1);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         transpose_wh_tile(tt::CB::c_in0, 0, 0);
         pack_tile(0, tt::CB::c_out0);
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, 1);
         cb_pop_front(tt::CB::c_in0, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -27,7 +27,7 @@ void MAIN {
     // out = in0[r x k]*in1[k x c]
     mm_init();
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         if (block_id > 0) {
             copy_tile_to_dst_init_short();
             cb_wait_front(partials_cb, out_block_num_tiles);
@@ -68,7 +68,7 @@ void MAIN {
                 cb_push_back(partials_cb, out_block_num_tiles);
             }
         }
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_tile_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_tile_compute.cpp
@@ -23,7 +23,7 @@ void MAIN {
     // we are looking at block
     // out = in0[r x k]*in1[k x c]
     mm_init();
-    acquire_dst(tt::DstMode::Half);
+    acquire_dst();
 
     uint32_t out_tile_index = 0;
     uint32_t in0_index_r_offset = 0;
@@ -50,6 +50,6 @@ void MAIN {
         pack_tile(tile_index, out_cb);
     }
     cb_push_back(out_cb, out_num_tiles);
-    release_dst(tt::DstMode::Half);
+    release_dst();
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/single_tile_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/single_tile_compute.cpp
@@ -21,14 +21,14 @@ void MAIN {
     const bool transpose = false;
     mm_init();
     cb_reserve_back(out_cb, num_out_tiles);
-    acquire_dst(tt::DstMode::Half);
+    acquire_dst();
     cb_wait_front(in0_cb, num_in0_tiles);
     cb_wait_front(in1_cb, num_in1_tiles);
     matmul_tiles(in0_cb, in1_cb, in0_tile_index, in1_tile_index, out_tile_index, transpose);
     pack_tile(0, out_cb);
     cb_pop_front(in0_cb, num_in0_tiles);
     cb_pop_front(in1_cb, num_in1_tiles);
-    release_dst(tt::DstMode::Half);
+    release_dst();
     cb_push_back(out_cb, num_out_tiles);
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
@@ -41,11 +41,11 @@ void MAIN {
         unpack_tilizeA_B_block(tt::CB::c_in0, tt::CB::c_in1, per_core_block_tile_cnt, b);
 
         for(uint i=0; i<per_core_block_tile_cnt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             add_tiles_math(tt::CB::c_in0, tt::CB::c_in1, i, i, 0);
             // dprint_tensix_dest_reg(0);
             pack_tile(0, tt::CB::c_out0);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
 
         cb_push_back(tt::CB::c_out0, per_core_block_tile_cnt);

--- a/tt_metal/include/compute_kernel_api/reg_api.h
+++ b/tt_metal/include/compute_kernel_api/reg_api.h
@@ -17,15 +17,11 @@ namespace ckernel {
  *
  * This is only available on the compute engine.
  *
- * DOX-TODO(Describe meanings of dst_mode values).
- *
  * Return value: None
  *
- * | Argument | Description                                                | Type     | Valid Range         | Required |
- * |----------|------------------------------------------------------------|----------|---------------------|----------|
- * | dst_mode | Specifies how the destination register is going to be used | DstMode  | Full, Half, Tile    | True     |
+ * How the destination register will be shared and synchronized between TRISC threads will depend on the compute kernel configuration.
  */
-ALWI void acquire_dst(tt::DstMode mode) {
+ALWI void acquire_dst() {
     MATH(( llk_math_wait_for_dest_available()  ));
 
     PACK(( llk_packer_wait_for_math_done()  ));
@@ -58,13 +54,9 @@ ALWI void tile_regs_wait() {
  *
  * Return value: None
  *
- * DOX-TODO(Describe meanings of dst_mode values).
- *
- * | Argument | Description                                                | Type     | Valid Range                                 | Required |
- * |----------|------------------------------------------------------------|----------|---------------------------------------------|----------|
- * | dst_mode | Specifies how the destination register is going to be used | uint32_t | DstMode::Full, DstMode::Half, DstMode::Tile | True     |
+ * How the destination register will be shared and synchronized between TRISC threads will depend on the compute kernel configuration.
  */
-ALWI void release_dst(tt::DstMode mode) {
+ALWI void release_dst() {
     MATH(( llk_math_dest_section_done()  ));
 
     PACK(( llk_pack_dest_section_done()  ));

--- a/tt_metal/kernels/compute/eltwise_sfpu.cpp
+++ b/tt_metal/kernels/compute/eltwise_sfpu.cpp
@@ -17,7 +17,7 @@ void MAIN {
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
         cb_reserve_back(tt::CB::c_out0, per_core_block_dim);
         for(uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
 
             // Pop tile after tile, copy to DST and pack
             cb_wait_front(tt::CB::c_in0, 1);
@@ -32,7 +32,7 @@ void MAIN {
 
             cb_pop_front(tt::CB::c_in0, 1);
 
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_push_back(tt::CB::c_out0, per_core_block_dim);
     }

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -37,7 +37,7 @@ void MAIN {
     cb_push_back(cb_out0, 1);
 
     /*
-    acquire_dst(tt::DstMode::Full);
+    acquire_dst();
 
     cb_wait_front(tt::CB::c_in0, 1);
     cb_wait_front(tt::CB::c_in1, 1);
@@ -51,7 +51,7 @@ void MAIN {
     pack_tile(0, tt::CB::c_out0);
     cb_push_back(tt::CB::c_out0, 1);
 
-    release_dst(tt::DstMode::Full);
+    release_dst();
     */
 }
 }

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/add.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/add.cpp
@@ -36,7 +36,7 @@ void MAIN {
     // Loop over all the tiles and perform the computation
     for(uint32_t i = 0; i < n_tiles; i++) {
         // Make sure there is a valid register we can use.
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         // Wait until there is a tile in both input circular buffers
         cb_wait_front(cb_in0, 1);
         cb_wait_front(cb_in1, 1);
@@ -51,7 +51,7 @@ void MAIN {
         cb_pop_front(cb_in0, 1);
         cb_pop_front(cb_in1, 1);
         // Release the held register
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 }

--- a/tt_metal/programming_examples/matmul_common/kernels/compute/bmm.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/compute/bmm.cpp
@@ -31,7 +31,7 @@ void MAIN {
     for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) // output tile of C
     for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C) // output tile index of C
     {
-        acquire_dst(tt::DstMode::Full);
+        acquire_dst();
         for (uint32_t kt = 0; kt < Kt; kt++) {
             cb_wait_front(tt::CB::c_in0, onetile);
             cb_wait_front(tt::CB::c_in1, onetile);
@@ -46,7 +46,7 @@ void MAIN {
         pack_tile(0, tt::CB::c_out0);
         cb_push_back(tt::CB::c_out0, onetile);
 
-        release_dst(tt::DstMode::Full);
+        release_dst();
     }
 
 

--- a/tt_metal/programming_examples/matmul_common/kernels/compute/bmm_large_block_zm.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/compute/bmm_large_block_zm.cpp
@@ -41,7 +41,7 @@ void MAIN {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
 
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         copy_tile_to_dst_init_short();
@@ -91,7 +91,7 @@ void MAIN {
                         cb_push_back(tt::CB::c_intermed0, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp
@@ -15,7 +15,7 @@ void MAIN {
     unary_op_init_common(tt::CB::c_in0);
     for(uint32_t b=0;b<per_core_tile_cnt;++b)
     {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         // Pop tile after tile, copy to DST and pack
         cb_wait_front(tt::CB::c_in0, 1);
@@ -27,7 +27,7 @@ void MAIN {
         cb_pop_front(tt::CB::c_in0, 1);
         cb_push_back(tt::CB::c_out0, 1);
 
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
@@ -29,8 +29,8 @@
 
 
 // Deprecated
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace ckernel {
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/transpose_wh.cpp
@@ -20,10 +20,10 @@ void MAIN {
         cb_wait_front(tt::CB::c_in0, 1);
         cb_reserve_back(tt::CB::c_out0, 1);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         transpose_wh_tile(tt::CB::c_in0, 0, 0);
         pack_tile(0, tt::CB::c_out0);
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, 1);
         cb_pop_front(tt::CB::c_in0, 1);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot/single_core/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot/single_core/kernels/moreh_dot.cpp
@@ -8,8 +8,8 @@
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/kernels/moreh_dot_backward.cpp
@@ -4,8 +4,8 @@
 
 #include "compute_kernel_api/bcast.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -20,8 +20,8 @@
 
 #define DEBUG_PRINT 0
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 inline void tilize_in(
     uint32_t in_cb_id,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
@@ -24,7 +24,7 @@ void MAIN {
 
         cb_reserve_back(tt::CB::c_out0, onetile);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         cb_wait_front(tt::CB::c_in0, onetile);
 
@@ -33,7 +33,7 @@ void MAIN {
 
         cb_pop_front(tt::CB::c_in0, onetile);
 
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, onetile);
         cb_pop_front(tt::CB::c_in1, onetile);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -25,13 +25,13 @@ void MAIN {
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(tt::CB::c_in1, onetile);
             for (uint32_t ht = 0; ht < Ht_per_batch_b; ht+=h_blk) {
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
                 for (uint32_t htr = 0; htr<h_blk; htr++) {
                     uint32_t current_index = b_offset + (ht + htr) * Wt + wt;
                     BCAST_OP<BroadcastType::ROW>(tt::CB::c_in0, tt::CB::c_in1, current_index, 0, htr);
                     pack_tile<true>(htr, tt::CB::c_out0, current_index);
                 }
-                release_dst(tt::DstMode::Half);
+                release_dst();
             }
             cb_pop_front(tt::CB::c_in1, onetile);
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
@@ -26,7 +26,7 @@ void MAIN {
         #endif
         cb_reserve_back(tt::CB::c_out0, onetile);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         cb_wait_front(tt::CB::c_in0, onetile);
 
@@ -37,7 +37,7 @@ void MAIN {
         #ifndef BCAST_SCALAR
         cb_pop_front(tt::CB::c_in1, onetile);
         #endif
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, onetile);
     } } }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
@@ -23,14 +23,14 @@ void MAIN {
 
             cb_reserve_back(tt::CB::c_out0, onetile);
 
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
 
             cb_wait_front(tt::CB::c_in0, onetile);
             BCAST_OP<BroadcastType::COL>(tt::CB::c_in0, tt::CB::c_in1, 0, 0, 0);
             pack_tile(0, tt::CB::c_out0);
             cb_pop_front(tt::CB::c_in0, onetile);
 
-            release_dst(tt::DstMode::Half);
+            release_dst();
 
             cb_push_back(tt::CB::c_out0, onetile);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp
@@ -15,7 +15,7 @@ void MAIN {
     unary_op_init_common(tt::CB::c_in0);
     for(uint32_t b=0;b<per_core_tile_cnt;++b)
     {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         // Pop tile after tile, copy to DST and pack
         cb_wait_front(tt::CB::c_in0, 1);
@@ -27,7 +27,7 @@ void MAIN {
         cb_pop_front(tt::CB::c_in0, 1);
         cb_push_back(tt::CB::c_out0, 1);
 
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
@@ -22,10 +22,10 @@ void MAIN {
         cb_wait_front(tt::CB::c_in0, 1);
         cb_reserve_back(tt::CB::c_out0, 1);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         transpose_wh_tile(tt::CB::c_in0, 0, 0);
         pack_tile(0, tt::CB::c_out0);
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(tt::CB::c_out0, 1);
         cb_pop_front(tt::CB::c_in0, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
@@ -10,8 +10,8 @@
 #include "compute_kernel_api/tilize.h"
 #include "compute_kernel_api/untilize.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles, uint32_t in1_idx) {
     // Multiply input by cos

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
@@ -9,8 +9,8 @@
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/matmul.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/compute/transpose_wh_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/compute/transpose_wh_sharded.cpp
@@ -24,10 +24,10 @@ void MAIN {
         cb_wait_front(cb_im0, 1);
         cb_reserve_back(cb_out1, 1);
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         transpose_wh_tile(cb_im0, 0, 0);
         pack_tile(0, cb_out1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
 
         cb_push_back(cb_out1, 1);
         cb_pop_front(cb_im0, 1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
@@ -31,7 +31,7 @@ void MAIN {
         for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C)      // output tile of C
             for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C)  // output tile index of C
             {
-                acquire_dst(tt::DstMode::Full);
+                acquire_dst();
                 for (uint32_t kt = 0; kt < Kt; kt++) {
                     cb_wait_front(tt::CB::c_in0, onetile);
                     cb_wait_front(tt::CB::c_in1, onetile);
@@ -46,7 +46,7 @@ void MAIN {
                 pack_tile(0, tt::CB::c_out0);
                 cb_push_back(tt::CB::c_out0, onetile);
 
-                release_dst(tt::DstMode::Full);
+                release_dst();
             }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
@@ -38,7 +38,7 @@ void MAIN {
             for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                    acquire_dst(tt::DstMode::Half);
+                    acquire_dst();
 
                     if (enable_reload) {
                         copy_tile_to_dst_init_short_with_dt(tt::CB::c_in1, tt::CB::c_intermed0);
@@ -94,7 +94,7 @@ void MAIN {
                         cb_push_back(tt::CB::c_intermed0, out_subblock_num_tiles);
                     }
 
-                    release_dst(tt::DstMode::Half);
+                    release_dst();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/kernels/moreh_cumsum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/kernels/moreh_cumsum_nc.cpp
@@ -7,8 +7,8 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -8,8 +8,8 @@
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/kernels/moreh_dot_backward.cpp
@@ -4,8 +4,8 @@
 
 #include "compute_kernel_api/bcast.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -16,8 +16,8 @@
 #include "compute_kernel_api/layernorm.h"
 
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 
 namespace NAMESPACE {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -24,8 +24,8 @@
 #include "compute_kernel_api/layernorm.h"
 
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 
 namespace NAMESPACE {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -19,8 +19,8 @@
 #include "compute_kernel_api/layernorm.h"
 
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 
 namespace NAMESPACE {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -16,8 +16,8 @@
 #include "debug/dprint.h"
 #include "debug/dprint_tensix.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 // for scale+mask+softmax:
 // bcast HW (mul by 1 tile)  example: (  [2,1,1024,64] * [1,1,32,32]  )

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -15,8 +15,8 @@
 
 #include "debug/dprint.h"
 
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
 
 template<uint32_t block_w, uint32_t num_subblocks_w, uint32_t subblock_w>
 ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t cb_max, uint32_t cb_out) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -24,7 +24,7 @@ void MAIN {
             // tiles are expected to be coming in in NCWH order (H-contiguous)
             // reducing in W means out[0][w] = sum(h=0..H-1, in[h][w])
             // in this case we just sequentially add to accumulator all the H-tiles in a column
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             for(uint32_t ht = 0; ht < Ht; ++ht) {
                 cb_wait_front(tt::CB::c_in0, onetile);
                 // REDUCE_OP is expected to come from add_define
@@ -35,7 +35,7 @@ void MAIN {
             cb_reserve_back(tt::CB::c_out0, onetile);
             pack_tile(reduce_dst_idx, tt::CB::c_out0);
             cb_push_back(tt::CB::c_out0, onetile);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -19,7 +19,7 @@ void MAIN {
     for (uint32_t nc = 0; nc < NC; nc++) {
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for(uint32_t ht = 0; ht < Ht; ++ht) {
             // tiles are expected to be coming in in NCHW order (W-contiguous)
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
@@ -34,7 +34,7 @@ void MAIN {
         cb_reserve_back(tt::CB::c_out0, onetile);
         pack_tile(reduce_dst_idx, tt::CB::c_out0);
         cb_push_back(tt::CB::c_out0, onetile);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -32,7 +32,7 @@ void MAIN {
             // tiles are expected to be coming in in NCHW order (W-contiguous)
             // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
             // in this case we just sequentially add to accumulator all the W-tiles in a row
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             for(uint32_t wt = 0; wt < Wt; ++wt) {
                 cb_wait_front(tt::CB::c_in0, onetile);
                 // REDUCE_OP is expected to come from add_define
@@ -47,7 +47,7 @@ void MAIN {
             cb_reserve_back(tt::CB::c_out0, onetile);
             pack_tile(reduce_dst_idx, tt::CB::c_out0);
             cb_push_back(tt::CB::c_out0, onetile);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -46,7 +46,7 @@ void MAIN {
 
         // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
         for (uint32_t wt = 0; wt < Wt; wt+=2) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             // local sort into k groups
             cb_wait_front(input_cb_index, 2);
             cb_wait_front(index_cb_index, 2);
@@ -76,7 +76,7 @@ void MAIN {
 
             cb_pop_front(input_cb_index, 2);
             cb_pop_front(index_cb_index, 2);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
 
         cb_push_back(input_transposed_cb_index, Wt);
@@ -94,7 +94,7 @@ void MAIN {
 
             for (uint32_t left_ind = 0; left_ind < Wt - (1 << m_iter); left_ind += 2 << m_iter) {
                 uint32_t right_ind = left_ind + (1 << m_iter);
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
 
                 copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
                 copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
@@ -118,7 +118,7 @@ void MAIN {
                 // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for topk, which was in index_dest_start
                 pack_reconfig_data_format(index_transposed_cb_index);
                 pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-                release_dst(tt::DstMode::Half);
+                release_dst();
                 a = !a;
             }
             cb_reserve_back(input_transposed_cb_index, Wt);
@@ -139,12 +139,12 @@ void MAIN {
         pack_reconfig_data_format(input_transposed_cb_index);
         cb_wait_front(input_transposed_cb_index, Kt);
         for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             cb_reserve_back(values_cb_index, 1);
             transpose_wh_tile(input_transposed_cb_index, i, 0);
             pack_tile(0, values_cb_index);
             cb_push_back(values_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(input_transposed_cb_index, Wt);
         cb_pop_front(input_transposed_cb_index, Wt);
@@ -155,12 +155,12 @@ void MAIN {
         pack_reconfig_data_format(index_transposed_cb_index);
         cb_wait_front(index_transposed_cb_index, Kt);
         for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             cb_reserve_back(output_ind_cb_index, 1);
             transpose_wh_tile(index_transposed_cb_index, i, 0);
             pack_tile(0, output_ind_cb_index);
             cb_push_back(output_ind_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(index_transposed_cb_index, Wt);
         cb_pop_front(index_transposed_cb_index, Wt);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -52,14 +52,14 @@ void MAIN {
         pack_reconfig_data_format(input_transposed_cb_index);
         // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
         for (uint32_t wt = 0; wt < Wt; wt++) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             // copy in inputs from input_cb_index - TODO: figure out how to optimize this out
             cb_reserve_back(input_transposed_cb_index, 1);
             copy_tile(input_cb_index, wt, 0);
             // pack value tiles into cb_intermed2
             pack_tile(0, input_transposed_cb_index);
             cb_push_back(input_transposed_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(input_transposed_cb_index, Wt);
         cb_pop_front(input_cb_index, Wt);
@@ -67,14 +67,14 @@ void MAIN {
         copy_tile_to_dst_init_short_with_dt(input_cb_index, index_cb_index);
         pack_reconfig_data_format(index_transposed_cb_index);
         for (uint32_t wt = 0; wt < Wt; wt++) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             // copy in inputs from index_cb_index
             cb_reserve_back(index_transposed_cb_index, 1);
             copy_tile(index_cb_index, wt, 0);
             // pack value tiles into cb_intermed3
             pack_tile(0, index_transposed_cb_index);
             cb_push_back(index_transposed_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(index_transposed_cb_index, Wt);
         cb_pop_front(index_cb_index, Wt);
@@ -92,7 +92,7 @@ void MAIN {
             uint32_t stride = 1 << m_iter;
             for (uint32_t left_ind = 0; left_ind < Wt - stride; left_ind += 2 << m_iter) {
                 uint32_t right_ind = left_ind + stride;
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
 
                 // unpack values into dest
                 copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
@@ -116,7 +116,7 @@ void MAIN {
                 // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for topk, which was in index_dest_start
                 pack_reconfig_data_format(index_transposed_cb_index);
                 pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-                release_dst(tt::DstMode::Half);
+                release_dst();
                 direction = !direction;
             }
             cb_reserve_back(input_transposed_cb_index, Wt);
@@ -135,12 +135,12 @@ void MAIN {
         pack_reconfig_data_format(input_transposed_cb_index);
         cb_wait_front(input_transposed_cb_index, Kt);
         for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             cb_reserve_back(values_cb_index, 1);
             transpose_wh_tile(input_transposed_cb_index, i, 0);
             pack_tile(0, values_cb_index);
             cb_push_back(values_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(input_transposed_cb_index, Wt);
         cb_pop_front(input_transposed_cb_index, Wt);
@@ -151,12 +151,12 @@ void MAIN {
         pack_reconfig_data_format(index_transposed_cb_index);
         cb_wait_front(index_transposed_cb_index, Kt);
         for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             cb_reserve_back(output_ind_cb_index, 1);
             transpose_wh_tile(index_transposed_cb_index, i, 0);
             pack_tile(0, output_ind_cb_index);
             cb_push_back(output_ind_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(index_transposed_cb_index, Wt);
         cb_pop_front(index_transposed_cb_index, Wt);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -51,7 +51,7 @@ void MAIN {
         // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
         for (uint32_t wt = 0; wt < Wt; wt+=2) {
 
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             // transpose tiles and then local sort into k groups
             cb_wait_front(input_cb_index, 2);
             cb_wait_front(index_cb_index, 2);
@@ -81,7 +81,7 @@ void MAIN {
 
             cb_pop_front(input_cb_index, 2);
             cb_pop_front(index_cb_index, 2);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
 
         cb_push_back(input_transposed_cb_index, Wt);
@@ -99,7 +99,7 @@ void MAIN {
             uint32_t stride = 1 << m_iter;
             for (uint32_t left_ind = 0; left_ind < Wt - stride; left_ind += 2 << m_iter) {
                 uint32_t right_ind = left_ind + stride;
-                acquire_dst(tt::DstMode::Half);
+                acquire_dst();
 
                 copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
                 copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
@@ -123,7 +123,7 @@ void MAIN {
                 // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for topk, which was in index_dest_start
                 pack_reconfig_data_format(index_transposed_cb_index);
                 pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
-                release_dst(tt::DstMode::Half);
+                release_dst();
                 direction = !direction;
             }
             cb_reserve_back(input_transposed_cb_index, Wt);
@@ -142,12 +142,12 @@ void MAIN {
         pack_reconfig_data_format(input_transposed_cb_index);
         cb_wait_front(input_transposed_cb_index, Kt);
         for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             cb_reserve_back(values_cb_index, 1);
             copy_tile(input_transposed_cb_index, i, 0);
             pack_tile(0, values_cb_index);
             cb_push_back(values_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(input_transposed_cb_index, Wt);
         cb_pop_front(input_transposed_cb_index, Wt);
@@ -158,12 +158,12 @@ void MAIN {
         pack_reconfig_data_format(index_transposed_cb_index);
         cb_wait_front(index_transposed_cb_index, Kt);
         for (uint32_t i = 0; i < Kt; ++i) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             cb_reserve_back(output_ind_cb_index, 1);
             copy_tile(index_transposed_cb_index, i, 0);
             pack_tile(0, output_ind_cb_index);
             cb_push_back(output_ind_cb_index, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
         cb_wait_front(index_transposed_cb_index, Wt);
         cb_pop_front(index_transposed_cb_index, Wt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -29,7 +29,7 @@ void max_block_inplace() {
     cb_wait_front(in0, num_tiles);
     cb_wait_front(in1, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in0, 0, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
         cb_pop_front(in0, 1);
@@ -37,7 +37,7 @@ void max_block_inplace() {
         max_tile(dst_reg_0, dst_reg_1);
         pack_tile(dst_reg_0, in0);
         cb_push_back(in0, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -60,7 +60,7 @@ void reduce_c() {
     constexpr uint32_t reduce_dst_idx = 0;
 
     for (uint32_t i = 0; i < rows; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for (uint32_t j = 0; j < cols; j++) {
             reduce_tile<pool_type, reduce_dim>(in0_cb, scale_cb, i*cols+j, 0, reduce_dst_idx);
         }
@@ -68,7 +68,7 @@ void reduce_c() {
         cb_reserve_back(out_cb, 1);
         pack_tile(reduce_dst_idx, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 
    reduce_revert_delta<reduce_dim>(out_cb);
@@ -82,14 +82,14 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
 
     cb_wait_front(in_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in_cb, 0, 0);
         cb_pop_front(in_cb, 1);
         recip_tile(0);
         cb_reserve_back(in_cb, 1);
         pack_tile(0, in_cb);
         cb_push_back(in_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -140,13 +140,13 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t row
     cb_wait_front(in1_cb, rows);
     for (uint32_t i = 0; i < rows; ++i) {
         for (uint32_t j = 0; j < cols; ++j) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
             cb_pop_front(in0_cb, 1);
             cb_reserve_back(in0_cb, 1);
             pack_tile(0, in0_cb);
             cb_push_back(in0_cb, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
     cb_pop_front(in1_cb, rows);
@@ -166,7 +166,7 @@ void mul_block_bcast_scalar_inplace() {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_scalar_cb, 1);
     for (uint32_t g = 0; g < granularity; ++g) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for (uint32_t i = 0; i < dst_tiles; ++i) {
             mul_tiles_bcast_scalar(in0_cb, in1_scalar_cb, i, 0, i);
         }
@@ -176,7 +176,7 @@ void mul_block_bcast_scalar_inplace() {
             pack_tile(i, in0_cb);
         }
         cb_push_back(in0_cb, dst_tiles);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -189,13 +189,13 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         add_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
         pack_tile(0, in0_cb);
         cb_push_back(in0_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 
     cb_pop_front(in1_cb, num_tiles);
@@ -210,13 +210,13 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         mul_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
         pack_tile(0, in0_cb);
         cb_push_back(in0_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -233,7 +233,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
 
     for (uint32_t i = 0; i < num_tiles; i++) {
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         sub_tiles(in0_cb, in1_cb, i, i, 0);
 
@@ -242,7 +242,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
         pack_tile(0, out_cb);
 
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -259,11 +259,11 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
 
     #pragma GCC unroll 0
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in_cb, i, 0/*dst*/);
         pack_tile(0, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
     cb_pop_front(in_cb, num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa_noncausal.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa_noncausal.cpp
@@ -29,7 +29,7 @@ void max_block_inplace() {
     cb_wait_front(in0, num_tiles);
     cb_wait_front(in1, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in0, 0, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
         cb_pop_front(in0, 1);
@@ -37,7 +37,7 @@ void max_block_inplace() {
         max_tile(dst_reg_0, dst_reg_1);
         pack_tile(dst_reg_0, in0);
         cb_push_back(in0, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -60,7 +60,7 @@ void reduce_c() {
     constexpr uint32_t reduce_dst_idx = 0;
 
     for (uint32_t i = 0; i < rows; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for (uint32_t j = 0; j < cols; j++) {
             reduce_tile<pool_type, reduce_dim>(in0_cb, scale_cb, i*cols+j, 0, reduce_dst_idx);
         }
@@ -68,7 +68,7 @@ void reduce_c() {
         cb_reserve_back(out_cb, 1);
         pack_tile(reduce_dst_idx, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 
    reduce_revert_delta<reduce_dim>(out_cb);
@@ -83,14 +83,14 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
 
     cb_wait_front(in_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in_cb, 0, 0);
         cb_pop_front(in_cb, 1);
         recip_tile(0);
         cb_reserve_back(in_cb, 1);
         pack_tile(0, in_cb);
         cb_push_back(in_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -141,13 +141,13 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t row
     cb_wait_front(in1_cb, rows);
     for (uint32_t i = 0; i < rows; ++i) {
         for (uint32_t j = 0; j < cols; ++j) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
             cb_pop_front(in0_cb, 1);
             cb_reserve_back(in0_cb, 1);
             pack_tile(0, in0_cb);
             cb_push_back(in0_cb, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
     cb_pop_front(in1_cb, rows);
@@ -167,7 +167,7 @@ void mul_block_bcast_scalar_inplace() {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_scalar_cb, 1);
     for (uint32_t g = 0; g < granularity; ++g) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for (uint32_t i = 0; i < dst_tiles; ++i) {
             mul_tiles_bcast_scalar(in0_cb, in1_scalar_cb, i, 0, i);
         }
@@ -177,7 +177,7 @@ void mul_block_bcast_scalar_inplace() {
             pack_tile(i, in0_cb);
         }
         cb_push_back(in0_cb, dst_tiles);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -190,13 +190,13 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         add_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
         pack_tile(0, in0_cb);
         cb_push_back(in0_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 
     cb_pop_front(in1_cb, num_tiles);
@@ -211,13 +211,13 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         mul_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
         pack_tile(0, in0_cb);
         cb_push_back(in0_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -234,7 +234,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
 
     for (uint32_t i = 0; i < num_tiles; i++) {
 
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
 
         sub_tiles(in0_cb, in1_cb, i, i, 0);
 
@@ -243,7 +243,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
         pack_tile(0, out_cb);
 
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -259,11 +259,11 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
     cb_reserve_back(out_cb, num_tiles);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in_cb, i, 0/*dst*/);
         pack_tile(0, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
     cb_pop_front(in_cb, num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -29,7 +29,7 @@ void max_block_inplace(uint32_t in0, uint32_t in1, uint32_t num_tiles) {
     cb_wait_front(in0, num_tiles);
     cb_wait_front(in1, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in0, 0, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
         cb_pop_front(in0, 1);
@@ -37,7 +37,7 @@ void max_block_inplace(uint32_t in0, uint32_t in1, uint32_t num_tiles) {
         max_tile(dst_reg_0, dst_reg_1);
         pack_tile(dst_reg_0, in0);
         cb_push_back(in0, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -52,12 +52,12 @@ void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) 
     cb_wait_front(in1, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in0, i, dst_reg_0);
         copy_tile(in1, i, dst_reg_1);
         max_tile(dst_reg_0, dst_reg_1);
         pack_tile(dst_reg_0, out_cb, i);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
     cb_push_back(out_cb, num_tiles);
 }
@@ -81,7 +81,7 @@ void reduce_c() {
     constexpr uint32_t reduce_dst_idx = 0;
 
     for (uint32_t i = 0; i < rows; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for (uint32_t j = 0; j < cols; j++) {
             reduce_tile<pool_type, reduce_dim>(in0_cb, scale_cb, i*cols+j, 0, reduce_dst_idx);
         }
@@ -89,7 +89,7 @@ void reduce_c() {
         cb_reserve_back(out_cb, 1);
         pack_tile(reduce_dst_idx, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 
     reduce_revert_delta<reduce_dim>(out_cb);
@@ -103,14 +103,14 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
 
     cb_wait_front(in_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in_cb, 0, 0);
         cb_pop_front(in_cb, 1);
         recip_tile(0);
         cb_reserve_back(in_cb, 1);
         pack_tile(0, in_cb);
         cb_push_back(in_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -160,13 +160,13 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t row
     cb_wait_front(in1_cb, rows);
     for (uint32_t i = 0; i < rows; ++i) {
         for (uint32_t j = 0; j < cols; ++j) {
-            acquire_dst(tt::DstMode::Half);
+            acquire_dst();
             mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
             cb_pop_front(in0_cb, 1);
             cb_reserve_back(in0_cb, 1);
             pack_tile(0, in0_cb);
             cb_push_back(in0_cb, 1);
-            release_dst(tt::DstMode::Half);
+            release_dst();
         }
     }
     cb_pop_front(in1_cb, rows);
@@ -185,7 +185,7 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb, uint32_t in1_scalar_cb, uin
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_scalar_cb, 1);
     for (uint32_t g = 0; g < granularity; ++g) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         for (uint32_t i = 0; i < dst_tiles; ++i) {
             mul_tiles_bcast_scalar(in0_cb, in1_scalar_cb, i, 0, i);
         }
@@ -195,7 +195,7 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb, uint32_t in1_scalar_cb, uin
             pack_tile(i, in0_cb);
         }
         cb_push_back(in0_cb, dst_tiles);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -209,13 +209,13 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         add_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
         pack_tile(0, in0_cb);
         cb_push_back(in0_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
     if (pop_in1) cb_pop_front(in1_cb, num_tiles);
 }
@@ -230,10 +230,10 @@ void add_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_t
     cb_wait_front(in1_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         add_tiles(in0_cb, in1_cb, i, i, 0);
         pack_tile(0, out_cb, i);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
     cb_push_back(out_cb, num_tiles);
 
@@ -250,13 +250,13 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         mul_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
         cb_reserve_back(in0_cb, 1);
         pack_tile(0, in0_cb);
         cb_push_back(in0_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -271,12 +271,12 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     cb_reserve_back(out_cb, num_tiles);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         sub_tiles(in0_cb, in1_cb, i, i, 0);
         exp_tile<true>(0);
         pack_tile(0, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
 }
 
@@ -293,11 +293,11 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
 
     #pragma GCC unroll 0
     for (uint32_t i = 0; i < num_tiles; i++) {
-        acquire_dst(tt::DstMode::Half);
+        acquire_dst();
         copy_tile(in_cb, i, 0/*dst*/);
         pack_tile(0, out_cb);
         cb_push_back(out_cb, 1);
-        release_dst(tt::DstMode::Half);
+        release_dst();
     }
     cb_pop_front(in_cb, num_tiles);
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/13547)

### Problem description
For a while we have been ignoring the arguments inside functions release_dst and acquire_dst and using SyncHalf for the lower level kernels and recently we use the synchronization mechanism that is defined in a header file generated during compilation based on the configuration of the compute kernel. Thus we need to remove the unused arguments inside release_dst and acquire_dst to avoid confusion.

### What's changed
Removed unused arguments (specifying synchronization mechanism for dst register) from release_dst and acquire_dst functions. 

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
