### PR TITLE
#0: Switch reduction ops to ttnn::SimpleShape

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
@@ -47,15 +47,13 @@ void ArgMax::validate_with_output_tensors(
 
 }
 
-std::vector<tt::tt_metal::LegacyShape> ArgMax::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
-    auto input_shape = input_tensors[0].get_legacy_shape();
+std::vector<ttnn::SimpleShape> ArgMax::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
     if (this->dim.has_value()) {
-        tt::tt_metal::LegacyShape output_shape({input_shape[0], input_shape[1], 1, input_shape[2]});
-        return {output_shape};
+        auto input_shape = input_tensors[0].get_logical_shape();
+        return {ttnn::SimpleShape{input_shape[0], input_shape[1], 1, input_shape[2]}};
     }
     else {
-        tt::tt_metal::LegacyShape output_shape({1, 1, 1, 1});
-        return {output_shape};
+        return {ttnn::SimpleShape{1, 1, 1, 1}};
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.hpp
@@ -19,7 +19,7 @@ struct ArgMax {
     const MemoryConfig output_mem_config;
 
     void validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_op.hpp
@@ -16,7 +16,7 @@ struct MoeDeviceOperation {
     const MemoryConfig output_mem_config;
 
     void validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -27,9 +27,8 @@ void Prod_op::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Error");
 }
 
-std::vector<tt::tt_metal::LegacyShape> Prod_op::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return {input_tensor.get_legacy_shape()};
+std::vector<ttnn::SimpleShape> Prod_op::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    return {input_tensors.at(0).get_logical_shape()};
 }
 
 std::vector<Tensor> Prod_op::create_output_tensors(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.hpp
@@ -22,7 +22,7 @@ struct Prod_op {
     const MemoryConfig output_mem_config;
     const DataType output_dtype;  // TODO: Uplift output_dtype as an option for general dot/bmm
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -51,10 +51,10 @@ void TopK::validate_with_output_tensors(
     }
 }
 
-std::vector<tt::tt_metal::LegacyShape> TopK::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_legacy_shape();
-    return {{input_shape[0], input_shape[1], input_shape[2], this->k}, {input_shape[0], input_shape[1], input_shape[2], this->k}};
+std::vector<ttnn::SimpleShape> TopK::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    auto output_shape = input_tensors.at(0).get_logical_shape();
+    output_shape[-1] = this->k;
+    return {output_shape, output_shape};
 }
 
 std::vector<Tensor> TopK::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
@@ -19,7 +19,7 @@ struct TopK {
     const MemoryConfig output_mem_config;
 
     void validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -174,7 +174,7 @@ void validate_sharded_buffer_allocation(
         auto tile_shape = tile.value_or(Tile{{constants::TILE_HEIGHT, constants::TILE_WIDTH}}).get_tile_shape();
         TT_FATAL(
             (shard_shape[0] % tile_shape[0] == 0 && shard_shape[1] % tile_shape[1] == 0),
-            "Shard shape must be tile sized");
+            "Shard shape {} must be tile {} sized!", shard_shape, tile_shape);
     } else if (layout == Layout::ROW_MAJOR) {
         TT_FATAL(shard_shape[1] * tensor_impl::element_size_bytes(data_type) % sizeof(uint32_t) == 0, "Error");
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/pull/13847)

### Problem description
Remove `LegacyShape`.

### What's changed
Switch `argmax`, `prod_all`, `top_k` to `ttnn::SimpleShape`.
- Generic reduction supports padding along dims 0 and 1 so need to wait for TensorLayout
- Add assert for interleaved output for generic reduction along W or HW (and better error messages)
- Add better error message for shard shape and tile shape in validate_sharded_buffer_allocation

### Checklist
- [x] Post commit CI passes
  - all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/11373615168
  - T3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11388699483
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
