### PR TITLE
#13766: Revise Clone Operation

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/test_clone.py
@@ -4,7 +4,6 @@
 
 import pytest
 import torch
-import copy
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc
@@ -62,11 +61,7 @@ def to_torch(
     """
     Converts a TTNN tensor back to a PyTorch tensor with the specified shape.
 
-    This function handles tensors with 0 or 1 dimensions by adjusting the unpadding shape:
-    - If the specified shape is empty (`len(shape) == 0`), `unpad_shape` is set to `[1, 1]`.
-    - If the specified shape is 1-dimensional, `unpad_shape` is set to `[1, shape[0]]`.
-
-    The TTNN tensor is converted to `ROW_MAJOR_LAYOUT` and unpadded using `unpad_shape`.
+    The TTNN tensor is converted to `ROW_MAJOR_LAYOUT` and unpadded.
     It is then converted to a PyTorch tensor and reshaped to the specified shape.
 
     Parameters:
@@ -81,14 +76,9 @@ def to_torch(
     """
     if ttnn_tensor is None:
         return None
-    unpad_shape = copy.deepcopy(shape)
-    if len(shape) == 0:
-        unpad_shape = [1, 1]
-    if len(shape) == 1:
-        unpad_shape = [1, shape[0]]
     ttnn_tensor = ttnn_tensor.cpu()
     if ttnn_tensor.layout == ttnn.TILE_LAYOUT:
-        ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(unpad_shape)
+        ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
     torch_tensor = ttnn.to_torch(ttnn_tensor)
     torch_tensor = torch.reshape(torch_tensor, shape=shape)
     return torch_tensor

--- a/tests/ttnn/unit_tests/operations/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/test_clone.py
@@ -4,15 +4,88 @@
 
 import pytest
 import torch
+import copy
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 
-from tests.ttnn.unit_tests.operations.test_utils import (
-    to_cpu,
-    to_npu,
-)
+
+def to_ttnn(
+    torch_tensor,
+    device,
+    *,
+    ttnn_layout=ttnn.TILE_LAYOUT,
+):
+    """
+    Converts a PyTorch tensor to a TTNN tensor with the specified device and layout.
+
+    This function handles tensors with 0 or 1 dimensions by reshaping them to have at least 2 dimensions:
+    - If the input tensor is a scalar (0-dimensional), it is reshaped to shape `[1, 1]`.
+    - If the input tensor is 1-dimensional, it is reshaped to shape `[1, length]`.
+
+    Parameters:
+    torch_tensor: torch.Tensor or None
+        The PyTorch tensor to convert. If None, the function returns None.
+    device: ttnn.device
+        The device to which the TTNN tensor will be moved.
+    ttnn_layout: ttnn.TILE_LAYOUT or ttnn.ROW_MAJOR_LAYOUT, optional
+        The desired layout for the TTNN tensor. Defaults to `ttnn.TILE_LAYOUT`.
+
+    Returns:
+    ttnn.Tensor or None
+        The converted TTNN tensor, with the specified layout and moved to the specified device.
+    """
+    if torch_tensor is None:
+        return None
+    if len(torch_tensor.shape) == 0:
+        torch_tensor = torch.reshape(torch_tensor, shape=[1, 1])
+    if len(torch_tensor.shape) == 1:
+        torch_tensor = torch.reshape(torch_tensor, shape=[1, len(torch_tensor)])
+    ttnn_tensor = ttnn.from_torch(torch_tensor)
+    if ttnn_layout == ttnn.TILE_LAYOUT:
+        ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=ttnn.TILE_LAYOUT)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device=device)
+    return ttnn_tensor
+
+
+def to_torch(
+    ttnn_tensor,
+    shape,
+):
+    """
+    Converts a TTNN tensor back to a PyTorch tensor with the specified shape.
+
+    This function handles tensors with 0 or 1 dimensions by adjusting the unpadding shape:
+    - If the specified shape is empty (`len(shape) == 0`), `unpad_shape` is set to `[1, 1]`.
+    - If the specified shape is 1-dimensional, `unpad_shape` is set to `[1, shape[0]]`.
+
+    The TTNN tensor is converted to `ROW_MAJOR_LAYOUT` and unpadded using `unpad_shape`.
+    It is then converted to a PyTorch tensor and reshaped to the specified shape.
+
+    Parameters:
+    ttnn_tensor: ttnn.Tensor or None
+        The TTNN tensor to convert. If None, the function returns None.
+    shape: list
+        The desired shape of the output PyTorch tensor.
+
+    Returns:
+    torch.Tensor or None
+        The converted PyTorch tensor reshaped to the specified shape.
+    """
+    if ttnn_tensor is None:
+        return None
+    unpad_shape = copy.deepcopy(shape)
+    if len(shape) == 0:
+        unpad_shape = [1, 1]
+    if len(shape) == 1:
+        unpad_shape = [1, shape[0]]
+    ttnn_tensor = ttnn_tensor.cpu()
+    if ttnn_tensor.layout == ttnn.TILE_LAYOUT:
+        ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(unpad_shape)
+    torch_tensor = ttnn.to_torch(ttnn_tensor)
+    torch_tensor = torch.reshape(torch_tensor, shape=shape)
+    return torch_tensor
 
 
 def get_lib_dtype(lib, dtype):
@@ -69,9 +142,9 @@ def run_clone(
     pytest.skip: When certain conditions on dtype mismatch or layout are not met.
     """
     if input_dtype == "int32":
-        cpu_input = torch.randint(low=-10, high=11, size=shape, dtype=get_lib_dtype(torch, input_dtype))
+        torch_input = torch.randint(low=-10, high=11, size=shape, dtype=get_lib_dtype(torch, input_dtype))
     else:
-        cpu_input = 2 * torch.rand(size=shape, dtype=get_lib_dtype(torch, input_dtype)) - 1
+        torch_input = 2 * torch.rand(size=shape, dtype=get_lib_dtype(torch, input_dtype)) - 1
 
     if input_dtype == "int32":
         if output_dtype and output_dtype != "int32":
@@ -80,23 +153,24 @@ def run_clone(
         pytest.skip("For int32 output, input_dtype must also be int32.")
     if output_dtype != input_dtype and output_dtype and not tilized:
         pytest.skip("When not tilized, dtype conversion is not supported.")
+    if not tilized and shape and shape[-1] % 2 == 1:
+        pytest.skip("TTNN failed to create a ROW_MAJOR_LAYOUT tensor from a PyTorch tensor with an odd last dimension.")
 
-    npu_input = to_npu(
-        cpu_input,
+    ttnn_input = to_ttnn(
+        torch_input,
         device,
-        npu_dtype=get_lib_dtype(ttnn, input_dtype),
-        npu_layout=ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT,
+        ttnn_layout=ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT,
     ).to(device, input_memory_config)
 
-    npu_output = ttnn.clone(
-        npu_input,
+    ttnn_output = ttnn.clone(
+        ttnn_input,
         dtype=get_lib_dtype(ttnn, output_dtype),
         memory_config=output_memory_config,
     )
 
-    cpu_output = to_cpu(npu_output, shape)
+    torch_output = to_torch(ttnn_output, shape)
 
-    passing, out = comp_allclose_and_pcc(torch.ops.aten.clone(cpu_input), cpu_output, rtol=0.01, atol=0.01)
+    passing, out = comp_allclose_and_pcc(torch.ops.aten.clone(torch_input), torch_output, rtol=0.01, atol=0.01)
     logger.info(out)
     assert passing
 
@@ -249,7 +323,7 @@ def test_clone_callback(
             device,
         )
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        ttnn_dummy = to_ttnn(torch_dummy, device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0

--- a/tests/ttnn/unit_tests/operations/test_copy_ops.py
+++ b/tests/ttnn/unit_tests/operations/test_copy_ops.py
@@ -13,41 +13,6 @@ from models.utility_functions import skip_for_grayskull
 from models.utility_functions import is_grayskull
 
 
-def run_clone_test(N, C, H, W, memory_config, dtype, device):
-    torch.manual_seed(2005)
-    shape = [N, C, H, W]
-    torch_dtype = torch.bfloat16
-
-    input = torch.randn(shape, dtype=torch_dtype)
-    input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
-    tensor = ttnn.clone(input, memory_config=memory_config, dtype=dtype)
-    assert tensor.shape == input.shape
-    assert tensor.dtype == dtype
-    assert tensor.memory_config() == memory_config
-    assert_with_pcc(ttnn.to_torch(input), ttnn.to_torch(tensor), 0.99)
-
-
-@skip_for_grayskull()
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ),
-    ids=[
-        "BFLOAT16_B",
-        "BFLOAT8_B",
-    ],
-)
-@pytest.mark.parametrize(
-    "N, C, H, W,",
-    ((1, 1, 32, 64),),
-)
-@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_clone(N, C, H, W, memory_config, dtype, device):
-    run_clone_test(N, C, H, W, memory_config, dtype, device)
-
-
 def run_copy_test(N, C, H, W, layout, device):
     torch.manual_seed(2005)
     shape = [N, C, H, W]

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/clone.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/clone.cpp
@@ -8,7 +8,10 @@
 
 namespace ttnn::operations::data_movement::clone {
 Tensor Clone::invoke(
-    const Tensor& input, const std::optional<DataType>& dtype, const std::optional<MemoryConfig>& memory_config) {
-    return ttnn::prim::clone(input, dtype, memory_config);
+    const Tensor& input,
+    const std::optional<DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return ttnn::prim::clone(input, dtype, memory_config, compute_kernel_config);
 }
 }  // namespace ttnn::operations::data_movement::clone

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/clone.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/clone.hpp
@@ -4,11 +4,15 @@
 
 #pragma once
 #include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::data_movement::clone {
 struct Clone {
     static Tensor invoke(
-        const Tensor& input, const std::optional<DataType>& dtype, const std::optional<MemoryConfig>& memory_config);
+        const Tensor& input,
+        const std::optional<DataType>& dtype,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::data_movement::clone
 

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
@@ -21,6 +21,7 @@ void bind_clone_operation(py::module& module) {
         * :attr:`input`: The tensor to be cloned.
         * :attr:`dtype`: The target data type of the cloned tensor.
         * :attr:`memory_config`: The memory configuration for the clone, options include DRAM_MEMORY_CONFIG or L1_MEMORY_CONFIG.
+        * :attr:`compute_kernel_config`: The configuration for the compute kernel.
     )doc";
 
     bind_registered_operation(
@@ -32,6 +33,7 @@ void bind_clone_operation(py::module& module) {
             py::kw_only(),
             py::arg("dtype") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt,
         });
 }
 }  // namespace ttnn::operations::data_movement::clone

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -52,11 +52,15 @@ CloneOperation::tensor_return_value_t CloneOperation::create_output_tensors(
 }
 
 std::tuple<CloneOperation::operation_attributes_t, CloneOperation::tensor_args_t> CloneOperation::invoke(
-    const Tensor& input, const std::optional<DataType>& dtype, const std::optional<MemoryConfig>& memory_config) {
+    const Tensor& input,
+    const std::optional<DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     return {
         operation_attributes_t{
             dtype.value_or(input.get_dtype()),
             memory_config.value_or(input.memory_config()),
+            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
         },
         tensor_args_t{input},
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -44,7 +44,7 @@ CloneOperation::tensor_return_value_t CloneOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;
     return create_device_tensor(
-        tensor_args.input.get_legacy_shape(),
+        compute_output_shapes(operation_attributes, tensor_args),
         operation_attributes.dtype,
         input.get_layout(),
         input.device(),

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::data_movement::clone {
 
@@ -10,6 +11,7 @@ struct CloneOperation {
     struct operation_attributes_t {
         const DataType dtype;
         const MemoryConfig memory_config;
+        const DeviceComputeKernelConfig compute_kernel_config;
     };
 
     struct tensor_args_t {
@@ -50,7 +52,10 @@ struct CloneOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input, const std::optional<DataType>& dtype, const std::optional<MemoryConfig>& memory_config);
+        const Tensor& input,
+        const std::optional<DataType>& dtype,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::data_movement::clone

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
@@ -16,13 +16,13 @@ struct CloneOperation {
         const Tensor& input;
     };
 
-    using shape_return_value_t = ttnn::SimpleShape;
+    using shape_return_value_t = SimpleShape;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
         struct shared_variables_t {
-            KernelHandle unary_reader_kernel_id;
-            KernelHandle unary_writer_kernel_id;
+            KernelHandle read_kernel_id;
+            KernelHandle write_kernel_id;
             std::vector<CoreCoord> cores;
         };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
@@ -11,52 +11,44 @@ CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory:
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    using namespace tt;
-    using namespace tt::tt_metal;
+    using namespace tt::constants;
     using namespace tt::tt_metal::detail;
+    using namespace tt::tt_metal;
+    using namespace tt;
+
+    Program program;
 
     const auto& input = tensor_args.input;
-    Program program = Program();
-
+    auto src_cb_data_format = datatype_to_dataformat_converter(input.get_dtype());
+    auto dst_cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    bool convert_dtype = src_cb_data_format != dst_cb_data_format;
     bool tilized = output.get_layout() == Layout::TILE;
+    auto compute_unit_size = [&](const auto& tensor, const auto& data_format) {
+        return tilized ? TileSize(data_format) : tensor.get_logical_shape()[-1] * tensor.element_size();
+    };
+    uint32_t input_unit_size = compute_unit_size(input, src_cb_data_format);
+    uint32_t output_unit_size = compute_unit_size(output, dst_cb_data_format);
+    uint32_t num_units = tilized ? output.volume() / TILE_HW : output.volume() / output.get_logical_shape()[-1];
 
-    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(input.get_dtype());
-    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
-    bool convert_dtype = input_cb_data_format != output_cb_data_format;
-    uint32_t input_unit_size =
-        tilized ? TileSize(input_cb_data_format) : input.get_logical_shape()[-1] * input.element_size();
-    uint32_t output_unit_size =
-        tilized ? TileSize(output_cb_data_format) : output.get_logical_shape()[-1] * output.element_size();
-
-    uint32_t num_units =
-        tilized ? output.volume() / constants::TILE_HW : output.volume() / output.get_logical_shape()[-1];
-
-    Device* device = output.device();
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = output.device()->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_units);
 
-    uint32_t src0_cb_index = CB::c_in0;
-    uint32_t num_input_units = 2;
+    uint32_t src_cb_id = CB::c_in4;
     uint32_t aligned_input_unit_size = round_up_to_mul32(input_unit_size);
-    auto cb_src0_config =
-        CircularBufferConfig(num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, aligned_input_unit_size);
-    auto cb_src0 = CreateCircularBuffer(program, all_cores, cb_src0_config);
+    auto cb_src_config = CircularBufferConfig(2 * aligned_input_unit_size, {{src_cb_id, src_cb_data_format}})
+                             .set_page_size(src_cb_id, aligned_input_unit_size);
+    auto cb_src = CreateCircularBuffer(program, all_cores, cb_src_config);
 
-    uint32_t output_cb_index = src0_cb_index;
+    uint32_t dst_cb_id = src_cb_id;
     if (convert_dtype) {
-        output_cb_index = CB::c_out0;
-        uint32_t num_output_units = 2;
+        dst_cb_id = CB::c_out4;
         uint32_t aligned_output_unit_size = round_up_to_mul32(output_unit_size);
-        auto output_cb_config =
-            CircularBufferConfig(
-                num_output_units * aligned_output_unit_size, {{output_cb_index, output_cb_data_format}})
-                .set_page_size(output_cb_index, aligned_output_unit_size);
-        auto cb_output = CreateCircularBuffer(program, all_cores, output_cb_config);
+        auto cb_dst_config = CircularBufferConfig(2 * aligned_output_unit_size, {{dst_cb_id, dst_cb_data_format}})
+                                 .set_page_size(dst_cb_id, aligned_output_unit_size);
+        auto cb_dst = CreateCircularBuffer(program, all_cores, cb_dst_config);
     }
 
     auto src_buffer = input.buffer();
@@ -66,86 +58,115 @@ CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory:
 
     vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
     if (tilized) {
-        reader_compile_time_args = {(uint32_t)src_is_dram};
-        writer_compile_time_args = {(uint32_t)output_cb_index, (uint32_t)dst_is_dram};
+        reader_compile_time_args = {
+            (uint32_t)src_cb_id,
+            (uint32_t)src_is_dram,
+        };
+        writer_compile_time_args = {
+            (uint32_t)dst_cb_id,
+            (uint32_t)dst_is_dram,
+        };
     } else {
         bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_unit_size);
         uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (uint32_t)log2(input_unit_size) : 0;
         reader_compile_time_args = {
-            (uint32_t)src0_cb_index,
+            (uint32_t)src_cb_id,
             (uint32_t)src_is_dram,
             (uint32_t)src_stick_size_is_power_of_two,
             (uint32_t)src_log2_stick_size};
         bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(output_unit_size);
         uint32_t dst_log2_stick_size = dst_stick_size_is_power_of_two ? (uint32_t)log2(output_unit_size) : 0;
         writer_compile_time_args = {
-            (uint32_t)output_cb_index,
+            (uint32_t)dst_cb_id,
             (uint32_t)dst_is_dram,
             (uint32_t)dst_stick_size_is_power_of_two,
             (uint32_t)dst_log2_stick_size};
     }
-    map<string, string> kernel_defines;
-    KernelHandle unary_reader_kernel_id = CreateKernel(
+
+    auto read_kernel_id = CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp"
                 : "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp",
         all_cores,
-        ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+        ReaderDataMovementConfig(reader_compile_time_args, {}));
 
-    KernelHandle unary_writer_kernel_id = CreateKernel(
+    auto write_kernel_id = CreateKernel(
         program,
         tilized ? "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp"
                 : "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm.cpp",
         all_cores,
-        WriterDataMovementConfig(writer_compile_time_args, kernel_defines));
+        WriterDataMovementConfig(writer_compile_time_args, {}));
 
     if (convert_dtype) {
-        vector<uint32_t> compute_kernel_args_group_1 = {num_units_per_core_group_1};
-        auto eltwise_unary_kernel_group_1 = CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp",
-            core_group_1,
-            ComputeConfig{.compile_args = compute_kernel_args_group_1});
-
-        if (!core_group_2.ranges().empty()) {
-            vector<uint32_t> compute_kernel_args_group_2 = {num_units_per_core_group_2};
-            auto eltwise_unary_kernel_group_2 = CreateKernel(
-                program,
-                "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp",
-                core_group_2,
-                ComputeConfig{.compile_args = compute_kernel_args_group_2});
-        }
+        auto create_compute_kernel = [&](const auto& core_group, uint32_t num_units_per_core) {
+            if (!core_group.ranges().empty()) {
+                vector<uint32_t> compute_kernel_args = {
+                    (uint32_t)src_cb_id,
+                    (uint32_t)dst_cb_id,
+                    (uint32_t)num_units_per_core,
+                };
+                CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp",
+                    core_group,
+                    ComputeConfig{.compile_args = compute_kernel_args});
+            }
+        };
+        create_compute_kernel(core_group_1, num_units_per_core_group_1);
+        create_compute_kernel(core_group_2, num_units_per_core_group_2);
     }
 
     uint32_t start_id = 0;
-    uint32_t g1_numcores = core_group_1.num_cores();
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
+    uint32_t num_cores_group1 = core_group_1.num_cores();
+    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
 
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
-
+    for (size_t i = 0; i < cores.size(); ++i) {
+        const auto& core = cores[i];
+        uint32_t num_units_per_core = i < num_cores_group1 ? num_units_per_core_group_1 : num_units_per_core_group_2;
         if (tilized) {
             SetRuntimeArgs(
-                program, unary_reader_kernel_id, core, {src_buffer->address(), num_units_per_core, start_id});
+                program,
+                read_kernel_id,
+                core,
+                {
+                    (uint32_t)src_buffer->address(),
+                    (uint32_t)num_units_per_core,
+                    (uint32_t)start_id,
+                });
             SetRuntimeArgs(
-                program, unary_writer_kernel_id, core, {dst_buffer->address(), num_units_per_core, start_id});
+                program,
+                write_kernel_id,
+                core,
+                {
+                    (uint32_t)dst_buffer->address(),
+                    (uint32_t)num_units_per_core,
+                    (uint32_t)start_id,
+                });
         } else {
             SetRuntimeArgs(
                 program,
-                unary_reader_kernel_id,
+                read_kernel_id,
                 core,
-                {src_buffer->address(), input_unit_size, num_units_per_core, start_id});
+                {
+                    (uint32_t)src_buffer->address(),
+                    (uint32_t)input_unit_size,
+                    (uint32_t)num_units_per_core,
+                    (uint32_t)start_id,
+                });
             SetRuntimeArgs(
                 program,
-                unary_writer_kernel_id,
+                write_kernel_id,
                 core,
-                {dst_buffer->address(), output_unit_size, num_units_per_core, start_id});
+                {
+                    (uint32_t)dst_buffer->address(),
+                    (uint32_t)output_unit_size,
+                    (uint32_t)num_units_per_core,
+                    (uint32_t)start_id,
+                });
         }
         start_id += num_units_per_core;
     }
-
-    return {std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, cores}};
+    return {std::move(program), {read_kernel_id, write_kernel_id, cores}};
 }
 
 void CloneOperation::ProgramFactory::override_runtime_arguments(
@@ -154,21 +175,15 @@ void CloneOperation::ProgramFactory::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     const auto& program = cached_program.program;
-    const auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
-    const auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
-    auto cores = cached_program.shared_variables.cores;
+    const auto& read_kernel_id = cached_program.shared_variables.read_kernel_id;
+    const auto& write_kernel_id = cached_program.shared_variables.write_kernel_id;
+    const auto& cores = cached_program.shared_variables.cores;
 
     auto src_buffer_address = tensor_args.input.buffer()->address();
     auto dst_buffer_address = output.buffer()->address();
     for (const auto& core : cores) {
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
-            runtime_args[0] = src_buffer_address;
-        }
-        {
-            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
-            runtime_args[0] = dst_buffer_address;
-        }
+        GetRuntimeArgs(program, read_kernel_id, core)[0] = src_buffer_address;
+        GetRuntimeArgs(program, write_kernel_id, core)[0] = dst_buffer_address;
     }
 }
 }  // namespace ttnn::operations::data_movement::clone

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
@@ -98,6 +98,8 @@ CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory:
         WriterDataMovementConfig(writer_compile_time_args, {}));
 
     if (convert_dtype) {
+        auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+            get_compute_kernel_config_args(input.device()->arch(), operation_attributes.compute_kernel_config);
         auto create_compute_kernel = [&](const auto& core_group, uint32_t num_units_per_core) {
             if (!core_group.ranges().empty()) {
                 vector<uint32_t> compute_kernel_args = {
@@ -109,7 +111,13 @@ CloneOperation::ProgramFactory::cached_program_t CloneOperation::ProgramFactory:
                     program,
                     "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp",
                     core_group,
-                    ComputeConfig{.compile_args = compute_kernel_args});
+                    ComputeConfig{
+                        .math_fidelity = math_fidelity,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .math_approx_mode = math_approx_mode,
+                        .compile_args = compute_kernel_args,
+                    });
             }
         };
         create_compute_kernel(core_group_1, num_units_per_core_group_1);

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp
@@ -2,27 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
 namespace NAMESPACE {
 void MAIN {
-    uint32_t per_core_tile_count = get_compile_time_arg_val(0);
-    unary_op_init_common(tt::CB::c_in0);
-    for (uint32_t tile_index = 0; tile_index < per_core_tile_count; ++tile_index) {
-        cb_wait_front(tt::CB::c_in0, 1);
-        cb_reserve_back(tt::CB::c_out0, 1);
+    uint32_t src_cb_id = get_compile_time_arg_val(0);
+    uint32_t dst_cb_id = get_compile_time_arg_val(1);
+    uint32_t num_tiles = get_compile_time_arg_val(2);
+    unary_op_init_common(src_cb_id, dst_cb_id);
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        cb_wait_front(src_cb_id, 1);
         tile_regs_acquire();
-        copy_tile(tt::CB::c_in0, 0, 0);
+        copy_tile(src_cb_id, 0, 0);
         tile_regs_commit();
+        cb_pop_front(src_cb_id, 1);
+
+        cb_reserve_back(dst_cb_id, 1);
         tile_regs_wait();
-        pack_tile(0, tt::CB::c_out0);
+        pack_tile(0, dst_cb_id, 0);
         tile_regs_release();
-        cb_pop_front(tt::CB::c_in0, 1);
-        cb_push_back(tt::CB::c_out0, 1);
+        cb_push_back(dst_cb_id, 1);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
@@ -5,6 +5,7 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
+    uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
@@ -12,7 +13,7 @@ void kernel_main() {
     constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
 
     const InterleavedAddrGenFast<input_is_dram> s = {
-        .bank_base_address = get_arg_val<uint32_t>(0),
+        .bank_base_address = input_buffer_address,
         .page_size = get_tile_size(src_cb_id),
         .data_format = get_dataformat(src_cb_id),
     };
@@ -20,7 +21,8 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_reserve_back(src_cb_id, 1);
-        noc_async_read_tile(i, s, get_write_ptr(src_cb_id));
+        uint32_t src_cb_write_addr = get_write_ptr(src_cb_id);
+        noc_async_read_tile(i, s, src_cb_write_addr);
         noc_async_read_barrier();
         cb_push_back(src_cb_id, 1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel.cpp
@@ -5,15 +5,14 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
 
-    const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr,
+    const InterleavedAddrGenFast<input_is_dram> s = {
+        .bank_base_address = get_arg_val<uint32_t>(0),
         .page_size = get_tile_size(src_cb_id),
         .data_format = get_dataformat(src_cb_id),
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
@@ -5,6 +5,7 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
+    uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
     uint32_t stick_size = get_arg_val<uint32_t>(1);
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
@@ -16,12 +17,12 @@ void kernel_main() {
 #if (src_stick_size_is_power_of_two)
     constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
     const InterleavedPow2AddrGen<input_is_dram> s = {
-        .bank_base_address = get_arg_val<uint32_t>(0),
+        .bank_base_address = input_buffer_address,
         .log_base_2_of_page_size = src_log_base_2_of_page_size,
     };
 #else
     const InterleavedAddrGen<input_is_dram> s = {
-        .bank_base_address = get_arg_val<uint32_t>(0),
+        .bank_base_address = input_buffer_address,
         .page_size = stick_size,
     };
 #endif
@@ -29,7 +30,9 @@ void kernel_main() {
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_reserve_back(src_cb_id, 1);
-        noc_async_read(get_noc_addr(i, s), get_write_ptr(src_cb_id), stick_size);
+        uint64_t input_noc_addr = get_noc_addr(i, s);
+        uint32_t src_cb_write_addr = get_write_ptr(src_cb_id);
+        noc_async_read(input_noc_addr, src_cb_write_addr, stick_size);
         noc_async_read_barrier();
         cb_push_back(src_cb_id, 1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
-
 #include "dataflow_api.h"
 
 void kernel_main() {
@@ -12,25 +10,23 @@ void kernel_main() {
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
 
-#define src_stick_size_is_pow2 get_compile_time_arg_val(2) == 1
-#if (src_stick_size_is_pow2)
+#define src_stick_size_is_power_of_two get_compile_time_arg_val(2) == 1
+#if (src_stick_size_is_power_of_two)
     constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
-    const InterleavedPow2AddrGen<src0_is_dram> s0 = {
+    const InterleavedPow2AddrGen<src_is_dram> s = {
         .bank_base_address = src_addr, .log_base_2_of_page_size = src_log_base_2_of_page_size};
 #else
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
+    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = stick_size};
 #endif
 
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint64_t src_noc_addr = get_noc_addr(i, s0);
-        noc_async_read(src_noc_addr, l1_write_addr, stick_size);
+        cb_reserve_back(src_cb_id, 1);
+        noc_async_read(get_noc_addr(i, s), get_write_ptr(src_cb_id), stick_size);
         noc_async_read_barrier();
-        cb_push_back(cb_id_in0, 1);
+        cb_push_back(src_cb_id, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/read_kernel_rm.cpp
@@ -5,21 +5,25 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t stick_size = get_arg_val<uint32_t>(1);
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
 
 #define src_stick_size_is_power_of_two get_compile_time_arg_val(2) == 1
 #if (src_stick_size_is_power_of_two)
     constexpr uint32_t src_log_base_2_of_page_size = get_compile_time_arg_val(3);
-    const InterleavedPow2AddrGen<src_is_dram> s = {
-        .bank_base_address = src_addr, .log_base_2_of_page_size = src_log_base_2_of_page_size};
+    const InterleavedPow2AddrGen<input_is_dram> s = {
+        .bank_base_address = get_arg_val<uint32_t>(0),
+        .log_base_2_of_page_size = src_log_base_2_of_page_size,
+    };
 #else
-    const InterleavedAddrGen<src_is_dram> s = {.bank_base_address = src_addr, .page_size = stick_size};
+    const InterleavedAddrGen<input_is_dram> s = {
+        .bank_base_address = get_arg_val<uint32_t>(0),
+        .page_size = stick_size,
+    };
 #endif
 
     uint32_t end_id = start_id + num_sticks;

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
@@ -5,15 +5,14 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
 
-    const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr,
+    const InterleavedAddrGenFast<output_is_dram> s = {
+        .bank_base_address = get_arg_val<uint32_t>(0),
         .page_size = get_tile_size(dst_cb_id),
         .data_format = get_dataformat(dst_cb_id),
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
@@ -9,22 +9,20 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
 
-    constexpr uint32_t one_tile = 1;
-    const uint32_t tile_bytes = get_tile_size(cb_id_out);
-    const DataFormat data_format = get_dataformat(cb_id_out);
-
     const InterleavedAddrGenFast<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+        .bank_base_address = dst_addr,
+        .page_size = get_tile_size(dst_cb_id),
+        .data_format = get_dataformat(dst_cb_id),
+    };
 
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_wait_front(cb_id_out, one_tile);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        noc_async_write_tile(i, s, l1_read_addr);
+        cb_wait_front(dst_cb_id, 1);
+        noc_async_write_tile(i, s, get_read_ptr(dst_cb_id));
         noc_async_write_barrier();
-        cb_pop_front(cb_id_out, one_tile);
+        cb_pop_front(dst_cb_id, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel.cpp
@@ -5,6 +5,7 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
+    uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
 
@@ -12,7 +13,7 @@ void kernel_main() {
     constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
 
     const InterleavedAddrGenFast<output_is_dram> s = {
-        .bank_base_address = get_arg_val<uint32_t>(0),
+        .bank_base_address = output_buffer_address,
         .page_size = get_tile_size(dst_cb_id),
         .data_format = get_dataformat(dst_cb_id),
     };
@@ -20,7 +21,8 @@ void kernel_main() {
     uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_wait_front(dst_cb_id, 1);
-        noc_async_write_tile(i, s, get_read_ptr(dst_cb_id));
+        uint32_t dst_cb_read_addr = get_read_ptr(dst_cb_id);
+        noc_async_write_tile(i, s, dst_cb_read_addr);
         noc_async_write_barrier();
         cb_pop_front(dst_cb_id, 1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/write_kernel_rm.cpp
@@ -5,21 +5,25 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t stick_size = get_arg_val<uint32_t>(1);
     uint32_t num_sticks = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t dst_cb_id = get_compile_time_arg_val(0);
-    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool output_is_dram = get_compile_time_arg_val(1) == 1;
 
 #define dst_stick_size_is_power_of_two get_compile_time_arg_val(2) == 1
 #if (dst_stick_size_is_power_of_two)
     constexpr uint32_t dst_log_base_2_of_page_size = get_compile_time_arg_val(3);
-    const InterleavedPow2AddrGen<dst_is_dram> s = {
-        .bank_base_address = dst_addr, .log_base_2_of_page_size = dst_log_base_2_of_page_size};
+    const InterleavedPow2AddrGen<output_is_dram> s = {
+        .bank_base_address = get_arg_val<uint32_t>(0),
+        .log_base_2_of_page_size = dst_log_base_2_of_page_size,
+    };
 #else
-    const InterleavedAddrGen<dst_is_dram> s = {.bank_base_address = dst_addr, .page_size = stick_size};
+    const InterleavedAddrGen<output_is_dram> s = {
+        .bank_base_address = get_arg_val<uint32_t>(0),
+        .page_size = stick_size,
+    };
 #endif
 
     uint32_t end_id = start_id + num_sticks;

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -30,7 +30,7 @@ Tensor AutoFormat::move_tensor_to_mem_config(const Tensor& input, const MemoryCo
     if (input.storage_type() != StorageType::DEVICE) {
         return ttnn::data_transfer_to_device(input, AutoFormat::GetDefaultDevice(), mem_config);
     } else if (input.memory_config() != mem_config) {
-        return ttnn::clone(input, std::nullopt, mem_config);
+        return ttnn::clone(input, std::nullopt, mem_config, std::nullopt);
     } else {
         return input;
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue: [13766](https://github.com/tenstorrent/tt-metal/issues/13766)

### Problem description
Clone operation need to be revised:
- Kernels
- Test cases
- Coding conventions

### What's changed
- The kernel functions have been revised:
  - **compute_kernel.cpp**: 
    - Added support for `src_cb_id` and `dst_cb_id` as compile-time arguments
    - Properly handled double buffering
  - **read_kernel_id**: Added support for `src_cb_id` as a compile-time argument 
  - **write_kernel_id**: Added support for `dst_cb_id` as a compile-time argument 
- **clone_program_factory.cpp**: Naming and coding conventions are consistent throughout, aligning with the kernels. For now, we can simply change the `cb_id` pair used in this file.
- **clone_device_operation**: Replaced `Shape` with `SimpleShape` for consistency.
- **test_clone.py**: Properly handled test cases using `ROW_MAJOR_LAYOUT`. I noticed that the `to_npu` utility function was performing padding on `ROW_MAJOR_LAYOUT` tensors, which is not the expected behavior. To address this, I wrote `to_ttnn` and `to_torch` to manage it correctly. Update: I use `from_torch`, `to_torch` directly instead.
- **test_copy_ops.py**: Removed the old test clone script. Actually, there were two files to test the clone operation. One was removed in a previous PR.
- Support **compute_kernel_config**
### Checklist
- [x] Post commit CI passes:
+ [All post-commit tests #17677](https://github.com/tenstorrent/tt-metal/actions/runs/11307601928)
+ [All post-commit tests #17678](https://github.com/tenstorrent/tt-metal/actions/runs/11308186480)
+ [All post-commit tests #17695](https://github.com/tenstorrent/tt-metal/actions/runs/11317127378)
+ [All post-commit tests #17706](https://github.com/tenstorrent/tt-metal/actions/runs/11321658595)
+ [All post-commit tests #17839](https://github.com/tenstorrent/tt-metal/actions/runs/11359594578)
- [X] Blackhole Post commit (if applicable): N/A
- [X] Model regression CI testing passes (if applicable): N/A
- [X] Device performance regression CI testing passes (if applicable): N/A
- [X] New/Existing tests provide coverage for changes: 64/64 test cases passed

| Test Case                 | Number of Test Cases |
|---------------------------|----------------------|
| `test_clone_shape`         | 22                   |
| `test_clone_memory_config` | 12                   |
| `test_clone_dtype_conversion` | 28               |
| `test_clone_callback`      | 2                    |
