### PR TITLE
#13782: Adding a timeout for clang-tidy

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -95,6 +95,8 @@ jobs:
     - name: Analyze
       run: |
         git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j4
+      timeout-minutes: 10
+      continue-on-error: true
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@837ad8077b1f554dab31a8a43e8bb12c89d2f144
       with:


### PR DESCRIPTION
### Ticket
#13782 

### Problem description
Adding a timeout for clang-tidy in case a big PR causes it to run a long time.

### What's changed
timeout and continue on error for clang-tidy analyze step

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
