### PR TITLE
#13867: Fix build failure due to incomplete type in fmt formatter

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "ttnn/tensor/types.hpp"
-#include "ttnn/operations/core/core.hpp"
-
-#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
+#include "ttnn/decorators.hpp"
 
 #include <ranges>
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/cpp/ttnn/operations/eltwise/ternary/where.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/operations/core/core.hpp"
 
 namespace ttnn::operations::experimental::reduction {
 

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -215,6 +215,15 @@ const uint32_t LegacyShape::get_normalized_index(std::int64_t index) const {
     return normalized_index;
 }
 
+Array4D LegacyShape::to_array_4D() const {
+    TT_FATAL(rank() == 4, "to_array_4D is only valid for 4D shapes! Called for {}.", *this);
+    Array4D ret_array;
+    for (int i = 0; i < rank(); i++) {
+        ret_array[i] = this->operator[](i);
+    }
+    return ret_array;
+}
+
 bool operator==(const ReplicateTensor& a, const ReplicateTensor& b) {
     return a.replication_factor == b.replication_factor; // All instances are considered equal because there are no data members.
 }

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -303,14 +303,7 @@ class LegacyShape {
     }
     friend std::ostream &operator<<(std::ostream &os, const LegacyShape &shape);
 
-    Array4D to_array_4D() const {
-        TT_FATAL(rank() == 4, "to_array_4D is only valid for 4D shapes! Called for {}.", *this);
-        Array4D ret_array;
-        for (int i = 0; i < rank(); i++) {
-            ret_array[i] = this->operator[](i);
-        }
-        return ret_array;
-    }
+    Array4D to_array_4D() const;
 };
 
 inline std::ostream &operator<<(std::ostream &os, const tt::tt_metal::LegacyShape &shape) {


### PR DESCRIPTION
### Ticket
Link to Github Issue (https://github.com/tenstorrent/tt-metal/issues/13867)

### Problem description
There are compilation errors when building the project with `tt-metal `as a submodule.
The error points to incomplete types being used in `fmt` formatter functions.
The issue occurs specifically when attempting to format `std::array<unsigned int, 2>` and a custom type `tt::tt_metal::LegacyShape`.

### What's changed
- Move `Array4D to_array_4D()` member function implementation in `LegacyShape` class to source file.
-Clean up headers to resolve fmt-related issues

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
