### PR TITLE
#13127: Switch normalization ops to ttnn::SimpleShape

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
@@ -68,9 +68,8 @@ void GroupNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
         TT_FATAL(input_mask.value().get_legacy_shape()[3] % TILE_WIDTH == 0, "Error");
     }
 }
-std::vector<tt::tt_metal::LegacyShape> GroupNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
+std::vector<ttnn::SimpleShape> GroupNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    return {input_tensors.at(0).get_logical_shape()};
 }
 std::vector<Tensor> GroupNorm::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.hpp
@@ -57,7 +57,7 @@ struct GroupNorm {
     GroupNormShardedMultiCoreProgramConfig program_config;
 
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -153,20 +153,14 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
 
 
 }
-std::vector<tt::tt_metal::LegacyShape> LayerNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
+std::vector<ttnn::SimpleShape> LayerNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    auto output_shape = input_tensors.at(0).get_logical_shape();
     if (this->distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER)
     {
-        auto output_shape = input_tensor.get_legacy_shape();
-        auto padding = output_shape.padding();
         uint32_t num_tiles_w = this->norm_type == LayerNormType::LAYERNORM ? 2 : 1;
         output_shape[3] = num_tiles_w * TILE_WIDTH;
-        return {tt::tt_metal::LegacyShape(output_shape, padding)};
     }
-    else
-    {
-        return {input_tensor.get_legacy_shape()};
-    }
+    return {output_shape};
 }
 std::vector<Tensor> LayerNorm::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
@@ -52,7 +52,7 @@ struct LayerNorm {
     const DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -81,9 +81,8 @@ void LayerNormPostAllGather::validate(const std::vector<Tensor> &input_tensors, 
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> LayerNormPostAllGather::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
+std::vector<ttnn::SimpleShape> LayerNormPostAllGather::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    return {input_tensors.at(0).get_logical_shape()};
 }
 
 std::vector<Tensor> LayerNormPostAllGather::create_output_tensors(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.hpp
@@ -33,7 +33,7 @@ struct LayerNormPostAllGather {
     const DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
@@ -32,19 +32,17 @@ void LayerNormPreAllGather::validate(const std::vector<Tensor> &input_tensors) c
     TT_FATAL(tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
 }
 
-std::vector<tt::tt_metal::LegacyShape> LayerNormPreAllGather::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+std::vector<ttnn::SimpleShape> LayerNormPreAllGather::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
 
-    auto output_shape = input_tensor.get_legacy_shape();
-    auto padding = output_shape.padding();
+    auto output_shape = input_tensors.at(0).get_logical_shape();
     uint32_t num_tiles_w = 1;
     if (this->norm_type == LayerNormDistributedType::LAYERNORM) {
         num_tiles_w = 2;
     }
     output_shape[3] = num_tiles_w * TILE_WIDTH;
-    padding[3] = Padding::PadDimension{0, 31};
 
-    return {tt::tt_metal::LegacyShape(output_shape, padding)};
+    return {output_shape};
 }
 
 std::vector<Tensor> LayerNormPreAllGather::create_output_tensors(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp
@@ -29,7 +29,7 @@ struct LayerNormPreAllGather {
     const DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Remove `LegacyShape`.

### What's changed
Switching normalization ops to use `ttnn::SimpleShape`.

### Checklist
- [x] Post commit CI passes:
  - all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/11367798845
  - T3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11367815552
  - Nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/11372611145
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable): 
  - model demo: https://github.com/tenstorrent/tt-metal/actions/runs/11372606453
  - model perf: https://github.com/tenstorrent/tt-metal/actions/runs/11372602133
  - model device: https://github.com/tenstorrent/tt-metal/actions/runs/11372604392
- [x] New/Existing tests provide coverage for changes
