### PR TITLE
#0: no core timeout for simulators

### DIFF
--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -318,6 +318,7 @@ void wait_until_cores_done(
     // poll the cores until the set of not done cores is empty
     int loop_count = 1;
     auto start = std::chrono::high_resolution_clock::now();
+    if (std::getenv("TT_METAL_SIMULATOR_EN")) timeout_ms = 0;
     while (!not_done_phys_cores.empty()) {
         if (timeout_ms > 0) {
             auto now = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Ignore timeout for cores when targeting simulator (VCS or Versim) since simulator will always take longer to run

### What's changed
The `TT_METAL_SIMULATOR_EN=1` will be set to indicate we are targeting a simulator backend. Check this env var and set timeout to 0 to prevent timing out in `wait_until_cores_done` function in `llrt.cpp`.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11308436210
