### PR TITLE
Apply unpack_to_dest and use matmul_tiles instread of reduce_tile in w-dim

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
@@ -359,7 +359,7 @@ def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major
     else:
         dev_idx = (
             ttnn.Tensor(idx, ttnn.int32)
-            .reshape([1, 1, 1, 1, index_size])
+            .reshape([1, index_size])
             .pad_to_tile(float("nan"))
             .to(ttnn.TILE_LAYOUT)
             .to(device)
@@ -452,7 +452,7 @@ def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, row_ma
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape([1, 1, 1, 1, index_size])
+                .reshape([1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -541,7 +541,7 @@ def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, row_
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape([1, 1, 1, 1, index_size])
+                .reshape([1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -625,7 +625,7 @@ def test_getitem_tilized_four_indices(shape_index_dims, dtype, index_size, row_m
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape([1, 1, 1, 1, index_size])
+                .reshape([1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -706,7 +706,7 @@ def test_getitem_tilized_five_indices(shape_index_dims, dtype, index_size, row_m
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape([1, 1, 1, 1, index_size])
+                .reshape([1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -751,7 +751,7 @@ def run_moreh_geitem_tilized_one_index(shape_index_dim, dtype, index_size, row_m
     else:
         dev_idx = (
             ttnn.Tensor(idx, ttnn.int32)
-            .reshape([1, 1, 1, 1, index_size])
+            .reshape([1, index_size])
             .pad_to_tile(float("nan"))
             .to(ttnn.TILE_LAYOUT)
             .to(device)

--- a/tests/ttnn/unit_tests/operations/test_moreh_linear.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_linear.py
@@ -5,32 +5,14 @@
 import pytest
 import torch
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc
-from tests.ttnn.unit_tests.operations.test_moreh_matmul import get_tensors
+from models.utility_functions import comp_allclose_and_pcc, skip_for_grayskull
+from tests.ttnn.unit_tests.operations.test_moreh_matmul import get_tensors, get_bias_tensors
 from loguru import logger
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
 )
-
-
-# TODO: add this feature in get_tensors method
-def get_bias_tensors(bias_shape, require_bias_grad, device):
-    npu_dtype = ttnn.bfloat16
-    cpu_dtype = torch.bfloat16
-    npu_layout = ttnn.TILE_LAYOUT
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-
-    bias = torch.randint(-10, 10, bias_shape, dtype=cpu_dtype)
-    tt_bias = ttnn.Tensor(bias, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-
-    tt_bias_grad = None
-    if require_bias_grad:
-        bias_grad = torch.full(bias_shape, float("nan"), dtype=cpu_dtype)
-        tt_bias_grad = ttnn.Tensor(bias_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-
-    return tt_bias, bias, tt_bias_grad
 
 
 def moreh_linear(shapes, has_bias, has_output, compute_kernel_config, device):
@@ -267,3 +249,93 @@ def test_moreh_linear_backward_enable_cache(shapes, device, use_program_cache):
         num_program_cache_entries_list.append(device.num_program_cache_entries())
         assert passing
     assert len(set(num_program_cache_entries_list)) == 1
+
+
+@skip_for_grayskull("GS does not support fp32")
+@pytest.mark.parametrize(
+    "shapes",
+    (
+        # input, weight, bias(1d or scalar), output
+        # GPT2-Small cases
+        ([8, 512, 768], [2304, 768], [1, 2304], [8, 512, 2304]),
+        ([8, 512, 768], [768, 768], [1, 768], [8, 512, 768]),
+        ([8, 512, 768], [3072, 768], [1, 3072], [8, 512, 3072]),
+    ),
+)
+def test_moreh_bias_backward_fp32(shapes, device):
+    torch.manual_seed(3072)
+    compute_kernel_fp32_config = get_compute_kernel_options(True)
+    compute_kernel_config = get_compute_kernel_options(False)
+    requires_input_grad, requires_weight_grad, requires_bias_grad = (True, False, True)
+    input_shape, weight_shape, bias_shape, output_shape = shapes
+    (
+        tt_input,
+        tt_weight,
+        _,
+        tt_output_grad,
+        tt_input_grad,
+        _,
+        torch_input,
+        torch_weight,
+        torch_output_grad,
+    ) = get_tensors(
+        input_shape, weight_shape, output_shape, requires_input_grad, requires_weight_grad, False, device, False
+    )
+    tt_bias, torch_bias, tt_bias_grad = get_bias_tensors(bias_shape, requires_bias_grad, device, False)
+    (_, _, _, _, tt_input_grad_fp32, _, _, _, _) = get_tensors(
+        input_shape, weight_shape, output_shape, requires_input_grad, requires_weight_grad, False, device, False
+    )
+    (_, _, tt_bias_grad_fp32) = get_bias_tensors(bias_shape, requires_bias_grad, device, False)
+    ## tt linear backward (fp32 mode)
+    tt_input_grad_fp32, _, tt_bias_grad_fp32 = ttnn.operations.moreh.linear_backward(
+        tt_output_grad,
+        tt_input,
+        tt_weight,
+        are_required_outputs=(requires_input_grad, requires_weight_grad, requires_bias_grad),
+        bias=tt_bias,
+        input_grad=tt_input_grad_fp32,
+        weight_grad=None,
+        bias_grad=tt_bias_grad_fp32,
+        compute_kernel_config=compute_kernel_fp32_config,
+    )
+    ## tt linear backward (bf16 mode)
+    tt_input_grad, _, tt_bias_grad = ttnn.operations.moreh.linear_backward(
+        tt_output_grad,
+        tt_input,
+        tt_weight,
+        are_required_outputs=(requires_input_grad, requires_weight_grad, requires_bias_grad),
+        bias=tt_bias,
+        input_grad=tt_input_grad,
+        weight_grad=None,
+        bias_grad=tt_bias_grad,
+        compute_kernel_config=compute_kernel_config,
+    )
+    torch_input_fp32 = torch_input.float()
+    torch_weight_fp32 = torch_weight.float()
+    torch_bias_fp32 = torch_bias.float()
+    ## reference
+    torch_output = torch.nn.functional.linear(
+        torch_input_fp32.requires_grad_(requires_input_grad),
+        torch_weight_fp32.requires_grad_(requires_weight_grad),
+        torch_bias_fp32.requires_grad_(requires_bias_grad),
+    )
+    torch_output.backward(torch_output_grad.float())
+    ## test for equivalance
+    rtol = atol = 0.1
+    tt_bias_grad_fp32_cpu = tt_bias_grad_fp32.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(bias_shape).to_torch()
+    tt_bias_grad_cpu = tt_bias_grad.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(bias_shape).to_torch()
+    passing, output_pcc = comp_allclose_and_pcc(
+        torch_bias_fp32.grad, tt_bias_grad_fp32_cpu, pcc=0.98, rtol=rtol, atol=atol
+    )
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+    assert passing
+    diff_fp32 = torch.abs(torch_bias_fp32.grad - tt_bias_grad_fp32_cpu)
+    logger.debug(f"std={torch.std(diff_fp32)}")
+    logger.debug(f"mean={diff_fp32.mean()}")
+    logger.debug(f"topk(5) {torch.topk(diff_fp32.reshape(-1), 5)}")
+    diff = torch.abs(torch_bias_fp32.grad - tt_bias_grad_cpu)
+    logger.debug(f"std={torch.std(diff)}")
+    logger.debug(f"mean={diff.mean()}")
+    logger.debug(f"topk(5) {torch.topk(diff.reshape(-1), 5)}")
+    assert diff_fp32.mean() < diff.mean()

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -329,6 +329,7 @@ def test_moreh_matmul_1d(input_shape, device):
 
     assert passing
 
+
 @pytest.mark.parametrize(
     "params",
     (
@@ -476,6 +477,7 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
         logger.debug(f"other_grad passing={passing}")
         logger.debug(f"other_grad pcc={output_pcc}")
         assert passing
+
 
 @skip_for_grayskull("GS does not support fp32")
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
@@ -34,8 +34,8 @@ void MorehGetItemOperation::validate_inputs(
         auto index_layout = index_tensor.get_layout();
         if (index_layout == Layout::ROW_MAJOR) {
             TT_FATAL(index_shape.rank() == 1, "Index tensor must be 1D for ROW_MAJOR layout!");
-        } else if (index_layout == Layout::TILE) {
-            TT_FATAL(index_shape.rank() == 5, "Index tensor must be 5D for TILE layout!");
+        } else {
+            // nothing
         }
         TT_FATAL(
             !(input_layout == Layout::ROW_MAJOR && index_layout == Layout::TILE),

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/reader_moreh_bias_backward_h.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
-
 void kernel_main() {
     ArgFetcher arg_fetcher;
     const uint32_t src0_addr = arg_fetcher.get_next_arg_val<uint32_t>();
@@ -17,16 +17,12 @@ void kernel_main() {
     const bool do_mask_w = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t scaler = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_scaler = 1;
     constexpr uint32_t cb_id_mask_h_w = 2;
 
-    union {
-        float f;
-        uint32_t u;
-    } scaler;
-    scaler.f = 1.0f;
-    fill_cb_with_value(cb_id_scaler, scaler.u);
+    generate_reduce_scaler(cb_id_scaler, scaler);
 
     if (do_mask_h || do_mask_w) {
         generate_mask_h_w(cb_id_mask_h_w, mask_h, mask_w);
@@ -41,7 +37,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     for (uint32_t wt = 0; wt < Wt_per_core; ++wt) {
         uint32_t read_tile_id = start_id + wt;
-        for (uint32_t b= 0; b < batch_num; ++b) {
+        for (uint32_t b = 0; b < batch_num; ++b) {
             cb_reserve_back(cb_id_in0, onetile);
             l1_write_addr_in0 = get_write_ptr(cb_id_in0);
             noc_async_read_tile(read_tile_id, s0, l1_write_addr_in0);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/reader_moreh_mean_w.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_mm_scaler.hpp"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
@@ -13,29 +14,7 @@ void kernel_main() {
     constexpr uint32_t scaler = get_compile_time_arg_val(1);
 
     constexpr uint32_t cb_id_in2 = tt::CB::c_in2;
-    cb_reserve_back(cb_id_in2, 1);
-    constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t write_addr = get_write_ptr(cb_id_in2);
-    // Fill tile with zeros
-    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read(zeros_noc_addr, write_addr, MEM_ZEROS_SIZE);
-        write_addr += MEM_ZEROS_SIZE;
-    }
-    noc_async_read_barrier();
-    if constexpr (scaler != 0) {
-        volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id_in2));
-        uint32_t idx = 0;
-        for (uint32_t k = 0; k < 4; ++k) {
-            uint32_t curr_idx = idx;
-            for (uint32_t j = 0; j < 8; ++j) {
-                ptr[curr_idx] = scaler;
-                curr_idx++;
-            }
-            idx += 128;
-        }
-    }
-    cb_push_back(cb_id_in2, 1);
+    generate_mm_scaler(cb_id_in2, scaler);
 
     constexpr uint32_t cb_id_mask_w = tt::CB::c_in3;
 #ifdef DO_MASK_W

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -170,8 +170,6 @@ MorehMeanBackwardOperation::MorehMeanBackwardFactory::create(
         tt::operations::primary::ComputeKernelConfig{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            // TODO(hyungsuk): change unpack_to_dest_mode from false to fp32_dest_acc_en after fix #10337
-            // .unpack_to_dest_mode = fp32_dest_acc_en,
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .math_approx_mode = math_approx_mode,
             .defines = compute_defines});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -160,8 +160,10 @@ MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSu
         1,                          // NC
         origin_H};
 
-    // set unpack_to_dest_mode to the same value as fp32_dest_acc_en
     vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[tt::CB::c_intermed0] = UnpackToDestMode::UnpackToDestFp32;
+    }
     auto reduce_compute_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_name,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "compute_kernel_api/matmul.h"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
 
 namespace NAMESPACE {
@@ -10,7 +11,6 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
     constexpr uint32_t origin_W = get_compile_time_arg_val(3);
-
 
     auto cb_input = tt::CB::c_in0;
     constexpr auto cb_scaler = tt::CB::c_in2;
@@ -44,22 +44,20 @@ void MAIN {
                 tile_regs_acquire();
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
                     cb_wait_front(cb_input, onetile);
-
-                    #if defined FP32_DEST_ACC_EN
-                        unpack_reconfig_data_format(cb_input, cb_scaler);
-                    #endif
-                    reduce_init_delta<false>();
-                    reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-                    reduce_revert_delta();
+#if defined FP32_DEST_ACC_EN
+                    unpack_reconfig_data_format(cb_input, cb_scaler);
+#endif
+                    mm_init_short(cb_input, cb_scaler, false);
+                    matmul_tiles(cb_input, cb_scaler, 0, 0, reduce_dst_idx, false);
 
                     cb_pop_front(cb_input, onetile);
                 }
                 tile_regs_commit();
                 cb_reserve_back(cb_accum_dst, onetile);
                 tile_regs_wait();
-                #if defined FP32_DEST_ACC_EN
-                    pack_reconfig_data_format(cb_accum_dst);
-                #endif
+#if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_accum_dst);
+#endif
                 pack_tile(reduce_dst_idx, cb_accum_dst);
                 tile_regs_release();
                 cb_push_back(cb_accum_dst, onetile);
@@ -68,9 +66,9 @@ void MAIN {
             if (do_mask_w) {
                 tile_regs_acquire();
                 cb_wait_front(cb_input, onetile);
-                #if defined FP32_DEST_ACC_EN
-                    unpack_reconfig_data_format_srca(cb_input);
-                #endif
+#if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format_srca(cb_input);
+#endif
                 copy_tile_to_dst_init_short(cb_input);
                 copy_tile(cb_input, 0, reduce_dst_idx);
                 copy_tile(cb_mask_w, 0, mask_dst_idx);
@@ -80,9 +78,9 @@ void MAIN {
 
                 cb_reserve_back(cb_masked_input, onetile);
                 tile_regs_wait();
-                #if defined FP32_DEST_ACC_EN
-                    pack_reconfig_data_format(cb_masked_input);
-                #endif
+#if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_masked_input);
+#endif
                 pack_tile(reduce_dst_idx, cb_masked_input);
                 tile_regs_release();
                 cb_push_back(cb_masked_input, onetile);
@@ -94,27 +92,26 @@ void MAIN {
             tile_regs_acquire();
             cb_wait_front(cb_input, onetile);
             if (!is_w_single_tile) {
-                #if defined FP32_DEST_ACC_EN
-                    unpack_reconfig_data_format_srca(cb_accum_dst);
-                #endif
+#if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format_srca(cb_accum_dst);
+#endif
                 cb_wait_front(cb_accum_dst, onetile);
                 copy_tile_to_dst_init_short(cb_accum_dst);
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
-            #if defined FP32_DEST_ACC_EN
-                unpack_reconfig_data_format(cb_input, cb_scaler);
-            #endif
-            reduce_init_delta<false>();
-            reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-            reduce_revert_delta();
+#if defined FP32_DEST_ACC_EN
+            unpack_reconfig_data_format(cb_input, cb_scaler);
+#endif
+            mm_init_short(cb_input, cb_scaler, false);
+            matmul_tiles(cb_input, cb_scaler, 0, 0, reduce_dst_idx, false);
             tile_regs_commit();
 
             cb_reserve_back(cb_out, onetile);
             tile_regs_wait();
-            #if defined FP32_DEST_ACC_EN
-                pack_reconfig_data_format(cb_out);
-            #endif
+#if defined FP32_DEST_ACC_EN
+            pack_reconfig_data_format(cb_out);
+#endif
             pack_tile(reduce_dst_idx, cb_out);
             tile_regs_release();
             cb_push_back(cb_out, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
-#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_mm_scaler.hpp"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -14,7 +14,7 @@ void kernel_main() {
     constexpr uint32_t scaler = get_compile_time_arg_val(1);
 
     constexpr uint32_t cb_id_in2 = 2;
-    generate_reduce_scaler(cb_id_in2, scaler);
+    generate_mm_scaler(cb_id_in2, scaler);
 
     constexpr uint32_t cb_id_mask_w = 3;
 #ifdef DO_MASK_W

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
@@ -146,15 +146,17 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
     if (fp32_dest_acc_en) {
         reduce_defines["FP32_DEST_ACC_EN"] = "1";
     }
-    vector<uint32_t> compute_kernel_args_group_1 = {
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
         num_rows_per_core_group_1,  // Ht
         Wt,                         // Wt
         1,                          // NC
         origin_W,
     };
 
-    // set unpack_to_dest_mode to the same value as fp32_dest_acc_en
-    vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_dest_acc_en) {
+        unpack_to_dest_mode[tt::CB::c_intermed0] = UnpackToDestMode::UnpackToDestFp32;
+    }
     auto reduce_compute_kernel_group_1_id = tt::tt_metal::CreateKernel(
         program,
         compute_kernel_name,
@@ -168,7 +170,7 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
             .defines = reduce_defines});
 
     if (!core_group_2.ranges().empty()) {
-        vector<uint32_t> compute_kernel_args_group_2 = {
+        std::vector<uint32_t> compute_kernel_args_group_2 = {
             num_rows_per_core_group_2,  // Ht
             Wt,                         // Wt
             1,                          // NC


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13576

### Problem description
- Without `unpack_to_dest`, precision is lost when copying fp32 CB to dest register.
- `reduce_tiles` in w-dim has poor precision.

### What's changed
- Main changes
  - Apply `unpack_to_dest` to some moreh_ops.
  - Use `matmul_tiles` instread of `reduce_tiles` in w-dim.
- Miscellaneous changes
  - Do not check rank of tilized idx tensor in moreh_getitem.
  - Increase circular buffer size in moreh_matmul

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
