### PR TITLE
#13782: Parallelize clang-tidy

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -109,6 +109,6 @@ jobs:
         # to avoid GitHub API timeouts for heavily loaded
         # pull requests
         suggestions_per_comment: 10
-        continue-on-error: true
+      continue-on-error: true
     - name: Final step to signal success
       run: echo "The job passes even if 3rd party action fails."

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -94,7 +94,7 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j 4
+        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j4
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@837ad8077b1f554dab31a8a43e8bb12c89d2f144
       with:

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -94,7 +94,7 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j 4
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@837ad8077b1f554dab31a8a43e8bb12c89d2f144
       with:


### PR DESCRIPTION
### Ticket
#13782 

### Problem description
Can we make clang-tidy run faster in CI?

### What's changed
Try to use 4 cores for clang-tidy.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
