### PR TITLE
#5560: Add `all_reduce` op (experimental)

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -103,6 +103,7 @@ run_t3000_tteager_tests() {
   pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather.py -k post_commit ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather_matmul.py -k post_commit ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/operations/test_all_reduce_t3000_frequent.py ; fail+=$?
 
   # distributed layernorm
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/operations/test_distributed_layernorm.py ; fail+=$?

--- a/tests/ttnn/unit_tests/operations/test_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/test_all_reduce.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
+
+
+def is_unsupported_case(input_shape, scatter_dim, math_op, mem_config, num_devices, num_links, input_dtype, layout):
+    if scatter_dim != 3:
+        return True, "Only support for scatter_dim=3 is tested so far"
+
+    elem_size = 2 if input_dtype == ttnn.bfloat16 else 1
+    tensor_size_bytes = elem_size
+    for i in input_shape:
+        tensor_size_bytes *= i
+    num_l1_banks = 64
+    if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
+        return True, "L1 buffer can't support large tensor sizes"
+
+    # if input_dtype == ttnn.bfloat8_b and tuple(input_shape) == (1, 1, 2048, 1024) and scatter_dim == 3:
+    #     return True, "Known failure with bfp8_b data format"
+
+    return False, ""
+
+
+def run_with_trace(
+    t3k_mesh_device,
+    input_tensor_mesh,
+    scatter_dim,
+    num_links,
+    math_op,
+    output_mem_config,
+    n_worker,
+    n_buffer,
+    num_iters,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    output_tensor_mesh = ttnn.all_reduce(
+        input_tensor_mesh,
+        scatter_dim=scatter_dim,
+        math_op=math_op,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        num_workers=n_worker,
+        num_buffers_per_channel=n_buffer,
+    )
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.synchronize_device(t3k_mesh_device.get_device(device_id))
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(t3k_mesh_device, cq_id=0)
+    for i in range(num_iters):
+        output_tensor_mesh = ttnn.all_reduce(
+            input_tensor_mesh,
+            scatter_dim=scatter_dim,
+            math_op=math_op,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            num_workers=n_worker,
+            num_buffers_per_channel=n_buffer,
+        )
+    ttnn.end_trace_capture(t3k_mesh_device, trace_id, cq_id=0)
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.synchronize_device(t3k_mesh_device.get_device(device_id))
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(t3k_mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(t3k_mesh_device, trace_id)
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.synchronize_device(t3k_mesh_device.get_device(device_id))
+
+    return output_tensor_mesh
+
+
+def run_all_reduce_test(
+    t3k_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    scatter_dim,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async=True,
+    num_iters=1,
+    topology=ttnn.Topology.Ring,
+):
+    if len(t3k_mesh_device.get_device_ids()) != 8:
+        pytest.skip("Not T3000!")
+
+    debug = False
+
+    (is_known_failure, message) = is_unsupported_case(
+        per_chip_output_shape, scatter_dim, math_op, mem_config, num_devices, num_links, input_dtype, layout
+    )
+    if is_known_failure:
+        pytest.skip(f"Skipping unsupported case {message}.")
+
+    t3k_mesh_device.enable_async(enable_async)
+    if enable_async:
+        logger.info(f"Using Async Mode for Reduce Scatter Op Dispatch")
+
+    # Generate input tensors
+    canonical_input_shape = per_chip_output_shape.copy()
+    canonical_input_shape[scatter_dim] *= num_devices
+    tt_input_tensors = []
+
+    numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
+    input_tensors = [
+        torch.rand(canonical_input_shape).bfloat16() if not debug else torch.ones(canonical_input_shape).bfloat16()
+        for _ in range(num_devices)
+    ]
+
+    if debug:
+        input_tensors[-1] = torch.arange(numel).reshape(canonical_input_shape).bfloat16()
+    for i, canonical_input_tensor in enumerate(input_tensors):
+        tt_input_tensors.append(
+            ttnn.Tensor(canonical_input_tensor, input_dtype)
+            .to(layout)
+            .to(t3k_mesh_device.get_device(t3k_mesh_device.get_device_ids()[i]), mem_config)
+        )
+
+    assert len(tt_input_tensors) == num_devices
+
+    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+    # Run the op
+    for i in range(num_iters):
+        output_tensor_mesh = ttnn.all_reduce(
+            input_tensor_mesh,
+            scatter_dim=scatter_dim,
+            math_op=math_op,
+            num_links=num_links,
+            memory_config=mem_config,
+            topology=topology,
+        )
+
+        for device_id in t3k_mesh_device.get_device_ids():
+            ttnn.synchronize_device(t3k_mesh_device.get_device(device_id))
+        logger.info(f"Done iteration {i}")
+
+    # Compute golden
+    # TODO: Make it model how reduce scatter actually works for numerical correctness/ordering
+    golden_canonical_out_tensor = torch.zeros(canonical_input_shape).bfloat16()
+    for i, t in enumerate(input_tensors):
+        golden_canonical_out_tensor = torch.add(golden_canonical_out_tensor, t).bfloat16()
+
+    golden_output_tensors = torch.chunk(golden_canonical_out_tensor, num_devices, scatter_dim)
+
+    tt_out_tensors = ttnn.get_device_tensors(output_tensor_mesh)
+    logger.info(f"Compare")
+    # Compare
+    assert len(golden_output_tensors) == len(tt_out_tensors)
+    mismatch = False
+    for i, t in enumerate(tt_out_tensors):
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        eq, output = comp_pcc(tt_output_tensor, golden_output_tensors[i])
+        mismatch = mismatch or not eq
+        if not eq:
+            logger.error(f"output mismatch for tensor {i}")
+            if debug:
+                for w in range(tt_output_tensor.shape[0]):
+                    for z in range(tt_output_tensor.shape[1]):
+                        for y in range(tt_output_tensor.shape[2]):
+                            for x in range(tt_output_tensor.shape[3]):
+                                if tt_output_tensor[w, z, y, x] != golden_output_tensors[i][w, z, y, x]:
+                                    logger.error(
+                                        f"mismatch at {w}, {z}, {y}, {x}: {tt_output_tensor[w, z, y, x]} != {golden_output_tensors[i][w, z, y, x]}"
+                                    )
+
+        else:
+            logger.info(f"output match for tensor {i}")
+    assert not mismatch, f"{i} FAILED: {output}"
+
+
+# ~2:45 extra time in the current state
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        # (4, 1),
+        (8, 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape, scatter_dim, layout",
+    [
+        ([1, 2, 256, 32 * 8], 3, ttnn.TILE_LAYOUT),  # Input tensor is (16*32) x (64*32) = 8 * input tensor shape
+        ([1, 1, 32, 32 * 8], 3, ttnn.TILE_LAYOUT),
+        ([1, 8, 1024, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 4, 2048, 1024], 3, ttnn.TILE_LAYOUT),
+        # # # Has worker slice size warning - defaults to 1x1
+        ([1, 1, 128, 8192], 3, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
+@pytest.mark.parametrize("enable_async", [True])
+def test_ring_all_reduce_post_commit(
+    t3k_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    scatter_dim,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    num_iters=1,
+):
+    run_all_reduce_test(
+        t3k_mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        scatter_dim,
+        num_links,
+        math_op,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        num_iters=num_iters,
+        enable_async=enable_async,
+    )

--- a/tests/ttnn/unit_tests/operations/test_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/test_all_reduce.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -18,6 +18,9 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/all_gather_matmul_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
@@ -10,7 +10,6 @@ namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor ExecuteAllReduce::invoke(
     const ttnn::Tensor& input_tensor,
-    const uint32_t scatter_dim,
     ttnn::operations::reduction::ReduceType math_op,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
@@ -19,7 +18,7 @@ ttnn::Tensor ExecuteAllReduce::invoke(
     const std::optional<size_t> num_buffers_per_channel) {
 
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
-    return ttnn::operations::experimental::ccl::all_reduce(input_tensor, scatter_dim, math_op, num_links, out_memory_config, topology, num_workers, num_buffers_per_channel);
+    return ttnn::operations::experimental::ccl::all_reduce(input_tensor, math_op, num_links, out_memory_config, topology, num_workers, num_buffers_per_channel);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_reduce.hpp"
+
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+ttnn::Tensor ExecuteAllReduce::invoke(
+    const ttnn::Tensor& input_tensor,
+    const uint32_t scatter_dim,
+    ttnn::operations::reduction::ReduceType math_op,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    ttnn::ccl::Topology topology,
+    const std::optional<size_t> num_workers,
+    const std::optional<size_t> num_buffers_per_channel) {
+
+    MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
+    return ttnn::operations::experimental::ccl::all_reduce(input_tensor, scatter_dim, math_op, num_links, out_memory_config, topology, num_workers, num_buffers_per_channel);
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+
+namespace ttnn {
+namespace operations {
+namespace experimental {
+namespace ccl {
+
+struct ExecuteAllReduce {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const uint32_t scatter_dim,
+        ttnn::operations::reduction::ReduceType math_op,
+        const uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+        const std::optional<size_t> num_workers = std::nullopt,
+        const std::optional<size_t> num_buffers_per_channel = std::nullopt);
+};
+
+}  // namespace ccl
+}  // namespace experimental
+}  // namespace operations
+
+constexpr auto all_reduce =
+    ttnn::register_operation<"ttnn::all_reduce", ttnn::operations::experimental::ccl::ExecuteAllReduce>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
@@ -18,7 +18,6 @@ namespace ccl {
 struct ExecuteAllReduce {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        const uint32_t scatter_dim,
         ttnn::operations::reduction::ReduceType math_op,
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp
@@ -31,7 +31,10 @@ struct ExecuteAllReduce {
 }  // namespace experimental
 }  // namespace operations
 
+namespace experimental {
 constexpr auto all_reduce =
-    ttnn::register_operation<"ttnn::all_reduce", ttnn::operations::experimental::ccl::ExecuteAllReduce>();
+    ttnn::register_operation<"ttnn::experimental::all_reduce", ttnn::operations::experimental::ccl::ExecuteAllReduce>();
+
+}  // namespace experimental
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_reduce_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/experimental/ccl/all_reduce/all_reduce.hpp"
+#include "ttnn/types.hpp"
+
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+namespace detail {
+
+template <typename ccl_operation_t>
+void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const uint32_t scatter_dim,
+               ttnn::operations::reduction::ReduceType math_op,
+               const uint32_t num_links,
+               const ttnn::MemoryConfig& memory_config,
+               ttnn::ccl::Topology topology,
+               const std::optional<size_t> num_workers,
+               const std::optional<size_t> num_buffers_per_channel) -> ttnn::Tensor {
+                return self(input_tensor, scatter_dim, math_op, num_links, memory_config, topology, num_workers, num_buffers_per_channel);
+            },
+            py::arg("input_tensor"),
+            py::arg("scatter_dim"),
+            py::arg("math_op"),
+            py::kw_only(),
+            py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring,
+            py::arg("num_workers") = std::nullopt,
+            py::arg("num_buffers_per_channel") = std::nullopt});
+}
+
+}  // namespace detail
+
+
+void py_bind_all_reduce(pybind11::module& module) {
+
+    detail::bind_all_reduce(
+        module,
+        ttnn::all_reduce,
+        R"doc(
+
+        Performs an all_reduce operation on multi-device :attr:`input_tensor` across all devices.
+
+        Args:
+            input_tensor (ttnn.Tensor): multi-device tensor
+            dim (int): Dimension to perform operation
+
+        Keyword Args:
+            num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
+            num_workers (int, optional): Number of workers to use for the operation. Defaults to `None`.
+            num_buffers_per_channel (int, optional): Number of buffers per channel to use for the operation. Defaults to `None`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+        Example:
+
+            >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
+            >>> num_devices = 8
+            >>> dim = 3
+            >>> input_tensors = torch.chunk(full_tensor, num_devices, dim)
+            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
+            >>> tt_input_tensors = []
+            >>> for i, t in enumerate(input_tensors):
+                    tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
+            >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+            >>> output = ttnn.all_reduce(input_tensor_mesh, dim=0, topology=ttnn.Topology.Linear)
+
+        )doc");
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
@@ -54,7 +54,7 @@ void py_bind_all_reduce(pybind11::module& module) {
 
     detail::bind_all_reduce(
         module,
-        ttnn::all_reduce,
+        ttnn::experimental::all_reduce,
         R"doc(
 
         Performs an all_reduce operation on multi-device :attr:`input_tensor` across all devices.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
@@ -59,7 +59,6 @@ void py_bind_all_reduce(pybind11::module& module) {
 
         Args:
             input_tensor (ttnn.Tensor): multi-device tensor
-            dim (int): Dimension to perform operation
 
         Keyword Args:
             num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
@@ -75,7 +74,6 @@ void py_bind_all_reduce(pybind11::module& module) {
 
             >>> full_tensor = torch.randn([1, 1, 256, 256], dtype=torch.bfloat16)
             >>> num_devices = 8
-            >>> dim = 3
             >>> input_tensors = torch.chunk(full_tensor, num_devices, dim)
             >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
             >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
@@ -84,7 +82,7 @@ void py_bind_all_reduce(pybind11::module& module) {
                     tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], mem_config))
             >>> input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
 
-            >>> output = ttnn.all_reduce(input_tensor_mesh, dim=0, topology=ttnn.Topology.Linear)
+            >>> output = ttnn.experimental.all_reduce(input_tensor_mesh, topology=ttnn.Topology.Linear)
 
         )doc");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
@@ -27,17 +27,15 @@ void bind_all_reduce(pybind11::module& module, const ccl_operation_t& operation,
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,
-               const uint32_t scatter_dim,
                ttnn::operations::reduction::ReduceType math_op,
                const uint32_t num_links,
                const ttnn::MemoryConfig& memory_config,
                ttnn::ccl::Topology topology,
                const std::optional<size_t> num_workers,
                const std::optional<size_t> num_buffers_per_channel) -> ttnn::Tensor {
-                return self(input_tensor, scatter_dim, math_op, num_links, memory_config, topology, num_workers, num_buffers_per_channel);
+                return self(input_tensor, math_op, num_links, memory_config, topology, num_workers, num_buffers_per_channel);
             },
             py::arg("input_tensor"),
-            py::arg("scatter_dim"),
             py::arg("math_op"),
             py::kw_only(),
             py::arg("num_links") = 1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+void py_bind_all_reduce(pybind11::module& module);
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp"
+#include "ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp"
+#include "ttnn/operations/ccl/all_gather/all_gather.hpp"
+#include "tt_metal/host_api.hpp"
+
+#include <cstdint>
+
+namespace ttnn {
+
+void AllReduce::validate(const std::vector<Tensor>& input_tensors) const {
+    for (auto const& t : input_tensors) {
+        TT_FATAL(
+            t.get_legacy_shape()[this->scatter_dim] / this->ring_size > 0,
+            "All reduce input tensor shape on dim {} must be divisible by ring size", this->scatter_dim);
+        TT_FATAL(
+            t.get_legacy_shape()[this->scatter_dim] % this->ring_size == 0,
+            "All reduce input tensor shape on dim {} must be divisible by ring size", this->scatter_dim);
+
+        TT_FATAL(this->topology != ccl::Topology::Linear || !t.is_sharded(), "Sharded tensors are not supported for all reduce on a linear topology");
+    }
+}
+
+std::vector<ttnn::SimpleShape> AllReduce::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    auto shape = input_tensors[0].get_logical_shape();
+    TT_FATAL(
+        shape[this->scatter_dim] % this->ring_size == 0,
+        "The size of the scatter dimension must be a multiple of the ring size");
+    shape[this->scatter_dim] /= this->ring_size;
+    return std::vector<ttnn::SimpleShape>(input_tensors.size(), shape);
+}
+
+std::vector<Tensor> AllReduce::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensor.get_dtype(), input_tensor.get_layout(), this->output_mem_config);
+}
+
+operation::ProgramWithCallbacks AllReduce::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    return ccl::reduce_scatter_detail::reduce_scatter_with_workers(
+        input_tensors.at(0),
+        output_tensors.at(0),
+        this->binary_op_type,
+        this->scatter_dim,
+        this->num_links,
+        this->ring_size,
+        this->ring_index,
+        this->receiver_device_id,
+        this->sender_device_id,
+        this->topology,
+        this->user_defined_num_workers,
+        this->user_defined_num_buffers_per_channel);
+}
+
+static ttnn::operations::binary::BinaryOpType convert_reduce_type_to_eltwise_type(ttnn::operations::reduction::ReduceType reduce_op) {
+    // Leaving switch statement for future support of additional types.
+    switch (reduce_op) {
+        case ttnn::operations::reduction::ReduceType::Sum:
+            return ttnn::operations::binary::BinaryOpType::ADD;
+        default:
+            TT_THROW("All reduce only supports reduce_type Sum. Op type {} not supported.", reduce_op);
+            return ttnn::operations::binary::BinaryOpType::ADD;
+    }
+}
+
+namespace operations{
+namespace experimental{
+namespace ccl{
+Tensor all_reduce(
+    const Tensor& input_tensor,
+    const uint32_t scatter_dim,
+    ttnn::operations::reduction::ReduceType math_op,
+    const uint32_t num_links,
+    const MemoryConfig& output_mem_config,
+    ttnn::ccl::Topology topology,
+    const std::optional<size_t> user_defined_num_workers,
+    const std::optional<size_t> user_defined_num_buffers_per_channel) {
+    ttnn::operations::binary::BinaryOpType binary_op_type = convert_reduce_type_to_eltwise_type(math_op);
+    TT_FATAL(std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "This op is only supported for Fast Dispatch");
+    TT_FATAL(topology == ttnn::ccl::Topology::Ring, "All Reduce op is currently supported only on Ring topology");
+
+    auto devices = input_tensor.get_workers();
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    operation::launch_op(
+        [binary_op_type, scatter_dim, num_links, output_mem_config, topology, devices, user_defined_num_workers, user_defined_num_buffers_per_channel](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            TT_FATAL(input_tensors.size() >= 1, "All reduce op expects an input tensor but it received none");
+            bool is_linear = topology == ttnn::ccl::Topology::Linear;
+
+            const auto& input_tensor = input_tensors.at(0);
+            uint32_t num_devices = devices.size();
+            uint32_t device_index = 0; // Initialize device index
+            std::optional<chip_id_t> receiver_device_id = std::nullopt; // Initialize receiver device ID
+            std::optional<chip_id_t> sender_device_id = std::nullopt; // Initialize sender device ID
+            for (uint32_t i = 0; i < num_devices; ++i) {
+                if (devices.at(i) == input_tensor.device()) {
+
+                    bool is_last_chip_in_clockwise_direction = is_linear && i == (num_devices - 1);
+                    bool is_last_chip_in_counter_clockwise_direction = is_linear && i == 0;
+                    device_index = i;
+                    receiver_device_id = is_last_chip_in_clockwise_direction ?
+                        std::nullopt :
+                        std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
+                    sender_device_id = is_last_chip_in_counter_clockwise_direction ?
+                        std::nullopt :
+                        std::optional<chip_id_t>(devices.at((i + num_devices - 1) % num_devices)->id());
+                    break;
+                }
+            }
+            TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error in all reduce op setup");
+
+            return operation::run(
+                ttnn::AllReduce{
+                    binary_op_type,
+                    scatter_dim,
+                    num_links,
+                    num_devices,
+                    device_index,
+                    receiver_device_id,
+                    sender_device_id,
+                    output_mem_config,
+                    topology,
+                    user_defined_num_workers,
+                    user_defined_num_buffers_per_channel},
+                {input_tensor});
+        },
+     {input_tensor},
+     output_tensors);
+    // Perform all_gather operation
+    Tensor gathered_output = ttnn::all_gather(output_tensors.at(0), scatter_dim);
+    return gathered_output;
+}
+
+} // namespace ccl
+} // namespace experimental
+} // namespace operations
+
+};  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -20,7 +20,7 @@ void AllReduce::validate(const std::vector<Tensor>& input_tensors) const {
             t.get_legacy_shape()[this->scatter_dim] % this->ring_size == 0,
             "All reduce input tensor shape on dim {} must be divisible by ring size", this->scatter_dim);
 
-        TT_FATAL(this->topology != ccl::Topology::Linear || !t.is_sharded(), "Sharded tensors are not supported for all reduce on a linear topology");
+        TT_FATAL(!t.is_sharded(), "Sharded tensors are not supported for all reduce currently");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
@@ -13,7 +13,6 @@ namespace ttnn {
 
 struct AllReduce {
     const ttnn::operations::binary::BinaryOpType binary_op_type;
-    const uint32_t scatter_dim;
     const uint32_t num_links;
     const uint32_t ring_size;
     const uint32_t ring_index;
@@ -37,7 +36,6 @@ namespace experimental{
 namespace ccl{
     Tensor all_reduce(
     const Tensor &input_tensor,
-    const uint32_t scatter_split_dim,
     ttnn::operations::reduction::ReduceType reduce_op = ttnn::operations::reduction::ReduceType::Sum,
     const uint32_t num_links = 1,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/run_operation.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+namespace ttnn {
+
+struct AllReduce {
+    const ttnn::operations::binary::BinaryOpType binary_op_type;
+    const uint32_t scatter_dim;
+    const uint32_t num_links;
+    const uint32_t ring_size;
+    const uint32_t ring_index;
+    const std::optional<chip_id_t> receiver_device_id;
+    const std::optional<chip_id_t> sender_device_id;
+    const MemoryConfig output_mem_config;
+    const ttnn::ccl::Topology topology;
+    const std::optional<size_t> user_defined_num_workers;
+    const std::optional<size_t> user_defined_num_buffers_per_channel;
+
+    void validate(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+};
+
+
+namespace operations{
+namespace experimental{
+namespace ccl{
+    Tensor all_reduce(
+    const Tensor &input_tensor,
+    const uint32_t scatter_split_dim,
+    ttnn::operations::reduction::ReduceType reduce_op = ttnn::operations::reduction::ReduceType::Sum,
+    const uint32_t num_links = 1,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+    const std::optional<size_t> user_defined_num_workers = std::nullopt,
+    const std::optional<size_t> user_defined_num_buffers_per_channel = std::nullopt);
+} // namespace ccl
+} // namespace experimental
+} // namespace operations
+
+
+};  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -30,6 +30,7 @@
 #include "ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_pybind.hpp"
 #include "ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_matmul/all_gather_matmul_pybind.hpp"
+#include "ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.hpp"
 #include "ttnn/operations/experimental/plusone/plusone_pybind.hpp"
 namespace ttnn::operations::experimental {
 
@@ -70,6 +71,7 @@ void py_module(py::module& module) {
     // CCL ops
     auto m_experimental_ccl = module.def_submodule("ccl", "experiemental collective communication operations");
     ccl::py_bind_all_gather_matmul(m_experimental_ccl);
+    ccl::py_bind_all_reduce(m_experimental_ccl);
 }
 
 }  // namespace ttnn::operations::experimental


### PR DESCRIPTION
Tracking Issue : #5560 

Add `all_reduce` op under experimental folder


## Q: Is only sum as reduce op is supported?
 
A: Today yes. Future, no. We'd need to support min, max, and other reduction operations.

## Q: What is the output shape after all_reduce, is it equal to the shape on one device?

A: Yes (for cases where for whatever reason one of the devices may have less data, it would be the size of the larger tensors, and the device with a smaller tensor would logically be padded with identity value elements. Whether this is a legitimate use case for this operation I am not sure atm).

## Q: After all reduce, will all devices have the same reduced tensor?

A: Yes

## Q: Do we do reduce over the batch dimension only?

A: Not exactly. All-reduce is a rank-wise operation. That is we are doing element-wise reductions for tensors across devices. For reference, we are following the semantics outlined [here](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/collectives.html#allreduce).

## Q: What is the memory footprint on one device? e.g we have 32 devices and call reduce on tensor with volume 16k how how many dram will be allocated during this op?

A:
#### Today
memory consumption is inefficient because we are providing the least optimized functional implementation for all-reduce (composite all-gather + eltwise operation).

if # devices = n and input tensor size per device = m, then the total memory working set size (per chip) will be (today) (n + 1) * m

That is n * m needed to store the intermediate all-gather results and then another m to store the final output. After the operation the n *m can be returned to the allocation

#### Near future
We will enable the reduce_scatter + all-gather (composite) optimization that will both reduce memory pressure and improve performance. This has 2 constraints:

All-gather and reduce scatter must enable support for non-uniform tensor sizes across chips
the input tensor shape must have a dim size > n
technically it just needs a volume > n but that would require multi-dimension scatter/concat dim for reduce scatter/all-gather which is totally out of the picture for the foreseeable future
With this version total memory pressure (per chip) would be m + m * (1/n) where m * (1/n) is the size of the intermediate tensor between reduce_scatter and all-gather

#### Long Term
We will support a proper non-composite implementation in which the memory needed per chip will simply b m



### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11363163144
- [x] T3K Pipelines - https://github.com/tenstorrent/tt-metal/actions/runs/11363166696
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
