### PR TITLE
#13127: Refactor part of data_movement ops `compute_output_shapes` to use `SimpleShape`

### DIFF
--- a/tests/tt_eager/ops/test_tilize_zero_padding.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
         auto padded_shape = a.get_legacy_shape();
         padded_shape[2] = round_up(padded_shape[2], TILE_HEIGHT);
         padded_shape[3] = round_up(padded_shape[3], TILE_WIDTH);
-        Tensor padded_host_a = host_a.pad(padded_shape, {0,0,0,0}, 0);
+        Tensor padded_host_a = host_a.pad(padded_shape, ttnn::SimpleShape{0,0,0,0}, 0);
         Tensor golden = padded_host_a.to(Layout::TILE);
         auto golden_vec =  owned_buffer::get_as<bfloat16>(golden);
         auto result_vec = owned_buffer::get_as<bfloat16>(c);

--- a/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
         auto padded_shape = g.get_legacy_shape();
         padded_shape[2] = round_up(padded_shape[2], TILE_HEIGHT);
         padded_shape[3] = round_up(padded_shape[3], TILE_WIDTH);
-        Tensor padded_g = g.pad(padded_shape, {0,0,0,0}, 0);
+        Tensor padded_g = g.pad(padded_shape, ttnn::SimpleShape{0,0,0,0}, 0);
         Tensor golden = padded_g.to(Layout::TILE);
         auto golden_vec =  owned_buffer::get_as<bfloat16>(golden);
         auto result_vec = owned_buffer::get_as<bfloat16>(c);

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1132,7 +1132,7 @@ void pytensor_module(py::module &m_tensor) {
             [](const Tensor &self,
                 const std::array<uint32_t, 4> &output_tensor_shape,
                 const std::array<uint32_t, 4> &input_tensor_start,
-                float pad_value) { return self.pad(output_tensor_shape, input_tensor_start, pad_value); },
+                float pad_value) { return self.pad(output_tensor_shape, ttnn::SimpleShape(input_tensor_start), pad_value); },
             R"doc(
             Pad TT Tensor with given pad value ``arg2``.
 

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1204,7 +1204,7 @@ void pytensor_module(py::module &m_tensor) {
             [](const Tensor &self,
                 const std::array<uint32_t, 4> &output_tensor_start,
                 const std::array<uint32_t, 4> &output_tensor_end) {
-                return self.unpad(output_tensor_start, output_tensor_end);
+                return self.unpad(ttnn::SimpleShape(output_tensor_start), ttnn::SimpleShape(output_tensor_end));
             },
             R"doc(
             Unpad this TT Tensor.
@@ -1326,7 +1326,7 @@ void pytensor_module(py::module &m_tensor) {
         .def(
             "unpad_from_tile",
             [](const Tensor &self, const std::vector<uint32_t> &output_tensor_shape) {
-                return self.unpad_from_tile(output_tensor_shape);
+                return self.unpad_from_tile(ttnn::SimpleShape(output_tensor_shape));
             },
             R"doc(
             Unpads TT Tensor from given input tensor ``arg0``.

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -189,7 +189,7 @@ Tensor to_layout_impl(
             return device ? tensor.to(layout, device) : tensor.to(layout);
         } else if (layout == ttnn::ROW_MAJOR_LAYOUT) {
             tensor = device ? tensor.to(layout, device) : tensor.to(layout);
-            tensor = tensor.unpad_from_tile(tensor.get_shape().value.without_padding());
+            tensor = tensor.unpad_from_tile(tensor.get_logical_shape());
             return ttnn::reshape(tensor, ttnn::Shape(tt::tt_metal::LegacyShape{output_shape}));
         } else if (layout == ttnn::TILE_LAYOUT) {
             std::vector<uint32_t> padded_output_shape;

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -202,7 +202,7 @@ Tensor to_layout_impl(
                 }
                 padded_input_start.push_back(0);
             }
-            tensor = tensor.pad(padded_output_shape, padded_input_start, 0);
+            tensor = tensor.pad(padded_output_shape, ttnn::SimpleShape(std::move(padded_input_start)), 0);
             tensor = device ? tensor.to(layout, device) : tensor.to(layout);
             return ttnn::reshape(tensor, ttnn::Shape(tt::tt_metal::LegacyShape{output_shape, padded_output_shape}));
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -131,7 +131,7 @@ std::vector<Tensor> EltwiseBinaryBroadcast::create_output_tensors(const std::vec
         }
         auto mem_config = this->output_mem_config;
         mem_config.shard_spec = shard_spec;
-        return {create_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
+        return {create_device_tensor(input_tensor.get_legacy_shape(), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -37,14 +37,14 @@ void CloneOperation::validate_on_program_cache_hit(
 
 CloneOperation::shape_return_value_t CloneOperation::compute_output_shapes(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tensor_args.input.get_shape();
+    return tensor_args.input.get_logical_shape();
 };
 
 CloneOperation::tensor_return_value_t CloneOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;
     return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
+        tensor_args.input.get_legacy_shape(),
         operation_attributes.dtype,
         input.get_layout(),
         input.device(),

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.hpp
@@ -16,7 +16,7 @@ struct CloneOperation {
         const Tensor& input;
     };
 
-    using shape_return_value_t = Shape;
+    using shape_return_value_t = ttnn::SimpleShape;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -33,8 +33,9 @@ void CopyDeviceOperation::validate_with_output_tensors(const std::vector<Tensor>
     DataType output_dtype = this->output_dtype;
     if(!output_tensors.empty() && output_tensors.at(0).has_value()){
         const auto& out_tensor = output_tensors.at(0).value();
-        const auto output_shape_required = input_tensors.size() == 2 ? input_tensors[1].get_legacy_shape() : input_tensor_a.legacy_shape();
-        TT_FATAL(out_tensor.get_legacy_shape() == output_shape_required, "The input tensors need a shape of {}, however the output tensor is only {}", output_shape_required,  out_tensor.get_legacy_shape());
+        const auto& output_shape_tensor = input_tensors.size() == 2 ? input_tensors[1] : input_tensor_a;
+        TT_FATAL(out_tensor.get_logical_shape() == output_shape_tensor.get_logical_shape() && out_tensor.get_padded_shape() == output_shape_tensor.get_padded_shape(),
+            "The input tensors need a shape of {}/{}, however the output tensor is only {}/{}", output_shape_tensor.get_logical_shape(), output_shape_tensor.get_padded_shape(),  out_tensor.get_logical_shape(), out_tensor.get_padded_shape());
         output_dtype = out_tensor.get_dtype();
     }
     if (output_dtype != input_tensor_a.get_dtype()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
@@ -23,7 +23,7 @@ struct CopyDeviceOperation {
     const DataType output_dtype;
 
     void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
 
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -78,9 +78,8 @@ void FillRM::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "FillRM does not currently support sharding");
 }
 
-std::vector<tt::tt_metal::LegacyShape> FillRM::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    tt::tt_metal::LegacyShape output_shape = {this->N, this->C, this->H, this->W};
-    return {output_shape};
+std::vector<ttnn::SimpleShape> FillRM::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    return {ttnn::SimpleShape({this->N, this->C, this->H, this->W})};
 }
 
 std::vector<Tensor> FillRM::create_output_tensors(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.hpp
@@ -26,7 +26,7 @@ struct FillRM  {
     const MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -48,10 +48,9 @@ void Fold::validate_on_program_cache_hit(const operation_attributes_t &op_attr, 
 
 Fold::shape_return_value_t Fold::compute_output_shapes(const operation_attributes_t &op_attr, const tensor_args_t &tensors) {
     auto input_tensor = tensors.input_tensor;
-    const Shape &input_shape = Shape(input_tensor.get_legacy_shape());
+    const ttnn::SimpleShape input_shape = input_tensor.get_logical_shape();
     // we concatenate (stride_h sticks in H-dim) * (stride_w in W-dim) into 1 stick along C-dim
-    Shape output_shape = Shape(tt::tt_metal::LegacyShape({1, 1, input_shape[0] * input_shape[1] * input_shape[2] / (op_attr.stride_h * op_attr.stride_w), input_shape[3] * op_attr.stride_h * op_attr.stride_w}));
-    return output_shape;
+    return ttnn::SimpleShape({1, 1, input_shape[0] * input_shape[1] * input_shape[2] / (op_attr.stride_h * op_attr.stride_w), input_shape[3] * op_attr.stride_h * op_attr.stride_w});
 }
 
 Fold::tensor_return_value_t Fold::create_output_tensors(const operation_attributes_t &op_attr, const tensor_args_t &tensors) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -24,7 +24,7 @@ struct Fold {
         const Tensor& input_tensor;
     };
 
-    using shape_return_value_t = ttnn::Shape;
+    using shape_return_value_t = ttnn::SimpleShape;
     using tensor_return_value_t = Tensor;
 
     struct SingleCore {

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
@@ -28,9 +28,8 @@ void IndexedFill::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Index Fill does not currently support sharding");
 }
 
-std::vector<tt::tt_metal::LegacyShape> IndexedFill::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(1);
-    return {input_tensor.get_legacy_shape()};
+std::vector<ttnn::SimpleShape> IndexedFill::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    return {input_tensors.at(1).get_logical_shape()};
 }
 
 std::vector<Tensor> IndexedFill::create_output_tensors(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.hpp
@@ -13,7 +13,7 @@ struct IndexedFill {
     const MemoryConfig output_mem_config;
     const int64_t dim;
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -15,9 +15,8 @@ void MoveDeviceOperation::validate(const std::vector<Tensor> &input_tensors) con
     const auto& input_tensor_a = input_tensors.at(0);
 }
 
-std::vector<tt::tt_metal::LegacyShape> MoveDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
+std::vector<ttnn::SimpleShape> MoveDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    return {input_tensors.at(0).get_logical_shape()};
 }
 
 std::vector<Tensor> MoveDeviceOperation::create_output_tensors(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -22,7 +22,7 @@ struct MoveDeviceOperation {
     const MoveOpParallelizationStrategy move_op_parallelization_strategy;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     MoveOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.cpp
@@ -21,10 +21,9 @@ void NonZeroIndices::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Non-zero does not currently support sharding");
 }
 
-std::vector<tt::tt_metal::LegacyShape> NonZeroIndices::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    tt::tt_metal::LegacyShape num_non_zero_shape({1,1,1,8});
-    return {num_non_zero_shape, input_tensor.get_legacy_shape()};
+std::vector<ttnn::SimpleShape> NonZeroIndices::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    ttnn::SimpleShape num_non_zero_shape({1,1,1,8});
+    return {std::move(num_non_zero_shape), input_tensors.at(0).get_logical_shape()};
 }
 
 std::vector<Tensor> NonZeroIndices::create_output_tensors(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_op.hpp
@@ -19,7 +19,7 @@ namespace operations::data_movement {
 struct NonZeroIndices {
     const MemoryConfig output_mem_config;
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -44,24 +44,13 @@ void Pad::validate_with_output_tensors(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> Pad::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    return {tt::tt_metal::LegacyShape(this->output_tensor_shape)};
+std::vector<ttnn::SimpleShape> Pad::compute_output_shapes(const std::vector<Tensor>&) const {
+    return {this->output_tensor_shape.logical_shape()};
 }
 
 std::vector<Tensor> Pad::create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto shapes = compute_output_shapes(input_tensors);
-
-    if (this->output_mem_config.is_sharded()) {
-        return {create_device_tensor(
-            shapes[0],
-            input_tensor.get_dtype(),
-            input_tensor.get_layout(),
-            input_tensor.device(),
-            this->output_mem_config)};
-    } else {
-        return {create_device_tensor(shapes[0], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), this->output_mem_config)};
-    }
+    return {create_device_tensor(output_tensor_shape, input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), this->output_mem_config)};
 }
 
 operation::ProgramWithCallbacks Pad::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.hpp
@@ -13,13 +13,13 @@ namespace ttnn::operations::data_movement {
 
 struct Pad {
     const tt::tt_metal::LegacyShape output_tensor_shape;
-    const tt::tt_metal::LegacyShape input_tensor_start;
+    const ttnn::SimpleShape input_tensor_start;
     const float pad_value;
     const MemoryConfig output_mem_config;
     const bool use_multicore;
 
     void validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -18,7 +18,7 @@ namespace ttnn::operations::data_movement::detail {
 operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
                                                      Tensor &output,
                                                      const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                     const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                     const ttnn::SimpleShape &input_tensor_start,
                                                      const float pad_value) {
     Program program{};
 
@@ -171,7 +171,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
 operation::ProgramWithCallbacks pad_rm_opt(const Tensor &a,
                                            Tensor &output,
                                            const Shape &output_tensor_shape,
-                                           const Shape &input_tensor_start,
+                                           const ttnn::SimpleShape &input_tensor_start,
                                            const float pad_value) {
     Program program{};
 
@@ -285,7 +285,7 @@ operation::ProgramWithCallbacks pad_rm_opt(const Tensor &a,
     return {std::move(program), override_runtime_args_callback};
 }
 
-operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Shape &output_tensor_shape, const Shape &input_tensor_start, const float pad_value) {
+operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Shape &output_tensor_shape, const ttnn::SimpleShape &input_tensor_start, const float pad_value) {
 
     tt::tt_metal::Program program{};
 
@@ -389,7 +389,7 @@ operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Sh
     return {std::move(program), override_runtime_args_callback};
 }
 
-operation::ProgramWithCallbacks pad_tile(const Tensor &a, Tensor& output, const tt::tt_metal::LegacyShape &output_tensor_shape, const tt::tt_metal::LegacyShape &input_tensor_start, const float pad_value) {
+operation::ProgramWithCallbacks pad_tile(const Tensor &a, Tensor& output, const tt::tt_metal::LegacyShape &output_tensor_shape, const ttnn::SimpleShape &input_tensor_start, const float pad_value) {
 
     tt::tt_metal::Program program{};
 
@@ -639,7 +639,7 @@ inline std::tuple<uint32_t, uint32_t, uint32_t, CoreRangeSet, CoreRangeSet, uint
 operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
                                                                 Tensor &output,
                                                                 const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                                const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                                const ttnn::SimpleShape &input_tensor_start,
                                                                 const float pad_value) {
     Program program{};
 
@@ -872,7 +872,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
 
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runtime_args_rm(const Tensor &input_tensor,
                                                                                         Tensor &output_tensor,
-                                                                                        const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                                                        const ttnn::SimpleShape &input_tensor_start,
                                                                                         uint32_t num_cores_total,
                                                                                         uint32_t num_cores,
                                                                                         uint32_t num_cores_y,
@@ -901,7 +901,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
 
 
     uint32_t max_read_size = 2048;
-    auto front_pad = ttnn::Shape(input_tensor_start);
+    auto& front_pad = input_tensor_start;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
     for(uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -976,7 +976,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
 operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(const Tensor &a,
                                                                 Tensor &output,
                                                                 const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                                const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                                const ttnn::SimpleShape &input_tensor_start,
                                                                 const float pad_value) {
     Program program{};
 
@@ -986,7 +986,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(const Tensor 
     uint32_t W_padded = output_tensor_shape[3], H_padded = output_tensor_shape[2], C_padded = output_tensor_shape[1], N_padded = output_tensor_shape[0];
     uint32_t NCH_padded = H_padded * C_padded * N_padded;
 
-    auto front_pad = ttnn::Shape(input_tensor_start);
+    auto& front_pad = input_tensor_start;
 
     auto stick_size = W * a.element_size();
     auto stick_size_padded = W_padded * a.element_size();
@@ -1161,7 +1161,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
 inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_pad_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    const tt::tt_metal::LegacyShape &input_tensor_start,
+    const ttnn::SimpleShape &input_tensor_start,
     uint32_t num_cores_padded,
     bool row_major,
     uint32_t num_cores_x_padded,
@@ -1189,7 +1189,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val(num_cores_padded);
 
-    auto front_pad = ttnn::Shape(input_tensor_start);
+    auto& front_pad = input_tensor_start;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
     for(uint32_t i = 0, curr_sticks_read = 0; i < num_cores_padded; i++) {
         CoreCoord core;
@@ -1322,7 +1322,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
                                                                 Tensor &output,
                                                                 const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                                const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                                const ttnn::SimpleShape &input_tensor_start,
                                                                 const float pad_value) {
     Program program{};
 
@@ -1332,7 +1332,7 @@ operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
     uint32_t W_padded = output_tensor_shape[3], H_padded = output_tensor_shape[2], C_padded = output_tensor_shape[1], N_padded = output_tensor_shape[0];
     uint32_t num_padded_sticks = H_padded * C_padded * N_padded;
 
-    auto front_pad = ttnn::Shape(input_tensor_start);
+    auto& front_pad = input_tensor_start;
 
     tt::log_debug("H_padded: {}", H_padded);
     tt::log_debug("front_pad: {}", front_pad);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.hpp
@@ -10,24 +10,24 @@ namespace ttnn::operations::data_movement::detail {
 operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
                                                      Tensor &output,
                                                      const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                     const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                     const ttnn::SimpleShape &input_tensor_start,
                                                      const float pad_value);
 
 
 operation::ProgramWithCallbacks pad_rm_opt(const Tensor &a,
                                            Tensor &output,
                                            const Shape &output_tensor_shape,
-                                           const Shape &input_tensor_start,
+                                           const ttnn::SimpleShape &input_tensor_start,
                                            const float pad_value);
 
-operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Shape &output_tensor_shape, const Shape &input_tensor_start, const float pad_value);
+operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Shape &output_tensor_shape, const ttnn::SimpleShape &input_tensor_start, const float pad_value);
 
-operation::ProgramWithCallbacks pad_tile(const Tensor &a, Tensor& output, const tt::tt_metal::LegacyShape &output_tensor_shape, const tt::tt_metal::LegacyShape &input_tensor_start, const float pad_value);
+operation::ProgramWithCallbacks pad_tile(const Tensor &a, Tensor& output, const tt::tt_metal::LegacyShape &output_tensor_shape, const ttnn::SimpleShape &input_tensor_start, const float pad_value);
 
 operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
                                                                 Tensor &output,
                                                                 const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                                const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                                const ttnn::SimpleShape &input_tensor_start,
                                                                 const float pad_value);
 
 
@@ -35,14 +35,14 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
 operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(const Tensor &a,
                                                                 Tensor &output,
                                                                 const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                                const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                                const ttnn::SimpleShape &input_tensor_start,
                                                                 const float pad_value);
 
 
 operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
                                                 Tensor &output,
                                                 const tt::tt_metal::LegacyShape &output_tensor_shape,
-                                                const tt::tt_metal::LegacyShape &input_tensor_start,
+                                                const ttnn::SimpleShape &input_tensor_start,
                                                 const float pad_value);
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -30,7 +30,7 @@ static ttnn::Tensor pad_impl(
             return input_tensor;
         }
         else {
-            return input_tensor.pad(tt::tt_metal::LegacyShape(output_padded_shape), tt::tt_metal::LegacyShape(input_tensor_start), value);
+            return input_tensor.pad(tt::tt_metal::LegacyShape(output_padded_shape), ttnn::SimpleShape(input_tensor_start), value);
         }
     }
     // on device
@@ -42,7 +42,7 @@ static ttnn::Tensor pad_impl(
 
         auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
         auto output_tensor = operation::run(
-            Pad{tt::tt_metal::LegacyShape(output_padded_shape), tt::tt_metal::LegacyShape(input_tensor_start), value, memory_config, use_multicore},
+            Pad{tt::tt_metal::LegacyShape(output_padded_shape), ttnn::SimpleShape(input_tensor_start), value, memory_config, use_multicore},
             {input_tensor}, {}, {}, queue_id).front();
 
         return output_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
@@ -32,8 +32,8 @@ void RepeatDeviceOperation::validate(const std::vector<Tensor> &input_tensors) c
         "Output of repeat must be interleaved.");
 }
 
-std::vector<tt::tt_metal::LegacyShape> RepeatDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    tt::tt_metal::LegacyShape shape_out = input_tensors[0].get_legacy_shape();
+std::vector<ttnn::SimpleShape> RepeatDeviceOperation::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    ttnn::SimpleShape shape_out = input_tensors[0].get_logical_shape();
     shape_out[this->repeat_dim] *= this->num_repeats;
     return {shape_out};
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.hpp
@@ -17,7 +17,7 @@ struct RepeatDeviceOperation {
     const MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -122,7 +122,7 @@ ttnn::Tensor SliceOperation::invoke(
             return input_tensor;
         } else {
             auto input_4d_rm = ttnn::to_layout(input_4d, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (Device *)nullptr);
-            auto output_4d =  input_4d_rm.unpad(tt::tt_metal::LegacyShape(modified_begins), tt::tt_metal::LegacyShape(modified_ends));
+            auto output_4d =  input_4d_rm.unpad(ttnn::SimpleShape(modified_begins), ttnn::SimpleShape(modified_ends));
             auto output_4d_rm = ttnn::to_layout(output_4d, input_tensor.get_layout(), std::nullopt, std::nullopt, (Device *)nullptr);
             return ttnn::reshape(output_4d_rm, output_shape);
         }
@@ -269,7 +269,7 @@ ttnn::Tensor SliceOperation::invoke<uint32_t, 4>(
         return input_tensor;
     } else {
         auto input_4d_rm = ttnn::to_layout(input_tensor, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (Device *)nullptr);
-        auto output_4d =  input_4d_rm.unpad(tt::tt_metal::LegacyShape(begins), tt::tt_metal::LegacyShape(ends));
+        auto output_4d =  input_4d_rm.unpad(ttnn::SimpleShape(begins), ttnn::SimpleShape(ends));
         auto output_4d_rm = ttnn::to_layout(output_4d, input_tensor.get_layout(), std::nullopt, std::nullopt, (Device *)nullptr);
         return ttnn::reshape(output_4d_rm, output_shape);
     }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -556,7 +556,7 @@ void Tensor::print() const {
     tensor_ops::tensor_print(*this);
 }
 
-Tensor Tensor::pad(const tt::tt_metal::LegacyShape& output_tensor_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) const {
+Tensor Tensor::pad(const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) const {
     return tensor_ops::tensor_pad(*this, output_tensor_shape, input_tensor_start, pad_value);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -560,7 +560,7 @@ Tensor Tensor::pad(const tt::tt_metal::LegacyShape& output_tensor_shape, const t
     return tensor_ops::tensor_pad(*this, output_tensor_shape, input_tensor_start, pad_value);
 }
 
-Tensor Tensor::unpad(const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) const {
+Tensor Tensor::unpad(const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) const {
     return tensor_ops::tensor_unpad(*this, output_tensor_start, output_tensor_end);
 }
 
@@ -568,7 +568,7 @@ Tensor Tensor::pad_to_tile(float pad_value) const {
     return tensor_ops::tensor_pad_to_tile(*this, pad_value);
 }
 
-Tensor Tensor::unpad_from_tile(const tt::tt_metal::LegacyShape& output_tensor_shape) const {
+Tensor Tensor::unpad_from_tile(const ttnn::SimpleShape& output_tensor_shape) const {
     return tensor_ops::tensor_unpad_from_tile(*this, output_tensor_shape);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -160,11 +160,11 @@ struct Tensor {
 
     Tensor cpu_sharded() const;
 
-    Tensor unpad(const tt::tt_metal::LegacyShape &output_tensor_start, const tt::tt_metal::LegacyShape &output_tensor_end) const;
+    Tensor unpad(const ttnn::SimpleShape &output_tensor_start, const ttnn::SimpleShape &output_tensor_end) const;
 
     Tensor pad_to_tile(float pad_value) const;
 
-    Tensor unpad_from_tile(const tt::tt_metal::LegacyShape &output_tensor_shape) const;
+    Tensor unpad_from_tile(const ttnn::SimpleShape &output_tensor_shape) const;
 
     const std::string write_to_string() const;
     void print() const;

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -154,7 +154,7 @@ struct Tensor {
 
     Tensor to(Layout target_layout, distributed::MeshDevice *mesh_device) const;
 
-    Tensor pad(const tt::tt_metal::LegacyShape &output_tensor_shape, const tt::tt_metal::LegacyShape &input_tensor_start, float pad_value) const;
+    Tensor pad(const tt::tt_metal::LegacyShape &output_tensor_shape, const ttnn::SimpleShape &input_tensor_start, float pad_value) const;
 
     Tensor cpu(bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId) const;
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -312,7 +312,7 @@ Tensor pad_bfloat8_b(
         tensor.get_tile());
 }
 
-Tensor unpad_bfloat8_b(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) {
+Tensor unpad_bfloat8_b(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and unpad
@@ -363,7 +363,7 @@ Tensor pad_bfloat4_b(
         tensor.get_tile());
 }
 
-Tensor unpad_bfloat4_b(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) {
+Tensor unpad_bfloat4_b(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and unpad
@@ -1279,7 +1279,7 @@ Tensor pad<bfloat4_b>(
 }
 
 template <typename T>
-Tensor unpad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) {
+Tensor unpad(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
     const auto input_shape = tensor.get_legacy_shape();
     const auto input_strides = tensor.strides();
 
@@ -1341,20 +1341,20 @@ Tensor unpad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tenso
     return Tensor(OwnedStorage{output_buffer}, output_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
 }
 
-template Tensor unpad<bfloat16>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
-template Tensor unpad<float>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
-template Tensor unpad<int32_t>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
-template Tensor unpad<uint32_t>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
-template Tensor unpad<uint16_t>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
-template Tensor unpad<uint8_t>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
+template Tensor unpad<bfloat16>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
+template Tensor unpad<float>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
+template Tensor unpad<int32_t>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
+template Tensor unpad<uint32_t>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
+template Tensor unpad<uint16_t>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
+template Tensor unpad<uint8_t>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
 
 template <>
-Tensor unpad<bfloat8_b>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) {
+Tensor unpad<bfloat8_b>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
     return unpad_bfloat8_b(tensor, output_tensor_start, output_tensor_end);
 }
 
 template <>
-Tensor unpad<bfloat4_b>(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) {
+Tensor unpad<bfloat4_b>(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
     return unpad_bfloat4_b(tensor, output_tensor_start, output_tensor_end);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -287,7 +287,7 @@ void validate_on_device_dtype_and_layout(Device* device, const ttnn::SimpleShape
 }
 
 Tensor pad_bfloat8_b(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) {
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and pad
@@ -338,7 +338,7 @@ Tensor unpad_bfloat8_b(const Tensor& tensor, const tt::tt_metal::LegacyShape& ou
 }
 
 Tensor pad_bfloat4_b(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) {
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and pad
@@ -1164,7 +1164,7 @@ Tensor to_layout<bfloat4_b>(const Tensor& tensor, Layout target_layout) {
 // ======================================================================================
 
 template <typename T>
-Tensor pad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) {
+Tensor pad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
     if (ttnn::distributed::is_multi_device_tensor(tensor)) {
         return transform(tensor, [&](const Tensor& device_tensor) {
             return pad<T>(device_tensor, output_shape, input_tensor_start, pad_value);
@@ -1254,27 +1254,27 @@ Tensor pad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, 
 }
 
 template Tensor pad<bfloat16>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 template Tensor pad<float>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 template Tensor pad<int32_t>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 template Tensor pad<uint32_t>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 template Tensor pad<uint16_t>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 template Tensor pad<uint8_t>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 
 template <>
 Tensor pad<bfloat8_b>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) {
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
     return pad_bfloat8_b(tensor, output_shape, input_tensor_start, pad_value);
 }
 
 template <>
 Tensor pad<bfloat4_b>(
-    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) {
+    const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
     return pad_bfloat4_b(tensor, output_shape, input_tensor_start, pad_value);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -307,7 +307,7 @@ template <typename T>
 Tensor pad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 
 template <typename T>
-Tensor unpad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
+Tensor unpad(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
 
 // ======================================================================================
 //                                         Print

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -304,7 +304,7 @@ Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout);
 //                                  .pad() and .unpad()
 // ======================================================================================
 template <typename T>
-Tensor pad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+Tensor pad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 
 template <typename T>
 Tensor unpad(const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -255,7 +255,7 @@ void tensor_print(const Tensor& input_tensor) {
     GraphTracker::instance().track_function_end();
 }
 
-Tensor tensor_pad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value) {
+Tensor tensor_pad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::pad", input_tensor, output_tensor_shape, input_tensor_start, pad_value);
     TT_ASSERT(
@@ -314,7 +314,7 @@ Tensor tensor_pad_to_tile(const Tensor& input_tensor, float pad_value)  {
     input_tensor_start.push_back(0);
     input_tensor_start.push_back(0);
 
-    auto output = input_tensor.pad(tt::tt_metal::LegacyShape(shape, padded_shape), tt::tt_metal::LegacyShape{input_tensor_start}, pad_value);
+    auto output = input_tensor.pad(tt::tt_metal::LegacyShape(shape, padded_shape), ttnn::SimpleShape{std::move(input_tensor_start)}, pad_value);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -279,7 +279,7 @@ Tensor tensor_pad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& o
     return output;
 }
 
-Tensor tensor_unpad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end) {
+Tensor tensor_unpad(const Tensor& input_tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::unpad", input_tensor, output_tensor_start, output_tensor_end);
     TT_ASSERT(input_tensor.get_layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for unpadding");
@@ -320,7 +320,7 @@ Tensor tensor_pad_to_tile(const Tensor& input_tensor, float pad_value)  {
     return output;
 }
 
-Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape) {
+Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const ttnn::SimpleShape& output_tensor_shape) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::unpad_from_tile", input_tensor, output_tensor_shape);
 
@@ -342,7 +342,7 @@ Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Le
         output_tensor_start.push_back(0);
         output_tensor_end.push_back(output_tensor_shape[index]);
     }
-    auto output = input_tensor.unpad(output_tensor_start, output_tensor_end);
+    auto output = input_tensor.unpad(ttnn::SimpleShape(std::move(output_tensor_start)), ttnn::SimpleShape(std::move(output_tensor_end)));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -36,11 +36,11 @@ void tensor_print(const Tensor& input_tensor);
 
 Tensor tensor_pad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 
-Tensor tensor_unpad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
+Tensor tensor_unpad(const Tensor& input_tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end);
 
 Tensor tensor_pad_to_tile(const Tensor& input_tensor, float pad_value);
 
-Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape);
+Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const ttnn::SimpleShape& output_tensor_shape);
 
 Tensor tensor_reshape(const Tensor& input_tensor, int N, int C, int H, int W);
 

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -34,7 +34,7 @@ Tensor tensor_cpu_sharded(const Tensor& input_tensor);
 
 void tensor_print(const Tensor& input_tensor);
 
-Tensor tensor_pad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const tt::tt_metal::LegacyShape& input_tensor_start, float pad_value);
+Tensor tensor_pad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value);
 
 Tensor tensor_unpad(const Tensor& input_tensor, const tt::tt_metal::LegacyShape& output_tensor_start, const tt::tt_metal::LegacyShape& output_tensor_end);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13127

### Problem description
We need to replace the usages of LegacyShape with SimpleShape where possible to make the code cleaner and easier

### What's changed
Ported more ops to use SimpleShape in `compute_output_shapes`
Made `pad` and `unpad` use SimpleShape

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11337323057)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
