### PR TITLE
#13656: Deprecate support for mutating program after initial compilation on any device

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -210,9 +210,9 @@ bool test_compile_program_after_clean_kernel_binary_directory(Device *device) {
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
 
     ClearKernelCache(device->build_key());
-    program.invalidate_compile();
-    auto second_kernel_cache_status = CompileProgramTestWrapper(device, program);
-    assert_program_cache_hit_status(program, /*hit_expected=*/false, second_kernel_cache_status);
+    auto second_program = create_program(device, default_attributes);
+    auto second_kernel_cache_status = CompileProgramTestWrapper(device, second_program);
+    assert_program_cache_hit_status(second_program, /*hit_expected=*/false, second_kernel_cache_status);
     assert_kernel_hash_matches(kernel_name_to_hash, second_kernel_cache_status);
 
     return pass;

--- a/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
@@ -18,7 +18,7 @@ using namespace tt;
 
 namespace unit_tests::initialize_semaphores {
 
-void initialize_and_compile_program(tt_metal::Device *device, tt_metal::Program &program, const CoreRange &core_range) {
+void initialize_program(tt_metal::Device *device, tt_metal::Program &program, const CoreRange &core_range) {
     uint32_t single_tile_size = tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
     uint32_t num_tiles = 2048;
 
@@ -57,8 +57,6 @@ void initialize_and_compile_program(tt_metal::Device *device, tt_metal::Program 
         "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp",
         core_range,
         tt_metal::ComputeConfig{.compile_args = compute_kernel_args});
-
-    tt_metal::detail::CompileProgram(device, program);
 }
 
 void create_and_read_max_num_semaphores(
@@ -70,6 +68,8 @@ void create_and_read_max_num_semaphores(
         golden.push_back(initial_value);
         ASSERT_TRUE(semaphore_id == i);
     }
+
+    tt_metal::detail::CompileProgram(device, program);
 
     program.finalize();
 
@@ -106,7 +106,7 @@ TEST_F(DeviceFixture, InitializeLegalSemaphores) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         tt_metal::Program program = tt_metal::CreateProgram();
         CoreRange core_range({0, 0}, {1, 1});
-        unit_tests::initialize_semaphores::initialize_and_compile_program(devices_.at(id), program, core_range);
+        unit_tests::initialize_semaphores::initialize_program(devices_.at(id), program, core_range);
         unit_tests::initialize_semaphores::create_and_read_max_num_semaphores(devices_.at(id), program, core_range);
     }
 }
@@ -115,7 +115,7 @@ TEST_F(DeviceFixture, InitializeIllegalSemaphores) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         tt_metal::Program program = tt_metal::CreateProgram();
         CoreRange core_range({0, 0}, {1, 1});
-        unit_tests::initialize_semaphores::initialize_and_compile_program(devices_.at(id), program, core_range);
+        unit_tests::initialize_semaphores::initialize_program(devices_.at(id), program, core_range);
         unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(
             devices_.at(id), program, core_range);
     }

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -141,8 +141,6 @@ class Program {
 
     void compile(Device * device, bool fd_bootloader_mode = false);
 
-    void invalidate_compile();
-
     void invalidate_circular_buffer_allocation();
 
     void allocate_circular_buffers(const Device *device);
@@ -213,7 +211,7 @@ class Program {
     std::vector<Semaphore> semaphores_;
 
     CoreRangeSet worker_crs_;
-    std::unordered_map<chip_id_t, bool> compile_needed_;
+    std::unordered_set<chip_id_t> compiled_;
     bool local_circular_buffer_allocation_needed_;
 
     static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13656

### Problem description
We used to support mutating programs after initial compilation (adding kernels, cbs, sems) and would trigger a recompile if this was done. FD changes related to generating needed state/caching data is not regenerated in this case and would be stale, so support for this was now bugged. There doesn't seem to be any use cases for this so we decided to deprecate support for this instead of tracking a dirty flag to regenerate FD state.

### What's changed
Deprecate support for mutating programs after initial compilation. Assert out if user attempts to do so.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
