### PR TITLE
#13711: interactive web demo for SD

### DIFF
--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/README.md
@@ -1,0 +1,29 @@
+# Stable Diffusion Web Demo
+
+## Introduction
+Stable Diffusion is a latent text-to-image diffusion model capable of generating photo-realistic images given any text input. These instructions pertain to running Stable Diffusion with an interactive web interface.
+
+## How to Run
+
+> [!NOTE]
+>
+> If you are using Wormhole, you must set the `WH_ARCH_YAML` environment variable.
+>
+> ```
+> export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+> ```
+
+> In order to post the generated image from the SD model to your local computer, make sure to ssh into the port 8501:
+> ```
+> ssh -L8501:localhost:8501 username@IP_ADDRESS
+> ```
+
+
+To run the demo, make sure to build the project, activate the environment, and set the appropriate environment variables.
+For more information, refer [installation and build guide](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md).
+
+The interface of this project is built with [Streamlit](https://streamlit.io). Use `pip install streamlit` to install the Streamlit dependencies on your machine.
+
+The web demo utilizes a [Flask](https://flask.palletsprojects.com/en/3.0.x/) server. Use `pip install Flask` to install the Flask dependencies on your machine.
+
+Use `python models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py` to run the web demo. It should automatically pop-up at this [address](http://localhost:8501) (localhost:8501).

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
@@ -1,0 +1,135 @@
+from flask import Flask, request, jsonify, send_from_directory, send_file, send_from_directory
+import json
+import os
+import atexit
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def hello_world():
+    return "Hello, World!"
+
+
+@app.route("/submit", methods=["POST"])
+def submit():
+    data = request.get_json()
+    prompt = data.get("prompt")
+    print(prompt)
+
+    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+
+    if not os.path.isfile(json_file_path):
+        with open(json_file_path, "w") as f:
+            json.dump({"prompts": []}, f)
+
+    with open(json_file_path, "r") as f:
+        prompts_data = json.load(f)
+
+    prompts_data["prompts"].append({"prompt": prompt, "status": "not generated"})
+
+    with open(json_file_path, "w") as f:
+        json.dump(prompts_data, f, indent=4)
+
+    return jsonify({"message": "Prompt received and added to queue."})
+
+
+@app.route("/update_status", methods=["POST"])
+def update_status():
+    data = request.get_json()
+    prompt = data.get("prompt")
+
+    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+
+    with open(json_file_path, "r") as f:
+        prompts_data = json.load(f)
+
+    for p in prompts_data["prompts"]:
+        if p["prompt"] == prompt:
+            p["status"] = "generated"
+            break
+
+    with open(json_file_path, "w") as f:
+        json.dump(prompts_data, f, indent=4)
+
+    return jsonify({"message": "Prompt status updated to generated."})
+
+
+@app.route("/get_image", methods=["GET"])
+def get_image():
+    image_name = "interactive_512x512_ttnn.png"
+    directory = os.getcwd()  # Get the current working directory
+    return send_from_directory(directory, image_name)
+
+
+@app.route("/image_exists", methods=["GET"])
+def image_exists():
+    image_path = "interactive_512x512_ttnn.png"
+    if os.path.isfile(image_path):
+        return jsonify({"exists": True}), 200
+    else:
+        return jsonify({"exists": False}), 200
+
+
+@app.route("/clean_up", methods=["POST"])
+def clean_up():
+    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+
+    with open(json_file_path, "r") as f:
+        prompts_data = json.load(f)
+
+    prompts_data["prompts"] = [p for p in prompts_data["prompts"] if p["status"] != "done"]
+
+    with open(json_file_path, "w") as f:
+        json.dump(prompts_data, f, indent=4)
+
+    return jsonify({"message": "Cleaned up done prompts."})
+
+
+@app.route("/get_latest_time", methods=["GET"])
+def get_latest_time():
+    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+
+    if not os.path.isfile(json_file_path):
+        return jsonify({"message": "No prompts found"}), 404
+
+    with open(json_file_path, "r") as f:
+        prompts_data = json.load(f)
+
+    # Filter prompts that have a total_acc time available
+    completed_prompts = [p for p in prompts_data["prompts"] if "total_acc" in p]
+
+    if not completed_prompts:
+        return jsonify({"message": "No completed prompts with time available"}), 404
+
+    # Get the latest prompt with total_acc
+    latest_prompt = completed_prompts[-1]  # Assuming prompts are in chronological order
+
+    return (
+        jsonify(
+            {
+                "prompt": latest_prompt["prompt"],
+                "total_acc": latest_prompt["total_acc"],
+                "batch_size": latest_prompt["batch_size"],
+                "steps": latest_prompt["steps"],
+            }
+        ),
+        200,
+    )
+
+
+def cleanup():
+    if os.path.isfile("models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"):
+        os.remove("models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json")
+        print(f"Deleted json")
+
+    if os.path.isfile("interactive_512x512_ttnn.png"):
+        os.remove("interactive_512x512_ttnn.png")
+        print(f"Deleted image")
+
+
+atexit.register(cleanup)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 from flask import Flask, request, jsonify, send_from_directory, send_file, send_from_directory
 import json
 import os

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
@@ -1,0 +1,268 @@
+import ttnn
+import json
+import torch
+import pytest
+import numpy as np
+from PIL import Image
+from loguru import logger
+from tqdm.auto import tqdm
+from datasets import load_dataset
+import os
+import time
+import random
+
+from transformers import CLIPTextModel, CLIPTokenizer
+from diffusers import (
+    AutoencoderKL,
+    UNet2DConditionModel,
+    StableDiffusionPipeline,
+)
+from models.utility_functions import skip_for_grayskull
+from models.utility_functions import (
+    enable_persistent_kernel_cache,
+    disable_persistent_kernel_cache,
+)
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
+from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
+    UNet2DConditionModel as UNet2D,
+)
+from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import round_up_to_tile_dim
+from torchvision.transforms import ToTensor
+from torchmetrics.multimodal.clip_score import CLIPScore
+from torchmetrics.image.fid import FrechetInceptionDistance
+from scipy import integrate
+
+
+def constant_prop_time_embeddings(timesteps, sample, time_proj):
+    timesteps = timesteps[None]
+    timesteps = timesteps.expand(sample.shape[0])
+    t_emb = time_proj(timesteps)
+    return t_emb
+
+
+def tt_guide(noise_pred, guidance_scale):  # will return latents
+    noise_pred_uncond = noise_pred[:1, :, :, :]
+    noise_pred_text = ttnn.slice(
+        noise_pred,
+        [1, 0, 0, 0],
+        [
+            noise_pred.shape[0],
+            noise_pred.shape[1],
+            noise_pred.shape[2],
+            noise_pred.shape[3],
+        ],
+    )
+    noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+    return noise_pred
+
+
+def run_interactive_demo_inference(device, num_inference_steps, image_size=(256, 256)):
+    disable_persistent_kernel_cache()
+    device.enable_program_cache()
+
+    # Until di/dt issues are resolved
+    os.environ["SLOW_MATMULS"] = "1"
+    assert (
+        num_inference_steps >= 4
+    ), f"PNDMScheduler only supports num_inference_steps >= 4. Found num_inference_steps={num_inference_steps}"
+
+    height, width = image_size
+
+    torch_device = "cpu"
+    # 1. Load the autoencoder model which will be used to decode the latents into image space.
+    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    vae.to(torch_device)
+    vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
+
+    # 2. Load the tokenizer and text encoder to tokenize and encode the text.
+    tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
+    text_encoder = CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
+
+    # 3. The UNet model for generating the latents.
+    unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
+
+    # 4. load the K-LMS scheduler with some fitting parameters.
+    ttnn_scheduler = TtPNDMScheduler(
+        beta_start=0.00085,
+        beta_end=0.012,
+        beta_schedule="scaled_linear",
+        num_train_timesteps=1000,
+        skip_prk_steps=True,
+        steps_offset=1,
+        device=device,
+    )
+
+    text_encoder.to(torch_device)
+    unet.to(torch_device)
+
+    config = unet.config
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
+    )
+    input_height = 64
+    input_width = 64
+    reader_patterns_cache = {} if height == 512 and width == 512 else None
+    model = UNet2D(device, parameters, 2, input_height, input_width, reader_patterns_cache)
+
+    guidance_scale = 7.5  # Scale for classifier-free guidance
+    random_seed = random.randrange(200) + 2
+    # generator = torch.manual_seed(174)  # 10233 Seed generator to create the inital latent noise
+    generator = torch.manual_seed(random_seed)
+    batch_size = 1
+
+    # Initial random noise
+    latents = torch.randn(
+        (batch_size, unet.config.in_channels, height // vae_scale_factor, width // vae_scale_factor),
+        generator=generator,
+    )
+    latents = latents.to(torch_device)
+
+    ttnn_scheduler.set_timesteps(num_inference_steps)
+
+    latents = latents * ttnn_scheduler.init_noise_sigma
+    rand_latents = torch.tensor(latents)
+    rand_latents = ttnn.from_torch(rand_latents, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # ttnn_latents = ttnn.from_torch(ttnn_latents, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_latent_model_input = ttnn.concat([rand_latents, rand_latents], dim=0)
+    _tlist = []
+    for t in ttnn_scheduler.timesteps:
+        _t = constant_prop_time_embeddings(t, ttnn_latent_model_input, unet.time_proj)
+        _t = _t.unsqueeze(0).unsqueeze(0)
+        _t = _t.permute(2, 0, 1, 3)  # pre-permute temb
+        _t = ttnn.from_torch(_t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        _tlist.append(_t)
+
+    time_step = ttnn_scheduler.timesteps.tolist()
+
+    prevPrompt = ""
+    json_file_path = "models/demos/wormhole/stable_diffusion/demo/web_demo/input_prompts.json"
+
+    while True:
+        while not os.path.exists(json_file_path):
+            print(f"Waiting for the file {json_file_path} to be created...")
+            time.sleep(5)
+
+        ttnn_scheduler.set_timesteps(num_inference_steps)
+
+        with open(json_file_path, "r") as f:
+            data = json.load(f)
+            input_prompts = data["prompts"]
+
+        new_prompt = ""
+        currInd = 0
+        for i in range(len(input_prompts)):
+            if input_prompts[i]["status"] == "not generated":
+                currInd = i
+                new_prompt = input_prompts[i]["prompt"]
+                input_prompts[i]["status"] = "generated"
+                break
+
+        if new_prompt == "":
+            print("No 'not generated' prompts found, waiting...")
+            time.sleep(5)
+            continue
+
+        if new_prompt == prevPrompt:
+            continue
+        elif len(new_prompt) > 0:
+            input_prompt = [new_prompt]
+            prevPrompt = new_prompt
+        if input_prompt[0] == "q":
+            break
+
+        experiment_name = f"interactive_{height}x{width}"
+        logger.info(f"input prompt : {input_prompt}")
+        batch_size = len(input_prompt)
+
+        with open(json_file_path, "w") as f:
+            json.dump({"prompts": input_prompts}, f, indent=4)
+
+        ## First, we get the text_embeddings for the prompt. These embeddings will be used to condition the UNet model.
+        # Tokenizer and Text Encoder
+        text_input = tokenizer(
+            input_prompt,
+            padding="max_length",
+            max_length=tokenizer.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        text_embeddings = text_encoder(text_input.input_ids.to(torch_device))[0]
+        max_length = text_input.input_ids.shape[-1]
+        uncond_input = tokenizer([""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt")
+        uncond_embeddings = text_encoder(uncond_input.input_ids.to(torch_device))[0]
+
+        # For classifier-free guidance, we need to do two forward passes: one with the conditioned input (text_embeddings),
+        # and another with the unconditional embeddings (uncond_embeddings).
+        # In practice, we can concatenate both into a single batch to avoid doing two forward passes.
+        text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
+        ttnn_text_embeddings = torch.nn.functional.pad(text_embeddings, (0, 0, 0, 19))
+        ttnn_text_embeddings = ttnn.from_torch(
+            ttnn_text_embeddings, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device
+        )
+
+        iter = 0
+        ttnn_latents = rand_latents
+
+        total_accum = 0
+        for index in tqdm(range(len(time_step))):
+            t0 = time.time()
+            ttnn_latent_model_input = ttnn.concat([ttnn_latents, ttnn_latents], dim=0)
+            _t = _tlist[index]
+            t = time_step[index]
+
+            with torch.no_grad():
+                ttnn_output = model(
+                    ttnn_latent_model_input,  # input
+                    timestep=_t,
+                    encoder_hidden_states=ttnn_text_embeddings,
+                    class_labels=None,
+                    attention_mask=None,
+                    cross_attention_kwargs=None,
+                    return_dict=True,
+                    config=config,
+                )
+
+            noise_pred = tt_guide(ttnn_output, guidance_scale)
+
+            ttnn_latents = ttnn_scheduler.step(noise_pred, t, ttnn_latents).prev_sample
+            total_accum += time.time() - t0
+            iter += 1
+        print(f"Time taken for {iter} iterations: total: {total_accum:.3f}")
+
+        latents = ttnn.to_torch(ttnn_latents).to(torch.float32)
+
+        latents = 1 / 0.18215 * latents
+        with torch.no_grad():
+            image = vae.decode(latents).sample
+
+        image = (image / 2 + 0.5).clamp(0, 1)
+        image = image.detach().cpu().permute(0, 2, 3, 1).numpy()
+        images = (image * 255).round().astype("uint8")
+        pil_images = [Image.fromarray(image) for image in images][0]
+        ttnn_output_path = f"{experiment_name}_ttnn.png"
+        pil_images.save(ttnn_output_path)
+
+        input_prompts[currInd]["status"] = "done"
+        input_prompts[currInd]["total_acc"] = total_accum
+        input_prompts[currInd]["batch_size"] = batch_size
+        input_prompts[currInd]["steps"] = num_inference_steps
+
+        with open(json_file_path, "w") as f:
+            json.dump({"prompts": input_prompts}, f, indent=4)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "num_inference_steps",
+    ((50),),
+)
+@pytest.mark.parametrize(
+    "image_size",
+    ((512, 512),),
+)
+def test_interactive_demo(device, num_inference_steps, image_size):
+    return run_interactive_demo_inference(device, num_inference_steps, image_size)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import ttnn
 import json
 import torch

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
@@ -1,0 +1,90 @@
+import streamlit as st
+import requests
+from PIL import Image
+import io
+import time
+import os
+import json
+
+DOWNLOAD_PATH = os.path.join(os.path.expanduser("~"), "interactive_512x512_ttnn.png")
+
+# Add space below the title
+st.title("TT Stable Diffusion Playground")
+st.markdown("<br>", unsafe_allow_html=True)
+
+# Display an image logo at the end of the title
+
+# Popover for Device ID input
+with st.expander("Add Device ID"):
+    device_id = st.text_input("What's your device ID? 10.229.36.110")
+
+st.markdown("<br>", unsafe_allow_html=True)
+
+prompt = st.text_input("Enter your prompt:", "")
+
+curr = ""
+
+
+# Function to save image to Downloads and display it
+def save_and_display_image(image_data):
+    try:
+        image = Image.open(io.BytesIO(image_data))
+        image.save(DOWNLOAD_PATH)
+        if curr:  # Only add caption if curr is not an empty string
+            image_placeholder.image(image, caption=curr, use_column_width=True)
+        else:
+            image_placeholder.image(image, use_column_width=True)
+    except Exception as e:
+        st.error(f"Error processing image: {e}")
+
+
+# Placeholder for the image
+image_placeholder = st.empty()
+
+
+# Function to check and update the image
+def check_and_update_image(server_url):
+    global curr  # Make curr accessible to this function
+    try:
+        prompt_response = requests.get(f"{server_url}/get_latest_time")
+        image_response = requests.get(f"{server_url}/get_image")
+        if image_response.status_code == 200 and image_response.content:
+            save_and_display_image(image_response.content)
+        if prompt_response.status_code == 200 and prompt_response.content:
+            decoded_string = prompt_response.content.decode("utf-8").strip()
+            parsed_data = json.loads(decoded_string)
+            total_acc = round(parsed_data.get("total_acc"), 2)
+            batch_size = round(parsed_data.get("batch_size"), 0)
+            steps = round(parsed_data.get("steps"), 0)
+            promp = parsed_data.get("prompt")
+            curr = f"{total_acc} seconds to generate '{promp}' with batch size of {batch_size} and {steps} steps"
+            print(curr)
+    except requests.exceptions.RequestException as e:
+        st.error(f"Error connecting to the server: {e}")
+
+
+# Button to generate the image
+if st.button("Generate Image"):
+    if not device_id:
+        st.error("Please enter your device ID.")
+    else:
+        SERVER_URL = f"http://{device_id}:5000"
+        with st.spinner("Running Stable Diffusion"):
+            try:
+                data = {"prompt": prompt}
+                response = requests.post(f"{SERVER_URL}/submit", json=data)
+                if response.status_code != 200:
+                    st.error(f"Error submitting prompt: {response.status_code} - {response.text}")
+            except requests.exceptions.RequestException as e:
+                st.error(f"Error connecting to the server: {e}")
+            else:
+                while True:
+                    check_and_update_image(SERVER_URL)
+                    time.sleep(2)
+
+hide_decoration_bar_style = """
+    <style>
+        header {visibility: hidden;}
+    </style>
+"""
+st.markdown(hide_decoration_bar_style, unsafe_allow_html=True)

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import streamlit as st
 import requests
 from PIL import Image

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import subprocess
 import signal
 import sys

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
@@ -1,0 +1,48 @@
+import subprocess
+import signal
+import sys
+import os
+
+# Two scripts to run
+script1 = "pytest models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py"
+script2 = "python models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py"
+script3 = "streamlit run models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py"
+
+# Start both scripts using subprocess
+process1 = subprocess.Popen(script1, shell=True)
+process2 = subprocess.Popen(script2, shell=True)
+process3 = subprocess.Popen(script3, shell=True)
+
+
+# Function to kill process using port 5000
+def kill_port_5000():
+    try:
+        result = subprocess.check_output("lsof -i :5000 | grep LISTEN | awk '{print $2}'", shell=True)
+        pid = int(result.strip())
+        print(f"Killing process {pid} using port 5000")
+        os.kill(pid, signal.SIGTERM)
+    except subprocess.CalledProcessError:
+        print("No process found using port 5000")
+    except Exception as e:
+        print(f"Error occurred: {e}")
+
+
+# Function to terminate both processes and kill port 5000
+def signal_handler(sig, frame):
+    print("Terminating processes...")
+    process1.terminate()
+    process2.terminate()
+    kill_port_5000()
+    print("Processes terminated and port 5000 cleared.")
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, signal_handler)
+signal.signal(signal.SIGTERM, signal_handler)
+
+print("Running. Press Ctrl+C to stop.")
+try:
+    process1.wait()
+    process2.wait()
+except KeyboardInterrupt:
+    signal_handler(None, None)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13711)

### Problem description
An interactive web demo for stable diffusion

### What's changed
streamlit and Flask python libraries are used to create an interactive demo of stable diffusion running on N150. The user can use local port to give a prompt locally/clinet side, the model will receive the prompt on the server side, generate the image and post it to the client side.  

### Checklist (test in progress)
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
