### PR TITLE
#11133: Add link to target workflow on GitHub Actions page

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -76,6 +76,8 @@ jobs:
           echo $attempt_number
           echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
           echo "attempt-number=$attempt_number" >> "$GITHUB_OUTPUT"
+
+          echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/tenstorrent/tt-metal/actions/runs/$run_id/attempts/$attempt_number"
       - name: Output auxiliary values
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Ticket

#11133

### Problem description

We have to manually form the URL to visit the CI page of the targeted workflow run if we want to see what ran.

### What's changed

We added a convenience annotation to show the link on the produce data workflow run.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
