### PR TITLE
#13804: Unit Tests Revision

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/test_clone.py
@@ -13,28 +13,8 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
+    get_lib_dtype,
 )
-
-
-def get_lib_dtype(lib, dtype):
-    """
-    Maps string-based data types to their corresponding library-specific dtypes.
-
-    Parameters:
-    lib: library module (e.g., torch, ttnn)
-        The library for which the dtype mapping is required.
-    dtype: str
-        The string representation of the data type (e.g., 'bfloat16', 'float32', 'int32').
-
-    Returns:
-    Corresponding library-specific dtype or None if not found.
-    """
-    dtype_map = {
-        "bfloat16": lib.bfloat16,
-        "float32": lib.float32,
-        "int32": lib.int32,
-    }
-    return dtype_map.get(dtype, None)
 
 
 def run_clone(
@@ -90,6 +70,7 @@ def run_clone(
     ttnn_input = ttnn.from_torch(
         torch_input,
         device=device,
+        dtype=get_lib_dtype(ttnn, input_dtype),
         layout=ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT,
     ).to(device, input_memory_config)
 

--- a/tests/ttnn/unit_tests/operations/test_fast_reduce_nc.py
+++ b/tests/ttnn/unit_tests/operations/test_fast_reduce_nc.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc, comp_pcc, skip_for_grayskull
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,

--- a/tests/ttnn/unit_tests/operations/test_moreh_adam.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_adam.py
@@ -12,7 +12,7 @@ from models.utility_functions import (
     comp_allclose_and_pcc,
 )
 from loguru import logger
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,

--- a/tests/ttnn/unit_tests/operations/test_moreh_adam.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_adam.py
@@ -16,6 +16,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
+    to_ttnn,
 )
 
 
@@ -153,12 +154,15 @@ def test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_
         ([2, 2, 2, 2, 2, 2, 64, 64], 0.0, (0.9, 0.999), 1e-06, 0.0, False, False),
     ),
 )
-def test_moreh_adam_enable_cache(params, device, use_program_cache):
-    for i in range(4):
+def test_moreh_adam_callback(params, device, use_program_cache):
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
         shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en = params
-        if i % 2 == 1:
-            amsgrad = not amsgrad
-
         test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en, device)
-
-    assert device.num_program_cache_entries() == 2
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/tests/ttnn/unit_tests/operations/test_moreh_arange.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_arange.py
@@ -100,14 +100,7 @@ def test_arange(start_end_step, optional_output, dtype, tilized, device):
 @pytest.mark.parametrize(
     "start_end_step",
     [
-        [0, 32, 1],
-        [2.3, 15.3, 0.5],
-        [10.9, -13, -0.3],
-        [-100, 32 * 10, 1],
-        [0, 32000, 1],
-        [2300.3, 15300.3, 0.5392],
         [10900.9, -13000, -0.3111],
-        [-10000, 32 * 10000, 1],
     ],
 )
 @pytest.mark.parametrize(
@@ -120,14 +113,13 @@ def test_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 def test_arange_callback(start_end_step, optional_output, dtype, device, use_program_cache):
     """Test arange functionality with callback and program cache validation."""
+    torch.manual_seed(2024)
     num_program_cache_entries_list = []
-    for i in range(4):
-        if i % 2 == 0:
-            run_moreh_arange(start_end_step, optional_output, dtype, True, device)
-        else:
-            run_moreh_arange(start_end_step, optional_output, dtype, False, device)
+    for i in range(2):
+        run_moreh_arange(start_end_step, optional_output, dtype, True, device)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
-    assert num_program_cache_entries_list == [1, 2, 2, 2]
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/tests/ttnn/unit_tests/operations/test_moreh_arange.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_arange.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc
-from tests.ttnn.unit_tests.operations.test_utils import to_npu
+from tests.ttnn.unit_tests.operations.test_utils import to_ttnn
 
 
 def get_lib_dtype(lib, dtype):
@@ -137,7 +137,7 @@ def test_arange_callback(start_end_step, optional_output, dtype, device, use_pro
         else:
             run_moreh_arange(start_end_step, optional_output, dtype, False, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list == [1, 2, 2, 2]

--- a/tests/ttnn/unit_tests/operations/test_moreh_arange.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_arange.py
@@ -8,17 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc
-from tests.ttnn.unit_tests.operations.test_utils import to_ttnn
-
-
-def get_lib_dtype(lib, dtype):
-    """Maps dtype to corresponding library dtype."""
-    dtype_map = {
-        "int32": lib.int32,
-        "bfloat16": lib.bfloat16,
-        "float32": lib.float32,
-    }
-    return dtype_map.get(dtype, None)
+from tests.ttnn.unit_tests.operations.test_utils import to_ttnn, get_lib_dtype
 
 
 def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):

--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -15,7 +15,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_npu,
+    to_ttnn,
 )
 
 
@@ -162,7 +162,7 @@ def test_moreh_bmm_callback(shape, optional_output, compute_kernel_options, devi
     for i in range(2):
         run_moreh_bmm(shape, optional_output, compute_kernel_options, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0
@@ -217,7 +217,7 @@ def test_moreh_bmm_backward_callback(shape, requires_grad, compute_kernel_option
     for i in range(2):
         run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0

--- a/tests/ttnn/unit_tests/operations/test_moreh_dot.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_dot.py
@@ -12,7 +12,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_npu,
+    to_ttnn,
 )
 
 
@@ -192,7 +192,7 @@ def test_moreh_matmul_1d_callback(input_shape, dtype, device, use_program_cache)
             .to_torch()
         )
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0

--- a/tests/ttnn/unit_tests/operations/test_moreh_dot_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_dot_backward.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,

--- a/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
@@ -9,7 +9,7 @@ import pytest
 from models.utility_functions import comp_allclose_and_pcc, is_blackhole, skip_for_blackhole
 from loguru import logger
 
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import to_npu
+from tests.ttnn.unit_tests.operations.test_utils import to_ttnn
 
 
 def to_output_5d_shape(shape, index_dims, index_size):
@@ -274,7 +274,7 @@ def test_getitem_RAW_MAJOR_callback(shape_index_dim, dtype, index_size, device, 
     for _ in range(2):
         run_getitem_RAW_MAJOR(shape_index_dim, dtype, index_size, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
 
 
 @skip_for_blackhole("Mismatching on Blackhole, see #12349")
@@ -819,4 +819,4 @@ def test_getitem_tilized_one_index_callback(
     for _ in range(2):
         run_moreh_geitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major_index, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)

--- a/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_getitem.py
@@ -270,11 +270,15 @@ def run_getitem_RAW_MAJOR(shape_index_dim, dtype, index_size, device):
 )
 def test_getitem_RAW_MAJOR_callback(shape_index_dim, dtype, index_size, device, use_program_cache):
     torch.manual_seed(2024)
-
-    for _ in range(2):
+    num_program_cache_entries_list = []
+    for i in range(2):
         run_getitem_RAW_MAJOR(shape_index_dim, dtype, index_size, device)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 @skip_for_blackhole("Mismatching on Blackhole, see #12349")
@@ -816,7 +820,12 @@ def test_getitem_tilized_one_index_callback(
     shape_index_dim, dtype, index_size, row_major_index, device, use_program_cache
 ):
     torch.manual_seed(2024)
-    for _ in range(2):
+    num_program_cache_entries_list = []
+    for i in range(2):
         run_moreh_geitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major_index, device)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/tests/ttnn/unit_tests/operations/test_moreh_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_group_norm.py
@@ -324,10 +324,16 @@ def test_moreh_group_norm(N, C_num_groups, HW, eps, affine, compute_mean_rstd, d
     ],
 )
 def test_moreh_group_norm_callback(N, C_num_groups, HW, eps, affine, compute_mean_rstd, device, use_program_cache):
-    for _ in range(2):
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
         run_test_moreh_group_norm(N, C_num_groups, HW, eps, affine, compute_mean_rstd, device)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 def run_test_moreh_group_norm_backward(
@@ -525,9 +531,15 @@ def test_moreh_group_norm_backward_callback(
     device,
     use_program_cache,
 ):
-    for _ in range(2):
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
         run_test_moreh_group_norm_backward(
             N, C_num_groups, HW, eps, affine, input_requires_grad, gamma_requires_grad, beta_requires_grad, device
         )
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/tests/ttnn/unit_tests/operations/test_moreh_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_group_norm.py
@@ -11,32 +11,7 @@ from models.utility_functions import comp_allclose
 from loguru import logger
 
 
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import TILE_HEIGHT, TILE_WIDTH
-
-
-def to_cpu(npu_tensor, shape, *, cpu_layout=ttnn.ROW_MAJOR_LAYOUT):
-    if npu_tensor is None:
-        return None
-    if not isinstance(shape, (list, tuple)):
-        shape = tuple(shape)
-    cpu_tensor = npu_tensor.cpu().to(cpu_layout).unpad_from_tile(shape).to_torch()
-    return cpu_tensor
-
-
-def to_npu(
-    cpu_tensor,
-    device,
-    *,
-    npu_layout=ttnn.TILE_LAYOUT,
-    npu_dtype=ttnn.bfloat16,
-    shape=None,
-):
-    if cpu_tensor is None:
-        return None
-    if shape is not None:
-        cpu_tensor = cpu_tensor.view(shape)
-    npu_tensor = ttnn.Tensor(cpu_tensor, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    return npu_tensor
+from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH, to_ttnn, to_torch
 
 
 def torch_group_norm(input, num_groups, gamma=None, beta=None, eps=1e-05, compute_mean_rstd=True):
@@ -94,16 +69,16 @@ def tt_group_norm(input, num_groups, gamma=None, beta=None, eps=1e-05, compute_m
     gamma_beta_shape = [1, 1, 1, C]
     mean_rstd_shape = [1, 1, N, num_groups]
 
-    npu_input = to_npu(input, device)
-    npu_gamma = to_npu(gamma, device, shape=gamma_beta_shape)
-    npu_beta = to_npu(beta, device, shape=gamma_beta_shape)
+    npu_input = to_ttnn(input, device=device)
+    npu_gamma = to_ttnn(gamma, device=device, shape=gamma_beta_shape)
+    npu_beta = to_ttnn(beta, device=device, shape=gamma_beta_shape)
 
     npu_mean = npu_rstd = None
     if compute_mean_rstd:
         npu_mean = torch.empty(mean_rstd_shape, dtype=torch.bfloat16)
-        npu_mean = to_npu(npu_mean, device)
+        npu_mean = to_ttnn(npu_mean, device=device)
         npu_rstd = torch.empty(mean_rstd_shape, dtype=torch.bfloat16)
-        npu_rstd = to_npu(npu_rstd, device)
+        npu_rstd = to_ttnn(npu_rstd, device=device)
 
     # Forward
     npu_output, npu_mean, npu_rstd = ttnn.operations.moreh.group_norm(
@@ -117,12 +92,12 @@ def tt_group_norm(input, num_groups, gamma=None, beta=None, eps=1e-05, compute_m
         rstd=npu_rstd,
     )
 
-    tt_output = to_cpu(npu_output, input.shape)
+    tt_output = to_torch(npu_output, shape=input.shape)
 
     tt_mean = tt_rstd = None
     if compute_mean_rstd:
-        tt_mean = to_cpu(npu_mean, mean_rstd_shape).view(N, num_groups)
-        tt_rstd = to_cpu(npu_rstd, mean_rstd_shape).view(N, num_groups)
+        tt_mean = to_torch(npu_mean, shape=mean_rstd_shape).view(N, num_groups)
+        tt_rstd = to_torch(npu_rstd, shape=mean_rstd_shape).view(N, num_groups)
 
     return tt_output, tt_mean, tt_rstd
 
@@ -148,26 +123,26 @@ def tt_group_norm_backward(
     var = ((x_view - mean) ** 2).mean(dim=-1, keepdim=False)
     rstd = (var + eps).rsqrt()
 
-    npu_output_grad = to_npu(output_grad, device)
-    npu_input = to_npu(input, device)
-    npu_mean = to_npu(mean, device, shape=mean_rstd_shape)
-    npu_rstd = to_npu(rstd, device, shape=mean_rstd_shape)
-    npu_gamma = to_npu(gamma, device, shape=gamma_beta_shape)
+    npu_output_grad = to_ttnn(output_grad, device=device)
+    npu_input = to_ttnn(input, device=device)
+    npu_mean = to_ttnn(mean, device=device, shape=mean_rstd_shape)
+    npu_rstd = to_ttnn(rstd, device=device, shape=mean_rstd_shape)
+    npu_gamma = to_ttnn(gamma, device=device, shape=gamma_beta_shape)
 
     npu_dx = None
     if input_requires_grad:
         npu_dx = torch.empty(input.shape, dtype=torch.bfloat16)
-        npu_dx = to_npu(npu_dx, device)
+        npu_dx = to_ttnn(npu_dx, device=device)
 
     npu_dg = None
     if gamma_requires_grad:
         npu_dg = torch.empty(gamma_beta_shape, dtype=torch.bfloat16)
-        npu_dg = to_npu(npu_dg, device)
+        npu_dg = to_ttnn(npu_dg, device=device)
 
     npu_db = None
     if beta_requires_grad:
         npu_db = torch.empty(gamma_beta_shape, dtype=torch.bfloat16)
-        npu_db = to_npu(npu_db, device)
+        npu_db = to_ttnn(npu_db, device=device)
 
     # Backward
     npu_dx, npu_dg, npu_db = ttnn.operations.moreh.group_norm_backward(
@@ -183,13 +158,13 @@ def tt_group_norm_backward(
         beta_grad=npu_db,
     )
 
-    tt_input_grad = to_cpu(npu_dx, input.shape)
+    tt_input_grad = to_torch(npu_dx, shape=input.shape)
 
     tt_gamma_grad = tt_beta_grad = None
     if npu_dg is not None:
-        tt_gamma_grad = to_cpu(npu_dg, gamma_beta_shape).view(C)
+        tt_gamma_grad = to_torch(npu_dg, shape=gamma_beta_shape).view(C)
     if npu_db is not None:
-        tt_beta_grad = to_cpu(npu_db, gamma_beta_shape).view(C)
+        tt_beta_grad = to_torch(npu_db, shape=gamma_beta_shape).view(C)
 
     return tt_input_grad, tt_gamma_grad, tt_beta_grad
 
@@ -352,7 +327,7 @@ def test_moreh_group_norm_callback(N, C_num_groups, HW, eps, affine, compute_mea
     for _ in range(2):
         run_test_moreh_group_norm(N, C_num_groups, HW, eps, affine, compute_mean_rstd, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
 
 
 def run_test_moreh_group_norm_backward(
@@ -555,4 +530,4 @@ def test_moreh_group_norm_backward_callback(
             N, C_num_groups, HW, eps, affine, input_requires_grad, gamma_requires_grad, beta_requires_grad, device
         )
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)

--- a/tests/ttnn/unit_tests/operations/test_moreh_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_layer_norm.py
@@ -547,10 +547,16 @@ def test_moreh_layer_norm_backward_compute_kernel_options(
     ],
 )
 def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affine, eps, device, use_program_cache):
-    torch.manual_seed(2023)
-    for _ in range(2):
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
         run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, device)
-    assert device.num_program_cache_entries() == 1
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 @skip_for_grayskull("Using the transpose function in copy_tile causes a hang.")
@@ -569,10 +575,16 @@ def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affi
 def test_moreh_layer_norm_backward_callback(
     input_shape_normalized_dims, elementwise_affine, eps, device, use_program_cache
 ):
-    torch.manual_seed(2023)
-    for _ in range(2):
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for i in range(2):
         run_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, device)
-    assert device.num_program_cache_entries() == (2 if elementwise_affine else 1)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 @skip_for_grayskull("Using the transpose function in copy_tile causes a hang.")

--- a/tests/ttnn/unit_tests/operations/test_moreh_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_layer_norm.py
@@ -17,52 +17,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
     TILE_HEIGHT,
     TILE_WIDTH,
+    to_torch,
+    to_ttnn,
 )
 from models.utility_functions import skip_for_grayskull, skip_for_blackhole
-
-
-def create_tt_tensor(tensor: torch.Tensor, dtype, device, layout):
-    return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device)
-
-
-def to_cpu(npu_tensor, shape, *, cpu_layout=ttnn.ROW_MAJOR_LAYOUT):
-    if npu_tensor is None:
-        return None
-    if not isinstance(shape, (list,)):
-        shape = list(shape)
-
-    unpad_shape = copy.copy(shape)
-    if shape == []:
-        unpad_shape = [1, 1]
-    if len(shape) == 1:
-        unpad_shape = [1] + shape
-
-    cpu_tensor = npu_tensor.cpu().to(cpu_layout).unpad_from_tile(unpad_shape).to_torch().reshape(shape)
-
-    return cpu_tensor
-
-
-def to_npu(
-    cpu_tensor,
-    device,
-    *,
-    npu_layout=ttnn.TILE_LAYOUT,
-    npu_dtype=ttnn.bfloat16,
-    shape=None,
-):
-    if cpu_tensor is None:
-        return None
-    if shape is not None:
-        cpu_tensor = cpu_tensor.view(shape)
-
-    if len(cpu_tensor.shape) == 1:
-        cpu_tensor = cpu_tensor.reshape([1, len(cpu_tensor)])
-
-    if len(cpu_tensor.shape) == 0:
-        cpu_tensor = cpu_tensor.reshape([1, 1])
-
-    npu_tensor = create_tt_tensor(cpu_tensor, npu_dtype, device, npu_layout)
-    return npu_tensor
 
 
 def torch_layer_norm(input, *, normalized_dims=1, eps=1e-5, gamma=None, beta=None):
@@ -124,25 +82,25 @@ def tt_layer_norm(
     cpu_dtype = torch.bfloat16
 
     # input
-    npu_input = to_npu(input, device)
+    npu_input = to_ttnn(input, device=device)
 
     # output
     output = torch.empty_like(input)
-    npu_output = to_npu(output, device)
+    npu_output = to_ttnn(output, device=device)
 
     # gamma
-    npu_gamma = to_npu(gamma, device)
+    npu_gamma = to_ttnn(gamma, device=device)
 
     # beta
-    npu_beta = to_npu(beta, device)
+    npu_beta = to_ttnn(beta, device=device)
 
     # mean for inplace update
     cpu_mean = torch.full(mean_rstd_shape, float("nan"), dtype=cpu_dtype)
-    npu_mean = to_npu(cpu_mean, device)
+    npu_mean = to_ttnn(cpu_mean, device=device)
 
     # rstd for inplace update
     cpu_rstd = torch.full(mean_rstd_shape, float("nan"), dtype=cpu_dtype)
-    npu_rstd = to_npu(cpu_rstd, device)
+    npu_rstd = to_ttnn(cpu_rstd, device=device)
 
     # Forward
     npu_output, npu_mean, npu_rstd = ttnn.operations.moreh.layer_norm(
@@ -157,9 +115,9 @@ def tt_layer_norm(
         compute_kernel_config=compute_kernel_config,
     )
 
-    tt_output = to_cpu(npu_output, input_shape)
-    tt_mean = to_cpu(npu_mean, mean_rstd_shape) if create_mean_rstd else None
-    tt_rstd = to_cpu(npu_rstd, mean_rstd_shape) if create_mean_rstd else None
+    tt_output = to_torch(npu_output, shape=input_shape)
+    tt_mean = to_torch(npu_mean, shape=mean_rstd_shape) if create_mean_rstd else None
+    tt_rstd = to_torch(npu_rstd, shape=mean_rstd_shape) if create_mean_rstd else None
 
     return tt_output, tt_mean, tt_rstd
 
@@ -183,13 +141,13 @@ def tt_layer_norm_backward(
     cpu_dtype = torch.bfloat16
 
     # input
-    npu_input = to_npu(input, device)
+    npu_input = to_ttnn(input, device=device)
 
     # output_grad
-    npu_output_grad = to_npu(output_grad, device)
+    npu_output_grad = to_ttnn(output_grad, device=device)
 
     # gamma
-    npu_gamma = to_npu(gamma, device)
+    npu_gamma = to_ttnn(gamma, device=device)
 
     # mean, rstd
     mean_rstd_dims = list(range(-normalized_dims, 0))
@@ -198,24 +156,24 @@ def tt_layer_norm_backward(
     var = ((input.clone() - mean) ** 2).mean(dim=mean_rstd_dims, keepdim=True)
     rstd = (var + eps).rsqrt()
 
-    npu_mean = to_npu(mean, device, shape=mean_rstd_shape)
-    npu_rstd = to_npu(rstd, device, shape=mean_rstd_shape)
+    npu_mean = to_ttnn(mean, device=device, shape=mean_rstd_shape)
+    npu_rstd = to_ttnn(rstd, device=device, shape=mean_rstd_shape)
 
     # input_grad for inplace update
     cpu_input_grad = torch.full(input_shape, float("nan"), dtype=cpu_dtype)
-    npu_input_grad = to_npu(cpu_input_grad, device)
+    npu_input_grad = to_ttnn(cpu_input_grad, device=device)
 
     # gamma_grad for inplace update
     npu_gamma_grad = None
     if gamma is not None:
         cpu_gamma_grad = torch.full(gamma_beta_shape, float("nan"), dtype=cpu_dtype)
-        npu_gamma_grad = to_npu(cpu_gamma_grad, device)
+        npu_gamma_grad = to_ttnn(cpu_gamma_grad, device=device)
 
     # beta_grad for inplace update
     npu_beta_grad = None
     if beta is not None:
         cpu_beta_grad = torch.full(gamma_beta_shape, float("nan"), dtype=cpu_dtype)
-        npu_beta_grad = to_npu(cpu_beta_grad, device)
+        npu_beta_grad = to_ttnn(cpu_beta_grad, device=device)
 
     # Backward
     _, npu_gamma_grad, _ = ttnn.operations.moreh.layer_norm_backward(
@@ -231,11 +189,11 @@ def tt_layer_norm_backward(
         compute_kernel_config=compute_kernel_config,
     )
 
-    tt_input_grad = to_cpu(npu_input_grad, input_shape)
-    tt_gamma_grad = to_cpu(npu_gamma_grad, gamma_beta_shape)
+    tt_input_grad = to_torch(npu_input_grad, shape=input_shape)
+    tt_gamma_grad = to_torch(npu_gamma_grad, shape=gamma_beta_shape)
     if tt_gamma_grad is not None:
         tt_gamma_grad = tt_gamma_grad.view(normalized_shape)
-    tt_beta_grad = to_cpu(npu_beta_grad, gamma_beta_shape)
+    tt_beta_grad = to_torch(npu_beta_grad, shape=gamma_beta_shape)
     if tt_beta_grad is not None:
         tt_beta_grad = tt_beta_grad.view(normalized_shape)
 

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -15,7 +15,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_npu,
+    to_ttnn,
 )
 
 
@@ -432,7 +432,7 @@ def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
 
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
     assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
@@ -457,8 +457,7 @@ def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_c
         assert num_program_cache_entries > 0
 
     torch_dummy = torch.randn([32, 32])
-    tt_dummy = to_npu(torch_dummy, device)
-
+    tt_dummy = to_ttnn(torch_dummy, device=device)
     return tt_npu, num_program_cache_entries
 
 

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -9,7 +9,7 @@ from loguru import logger
 import ttnn
 import ttnn.operations
 from models.utility_functions import comp_allclose_and_pcc, skip_for_grayskull
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,

--- a/tests/ttnn/unit_tests/operations/test_moreh_mean.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_mean.py
@@ -202,17 +202,16 @@ def test_moreh_mean_compute_kernel_options(input_shape_dim, compute_kernel_optio
     ],
 )
 def test_moreh_mean_callback(input_shape_dim, device, use_program_cache):
-    torch.manual_seed(2023)
-
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_mean(input_shape_dim, device, keepdim=True)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
-        if i == 0:
-            num_program_cache_entries = device.num_program_cache_entries()
-            assert num_program_cache_entries > 0
-        else:
-            assert device.num_program_cache_entries() == num_program_cache_entries
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 @pytest.mark.parametrize(
@@ -275,17 +274,16 @@ def test_moreh_mean_backward_compute_kernel_options(input_shape_dim, compute_ker
     ],
 )
 def test_moreh_mean_backward_callback(input_shape_dim, device, use_program_cache):
-    torch.manual_seed(2023)
-
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_mean_backward(input_shape_dim, device, keepdim=True)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
-        if i == 0:
-            num_program_cache_entries = device.num_program_cache_entries()
-            assert num_program_cache_entries > 0
-        else:
-            assert device.num_program_cache_entries() == num_program_cache_entries
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_moreh_mean.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_mean.py
@@ -10,12 +10,12 @@ import tt_lib as ttl
 import ttnn
 from models.utility_functions import comp_allclose
 
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_cpu,
-    to_npu,
+    to_torch,
+    to_ttnn,
     TILE_HEIGHT,
     TILE_WIDTH,
     check_dim,
@@ -38,8 +38,8 @@ def get_tt_tensors(torch_input, output_shape, device):
     torch_input = torch_input.bfloat16()
     torch_output = torch.empty(output_shape, dtype=torch.bfloat16)
 
-    tt_input = to_npu(torch_input, device)
-    tt_output = to_npu(torch_output, device)
+    tt_input = to_ttnn(torch_input, device=device)
+    tt_output = to_ttnn(torch_output, device=device)
     return tt_input, tt_output
 
 
@@ -59,8 +59,8 @@ def get_tt_backward_tensors(torch_output_grad, input_grad_shape, device):
 
     torch_input_grad = torch.empty(input_grad_shape, dtype=cpu_dtype)
 
-    tt_input_grad = to_npu(torch_input_grad, device)
-    tt_output_grad = to_npu(torch_output_grad, device)
+    tt_input_grad = to_ttnn(torch_input_grad, device=device)
+    tt_output_grad = to_ttnn(torch_output_grad, device=device)
 
     return tt_output_grad, tt_input_grad
 
@@ -82,7 +82,7 @@ def run_moreh_mean(input_shape_dim, device, keepdim=False, compute_kernel_option
     ttnn.operations.moreh.mean(
         tt_input, dim=dim, keepdim=keepdim, output=tt_output, compute_kernel_config=compute_kernel_config
     )
-    tt_output_cpu = to_cpu(tt_output, torch_output.shape)
+    tt_output_cpu = to_torch(tt_output, shape=torch_output.shape)
 
     # test for equivalance
     rtol = atol = 0.1
@@ -130,7 +130,7 @@ def run_moreh_mean_backward(input_shape_dim, device, keepdim=False, compute_kern
             compute_kernel_config=compute_kernel_config,
         )
 
-    tt_input_grad_cpu = to_cpu(tt_input_grad, torch_input.grad.shape)
+    tt_input_grad_cpu = to_torch(tt_input_grad, shape=torch_input.grad.shape)
 
     # test for equivalance
     rtol = atol = 0.1
@@ -207,7 +207,7 @@ def test_moreh_mean_callback(input_shape_dim, device, use_program_cache):
     for i in range(2):
         run_moreh_mean(input_shape_dim, device, keepdim=True)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0
@@ -280,7 +280,7 @@ def test_moreh_mean_backward_callback(input_shape_dim, device, use_program_cache
     for i in range(2):
         run_moreh_mean_backward(input_shape_dim, device, keepdim=True)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0

--- a/tests/ttnn/unit_tests/operations/test_moreh_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_norm.py
@@ -353,6 +353,7 @@ def test_moreh_norm_callback(input_shape, p, dim_rtol_atol, keepdim, device, use
         tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
@@ -500,4 +501,5 @@ def test_moreh_norm_backward_callback(input_shape, p, dim_rtol_atol, keepdim, de
         tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
@@ -14,7 +14,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_npu,
+    to_ttnn,
 )
 
 
@@ -343,7 +343,7 @@ def test_softmax_callback(shape_dim_strategy, device, use_program_cache):
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
 
     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
@@ -385,7 +385,7 @@ def test_softmax_backward_callback(shape_dim_strategy, device, use_program_cache
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
 
     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
@@ -15,7 +15,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_npu,
+    to_ttnn,
 )
 
 
@@ -418,7 +418,7 @@ def test_softmin_callback(shape_dim_strategy, device, use_program_cache):
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_npu(torch_dummy, device)
+        tt_dummy = to_ttnn(torch_dummy, device=device)
 
     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
@@ -442,7 +442,7 @@ def softmin_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cach
         assert num_program_cache_entries > 0
 
     torch_dummy = torch.randn([32, 32])
-    tt_dummy = to_npu(torch_dummy, device)
+    tt_dummy = to_ttnn(torch_dummy, device=device)
 
     return tt_npu, num_program_cache_entries
 

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -43,6 +43,10 @@ def get_compute_kernel_options(compute_kernel_options):
 
 
 def to_torch(ttnn_tensor, *, shape=None):
+    """
+    Converts a ttnn tensor to a torch tensor. If ttnn tensor is None, returns None.
+    If shape specified, reshapes the resulting torch tensor to the given shape.
+    """
     if ttnn_tensor is None:
         return None
     torch_tensor = ttnn.to_torch(ttnn_tensor)
@@ -60,6 +64,12 @@ def to_ttnn(
     memory_config=None,
     shape=None,
 ):
+    """
+    Converts a torch tensor to a ttnn tensor, with optional arguments to control
+    the device, data type, memory layout, and memory configuration. The tensor can
+    also be reshaped if a shape is provided. If the torch tensor is a scalar (a tensor
+    with zero dimensions), it will be automatically reshaped to have a shape of [1, 1].
+    """
     if torch_tensor is None:
         return None
     if shape is not None:

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -145,3 +145,24 @@ def check_dim(input_shape, dim, keepdim):
             for i in dim:
                 if len(input_shape) - 2 <= i:
                     pytest.skip("`keepdim == false` don't support last 2-dim")
+
+
+def get_lib_dtype(lib, dtype):
+    """
+    Maps string-based data types to their corresponding library-specific dtypes.
+
+    Parameters:
+    lib: library module (e.g., torch, ttnn)
+        The library for which the dtype mapping is required.
+    dtype: str
+        The string representation of the data type (e.g., 'bfloat16', 'float32', 'int32').
+
+    Returns:
+    Corresponding library-specific dtype or None if not found.
+    """
+    dtype_map = {
+        "bfloat16": lib.bfloat16,
+        "float32": lib.float32,
+        "int32": lib.int32,
+    }
+    return dtype_map.get(dtype, None)


### PR DESCRIPTION
### Ticket
Link to Github Issue: [#13804](https://github.com/tenstorrent/tt-metal/issues/13804)

### Problem description
The Python test files for all Moreh operations in `ttnn` and `test_utils.py` need to be revised.

I noticed that the `to_npu` utility function was performing padding on `ROW_MAJOR_LAYOUT` tensors, which is not the expected behavior.

### What's changed
I have written `to_ttnn` and `to_torch` to replace `to_npu` and `to_cpu`, ensuring proper management. Additionally, all related test files will be revised.  
- Added support for test utilities: `to_torch`, `to_ttnn`, `get_lib_dtype`  
- Fixed the issue of mistakenly importing old `test_utils`  
- Revised callback test cases  

1. Why not `to_npu`, `to_cpu`?  
   - The `ttnn` tensor can be on both CPU and NPU.

2. The format of the callback test should be:
```C
torch.manual_seed(2024)
num_program_cache_entries_list = []
for i in range(2):
    run(...)
    torch_dummy = torch.randn([32, 32])
    tt_dummy = to_ttnn(torch_dummy, device=device)
    num_program_cache_entries_list.append(device.num_program_cache_entries())
logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
assert num_program_cache_entries_list[0] > 0
assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
```

3. Why not simply remove `to_npu`, `to_cpu` and manually use `ttnn.from_torch` and `ttnn.to_torch`?  
   It's not that simple. For example:  
   - `to_npu` can return `None` if the torch tensor is `None`.  
   - `to_npu` allows reshaping before converting the torch tensor to a ttnn tensor.  
   - `to_cpu` allows reshaping after converting a ttnn tensor back to a torch tensor.  

For these reasons, supporting `to_ttnn` and `to_torch` with the same functionality as `ttnn.from_torch` and `ttnn.to_torch` is the best approach for now.
- It makes the review process easier to follow.  
- It does not affect the functionality of existing test files.

In the future, all new test files should manually use `ttnn.from_torch` and `ttnn.to_torch`, as this will help the author of the code better understand the behavior of the tests they write.

4. Why support `get_lib_dtype`?
This is convenient in the future, where we need to test on various dtypes of both torch and ttnn.

### Checklist
- [x] Post commit CI passes:
+ [All post-commit tests #17897](https://github.com/tenstorrent/tt-metal/actions/runs/11369871418)
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] Device performance regression CI testing passes (if applicable): N/A
- [x] New/Existing tests provide coverage for changes: N/A
