### PR TITLE
#0: Move input and output queue data structures in vc_packet_router to stack

### DIFF
--- a/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
@@ -7,9 +7,6 @@
 #include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_helpers.hpp"
 
-packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
-packet_output_queue_state_t output_queues[MAX_SWITCH_FAN_OUT];
-
 constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
@@ -207,6 +204,8 @@ constexpr uint8_t input_packetize_dest_endpoint[MAX_SWITCH_FAN_IN] =
     };
 
 void kernel_main() {
+    packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
+    packet_output_queue_state_t output_queues[MAX_SWITCH_FAN_OUT];
 
     write_kernel_status(kernel_status, PQ_TEST_STATUS_INDEX, PACKET_QUEUE_TEST_STARTED);
     write_kernel_status(kernel_status, PQ_TEST_MISC_INDEX, 0xff000000);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
  - TG Unit tests erroring out with code space issues, since .bss region did not fit inside NCRISC LDM section, with changes pushed @ https://github.com/tenstorrent/tt-metal/commit/9e9dc003e0a3938c75f934ce149ab0ffa6ad4619
 
### What's changed
  - In `vc_packet_router.cpp`, `input_queues` and `output_queues` were previously created as unintialized global variables, which put them in the .bss region
  - Moved to stack, since .bss region was overflowing, with 2 CQs on TG

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
