### PR TITLE
#13257: Decouple CMAKE_INSTALL_PREFIX and PROJECT_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,13 +128,6 @@ endif()
 
 unset(SANITIZER_ENABLED)
 
-include(GNUInstallDirs)
-set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}")
-set(CMAKE_INSTALL_LIBDIR "${PROJECT_BINARY_DIR}/lib")
-set(CMAKE_INSTALL_BINDIR "${PROJECT_BINARY_DIR}/tmp/bin")
-set(CMAKE_INSTALL_INCLUDEDIR "${PROJECT_BINARY_DIR}/tmp/include")
-set(CMAKE_INSTALL_DATAROOTDIR "${PROJECT_BINARY_DIR}/tmp/share")
-
 ############################################################################################################################
 # Find all required libraries to build
 ############################################################################################################################
@@ -270,15 +263,17 @@ endif(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
 # For top level install: cmake --build build --target install  or  make/ninja install -C build
 ############################################################################################################################
 # Install for build artifacts that will upload build/lib
+include(GNUInstallDirs)
+
 install(TARGETS tt_metal
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT tt_build_artifacts
+    COMPONENT dev
 )
 install(TARGETS ttnn
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT tt_build_artifacts
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT dev
 )
 if(WITH_PYTHON_BINDINGS)
     # Install .so into src files for pybinds implementation


### PR DESCRIPTION
### Ticket
Closes #13257 

### Problem description
See issue

### What's changed
Don't hardcode CMAKE_INSTALL_PREFIX
Don't override default linux install directories from GnuInstallDirs
We need the variables to be programmatic.
For instance, generating debians using CPACK, or writing Anaconda build recipe depends on CMAKE_INSTALL_PREFIX.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11336867066
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
