### PR TITLE
#12955: add support for closing tunnels independently

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2906,8 +2906,6 @@ bool Device::close() {
         }
     }
 
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);
     // After device close, no buffers on this device should be used

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -356,6 +356,9 @@ std::vector<Device*> DevicePool::get_all_active_devices() const {
 }
 
 bool DevicePool::close_device(chip_id_t device_id) {
+    // Sync and close one device
+    // Currently can only call this on mmio chips, once we split dispatch kernel shutdown
+    // from device close, we can call this on remote devices too
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
     bool pass = true;
     const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
@@ -371,13 +374,97 @@ bool DevicePool::close_device(chip_id_t device_id) {
     return pass;
 }
 
+void DevicePool::close_devices(std::vector<Device *> devices) {
+    // Sync and close all tunnels needed to support <devices>
+    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
+
+    // Ordered, because we need to shutdown tunnels from the farthest to the closest.
+    std::vector<chip_id_t> devices_to_close;
+
+    // Loop over all devices and add remote devices to devices_to_close
+    // For Galaxy if an mmio device's tunnels are being closed, close the mmio device as well
+    for (const auto dev : devices) {
+        const auto &mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
+        if (std::find(devices_to_close.begin(), devices_to_close.end(), dev->id()) == devices_to_close.end()) {
+            auto mmio_dev_handle = tt::DevicePool::instance().get_active_device(mmio_device_id);
+            auto tunnels_from_mmio = mmio_dev_handle->tunnels_from_mmio_;
+            //iterate over all tunnels origination from this mmio device
+            for (auto t : tunnels_from_mmio) {
+                //iterate over all tunneled devices (tunnel stops) in this tunnel
+                for (uint32_t ts = t.size() - 1; ts > 0; ts--) {
+                    if (t[ts] == dev->id()) {
+                        // found the target device to shutdown, add all devices in this tunnel
+                        for (uint32_t i = t.size() - 1; i > 0; i--) {
+                            devices_to_close.push_back(t[i]);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    // Loop over all devices and add any mmio devices
+    for (const auto dev : devices) {
+        if(dev->is_mmio_capable()) {
+            devices_to_close.push_back(dev->id());
+        }
+    }
+    // FIXME: ideally we can close mmio devices, and other active devices in the destructor of DevicePool.
+    // Was encountering issues with the dispatch_constants being destroyed before the DevicePool destructor,
+    // which leads to device->close() hitting asserts. We need to move the ownership of dispatch_constants
+    // to the device, so it doesn't go out of scope before the device is closed.
+    bool auto_close_mmio = is_galaxy;
+    // For Galaxy if an mmio device's tunnels are being closed, close the mmio device as well
+    if (is_galaxy) {
+        for (const auto dev : devices) {
+            bool auto_close_mmio = true;
+            const auto &mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
+            auto mmio_dev_handle = tt::DevicePool::instance().get_active_device(mmio_device_id);
+            auto tunnels_from_mmio = mmio_dev_handle->tunnels_from_mmio_;
+            //iterate over all tunnels origination from this mmio device
+            for (auto t : tunnels_from_mmio) {
+                //iterate over all tunneled devices (tunnel stops) in this tunnel
+                for (uint32_t ts = t.size() - 1; ts > 0; ts--) {
+                    // If the device is active and not in the list of devices to close, don't auto close mmio
+                    if (this->is_device_active(t[ts]) and std::find(devices_to_close.begin(), devices_to_close.end(), t[ts]) == devices_to_close.end()) {
+                        auto_close_mmio = false;
+                        break;
+                    }
+                }
+            }
+            if (auto_close_mmio and std::find(devices_to_close.begin(), devices_to_close.end(), mmio_device_id) == devices_to_close.end()) {
+                devices_to_close.push_back(mmio_device_id);
+            }
+        }
+    }
+
+    // Global Sync across all devices that are being closed
+    // We need to ensure that commands sent to each device have been completed
+    // before closing any device + modifying routing info.
+    // If this is not done, non-blocking CCLs followed by a close will hang, since
+    // the main thread will modify device state while the CCL is running on device.
+    for (const auto dev_id : devices_to_close) {
+        auto *dev = tt::DevicePool::instance().get_active_device(dev_id);
+        dev->synchronize(); // Synchronize worker queue
+        Synchronize(dev); // Synchronize device
+    }
+
+    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false, devices_to_close);
+    for (const auto dev_id : devices_to_close) {
+        auto *dev = tt::DevicePool::instance().get_active_device(dev_id);
+        dev->close();
+        // When a device is closed, its worker thread is joined. Stop tracking this
+        // worker thread.
+        this->unregister_worker_thread_for_device(this->devices[dev_id].get());
+    }
+}
+
 DevicePool::~DevicePool() {
     log_debug(tt::LogMetal, "DevicePool destructor");
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-
     for (const auto& dev : this->devices) {
         if (dev != nullptr and dev->is_initialized()) {
-            dev->close();
+            // See FIXME in close_devices
+            TT_FATAL(false, "Device {} was not closed before DevicePool destruction", dev->id());
         }
     }
     this->devices.clear();

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "tt_metal/host_api.hpp"
 #include "impl/debug/dprint_server.hpp"
 #include "impl/debug/noc_logging.hpp"
 #include "impl/debug/watcher_server.hpp"
@@ -35,6 +36,7 @@ class DevicePool {
     Device *get_active_device(chip_id_t device_id) const;
     std::vector<Device *> get_all_active_devices() const;
     bool close_device(chip_id_t device_id);
+    void close_devices(std::vector<Device *> devices);
     bool is_device_active(chip_id_t id) const;
     void register_worker_thread_for_device(Device* device, std::thread::id worker_thread_id);
     void unregister_worker_thread_for_device(Device* device);
@@ -61,6 +63,7 @@ class DevicePool {
     std::thread::id device_pool_creation_thread_id;
     bool skip_remote_devices;
     std::unordered_set<uint32_t> firmware_built_keys;
+
 
     // Determine which CPU cores the worker threads need to be placed on for each device
     std::unordered_map<uint32_t, uint32_t> device_to_core_map;

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -64,6 +64,7 @@ struct dispatch_constants {
         return *inst;
     }
 
+
     static constexpr uint8_t MAX_NUM_HW_CQS = 2;
     typedef uint16_t prefetch_q_entry_type;
     static constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -195,7 +195,8 @@ class Cluster {
     //       set_internal_routing_info_for_ethernet_cores(false);
     //       CloseDevice(0)
     //       CloseDevice(1)
-    void set_internal_routing_info_for_ethernet_cores(bool enable_internal_routing) const;
+    // If device_ids is not specified, all devices in the cluster will be toggled.
+    void set_internal_routing_info_for_ethernet_cores(bool enable_internal_routing, std::vector<chip_id_t> device_ids={}) const;
 
     // Returns MMIO device ID (logical) that controls given `device_id`. If `device_id` is MMIO device it is returned.
     chip_id_t get_associated_mmio_device(chip_id_t device_id) const {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -319,61 +319,11 @@ std::map<chip_id_t, Device *> CreateDevices(
 }
 
 void CloseDevices(std::map<chip_id_t, Device *> devices) {
-    // Global Sync across all devices in the pool.
-    // We need to ensure that commands sent to each device have been completed
-    // before closing any device + modifying routing info.
-    // If this is not done, non-blocking CCLs followed by a close will hang, since
-    // the main thread will modify device state while the CCL is running on device.
-    for (const auto &[device_id, dev] : devices) {
-        dev->synchronize(); // Synchronize worker queue
-        Synchronize(dev); // Synchronize device
+    std::vector<Device *> devices_to_close;
+    for (auto& [id, device] : devices) {
+        devices_to_close.push_back(device);
     }
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-    std::map<chip_id_t, Device *> mmio_devices = {};
-    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
-
-    if (is_galaxy) {
-        //On Galaxy, gateway wormhole devices (mmio devices) are not included in the set of devices
-        //created by CreateDevices(). So when closing devices, we need to find the corresponding
-        //gateway chips for all the tunneled devcies.
-        for (const auto &[device_id, dev] : devices) {
-            const auto &mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-            if (mmio_devices.find(mmio_device_id) == mmio_devices.end()) {
-                auto dev_handle = tt::DevicePool::instance().get_active_device(mmio_device_id);
-                mmio_devices.insert({mmio_device_id, dev_handle});
-            }
-        }
-    } else {
-        for (const auto &[device_id, dev] : devices) {
-            if(dev->is_mmio_capable()) {
-                mmio_devices.insert({device_id, dev});
-            }
-        }
-        for (const auto &[device_id, dev] : mmio_devices) {
-            devices.erase(device_id);
-        }
-    }
-
-    for (const auto &[device_id, dev] : mmio_devices) {
-        //For each mmio device, first close all the remote tunneled devices.
-        //Close the farthest tunneled device first.
-        auto tunnels_from_mmio = dev->tunnels_from_mmio_;
-        //iterate over all tunnels origination from this mmio device
-        for (auto t : tunnels_from_mmio) {
-            //iterate over all tunneled devices (tunnel stops) in this tunnel and close them.
-            for (uint32_t ts = t.size() - 1; ts > 0; ts--) {
-                if (devices.find(t[ts]) != devices.end()) {
-                    devices[t[ts]]->close();
-                    // When a device is closed, its worker thread is joined. Stop tracking this
-                    // worker thread.
-                    tt::DevicePool::instance().unregister_worker_thread_for_device(devices[t[ts]]);
-                }
-            }
-        }
-        //finally close the mmio device
-        dev->close();
-        tt::DevicePool::instance().unregister_worker_thread_for_device(dev);
-    }
+    tt::DevicePool::instance().close_devices(devices_to_close);
 }
 
 bool InWorkerThread() {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/commit/d118d0a66ddb6918e3a1aa594c83f92c7d318e0f)

### Problem description
Need support for closing individual tunnels in cluster.

### What's changed
Move CloseDevices functionality to DevicePool.
Updated Device to allow for `dev->close()` and `dev->initialize_and_launch_firmware()` to work.
Cleaned up `set_internal_routing_info_for_ethernet_cores`, change it to work for subset of devices.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
