### PR TITLE
#13690: Allow buffers to be allocated when a trace is live on device

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -153,7 +153,13 @@ TEST_F(SingleDeviceTraceFixture, EnqueueProgramTraceCapture) {
     uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     EnqueueProgram(command_queue, simple_program, false);
     EndTraceCapture(this->device_, command_queue.id(), tid);
-
+    // Create and Enqueue a Program with a live trace to ensure that a warning is generated
+    Buffer input_temp(this->device_, 2048, 2048, BufferType::DRAM);
+    Buffer output_temp(this->device_, 2048, 2048, BufferType::DRAM);
+    Program simple_program_temp = create_simple_unary_program(input_temp, output_temp);
+    EnqueueProgram(command_queue, simple_program_temp, true);
+    // Run trace that can clobber the temporary buffers created above
+    EnqueueProgram(command_queue, simple_program, false);
     EnqueueTrace(command_queue, tid, true);
     EnqueueReadBuffer(command_queue, output, trace_output_data.data(), true);
     EXPECT_TRUE(eager_output_data == trace_output_data);

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -101,9 +101,9 @@ DeviceAddr base_alloc(const AllocatorConfig & config, BankManager &bank_manager,
 
 DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, DeviceAddr page_size, const BufferType &buffer_type, bool bottom_up, std::optional<uint32_t> num_shards = std::nullopt);
 
-void disable_allocs(Allocator &allocator);
+void mark_allocations_unsafe(Allocator &allocator);
 
-void enable_allocs(Allocator &allocator);
+void mark_allocations_safe(Allocator &allocator);
 
 void deallocate_buffer(Allocator &allocator, DeviceAddr address, const BufferType &buffer_type);
 void deallocate_buffers(Allocator &allocator);
@@ -114,8 +114,9 @@ void clear(Allocator &allocatator);
 
 struct Allocator {
     Allocator(const AllocatorConfig &alloc_config, const allocator::AllocDescriptor &alloc_descriptor);
-
-    bool disabled_allocs = false;
+    // Set to true if allocating a buffer is unsafe. This happens when a live trace on device can corrupt
+    // memory allocated by the user (memory used by trace is not tracked in the allocator once the trace is captured).
+    bool allocations_unsafe = false;
     allocator::BankManager dram_manager;
     allocator::BankManager l1_manager;
     allocator::BankManager l1_small_manager;

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -336,8 +336,8 @@ class Device {
     bool distributed_dispatcher() const;
 
    private:
-    void DisableAllocs();
-    void EnableAllocs();
+    void MarkAllocationsUnsafe();
+    void MarkAllocationsSafe();
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
 };
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13690&source=gmail-imap&ust=1729178392000000&usg=AOvVaw3CoOyT-upWjw_QHuHrJlYs

### Problem description
  - Trace infra does not allow users to interleave traced and untraced workloads, even if the intermediates/outputs of the untraced workload are fully consumed before a trace is run
  - Untraced workloads will allocate memory on device. When a live trace exists, allocations are disabled -> assert out
  - Blocking vLLM effort, where model writers try to interleave untraced Prefill with traced Decode

### What's changed
  - Instead of asserting out, print a warning informing the user that mixing modes can can lead to data corruptions
  - Allows interleaving of traced and untraced workloads (this is safe as long as untraced outputs/intermediates are fully consumed before a trace is run)

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
