### PR TITLE
Second dimension support for binop

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_broadcast.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_broadcast.py
@@ -27,7 +27,7 @@ shape1 = [
 @pytest.mark.parametrize("dtype", (ttnn.bfloat16, ttnn.bfloat8_b))
 def test_run_bcast_h_test(input_shapes, bcast_op_type, dtype, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ] * 2
     comparison_func = partial(comparison_funcs.comp_pcc)
     run_single_pytorch_test(
@@ -60,7 +60,7 @@ if is_wormhole_b0():
 @pytest.mark.parametrize("dtype", (ttnn.bfloat16, ttnn.bfloat8_b))
 def test_run_bcast_w_test(input_shapes, bcast_op_type, dtype, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ] * 2
     comparison_func = partial(comparison_funcs.comp_pcc)
     run_single_pytorch_test(
@@ -93,7 +93,7 @@ if is_wormhole_b0():
 @pytest.mark.parametrize("dtype", (ttnn.bfloat16, ttnn.bfloat8_b))
 def test_run_bcast_hw_test(input_shapes, bcast_op_type, dtype, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ] * 2
     comparison_func = partial(comparison_funcs.comp_pcc)
     run_single_pytorch_test(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_mul_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_mul_bcast.py
@@ -17,11 +17,26 @@ from torch.nn import functional as F
 def test_mul_channel_bcast_repeat(device, h, w):
     torch_input_tensor_a = torch.rand((16, 16, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((16, 1, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
     output = ttnn.mul(input_tensor_a, input_tensor_b)
     output = ttnn.to_torch(output)
 
+    torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
+    assert_with_pcc(torch_output_tensor, output, 0.9999)
+
+
+@pytest.mark.parametrize("h", [32])
+@pytest.mark.parametrize("w", [64])
+def test_mul_batch_bcast_repeat(device, h, w):
+    torch_input_tensor_a = torch.rand((1, 16, h, w), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((16, 16, h, w), dtype=torch.bfloat16)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output = ttnn.mul(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+
+    torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
     assert_with_pcc(torch_output_tensor, output, 0.9999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_mul_channel.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_mul_channel.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from torch.nn import functional as F
+
+
+@pytest.mark.parametrize("h", [32])
+@pytest.mark.parametrize("w", [64])
+def test_mul_channel_bcast_repeat(device, h, w):
+    torch_input_tensor_a = torch.rand((16, 16, h, w), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((16, 1, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output = ttnn.mul(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_output_tensor, output, 0.9999)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -117,6 +117,12 @@ auto preprocess_inputs(
             Shape repeats(std::array<uint32_t, 4>{first_shape[0], 1, 1, 1});
             second = ttnn::repeat(second, repeats);
         }
+        // repeats second if it is smaller
+        if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[1] > second_shape[1]) {
+            tt::log_warning(tt::LogOp, "Using repeat op to broadcast channel dim");
+            Shape repeats(std::array<uint32_t, 4>{1, first_shape[1], 1, 1});
+            second = ttnn::repeat(second, repeats);
+        }
     };
     repeat_smaller(input_tensor_a, input_tensor_b);
     repeat_smaller(input_tensor_b, input_tensor_a);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -110,14 +110,15 @@ auto preprocess_inputs(
     auto repeat_smaller = [](const auto &first, auto &second) {
         const auto first_shape = first.get_shape();
         const auto second_shape = second.get_shape();
-
         // repeats second if it is smaller
         if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[0] > second_shape[0]) {
+            TT_FATAL(second_shape[0] == 1, "Dimension trying to broadcast is not equal to 1");
             Shape repeats(std::array<uint32_t, 4>{first_shape[0], 1, 1, 1});
             second = ttnn::repeat(second, repeats);
         }
         // repeats second if it is smaller
         if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[1] > second_shape[1]) {
+            TT_FATAL(second_shape[1] == 1, "Dimension trying to broadcast is not equal to 1");
             Shape repeats(std::array<uint32_t, 4>{1, first_shape[1], 1, 1});
             second = ttnn::repeat(second, repeats);
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -113,13 +113,11 @@ auto preprocess_inputs(
 
         // repeats second if it is smaller
         if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[0] > second_shape[0]) {
-            tt::log_warning(tt::LogOp, "Using repeat op to broadcast batch dim");
             Shape repeats(std::array<uint32_t, 4>{first_shape[0], 1, 1, 1});
             second = ttnn::repeat(second, repeats);
         }
         // repeats second if it is smaller
         if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[1] > second_shape[1]) {
-            tt::log_warning(tt::LogOp, "Using repeat op to broadcast channel dim");
             Shape repeats(std::array<uint32_t, 4>{1, first_shape[1], 1, 1});
             second = ttnn::repeat(second, repeats);
         }


### PR DESCRIPTION
### Ticket
#13646 

### Problem description
Missing second dimension support for binary op

### What's changed
Currently used repeat function to achieve the functionality

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11273939090)
