### PR TITLE
Power op PCC drop issue

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
@@ -15,7 +15,7 @@ from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
 def run_pow_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
     torch.manual_seed(data_seed)
 
-    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100).to(torch.bfloat16)
+    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100)
     y = random.uniform(0, 10)
 
     try:


### PR DESCRIPTION
### Ticket
#8593

### Problem description
PCC drop for power op

### What's changed
- Reference code has issue due to bf16 conversion hence update the test accordingly
- In TT we explicitly added a condition to return NaN if the values are negative. In torch for BF16 Nan is represented in large values instead of NaN which will be causing PCC drop hence removed the conversion part in torch ref code in this file

Explained the reason why change is required in this - 
https://github.com/tenstorrent/tt-metal/issues/8593#issuecomment-2416999350

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11368643876)
