### PR TITLE
#0: Fix PROFILER_LOGS_DIR import in sweeps

### DIFF
--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -9,7 +9,8 @@ import importlib
 import datetime
 import os
 import enlighten
-from tt_metal.tools.profiler.process_ops_logs import get_device_data_generate_report, PROFILER_LOGS_DIR
+from tt_metal.tools.profiler.process_ops_logs import get_device_data_generate_report
+from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR
 from multiprocessing import Process, Queue
 from queue import Empty
 import subprocess


### PR DESCRIPTION
### Ticket

### Problem description
Broken import from this PR: #13581 

### What's changed
Fixed the import in `runner.py` 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
