### PR TITLE
#596: Refactor common_runtime_address_map - move PROFILER constants

### DIFF
--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -8,18 +8,10 @@
 #include "common_values.hpp"
 #include "dev_mem_map.h"
 #include "noc/noc_parameters.h"
-#include "hostdevcommon/profiler_common.h"
 
 /*
 * This file contains addresses that are visible to both host and device compiled code.
 */
-
-// TODO: move these out of the memory map into profiler code
-constexpr static std::uint32_t PROFILER_OP_SUPPORT_COUNT = 1000;
-constexpr static std::uint32_t PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC = kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE * (kernel_profiler::PROFILER_L1_PROGRAM_ID_COUNT +  kernel_profiler::PROFILER_L1_GUARANTEED_MARKER_COUNT + kernel_profiler::PROFILER_L1_OP_MIN_OPTIONAL_MARKER_COUNT) * PROFILER_OP_SUPPORT_COUNT;
-constexpr static std::uint32_t PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC = PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC * sizeof(uint32_t);
-
-static_assert (PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC > kernel_profiler::PROFILER_L1_BUFFER_SIZE);
 
 // Kernel config buffer is WIP
 // Size is presently based on the old sizes of the RTAs + CB config + Sems

--- a/tt_metal/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/profiler_common.h
@@ -58,3 +58,9 @@ namespace kernel_profiler{
     constexpr static std::uint32_t PROFILER_L1_BUFFER_SIZE = PROFILER_L1_VECTOR_SIZE * sizeof(uint32_t);
 
 }
+
+constexpr static std::uint32_t PROFILER_OP_SUPPORT_COUNT = 1000;
+constexpr static std::uint32_t PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC = kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE * (kernel_profiler::PROFILER_L1_PROGRAM_ID_COUNT +  kernel_profiler::PROFILER_L1_GUARANTEED_MARKER_COUNT + kernel_profiler::PROFILER_L1_OP_MIN_OPTIONAL_MARKER_COUNT) * PROFILER_OP_SUPPORT_COUNT;
+constexpr static std::uint32_t PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC = PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC * sizeof(uint32_t);
+
+static_assert (PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC > kernel_profiler::PROFILER_L1_BUFFER_SIZE);


### PR DESCRIPTION
### Ticket
#596 
#11830 

### Problem description
We are trying to eliminate common_runtime_address_map, as it is not truly common.
It is a function of ARCH_NAME.
These constants were previously flagged as being in the wrong place.
Moving them to profiler_common.h is a simple solution to rehoming them.

### What's changed
Move profiler related constants from `common_runtime_address_map` to `profiler_common` header file.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11336447989
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
