### PR TITLE
Improve matmul error message when inner dimensions do not match

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -58,7 +58,7 @@ ttnn::Tensor bound_matmul(
     const auto height_b = input_tensor_b_shape[-2];
 
     if (width_a != height_b) {
-        TT_THROW("ttnn.matmul: The width of the first tensor must be equal to the height of the second tensor");
+        TT_THROW("ttnn.matmul: The width of the first tensor must be equal to the height of the second tensor ({} != {}). The shape of first tensor was {} and the shape of second tensor was {})", width_a, height_b, input_tensor_a_shape, input_tensor_b_shape);
     }
 
     const bool has_program_config = parameters.program_config.has_value();


### PR DESCRIPTION
### Summary

Add a bit of extra information to save user's time when encountering a `matmul` shape error:

```bash
E       RuntimeError: TT_THROW @ ../ttnn/cpp/ttnn/operations/matmul/matmul.cpp:61: tt::exception
E       info:
E       ttnn.matmul: The width of the first tensor must be equal to the height of the second tensor (64 != 32). The shape of first tensor was ttnn.Shape([1, 1, 32, 64]) and the shape of second tensor was ttnn.Shape([1, 1, 32, 32]))
```

- [x] Post-commit pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/11350513180
