### PR TITLE
Attach Golden Function (already implemented ) For Reshape (accidentally unattached in previous PR)

### DIFF
--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -143,6 +143,7 @@ Example::
     ttnn.Shape([32, 64])
 
 """
+ttnn.attach_golden_function(ttnn.reshape, golden_function=_golden_function)
 
 # TODO(arakhmati): remove this once underlying C++ code can handle non-4D shapes
 ttnn.register_python_operation(name="ttnn.unsqueeze_to_4D")(ttnn._ttnn.operations.core.unsqueeze_to_4D)


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/13613)

### Problem description
In previous PR (link to previous PR: https://github.com/tenstorrent/tt-metal/pull/13022) that removed python implementation of reshape pybind, accidentally removed the attaching of the golden function. 
Failing Nightly : https://github.com/tenstorrent/tt-metal/actions/runs/11219413349/job/31187933168

### What's changed
This PR adds back the attaching of the golden function required for nightly

### Checklist
- [ ] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11245878456)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [ ]  Nightly https://github.com/tenstorrent/tt-metal/actions/runs/11245884501
