### PR TITLE
#13127: Switch create_device_tensor to automatically figure out padding if only height and width are padded to nearest tile

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -705,7 +705,27 @@ Tensor create_device_tensor(
 
 Tensor create_device_tensor(
     const ttnn::Shape& shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
-    return create_device_tensor(shape.logical_shape(), shape.padded_shape(), data_type, layout, device, memory_config, tile);
+
+    if (layout == Layout::ROW_MAJOR) {
+        if (shape.has_tile_padding()) {
+            tt::log_debug("ttnn::Shape {} represents a row_major tensor with padding! Falling back to pass logical and padded shape to create_device_tensor.", shape);
+            return create_device_tensor(shape.logical_shape(), shape.padded_shape(), data_type, layout, device, memory_config, tile);
+        }
+    } else {
+        for (size_t dim = 0; dim < shape.rank(); dim++) {
+            if (dim < shape.rank() - 2) {
+                if (shape.has_tile_padding(dim)) {
+                    tt::log_debug("ttnn::Shape {} has padding along dims that are not height and width! Falling back to pass logical and padded shape to create_device_tensor.", shape);
+                    return create_device_tensor(shape.logical_shape(), shape.padded_shape(), data_type, layout, device, memory_config, tile);
+                }
+            } else if (shape.padded_shape()[dim] - shape.logical_shape()[dim] >= ttnn::TILE_SIZE) {
+                // NOTE: This also covers the case where logical dim 0 is padded up to 32
+                tt::log_debug("ttnn::Shape {} has padding along height or width that exceeds nearest tile! Falling back to pass logical and padded shape to create_device_tensor.", shape);
+                return create_device_tensor(shape.logical_shape(), shape.padded_shape(), data_type, layout, device, memory_config, tile);
+            }
+        }
+    }
+    return create_device_tensor(shape.logical_shape(), data_type, layout, device, memory_config, tile);
 }
 
 namespace detail {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Remove `LegacyShape`. This change makes all padding along height and width be automatic (with some exceptions) when creating device tensor.

### What's changed
Strip padding and call `create_device_tensor` with logical shape only if padding is only along height or width to nearest tile
    - Add warning for user when trying to create row_major layout device tensor with any padding
    - Add warning for user when trying to create tile layout device tensor with padding along non-height or width
    - Add warning for user when trying to create tile layout device tensor with padding along height or width that exceeds the nearest tile

### Checklist
- [x] Post commit CI passes (some exisiting failures with other pipelines)
  - [x] all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/11349681607
  - [ ] nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/11349700575
  - [ ] models demos: https://github.com/tenstorrent/tt-metal/actions/runs/11349686484
  - [ ] models perf: ~https://github.com/tenstorrent/tt-metal/actions/runs/11349691878~ https://github.com/tenstorrent/tt-metal/actions/runs/11352699288 (after switching to `log_debug`)
  - [ ] models device: https://github.com/tenstorrent/tt-metal/actions/runs/11349689052
  - [x] T3K frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11349694360
- [x] New/Existing tests provide coverage for changes
