### PR TITLE
#13806: versim setup (without umd bump)

### DIFF
--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -38,7 +38,7 @@ inline std::string get_core_descriptor_file(const tt::ARCH &arch, CoreType dispa
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported"); // will be overwritten in tt_global_state constructor
             case tt::ARCH::GRAYSKULL: throw std::runtime_error("GRAYSKULL arch not supported for simulator");
             case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported for simulator");
-            case tt::ARCH::WORMHOLE_B0: throw std::runtime_error("WORMHOLE_B0 arch not supported for simulator");
+            case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
             case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
             default: throw std::runtime_error("Unsupported device arch");
         };

--- a/tt_metal/common/test_common.hpp
+++ b/tt_metal/common/test_common.hpp
@@ -37,7 +37,7 @@ inline std::string get_soc_description_file(const tt::ARCH &arch, tt::TargetDevi
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported");
             case tt::ARCH::GRAYSKULL: throw std::runtime_error("GRAYSKULL arch not supported");
             case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported");
-            case tt::ARCH::WORMHOLE_B0: throw std::runtime_error("WORMHOLE_B0 arch not supported");
+            case tt::ARCH::WORMHOLE_B0: return tt_metal_home + "tt_metal/soc_descriptors/wormhole_b0_versim.yaml";
             case tt::ARCH::BLACKHOLE: return tt_metal_home + "tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml";
             default: throw std::runtime_error("Unsupported device arch");
         };

--- a/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
@@ -8,14 +8,30 @@
 galaxy:
   1:
     compute_with_storage_grid_range:
-      start: [0, 0]
-      end: [0, 0]
+      start: [1, 1]
+      end: [1, 1]
 
     storage_cores:
       []
 
     dispatch_cores:
       []
+
+    dispatch_core_type:
+      "tensix"
+  2:
+    compute_with_storage_grid_range:
+      start: [1, 1]
+      end: [1, 1]
+
+    storage_cores:
+      []
+
+    dispatch_cores:
+      []
+
+    dispatch_core_type:
+      "tensix"
 
 nebula_x1:
   1:
@@ -29,6 +45,22 @@ nebula_x1:
     dispatch_cores:
       []
 
+    dispatch_core_type:
+      "tensix"
+  2:
+    compute_with_storage_grid_range:
+      start: [1, 1]
+      end: [1, 1]
+
+    storage_cores:
+      []
+
+    dispatch_cores:
+      []
+
+    dispatch_core_type:
+      "tensix"
+
 nebula_x2:
   1:
     compute_with_storage_grid_range:
@@ -40,3 +72,19 @@ nebula_x2:
 
     dispatch_cores:
       []
+
+    dispatch_core_type:
+      "tensix"
+  2:
+    compute_with_storage_grid_range:
+      start: [1, 1]
+      end: [1, 1]
+
+    storage_cores:
+      []
+
+    dispatch_cores:
+      []
+
+    dispatch_core_type:
+      "tensix"

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -144,7 +144,7 @@ void Cluster::generate_cluster_descriptor() {
                                    : "";
 
     // create-eth-map not available for Blackhole bring up
-    if (this->arch_ == tt::ARCH::GRAYSKULL or this->arch_ == tt::ARCH::BLACKHOLE) {
+    if (this->arch_ == tt::ARCH::GRAYSKULL or this->arch_ == tt::ARCH::BLACKHOLE or this->target_type_ == TargetDevice::Simulator) {
         // Cannot use tt_SiliconDevice::detect_available_device_ids because that returns physical device IDs
         std::vector<chip_id_t> physical_mmio_device_ids;
         std::set<chip_id_t> logical_mmio_device_ids;
@@ -193,7 +193,7 @@ void Cluster::generate_cluster_descriptor() {
             this->cluster_desc_->get_all_chips().size()/4,
             this->cluster_desc_->get_all_chips().size(),
             total_num_hugepages);
-    } else {
+    } else if (this->target_type_ != TargetDevice::Simulator){
     // TODO (abhullar): ignore hugepage set up for BH bringup
         TT_FATAL(
             this->arch_ == tt::ARCH::BLACKHOLE or total_num_hugepages >= this->cluster_desc_->get_all_chips().size(),

--- a/tt_metal/soc_descriptors/wormhole_b0_versim.yaml
+++ b/tt_metal/soc_descriptors/wormhole_b0_versim.yaml
@@ -1,0 +1,65 @@
+# soc-descriptor yaml
+# Anything using [#-#] is noc coordinates
+# Anything using [[#, #]] is logical coordinates (Can be relative)
+# relative index: 0 means first row, -1 means last row of functional grid...
+grid:
+  x_size: 2
+  y_size: 2
+
+arc:
+  [ ]
+
+pcie:
+  [ ]
+
+dram:
+  [
+    [0-0, 0-1],
+  ]
+
+dram_preferred_eth_endpoint:
+  [ 0-0 ]
+
+dram_preferred_worker_endpoint:
+  [ 0-1 ]
+
+dram_address_offsets:
+  [ 0 ]
+
+eth:
+  [ ]
+
+functional_workers:
+  [
+   1-1,
+  ]
+
+harvested_workers:
+  []
+
+router_only:
+  [
+   1-0
+  ]
+
+worker_l1_size:
+  1499136
+
+dram_bank_size:
+  1073741824
+
+eth_l1_size:
+  262144
+
+arch_name: WORMHOLE_B0
+
+features:
+  unpacker:
+    version: 2
+    inline_srca_trans_without_srca_trans_instr: True
+  math:
+    dst_size_alignment: 32768
+  packer:
+    version: 2
+  overlay:
+    version: 2


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13806

### Problem description
Necessary changes for Versim integration into metal.

### What's changed

- Added/changed relevant soc/core descriptor files.
- Ignored hugepage setup check since Versim can be run on machines without hugepages setup

### Checklist
- [ ] Post commit CI passes
