### PR TITLE
#0: Custom target metal_tests need not depend on programming_examples

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -60,7 +60,6 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests_frequent)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/perf_microbenchmark)
 
 add_custom_target(metal_tests DEPENDS
-    programming_examples
     ${METAL_TEST_TARGETS}
     unit_tests
     unit_tests_fast_dispatch


### PR DESCRIPTION
### Ticket
NA

### Problem description
We have logically separated programming_examples from tests
However there is a custom target for building all metal_tests that depends on programming_examples.

### What's changed
Removed artificial dependency

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
