### PR TITLE
#11836: Adding processor classes and types to the HAL

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -180,6 +180,8 @@ int main(int argc, char **argv) {
 
             std::vector<std::thread> ths;
             ths.reserve(num_devices);
+            uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
+            uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
             for (int i = 0; i < num_devices; i++) {
                 auto& device = devices[i];
                 auto& program = new_programs[i];
@@ -197,7 +199,8 @@ int main(int argc, char **argv) {
                         TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
                         std::string brisc_hex_path = device->build_kernel_target_path(
-                            JitBuildProcessorType::DATA_MOVEMENT,
+                            programmable_core_index,
+                            dm_class_idx,
                             0,
                             get_latest_kernel_binary_path(mask, riscv0_kernel));
                         ll_api::memory brisc_binary = llrt::get_risc_binary(brisc_hex_path, 0, llrt::PackSpans::PACK);
@@ -205,7 +208,8 @@ int main(int argc, char **argv) {
                             brisc_binary == brisc_binaries.at(mask).at(0),
                             "Expected saved BRISC binary to be the same as binary in persistent cache");
                         std::string ncrisc_hex_path = device->build_kernel_target_path(
-                            JitBuildProcessorType::DATA_MOVEMENT,
+                            programmable_core_index,
+                            dm_class_idx,
                             1,
                             get_latest_kernel_binary_path(mask, riscv1_kernel));
                         ll_api::memory ncrisc_binary = llrt::get_risc_binary(ncrisc_hex_path, 1, llrt::PackSpans::PACK);
@@ -215,7 +219,8 @@ int main(int argc, char **argv) {
                         for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
                             std::string trisc_id_str = std::to_string(trisc_id);
                             std::string trisc_hex_path = device->build_kernel_target_path(
-                                JitBuildProcessorType::COMPUTE,
+                                programmable_core_index,
+                                compute_class_idx,
                                 trisc_id,
                                 get_latest_kernel_binary_path(mask, compute_kernel));
                             ll_api::memory trisc_binary = llrt::get_risc_binary(trisc_hex_path, 2, llrt::PackSpans::PACK);

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/erisc_app_direct_send.cpp
@@ -98,8 +98,9 @@ bool send_over_eth(
     llrt::write_hex_vec_to_core(receiver_device->id(), receiver_core, args_1, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
 
     // TODO: this should be updated to use kernel api
-    ll_api::memory binary_mem_send = llrt::get_risc_binary(sender_device->build_firmware_target_path(JitBuildProcessorType::ETHERNET, 0));
-    ll_api::memory binary_mem_receive = llrt::get_risc_binary(receiver_device->build_firmware_target_path(JitBuildProcessorType::ETHERNET, 0));
+    uint32_t active_eth_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+    ll_api::memory binary_mem_send = llrt::get_risc_binary(sender_device->build_firmware_target_path(active_eth_index, 0, 0));
+    ll_api::memory binary_mem_receive = llrt::get_risc_binary(receiver_device->build_firmware_target_path(active_eth_index, 0, 0));
 
     for (const auto& eth_core : eth_cores) {
         llrt::write_hex_vec_to_core(

--- a/tt_metal/hw/inc/blackhole/core_config.h
+++ b/tt_metal/hw/inc/blackhole/core_config.h
@@ -45,5 +45,5 @@ enum class DramProcessorTypes : uint8_t {
 
 constexpr uint8_t MaxProcessorsPerCoreType = 5;
 constexpr uint8_t NumTensixDispatchClasses = 3;
-constexpr uint8_t NumEthDispatchClasses = 2;
+constexpr uint8_t NumEthDispatchClasses = 1;
 constexpr uint8_t NumDramDispatchClasses = 1;

--- a/tt_metal/hw/inc/blackhole/core_config.h
+++ b/tt_metal/hw/inc/blackhole/core_config.h
@@ -24,21 +24,26 @@ enum class AddressableCoreType : uint8_t {
 };
 
 enum class TensixProcessorTypes : uint8_t {
-    BRISC  = 0,
-    NCRISC = 1,
-    TRISC0 = 2,
-    TRISC1 = 3,
-    TRISC2 = 4,
-
     DM0    = 0,
     DM1    = 1,
     MATH0  = 2,
     MATH1  = 3,
     MATH2  = 4,
+    COUNT  = 5
 };
 
 enum class EthProcessorTypes : uint8_t {
     DM0    = 0,
+    DM1    = 1,
+    COUNT  = 2
+};
+
+enum class DramProcessorTypes : uint8_t {
+    DM0     = 0,
+    COUNT   = 1
 };
 
 constexpr uint8_t MaxProcessorsPerCoreType = 5;
+constexpr uint8_t NumTensixDispatchClasses = 3;
+constexpr uint8_t NumEthDispatchClasses = 2;
+constexpr uint8_t NumDramDispatchClasses = 1;

--- a/tt_metal/hw/inc/grayskull/core_config.h
+++ b/tt_metal/hw/inc/grayskull/core_config.h
@@ -22,17 +22,13 @@ enum class AddressableCoreType : uint8_t {
 };
 
 enum class TensixProcessorTypes : uint8_t {
-    BRISC  = 0,
-    NCRISC = 1,
-    TRISC0 = 2,
-    TRISC1 = 3,
-    TRISC2 = 4,
-
     DM0    = 0,
     DM1    = 1,
     MATH0  = 2,
     MATH1  = 3,
     MATH2  = 4,
+    COUNT  = 5
 };
 
 constexpr uint8_t MaxProcessorsPerCoreType = 5;
+constexpr uint8_t NumTensixDispatchClasses = 3;

--- a/tt_metal/hw/inc/wormhole/core_config.h
+++ b/tt_metal/hw/inc/wormhole/core_config.h
@@ -24,21 +24,19 @@ enum class AddressableCoreType : uint8_t {
 };
 
 enum class TensixProcessorTypes : uint8_t {
-    BRISC  = 0,
-    NCRISC = 1,
-    TRISC0 = 2,
-    TRISC1 = 3,
-    TRISC2 = 4,
-
     DM0    = 0,
     DM1    = 1,
     MATH0  = 2,
     MATH1  = 3,
     MATH2  = 4,
+    COUNT  = 5
 };
 
 enum class EthProcessorTypes : uint8_t {
     DM0    = 0,
+    COUNT  = 1
 };
 
 constexpr uint8_t MaxProcessorsPerCoreType = 5;
+constexpr uint8_t NumTensixDispatchClasses = 3;
+constexpr uint8_t NumEthDispatchClasses = 1;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -279,34 +279,61 @@ void Device::initialize_build() {
     uint32_t dispatch_message_addr =
         dispatch_constants::get(dispatch_core_type, this->num_hw_cqs_).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
 
-    auto init_helper = [this, dispatch_message_addr] (bool is_fw) -> JitBuildStateSet {
+    // TODO now: total number of processor types should be pulled from the HAL
+    uint32_t num_build_states = this->arch() == tt::ARCH::GRAYSKULL ? 5 : 7;
+
+    auto init_helper = [this, dispatch_message_addr, num_build_states] (bool is_fw) -> JitBuildStateSet {
         std::vector<std::shared_ptr<JitBuildState>> build_states;
 
-        build_states.resize(arch() == tt::ARCH::GRAYSKULL ? 5 : 7);
+        build_states.resize(num_build_states);
+        uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
+        if (is_fw) {
+            this->build_state_indices_.resize(programmable_core_type_count);
+        }
 
-        build_states[build_processor_type_to_index(JitBuildProcessorType::DATA_MOVEMENT).first + 0] =
-            std::make_shared<JitBuildDataMovement>(
-                this->build_env_, JitBuiltStateConfig{.processor_id = 0, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-        build_states[build_processor_type_to_index(JitBuildProcessorType::DATA_MOVEMENT).first + 1] =
-            std::make_shared<JitBuildDataMovement>(
-                this->build_env_, JitBuiltStateConfig{.processor_id = 1, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-        build_states[build_processor_type_to_index(JitBuildProcessorType::COMPUTE).first + 0] =
-            std::make_shared<JitBuildCompute>(
-                this->build_env_, JitBuiltStateConfig{.processor_id = 0, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-        build_states[build_processor_type_to_index(JitBuildProcessorType::COMPUTE).first + 1] =
-            std::make_shared<JitBuildCompute>(
-                this->build_env_, JitBuiltStateConfig{.processor_id = 1, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-        build_states[build_processor_type_to_index(JitBuildProcessorType::COMPUTE).first + 2] =
-            std::make_shared<JitBuildCompute>(
-                this->build_env_, JitBuiltStateConfig{.processor_id = 2, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-
-        if (arch() != tt::ARCH::GRAYSKULL) {
-            build_states[build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0] =
-                std::make_shared<JitBuildEthernet>(
-                    this->build_env_, JitBuiltStateConfig{.processor_id = 0, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
-            build_states[build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 1] =
-                std::make_shared<JitBuildEthernet>(
-                    this->build_env_, JitBuiltStateConfig{.processor_id = 1, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
+        uint32_t index = 0;
+        for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
+            HalProgrammableCoreType core_type = magic_enum::enum_value<HalProgrammableCoreType>(programmable_core);
+            uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
+            if (is_fw) {
+                this->build_state_indices_[programmable_core].resize(processor_class_count);
+            }
+            for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
+                auto compute_proc_class = magic_enum::enum_cast<HalProcessorClassType>(processor_class);
+                bool is_compute_processor = compute_proc_class.has_value() and compute_proc_class.value() == HalProcessorClassType::COMPUTE;
+                uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
+                if (is_fw) {
+                    this->build_state_indices_[programmable_core][processor_class] = {index, processor_types_count};
+                }
+                for (uint32_t processor_type = 0; processor_type < processor_types_count; processor_type++) {
+                    switch (core_type) {
+                        case HalProgrammableCoreType::TENSIX: {
+                            if (is_compute_processor) {
+                                build_states[index] = std::make_shared<JitBuildCompute>(
+                                    this->build_env_, JitBuiltStateConfig{.processor_id = processor_type, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
+                            } else {
+                                // TODO: Make .processor_id = processor_type when brisc and ncrisc are considered one processor class
+                                build_states[index] = std::make_shared<JitBuildDataMovement>(
+                                    this->build_env_, JitBuiltStateConfig{.processor_id = processor_class, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
+                            }
+                            break;
+                        }
+                        case HalProgrammableCoreType::ACTIVE_ETH: {
+                            build_states[index] = std::make_shared<JitBuildActiveEthernet>(
+                                this->build_env_, JitBuiltStateConfig{.processor_id = processor_type, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
+                            break;
+                        }
+                        case HalProgrammableCoreType::IDLE_ETH: {
+                            build_states[index] = std::make_shared<JitBuildIdleEthernet>(
+                                this->build_env_, JitBuiltStateConfig{.processor_id = processor_type, .is_fw=is_fw, .dispatch_message_addr=dispatch_message_addr});
+                            break;
+                        }
+                        default:
+                            TT_THROW("Unsupported programable core type {} to initialize build states", magic_enum::enum_name(core_type));
+                    }
+                    index++;
+                }
+            }
         }
 
        return build_states;
@@ -324,71 +351,81 @@ void Device::build_firmware() {
     jit_build_set(this->firmware_build_states_, nullptr);
 }
 
-void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg, go_msg_t* go_msg) {
+void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreCoord phys_core, launch_msg_t *launch_msg, go_msg_t* go_msg) {
     ZoneScoped;
 
-    if (llrt::is_ethernet_core(phys_core, this->id())) {
-        //ethernet core.
-        //Determine if its a connected or unconnected ethernet core.
-        //Unconnected ethernet cores will get idle_erisc fw.
-        auto active_eth_cores = this->get_active_ethernet_cores();
+    uint32_t core_type_idx = hal.get_programmable_core_type_index(core_type);
+    uint32_t processor_class_count = hal.get_processor_classes_count(core_type);
 
-        if (active_eth_cores.find(logical_core_from_ethernet_core(phys_core)) != active_eth_cores.end()) {
-            if (not llrt::OptionsG.get_skip_loading_fw()) {
-                int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0;
-                ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""), eriscv_id);
-                uint32_t fw_size = binary_mem.get_text_size();
-                log_debug(LogDevice, "ERISC fw binary size: {} in bytes", fw_size);
-                llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
-            }
-            llrt::launch_erisc_app_fw_on_core(this->id(), phys_core);
-            // Ethernet worker core. Launch messages will be sent by FD infra if it's enabled
-            launch_msg->kernel_config.mode = this->using_slow_dispatch() ? DISPATCH_MODE_HOST :  DISPATCH_MODE_DEV;
-        } else {
-            tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), phys_core));
-            if (not llrt::OptionsG.get_skip_loading_fw()) {
-                int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 1;
-                ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""), eriscv_id);
-                uint32_t fw_size = binary_mem.get_text_size();
-                log_debug(LogDevice, "ERISC fw binary size: {} in bytes", fw_size);
-                llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
-            }
+    switch (core_type) {
+        case HalProgrammableCoreType::TENSIX: {
             llrt::program_risc_startup_addr(this->id(), phys_core);
-            // Idle ethernet core. Used by FD infra. Host will write launch messages during init.
-            launch_msg->kernel_config.mode = DISPATCH_MODE_HOST;
-        }
-    } else {
-        llrt::program_risc_startup_addr(this->id(), phys_core);
-        for (int riscv_id = 0; riscv_id < 5; riscv_id++) {
-            ll_api::memory binary_mem =
-                llrt::get_risc_binary(firmware_build_states_[riscv_id]->get_target_out_path(""), riscv_id);
-            uint32_t fw_size = binary_mem.get_text_size();
-            if (riscv_id == 1) {
-                // In this context, ncrisc_kernel_size16 is the size of the fw
-                launch_msg->kernel_config.ncrisc_kernel_size16 = (fw_size + 15) >> 4;
+            for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
+                auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
+                for (uint32_t riscv_id = build_idx; riscv_id < (build_idx + num_build_states); riscv_id++) {
+                    ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[riscv_id]->get_target_out_path(""), riscv_id);
+                    uint32_t fw_size = binary_mem.get_text_size();
+                    if (riscv_id == 1) { // TODO: clean up how brisc/ncrisc are handled
+                        // In this context, ncrisc_kernel_size16 is the size of the fw
+                        launch_msg->kernel_config.ncrisc_kernel_size16 = (fw_size + 15) >> 4;
+                    }
+                    log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
+                    if (not llrt::OptionsG.get_skip_loading_fw()) {
+                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
+                    }
+                }
             }
-            log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
-            if (not llrt::OptionsG.get_skip_loading_fw()) {
-                llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
-            }
-        }
-        if (this->using_slow_dispatch()) {
-            // Host always writes launch messages
-            launch_msg->kernel_config.mode = DISPATCH_MODE_HOST;
-        } else {
-            std::vector<CoreCoord> physical_dispatch_cores = {};
-            if (dispatch_core_manager::instance().get_dispatch_core_type(this->id()) == CoreType::WORKER) {
-                physical_dispatch_cores = this->worker_cores_from_logical_cores(dispatch_core_manager::instance().get_all_logical_dispatch_cores(this->id()));
-            }
-            if (std::find(physical_dispatch_cores.begin(), physical_dispatch_cores.end(), phys_core) != physical_dispatch_cores.end()) {
-                // Dispatch cores - Host writes launch messages
+
+            if (this->using_slow_dispatch()) {
+                // Host always writes launch messages
                 launch_msg->kernel_config.mode = DISPATCH_MODE_HOST;
             } else {
-                // Worker cores - Dispatcher will write launch messages
-                launch_msg->kernel_config.mode = DISPATCH_MODE_DEV;
+                std::vector<CoreCoord> physical_dispatch_cores = {};
+                if (dispatch_core_manager::instance().get_dispatch_core_type(this->id()) == CoreType::WORKER) {
+                    physical_dispatch_cores = this->worker_cores_from_logical_cores(dispatch_core_manager::instance().get_all_logical_dispatch_cores(this->id()));
+                }
+                if (std::find(physical_dispatch_cores.begin(), physical_dispatch_cores.end(), phys_core) != physical_dispatch_cores.end()) {
+                    // Dispatch cores - Host writes launch messages
+                    launch_msg->kernel_config.mode = DISPATCH_MODE_HOST;
+                } else {
+                    // Worker cores - Dispatcher will write launch messages
+                    launch_msg->kernel_config.mode = DISPATCH_MODE_DEV;
+                }
             }
+
+            break;
         }
+        case HalProgrammableCoreType::ACTIVE_ETH:
+        case HalProgrammableCoreType::IDLE_ETH: {
+            bool is_idle_eth = core_type == HalProgrammableCoreType::IDLE_ETH;
+            if (is_idle_eth) {
+                tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), phys_core));
+            }
+            if (not llrt::OptionsG.get_skip_loading_fw()) {
+                for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
+                    auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
+                    for (uint32_t eriscv_id = build_idx; eriscv_id < (build_idx + num_build_states); eriscv_id++) {
+                        ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""), eriscv_id);
+                        uint32_t fw_size = binary_mem.get_text_size();
+                        log_debug(LogDevice, "ERISC fw binary size: {} in bytes", fw_size);
+                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+                    }
+                }
+            }
+            if (is_idle_eth) {
+                llrt::program_risc_startup_addr(this->id(), phys_core);
+            } else {
+                llrt::launch_erisc_app_fw_on_core(this->id(), phys_core);
+            }
+            // Ethernet worker core. Launch messages will be sent by FD infra if it's enabled
+            // Idle ethernet core. Used by FD infra. Host will write launch messages during init.
+            launch_msg->kernel_config.mode = (this->using_slow_dispatch() or is_idle_eth) ? DISPATCH_MODE_HOST :  DISPATCH_MODE_DEV;
+            break;
+        }
+        default:
+            TT_THROW("Unsupported programable core type {} to initialize build states", magic_enum::enum_name(core_type));
     }
+
     // Initialize each entry in the launch_msg ring buffer with the correct dispatch mode - Cores that don't get a valid
     // launch_message during program execution need to at least have the correct dispatch mode.
     // When using Fast Dispatch on Tensix:
@@ -584,7 +621,7 @@ void Device::initialize_and_launch_firmware() {
                 CoreCoord worker_core = this->worker_core_from_logical_core(logical_core);
                 tt::llrt::write_hex_vec_to_core(
                     this->id(), worker_core, core_info_vec, this->get_dev_addr(worker_core, HalL1MemAddrType::CORE_INFO));
-                this->initialize_firmware(worker_core, &launch_msg, &go_msg);
+                this->initialize_firmware(HalProgrammableCoreType::TENSIX, worker_core, &launch_msg, &go_msg);
                 not_done_cores.insert(worker_core);
             }
         }
@@ -604,14 +641,14 @@ void Device::initialize_and_launch_firmware() {
         CoreCoord phys_eth_core = this->ethernet_core_from_logical_core(eth_core);
         tt::llrt::write_hex_vec_to_core(
             this->id(), phys_eth_core, core_info_vec, this->get_dev_addr(phys_eth_core, HalL1MemAddrType::CORE_INFO));
-        this->initialize_firmware(phys_eth_core, &launch_msg, &go_msg);
+        this->initialize_firmware(HalProgrammableCoreType::ACTIVE_ETH, phys_eth_core, &launch_msg, &go_msg);
     }
 
     for (const auto &eth_core : this->get_inactive_ethernet_cores()) {
         CoreCoord phys_eth_core = this->ethernet_core_from_logical_core(eth_core);
         tt::llrt::write_hex_vec_to_core(
             this->id(), phys_eth_core, core_info_vec, this->get_dev_addr(phys_eth_core, HalL1MemAddrType::CORE_INFO));
-        this->initialize_firmware(phys_eth_core, &launch_msg, &go_msg);
+        this->initialize_firmware(HalProgrammableCoreType::IDLE_ETH, phys_eth_core, &launch_msg, &go_msg);
         not_done_cores.insert(phys_eth_core);
     }
 
@@ -3181,33 +3218,25 @@ float Device::sfpu_inf() const{
     return std::numeric_limits<float>::infinity();
 }
 
-pair<int, int> Device::build_processor_type_to_index(JitBuildProcessorType t) const {
-    constexpr int DataMovementBuildCount = 2;
-    constexpr int ComputeBuildCount = 3;
-    constexpr int EthernetBuildCount = 2;
-
-    switch (t) {
-    case JitBuildProcessorType::DATA_MOVEMENT: return pair<int, int>(0, DataMovementBuildCount);
-    case JitBuildProcessorType::COMPUTE: return pair<int, int>(DataMovementBuildCount, ComputeBuildCount);
-    case JitBuildProcessorType::ETHERNET: return pair<int, int>(DataMovementBuildCount + ComputeBuildCount, EthernetBuildCount);
-    default: TT_THROW("Bad processor type: {}", static_cast<std::underlying_type<JitBuildProcessorType>::type>(t));
-    }
-
-    // shh the warnings
-    return pair<int, int>(0, 0);
+pair<int, int> Device::build_processor_type_to_index(uint32_t programmable_core, uint32_t processor_class) const {
+    TT_ASSERT(programmable_core < this->build_state_indices_.size(),
+        "Programmable core type {} is not included in the FW or Kernel build state", programmable_core);
+    TT_ASSERT(processor_class < this->build_state_indices_[programmable_core].size(),
+        "Processor class type {} is not included in the FW or Kernel build state", processor_class);
+    return this->build_state_indices_[programmable_core][processor_class];
 }
 
 // Ideally the firmware getter would be private to the device, however, tests look for this
-const JitBuildState& Device::build_firmware_state(JitBuildProcessorType t, int i) const {
-    return *(this->firmware_build_states_[build_processor_type_to_index(t).first + i]);
+const JitBuildState& Device::build_firmware_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
+    return *(this->firmware_build_states_[build_processor_type_to_index(programmable_core, processor_class).first + i]);
 }
 
-const JitBuildState& Device::build_kernel_state(JitBuildProcessorType t, int i) const {
-    return *(this->kernel_build_states_[build_processor_type_to_index(t).first + i]);
+const JitBuildState& Device::build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const {
+    return *(this->kernel_build_states_[build_processor_type_to_index(programmable_core, processor_class).first + i]);
 }
 
-const JitBuildStateSubset Device::build_kernel_states(JitBuildProcessorType t) const {
-    pair<int, int> bptti = build_processor_type_to_index(t);
+const JitBuildStateSubset Device::build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const {
+    pair<int, int> bptti = build_processor_type_to_index(programmable_core, processor_class);
     JitBuildStateSubset subset = {
         &this->kernel_build_states_[bptti.first],
         bptti.second
@@ -3215,13 +3244,13 @@ const JitBuildStateSubset Device::build_kernel_states(JitBuildProcessorType t) c
     return subset;
 }
 
-const string Device::build_firmware_target_path(JitBuildProcessorType t, int i) const {
-    const JitBuildState& bs = build_firmware_state(t, i);
+const string Device::build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const {
+    const JitBuildState& bs = build_firmware_state(programmable_core, processor_class, i);
     return bs.get_target_out_path("");
 }
 
-const string Device::build_kernel_target_path(JitBuildProcessorType t, int i, const string& kernel_name) const {
-    const JitBuildState& bs = build_kernel_state(t, i);
+const string Device::build_kernel_target_path(uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const {
+    const JitBuildState& bs = build_kernel_state(programmable_core, processor_class, i);
     return bs.get_target_out_path(kernel_name);
 }
 

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -209,11 +209,11 @@ class Device {
 
     void generate_device_headers(const std::string &path) const;
     const JitBuildEnv& build_env() const { return this->build_env_; }
-    const string build_firmware_target_path(JitBuildProcessorType t, int i) const;
-    const string build_kernel_target_path(JitBuildProcessorType t, int i, const string& kernel_name) const;
-    const JitBuildState& build_firmware_state(JitBuildProcessorType t, int i) const;
-    const JitBuildState& build_kernel_state(JitBuildProcessorType t, int i) const;
-    const JitBuildStateSubset build_kernel_states(JitBuildProcessorType t) const;
+    const string build_firmware_target_path(uint32_t programmable_core, uint32_t processor_class, int i) const;
+    const string build_kernel_target_path(uint32_t programmable_core, uint32_t processor_class, int i, const string& kernel_name) const;
+    const JitBuildState& build_firmware_state(uint32_t programmable_core, uint32_t processor_class, int i) const;
+    const JitBuildState& build_kernel_state(uint32_t programmable_core, uint32_t processor_class, int i) const;
+    const JitBuildStateSubset build_kernel_states(uint32_t programmable_core, uint32_t processor_class) const;
     SystemMemoryManager& sysmem_manager() { return *sysmem_manager_; }
     HWCommandQueue& hw_command_queue(size_t cq_id = 0);
     CommandQueue& command_queue(size_t cq_id = 0);
@@ -235,7 +235,7 @@ class Device {
     void initialize_allocator(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {});
     void initialize_build();
     void build_firmware();
-    void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg, go_msg_t* go_msg);
+    void initialize_firmware(const HalProgrammableCoreType &core_type, CoreCoord phys_core, launch_msg_t *launch_msg, go_msg_t* go_msg);
     void reset_cores();
     void initialize_and_launch_firmware();
     void init_command_queue_host();
@@ -249,7 +249,7 @@ class Device {
     void get_associated_dispatch_phys_cores(
         std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &my_dispatch_cores,
         std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &other_dispatch_cores);
-    std::pair<int, int> build_processor_type_to_index(JitBuildProcessorType t) const;
+    std::pair<int, int> build_processor_type_to_index(uint32_t programmable_core, uint32_t processor_class) const;
 
     // Puts device into reset
     bool close();
@@ -280,6 +280,7 @@ class Device {
     JitBuildEnv build_env_;
     JitBuildStateSet firmware_build_states_;
     JitBuildStateSet kernel_build_states_;
+    std::vector<std::vector<std::pair<int, int>>> build_state_indices_;
 
     std::set<CoreCoord> compute_cores_;
     std::set<CoreCoord> storage_only_cores_;

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -545,13 +545,14 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
     for (uint32_t programmable_core_type_index = 0;
          programmable_core_type_index < hal.get_programmable_core_type_count();
          programmable_core_type_index++) {
+        uint32_t processor_classes = hal.get_processor_classes_count(programmable_core_type_index);
         for (auto& kg : program.get_kernel_groups(programmable_core_type_index)) {
             if (kg.total_rta_size != 0) {
                 // Reserve 2x for unique rtas as we pontentially split the cmds due to not fitting in one prefetch cmd
                 command_count += 2;
             }
         }
-        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+        for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
             uint32_t common_size = program.get_program_config(programmable_core_type_index).crta_sizes[dispatch_class];
             if (common_size != 0) {
                 command_count++;
@@ -568,6 +569,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
             continue;
         }
         CoreType core_type = hal.get_core_type(index);
+        uint32_t processor_classes = hal.get_processor_classes_count(index);
 
         for (auto& kg : program.get_kernel_groups(index)) {
             if (kg.total_rta_size != 0) {
@@ -578,7 +580,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
 
                             unique_rt_args_data.resize(unique_rt_args_data.size() + 1);
                             unique_rt_data_and_sizes.resize(unique_rt_data_and_sizes.size() + 1);
-                            for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+                            for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
                                 auto& optional_id = kg.kernel_ids[dispatch_class];
                                 if (optional_id) {
                                     auto kernel = detail::GetKernel(program, optional_id.value());
@@ -626,7 +628,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
             }
         }
 
-        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+        for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
             uint32_t common_size = program.get_program_config(index).crta_sizes[dispatch_class];
             for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                 auto kernel = detail::GetKernel(program, kernel_id);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -337,20 +337,27 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 void DataMovementKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
     jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
     device->generate_device_headers(build_options.path);
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    jit_build(device->build_kernel_state(JitBuildProcessorType::DATA_MOVEMENT, riscv_id), this);
+    jit_build(device->build_kernel_state(tensix_core_type, dm_class_idx, riscv_id), this);
 }
 
 void EthernetKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
     jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
     device->generate_device_headers(build_options.path);
-    int erisc_id = this->config_.eth_mode == Eth::IDLE ? 1 : 0;
-    jit_build(device->build_kernel_state(JitBuildProcessorType::ETHERNET, erisc_id), this);
+    uint32_t erisc_core_type = hal.get_programmable_core_type_index(
+        this->config_.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH
+    );
+    uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
+    jit_build(device->build_kernel_state(erisc_core_type, dm_class_idx, 0), this);
 }
 
 void ComputeKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
     jit_build_genfiles_triscs_src(device->build_env(), *this, this->kernel_src_);
-    JitBuildStateSubset build_states = device->build_kernel_states(JitBuildProcessorType::COMPUTE);
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
+    JitBuildStateSubset build_states = device->build_kernel_states(tensix_core_type, compute_class_idx);
     jit_build_subset(build_states, this);
 }
 
@@ -368,8 +375,10 @@ void DataMovementKernel::read_binaries(Device *device) {
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
     // TODO(pgk): consolidate read_binaries where possible
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
-    const JitBuildState &build_state = device->build_kernel_state(JitBuildProcessorType::DATA_MOVEMENT, riscv_id);
+    const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, dm_class_idx, riscv_id);
     ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), riscv_id, llrt::PackSpans::PACK);
     binaries.push_back(binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
@@ -381,8 +390,12 @@ void EthernetKernel::read_binaries(Device *device) {
     // untested
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
     std::vector<ll_api::memory> binaries;
+    uint32_t erisc_core_type = hal.get_programmable_core_type_index(
+        this->config_.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH
+    );
+    uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
+    const JitBuildState &build_state = device->build_kernel_state(erisc_core_type, dm_class_idx, 0);
     int erisc_id = this->config_.eth_mode == Eth::IDLE ? 1 : 0;
-    const JitBuildState &build_state = device->build_kernel_state(JitBuildProcessorType::ETHERNET, erisc_id);
     ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), erisc_id + 5, llrt::PackSpans::PACK);
     binaries.push_back(binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
@@ -393,8 +406,10 @@ void EthernetKernel::read_binaries(Device *device) {
 void ComputeKernel::read_binaries(Device *device) {
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
     std::vector<ll_api::memory> binaries;
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
-        const JitBuildState &build_state = device->build_kernel_state(JitBuildProcessorType::COMPUTE, trisc_id);
+        const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, compute_class_idx, trisc_id);
         ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), trisc_id + 2, llrt::PackSpans::PACK);
         binaries.push_back(binary_mem);
         uint32_t binary_size = binary_mem.get_packed_size();

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -95,7 +95,7 @@ class Kernel : public JitBuildSettings {
     std::map<std::string, std::string> defines() const { return defines_; }
 
     virtual RISCV processor() const = 0;
-    uint8_t dispatch_class() { return this->dispatch_class_; }
+    uint32_t dispatch_class() { return this->dispatch_class_; }
 
     virtual bool configure(Device *device, const CoreCoord &logical_core) const = 0;
 
@@ -217,8 +217,7 @@ class ComputeKernel : public Kernel {
    public:
     ComputeKernel(const KernelSource &kernel_src, const CoreRangeSet &cr_set, const ComputeConfig &config) :
         Kernel(kernel_src, cr_set, config.compile_args, config.defines), config_(config) {
-        // is this weird?
-        this->dispatch_class_ = magic_enum::enum_integer(HalProcessorClassType::COMPUTE) * magic_enum::enum_count<DataMovementProcessor>();
+        this->dispatch_class_ = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     }
 
     ~ComputeKernel() {}

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -28,12 +28,6 @@ using vector_cache_aligned = std::vector<T, tt::stl::aligned_allocator<T, CACHE_
 
 class JitBuildSettings;
 
-enum class JitBuildProcessorType {
-    DATA_MOVEMENT,
-    COMPUTE,
-    ETHERNET
-};
-
 struct JitBuiltStateConfig {
     int processor_id = 0;
     bool is_fw = false;
@@ -47,7 +41,8 @@ class JitBuildEnv {
     friend class JitBuildState;
     friend class JitBuildDataMovement;
     friend class JitBuildCompute;
-    friend class JitBuildEthernet;
+    friend class JitBuildActiveEthernet;
+    friend class JitBuildIdleEthernet;
 
   public:
     JitBuildEnv();
@@ -150,10 +145,16 @@ class JitBuildCompute : public JitBuildState {
     JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConfig &build_config);
 };
 
-class JitBuildEthernet : public JitBuildState {
+class JitBuildActiveEthernet : public JitBuildState {
   private:
   public:
-    JitBuildEthernet(const JitBuildEnv& env, const JitBuiltStateConfig &build_config);
+    JitBuildActiveEthernet(const JitBuildEnv& env, const JitBuiltStateConfig &build_config);
+};
+
+class JitBuildIdleEthernet : public JitBuildState {
+  private:
+  public:
+    JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuiltStateConfig &build_config);
 };
 
 // Abstract base class for kernel specialization

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -8,11 +8,14 @@
 
 #include "llrt/hal.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
+#include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"
 #include "hw/inc/blackhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
+
+#include <magic_enum.hpp>
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
@@ -22,8 +25,6 @@ namespace tt {
 namespace tt_metal {
 
 HalCoreInfoType create_active_eth_mem_map() {
-
-    constexpr uint32_t num_proc_per_idle_eth_core = 1;
 
     std::vector<DeviceAddr> mem_map_bases;
 
@@ -51,7 +52,13 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, mem_map_bases, mem_map_sizes, false};
+    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
+    std::vector<uint8_t> processor_types{0};
+    for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        processor_classes[processor_class_idx] = processor_types;
+    }
+
+    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -8,11 +8,14 @@
 
 #include "llrt/hal.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
+#include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"
 #include "hw/inc/blackhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
+
+#include <magic_enum.hpp>
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 
@@ -22,7 +25,6 @@ namespace tt_metal {
 
 HalCoreInfoType create_idle_eth_mem_map() {
 
-    constexpr uint32_t num_proc_per_idle_eth_core = 1;
     uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     static_assert(MEM_IERISC_MAP_END % L1_ALIGNMENT == 0);
@@ -53,7 +55,13 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, mem_map_bases, mem_map_sizes, false};
+    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
+    std::vector<uint8_t> processor_types{0};
+    for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        processor_classes[processor_class_idx] = processor_types;
+    }
+
+    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -56,13 +56,13 @@ uint32_t Hal::get_programmable_core_type_index(HalProgrammableCoreType programma
 
 HalCoreInfoType::HalCoreInfoType(HalProgrammableCoreType programmable_core_type,
                                  CoreType core_type,
-                                 uint32_t core_proc_count,
+                                 const std::vector<std::vector<uint8_t>> &processor_classes,
                                  const std::vector<DeviceAddr>& mem_map_bases,
                                  const std::vector<uint32_t>& mem_map_sizes,
                                  bool supports_cbs) :
     programmable_core_type_(programmable_core_type),
     core_type_(core_type),
-    proc_count_(core_proc_count),
+    processor_classes_(processor_classes),
     mem_map_bases_(mem_map_bases),
     mem_map_sizes_(mem_map_sizes),
     supports_cbs_(supports_cbs) {

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -8,11 +8,14 @@
 
 #include "llrt/hal.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
+#include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"
 #include "hw/inc/wormhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
+
+#include <magic_enum.hpp>
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
@@ -22,8 +25,6 @@ namespace tt {
 namespace tt_metal {
 
 HalCoreInfoType create_active_eth_mem_map() {
-
-    constexpr uint32_t num_proc_per_active_eth_core = 1;
 
     std::vector<DeviceAddr> mem_map_bases;
 
@@ -51,7 +52,13 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, num_proc_per_active_eth_core, mem_map_bases, mem_map_sizes, false};
+    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
+    std::vector<uint8_t> processor_types{0};
+    for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        processor_classes[processor_class_idx] = processor_types;
+    }
+
+    return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -8,11 +8,14 @@
 
 #include "llrt/hal.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
+#include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"
 #include "hw/inc/wormhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
+
+#include <magic_enum.hpp>
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 
@@ -22,7 +25,6 @@ namespace tt_metal {
 
 HalCoreInfoType create_idle_eth_mem_map() {
 
-    constexpr uint32_t num_proc_per_idle_eth_core = 1;
     uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     static_assert(MEM_IERISC_MAP_END % L1_ALIGNMENT == 0);
@@ -53,7 +55,13 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, mem_map_bases, mem_map_sizes, false};
+    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
+    std::vector<uint8_t> processor_types{0};
+    for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        processor_classes[processor_class_idx] = processor_types;
+    }
+
+    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -6,11 +6,15 @@
 
 #include "llrt/hal.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
+#include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"
 #include "hw/inc/wormhole/eth_l1_address_map.h"  // XXXX FIXME
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
+
+#include <magic_enum.hpp>
+#include <numeric>
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
@@ -20,7 +24,6 @@ namespace tt_metal {
 
 HalCoreInfoType create_tensix_mem_map() {
 
-    constexpr uint32_t num_proc_per_tensix_core = 5;
     uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     std::vector<DeviceAddr> mem_map_bases;
@@ -49,7 +52,16 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, mem_map_bases, mem_map_sizes, true};
+    std::vector<std::vector<uint8_t>> processor_classes(NumTensixDispatchClasses);
+    std::vector<uint8_t> processor_types;
+    for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
+        uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
+        processor_types.resize(num_processors);
+        std::iota(processor_types.begin(), processor_types.end(), 0);
+        processor_classes[processor_class_idx] = processor_types;
+    }
+
+    return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -798,6 +798,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
 
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
+        uint32_t processor_classes = hal.get_processor_classes_count(index);
         for (auto& kg : program.get_kernel_groups(index)) {
             uint32_t kernel_config_base = kg.launch_msg.kernel_config.kernel_config_base[index];
             for (const CoreRange &core_range : kg.core_ranges.ranges()) {
@@ -805,7 +806,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                         CoreCoord logical_core(x, y);
                         auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
-                        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+                        for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
                             auto& optional_id = kg.kernel_ids[dispatch_class];
                             if (optional_id) {
                                 const auto &kernel = detail::GetKernel(program, optional_id.value());


### PR DESCRIPTION
### Ticket
#11836 

### Problem description
Need HAL to understand processor types on a programmable core

### What's changed
- Added enums and consts in arch specific core_config files to specify num processors and types
- Added 2d array of processor class to processor types in `HalCoreInfoType`
- Replaced usages of `DISPATCH_CLASS_MAX` to pull num processor classes based on programmable core type 
- Added `JitBuildActiveEthernet` and `JitBuildIdleEthernet` and updated build initializers to use hal structures

TODO:
- [ ] Store kernels in program by programable core type + processor class
- [ ] Reconsider sizes of shared structures to be based on local processor class size
- [ ] Update classification of brisc/ncrisc on host (represent these as 1 processor class with and 2 distinct processor types rather than 2 processor classes)

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11449889384)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11449906925)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
