### PR TITLE
#13080: adjust out subblock h in vit matmuls to fit operation in dest registers

### DIFF
--- a/models/experimental/functional_vit/tt/ttnn_optimized_sharded_vit.py
+++ b/models/experimental/functional_vit/tt/ttnn_optimized_sharded_vit.py
@@ -54,7 +54,7 @@ def update_model_config(config, batch_size):
         "self_output_matmul_program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(core_grid.x, core_grid.y),
             in0_block_w=dim_t__x,  # 2,
-            out_subblock_h=seqL_t,  # 7,
+            out_subblock_h=1,
             out_subblock_w=dim_t__x,  # 2,
             per_core_M=seqL_t,  # 7,
             per_core_N=dim_t__x,  # 2,
@@ -74,7 +74,7 @@ def update_model_config(config, batch_size):
         "ff2_matmul_program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(core_grid.x, core_grid.y),
             in0_block_w=(4 * dim_t__x),  # 8,
-            out_subblock_h=seqL_t,  # 7,
+            out_subblock_h=1,
             out_subblock_w=dim_t__x,  # 2,
             per_core_M=seqL_t,  # 7,
             per_core_N=dim_t__x,  # 2,


### PR DESCRIPTION
### Ticket
Link to Github Issue #13080 

### Problem description
- The matmul program configs for a model used by a test on nightly need to be updated to fit in dest registers now that we require this in validate()

### What's changed
- update the out subblock h of the matmul program configs to allow the matmuls to fit in the available dest registers

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes

Testing:
- the test on Nightly - FD GS ttnn nightly grayskull no longer fails https://github.com/tenstorrent/tt-metal/actions/runs/11347159042/job/31558712465 vs previous https://github.com/tenstorrent/tt-metal/actions/runs/11306216000/job/31446769139
