### PR TITLE
#0: Cleanup lingering include paths to non-existent dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ target_link_libraries(metal_common_libs INTERFACE
 )
 
 # Note on flags:
+#   DFMT_HEADER_ONLY must be for every target or else they won't interact with the header only fmt as intended
 #   ttnn and tt_lib will break if built with LTO, so leaving -fno-lto in compile options
 add_library(linker_flags INTERFACE)
 
@@ -184,7 +185,7 @@ ADJUST_COMPILER_WARNINGS()
 
 add_library(compiler_flags INTERFACE)
 target_link_libraries(compiler_flags INTERFACE linker_flags compiler_warnings stdlib)
-target_compile_options(compiler_flags INTERFACE -mavx2 -fPIC -fvisibility-inlines-hidden -fno-lto)
+target_compile_options(compiler_flags INTERFACE -mavx2 -fPIC -DFMT_HEADER_ONLY -fvisibility-inlines-hidden -fno-lto)
 
 if(ENABLE_CODE_TIMERS)
     target_compile_options(compiler_flags INTERFACE -DTT_ENABLE_CODE_TIMERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,6 @@ target_link_libraries(metal_common_libs INTERFACE
 )
 
 # Note on flags:
-#   DFMT_HEADER_ONLY must be for every target or else they won't interact with the header only fmt as intended
 #   ttnn and tt_lib will break if built with LTO, so leaving -fno-lto in compile options
 add_library(linker_flags INTERFACE)
 
@@ -185,7 +184,7 @@ ADJUST_COMPILER_WARNINGS()
 
 add_library(compiler_flags INTERFACE)
 target_link_libraries(compiler_flags INTERFACE linker_flags compiler_warnings stdlib)
-target_compile_options(compiler_flags INTERFACE -mavx2 -fPIC -DFMT_HEADER_ONLY -fvisibility-inlines-hidden -fno-lto)
+target_compile_options(compiler_flags INTERFACE -mavx2 -fPIC -fvisibility-inlines-hidden -fno-lto)
 
 if(ENABLE_CODE_TIMERS)
     target_compile_options(compiler_flags INTERFACE -DTT_ENABLE_CODE_TIMERS)

--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -35,7 +35,6 @@ target_include_directories(unit_tests_common_o PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/tt_metal
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
     ${PROJECT_SOURCE_DIR}/tt_metal/common
     ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}/common

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -40,7 +40,6 @@ target_include_directories(tt_metal PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )
 target_compile_options(tt_metal PUBLIC -Wno-int-to-pointer-cast)
 add_dependencies(tt_metal hw_toolchain)

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -14,5 +14,4 @@ target_include_directories(common PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/tt_metal
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -543,7 +543,7 @@ set(TTNN_PUBLIC_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR} # ${PROJECT_SOURCE_DIR}/ttnn
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated # symlink to tt_eager; should become native folder once merge complete
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt)
+    )
 set(TTNN_PUBLIC_LINK_LIBRARIES compiler_flags metal_header_directories metal_common_libs tt_metal)
 set(TTNN_PUBLIC_LINK_DIRS "")
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
Cleanup

### What's changed
Delete any reference to `third_party/fmt` as it no longer exists.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11359423525
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
