### PR TITLE
#13127: Allow `compute_output_shapes` to use SimpleShape instead of LegacyShape, port some ops to SimpleShape

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -34,7 +34,7 @@ New Device Operation
 
     struct <NewOperation> {
         void validate(const std::vector<Tensor> &input_tensors) const;
-        std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
         std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
         operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     };
@@ -48,7 +48,7 @@ New Device Operation with a member
         int some_member
 
         void validate(const std::vector<Tensor> &input_tensors) const;
-        std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
         std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
         operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     };
@@ -61,7 +61,7 @@ New Device Operation with Optional Input Tensors
     struct <NewOperation> {
         void validate(const std::vector<Tensor> &input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-        std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
         std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
         operation::ProgramWithCallbacks create_program(
             const std::vector<Tensor>& input_tensors,
@@ -80,7 +80,7 @@ and create_output_tensors with the additional parameter for the output_tensors.
 
     struct <NewOperation> {
         void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-        std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+        std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
         std::vector<std::optional<Tensor>> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
         operation::ProgramWithOptionalOutputTensors create_program(const std::vector<Tensor>& input_tensors, std::vector<std::optional<Tensor>> &output_tensors) const;
 

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -27,7 +27,14 @@ std::vector<Tensor> run_operation(
     const operation::OptionalTensors& optional_output_tensors = {}) {
     static_assert(operation::detail::is_device_operation<OpConfig>(), "ttnn::run_operation can only dispatch Device Operations!");
     // Create output tensor vector by examining the number of output shapes created by the device operation
-    std::vector<Tensor> outputs(operation::DeviceOperation<operation::Tensors>(devop).compute_output_shapes(input_tensors).size());
+    auto output_shapes = operation::DeviceOperation<operation::Tensors>(devop).compute_output_shapes(input_tensors);
+    size_t output_shapes_size = 0;
+    if (std::holds_alternative<std::vector<ttnn::SimpleShape>>(output_shapes)) {
+        output_shapes_size = std::get<std::vector<ttnn::SimpleShape>>(output_shapes).size();
+    } else {
+        output_shapes_size = std::get<std::vector<tt::tt_metal::LegacyShape>>(output_shapes).size();
+    }
+    std::vector<Tensor> outputs(output_shapes_size);
     // Populate the workers of the output tensors, based on the input tensors. This is needed for the async engine.
     for (int i = 0; i < outputs.size(); i++) {
         outputs[i] = Tensor(operation::get_workers_for_op_output(std::move(input_tensors), std::move(optional_input_tensors)));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
@@ -48,7 +48,7 @@ void MorehClipGradNormStep1::validate(
     check_tensor(tmp_pow_sum, "moreh_clip_grad_norm_step1", "tmp_pow_sum");
 };
 
-std::vector<tt::tt_metal::LegacyShape> MorehClipGradNormStep1::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
+std::vector<ttnn::SimpleShape> MorehClipGradNormStep1::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
 
 std::vector<Tensor> MorehClipGradNormStep1::create_output_tensors(const std::vector<Tensor> &) const { return {}; }
 
@@ -105,7 +105,7 @@ void MorehClipGradNormStep2::validate(const std::vector<Tensor> &input_tensors) 
     check_tensor(total_norm, "moreh_clip_grad_norm_step2", "total_norm");
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehClipGradNormStep2::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
+std::vector<ttnn::SimpleShape> MorehClipGradNormStep2::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
 
 std::vector<Tensor> MorehClipGradNormStep2::create_output_tensors(const std::vector<Tensor> &) const { return {}; }
 
@@ -146,7 +146,7 @@ void MorehClipGradNormStep3::validate(
     check_tensor(clip_coef_clamped, "moreh_clip_grad_norm_step3", "clip_coef_clamped");
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehClipGradNormStep3::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
+std::vector<ttnn::SimpleShape> MorehClipGradNormStep3::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
 
 std::vector<Tensor> MorehClipGradNormStep3::create_output_tensors(const std::vector<Tensor> &) const { return {}; }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.hpp
@@ -32,7 +32,7 @@ struct MorehClipGradNormStep1 {
     void validate(
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors,
@@ -49,7 +49,7 @@ struct MorehClipGradNormStep2 {
     float norm_type;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &) const;
@@ -64,7 +64,7 @@ struct MorehClipGradNormStep3 {
     void validate(
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot/moreh_dot_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot/moreh_dot_op.cpp
@@ -46,13 +46,11 @@ void MorehDot::validate(const std::vector<Tensor>& input_tensors) const {
         "Operands to matmul need to be allocated in buffers on device!");
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehDot::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+std::vector<ttnn::SimpleShape> MorehDot::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    auto output_shape = input_tensor.get_legacy_shape();
-    auto padding = output_shape.padding();
-    output_shape[3] = TILE_WIDTH;
-    padding[3] = Padding::PadDimension{0, 31};
-    return {tt::tt_metal::LegacyShape(output_shape, padding)};
+    auto output_shape = input_tensor.get_logical_shape();
+    output_shape[3] = 1;
+    return {output_shape};
 }
 
 std::vector<Tensor> MorehDot::create_output_tensors(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot/moreh_dot_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot/moreh_dot_op.hpp
@@ -27,7 +27,7 @@ struct MorehDot {
     const DataType output_dtype;  // TODO: Uplift output_dtype as an option for general dot/bmm
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.cpp
@@ -63,7 +63,7 @@ void MorehDotBackward::validate(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehDotBackward::compute_output_shapes(const std::vector<Tensor>& inputs) const {
+std::vector<ttnn::SimpleShape> MorehDotBackward::compute_output_shapes(const std::vector<Tensor>& inputs) const {
     // Inplace
     return {};
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.hpp
@@ -29,7 +29,7 @@ operation::ProgramWithCallbacks moreh_dot_backward_single_core(
 struct MorehDotBackward {
     void validate(
         const std::vector<Tensor> &inputs, const std::vector<std::optional<const Tensor>> &optional_inputs) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
@@ -405,39 +405,26 @@ void MorehLayerNorm::validate_with_output_tensors(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehLayerNorm::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+std::vector<ttnn::SimpleShape> MorehLayerNorm::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     auto input = input_tensors.at(0);
 
     // compute mean_rstd_shape
-    tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
-    auto input_shape_without_padding = input_shape.without_padding();
+    auto input_shape = input.get_logical_shape();
     auto input_rank = input_shape.rank();
     auto output_rank = input_rank - normalized_dims;
 
-    std::vector<uint32_t> output_size_vec;
-    auto dimensions_pads = std::vector<Padding::PadDimension>();
+    std::vector<uint32_t> output_shape_vec;
 
     // special case handling
     if (output_rank == 1) {
-        output_size_vec.push_back(32);
-        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 31});
+        output_shape_vec.push_back(1);
     }
 
     for (uint32_t dim = 0 ; dim < output_rank; dim++) {
-        auto input_shape_without_padding_size = input_shape_without_padding[dim];
-        if (is_hw_dim(dim, output_rank)) {
-            output_size_vec.push_back(round_up_to_mul32(input_shape_without_padding_size));
-
-            auto padding_back = output_size_vec[dim] - input_shape_without_padding_size;
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = padding_back});
-        } else {
-            output_size_vec.push_back(input_shape_without_padding_size);
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
-        }
+        output_shape_vec.push_back(input_shape[dim]);
     }
 
-    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
-    auto mean_rstd_output_shape = tt::tt_metal::LegacyShape(output_size_vec, padding);
+    ttnn::SimpleShape mean_rstd_output_shape(std::move(output_shape_vec));
 
     return {input_shape, mean_rstd_output_shape, mean_rstd_output_shape};
 }
@@ -457,7 +444,7 @@ std::vector<Tensor> MorehLayerNorm::create_output_tensors(
         result.push_back(output_tensors.at(0).value());
     } else {
         TT_THROW("Create output tensor is not supported yet. Fix this after the #9552 issue is addressed.");
-        result.push_back(create_device_tensor(output_shapes.at(0), dtype, layout, device, this->memory_config));
+        //result.push_back(create_device_tensor(output_shapes.at(0), dtype, layout, device, this->memory_config));
     }
 
     if (output_tensors.at(1).has_value()) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
@@ -444,7 +444,7 @@ std::vector<Tensor> MorehLayerNorm::create_output_tensors(
         result.push_back(output_tensors.at(0).value());
     } else {
         TT_THROW("Create output tensor is not supported yet. Fix this after the #9552 issue is addressed.");
-        //result.push_back(create_device_tensor(output_shapes.at(0), dtype, layout, device, this->memory_config));
+        result.push_back(create_device_tensor(output_shapes.at(0), dtype, layout, device, this->memory_config));
     }
 
     if (output_tensors.at(1).has_value()) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.hpp
@@ -34,7 +34,7 @@ struct MorehLayerNorm {
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors,
         const std::vector<std::optional<Tensor>> &output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.cpp
@@ -62,10 +62,10 @@ void MorehLayerNormBackwardInputGrad::validate_with_output_tensors(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehLayerNormBackwardInputGrad::compute_output_shapes(
+std::vector<ttnn::SimpleShape> MorehLayerNormBackwardInputGrad::compute_output_shapes(
     const std::vector<Tensor>& input_tensors) const {
     auto input = input_tensors.at(0);
-    auto input_shape = input.get_legacy_shape();
+    auto input_shape = input.get_logical_shape();
 
     // The shapes of the input and output are always the same.
     return {input_shape};
@@ -131,7 +131,7 @@ void MorehLayerNormBackwardGammaBetaGrad::validate_with_output_tensors(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> MorehLayerNormBackwardGammaBetaGrad::compute_output_shapes(
+std::vector<ttnn::SimpleShape> MorehLayerNormBackwardGammaBetaGrad::compute_output_shapes(
     const std::vector<Tensor>& input_tensors) const {
     TT_THROW("The compute_output_shapes function in MorehLayerNormBackwardGammaBetaGrad is not implemented.");
     return {};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.hpp
@@ -30,7 +30,7 @@ struct MorehLayerNormBackwardInputGrad {
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors,
         const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors,
@@ -46,7 +46,7 @@ struct MorehLayerNormBackwardGammaBetaGrad {
     void validate_with_output_tensors(
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
@@ -39,7 +39,7 @@ struct MorehMatmul {
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors,
         const std::vector<std::optional<Tensor>> &output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -546,7 +546,7 @@ struct DeviceOperation final {
         compute_output_shapes_impl_{
             [](const storage_t& storage, const Tensors& input_tensors) -> const std::vector<tt::tt_metal::LegacyShape> {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
-                return operation.compute_output_shapes(input_tensors);
+                return {}; //operation.compute_output_shapes(input_tensors);
             }},
         create_output_tensors_impl_{
             [](const storage_t& storage,

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -384,6 +384,7 @@ template <class OutputTensorsT = Tensors>
 struct DeviceOperation final {
     using storage_t = std::array<std::byte, 1152>;
     using OutputTensors = OutputTensorsT;
+    using ComputedShapes = std::variant<std::vector<tt::tt_metal::LegacyShape>, std::vector<ttnn::SimpleShape>>;
 
     inline const std::string get_type_name() const { return this->get_type_name_impl_(this->type_erased_storage); }
 
@@ -395,7 +396,7 @@ struct DeviceOperation final {
             this->type_erased_storage, input_tensors, optional_input_tensors, optional_output_tensors);
     }
 
-    inline const std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const Tensors& input_tensors) const {
+    inline const ComputedShapes compute_output_shapes(const Tensors& input_tensors) const {
         return this->compute_output_shapes_impl_(this->type_erased_storage, input_tensors);
     }
 
@@ -544,9 +545,9 @@ struct DeviceOperation final {
                 }
             }},
         compute_output_shapes_impl_{
-            [](const storage_t& storage, const Tensors& input_tensors) -> const std::vector<tt::tt_metal::LegacyShape> {
+            [](const storage_t& storage, const Tensors& input_tensors) -> const ComputedShapes {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
-                return {}; //operation.compute_output_shapes(input_tensors);
+                return operation.compute_output_shapes(input_tensors);
             }},
         create_output_tensors_impl_{
             [](const storage_t& storage,
@@ -753,7 +754,7 @@ struct DeviceOperation final {
         const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
         const OptionalTensors&);
-    const std::vector<tt::tt_metal::LegacyShape> (*compute_output_shapes_impl_)(const storage_t& value, const Tensors&);
+    const ComputedShapes (*compute_output_shapes_impl_)(const storage_t& value, const Tensors&);
     const OutputTensors (*create_output_tensors_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
 
     CacheableProgram<OutputTensors> (*create_program_impl_)(

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -175,7 +175,7 @@ std::vector<Tensor> AllGather::create_output_tensors(const std::vector<Tensor> &
     const auto& input_tensor = input_tensors[0];
     if(this->output_mem_config.is_sharded()) {
         return {create_device_tensor(
-            ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
+            this->compute_output_shapes(input_tensors).at(0),
             input_tensor.get_dtype(),
             input_tensor.get_layout(),
             input_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -165,17 +165,17 @@ void AllGather::validate(const std::vector<Tensor> &input_tensors) const {
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> AllGather::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    auto shape = input_tensors[0].get_legacy_shape();
+std::vector<ttnn::SimpleShape> AllGather::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    auto shape = input_tensors[0].get_logical_shape();
     shape[this->dim] *= this->ring_size;
-    return std::vector<tt::tt_metal::LegacyShape>(input_tensors.size(), shape);
+    return std::vector<ttnn::SimpleShape>(input_tensors.size(), shape);
 }
 
 std::vector<Tensor> AllGather::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors[0];
     if(this->output_mem_config.is_sharded()) {
         return {create_device_tensor(
-            this->compute_output_shapes(input_tensors).at(0),
+            ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
             input_tensor.get_dtype(),
             input_tensor.get_layout(),
             input_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -132,7 +132,7 @@ struct AllGather {
     const ccl::Topology topology;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -22,13 +22,13 @@ void ReduceScatter::validate(const std::vector<Tensor>& input_tensors) const {
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> ReduceScatter::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    auto shape = input_tensors[0].get_legacy_shape();
+std::vector<ttnn::SimpleShape> ReduceScatter::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    auto shape = input_tensors[0].get_logical_shape();
     TT_FATAL(
         shape[this->scatter_dim] % this->ring_size == 0,
         "The size of the scatter dimension must be a multiple of the ring size");
     shape[this->scatter_dim] /= this->ring_size;
-    return std::vector<tt::tt_metal::LegacyShape>(input_tensors.size(), shape);
+    return std::vector<ttnn::SimpleShape>(input_tensors.size(), shape);
 }
 
 std::vector<Tensor> ReduceScatter::create_output_tensors(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -25,7 +25,7 @@ struct ReduceScatter {
     const std::optional<size_t> user_defined_num_buffers_per_channel;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
@@ -104,7 +104,7 @@ struct OptimizedConvNew {
             enable_subblock_padding(enable_subblock_padding) {}
 
     void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
@@ -104,7 +104,7 @@ struct OptimizedConvNew {
             enable_subblock_padding(enable_subblock_padding) {}
 
     void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
@@ -160,7 +160,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
             auto shard_spec = ShardSpec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
             auto mem_config = this->memory_config;
             mem_config.shard_spec = shard_spec;
-            return {create_device_tensor(ttnn::Shape(output_shape.as_vector()), this->dtype, output_layout, input_tensor.device(), mem_config)};
+            return {create_device_tensor(output_shape, this->dtype, output_layout, input_tensor.device(), mem_config)};
         } else if(this->memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             uint32_t total_height_tiles = (output_shape.volume() / output_shape[-1] + TILE_HEIGHT - 1) / TILE_HEIGHT;
             std::array<uint32_t, 2> shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, this->parallelization_config.per_core_out_matrix_width_ntiles * TILE_WIDTH};
@@ -168,7 +168,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
             auto shard_spec = ShardSpec{shard_grid, shard_shape, this->memory_config.shard_spec.value().orientation};
             auto mem_config = this->memory_config;
             mem_config.shard_spec = shard_spec;
-            return{create_device_tensor(ttnn::Shape(output_shape.as_vector()), this->dtype, output_layout, input_tensor.device(), mem_config)};
+            return{create_device_tensor(output_shape, this->dtype, output_layout, input_tensor.device(), mem_config)};
 
         } else if (this->memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(this->input_tensor_shape, sliding_window_config, this->parallelization_config.per_core_out_matrix_height_ntiles);
@@ -189,7 +189,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
             auto shard_spec = ShardSpec{shard_grid, shard_shape, this->memory_config.shard_spec.value().orientation};
             auto mem_config = this->memory_config;
             mem_config.shard_spec = shard_spec;
-            return {create_device_tensor(ttnn::Shape(output_shape.as_vector()), this->dtype, output_layout, input_tensor.device(), mem_config)};
+            return {create_device_tensor(output_shape, this->dtype, output_layout, input_tensor.device(), mem_config)};
         } else {
             TT_THROW("Unsupported shard scheme");
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
@@ -123,7 +123,7 @@ void OptimizedConvNew::validate(const std::vector<Tensor>& input_tensors, const 
     }
 }
 
-std::vector<ttnn::SimpleShape> OptimizedConvNew::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+std::vector<tt::tt_metal::LegacyShape> OptimizedConvNew::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a_shape = this->input_tensor_shape;
     uint32_t batch_size = input_tensor_a_shape[0];
     uint32_t conv_activation_h = input_tensor_a_shape[1];
@@ -140,9 +140,16 @@ std::vector<ttnn::SimpleShape> OptimizedConvNew::compute_output_shapes(const std
     uint32_t conv_output_h = output_shape[1];
     uint32_t conv_output_w = output_shape[2];
 
+    // Tiled output shape is padded shape. Padded to tile shape.
     auto shape_w = batch_size * conv_output_h * conv_output_w;
     auto shape_c = output_channels;
-    return {ttnn::SimpleShape({1, 1, shape_w, shape_c})};
+    auto padded_shape_w =
+        parallelization_config.num_cores_nhw * parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT;
+    auto padded_shape_c = tt::round_up(this->output_channels, TILE_WIDTH);
+    auto output_padding = Padding(
+        {{0, 0}, {0, 0}, {0, (padded_shape_w - shape_w)}, {0, (padded_shape_c - shape_c)}}, Padding::PadValue::Zero);
+    auto output_tensor_shape = ttnn::Shape(tt::tt_metal::LegacyShape({1, 1, padded_shape_w, padded_shape_c}, output_padding));
+    return {output_tensor_shape.value};
 }
 
 std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
@@ -152,7 +159,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
     if (this->memory_config.is_sharded()) {
         auto output_shape = this->compute_output_shapes(input_tensors).at(0);
         if (this->memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-            uint32_t total_height_tiles = (output_shape.volume() / output_shape[-1] + TILE_HEIGHT - 1) / TILE_HEIGHT;
+            uint32_t total_height_tiles = tt::tt_metal::compute_volume(output_shape) / output_shape[-1] / TILE_HEIGHT;
             uint32_t num_cores = total_height_tiles / this->parallelization_config.per_core_out_matrix_height_ntiles;
             CoreRangeSet shard_grid = tt::tt_metal::num_cores_to_corerange_set(num_cores, this->parallelization_config.grid_size, true);
 
@@ -162,7 +169,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
             mem_config.shard_spec = shard_spec;
             return {create_device_tensor(output_shape, this->dtype, output_layout, input_tensor.device(), mem_config)};
         } else if(this->memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-            uint32_t total_height_tiles = (output_shape.volume() / output_shape[-1] + TILE_HEIGHT - 1) / TILE_HEIGHT;
+            uint32_t total_height_tiles = tt::tt_metal::compute_volume(output_shape) / output_shape[-1] / TILE_HEIGHT;
             std::array<uint32_t, 2> shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, this->parallelization_config.per_core_out_matrix_width_ntiles * TILE_WIDTH};
             auto shard_grid = input_tensor.memory_config().shard_spec.value().grid;
             auto shard_spec = ShardSpec{shard_grid, shard_shape, this->memory_config.shard_spec.value().orientation};

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -131,7 +131,7 @@ std::vector<Tensor> EltwiseBinaryBroadcast::create_output_tensors(const std::vec
         }
         auto mem_config = this->output_mem_config;
         mem_config.shard_spec = shard_spec;
-        return {create_device_tensor(ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
+        return {create_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -47,9 +47,9 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tens
     TT_FATAL(is_floating_point(input_tensor_a.get_dtype()), "Unsupported data format");
     if(!output_tensors.empty() && output_tensors.at(0).has_value()){
         TT_FATAL(is_floating_point(output_tensors.at(0).value().get_dtype()), "Unsupported data format");
-        const std::vector<tt::tt_metal::LegacyShape> output_shape_required = this->compute_output_shapes(input_tensors);
+        const std::vector<ttnn::SimpleShape> output_shape_required = this->compute_output_shapes(input_tensors);
         const auto& out_tensor = output_tensors.at(0).value();
-        TT_FATAL(out_tensor.get_legacy_shape() == output_shape_required.at(0), "The input tensors need a shape of {}, however the output tensor is only {}", output_shape_required,  out_tensor.get_legacy_shape());
+        TT_FATAL(out_tensor.get_logical_shape() == output_shape_required.at(0), "The input tensors need a shape of {}, however the output tensor is only {}", output_shape_required,  out_tensor.get_legacy_shape());
     }
     if (this->in_place) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
@@ -109,9 +109,9 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tens
 }
 
 
-std::vector<tt::tt_metal::LegacyShape> EltwiseBinaryBroadcast::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+std::vector<ttnn::SimpleShape> EltwiseBinaryBroadcast::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
+    return {input_tensor.get_logical_shape()};
 }
 
 
@@ -131,7 +131,7 @@ std::vector<Tensor> EltwiseBinaryBroadcast::create_output_tensors(const std::vec
         }
         auto mem_config = this->output_mem_config;
         mem_config.shard_spec = shard_spec;
-        return {create_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
+        return {create_device_tensor(ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
@@ -29,7 +29,7 @@ struct EltwiseBinaryBroadcast {
     const bool in_place;
 
     void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -61,11 +61,11 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor> &input_tensors) c
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> ConcatDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    tt::tt_metal::LegacyShape shape_out = input_tensors[0].get_legacy_shape();
+std::vector<ttnn::SimpleShape> ConcatDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    ttnn::SimpleShape shape_out = input_tensors[0].get_logical_shape();
     shape_out[this->dim] = 0;
     for (const Tensor &in_ref : input_tensors) {
-        tt::tt_metal::LegacyShape curr_shape = in_ref.get_legacy_shape();
+        ttnn::SimpleShape curr_shape = in_ref.get_logical_shape();
         shape_out[this->dim] += curr_shape[this->dim];
     }
     return {shape_out};
@@ -76,7 +76,7 @@ std::vector<Tensor> ConcatDeviceOperation::create_output_tensors(const std::vect
 
     if (this->output_mem_config.is_sharded()) {
         return {create_device_tensor(
-            this->compute_output_shapes(input_tensors).at(0),
+            ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
             ref_in_tensor.get_dtype(),
             ref_in_tensor.get_layout(),
             ref_in_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -76,7 +76,7 @@ std::vector<Tensor> ConcatDeviceOperation::create_output_tensors(const std::vect
 
     if (this->output_mem_config.is_sharded()) {
         return {create_device_tensor(
-            ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
+            this->compute_output_shapes(input_tensors).at(0),
             ref_in_tensor.get_dtype(),
             ref_in_tensor.get_layout(),
             ref_in_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -15,7 +15,7 @@ struct ConcatDeviceOperation {
     uint32_t dim;
     const MemoryConfig output_mem_config;
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -54,15 +54,15 @@ void AllGatherMatmul::validate(const std::vector<Tensor> &input_tensors, const s
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> AllGatherMatmul::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+std::vector<ttnn::SimpleShape> AllGatherMatmul::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
 
     // All Gather shape
-    tt::tt_metal::LegacyShape all_gather_output_shape = this->all_gather_struct.compute_output_shapes({input_tensors[0]})[0];
-    tt::tt_metal::LegacyShape datacopy_output_shape = all_gather_output_shape;
+    ttnn::SimpleShape all_gather_output_shape = this->all_gather_struct.compute_output_shapes({input_tensors[0]})[0];
+    ttnn::SimpleShape datacopy_output_shape = all_gather_output_shape;
 
 
     // Matmul shape
-    tt::tt_metal::LegacyShape matmul_output_shapes = this->matmul_struct.compute_output_shapes({input_tensors[1], input_tensors[2]})[0];
+    ttnn::SimpleShape matmul_output_shapes = this->matmul_struct.compute_output_shapes({input_tensors[1], input_tensors[2]})[0];
 
     return {all_gather_output_shape, matmul_output_shapes, datacopy_output_shape};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
@@ -42,7 +42,7 @@ struct AllGatherMatmul {
 
     /* General */
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1363,7 +1363,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
                     return {create_device_tensor(
-                        ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
+                        this->compute_output_shapes(input_tensors).at(0),
                         this->output_dtype.value(),
                         output_layout,
                         input_tensor_a.device(),
@@ -1387,7 +1387,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
                     return {create_device_tensor(
-                        ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
+                        this->compute_output_shapes(input_tensors).at(0),
                         this->output_dtype.value(),
                         output_layout,
                         input_tensor_a.device(),
@@ -1419,7 +1419,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
                     return {create_device_tensor(
-                        ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
+                        this->compute_output_shapes(input_tensors).at(0),
                         this->output_dtype.value(),
                         output_layout,
                         input_tensor_a.device(),
@@ -1453,7 +1453,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
                     return {create_device_tensor(
-                        ttnn::Shape(this->compute_output_shapes(input_tensors).at(0).as_vector()),
+                        this->compute_output_shapes(input_tensors).at(0),
                         this->output_dtype.value(),
                         output_layout,
                         input_tensor_a.device(),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -169,7 +169,7 @@ struct Matmul {
     void validate(
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes_dram_sharded(
         const std::vector<Tensor> &input_tensors, uint32_t N_unpadded) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
@@ -50,14 +50,12 @@ void MorehDotOperation::validate_on_program_cache_hit(
 MorehDotOperation::shape_return_value_t MorehDotOperation::compute_output_shapes(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.output.has_value()) {
-        return tensor_args.output.value().get_shape();
+        return tensor_args.output.value().get_logical_shape();
     }
     const auto& input = tensor_args.input_a;
-    auto output_shape = input.get_shape().value;
-    auto padding = output_shape.padding();
-    output_shape[3] = tt::constants::TILE_WIDTH;
-    padding[3] = Padding::PadDimension{0, 31};
-    return ttnn::Shape{tt::tt_metal::LegacyShape(output_shape, padding)};
+    auto output_shape = input.get_logical_shape();
+    output_shape[3] = 1;
+    return ttnn::SimpleShape{std::move(output_shape)};
 }
 
 MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensors(
@@ -68,7 +66,7 @@ MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensor
     const auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
     const auto& input_tensor = tensor_args.input_a;
     return create_device_tensor(
-        output_shape,
+        ttnn::Shape(output_shape.as_vector()),
         input_tensor.tensor_attributes->dtype,
         input_tensor.tensor_attributes->layout,
         input_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
@@ -66,7 +66,7 @@ MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensor
     const auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
     const auto& input_tensor = tensor_args.input_a;
     return create_device_tensor(
-        ttnn::Shape(output_shape.as_vector()),
+        output_shape,
         input_tensor.tensor_attributes->dtype,
         input_tensor.tensor_attributes->layout,
         input_tensor.device(),

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
@@ -23,7 +23,7 @@ struct MorehDotOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using shape_return_value_t = SimpleShape;
     using tensor_return_value_t = Tensor;
 
     struct SingleCore {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.hpp
@@ -26,7 +26,7 @@ struct MorehDotBackwardOperation {
         const std::vector<std::optional<Tensor>> output_tensors;
     };
 
-    using shape_return_value_t = std::vector<std::optional<Shape>>;
+    using shape_return_value_t = std::vector<std::optional<ttnn::SimpleShape>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct SingleCore {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
@@ -84,20 +84,16 @@ MorehGroupNormOperation::shape_return_value_t MorehGroupNormOperation::compute_o
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     using namespace tt::constants;
     // mean, rstd (1, 1, N, num_groups)
-    const auto output_shape = tensor_args.input.get_shape();
-    const auto N = output_shape.value[0];
+    const auto output_shape = tensor_args.input.get_logical_shape();
+    const auto N = output_shape[0];
     const auto num_groups = operation_attributes.num_groups;
-    const std::vector<uint32_t> mean_rstd_origin_shape{
+    std::vector<uint32_t> mean_rstd_origin_shape{
         1,
         1,
-        TILE_HEIGHT * ((N + TILE_HEIGHT - 1) / TILE_HEIGHT),
-        TILE_WIDTH * ((num_groups + TILE_WIDTH - 1) / TILE_WIDTH)};
+        N,
+        num_groups};
 
-    auto mean_rstd_padding = output_shape.value.padding();
-    mean_rstd_padding[2] = Padding::PadDimension{0, TILE_HEIGHT - (N % TILE_HEIGHT)};
-    mean_rstd_padding[3] = Padding::PadDimension{0, TILE_WIDTH - (num_groups % TILE_WIDTH)};
-
-    Shape mean_rstd_shape = Shape(tt::tt_metal::LegacyShape(mean_rstd_origin_shape, mean_rstd_padding));
+    SimpleShape mean_rstd_shape(std::move(mean_rstd_origin_shape));
     return {output_shape, mean_rstd_shape, mean_rstd_shape};
 }
 
@@ -115,16 +111,16 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     if (tensor_args.output.has_value()) {
         result.push_back(tensor_args.output.value());
     } else {
-        result.push_back(
-            create_device_tensor(output_shapes[0].value(), dtype, layout, device, operation_attributes.memory_config));
+        //result.push_back(
+        //    create_device_tensor(output_shapes[0].value(), dtype, layout, device, operation_attributes.memory_config));
     }
 
     // mean
     if (tensor_args.mean.has_value()) {
         result.push_back(tensor_args.mean.value());
     } else if (operation_attributes.are_required_outputs[1]) {
-        result.push_back(create_device_tensor(
-            output_shapes[1].value(), dtype, layout, device, operation_attributes.mean_memory_config));
+        //result.push_back(create_device_tensor(
+        //    output_shapes[1].value(), dtype, layout, device, operation_attributes.mean_memory_config));
     } else {
         result.push_back(std::nullopt);
     }
@@ -133,8 +129,8 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     if (tensor_args.rstd.has_value()) {
         result.push_back(tensor_args.rstd.value());
     } else if (operation_attributes.are_required_outputs[2]) {
-        result.push_back(create_device_tensor(
-            output_shapes[2].value(), dtype, layout, device, operation_attributes.rstd_memory_config));
+        //result.push_back(create_device_tensor(
+        //    output_shapes[2].value(), dtype, layout, device, operation_attributes.rstd_memory_config));
     } else {
         result.push_back(std::nullopt);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
@@ -111,16 +111,16 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     if (tensor_args.output.has_value()) {
         result.push_back(tensor_args.output.value());
     } else {
-        //result.push_back(
-        //    create_device_tensor(output_shapes[0].value(), dtype, layout, device, operation_attributes.memory_config));
+        result.push_back(
+            create_device_tensor(output_shapes[0].value(), dtype, layout, device, operation_attributes.memory_config));
     }
 
     // mean
     if (tensor_args.mean.has_value()) {
         result.push_back(tensor_args.mean.value());
     } else if (operation_attributes.are_required_outputs[1]) {
-        //result.push_back(create_device_tensor(
-        //    output_shapes[1].value(), dtype, layout, device, operation_attributes.mean_memory_config));
+        result.push_back(create_device_tensor(
+            output_shapes[1].value(), dtype, layout, device, operation_attributes.mean_memory_config));
     } else {
         result.push_back(std::nullopt);
     }
@@ -129,8 +129,8 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     if (tensor_args.rstd.has_value()) {
         result.push_back(tensor_args.rstd.value());
     } else if (operation_attributes.are_required_outputs[2]) {
-        //result.push_back(create_device_tensor(
-        //    output_shapes[2].value(), dtype, layout, device, operation_attributes.rstd_memory_config));
+        result.push_back(create_device_tensor(
+            output_shapes[2].value(), dtype, layout, device, operation_attributes.rstd_memory_config));
     } else {
         result.push_back(std::nullopt);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
@@ -27,7 +27,7 @@ struct MorehGroupNormOperation {
         const std::optional<const Tensor> rstd;
     };
 
-    using shape_return_value_t = std::vector<std::optional<Shape>>;
+    using shape_return_value_t = std::vector<std::optional<SimpleShape>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct MorehGroupNormFactory {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -44,7 +44,7 @@ std::vector<Tensor> Prod::create_output_tensors(const std::vector<Tensor>& input
     return {};
 }
 
-std::vector<tt::tt_metal::LegacyShape> Prod::compute_output_shapes(const std::vector<Tensor>& inputs) const {
+std::vector<ttnn::SimpleShape> Prod::compute_output_shapes(const std::vector<Tensor>& inputs) const {
     // Inplace
     return {};
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.hpp
@@ -23,7 +23,7 @@ using namespace tt_metal;
 struct Prod {
     int64_t dim;
     void validate(const std::vector<Tensor> &inputs) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -302,6 +302,21 @@ template OptionalTensors run_without_autoformat<OptionalTensors>(
     const OptionalTensors& optional_output_tensors,
     uint8_t cq_id);
 
+std::vector<LegacyShape> extract_legacy_shapes(
+    const std::variant<std::vector<tt::tt_metal::LegacyShape>, std::vector<ttnn::SimpleShape>>&& shapes, const std::function<Layout(size_t idx)>& layout_provider) {
+    if (std::holds_alternative<std::vector<tt::tt_metal::LegacyShape>>(shapes)) {
+        return std::get<std::vector<tt::tt_metal::LegacyShape>>(std::move(shapes));
+    }
+    const auto& simple_shapes = std::get<std::vector<ttnn::SimpleShape>>(shapes);
+    std::vector<LegacyShape> legacy_shapes;
+    legacy_shapes.reserve(simple_shapes.size());
+    for (size_t idx = 0; idx < simple_shapes.size(); idx++) {
+        auto layout = layout_provider(idx);
+        legacy_shapes.emplace_back(simple_shapes[idx].as_vector(), get_physical_shape(simple_shapes[idx], layout).as_vector());
+    }
+    return legacy_shapes;
+}
+
 // To be deprecated/removed in favor of new implementation where ops specifically request how to format inputs/outputss
 Tensors run_with_autoformat(
     DeviceOperation<Tensors>&& operation,
@@ -314,7 +329,9 @@ Tensors run_with_autoformat(
     using ttnn::operations::experimental::auto_format::AutoFormat;
     ZoneScoped;
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
-    auto output_shapes = operation.compute_output_shapes(input_tensors);
+    auto output_shapes = extract_legacy_shapes(operation.compute_output_shapes(input_tensors), [](size_t) {
+        return Layout::TILE;
+    });
 
     Tensors formatted_input_tensors;
     formatted_input_tensors.reserve(input_tensors.size());
@@ -349,24 +366,14 @@ Tensors run_with_autoformat(
 
     auto output_tensors = run<Tensors>(std::move(operation), formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors, cq_id);
 
+    TT_ASSERT(output_tensors.size() == output_shapes.size());
+
     formatted_input_tensors.clear();
     formatted_optional_input_tensors.clear();
 
-    if (std::holds_alternative<std::vector<tt::tt_metal::LegacyShape>>(output_shapes)) {
-        auto& shapes = std::get<std::vector<tt::tt_metal::LegacyShape>>(output_shapes);
-        TT_ASSERT(output_tensors.size() == shapes.size());
-        for (auto i = 0; i < output_tensors.size(); ++i) {
-            output_tensors[i] = AutoFormat::format_output_tensor(output_tensors[i], shapes[i], device, Layout::TILE);
-        }
-    } else {
-        auto& shapes = std::get<std::vector<ttnn::SimpleShape>>(output_shapes);
-        TT_ASSERT(output_tensors.size() == shapes.size());
-        for (auto i = 0; i < output_tensors.size(); ++i) {
-            auto legacy_shape = tt::tt_metal::LegacyShape(shapes[i].as_vector(), shapes[i].get_physical_shape(Layout::TILE).as_vector());
-            output_tensors[i] = AutoFormat::format_output_tensor(output_tensors[i], legacy_shape, device, Layout::TILE);
-        }
+    for (auto i = 0; i < output_tensors.size(); ++i) {
+        output_tensors[i] = AutoFormat::format_output_tensor(output_tensors[i], output_shapes[i], device, Layout::TILE);
     }
-
     return output_tensors;
 }
 
@@ -382,7 +389,9 @@ Tensors run_with_autoformat(
     using ttnn::operations::experimental::auto_format::AutoFormat;
     ZoneScoped;
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
-    auto output_shapes = operation.compute_output_shapes(input_tensors);
+    auto output_shapes = extract_legacy_shapes(operation.compute_output_shapes(input_tensors), [&](size_t idx) {
+        return output_layouts[idx];
+    });
 
     TT_ASSERT(input_tensors.size() == input_formatting.size());
     TT_ASSERT(optional_input_tensors.size() == optional_input_formatting.size());
@@ -418,25 +427,15 @@ Tensors run_with_autoformat(
 
     auto output_tensors = run<Tensors>(std::move(operation), formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors, cq_id);
 
+    TT_ASSERT(output_tensors.size() == output_shapes.size());
     TT_ASSERT(output_tensors.size() == output_layouts.size());
 
     formatted_input_tensors.clear();
     formatted_optional_input_tensors.clear();
 
-    if (std::holds_alternative<std::vector<tt::tt_metal::LegacyShape>>(output_shapes)) {
-        auto& shapes = std::get<std::vector<tt::tt_metal::LegacyShape>>(output_shapes);
-        TT_ASSERT(output_tensors.size() == shapes.size());
-        for (auto i = 0; i < output_tensors.size(); ++i) {
-            output_tensors[i] =
-                AutoFormat::format_output_tensor(output_tensors[i], shapes[i], device, output_layouts[i]);
-        }
-    } else {
-        auto& shapes = std::get<std::vector<ttnn::SimpleShape>>(output_shapes);
-        TT_ASSERT(output_tensors.size() == shapes.size());
-        for (auto i = 0; i < output_tensors.size(); ++i) {
-            auto legacy_shape = tt::tt_metal::LegacyShape(shapes[i].as_vector(), shapes[i].get_physical_shape(output_layouts[i]).as_vector());
-            output_tensors[i] = AutoFormat::format_output_tensor(output_tensors[i], legacy_shape, device, output_layouts[i]);
-        }
+    for (auto i = 0; i < output_tensors.size(); ++i) {
+        output_tensors[i] =
+            AutoFormat::format_output_tensor(output_tensors[i], output_shapes[i], device, output_layouts[i]);
     }
 
     return output_tensors;

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -32,12 +32,12 @@ auto generic_create_output_tensors(
     OutputTensors output_tensors;
     output_tensors.reserve(output_shapes.size());
     for (const auto& output_shape : output_shapes) {
-        output_tensors.emplace_back(create_device_tensor(
+        /*output_tensors.emplace_back(create_device_tensor(
             output_shape,
             output_dtype.value_or(input_tensors.at(0).get_dtype()),
             output_layout,
             input_tensor.device(),
-            output_mem_config.value_or(input_tensors.at(0).memory_config()), tile));
+            output_mem_config.value_or(input_tensors.at(0).memory_config()), tile));*/
     }
     return output_tensors;
 }

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -32,12 +32,12 @@ auto generic_create_output_tensors(
     OutputTensors output_tensors;
     output_tensors.reserve(output_shapes.size());
     for (const auto& output_shape : output_shapes) {
-        /*output_tensors.emplace_back(create_device_tensor(
+        output_tensors.emplace_back(create_device_tensor(
             output_shape,
             output_dtype.value_or(input_tensors.at(0).get_dtype()),
             output_layout,
             input_tensor.device(),
-            output_mem_config.value_or(input_tensors.at(0).memory_config()), tile));*/
+            output_mem_config.value_or(input_tensors.at(0).memory_config()), tile));
     }
     return output_tensors;
 }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -698,24 +698,7 @@ Tensor create_device_tensor(
 
 Tensor create_device_tensor(
     const ttnn::SimpleShape& logical_shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
-    auto padded_shape = logical_shape;
-    if (layout == Layout::TILE) {
-        auto tile_height = TILE_HEIGHT;
-        auto tile_width = TILE_WIDTH;
-        if (tile.has_value()) {
-            auto tile_shape = tile.value().get_tile_shape();
-            tile_height = tile_shape[0];
-            tile_width = tile_shape[1];
-        }
-        auto rank = padded_shape.rank();
-        if (rank >= 1) {
-            padded_shape[rank - 1] = (padded_shape[rank - 1] + tile_width - 1) / tile_width * tile_width;
-            if (rank >= 2) {
-                padded_shape[rank - 2] = (padded_shape[rank - 2] + tile_height - 1) / tile_height * tile_height;
-            }
-        }
-    }
-    return create_device_tensor(logical_shape, padded_shape, data_type, layout, device, memory_config, tile);
+    return create_device_tensor(logical_shape, logical_shape.get_physical_shape(layout, tile), data_type, layout, device, memory_config, tile);
 }
 
 Tensor create_device_tensor(

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -697,6 +697,28 @@ Tensor create_device_tensor(
 }
 
 Tensor create_device_tensor(
+    const ttnn::SimpleShape& logical_shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
+    auto padded_shape = logical_shape;
+    if (layout == Layout::TILE) {
+        auto tile_height = TILE_HEIGHT;
+        auto tile_width = TILE_WIDTH;
+        if (tile.has_value()) {
+            auto tile_shape = tile.value().get_tile_shape();
+            tile_height = tile_shape[0];
+            tile_width = tile_shape[1];
+        }
+        auto rank = padded_shape.rank();
+        if (rank >= 1) {
+            padded_shape[rank - 1] = (padded_shape[rank - 1] + tile_width - 1) / tile_width * tile_width;
+            if (rank >= 2) {
+                padded_shape[rank - 2] = (padded_shape[rank - 2] + tile_height - 1) / tile_height * tile_height;
+            }
+        }
+    }
+    return create_device_tensor(logical_shape, padded_shape, data_type, layout, device, memory_config, tile);
+}
+
+Tensor create_device_tensor(
     const ttnn::Shape& shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
     return create_device_tensor(shape.logical_shape(), shape.padded_shape(), data_type, layout, device, memory_config, tile);
 }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -698,7 +698,7 @@ Tensor create_device_tensor(
 
 Tensor create_device_tensor(
     const ttnn::SimpleShape& logical_shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
-    return create_device_tensor(logical_shape, logical_shape.get_physical_shape(layout, tile), data_type, layout, device, memory_config, tile);
+    return create_device_tensor(logical_shape, get_physical_shape(logical_shape, layout, tile), data_type, layout, device, memory_config, tile);
 }
 
 Tensor create_device_tensor(

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -295,6 +295,14 @@ struct Tensor {
 
 Tensor create_device_tensor(
     const ttnn::SimpleShape &logical_shape,
+    DataType dtype,
+    Layout layout,
+    Device *device,
+    const MemoryConfig &memory_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
+    const std::optional<Tile>& tile = std::nullopt);
+
+Tensor create_device_tensor(
+    const ttnn::SimpleShape &logical_shape,
     const ttnn::SimpleShape &padded_shape,
     DataType dtype,
     Layout layout,

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -7,8 +7,8 @@
 
 namespace ttnn {
 
-SimpleShape SimpleShape::get_physical_shape(Layout layout, const std::optional<Tile>& tile) const {
-    SimpleShape padded_shape = *this;
+SimpleShape get_physical_shape(const SimpleShape& logical_shape, Layout layout, const std::optional<Tile>& tile) {
+    SimpleShape physical_shape = logical_shape;
     if (layout == Layout::TILE) {
         auto tile_height = tt::constants::TILE_HEIGHT;
         auto tile_width = tt::constants::TILE_WIDTH;
@@ -17,15 +17,15 @@ SimpleShape SimpleShape::get_physical_shape(Layout layout, const std::optional<T
             tile_height = tile_shape[0];
             tile_width = tile_shape[1];
         }
-        auto rank = padded_shape.rank();
+        auto rank = physical_shape.rank();
         if (rank >= 1) {
-            padded_shape[rank - 1] = (padded_shape[rank - 1] + tile_width - 1) / tile_width * tile_width;
+            physical_shape[rank - 1] = (physical_shape[rank - 1] + tile_width - 1) / tile_width * tile_width;
             if (rank >= 2) {
-                padded_shape[rank - 2] = (padded_shape[rank - 2] + tile_height - 1) / tile_height * tile_height;
+                physical_shape[rank - 2] = (physical_shape[rank - 2] + tile_height - 1) / tile_height * tile_height;
             }
         }
     }
-    return padded_shape;
+    return physical_shape;
 }
 
 }

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -65,6 +65,8 @@ public:
     static constexpr auto attribute_names = std::forward_as_tuple("value");
     auto attribute_values() const { return std::forward_as_tuple(this->value); }
 
+    SimpleShape get_physical_shape(Layout layout, const std::optional<Tile>& tile = std::nullopt) const;
+
 private:
     std::vector<uint32_t> value;
 };

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -65,11 +65,11 @@ public:
     static constexpr auto attribute_names = std::forward_as_tuple("value");
     auto attribute_values() const { return std::forward_as_tuple(this->value); }
 
-    SimpleShape get_physical_shape(Layout layout, const std::optional<Tile>& tile = std::nullopt) const;
-
 private:
     std::vector<uint32_t> value;
 };
+
+SimpleShape get_physical_shape(const SimpleShape& logical_shape, Layout layout, const std::optional<Tile>& tile = std::nullopt);
 
 } // namespace ttnn
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13127

### Problem description
We need to replace the usages of LegacyShape with SimpleShape where possible to make the code cleaner and easier

### What's changed
`DeviceOperation::compute_output_shapes` now returns a variant of either SimpleShape or LegacyShape (it should be just SimpleShape once all of the ops are ported)
Added `get_physical_shape(logical_shape, layout, tile)` function to reuse physical shape computation.
Added `create_device_tensor` overload which only takes `logical_shape` without `physical_shape`.
`run_operation.cpp` now handles SimpleShape by converting it to LegacyShape using a layout.
Ported some operations to use the new `compute_output_shapes` returning SimpleShape

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/11264371219)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
