### PR TITLE
atulk/13837: Created pybind for ttnn fill, created sweeps for ttnn fill

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/fill/fill_one_test.py
+++ b/tests/sweep_framework/sweeps/data_movement/fill/fill_one_test.py
@@ -1,0 +1,62 @@
+from typing import Optional, Tuple
+
+import torch
+
+torch.manual_seed(42)
+import random
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+import pdb
+
+
+def run(
+    fill_specs,
+    dtype,
+    layout,
+    *,
+    device,
+):
+    device.enable_async(False)
+
+    # Extract the shape and fill_value from the test case
+    shape = fill_specs["shape"]
+    fill_value = fill_specs["fill_value"]
+
+    # Create a tensor filled with `fill_value` using torch.full
+    torch_tensor = torch.full(shape, fill_value, dtype=torch.float32)
+
+    # Convert the torch tensor to the `ttnn` format
+    ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=layout, dtype=dtype)
+
+    # Measure performance of the full operation in `ttnn`
+    start_time = start_measuring_time()
+
+    # Apply the `ttnn.full` operation
+    N, C, H, W = shape
+    ttnn_filled_tensor = ttnn.full(N, C, H, W, fill_value, any=ttnn_tensor, memory_config=None, queue_id=0)
+
+    e2e_perf = stop_measuring_time(start_time)
+
+    # Convert the `ttnn` tensor back to PyTorch for comparison
+    ttnn_output_tensor = ttnn.to_torch(ttnn_filled_tensor)
+
+    # Compare the PyTorch and `ttnn` tensors
+    result = check_with_pcc(torch_tensor, ttnn_output_tensor, 0.999)
+
+    return [result, e2e_perf]
+
+
+if __name__ == "__main__":
+    # Run the test
+
+    fill_specs = {"shape": [32, 3, 32 * 10, 32 * 12], "fill_value": 0.5}
+
+    dtype = ttnn.bfloat16
+    layout = ttnn.TILE_LAYOUT
+    # layout = ttnn.ROW_MAJOR_LAYOUT
+    device_id = 0
+    device = ttnn.open_device(device_id=device_id)
+
+    print(run(fill_specs, dtype, layout, device=device))

--- a/tests/sweep_framework/sweeps/data_movement/full/full_one_test.py
+++ b/tests/sweep_framework/sweeps/data_movement/full/full_one_test.py
@@ -27,17 +27,11 @@ def run(
     # Create a tensor filled with `fill_value` using torch.full
     torch_tensor = torch.full(shape, fill_value, dtype=torch.float32)
 
-    # Create a random tensor in PyTorch of shape `shape` and dtype float32
-    rand_tensor = torch_random(shape, -256, 256, dtype=torch.float32)
-
-    # Convert the torch tensor to the `ttnn` format
-    ttnn_tensor = ttnn.from_torch(rand_tensor, device=device, layout=layout, dtype=dtype)
-
     # Measure performance of the full operation in `ttnn`
     start_time = start_measuring_time()
 
     # Apply the `ttnn.full` operation
-    ttnn_filled_tensor = ttnn.fill(fill_value, any=ttnn_tensor, memory_config=None)
+    ttnn_filled_tensor = ttnn.full(shape, fill_value, device, memory_config=None)
 
     e2e_perf = stop_measuring_time(start_time)
 
@@ -53,7 +47,7 @@ def run(
 if __name__ == "__main__":
     # Run the test
 
-    fill_specs = {"shape": [128, 128, 300, 300], "fill_value": 64}
+    fill_specs = {"shape": [23 * 7, 34 * 17], "fill_value": 64}
 
     dtype = ttnn.bfloat16
     # layout = ttnn.TILE_LAYOUT

--- a/tests/sweep_framework/sweeps/data_movement/full/full_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/full/full_pytorch2.py
@@ -75,14 +75,11 @@ def run(
     # Create a tensor filled with `fill_value` using torch.full
     torch_tensor = torch.full(shape, fill_value, dtype=torch.float32)
 
-    # Convert the torch tensor to the `ttnn` format
-    ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=layout, dtype=dtype)
-
     # Measure performance of the full operation in `ttnn`
     start_time = start_measuring_time()
 
-    # Apply the `ttnn.fill` operation
-    ttnn_filled_tensor = ttnn.fill(fill_value, ttnn_tensor, memory_config=None)
+    # Apply the `ttnn.full` operation
+    ttnn_filled_tensor = ttnn.full(shape, fill_value, device, memory_config=None)
 
     e2e_perf = stop_measuring_time(start_time)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
@@ -7,6 +7,11 @@
 #include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 
 namespace ttnn::operations::data_movement{
 
@@ -28,14 +33,123 @@ ttnn::Tensor FillOnesRMOperation::invoke(uint32_t N, uint32_t C, uint32_t H, uin
     return invoke(DefaultQueueId, N, C, H, W, hFill, wFill, any, memory_config_arg);
 }
 
-ttnn::Tensor FullOperation::invoke(uint8_t queue_id, uint32_t N, uint32_t C, uint32_t H, uint32_t W, float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config) {
+ttnn::Tensor FillImplementation::invoke(uint8_t queue_id, uint32_t N, uint32_t C, uint32_t H, uint32_t W, float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config) {
     auto output_memory_config = memory_config.value_or(any.memory_config());
-    // Pass hFill = 0 and wFill = 0 to fill the entire tensor with `fill_value`
-    return operation::run_without_autoformat(FillRM{N, C, H, W, 0, 0, fill_value, fill_value, output_memory_config}, {any}, {}, {}, queue_id).at(0);
+    if(any.get_layout() == ttnn::TILE_LAYOUT) return operation::run_without_autoformat(FillRM{N, C, H, W, 0, 0, fill_value, fill_value, output_memory_config}, {any}, {}, {}, queue_id).at(0);
+
+    ttnn::Tensor padded_tensor = any;
+    Tensor output_tensor;
+
+    // Check if the tensor is in ROW_MAJOR_LAYOUT and if padding is required
+    if (any.get_layout() == ttnn::ROW_MAJOR_LAYOUT) {
+        // Padding dimensions for H and W must be multiples of 32
+        uint32_t padded_H = (H % 32 == 0) ? H : ((H / 32) + 1) * 32;
+        uint32_t padded_W = (W % 32 == 0) ? W : ((W / 32) + 1) * 32;
+
+        if (padded_H != H || padded_W != W) {
+            // Create padding vector: (before, after) pairs for each dimension
+            std::vector<std::pair<uint32_t, uint32_t>> padding_vec = {
+                {0, 0},  // No padding for batch dimension N
+                {0, 0},  // No padding for channel dimension C
+                {0, padded_H - H},  // Padding for height (H)
+                {0, padded_W - W}   // Padding for width (W)
+            };
+
+            // Apply padding
+            padded_tensor = ttnn::pad(
+                queue_id,
+                any,
+                padding_vec,
+                fill_value,
+                false,
+                memory_config
+            );
+        }
+        else return operation::run_without_autoformat(FillRM{N, C, H, W, 0, 0, fill_value, fill_value, output_memory_config}, {padded_tensor}, {}, {}, queue_id).at(0);
+        output_tensor = operation::run_without_autoformat(FillRM{N, C, H, W, 0, 0, fill_value, fill_value, output_memory_config}, {padded_tensor}, {}, {}, queue_id).at(0);
+        // If the tensor was padded, slice it back to the original dimensions
+        // Define the slicing boundaries (keeping the original H and W)
+        std::array<uint32_t, 4> begins = {0, 0, 0, 0};  // No slicing on N, C dimensions
+        std::array<uint32_t, 4> ends = {N, C, H, W};    // Slice to the original H and W
+
+        // Slice the output tensor back to the original dimensions
+        output_tensor = ttnn::operations::data_movement::SliceOperation::invoke(
+            queue_id,
+            output_tensor,
+            begins,
+            ends,
+            {1, 1, 1, 1},      // No stride
+            memory_config
+        );
+    }
+    return output_tensor;
 }
 
-ttnn::Tensor FullOperation::invoke(uint32_t N, uint32_t C, uint32_t H, uint32_t W, float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config_arg) {
-    return invoke(DefaultQueueId, N, C, H, W, fill_value, any, memory_config_arg);
+ttnn::Tensor FullOperation::invoke(uint8_t queue_id, const std::vector<uint32_t>& shape, float fill_value, ttnn::Device* device, const std::optional<ttnn::MemoryConfig>& memory_config_arg) {
+    TT_FATAL(shape.size() <= 4, "Shape must be a vector of <= 4 integers [N, C, H, W]");
+
+    std::vector<uint32_t> padded_shape = shape;
+    while (padded_shape.size() < 4) {
+        padded_shape.insert(padded_shape.begin(), 1);
+    }
+    uint32_t N = padded_shape[0], C = padded_shape[1], H = padded_shape[2], W = padded_shape[3];
+    auto ttnn_shape = ttnn::SimpleShape(padded_shape);
+    const MemoryConfig memory_config = memory_config_arg.value_or(ttnn::DRAM_MEMORY_CONFIG);
+    ttnn::Tensor any = create_device_tensor(ttnn_shape, ttnn::DataType::BFLOAT16, ttnn::TILE_LAYOUT, device, memory_config);
+    ttnn::Tensor filled_tensor = FillImplementation::invoke(queue_id, N, C, H, W, fill_value, any, memory_config_arg);
+    ttnn::Tensor squeezed_tensor = filled_tensor;
+
+
+    //squeeze the tensor back to original shape
+    auto new_shape = squeezed_tensor.get_logical_shape();
+    while (new_shape != shape) {
+        squeezed_tensor = ttnn::operations::data_movement::SqueezeOperation::invoke(squeezed_tensor, 0);
+        new_shape = squeezed_tensor.get_logical_shape();
+    }
+    return squeezed_tensor;
+}
+
+ttnn::Tensor FullOperation::invoke(const std::vector<uint32_t>& shape, float fill_value, Device* device, const std::optional<ttnn::MemoryConfig>& memory_config_arg) {
+    return invoke(DefaultQueueId, shape, fill_value, device, memory_config_arg);
+}
+
+ttnn::Tensor FillOperation::invoke(uint8_t queue_id, float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config) {
+    auto shape = any.get_logical_shape();
+    TT_FATAL(shape.rank() <= 4, "Shape must be a vector of less than 4 integers [N, C, H, W]");
+
+    auto padded_shape = shape;
+    ttnn::Tensor mutable_tensor = any;
+
+    //unsqueeze the any tensor if padded shape length is different from original shape length
+    if (padded_shape.rank() < 4) {
+
+        //unsqueeze to 4D tensor
+        while (padded_shape.rank() < 4) {
+            mutable_tensor = ttnn::unsqueeze(mutable_tensor, 0);
+            padded_shape = mutable_tensor.get_logical_shape();
+        }
+
+        //fill operation
+        uint32_t N = padded_shape[0], C = padded_shape[1], H = padded_shape[2], W = padded_shape[3];
+        mutable_tensor = FillImplementation::invoke(queue_id, N, C, H, W, fill_value, mutable_tensor, memory_config);
+
+        //squeeze the tensor back to original shape
+        while(padded_shape != shape) {
+            mutable_tensor = ttnn::squeeze(mutable_tensor, 0);
+            padded_shape = mutable_tensor.get_logical_shape();
+        }
+
+        //return modified tensor
+        return mutable_tensor;
+    }
+
+    //or just perform operation and return tensor
+    uint32_t N = padded_shape[0], C = padded_shape[1], H = padded_shape[2], W = padded_shape[3];
+    return FillImplementation::invoke(queue_id, N, C, H, W, fill_value, any, memory_config);
+}
+
+ttnn::Tensor FillOperation::invoke(float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config_arg) {
+    return invoke(DefaultQueueId, fill_value, any, memory_config_arg);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
@@ -28,4 +28,14 @@ ttnn::Tensor FillOnesRMOperation::invoke(uint32_t N, uint32_t C, uint32_t H, uin
     return invoke(DefaultQueueId, N, C, H, W, hFill, wFill, any, memory_config_arg);
 }
 
+ttnn::Tensor FullOperation::invoke(uint8_t queue_id, uint32_t N, uint32_t C, uint32_t H, uint32_t W, float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config) {
+    auto output_memory_config = memory_config.value_or(any.memory_config());
+    // Pass hFill = 0 and wFill = 0 to fill the entire tensor with `fill_value`
+    return operation::run_without_autoformat(FillRM{N, C, H, W, 0, 0, fill_value, fill_value, output_memory_config}, {any}, {}, {}, queue_id).at(0);
+}
+
+ttnn::Tensor FullOperation::invoke(uint32_t N, uint32_t C, uint32_t H, uint32_t W, float fill_value, const ttnn::Tensor& any, const std::optional<ttnn::MemoryConfig>& memory_config_arg) {
+    return invoke(DefaultQueueId, N, C, H, W, fill_value, any, memory_config_arg);
+}
+
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.hpp
@@ -60,7 +60,7 @@ struct FillOnesRMOperation {
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 };
 
-struct FullOperation {
+struct FillImplementation {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         uint32_t N,
@@ -81,11 +81,40 @@ struct FullOperation {
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 };
 
+struct FillOperation {
+    static ttnn::Tensor invoke(
+        uint8_t queue_id,
+        float fill_value,
+        const ttnn::Tensor& any,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+
+    static ttnn::Tensor invoke(
+        float fill_value,
+        const ttnn::Tensor& any,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+};
+
+struct FullOperation {
+    static ttnn::Tensor invoke(
+        uint8_t queue_id,
+        const std::vector<uint32_t>& shape,
+        float fill_value,
+        Device* device,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+
+    static ttnn::Tensor invoke(
+        const std::vector<uint32_t>& shape,
+        float fill_value,
+        Device* device,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+};
+
 }  // namespace fill_rm
 }  // namespace operations
 
 constexpr auto fill_rm = ttnn::register_operation<"ttnn::fill_rm", ttnn::operations::data_movement::FillRMOperation>();
 constexpr auto fill_ones_rm = ttnn::register_operation<"ttnn::fill_ones_rm", ttnn::operations::data_movement::FillOnesRMOperation>();
 constexpr auto full = ttnn::register_operation<"ttnn::full", ttnn::operations::data_movement::FullOperation>();
+constexpr auto fill = ttnn::register_operation<"ttnn::fill", ttnn::operations::data_movement::FillOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.hpp
@@ -60,10 +60,32 @@ struct FillOnesRMOperation {
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 };
 
+struct FullOperation {
+    static ttnn::Tensor invoke(
+        uint8_t queue_id,
+        uint32_t N,
+        uint32_t C,
+        uint32_t H,
+        uint32_t W,
+        float fill_value,
+        const ttnn::Tensor& any,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+
+    static ttnn::Tensor invoke(
+        uint32_t N,
+        uint32_t C,
+        uint32_t H,
+        uint32_t W,
+        float fill_value,
+        const ttnn::Tensor& any,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+};
+
 }  // namespace fill_rm
 }  // namespace operations
 
 constexpr auto fill_rm = ttnn::register_operation<"ttnn::fill_rm", ttnn::operations::data_movement::FillRMOperation>();
 constexpr auto fill_ones_rm = ttnn::register_operation<"ttnn::fill_ones_rm", ttnn::operations::data_movement::FillOnesRMOperation>();
+constexpr auto full = ttnn::register_operation<"ttnn::full", ttnn::operations::data_movement::FullOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_pybind.cpp
@@ -192,30 +192,69 @@ void bind_full_op(py::module& module) {
         R"doc(
             Creates a tensor of shape (N, C, H, W) filled with the specified value.
 
-            This is a wrapper for `fill_rm` that sets `hOnes` and `wOnes` to `0`,
-            resulting in a tensor entirely filled with the given `fill_value`.
+            This is a wrapper for `fill_rm` that accepts a shape as a vector of integers
+            and fills the entire tensor with the given `fill_value`.
 
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
             | Argument | Description                                                           | Data type             | Valid range            | Required |
             +==========+=======================================================================+=======================+========================+==========+
-            | N        | Batch count of output tensor                                          | int                   | N > 0                  | Yes      |
+            | shape     | Shape of the tensor as a vector of 4 integers [N, C, H, W]           | std::vector<int>      | Length <= 4            | Yes      |
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
-            | C        | Channel count of output tensor                                        | int                   | C > 0                  | Yes      |
+            | fill_value| Value to fill the entire tensor with                                 | float                 |                        | Yes      |
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
-            | H        | Height count of output tensor                                         | int                   | H > 0                  | Yes      |
+            | device    | Device to allocate tensor on                                         | float                 |                        | Yes      |
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
-            | W        | Width count of output tensor                                          | int                   | W > 0                  | Yes      |
+
+            Args:
+                shape (list of int): The shape of the tensor in the form of [N, C, H, W].
+                fill_value (float): Value to fill the entire tensor.
+                device (ttnn.Device): Device to allocate the tensor on.
+
+            Returns:
+                ttnn.Tensor: The output tensor filled with `fill_value`.
+        )doc",
+        "full_tensor_op",
+        ttnn::full.base_name());
+
+    using OperationType = decltype(ttnn::full);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::full,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const std::vector<uint32_t>& shape,
+               const float fill_value,
+               ttnn::Device* device,
+               const std::optional<MemoryConfig>& memory_config,
+               uint8_t queue_id) {
+                   return self(queue_id, shape, fill_value, device, memory_config);
+               },
+            py::arg("shape"),
+            py::arg("fill_value"),
+            py::arg("device"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+void bind_fill_op(py::module& module) {
+    auto doc = fmt::format(
+        R"doc(
+            Fills a tensor with the specified value.
+
+            This is a wrapper for `fill_rm` that sets `hOnes` and `wOnes` to `0` and passes in N,C,H,W as the tensor shape,
+            returning the tensor filled with the given `fill_value`.
+
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | Argument | Description                                                           | Data type             | Valid range            | Required |
+            +==========+=======================================================================+=======================+========================+==========+
             | fill_value| Value to fill the entire tensor with                                 | float                 |                        | Yes      |
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
             | any      | Any input tensor with desired device and data types for output tensor | tt_lib.tensor.Tensor  |                        | Yes      |
             +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
 
             Args:
-                N (number): Batch count of output tensor.
-                C (number): Channel count of output tensor.
-                H (number): Height count of output tensor.
-                W (number): Width count of output tensor.
                 fill_value (number): Value to fill the entire tensor.
                 any (ttnn.tensor): Any input tensor with desired device and data types for output tensor.
 
@@ -226,29 +265,21 @@ void bind_full_op(py::module& module) {
             Returns:
                 ttnn.Tensor: the output tensor filled with `fill_value`.
         )doc",
-        ttnn::full.base_name());
+        ttnn::fill.base_name());
 
-    using OperationType = decltype(ttnn::full);
+    using OperationType = decltype(ttnn::fill);
     ttnn::bind_registered_operation(
         module,
-        ttnn::full,
+        ttnn::fill,
         doc,
         ttnn::pybind_overload_t{
             [](const OperationType& self,
-               uint32_t N,
-               uint32_t C,
-               uint32_t H,
-               uint32_t W,
                const float fill_value,
                const Tensor& any,
                const std::optional<MemoryConfig>& memory_config,
                uint8_t queue_id) {
-                   return self(queue_id, N, C, H, W, fill_value, any, memory_config);
+                   return self(queue_id, fill_value, any, memory_config);
                },
-            py::arg("N"),
-            py::arg("C"),
-            py::arg("H"),
-            py::arg("W"),
             py::arg("fill_value"),
             py::arg("any"),
             py::kw_only(),
@@ -261,6 +292,7 @@ void bind_fill_rm(py::module& module) {
    detail::bind_fill_rm_op(module);
    detail::bind_fill_ones_rm_op(module);
    detail::bind_full_op(module);
+   detail::bind_fill_op(module);
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_pybind.cpp
@@ -187,11 +187,80 @@ void bind_fill_ones_rm_op(py::module& module) {
 
 }
 
+void bind_full_op(py::module& module) {
+    auto doc = fmt::format(
+        R"doc(
+            Creates a tensor of shape (N, C, H, W) filled with the specified value.
+
+            This is a wrapper for `fill_rm` that sets `hOnes` and `wOnes` to `0`,
+            resulting in a tensor entirely filled with the given `fill_value`.
+
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | Argument | Description                                                           | Data type             | Valid range            | Required |
+            +==========+=======================================================================+=======================+========================+==========+
+            | N        | Batch count of output tensor                                          | int                   | N > 0                  | Yes      |
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | C        | Channel count of output tensor                                        | int                   | C > 0                  | Yes      |
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | H        | Height count of output tensor                                         | int                   | H > 0                  | Yes      |
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | W        | Width count of output tensor                                          | int                   | W > 0                  | Yes      |
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | fill_value| Value to fill the entire tensor with                                 | float                 |                        | Yes      |
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+            | any      | Any input tensor with desired device and data types for output tensor | tt_lib.tensor.Tensor  |                        | Yes      |
+            +----------+-----------------------------------------------------------------------+-----------------------+------------------------+----------+
+
+            Args:
+                N (number): Batch count of output tensor.
+                C (number): Channel count of output tensor.
+                H (number): Height count of output tensor.
+                W (number): Width count of output tensor.
+                fill_value (number): Value to fill the entire tensor.
+                any (ttnn.tensor): Any input tensor with desired device and data types for output tensor.
+
+            Keyword args:
+                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+                queue_id (int, optional): command queue id. Defaults to `0`.
+
+            Returns:
+                ttnn.Tensor: the output tensor filled with `fill_value`.
+        )doc",
+        ttnn::full.base_name());
+
+    using OperationType = decltype(ttnn::full);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::full,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               uint32_t N,
+               uint32_t C,
+               uint32_t H,
+               uint32_t W,
+               const float fill_value,
+               const Tensor& any,
+               const std::optional<MemoryConfig>& memory_config,
+               uint8_t queue_id) {
+                   return self(queue_id, N, C, H, W, fill_value, any, memory_config);
+               },
+            py::arg("N"),
+            py::arg("C"),
+            py::arg("H"),
+            py::arg("W"),
+            py::arg("fill_value"),
+            py::arg("any"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
 } //detail
 
 void bind_fill_rm(py::module& module) {
    detail::bind_fill_rm_op(module);
    detail::bind_fill_ones_rm_op(module);
+   detail::bind_full_op(module);
 }
 
 }  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
[#13837](https://github.com/tenstorrent/tt-metal/issues/13837)

### Problem description
 - create pybind for simple fill using fill_rm
 - create sweeps for fill

### What's changed
 - added to fill_rm pybind to create full function
 - added sweeps to test said function

### Post Commits
- there seem to be some problems executing the test device operation on this branch, needs to be looked at.
- Sweeps are passing at 100% for 12 tests I came up with, there aren't many traces to work with
- Other Post commits TBD...
