### PR TITLE
#0: Update TG and TGG ResNet-50 Perf numbers reported in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 | [ResNet-50 (224x224)](./models/demos/wormhole/resnet50)                     | 16    | [n150](https://tenstorrent.com/hardware/wormhole)        | 4,100   | 7,000      |             |
 | [ResNet-50 (224x224) (DP=8)](./models/demos/t3000/resnet50)                 | 128   | [QuietBox](https://tenstorrent.com/hardware/tt-quietbox) | 32,250  | 56,000     |             |
 | [ResNet-50 (224x224) (DP=32)](./models/demos/tg/resnet50)                   | 512   | [Galaxy](https://tenstorrent.com/hardware/galaxy)        | 95,900  | 224,000    |             |
-| [ResNet-50 (224x224) (DP=64)](./models/demos/tgg/resnet50)                  | 1024  | [Two Galaxies](https://tenstorrent.com/hardware/galaxy)  | 128,800 | 448,000    |             |
+| [ResNet-50 (224x224) (DP=64)](./models/demos/tgg/resnet50)                  | 1024  | [Two Galaxies](https://tenstorrent.com/hardware/galaxy)  | 145,000 | 448,000    |             |
 | [ViT](./models/demos/grayskull/vit)                                         | 9     | [e150](https://tenstorrent.com/hardware/grayskull)       | 1,360   | 2,000      |             |
 | [ViT](./models/demos/wormhole/vit)                                          | 8     | [n150](https://tenstorrent.com/hardware/wormhole)        | 912     | 1,600      |             |
 | [Stable Diffusion 1.4 (512x512)](./models/demos/wormhole/stable_diffusion)  | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 0.167   | 0.3        |             |

--- a/models/demos/tg/resnet50/README.md
+++ b/models/demos/tg/resnet50/README.md
@@ -20,4 +20,4 @@ ResNet50 is a deep convolutional neural network architecture with 50 layers, des
   pytest models/demos/tg/resnet50/tests/test_perf_e2e_resnet.py::test_perf_trace`
 ```
 + This will generate a CSV with the timings and throughputs.
-+ **Expected end-to-end perf**: For batch = 16 per device, or batch 512 in total, it is about `66,150 fps` currently. This may vary machine to machine.
++ **Expected end-to-end perf**: For batch = 16 per device, or batch 512 in total, it is about `95,900 fps` currently. This may vary machine to machine.

--- a/models/demos/tgg/resnet50/README.md
+++ b/models/demos/tgg/resnet50/README.md
@@ -20,4 +20,4 @@ ResNet50 is a deep convolutional neural network architecture with 50 layers, des
   pytest models/demos/tgg/resnet50/tests/test_perf_e2e_resnet.py::test_perf_trace`
 ```
 + This will generate a CSV with the timings and throughputs.
-+ **Expected end-to-end perf**: For batch = 16 per device, or batch 1024 in total, it is about `122,800 fps` currently. This may vary machine to machine.
++ **Expected end-to-end perf**: For batch = 16 per device, or batch 1024 in total, it is about `145,000 fps` currently. This may vary machine to machine.


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Perf numbers reported in README files were outdated.

### What's changed
Update numbers to match latest state after runtime perf optimizations.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
