### PR TITLE
#0: add initial implementation for new flow_control sender/receiver

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -3,6 +3,8 @@ set(UNIT_TESTS_COMMON_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/basic/test_device_init.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/common/test_bit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/common/test_dispatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/common/routing/test_queue_iterator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/common/routing/test_flow_control_host.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_flatten.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/matmul/test_matmul_large_block.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -36,6 +38,7 @@ target_include_directories(unit_tests_common_o PUBLIC
     ${PROJECT_SOURCE_DIR}/tt_metal
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
     ${PROJECT_SOURCE_DIR}/tt_metal/common
+    ${PROJECT_SOURCE_DIR}/tt_metal/common/routing
     ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}/common
 )

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/routing/test_flow_control_host.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/routing/test_flow_control_host.cpp
@@ -1,0 +1,615 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "tt_metal/impl/routing/flow_control/host_flow_control_sender.hpp"
+#include "tt_metal/impl/routing/flow_control/host_flow_control_receiver.hpp"
+
+//////////////////////////////
+// Flow Control Sender Tests
+//////////////////////////////
+TEST(FlowControlSenderHost, BasicCreditsSending_NonPowerOf2SizedQueue) {
+    size_t sender_local_wrptr = 0;
+    size_t sender_local_rdptr_ack = 0;
+    size_t sender_local_rdptr_completions = 0;
+
+    size_t sender_remote_wrptr = 0;
+    size_t sender_remote_rdptr_ack = 0;
+    size_t sender_remote_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcs = tt_metal::routing::flow_control::PacketizedHostFlowControlSender(
+        &sender_remote_wrptr,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &sender_local_wrptr, &sender_local_rdptr_ack, &sender_local_rdptr_completions, q_capacity));
+
+    ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+    ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+    ASSERT_EQ(fcs.get_num_outstanding_ack_credits(), 0);
+    ASSERT_EQ(fcs.local_has_free_credits(q_capacity), true);
+
+    for (size_t i = 0; i < q_capacity; i++) {
+        fcs.advance_write_credits(1);
+        fcs.send_credits();
+
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - i - 1);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - i - 1);
+        ASSERT_EQ(fcs.get_num_outstanding_ack_credits(), i + 1);
+        ASSERT_EQ(fcs.local_has_free_credits(q_capacity - i - 1), true);
+
+        ASSERT_EQ(sender_remote_wrptr, i + 1);
+    }
+    ASSERT_EQ(fcs.get_num_free_local_credits(), 0);
+    ASSERT_EQ(fcs.get_num_free_remote_credits(), 0);
+}
+
+// Test FCS pushing into an empty queue
+TEST(FlowControlSenderHost, BasicCreditsSending_PowerOf2SizedQueue) {
+    size_t sender_local_wrptr = 0;
+    size_t sender_local_rdptr_ack = 0;
+    size_t sender_local_rdptr_completions = 0;
+
+    size_t sender_remote_wrptr = 0;
+    size_t sender_remote_rdptr_ack = 0;
+    size_t sender_remote_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 8;
+    auto fcs = tt_metal::routing::flow_control::PacketizedHostFlowControlSender<q_capacity>(
+        &sender_remote_wrptr,
+        q_capacity,
+        RemoteQueuePtrManager<q_capacity>(
+            &sender_local_wrptr, &sender_local_rdptr_ack, &sender_local_rdptr_completions));
+
+    ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+    ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+    ASSERT_EQ(fcs.get_num_outstanding_ack_credits(), 0);
+    ASSERT_EQ(fcs.local_has_free_credits(q_capacity), true);
+
+    for (size_t i = 0; i < q_capacity; i++) {
+        fcs.advance_write_credits(1);
+        fcs.send_credits();
+
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - i - 1);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - i - 1);
+        ASSERT_EQ(fcs.get_num_outstanding_ack_credits(), i + 1);
+        ASSERT_EQ(fcs.local_has_free_credits(q_capacity - i - 1), true);
+
+        ASSERT_EQ(sender_remote_wrptr, i + 1);
+    }
+    ASSERT_EQ(fcs.get_num_free_local_credits(), 0);
+    ASSERT_EQ(fcs.get_num_free_remote_credits(), 0);
+}
+
+
+
+//////////////////////////////
+// Flow Control Receiver Tests
+//////////////////////////////
+
+// Test FCR APIs are correct for when data is "coming in"
+TEST(FlowControlReceiverHost, BasicAckAndCompletionCreditsSending_NonPowerOf2SizedQueue) {
+    size_t receiver_local_wrptr = 0;
+    size_t receiver_local_rdptr_ack = 0;
+    size_t receiver_local_rdptr_completions = 0;
+
+    size_t receiver_remote_wrptr = 0;
+    size_t receiver_remote_rdptr_ack = 0;
+    size_t receiver_remote_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &receiver_remote_rdptr_ack,
+        &receiver_remote_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &receiver_local_wrptr, &receiver_local_rdptr_ack, &receiver_local_rdptr_completions, q_capacity));
+
+    ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+    ASSERT_EQ(fcr.get_num_incompleted_credits(), 0);
+    ASSERT_EQ(fcr.local_has_unacknowledged_credits(), false);
+    ASSERT_EQ(fcr.local_has_incomplete_credits(), false);
+    ASSERT_EQ(fcr.local_has_data(), false);
+    ASSERT_EQ(fcr.local_has_free_credits(q_capacity), true);
+
+    for (size_t i = 0; i < q_capacity; i++) {
+        // "Signal" the flow control receiver that data is available
+        receiver_local_wrptr = i + 1;
+
+        ASSERT_EQ(fcr.local_has_data(), true);
+        ASSERT_EQ(fcr.local_has_free_credits(q_capacity - i - 1),  true);
+        ASSERT_EQ(fcr.local_has_free_credits(q_capacity - i),      false);
+
+        ASSERT_EQ(fcr.get_num_unacked_credits(), i + 1);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), i + 1);
+        ASSERT_EQ(fcr.local_has_unacknowledged_credits(), true);
+        ASSERT_EQ(fcr.local_has_incomplete_credits(), true);
+    }
+}
+
+// Test FCR APIs are correct for when data is "coming in"
+TEST(FlowControlReceiverHost, BasicAckAndCompletionCreditsSending_PowerOf2SizedQueue) {
+    size_t receiver_local_wrptr = 0;
+    size_t receiver_local_rdptr_ack = 0;
+    size_t receiver_local_rdptr_completions = 0;
+
+    size_t receiver_remote_wrptr = 0;
+    size_t receiver_remote_rdptr_ack = 0;
+    size_t receiver_remote_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 8;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &receiver_remote_rdptr_ack,
+        &receiver_remote_rdptr_completions,
+        RemoteQueuePtrManager<q_capacity>(
+            &receiver_local_wrptr, &receiver_local_rdptr_ack, &receiver_local_rdptr_completions));
+
+    ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+    ASSERT_EQ(fcr.get_num_incompleted_credits(), 0);
+    ASSERT_EQ(fcr.local_has_unacknowledged_credits(), false);
+    ASSERT_EQ(fcr.local_has_incomplete_credits(), false);
+    ASSERT_EQ(fcr.local_has_data(), false);
+    ASSERT_EQ(fcr.local_has_free_credits(q_capacity), true);
+
+    for (size_t i = 0; i < q_capacity; i++) {
+        // "Signal" the flow control receiver that data is available
+        receiver_local_wrptr = i + 1;
+
+        ASSERT_EQ(fcr.local_has_data(), true);
+        ASSERT_EQ(fcr.local_has_free_credits(q_capacity - i - 1),  true);
+        ASSERT_EQ(fcr.local_has_free_credits(q_capacity - i),      false);
+
+        ASSERT_EQ(fcr.get_num_unacked_credits(), i + 1);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), i + 1);
+        ASSERT_EQ(fcr.local_has_unacknowledged_credits(), true);
+        ASSERT_EQ(fcr.local_has_incomplete_credits(), true);
+    }
+}
+
+// Test FCR ack functionality in isolation
+// Test FCR APIs are correct for when data is "coming in"
+TEST(FlowControlReceiverHost, BasicDrainQueueAcksCreditsSending_PowerOf2SizedQueue) {
+    size_t receiver_local_wrptr = 0;
+    size_t receiver_local_rdptr_ack = 0;
+    size_t receiver_local_rdptr_completions = 0;
+
+    size_t receiver_remote_wrptr = 0;
+    size_t receiver_remote_rdptr_ack = 0;
+    size_t receiver_remote_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 8;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &receiver_remote_rdptr_ack,
+        &receiver_remote_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager<q_capacity>(
+            &receiver_local_wrptr, &receiver_local_rdptr_ack, &receiver_local_rdptr_completions, q_capacity));
+
+    receiver_local_wrptr = q_capacity;
+
+    // "Drain" the acks
+    for (size_t i = 0; i < q_capacity; i++) {
+        // "Signal" the flow control receiver that data is available
+        ASSERT_EQ(fcr.local_has_data(), true);
+
+        ASSERT_EQ(fcr.get_num_unacked_credits(), q_capacity - i);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), q_capacity);
+        ASSERT_EQ(fcr.local_has_unacknowledged_credits(), true);
+        ASSERT_EQ(fcr.local_has_incomplete_credits(), true);
+
+        fcr.advance_ack_credits(1);
+        fcr.send_ack_credits();
+    }
+    ASSERT_EQ(fcr.local_has_data(), true);
+
+    // Now "Drain" the completions
+    for (size_t i = 0; i < q_capacity; i++) {
+        ASSERT_EQ(fcr.local_has_data(), true);
+
+        ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), q_capacity - i);
+
+        ASSERT_EQ(fcr.local_has_unacknowledged_credits(), false);
+        ASSERT_EQ(fcr.local_has_incomplete_credits(), true);
+
+        fcr.advance_completion_credits(1);
+        fcr.send_completion_credits();
+    }
+
+    ASSERT_EQ(fcr.local_has_data(), false);
+}
+
+TEST(FlowControlReceiverHost, BasicDrainQueueAcksCreditsSending_NonPowerOf2SizedQueue_AllQueueStartOffsets) {
+    size_t receiver_local_wrptr = 0;
+    size_t receiver_local_rdptr_ack = 0;
+    size_t receiver_local_rdptr_completions = 0;
+
+    size_t receiver_remote_wrptr = 0;
+    size_t receiver_remote_rdptr_ack = 0;
+    size_t receiver_remote_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &receiver_remote_rdptr_ack,
+        &receiver_remote_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &receiver_local_wrptr, &receiver_local_rdptr_ack, &receiver_local_rdptr_completions, q_capacity));
+
+    for (size_t offset = 0; offset < q_capacity; offset++) {
+        auto start_offset = (offset + (offset * q_capacity)) % (2 * q_capacity);
+        if (offset > 0) {
+            receiver_local_wrptr = (receiver_local_wrptr + 1) % (2 * q_capacity);
+            // Start at the next offset into the queue
+            fcr.advance_ack_credits(1);
+            fcr.send_ack_credits();
+            fcr.advance_completion_credits(1);
+            fcr.send_completion_credits();
+        }
+
+        // fill the queue from this offset
+        receiver_local_wrptr = (start_offset + q_capacity) % (2 * q_capacity);
+
+        // "Drain" the acks
+        for (size_t i = 0; i < q_capacity; i++) {
+            // "Signal" the flow control receiver that data is available
+            ASSERT_EQ(fcr.local_has_data(), true);
+
+            ASSERT_EQ(fcr.get_num_unacked_credits(), q_capacity - i);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), q_capacity);
+            ASSERT_EQ(fcr.local_has_unacknowledged_credits(), true);
+            ASSERT_EQ(fcr.local_has_incomplete_credits(), true);
+
+            fcr.advance_ack_credits(1);
+            fcr.send_ack_credits();
+        }
+        ASSERT_EQ(fcr.local_has_data(), true);
+
+        // Now "Drain" the completions
+        for (size_t i = 0; i < q_capacity; i++) {
+            ASSERT_EQ(fcr.local_has_data(), true);
+
+            ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), q_capacity - i);
+
+            ASSERT_EQ(fcr.local_has_unacknowledged_credits(), false);
+            ASSERT_EQ(fcr.local_has_incomplete_credits(), true);
+
+            fcr.advance_completion_credits(1);
+            fcr.send_completion_credits();
+        }
+
+        ASSERT_EQ(fcr.local_has_data(), false);
+    }
+}
+
+
+
+/////////////////////////////////////////
+// Flow Control Sender + Receiver Tests
+/////////////////////////////////////////
+
+TEST(FlowControlSenderAndReceiverHost, BasicFillDrainSequence_FillOneDrainOne_LoopedOverAllOffsets) {
+    size_t receiver_wrptr = 0;
+    size_t receiver_rdptr_ack = 0;
+    size_t receiver_rdptr_completions = 0;
+
+    size_t sender_wrptr = 0;
+    size_t sender_rdptr_ack = 0;
+    size_t sender_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &sender_rdptr_ack,
+        &sender_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &receiver_wrptr, &receiver_rdptr_ack, &receiver_rdptr_completions, q_capacity));
+    auto fcs = tt_metal::routing::flow_control::PacketizedHostFlowControlSender(
+        &receiver_wrptr,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &sender_wrptr, &sender_rdptr_ack, &sender_rdptr_completions, q_capacity));
+
+    for (size_t offset = 0; offset < q_capacity; offset++) {
+        // Start at the next offset into the queue - checks here for sanity check
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+        ASSERT_EQ(fcr.local_has_data(), false);
+
+        fcs.advance_write_credits(1);
+        fcs.send_credits();
+        ASSERT_EQ(fcr.local_has_data(), true);
+        ASSERT_EQ(fcr.get_num_unacked_credits(), 1);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), 1);
+
+        fcr.advance_ack_credits(1);
+        fcr.advance_completion_credits(1);
+        fcr.send_ack_credits();
+        fcr.send_completion_credits();
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+
+
+        for (size_t i = 0; i < q_capacity; i++) {
+            ASSERT_EQ(fcr.local_has_data(), false);
+            fcs.advance_write_credits(1);
+            fcs.send_credits();
+            ASSERT_EQ(fcr.local_has_data(), true);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - 1);
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - 1);
+            ASSERT_EQ(fcr.get_num_unacked_credits(), 1);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), 1);
+
+            fcr.advance_ack_credits(1);
+            fcr.send_ack_credits();
+            ASSERT_EQ(fcr.local_has_data(), true);
+            ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), 1);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - 1);
+
+            fcr.advance_completion_credits(1);
+            fcr.send_completion_credits();
+            ASSERT_EQ(fcr.local_has_data(), false);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), 0);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+        }
+    }
+}
+
+TEST(FlowControlSenderAndReceiverHost, BasicFillDrainSequence_FillEntirelyThenAckEntirelyCompleteEntirely_LoopedOverAllOffsets) {
+    size_t receiver_wrptr = 0;
+    size_t receiver_rdptr_ack = 0;
+    size_t receiver_rdptr_completions = 0;
+
+    size_t sender_wrptr = 0;
+    size_t sender_rdptr_ack = 0;
+    size_t sender_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &sender_rdptr_ack,
+        &sender_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &receiver_wrptr, &receiver_rdptr_ack, &receiver_rdptr_completions, q_capacity));
+    auto fcs = tt_metal::routing::flow_control::PacketizedHostFlowControlSender(
+        &receiver_wrptr,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &sender_wrptr, &sender_rdptr_ack, &sender_rdptr_completions, q_capacity));
+
+    for (size_t offset = 0; offset < q_capacity; offset++) {
+        // Start at the next offset into the queue - checks here for sanity check
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+        ASSERT_EQ(fcr.local_has_data(), false);
+
+        fcs.advance_write_credits(1);
+        fcs.send_credits();
+        ASSERT_EQ(fcr.local_has_data(), true);
+        ASSERT_EQ(fcr.get_num_unacked_credits(), 1);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), 1);
+
+        fcr.advance_ack_credits(1);
+        fcr.advance_completion_credits(1);
+        fcr.send_ack_credits();
+        fcr.send_completion_credits();
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+
+
+        ASSERT_EQ(fcr.local_has_data(), false);
+        fcs.advance_write_credits(q_capacity);
+        fcs.send_credits();
+
+        ASSERT_EQ(fcr.local_has_data(), true);
+        ASSERT_EQ(fcs.get_num_free_local_credits(), 0);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), 0);
+        ASSERT_EQ(fcr.get_num_unacked_credits(), q_capacity);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), q_capacity);
+
+        fcr.advance_ack_credits(q_capacity);
+        fcr.send_ack_credits();
+        ASSERT_EQ(fcr.local_has_data(), true);
+        ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), 0);
+
+        fcr.advance_completion_credits(q_capacity);
+        fcr.send_completion_credits();
+        ASSERT_EQ(fcr.local_has_data(), false);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), 0);
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+    }
+}
+
+TEST(FlowControlSenderAndReceiverHost, BasicFillDrainSequence_FillAllPossibleContigSizesThenAckEntirelyCompleteEntirely_LoopedOverAllOffsets) {
+    size_t receiver_wrptr = 0;
+    size_t receiver_rdptr_ack = 0;
+    size_t receiver_rdptr_completions = 0;
+
+    size_t sender_wrptr = 0;
+    size_t sender_rdptr_ack = 0;
+    size_t sender_rdptr_completions = 0;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &sender_rdptr_ack,
+        &sender_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &receiver_wrptr, &receiver_rdptr_ack, &receiver_rdptr_completions, q_capacity));
+    auto fcs = tt_metal::routing::flow_control::PacketizedHostFlowControlSender(
+        &receiver_wrptr,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &sender_wrptr, &sender_rdptr_ack, &sender_rdptr_completions, q_capacity));
+
+    size_t sender_total_write_offset = 0;
+    size_t receiver_total_write_offset = 0;
+    size_t sender_total_ack_offset = 0;
+    size_t receiver_total_ack_offset = 0;
+    size_t sender_total_completion_offset = 0;
+    size_t receiver_total_completion_offset = 0;
+    for (size_t offset = 0; offset < q_capacity; offset++) {
+        // Start at the next offset into the queue - checks here for sanity check
+        ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+        ASSERT_EQ(fcr.local_has_data(), false);
+
+        for (size_t send_size = 1; send_size < q_capacity; send_size++) {
+            ASSERT_EQ(fcr.local_has_data(), false);
+            fcs.advance_write_credits(send_size);
+            sender_total_write_offset += send_size;
+            ASSERT_EQ(sender_total_write_offset % (2 * q_capacity), sender_wrptr);
+
+            fcs.send_credits();
+            receiver_total_write_offset += send_size;
+            ASSERT_EQ(receiver_total_write_offset % (2 * q_capacity), receiver_wrptr);
+
+            ASSERT_EQ(fcr.local_has_data(), true);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - send_size);
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - send_size);
+            ASSERT_EQ(fcr.get_num_unacked_credits(), send_size);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), send_size);
+
+            fcr.advance_ack_credits(send_size);
+            receiver_total_ack_offset += send_size;
+            ASSERT_EQ(receiver_total_ack_offset % (2 * q_capacity), receiver_rdptr_ack);
+
+            fcr.send_ack_credits();
+            sender_total_ack_offset += send_size;
+            ASSERT_EQ(sender_total_ack_offset % (2 * q_capacity), sender_rdptr_ack);
+            ASSERT_EQ(fcr.local_has_data(), true);
+            ASSERT_EQ(fcr.get_num_unacked_credits(), 0);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), send_size);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - send_size);
+
+            fcr.advance_completion_credits(send_size);
+            receiver_total_completion_offset += send_size;
+            ASSERT_EQ(receiver_total_completion_offset % (2 * q_capacity), receiver_rdptr_completions);
+            fcr.send_completion_credits();
+            sender_total_completion_offset += send_size;
+            ASSERT_EQ(sender_total_completion_offset % (2 * q_capacity), sender_rdptr_completions);
+            ASSERT_EQ(fcr.local_has_data(), false);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), 0);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity);
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity);
+        }
+    }
+}
+
+TEST(FlowControlSenderAndReceiverHost, BasicFillDrainSequence_SenderLeadsAcksBy3LeadsCompletionsBy3_LoopedOverAllOffsets) {
+    size_t receiver_wrptr = 0;
+    size_t receiver_rdptr_ack = 0;
+    size_t receiver_rdptr_completions = 0;
+
+    size_t sender_wrptr = 0;
+    size_t sender_rdptr_ack = 0;
+    size_t sender_rdptr_completions = 0;
+
+    size_t ack_delay = 3;
+    size_t completion_delay = 6;
+
+    static constexpr size_t q_capacity = 9;
+    auto fcr = tt_metal::routing::flow_control::PacketizedHostFlowControlReceiver(
+        &sender_rdptr_ack,
+        &sender_rdptr_completions,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &receiver_wrptr, &receiver_rdptr_ack, &receiver_rdptr_completions, q_capacity));
+    auto fcs = tt_metal::routing::flow_control::PacketizedHostFlowControlSender(
+        &receiver_wrptr,
+        q_capacity,
+        RemoteQueuePtrManager(
+            &sender_wrptr, &sender_rdptr_ack, &sender_rdptr_completions, q_capacity));
+
+    size_t sender_total_write_offset = 0;
+    size_t receiver_total_write_offset = 0;
+    size_t sender_total_ack_offset = 0;
+    size_t receiver_total_ack_offset = 0;
+    size_t sender_total_completion_offset = 0;
+    size_t receiver_total_completion_offset = 0;
+
+    size_t num_credits_to_send = 1000;
+    for (size_t c = 0; c < num_credits_to_send; c++) {
+        ASSERT_EQ(fcr.local_has_data(), c > 0);
+        fcs.advance_write_credits(1);
+        sender_total_write_offset += 1;
+        ASSERT_EQ(sender_total_write_offset % (2 * q_capacity), sender_wrptr);
+
+        fcs.send_credits();
+        receiver_total_write_offset += 1;
+        ASSERT_EQ(receiver_total_write_offset % (2 * q_capacity), receiver_wrptr);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), c >= completion_delay ? q_capacity - completion_delay - 1 : q_capacity - c - 1);
+        ASSERT_EQ(fcr.get_num_unacked_credits(), std::min(c+1,ack_delay + 1));
+
+        if (c >= ack_delay) {
+            fcr.advance_ack_credits(1);
+            receiver_total_ack_offset += 1;
+            ASSERT_EQ(receiver_total_ack_offset % (2 * q_capacity), receiver_rdptr_ack);
+
+            ASSERT_EQ(fcs.get_num_free_remote_credits(), c >= completion_delay ? q_capacity - completion_delay - 1 : q_capacity - c - 1);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - ack_delay - 1);
+            fcr.send_ack_credits();
+            sender_total_ack_offset += 1;
+            ASSERT_EQ(sender_total_ack_offset % (2 * q_capacity), sender_rdptr_ack);
+            ASSERT_EQ(fcr.local_has_data(), true);
+            ASSERT_EQ(fcr.get_num_unacked_credits(), ack_delay);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), std::min(c + 1, completion_delay + 1));
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - ack_delay);
+
+            if (c >= completion_delay) {
+                fcr.advance_completion_credits(1);
+                receiver_total_completion_offset += 1;
+                ASSERT_EQ(receiver_total_completion_offset % (2 * q_capacity), receiver_rdptr_completions);
+                fcr.send_completion_credits();
+                sender_total_completion_offset += 1;
+                ASSERT_EQ(sender_total_completion_offset % (2 * q_capacity), sender_rdptr_completions);
+                ASSERT_EQ(fcr.local_has_data(), true);
+                ASSERT_EQ(fcr.get_num_incompleted_credits(), completion_delay);
+                ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - completion_delay);
+            }
+        }
+        ASSERT_EQ(fcr.local_has_data(), true);
+    }
+
+    for (size_t c = 0; c < completion_delay; c++) {
+        if (c < ack_delay) {
+            fcr.advance_ack_credits(1);
+            receiver_total_ack_offset += 1;
+            ASSERT_EQ(receiver_total_ack_offset % (2 * q_capacity), receiver_rdptr_ack);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - (ack_delay - c));
+
+            fcr.send_ack_credits();
+            sender_total_ack_offset += 1;
+            ASSERT_EQ(sender_total_ack_offset % (2 * q_capacity), sender_rdptr_ack);
+            ASSERT_EQ(fcr.local_has_data(), true);
+            ASSERT_EQ(fcr.get_num_unacked_credits(), ack_delay - c - 1);
+            ASSERT_EQ(fcr.get_num_incompleted_credits(), completion_delay - c);
+            ASSERT_EQ(fcs.get_num_free_local_credits(), q_capacity - (ack_delay - c - 1));
+        }
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - (completion_delay - c));
+
+        fcr.advance_completion_credits(1);
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - (completion_delay - c));
+        receiver_total_completion_offset += 1;
+        ASSERT_EQ(receiver_total_completion_offset % (2 * q_capacity), receiver_rdptr_completions);
+
+        fcr.send_completion_credits();
+        sender_total_completion_offset += 1;
+        ASSERT_EQ(fcs.get_num_free_remote_credits(), q_capacity - (completion_delay - c - 1));
+        ASSERT_EQ(sender_total_completion_offset % (2 * q_capacity), sender_rdptr_completions);
+        ASSERT_EQ(fcr.local_has_data(), c != completion_delay - 1);
+        ASSERT_EQ(fcr.get_num_incompleted_credits(), completion_delay - c - 1);
+
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/routing/test_queue_iterator.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/routing/test_queue_iterator.cpp
@@ -1,0 +1,424 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "tt_metal/impl/routing/flow_control/queue_iterator.hpp"
+
+TEST(QueueIteratorAPI, Construction_NonConstexprQueueSize) {
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    for (size_t q_size = 1; q_size < 100; q_size++) {
+        auto qptrs = RemoteQueuePtrManager(&wrptr, &rdptr_ack, &rdptr_completions, q_size);
+
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+        ASSERT_EQ(qptrs.get_wrptr(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    }
+}
+
+TEST(QueueIteratorAPI, Construction_ConstexprQueueSizes_NonPowerOf2) {
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    {
+        constexpr size_t q_size = 1;
+        auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+        ASSERT_EQ(qptrs.get_wrptr(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    }
+    {
+        constexpr size_t q_size = 3;
+        auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+        ASSERT_EQ(qptrs.get_wrptr(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    }
+    {
+        constexpr size_t q_size = 5;
+        auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+        ASSERT_EQ(qptrs.get_wrptr(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    }
+    {
+        constexpr size_t q_size = 6;
+        auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+        ASSERT_EQ(qptrs.get_wrptr(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    }
+    {
+        constexpr size_t q_size = 1023;
+        auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+        ASSERT_EQ(qptrs.get_wrptr(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    }
+}
+
+template <size_t q_size>
+void test_qptrs() {
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+    ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+    ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+    ASSERT_EQ(qptrs.get_num_credits_incomplete(), 0);
+    ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+    ASSERT_EQ(qptrs.get_wrptr(), 0);
+    ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+    ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+    ASSERT_EQ(qptrs.get_queue_size(), q_size);
+};
+TEST(QueueIteratorAPI, Construction_ConstexprQueueSizes_PowerOf2) {
+    test_qptrs<2>();
+    test_qptrs<4>();
+    test_qptrs<8>();
+    test_qptrs<16>();
+    test_qptrs<32>();
+    test_qptrs<64>();
+    test_qptrs<128>();
+    test_qptrs<1024>();
+}
+
+TEST(QueueIteratorAPI, QueueFill_OneAtATime_PowerOf2) {
+    constexpr size_t q_size = 8;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+    for (size_t i = 0; i < q_size; i++) {
+        ASSERT_EQ(qptrs.get_wrptr(), i);
+        qptrs.advance_write_credits(1);
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size - (i + 1));
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size - (i + 1));
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), i + 1);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), i + 1);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+    }
+    ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    // check wrap-around
+    ASSERT_EQ(qptrs.get_wrptr(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), 0);
+}
+
+TEST(QueueIteratorAPI, QueueFill_OneAtATime_NonPowerOf2) {
+    constexpr size_t q_size = 9;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager(&wrptr, &rdptr_ack, &rdptr_completions, q_size);
+
+    for (size_t i = 0; i < q_size; i++) {
+        ASSERT_EQ(qptrs.get_wrptr(), i);
+        qptrs.advance_write_credits(1);
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size - (i + 1));
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size - (i + 1));
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), i + 1);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), i + 1);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+    }
+    ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    // check wrap-around
+    ASSERT_EQ(qptrs.get_wrptr(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), 0);
+}
+
+TEST(QueueIteratorAPI, QueueFill_MultipleAtATime_PowerOf2) {
+    constexpr size_t q_size = 8;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+    for (size_t i = 0; i < q_size; i += 3) {
+        ASSERT_EQ(qptrs.get_wrptr(), i);
+        auto n = std::min<size_t>(3, q_size - i);
+        auto end = i + n;
+        qptrs.advance_write_credits(n);
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size - end);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size - end);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), end);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), end);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+    }
+    ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    // check wrap-around
+    ASSERT_EQ(qptrs.get_wrptr(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), 0);
+}
+
+TEST(QueueIteratorAPI, QueueFill_MultipleAtATime_NonPowerOf2) {
+    constexpr size_t q_size = 9;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager(&wrptr, &rdptr_ack, &rdptr_completions, q_size);
+
+    for (size_t i = 0; i < q_size; i += 3) {
+        ASSERT_EQ(qptrs.get_wrptr(), i);
+        auto n = std::min<size_t>(3, q_size - i);
+        auto end = i + n;
+        qptrs.advance_write_credits(n);
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size - end);
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size - end);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), end);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), end);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+    }
+    ASSERT_EQ(qptrs.get_queue_size(), q_size);
+    // check wrap-around
+    ASSERT_EQ(qptrs.get_wrptr(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), 0);
+}
+
+TEST(QueueIteratorAPI, QueueDrain_OneAtATime_PowerOf2) {
+    constexpr size_t q_size = 8;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+    for (size_t i = 0; i < q_size; i++) {
+        qptrs.advance_write_credits(1);
+    }
+
+    // "Drain" the acks
+    for (size_t i = 0; i < q_size; i++) {
+        ASSERT_EQ(qptrs.get_local_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        qptrs.advance_read_ack_credits(1);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+    ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+
+    // "Drain" the completions
+    for (size_t i = 0; i < q_size; i++) {
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        qptrs.advance_read_completion_credits(1);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+}
+
+TEST(QueueIteratorAPI, QueueDrain_OneAtATime_NonPowerOf2) {
+    constexpr size_t q_size = 9;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager(&wrptr, &rdptr_ack, &rdptr_completions, q_size);
+
+    for (size_t i = 0; i < q_size; i++) {
+        qptrs.advance_write_credits(1);
+    }
+
+    // "Drain" the acks
+    for (size_t i = 0; i < q_size; i++) {
+        ASSERT_EQ(qptrs.get_local_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        qptrs.advance_read_ack_credits(1);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+    ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+
+    // "Drain" the completions
+    for (size_t i = 0; i < q_size; i++) {
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        qptrs.advance_read_completion_credits(1);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+}
+
+TEST(QueueIteratorAPI, QueueDrain_MultipleAtATime_PowerOf2) {
+    constexpr size_t q_size = 8;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+    for (size_t i = 0; i < q_size; i++) {
+        qptrs.advance_write_credits(1);
+    }
+
+    constexpr size_t drain_rate = 3;
+    // "Drain" the acks
+    for (size_t i = 0; i < q_size; i += drain_rate) {
+        auto num_to_ack = std::min(drain_rate, q_size - i);
+        ASSERT_EQ(qptrs.get_local_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        qptrs.advance_read_ack_credits(num_to_ack);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+    ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+
+    // "Drain" the completions
+    for (size_t i = 0; i < q_size; i += drain_rate) {
+        auto num_to_complete = std::min(drain_rate, q_size - i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        qptrs.advance_read_completion_credits(num_to_complete);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+}
+
+TEST(QueueIteratorAPI, QueueDrain_MultipleAtATime_NonPowerOf2) {
+    constexpr size_t q_size = 9;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager(&wrptr, &rdptr_ack, &rdptr_completions, q_size);
+
+    for (size_t i = 0; i < q_size; i++) {
+        qptrs.advance_write_credits(1);
+    }
+
+    constexpr size_t drain_rate = 3;
+    // "Drain" the acks
+    for (size_t i = 0; i < q_size; i += drain_rate) {
+        auto num_to_ack = std::min(drain_rate, q_size - i);
+        ASSERT_EQ(qptrs.get_local_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_acks(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), 0);
+        qptrs.advance_read_ack_credits(num_to_ack);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+    ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+    ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+
+    // "Drain" the completions
+    for (size_t i = 0; i < q_size; i += drain_rate) {
+        auto num_to_complete = std::min(drain_rate, q_size - i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        ASSERT_EQ(qptrs.get_num_credits_incomplete(), q_size - i);
+        ASSERT_EQ(qptrs.get_rdptr_completions(), i);
+        ASSERT_EQ(qptrs.get_remote_space_available(), i);
+        qptrs.advance_read_completion_credits(num_to_complete);
+    }
+    ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+}
+
+
+TEST(QueueIteratorAPI, QueueDrain_OneAtATime_PowerOf2_CyclingThroughQueue) {
+    constexpr size_t q_size = 8;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager<q_size>(&wrptr, &rdptr_ack, &rdptr_completions);
+
+    for (size_t start_wrptr = 0; start_wrptr < 2 * q_size; start_wrptr++) {
+
+        for (size_t i = 0; i < q_size; i++) {
+            qptrs.advance_write_credits(1);
+        }
+
+        // "Drain" the acks
+        for (size_t i = 0; i < q_size; i++) {
+            ASSERT_EQ(qptrs.get_local_space_available(), i);
+            ASSERT_EQ(qptrs.get_num_unacked_credits(), q_size - i);
+            ASSERT_EQ(qptrs.get_rdptr_acks(), (start_wrptr + i) % q_size);
+            ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+            ASSERT_EQ(qptrs.get_rdptr_completions(), start_wrptr % q_size);
+            qptrs.advance_read_ack_credits(1);
+        }
+        ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+
+        // "Drain" the completions
+        for (size_t i = 0; i < q_size; i++) {
+            ASSERT_EQ(qptrs.get_remote_space_available(), i);
+            ASSERT_EQ(qptrs.get_num_credits_incomplete(), q_size - i);
+            ASSERT_EQ(qptrs.get_rdptr_completions(), (start_wrptr + i) % q_size);
+            ASSERT_EQ(qptrs.get_remote_space_available(), i);
+            qptrs.advance_read_completion_credits(1);
+        }
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+
+        // Advance the wrptr to the next logical start_wrptr and make sure the queue is empty
+        qptrs.advance_write_credits(1);
+        qptrs.advance_read_ack_credits(1);
+        qptrs.advance_read_completion_credits(1);
+    }
+}
+
+TEST(QueueIteratorAPI, QueueDrain_OneAtATime_NonPowerOf2_CyclingThroughQueue) {
+    constexpr size_t q_size = 9;
+    size_t wrptr, rdptr_ack, rdptr_completions;
+    auto qptrs = RemoteQueuePtrManager(&wrptr, &rdptr_ack, &rdptr_completions, q_size);
+    for (size_t start_wrptr = 0; start_wrptr < 2 * q_size; start_wrptr++) {
+        for (size_t i = 0; i < q_size; i++) {
+            qptrs.advance_write_credits(1);
+        }
+
+        // "Drain" the acks
+        for (size_t i = 0; i < q_size; i++) {
+            ASSERT_EQ(qptrs.get_local_space_available(), i);
+            ASSERT_EQ(qptrs.get_num_unacked_credits(), q_size - i);
+            ASSERT_EQ(qptrs.get_rdptr_acks(), (start_wrptr + i) % q_size);
+            ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+            ASSERT_EQ(qptrs.get_rdptr_completions(), start_wrptr % q_size);
+            qptrs.advance_read_ack_credits(1);
+        }
+        ASSERT_EQ(qptrs.get_remote_space_available(), 0);
+        ASSERT_EQ(qptrs.get_local_space_available(), q_size);
+        ASSERT_EQ(qptrs.get_num_unacked_credits(), 0);
+
+        // "Drain" the completions
+        for (size_t i = 0; i < q_size; i++) {
+            ASSERT_EQ(qptrs.get_remote_space_available(), i);
+            ASSERT_EQ(qptrs.get_num_credits_incomplete(), q_size - i);
+            ASSERT_EQ(qptrs.get_rdptr_completions(), (start_wrptr + i) % q_size);
+            ASSERT_EQ(qptrs.get_remote_space_available(), i);
+            qptrs.advance_read_completion_credits(1);
+        }
+        ASSERT_EQ(qptrs.get_remote_space_available(), q_size);
+
+        // Advance the wrptr to the next logical start_wrptr and make sure the queue is empty
+        qptrs.advance_write_credits(1);
+        qptrs.advance_read_ack_credits(1);
+        qptrs.advance_read_completion_credits(1);
+    }
+}

--- a/tt_metal/impl/routing/flow_control/flow_control_enums.hpp
+++ b/tt_metal/impl/routing/flow_control/flow_control_enums.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+
+namespace tt_metal {
+
+namespace routing {
+enum class TransportMedium : uint8_t {
+    NOC,
+    ETHERNET,
+
+    // For testing in shared memory environment (e.g. basic host unit tests)
+    SHARED_MEM,
+};
+
+enum class PayloadMode : uint8_t {
+    // Header is included with the payload
+    PACKETIZED,
+
+    // No header, just raw data
+    PAGED
+};
+
+enum class RemoteCoreLocality : uint8_t {
+    LOCAL_CHIP,
+    REMOTE_CHIP
+};
+
+
+// Can we piggy back of another enum here instead of creating a new one?
+enum class RemoteCoreType : uint8_t {
+    WORKER,
+    ETHERNET,
+    DRAM
+};
+
+
+
+using l1_address_t = uint32_t;
+using noc_address_t = uint32_t;
+
+
+// TODO: split these off into separate headers for the separate use cases
+template <TransportMedium transport_medium> struct remote_payload_addr_t { using type = nullptr_t; };
+
+using host_address_t = uint64_t;
+// Host mem
+template <> struct remote_payload_addr_t<TransportMedium::SHARED_MEM> { using type = host_address_t; };
+template <> struct remote_payload_addr_t<TransportMedium::NOC> { using type = noc_address_t; };
+template <> struct remote_payload_addr_t<TransportMedium::ETHERNET> { using type = l1_address_t; };
+
+} // namespace routing
+} // namespace tt_metal

--- a/tt_metal/impl/routing/flow_control/flow_control_receiver.hpp
+++ b/tt_metal/impl/routing/flow_control/flow_control_receiver.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/impl/routing/flow_control/queue_iterator.hpp"
+
+#include <cstddef>
+
+template <class FlowControlReceiverImpl, size_t q_capacity = 0>
+struct FlowControlReceiver : public RemoteQueuePtrManagerFriend {
+    FlowControlReceiver(RemoteQueuePtrManager<q_capacity> const& q_ptrs) : RemoteQueuePtrManagerFriend(), q_ptrs(q_ptrs) {}
+
+    /*
+     * returns the number of credits available (i.e. the amount of space (indirectly) available to send to
+     * the downstream queue)
+     * Depending on the flow control mode (paged, packeted), this number represents different sizes
+     * 1 credit = 1 page in paged mode, 1 word (currently 16B) in packet mode
+     */
+    size_t get_num_unacked_credits() const { return q_ptrs.get_num_unacked_credits(); }
+
+    /*
+     * return the number of credit slots ahead is the wrptr of the rdptr completions pointer
+     */
+    size_t get_num_incompleted_credits() const { return q_ptrs.get_num_credits_incomplete(); }
+
+    /*
+     * returns true if any received credits were not acknowledged
+     */
+    bool local_has_unacknowledged_credits() const { return get_num_unacked_credits() > 0; }
+
+    /*
+     * returns true if any received credits were not completed
+     */
+    bool local_has_incomplete_credits() const { return get_num_incompleted_credits() > 0; }
+
+    /*
+     * returns true if there is any uncleared data locally
+     */
+    bool local_has_data() const { return get_num_incompleted_credits() > 0; }
+
+    /*
+     * returns true if this receiver has n credits worth of space available
+     */
+    bool local_has_free_credits(size_t n) { return q_ptrs.get_local_space_available() >= n; }
+
+
+    /*
+     * Sends the rdptr ack credits to the remote sender
+     */
+    void send_ack_credits() { static_cast<FlowControlReceiverImpl *>(this)->send_ack_credits_impl(*this->get_rdptr_acks_raw(q_ptrs)); }
+
+    /*
+     * Sends the rdptr completion credits to the remote sender
+     */
+    void send_completion_credits() { static_cast<FlowControlReceiverImpl *>(this)->send_completion_credits_impl(*this->get_rdptr_completions_raw(q_ptrs)); }
+
+    /*
+     * Advances the local rdptr_ack by n credits - call to acknowledge (to sender) the receipt of n credits (from sender)
+     * Does NOT send the credits
+     */
+    void advance_ack_credits(size_t n) { q_ptrs.advance_read_ack_credits(n); }
+
+    /*
+     * Advances the local rdptr_completions by n credits - call to notify (to sender) the clearing of n credits in our local buffer,
+     * indicating that sender can safely overwrite those n credits worth of buffering at any time.
+     * Does NOT send the credits
+     */
+    void advance_completion_credits(size_t n) { q_ptrs.advance_read_completion_credits(n); }
+
+   private:
+    RemoteQueuePtrManager<q_capacity> q_ptrs;
+};

--- a/tt_metal/impl/routing/flow_control/flow_control_sender.hpp
+++ b/tt_metal/impl/routing/flow_control/flow_control_sender.hpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/impl/routing/flow_control/queue_iterator.hpp"
+
+#include <cstddef>
+
+namespace tt_metal {
+namespace routing {
+namespace flow_control {
+
+/*
+ * Can this be shared between sender and receiver????
+ */
+template <class FlowControlSenderImpl, size_t q_capacity = 0>
+struct FlowControlSender : public RemoteQueuePtrManagerFriend {
+    FlowControlSender(RemoteQueuePtrManager<q_capacity> const& q_ptrs) : RemoteQueuePtrManagerFriend(), q_ptrs(q_ptrs) {}
+
+    /*
+     * returns the number of credits available (i.e. the amount of space (indirectly) available to send to
+     * the downstream queue)
+     * Depending on the flow control mode (paged, packeted), this number represents different sizes
+     * 1 credit = 1 page in paged mode, 1 word (currently 16B) in packet mode
+     */
+    size_t get_num_free_local_credits() const {
+        return q_ptrs.get_local_space_available();
+    }
+
+    /*
+     * returns the number of credits available on the remote receiver. This will be the queue size minus the distance
+     * ahead that wrptr is of the rdptr completions
+     */
+    size_t get_num_free_remote_credits() const {
+        return q_ptrs.get_remote_space_available();
+    }
+
+    /*
+     * returns the number of credits that we are waiting for in order to consider all past
+     * transfers as complete to the first level ack
+     */
+    size_t get_num_outstanding_ack_credits() const {
+        return q_ptrs.get_num_unacked_credits();
+    }
+
+    /*
+     * Does the local queue have n credits worth of available buffering?
+     */
+    bool local_has_free_credits(size_t n) {
+        return  q_ptrs.get_local_space_available() >= n;
+    }
+    /*
+     * Does the remote queue have n credits worth of available buffering?
+     */
+    bool remote_has_free_credits(size_t n) {
+        return q_ptrs.get_remote_space_available() >= n;
+    }
+
+    /*
+     * For sender side, this indicates we have sent some payload to the consumer and we want to notify them
+     * of the number of credits consumed by that payload
+     * Locally this will be a decrement but remotely it will be an increment1
+     * DOES NOT SEND CREDITS
+     */
+    void advance_write_credits(size_t n) {
+        q_ptrs.advance_write_credits(n);
+    }
+
+    /*
+     * implements the credit sending mechanics to the remote chip
+     */
+    void send_credits() {
+        static_cast<FlowControlSenderImpl*>(this)->send_credits_impl(*this->get_wrptr_raw(q_ptrs));
+    }
+
+    /*
+     * After receiving (ack) credits from remote receiver, increment our local (ack) credits
+     * This impl is if there is no remote updater - perhaps we can spin this out as another variant
+     * of the FCS to be local and remote updater
+     */
+    void advance_ack_credits(size_t n) {
+        q_ptrs.advance_read_ack_credits(n);
+    }
+
+    /*
+     * After receiving (completion) credits from remote receiver, increment our local (completion) credits
+     */
+    void advance_completion_credits(size_t n) {
+        q_ptrs.advance_read_completion_credits(n);
+    }
+
+    private:
+    RemoteQueuePtrManager<q_capacity> q_ptrs;
+};
+
+
+} // namespace flow_control
+}  // namespace routing
+} // namespace tt_metal

--- a/tt_metal/impl/routing/flow_control/host_flow_control_receiver.hpp
+++ b/tt_metal/impl/routing/flow_control/host_flow_control_receiver.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/impl/routing/flow_control/flow_control_receiver.hpp"
+#include "tt_metal/impl/routing/flow_control/queue_iterator.hpp"
+
+namespace tt_metal {
+namespace routing {
+namespace flow_control {
+
+template <size_t q_capacity = 0>
+struct PacketizedHostFlowControlReceiver
+    : public FlowControlReceiver<PacketizedHostFlowControlReceiver<q_capacity>, q_capacity> {
+    PacketizedHostFlowControlReceiver(
+        size_t *remote_rdptr_ack_address,
+        size_t *remote_rdptr_complete_address,
+        RemoteQueuePtrManager<q_capacity> const &q_ptrs) :
+        FlowControlReceiver<PacketizedHostFlowControlReceiver<q_capacity>, q_capacity>(q_ptrs),
+        remote_rdptr_ack_address(remote_rdptr_ack_address),
+        remote_rdptr_complete_address(remote_rdptr_complete_address) {}
+
+    PacketizedHostFlowControlReceiver(
+        size_t *remote_rdptr_ack_address,
+        size_t *remote_rdptr_complete_address,
+        size_t q_size,
+        RemoteQueuePtrManager<q_capacity> const &q_ptrs) :
+        FlowControlReceiver<PacketizedHostFlowControlReceiver<q_capacity>, q_capacity>(q_ptrs),
+        remote_rdptr_ack_address(remote_rdptr_ack_address),
+        remote_rdptr_complete_address(remote_rdptr_complete_address) {}
+
+    // implements the credit sending mechanics
+    void send_ack_credits_impl(size_t rdptr_ack) {
+        reinterpret_cast<volatile size_t *>(remote_rdptr_ack_address)[0] = rdptr_ack;
+    }
+
+    void send_completion_credits_impl(size_t rdptr_complete) {
+        reinterpret_cast<volatile size_t *>(remote_rdptr_complete_address)[0] = rdptr_complete;
+    }
+
+    size_t *remote_rdptr_ack_address;
+    size_t *remote_rdptr_complete_address;
+};
+
+}  // namespace flow_control
+}  // namespace routing
+}  // namespace tt_metal

--- a/tt_metal/impl/routing/flow_control/host_flow_control_sender.hpp
+++ b/tt_metal/impl/routing/flow_control/host_flow_control_sender.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/impl/routing/flow_control/flow_control_sender.hpp"
+#include "tt_metal/impl/routing/flow_control/queue_iterator.hpp"
+
+namespace tt_metal {
+namespace routing {
+namespace flow_control {
+
+template <size_t q_capacity = 0>
+struct PacketizedHostFlowControlSender
+    : public FlowControlSender<PacketizedHostFlowControlSender<q_capacity>, q_capacity> {
+    PacketizedHostFlowControlSender(size_t *remote_wrptr_address, RemoteQueuePtrManager<q_capacity> const &q_ptrs) :
+        FlowControlSender<PacketizedHostFlowControlSender<q_capacity>, q_capacity>(q_ptrs),
+        remote_wrptr_address(remote_wrptr_address) {}
+
+    PacketizedHostFlowControlSender(
+        size_t *remote_wrptr_address, size_t q_size, RemoteQueuePtrManager<q_capacity> const &q_ptrs) :
+        FlowControlSender<PacketizedHostFlowControlSender<q_capacity>, q_capacity>(q_ptrs),
+        remote_wrptr_address(remote_wrptr_address) {}
+
+    // implements the credit sending mechanics
+    void send_credits_impl(size_t wrptr) { reinterpret_cast<volatile size_t *>(remote_wrptr_address)[0] = wrptr; }
+
+    size_t *remote_wrptr_address;
+};
+
+}  // namespace flow_control
+}  // namespace routing
+}  // namespace tt_metal

--- a/tt_metal/impl/routing/flow_control/queue_iterator.hpp
+++ b/tt_metal/impl/routing/flow_control/queue_iterator.hpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+
+// Forward declaration;
+struct RemoteQueuePtrManagerFriend;
+
+template <size_t const_queue_size = 0>
+struct RemoteQueuePtrManager {
+    friend struct RemoteQueuePtrManagerFriend;
+
+    constexpr RemoteQueuePtrManager(
+        size_t* wrptr_ptr, size_t* rdptr_ack_ptr, size_t* rdptr_completions_ptr, size_t queue_size) :
+        size(queue_size), wrptr(wrptr_ptr), rdptr_acks(rdptr_ack_ptr), rdptr_completions(rdptr_completions_ptr) {
+        *wrptr = 0;
+        *rdptr_acks = 0;
+        *rdptr_completions = 0;
+    }
+
+    constexpr RemoteQueuePtrManager(size_t* wrptr_ptr, size_t* rdptr_ack_ptr, size_t* rdptr_completions_ptr) :
+        size(const_queue_size), wrptr(wrptr_ptr), rdptr_acks(rdptr_ack_ptr), rdptr_completions(rdptr_completions_ptr) {
+        *wrptr = 0;
+        *rdptr_acks = 0;
+        *rdptr_completions = 0;
+    }
+
+    /*
+     * Updates the local copy of the write pointer by advancing by n credits. Does NOT send any credits to the remote endpoint
+     * Only makes sense to call as a sender endpoint
+     */
+    void advance_write_credits(size_t n) { ptr_advance_impl(this->wrptr, n, this->size); }
+
+    /*
+     * Updates the local copy of the read ack pointer by advancing by n credits. Does NOT send any credits to the remote endpoint
+     * Only makes sense to call as a receiver endpoint
+     */
+    void advance_read_ack_credits(size_t n) { ptr_advance_impl(this->rdptr_acks, n, this->size); }
+
+    /*
+     * Updates the local copy of the read completions pointer by advancing by n credits. Does NOT send any credits to the remote endpoint
+     * Only makes sense to call as a receiver endpoint
+     */
+    void advance_read_completion_credits(size_t n) { ptr_advance_impl(this->rdptr_completions, n, this->size); }
+
+    /*
+     * Returns the number of credits that the rdptr_completions is behind the wrptr
+     */
+    size_t get_num_credits_incomplete() const {
+        auto wrptr_cached = get(this->wrptr);
+        auto rdptr_completions_cached = get(this->rdptr_completions);
+        if constexpr (is_power_of_2(const_queue_size)) {
+            return (wrptr_cached - rdptr_completions_cached) & pow2_full_q_mask;
+        } else {
+            // default impl - we can probably do better than this but this isn't our use case today
+            bool acks_ahead = wrptr_cached >= rdptr_completions_cached;
+            return acks_ahead ? wrptr_cached - rdptr_completions_cached
+                              : wrptr_cached + ((this->size * 2) - rdptr_completions_cached);
+        }
+    }
+
+    /*
+     * Returns the number of credits that the rdptr_ack is behind the wrptr
+     */
+    size_t get_num_unacked_credits() const {
+        auto wrptr_cached = get(this->wrptr);
+        auto rdptr_ack_cached = get(this->rdptr_acks);
+        if constexpr (is_power_of_2(const_queue_size)) {
+            return (wrptr_cached - rdptr_ack_cached) & pow2_full_q_mask;
+        } else {
+            // default impl - we can probably do better than this but this isn't our use case today
+            bool wrptr_ahead = wrptr_cached >= rdptr_ack_cached;
+            return wrptr_ahead ? (wrptr_cached - rdptr_ack_cached) : wrptr_cached + ((this->size * 2) - rdptr_ack_cached);
+        }
+    }
+
+    /*
+     * Only call as sender.
+     *
+     * Returns the number of buffer credits available on the sender side.
+     * Queue size - distance ahead wrptr is of rdptr_acks
+     */
+    size_t get_local_space_available() const { return this->size - get_num_unacked_credits(); }
+
+    /*
+     * Only call as sender.
+     *
+     * Returns the number of buffer credits available on the receiver side. The sender can safely
+     * write this many credits worth of data to the destination.
+     */
+    size_t get_remote_space_available() const { return this->size - get_num_credits_incomplete(); }
+
+    /*
+     * Get the local wrptr.
+     */
+    size_t get_wrptr() const { return get_ptr_impl(get(this->wrptr), this->size); }
+
+    /*
+     * Get the local rdptr_acks.
+     */
+    size_t get_rdptr_acks() const { return get_ptr_impl(get(this->rdptr_acks), this->size); }
+
+    /*
+     * Get the local rdptr_completions.
+     */
+    size_t get_rdptr_completions() const { return get_ptr_impl(get(this->rdptr_completions), this->size); }
+
+    /*
+     * Get the size of the queue, in credits.
+     */
+    size_t get_queue_size() const { return this->size; }
+
+    // The size of the queue, in credits
+    const size_t size;
+
+   protected:
+    // The local write pointer, in credits, into the queue. Wraps at 2 * q size
+    // NOTE: this can not directly be used for the index into the actual buffer
+    //       instead we must call get_wrptr()
+    volatile size_t *wrptr;
+
+
+    // The local read pointer (ack), in credits, into the queue. Wraps at 2 * q size
+    // NOTE: this can not directly be used for the index into the actual buffer
+    //       instead we must call get_rdptr_acks()
+    volatile size_t *rdptr_acks;
+
+    // The local read pointer (completions), in credits, into the queue. Wraps at 2 * q size
+    // NOTE: this can not directly be used for the index into the actual buffer
+    //       instead we must call get_rdptr_completions()
+    volatile size_t *rdptr_completions;
+
+   private:
+    // Internal helper functions
+    static size_t get(volatile size_t *ptr) { return *ptr; }
+
+    static size_t get_ptr_impl(size_t ptr, size_t q_size) {
+        if constexpr (is_power_of_2(const_queue_size)) {
+            return ptr & pow2_qptr_mask;
+        } else {
+            // default impl
+            auto result = ptr;
+            bool past_last_ptr_offset = q_size <= result;
+            result = result - ((q_size)*past_last_ptr_offset);
+            return result;
+        }
+    }
+
+    static void ptr_advance_impl(volatile size_t *ptr, size_t n, size_t q_size) {
+        if constexpr (is_power_of_2(const_queue_size)) {
+            *ptr = (*ptr + n) & pow2_full_q_mask;
+        } else {
+            // default impl
+            *ptr += n;
+            bool past_last_internal_ptr_val = (2 * q_size) <= *ptr;
+            *ptr = *ptr - (2 * q_size * past_last_internal_ptr_val);
+        }
+    }
+
+    static constexpr size_t pow2_full_q_mask = (const_queue_size << 1) - 1;
+    static constexpr size_t pow2_qptr_mask = const_queue_size - 1;
+    static constexpr bool is_power_of_2(size_t n) { return n && !(n & (n - 1)); }
+};
+
+struct RemoteQueuePtrManagerFriend {
+    // Why did I do this? Because it's way too easy to accidentally grab the raw wrptr/rdptr_acks/rdptr_completions pointers
+    // and use them directly in an offset calculation which would be incorrect. For this reason I wanted to make the user
+    // have to work to get access to the internals (e.g. for sending the credit pointer to remote) so they don't accidentally
+    // grab the wrong credit pointer. Most users will want
+    template <size_t const_queue_size>
+    volatile size_t *get_wrptr_raw(RemoteQueuePtrManager<const_queue_size> const& qptrs) const { return qptrs.wrptr; }
+    template <size_t const_queue_size>
+    volatile size_t *get_rdptr_acks_raw(RemoteQueuePtrManager<const_queue_size> const& qptrs) const { return qptrs.rdptr_acks; }
+    template <size_t const_queue_size>
+    volatile size_t *get_rdptr_completions_raw(RemoteQueuePtrManager<const_queue_size> const& qptrs) const { return qptrs.rdptr_completions; }
+};


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13392)

### Problem description
Want to migrate EDM and CCLs to use flow control that will be compatible with the tt-fabric. To support this we need to expose the interfaces to talk to a packet-queue like datastructure, from within kernels.

### What's changed
Added initial flow control components and single-producer, single-consumer ptr management. Currently tested in host only with host adapters that only override the credit transport mechanisms.

Note: majority of line additions are test code.

### Next steps:
I have a handful of changes on branches (including the appropriate noc and eth flow control adapters as well as payload sender adapters) ready to go to start integration into device kernels. With those I will:

1) Update EDM to support the new queue flow control interfaces and pull in those other changes
2) Update first CCL op (all-gather) to use this new queue type and flow control adapters in place of the prior approach
3) Add (packetized) compatibility test with the existing packet_queue (This will require a new noc stream-reg FlowControlSender/Receiver)
4) Add paged mode FlowControlSender/Receiver and enable in compatibility test with packet_queue
5) Bringup test that translates between paged and packetized mode with new infra.

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11282592853
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
