### PR TITLE
#13738: remove unused template from SimpleShape constructor

### DIFF
--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -34,7 +34,6 @@ Plan:
 **/
 class SimpleShape {
 public:
-    template <typename T>
     explicit SimpleShape(const std::vector<uint32_t>& shape) : value(shape) {}
     explicit SimpleShape(std::vector<uint32_t>&& shape) : value(std::move(shape)) {}
     explicit SimpleShape(std::initializer_list<uint32_t> ilist) : value(ilist) {}


### PR DESCRIPTION
### Ticket
#13738 

### Problem description
There is an unused template in the constructor for `SimpleShape` that prevents a simple use case of calling it with just a vector of `uint32_t` dimension sizes

### What's changed
- Removed the unnecessary templating
- ~~Removed some calls to `std::move` (since it is no longer necessary)~~ One certain team leader that understand what `std::move` is.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
