### PR TITLE
#13498 Fix Doc Release portion of Package Release workflow

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -89,7 +89,7 @@ jobs:
           cp -Lr docs/source/ttnn/* ttnn-docs
           rm ttnn-docs/conf.py  # Do not change conf.py
           echo "Copy tutorials and examples for TTNN from a different repo area."
-          cp -Lr ttnn/examples ttnn-docs/ttnn
+          cp -Lr ttnn/ttnn/examples ttnn-docs/ttnn
           echo "Make sure the links are updated in ttnn/usage.rst to the correct spot for the tutorials and examples."
           sed -i "s/..\/..\/..\/..\/ttnn\/examples/examples/g" ttnn-docs/ttnn/usage.rst
 

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -212,7 +212,7 @@ jobs:
       create-tag,
       create-and-upload-draft-release
     ]
-    if: ${{ needs.get-params.outputs.is-release-candidate && needs.get-params.outputs.should-create-release }}
+    if: ${{ needs.get-params.outputs.is-release-candidate =='true' && needs.get-params.outputs.should-create-release == 'true' }}
     uses: ./.github/workflows/docs-release.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -207,7 +207,12 @@ jobs:
           context: .
           file: dockerfile/ubuntu-20.04-amd64.Dockerfile
   release-docs:
-    needs: create-and-upload-draft-release
+    needs: [
+      get-params,
+      create-tag,
+      create-and-upload-draft-release
+    ]
+    if: ${{ needs.get-params.outputs.is-release-candidate && needs.get-params.outputs.should-create-release }}
     uses: ./.github/workflows/docs-release.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -212,7 +212,7 @@ jobs:
       create-tag,
       create-and-upload-draft-release
     ]
-    if: ${{ needs.get-params.outputs.is-release-candidate =='true' && needs.get-params.outputs.should-create-release == 'true' }}
+    if: ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
     uses: ./.github/workflows/docs-release.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}


### PR DESCRIPTION
### Ticket

#13498 

### Problem description

The ttnn/examples directory has moved one folder down as per https://github.com/tenstorrent/tt-metal/commit/ef12b43ecaa942778701139a9435b33fccb3472c

Also, we do not want to publish the documentation for every nightly run but only for the major releases (i.e. not `-rc`)

### What's changed

- Changed the bash command that was copying the folder from `ttnn/exmaples` to `ttnn/ttnn/examples`
- Added the check for `is-release-candidate` and `should-create-release` before invoking doc_release workflow.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
