### PR TITLE
#11207: Introduce v1::DeviceHandle

### DIFF
--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
 
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
 
     for (int device_id = 0; device_id < num_devices; device_id++) {
     try {

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
             ids.push_back(id);
         }
         tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
-        std::vector<Device*> devices = tt::DevicePool::instance().get_all_active_devices();
+        auto devices = tt::DevicePool::instance().get_all_active_devices();
         std::vector<Program> programs;
         std::set<uint32_t> build_keys;
         // kernel->binaries() returns 32B aligned binaries

--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -47,7 +47,7 @@ class DeviceFixture : public ::testing::Test {
         }
     }
 
-    std::vector<tt::tt_metal::Device*> devices_;
+    std::vector<tt::tt_metal::v1::DeviceHandle> devices_;
     tt::ARCH arch_;
     size_t num_devices_;
 };
@@ -116,7 +116,7 @@ class GalaxyFixture : public ::testing::Test {
         this->devices_.clear();
     }
 
-    std::vector<tt::tt_metal::Device*> devices_;
+    std::vector<tt::tt_metal::v1::DeviceHandle> devices_;
 
    private:
     std::map<chip_id_t, Device*> device_ids_to_devices_;

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -45,7 +45,7 @@ class N300DeviceFixture : public ::testing::Test {
         }
     }
 
-    std::vector<tt::tt_metal::Device*> devices_;
+    std::vector<tt::tt_metal::v1::DeviceHandle> devices_;
     tt::ARCH arch_;
     size_t num_devices_;
 };

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/ring_gather_kernels.cpp
@@ -76,7 +76,7 @@ std::vector<int> get_hamiltonian_cycle(vector<vector<int>>& adj, int N, int s = 
     return {};
 }
 
-std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices) {
+std::vector<v1::DeviceHandle> get_device_ring(std::vector<tt::tt_metal::v1::DeviceHandle> devices) {
     std::vector<std::vector<int>> adj(devices.size(), std::vector<int>(devices.size(), 0));
     for (uint32_t i = 0; i < devices.size(); ++i) {
         const auto& device = devices[i];
@@ -90,7 +90,7 @@ std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices)
     }
 
     const auto& device_ring_idx = get_hamiltonian_cycle(adj, devices.size(), 0);
-    std::vector<Device*> device_ring;
+    std::vector<v1::DeviceHandle> device_ring;
     device_ring.reserve(device_ring_idx.size());
     for (const auto& device_idx : device_ring_idx) {
         device_ring.push_back(devices[device_idx]);
@@ -99,7 +99,7 @@ std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices)
 }
 
 std::vector<std::tuple<Device*, Device*, CoreCoord, CoreCoord>> get_sender_receiver_cores(
-    std::vector<tt::tt_metal::Device*> device_ring) {
+    std::vector<tt::tt_metal::v1::DeviceHandle> device_ring) {
     std::vector<std::tuple<Device*, Device*, CoreCoord, CoreCoord>> sender_receivers;
     sender_receivers.reserve(device_ring.size() - 1);
 
@@ -169,7 +169,7 @@ namespace unit_tests::erisc::kernels {
  *                                         ╚══════╝░░░╚═╝░░░╚═╝░░╚═╝
  */
 bool eth_direct_ring_gather_sender_receiver_kernels(
-    std::vector<tt::tt_metal::Device*> device_ring,
+    std::vector<tt::tt_metal::v1::DeviceHandle> device_ring,
     const size_t& byte_size_per_device,
     const size_t& src_eth_l1_byte_address,
     const size_t& dst_eth_l1_byte_address,
@@ -313,7 +313,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
 }
 
 bool eth_interleaved_ring_gather_sender_receiver_kernels(
-    std::vector<tt::tt_metal::Device*> device_ring,
+    std::vector<tt::tt_metal::v1::DeviceHandle> device_ring,
     const BankedConfig& cfg,
     const size_t& src_eth_l1_byte_address,
     const size_t& dst_eth_l1_byte_address,

--- a/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
@@ -80,14 +80,13 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     }
 
     ASSERT_TRUE(num_devices > 0);
-    std::vector<tt::tt_metal::Device *> devices;
     vector<chip_id_t> ids;
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
     }
@@ -100,14 +99,13 @@ TEST_P(DeviceParamFixture, DeviceLoadBlankKernels) {
         GTEST_SKIP();
     }
     ASSERT_TRUE(num_devices > 0);
-    std::vector<tt::tt_metal::Device *> devices;
     vector<chip_id_t> ids;
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(unit_tests_common::basic::test_device_init::load_all_blank_kernels(device));
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -48,7 +48,7 @@ public:
 
 protected:
     tt::ARCH arch_;
-    vector<tt::tt_metal::Device*> devices_;
+    vector<tt::tt_metal::v1::DeviceHandle> devices_;
     bool slow_dispatch_;
     bool has_remote_devices_;
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/test_dispatch.cpp
@@ -9,7 +9,7 @@
 // Test sync w/ semaphores betweeen eth/tensix cores
 // Test will hang in the kernel if the sync doesn't work properly
 static void test_sems_across_core_types(CommonFixture *fixture,
-                                        vector<tt::tt_metal::Device*>& devices,
+                                        vector<tt::tt_metal::v1::DeviceHandle>& devices,
                                         bool active_eth) {
     // just something unique...
     constexpr uint32_t eth_sem_init_val = 33;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_device_pool.cpp
@@ -20,7 +20,7 @@ TEST_F(FDBasicFixture, DevicePoolOpenClose) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<tt_metal::Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
@@ -48,7 +48,7 @@ TEST_F(FDBasicFixture, DevicePoolReconfigDevices) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
@@ -80,7 +80,7 @@ TEST_F(FDBasicFixture, DevicePoolAddDevices) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
@@ -114,7 +114,7 @@ TEST_F(FDBasicFixture, DevicePoolReduceDevices) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/device/device_handle.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3263,9 +3263,9 @@ void Device::enable_async(bool enable) {
     // This is required for checking if a call is made from an application thread or a worker thread.
     // See InWorkerThread().
     if (enable) {
-        tt::DevicePool::instance().register_worker_thread_for_device(this, this->work_executor.get_worker_thread_id());
+        tt::DevicePool::instance().register_worker_thread_for_device(tt::DevicePool::instance().get_handle(this), this->work_executor.get_worker_thread_id());
     } else {
-        tt::DevicePool::instance().unregister_worker_thread_for_device(this);
+        tt::DevicePool::instance().unregister_worker_thread_for_device(tt::DevicePool::instance().get_handle(this));
     }
 }
 

--- a/tt_metal/impl/device/device_handle.cpp
+++ b/tt_metal/impl/device/device_handle.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/device/device_handle.hpp"
+
+#include "tt_metal/impl/device/device_pool.hpp"
+
+namespace tt::tt_metal {
+
+auto v1::DeviceHandle::operator->() const -> Device * { return static_cast<Device *>(*this); }
+
+v1::DeviceHandle::operator Device *() const {
+    TT_FATAL(this->key.version() & 1, "Invalid DeviceHandle; Expected valid key version");
+    const auto loc = this->key.index();
+    const auto &devices = DevicePool::instance().devices;
+    const auto size = devices.size();
+    TT_FATAL(loc < size, "Invalid DeviceHandle {}; Expected index less than {}", loc, size);
+    return devices[loc].get();
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_handle.hpp
+++ b/tt_metal/impl/device/device_handle.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_stl/slotmap.hpp"
+
+namespace tt {
+
+class DevicePool;
+
+namespace tt_metal {
+inline namespace v0 {
+
+class Device;
+
+}  // namespace v0
+
+namespace v1 {
+
+struct DeviceKey : stl::Key<std ::uint16_t, 12> {
+    using Key::Key;
+};
+
+class DeviceHandle {
+    friend DevicePool;
+
+    DeviceKey key;
+
+    DeviceHandle(DeviceKey key) : key(key) {}
+
+   public:
+    DeviceHandle() = default;
+
+    // TODO remove with v0
+    auto operator->() const -> Device *;
+
+    // TODO remove with v0
+    operator Device *() const;
+};
+
+}  // namespace v1
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -8,11 +8,21 @@
 #include "impl/debug/noc_logging.hpp"
 #include "impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_handle.hpp"
 #include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"
 namespace tt {
+namespace tt_metal::detail {
+
+void CloseDevices(std::map<chip_id_t, Device *> devices);
+
+}  // namespace tt_metal::detail
 
 using Device = tt_metal::Device;
 class DevicePool {
+    friend Device;
+    friend v1::DeviceHandle;
+    friend void tt_metal::detail::CloseDevices(std::map<chip_id_t, Device *> devices);
+
    public:
     DevicePool &operator=(const DevicePool &) = delete;
     DevicePool &operator=(DevicePool &&other) noexcept = delete;
@@ -32,12 +42,12 @@ class DevicePool {
         DispatchCoreType dispatch_core_type,
         const std::vector<uint32_t> &l1_bank_remap = {}) noexcept;
 
-    Device *get_active_device(chip_id_t device_id) const;
-    std::vector<Device *> get_all_active_devices() const;
+    v1::DeviceHandle get_active_device(chip_id_t device_id) const;
+    std::vector<v1::DeviceHandle> get_all_active_devices() const;
     bool close_device(chip_id_t device_id);
     bool is_device_active(chip_id_t id) const;
-    void register_worker_thread_for_device(Device* device, std::thread::id worker_thread_id);
-    void unregister_worker_thread_for_device(Device* device);
+    void register_worker_thread_for_device(v1::DeviceHandle device, std::thread::id worker_thread_id);
+    void unregister_worker_thread_for_device(v1::DeviceHandle device);
     const std::unordered_set<std::thread::id>& get_worker_thread_ids() const;
    private:
     ~DevicePool();
@@ -52,6 +62,7 @@ class DevicePool {
     size_t trace_region_size;
     std::vector<uint32_t> l1_bank_remap;
     std::mutex lock;
+    // TODO replace std::vector<std::unique_ptr<Device>> with stl::SlotMap<v1::DeviceKey, Device> when removing v0
     std::vector<std::unique_ptr<Device>> devices;
     // Used to track worker thread handles (1 worker thread created per device)
     // when we need to check if a call is made from an application thread or a
@@ -68,10 +79,12 @@ class DevicePool {
     void init_firmware_on_active_devices() const;
     void init_profiler_devices() const;
     void activate_device(chip_id_t id);
-    void initialize_device(Device *dev) const;
-    void deactivate_device(chip_id_t id);
+    void initialize_device(v1::DeviceHandle dev) const;
     void add_devices_to_pool(std::vector<chip_id_t> device_ids);
     static DevicePool *_inst;
+
+    // TODO remove with v0
+    v1::DeviceHandle get_handle(Device* device) const;
 };
 
 }  // namespace tt


### PR DESCRIPTION
### Ticket
#11207

### Problem description
In the v1 tt_metal API, objects will be replaced with opaque handles. To support the migration phase, opaque handles currently support conversion to object pointers, but that conversion will be removed along with v0 namespace.

### What's changed
Refactor API of DevicePool to return `v1::DeviceHandle` instead of `v0::Device *`

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11406767460)
- [ ] Blackhole Post commit (if applicable)
- [X] Model regression CI testing passes
  - [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/11407183869)
  - [(T3K) T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/11407109435)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
