### PR TITLE
#0: Add 2 CQ Resnet 50 functional and trace tests

### DIFF
--- a/.github/workflows/tgg-frequent-tests-impl.yaml
+++ b/.github/workflows/tgg-frequent-tests-impl.yaml
@@ -36,7 +36,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run frequent regression tests
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME

--- a/models/demos/tgg/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/tgg/resnet50/tests/test_resnet50_performant.py
@@ -16,6 +16,72 @@ from models.demos.ttnn_resnet.tests.multi_device.resnet50_performant import (
 
 
 @run_for_wormhole_b0()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize(
+    "device_batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    ((8, 8),),
+    indirect=True,
+)
+def test_run_resnet50_2cqs_inference(
+    mesh_device,
+    use_program_cache,
+    device_batch_size,
+    act_dtype,
+    weight_dtype,
+    math_fidelity,
+    enable_async_mode,
+    model_location_generator,
+):
+    run_resnet50_2cqs_inference(
+        mesh_device,
+        device_batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        model_location_generator,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 800768, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "device_batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    ((8, 8),),
+    indirect=True,
+)
+def test_run_resnet50_trace_2cqs_inference(
+    mesh_device,
+    use_program_cache,
+    device_batch_size,
+    act_dtype,
+    weight_dtype,
+    math_fidelity,
+    enable_async_mode,
+    model_location_generator,
+):
+    run_resnet50_trace_2cqs_inference(
+        mesh_device,
+        device_batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        model_location_generator,
+    )
+
+
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",

--- a/tests/scripts/tgg/run_tgg_frequent_tests.sh
+++ b/tests/scripts/tgg/run_tgg_frequent_tests.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 run_tgg_tests() {
   # Add tests here
   echo "LOG_METAL: running run_tgg_frequent_tests"
-  pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_tgg.py --timeout=1500 ; fail+=$?
-  pytest -n auto models/demos/tgg/resnet50/tests/test_resnet50_performant.py --timeout=900 ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace_tgg.py --timeout=2000 ; fail+=$?
+  pytest -n auto models/demos/tgg/resnet50/tests/test_resnet50_performant.py --timeout=1800 ; fail+=$?
 
   if [[ $fail -ne 0 ]]; then
     echo "LOG_METAL: run_tgg_frequent_tests failed"

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -20,8 +20,8 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 8), id="8x8_grid")], indirect=True)
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("enable_multi_cq", [False])  # To be toggled when Galaxy supports Multi-CQ
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 60000}], indirect=True)
+@pytest.mark.parametrize("enable_multi_cq", [True, False])  # To be toggled when Galaxy supports Multi-CQ
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 60000, "num_command_queues": 2}], indirect=True)
 def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_multi_cq):
     if mesh_device.get_num_devices() < 64:
         pytest.skip("Test is only valid on TGG")
@@ -118,8 +118,8 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 8), id="8x8_grid")], indirect=True)
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("enable_multi_cq", [False])  # To be toggled when Galaxy supports Multi-CQ
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
+@pytest.mark.parametrize("enable_multi_cq", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000, "num_command_queues": 2}], indirect=True)
 def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi_cq):
     torch.manual_seed(0)
     if mesh_device.get_num_devices() < 64:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
2 CQ TGG Functional Tests are missing from CI.

### What's changed
Add 2 CQ Functional Resnet tests for TGG and 2 CQ Trace Unit tests. Perf tests staged in a separate PR.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
