### PR TITLE
#11830: Move DRAM_BARRIER_BASE behind HAL

### DIFF
--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -14,11 +14,6 @@
 * This file contains addresses that are visible to both host and device compiled code.
 */
 
-// Reserved DRAM addresses
-// Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been committed
-constexpr static std::uint32_t DRAM_BARRIER_BASE = 0;
-constexpr static std::uint32_t DRAM_BARRIER_SIZE = ((sizeof(uint32_t) + DRAM_ALIGNMENT - 1) / DRAM_ALIGNMENT) * DRAM_ALIGNMENT;
-
 // TODO: move these out of the memory map into profiler code
 constexpr static std::uint32_t PROFILER_OP_SUPPORT_COUNT = 1000;
 constexpr static std::uint32_t PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC = kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE * (kernel_profiler::PROFILER_L1_PROGRAM_ID_COUNT +  kernel_profiler::PROFILER_L1_GUARANTEED_MARKER_COUNT + kernel_profiler::PROFILER_L1_OP_MIN_OPTIONAL_MARKER_COUNT) * PROFILER_OP_SUPPORT_COUNT;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -217,7 +217,8 @@ void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size
         {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_channels()),
          .dram_bank_size = soc_desc.dram_bank_size,
          .dram_bank_offsets = {},
-         .dram_unreserved_base = DRAM_BARRIER_BASE + DRAM_BARRIER_SIZE, // these should come from the HAL
+         .dram_unreserved_base = hal.get_dev_addr(HalDramMemAddrType::DRAM_BARRIER) + \
+                                 hal.get_dev_size(HalDramMemAddrType::DRAM_BARRIER),
          .l1_unreserved_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED),
          .worker_grid_size = this->logical_grid_size(),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
@@ -2824,7 +2825,6 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
     log_info(tt::LogMetal, "Initializing device {}. Program cache is {}enabled", this->id_, this->program_cache.is_enabled() ? "": "NOT ");
     log_debug(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
     TT_FATAL(num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS, "num_hw_cqs can be between 1 and {}", dispatch_core_manager::MAX_NUM_HW_CQS);
-    hal.initialize(this->arch());
     this->using_fast_dispatch = false;
     this->num_hw_cqs_ = num_hw_cqs;
     constexpr uint32_t harvesting_map_bits = 12;

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -8,6 +8,11 @@
 #include "llrt/blackhole/bh_hal.hpp"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 
+// Reserved DRAM addresses
+// Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been committed
+constexpr static std::uint32_t DRAM_BARRIER_BASE = 0;
+constexpr static std::uint32_t DRAM_BARRIER_SIZE = ((sizeof(uint32_t) + DRAM_ALIGNMENT - 1) / DRAM_ALIGNMENT) * DRAM_ALIGNMENT;
+
 namespace tt {
 
 namespace tt_metal {
@@ -30,6 +35,11 @@ void Hal::initialize_bh() {
 
     HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
     this->core_info_.push_back(idle_eth_mem_map);
+
+    this->dram_bases_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
+    this->dram_sizes_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
+    this->dram_bases_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
+    this->dram_sizes_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
 
     this->mem_alignments_.resize(utils::underlying_type<HalMemType>(HalMemType::COUNT));
     this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::L1)] = L1_ALIGNMENT;

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -18,6 +18,11 @@
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
+// Reserved DRAM addresses
+// Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been committed
+constexpr static std::uint32_t DRAM_BARRIER_BASE = 0;
+constexpr static std::uint32_t DRAM_BARRIER_SIZE = ((sizeof(uint32_t) + DRAM_ALIGNMENT - 1) / DRAM_ALIGNMENT) * DRAM_ALIGNMENT;
+
 namespace tt {
 
 namespace tt_metal {
@@ -56,6 +61,11 @@ void Hal::initialize_gs() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
     this->core_info_.push_back({HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, mem_map_bases, mem_map_sizes, true});
+
+    this->dram_bases_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
+    this->dram_sizes_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
+    this->dram_bases_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
+    this->dram_sizes_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
 
     this->mem_alignments_.resize(utils::underlying_type<HalMemType>(HalMemType::COUNT));
     this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::L1)] = L1_ALIGNMENT;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -44,6 +44,11 @@ enum class HalL1MemAddrType : uint8_t {
     COUNT = 10
 };
 
+enum class HalDramMemAddrType : uint8_t {
+    DRAM_BARRIER = 0,
+    COUNT = 1
+};
+
 enum class HalMemType : uint8_t {
     L1 = 0,
     DRAM = 1,
@@ -94,6 +99,8 @@ class Hal {
     std::mutex lock;
     bool initialized_;
     std::vector<HalCoreInfoType> core_info_;
+    std::vector<DeviceAddr> dram_bases_;
+    std::vector<uint32_t> dram_sizes_;
     std::vector<uint32_t> mem_alignments_;
 
     void initialize_gs();
@@ -117,6 +124,11 @@ class Hal {
     template <typename T = DeviceAddr>
     T get_dev_addr(uint32_t programmable_core_type_index, HalL1MemAddrType addr_type) const;
     uint32_t get_dev_size(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const;
+
+    // Overloads for Dram Params
+    template <typename T = DeviceAddr>
+    T get_dev_addr(HalDramMemAddrType addr_type) const;
+    uint32_t get_dev_size(HalDramMemAddrType addr_type) const;
 
     uint32_t get_alignment(HalMemType memory_type) const;
 
@@ -152,6 +164,19 @@ inline uint32_t Hal::get_dev_size(HalProgrammableCoreType programmable_core_type
     uint32_t index = utils::underlying_type<HalProgrammableCoreType>(programmable_core_type);
     TT_ASSERT(index < this->core_info_.size());
     return this->core_info_[index].get_dev_size(addr_type);
+}
+
+template <typename T>
+inline T Hal::get_dev_addr(HalDramMemAddrType addr_type) const {
+    uint32_t index = utils::underlying_type<HalDramMemAddrType>(addr_type);
+    TT_ASSERT(index < this->dram_bases_.size());
+    return reinterpret_cast<T>(this->dram_bases_[index]);
+}
+
+inline uint32_t Hal::get_dev_size(HalDramMemAddrType addr_type) const {
+    uint32_t index = utils::underlying_type<HalDramMemAddrType>(addr_type);
+    TT_ASSERT(index < this->dram_sizes_.size());
+    return this->dram_sizes_[index];
 }
 
 inline uint32_t Hal::get_alignment(HalMemType memory_type) const {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -286,8 +286,8 @@ void Cluster::open_driver(
     } else if (this->target_type_ == TargetDevice::Simulator) {
         device_driver = std::make_unique<tt_SimulationDevice>(sdesc_path);
     }
-    std::uint32_t DRAM_BARRIER_BASE = tt_metal::hal.get_dev_addr(tt_metal::HalDramMemAddrType::DRAM_BARRIER);
-    device_driver->set_device_dram_address_params(tt_device_dram_address_params{DRAM_BARRIER_BASE});
+    std::uint32_t dram_barrier_base = tt_metal::hal.get_dev_addr(tt_metal::HalDramMemAddrType::DRAM_BARRIER);
+    device_driver->set_device_dram_address_params(tt_device_dram_address_params{dram_barrier_base});
     device_driver->set_device_l1_address_params(l1_address_params);
 
     this->get_metal_desc_from_tt_desc(

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -37,6 +37,8 @@ Cluster::Cluster() {
 
     this->detect_arch_and_target();
 
+    tt_metal::hal.initialize(arch_);
+
     this->generate_cluster_descriptor();
 
     this->initialize_device_drivers();
@@ -284,7 +286,8 @@ void Cluster::open_driver(
     } else if (this->target_type_ == TargetDevice::Simulator) {
         device_driver = std::make_unique<tt_SimulationDevice>(sdesc_path);
     }
-    device_driver->set_device_dram_address_params(dram_address_params);
+    std::uint32_t DRAM_BARRIER_BASE = tt_metal::hal.get_dev_addr(tt_metal::HalDramMemAddrType::DRAM_BARRIER);
+    device_driver->set_device_dram_address_params(tt_device_dram_address_params{DRAM_BARRIER_BASE});
     device_driver->set_device_l1_address_params(l1_address_params);
 
     this->get_metal_desc_from_tt_desc(

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -23,6 +23,8 @@
 #include "dev_msgs.h"
 // clang-format on
 
+#include "llrt/hal.hpp"
+
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 
 using tt_target_dram = std::tuple<int, int, int>;
@@ -299,8 +301,6 @@ class Cluster {
 
     // Mapping of each devices' ethernet routing mode
     std::unordered_map<chip_id_t, std::unordered_map<CoreCoord, EthRouterMode>> device_eth_routing_info_;
-
-    tt_device_dram_address_params dram_address_params = {DRAM_BARRIER_BASE};
 
     tt_device_l1_address_params l1_address_params = {
         (uint32_t)MEM_NCRISC_FIRMWARE_BASE,

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -8,6 +8,11 @@
 #include "llrt/wormhole/wh_hal.hpp"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 
+// Reserved DRAM addresses
+// Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been committed
+constexpr static std::uint32_t DRAM_BARRIER_BASE = 0;
+constexpr static std::uint32_t DRAM_BARRIER_SIZE = ((sizeof(uint32_t) + DRAM_ALIGNMENT - 1) / DRAM_ALIGNMENT) * DRAM_ALIGNMENT;
+
 namespace tt {
 
 namespace tt_metal {
@@ -26,6 +31,11 @@ void Hal::initialize_wh() {
 
     HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
     this->core_info_.push_back(idle_eth_mem_map);
+
+    this->dram_bases_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
+    this->dram_sizes_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
+    this->dram_bases_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
+    this->dram_sizes_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
 
     this->mem_alignments_.resize(utils::underlying_type<HalMemType>(HalMemType::COUNT));
     this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::L1)] = L1_ALIGNMENT;


### PR DESCRIPTION
### Ticket
#11830 

### Problem description
Hal should abstract device specific DRAM Parameters

### What's changed
DRAM_BARRIER_BASE and DRAM_BARRIER_SIZE moved to device specific hal implementations
Hal initialization moved to tt_cluster.cpp when ARCH is first detected.
New enum introduced to Hal for Dram memory address types

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
