### PR TITLE
#596: Remove compile time usage of ARCH_NAME for linker scripts

### DIFF
--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -27,6 +27,16 @@ std::string tt::get_string_lowercase(tt::ARCH arch) {
     }
 }
 
+std::string tt::get_alias(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::GRAYSKULL: return "grayskull"; break;
+        case tt::ARCH::WORMHOLE: return "wormhole"; break;
+        case tt::ARCH::WORMHOLE_B0: return "wormhole"; break;
+        case tt::ARCH::BLACKHOLE: return "blackhole"; break;
+        default: return "invalid"; break;
+    }
+}
+
 tt::ARCH tt::get_arch_from_string(const std::string &arch_str) {
     tt::ARCH arch;
     if ((arch_str == "grayskull") || (arch_str == "GRAYSKULL")) {

--- a/tt_metal/common/tt_backend_api_types.hpp
+++ b/tt_metal/common/tt_backend_api_types.hpp
@@ -138,6 +138,7 @@ inline constexpr static uint32_t tile_size(const DataFormat& format) {
 
 std::string get_string(ARCH arch);
 std::string get_string_lowercase(ARCH arch);
+std::string get_alias(ARCH arch);
 ARCH get_arch_from_string(const std::string& arch_str);
 
 enum RISCV : uint8_t {

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -1,5 +1,9 @@
 # Temporary workaround for Issue #8767
-set(HW_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/runtime/hw/toolchain)
+set(ARCHS
+    grayskull
+    wormhole
+    blackhole
+)
 set(PROCS
     brisc
     ncrisc
@@ -13,34 +17,31 @@ set(TYPES
     kernel
 )
 
-if("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
-    set(DEV_MEM_MAP "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/dev_mem_map.h")
-    set(HW_INCLUDES "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole")
-else()
-    set(DEV_MEM_MAP "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}/dev_mem_map.h")
-    set(HW_INCLUDES "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}")
-endif()
+foreach(ARCH IN LISTS ARCHS)
+    set(DEV_MEM_MAP "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ARCH}/dev_mem_map.h")
+    set(HW_INCLUDES "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ARCH}")
+    set(HW_OUTPUT_DIR "${PROJECT_SOURCE_DIR}/runtime/hw/toolchain/${ARCH}")
+    foreach(PROC IN LISTS PROCS)
+        foreach(TYPE IN LISTS TYPES)
+            set(HW_OUTPUT_FILE "${HW_OUTPUT_DIR}/${TYPE}_${PROC}.ld")
+            string(TOUPPER ${PROC} PROC_DEFINE)
+            string(TOUPPER ${TYPE} TYPE_DEFINE)
 
-foreach(PROC IN LISTS PROCS)
-    foreach(TYPE IN LISTS TYPES)
-        set(HW_OUTPUT_FILE "${HW_OUTPUT_DIR}/${TYPE}_${PROC}.ld")
-        string(TOUPPER ${PROC} PROC_DEFINE)
-        string(TOUPPER ${TYPE} TYPE_DEFINE)
+            # custom command to preprocess/generate the output file
+            add_custom_command(
+              OUTPUT ${HW_OUTPUT_FILE}
+              COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_OUTPUT_DIR}
+              COMMAND ${CMAKE_CXX_COMPILER} -DLD_TARGET=${PROC_DEFINE} -DLD_TYPE=${TYPE_DEFINE} -DTARGET_${PROC_DEFINE} -DTYPE_${TYPE_DEFINE} -DCOMPILE_FOR_${PROC_DEFINE} -I${HW_INCLUDES} -E -P -x c -o ${HW_OUTPUT_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/main.ld
+              DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/main.ld ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/memory.ld ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/sections.ld ${DEV_MEM_MAP}
+              COMMENT "Preprocessing toolchain/${PROC}.ld"
+              VERBATIM
+              )
 
-        # custom command to preprocess/generate the output file
-        add_custom_command(
-          OUTPUT ${HW_OUTPUT_FILE}
-          COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_OUTPUT_DIR}
-          COMMAND ${CMAKE_CXX_COMPILER} -DLD_TARGET=${PROC_DEFINE} -DLD_TYPE=${TYPE_DEFINE} -DTARGET_${PROC_DEFINE} -DTYPE_${TYPE_DEFINE} -DCOMPILE_FOR_${PROC_DEFINE} -I${HW_INCLUDES} -E -P -x c -o ${HW_OUTPUT_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/main.ld
-          DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/main.ld ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/memory.ld ${CMAKE_CURRENT_SOURCE_DIR}/toolchain/sections.ld ${DEV_MEM_MAP}
-          COMMENT "Preprocessing toolchain/${PROC}.ld"
-          VERBATIM
-          )
-
-        # add output file to the custom target
-        list(APPEND PREPROCESSED_LD_FILES ${HW_OUTPUT_FILE})
-    endforeach()
-endforeach()
+            # add output file to the custom target
+            list(APPEND PREPROCESSED_LD_FILES ${HW_OUTPUT_FILE})
+        endforeach(TYPE IN LISTS TYPES)
+    endforeach(PROC IN LISTS PORCS)
+endforeach(ARCH IN LISTS ARCHS)
 
 # Build hw lib objects
 if("$ENV{ARCH_NAME}" STREQUAL "grayskull")

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -43,79 +43,87 @@ foreach(ARCH IN LISTS ARCHS)
     endforeach(PROC IN LISTS PORCS)
 endforeach(ARCH IN LISTS ARCHS)
 
-# Build hw lib objects
-if("$ENV{ARCH_NAME}" STREQUAL "grayskull")
-    set(GPP_FLAGS -mgrayskull -march=rv32iy -mtune=rvtt-b1 -mabi=ilp32)
-    set(ALIAS_ARCH_NAME "grayskull")
-elseif("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0" OR "$ENV{ARCH_NAME}" STREQUAL "wormhole")
-    set(GPP_FLAGS -mwormhole -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32)
-    set(ALIAS_ARCH_NAME "wormhole")
-elseif("$ENV{ARCH_NAME}" STREQUAL "blackhole")
-    set(GPP_FLAGS -mblackhole -march=rv32iml -mtune=rvtt-b1 -mabi=ilp32)
-    set(ALIAS_ARCH_NAME "blackhole")
-endif()
+# Function appends b0 if its wormhole
+function(get_alias INPUT_STRING OUTPUT_VAR)
+    if("${INPUT_STRING}" STREQUAL "wormhole")
+        set(${OUTPUT_VAR} "wormhole_b0" PARENT_SCOPE)
+    else()
+        set(${OUTPUT_VAR} "${INPUT_STRING}" PARENT_SCOPE)
+    endif()
+endfunction()
 
-set(GPP_FLAGS ${GPP_FLAGS} -std=c++17 -flto -ffast-math -fno-use-cxa-atexit -fno-exceptions -Wall -Werror -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function -Os -fno-tree-loop-distribute-patterns)
-
-set(HW_LIB_DIR ${PROJECT_SOURCE_DIR}/runtime/hw/lib)
+# Define the compiler command
 set(GPP_CMD ${PROJECT_SOURCE_DIR}/tt_metal/third_party/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
-# -Os -fno-tree-loop-distribute-patterns -DARCH_$ENV{ARCH_NAME} -DCOMPILE_FOR_NCRISC -DLOCAL_MEM_EN=0 -DFW_BUILD
-set(GPP_INCLUDES -I. -I.. -I${PROJECT_SOURCE_DIR} -I${PROJECT_SOURCE_DIR}/tt_metal -I${PROJECT_SOURCE_DIR}/tt_metal/include -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/debug -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ALIAS_ARCH_NAME} -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ALIAS_ARCH_NAME}/$ENV{ARCH_NAME}_defines -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ALIAS_ARCH_NAME}/noc -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/device/$ENV{ARCH_NAME} -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/$ENV{ARCH_NAME}/metal/common -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/$ENV{ARCH_NAME}/metal/llk_io -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk_$ENV{ARCH_NAME}/common/inc -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk_$ENV{ARCH_NAME}/llk_lib -I${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/$ENV{ARCH_NAME}/metal/common -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/$ENV{ARCH_NAME}/metal/llk_io)
 
-add_custom_command(
-    OUTPUT tmu-crt0
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/tmu-crt0.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/tmu-crt0.S
-    COMMENT "Building hw lib tmu-crt0.o"
-    VERBATIM
-)
+# Define flags for each architecture
+set(GPP_FLAGS_grayskull -mgrayskull -march=rv32iy -mtune=rvtt-b1 -mabi=ilp32)
+set(GPP_FLAGS_wormhole  -mwormhole -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32)
+set(GPP_FLAGS_blackhole -mblackhole -march=rv32iml -mtune=rvtt-b1 -mabi=ilp32)
 
-add_custom_command(
-    OUTPUT tmu-crt0k
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/tmu-crt0k.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/tmu-crt0k.S
-    COMMENT "Building hw lib tmu-crt0k.o"
-    VERBATIM
-)
+# Define common flags for all architectures
+set(GPP_FLAGS_common -std=c++17 -flto -ffast-math -fno-use-cxa-atexit -fno-exceptions -Wall -Werror -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function -Os -fno-tree-loop-distribute-patterns)
 
-add_custom_command(
-    OUTPUT substitutes
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/substitutes.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/substitutes.cpp
-    COMMENT "Building hw lib substitutes.o"
-    VERBATIM
-)
+# We are going to build 5 or 6 object files foreach ARCH
+foreach(ARCH IN LISTS ARCHS)
+    get_alias(${ARCH} ARCH_B0)
 
-add_custom_command(
-    OUTPUT tdma_xmov
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/tdma_xmov.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/tdma_xmov.c
-    COMMENT "Building hw lib tdma_xmov.o"
-    VERBATIM
-)
-
-add_custom_command(
-    OUTPUT noc
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-    COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/noc.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/${ALIAS_ARCH_NAME}/noc.c
-    COMMENT "Building hw lib noc.o"
-    VERBATIM
-)
-
-list(APPEND HW_LIB tmu-crt0 tmu-crt0k substitutes tdma_xmov noc)
-
-# Only build ncrisc haltl for Grayskull and Wormhole since Blackhole ncrisc does not have IRAM
-if (ALIAS_ARCH_NAME STREQUAL "grayskull" OR ALIAS_ARCH_NAME STREQUAL "wormhole")
-    add_custom_command(
-        OUTPUT ncrisc-halt
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
-        COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/ncrisc-halt.o ${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/ncrisc-halt.S
-        COMMENT "Building hw lib ncrisc-halt.o"
-        VERBATIM
+    # These are the set of object files we are to build foreach ARCH
+    set(HWLIBS
+        tmu-crt0
+        tmu-crt0k
+        substitutes
+        tdma_xmov
+        noc
+        ncrisc-halt
     )
-    list(APPEND HW_LIB ncrisc-halt)
-endif()
+
+    # Map each .o to its source file
+    set(tmu-crt0_SOURCE        "${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/tmu-crt0.S")
+    set(tmu-crt0k_SOURCE       "${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/tmu-crt0k.S")
+    set(substitutes_SOURCE     "${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/substitutes.cpp")
+    set(tdma_xmov_SOURCE       "${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/tdma_xmov.c")
+    set(noc_SOURCE             "${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src/${ARCH}/noc.c")
+    set(ncrisc-halt_SOURCE     "${PROJECT_SOURCE_DIR}/tt_metal/hw/toolchain/ncrisc-halt.S")
+
+    # Set GPP_FLAGS based on ARCH
+    set(GPP_FLAGS ${GPP_FLAGS_${ARCH}} ${GPP_FLAGS_common})
+
+    # Dump object files to this directory
+    set(HW_LIB_DIR ${PROJECT_SOURCE_DIR}/runtime/hw/lib/${ARCH})
+
+    # Includes independent from ARCH
+    set(GPP_INCLUDES -I. -I.. -I${PROJECT_SOURCE_DIR} -I${PROJECT_SOURCE_DIR}/tt_metal -I${PROJECT_SOURCE_DIR}/tt_metal/include -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/debug -I${PROJECT_SOURCE_DIR}/tt_metal/hw/firmware/src)
+
+    # Architecture specific include paths
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ARCH})
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ARCH}/${ARCH_B0}_defines)
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${ARCH}/noc)
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/device/${ARCH})
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/${ARCH_B0}/metal/common)
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/${ARCH_B0}/metal/llk_io)
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk_${ARCH_B0}/common/inc)
+    list(APPEND GPP_INCLUDES -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk_${ARCH_B0}/llk_lib)
+
+    foreach(HWLIB IN LISTS HWLIBS)
+
+        if("${ARCH}" STREQUAL "blackhole" AND "${HWLIB}" STREQUAL "ncrisc-halt")
+            continue() # Skip the iteration, blackhole doesn't have IRAM
+        endif()
+
+        set(HW_OUTPUT_FILE "${HW_LIB_DIR}/${HWLIB}.o")
+        add_custom_command(
+            OUTPUT ${HW_OUTPUT_FILE}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
+            COMMAND ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/${HWLIB}.o ${${HWLIB}_SOURCE}
+            COMMENT "Building hw lib ${HWLIB}.o"
+            VERBATIM
+        )
+        list(APPEND PREPROCESSED_O_FILES ${HW_OUTPUT_FILE})
+
+    endforeach(HWLIB IN LISTS HWLIBS)
+endforeach(ARCH IN LISTS ARCHS)
 
 # custom target that depends on all the output files
-add_custom_target(hw_toolchain ALL DEPENDS ${PREPROCESSED_LD_FILES} ${HW_LIB})
+add_custom_target(hw_toolchain ALL DEPENDS ${PREPROCESSED_LD_FILES} ${PREPROCESSED_O_FILES})

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -230,9 +230,9 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuil
             }
 
             if (this->is_fw_) {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/firmware_brisc.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_brisc.ld ";
             } else {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/kernel_brisc.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/kernel_brisc.ld ";
             }
 
             break;
@@ -252,9 +252,9 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuil
             }
 
             if (this->is_fw_) {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/firmware_ncrisc.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_ncrisc.ld ";
             } else {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/kernel_ncrisc.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/kernel_ncrisc.ld ";
             }
 
             break;
@@ -307,9 +307,9 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
             this->defines_ += "-DCOMPILE_FOR_TRISC=0 ";
 
             if (this->is_fw_) {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/firmware_trisc0.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_trisc0.ld ";
             } else {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/kernel_trisc0.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/kernel_trisc0.ld ";
             }
 
             break;
@@ -322,9 +322,9 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
             this->defines_ += "-DCOMPILE_FOR_TRISC=1 ";
 
             if (this->is_fw_) {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/firmware_trisc1.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_trisc1.ld ";
             } else {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/kernel_trisc1.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/kernel_trisc1.ld ";
             }
 
             break;
@@ -337,9 +337,9 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
             this->defines_ += "-DCOMPILE_FOR_TRISC=2 ";
 
             if (this->is_fw_) {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/firmware_trisc2.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_trisc2.ld ";
             } else {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/kernel_trisc2.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/kernel_trisc2.ld ";
             }
 
             break;
@@ -421,9 +421,9 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, const JitBuiltStateCo
             this->lflags_ = env_.lflags_ + "-Os ";
 
             if (this->is_fw_) {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/firmware_ierisc.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/firmware_ierisc.ld ";
             } else {
-                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/kernel_ierisc.ld ";
+                this->lflags_ += "-T" + env_.root_ + "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/kernel_ierisc.ld ";
             }
 
             break;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -172,7 +172,7 @@ void JitBuildState::finish_init() {
     }
 
     // Append hw build objects compiled offline
-    std::string build_dir = llrt::OptionsG.get_root_dir() + "runtime/hw/lib/";
+    std::string build_dir = llrt::OptionsG.get_root_dir() + "runtime/hw/lib/" + get_alias(env_.arch_) + "/";
     if (this->is_fw_) {
         if (this->target_name_ == "brisc") {
             this->link_objs_ += build_dir + "tdma_xmov.o ";


### PR DESCRIPTION
### Ticket
#596 

### Problem description
See issue

### What's changed
There are linker scripts generated for RISCV cores that are used in the jit_build component.
Instead of generating the necessary files for one architecture, pregenerate all three.
At runtime, bring in the pertinent linker script depending on the detected architecture.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
