### PR TITLE
#0: Cache in_worker_thread boolean inside InWorkerThread

### DIFF
--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -24,10 +24,6 @@ class DevicePool {
         return *_inst;
     }
 
-    static bool is_instantiated() {
-        return (_inst != nullptr);
-    }
-
     static void initialize(
         std::vector<chip_id_t> device_ids,
         const uint8_t num_hw_cqs,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
  - Repeated set lookups/recomputations caused significant degradation in host performance

### What's changed
Use cached values to avoid recomputation.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
