### PR TITLE
#13127: Update get_physical_shape to handle alignment/padding requirements for row major layout

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -698,7 +698,7 @@ Tensor create_device_tensor(
 
 Tensor create_device_tensor(
     const ttnn::SimpleShape& logical_shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
-    return create_device_tensor(logical_shape, get_physical_shape(logical_shape, layout, tile), data_type, layout, device, memory_config, tile);
+    return create_device_tensor(logical_shape, get_physical_shape(logical_shape, data_type, layout, tile), data_type, layout, device, memory_config, tile);
 }
 
 Tensor create_device_tensor(

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -4,11 +4,13 @@
 
 #include <cstdint>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor_impl.hpp"
 
 namespace ttnn {
 
-SimpleShape get_physical_shape(const SimpleShape& logical_shape, Layout layout, const std::optional<Tile>& tile) {
+SimpleShape get_physical_shape(const SimpleShape& logical_shape, DataType data_type, Layout layout, const std::optional<Tile>& tile) {
     SimpleShape physical_shape = logical_shape;
+    auto rank = physical_shape.rank();
     if (layout == Layout::TILE) {
         auto tile_height = tt::constants::TILE_HEIGHT;
         auto tile_width = tt::constants::TILE_WIDTH;
@@ -17,12 +19,18 @@ SimpleShape get_physical_shape(const SimpleShape& logical_shape, Layout layout, 
             tile_height = tile_shape[0];
             tile_width = tile_shape[1];
         }
-        auto rank = physical_shape.rank();
         if (rank >= 1) {
             physical_shape[rank - 1] = (physical_shape[rank - 1] + tile_width - 1) / tile_width * tile_width;
             if (rank >= 2) {
                 physical_shape[rank - 2] = (physical_shape[rank - 2] + tile_height - 1) / tile_height * tile_height;
             }
+        }
+    }
+    if (layout == Layout::ROW_MAJOR) {
+        auto element_size = tt::tt_metal::tensor_impl::element_size_bytes(data_type);
+        auto row_alignment = sizeof(uint32_t) / element_size;
+        if (rank >= 1) {
+            physical_shape[rank - 1] = (physical_shape[rank - 1] + row_alignment - 1) / row_alignment * row_alignment;
         }
     }
     return physical_shape;

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -65,13 +65,11 @@ public:
     static constexpr auto attribute_names = std::forward_as_tuple("value");
     auto attribute_values() const { return std::forward_as_tuple(this->value); }
 
+    friend std::ostream &operator<<(std::ostream &os, const SimpleShape &shape);
+
 private:
     std::vector<uint32_t> value;
 };
-
-SimpleShape get_physical_shape(const SimpleShape& logical_shape, Layout layout, const std::optional<Tile>& tile = std::nullopt);
-
-} // namespace ttnn
 
 inline std::ostream &operator<<(std::ostream &os, const ttnn::SimpleShape &shape) {
     os << "SimpleShape([";
@@ -84,6 +82,8 @@ inline std::ostream &operator<<(std::ostream &os, const ttnn::SimpleShape &shape
     os << "])";
     return os;
 }
+
+} // namespace ttnn
 
 namespace tt {
 
@@ -888,5 +888,7 @@ static std::ostream &operator<<(std::ostream &os, const Shape &shape) {
 }  // namespace types
 
 using types::Shape;
+
+SimpleShape get_physical_shape(const SimpleShape& logical_shape, DataType data_type, Layout layout, const std::optional<Tile>& tile = std::nullopt);
 
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13127

### Problem description
The padding/alignment for row major layout wasn't correctly managed in get_physical_shape

### What's changed
Handle padding for row major layout, pass DataType into get_physical_shape, because the paddings depends on the data type
Moved `SimpleShape::operator<<` to `ttnn` namespace

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
