### PR TITLE
#0: Remove skipping tests that now pass on BH

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/helper_funcs/test_linear.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/helper_funcs/test_linear.py
@@ -51,9 +51,6 @@ def test_linear_no_bias(input_shapes, device):
     ),
 )
 def test_linear_with_bias(input_shapes, device):
-    if is_blackhole() and input_shapes[0] == [1, 1, 64, 128]:
-        pytest.skip("Failing case for BH, see #12349")
-
     comparison_func = partial(comparison_funcs.comp_pcc)
 
     datagen_func = [

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
@@ -16,7 +16,6 @@ from models.utility_functions import (
     print_diff_argmax,
     is_close,
     comp_pcc,
-    skip_for_blackhole,
 )
 import torch
 
@@ -62,6 +61,5 @@ def run_tilize_matmul_test(M, K, N, device):
     assert passing_pcc
 
 
-@skip_for_blackhole("Hanging on BH, see #12349")
 def test_tilize_hpadding_matmul(device):
     run_tilize_matmul_test(4, 32 * 9, 32, device)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_matmul.py
@@ -6,7 +6,7 @@
 import ttnn
 from loguru import logger
 
-from models.utility_functions import untilize, tilize_to_list, comp_pcc, skip_for_blackhole
+from models.utility_functions import untilize, tilize_to_list, comp_pcc
 import torch
 
 
@@ -46,6 +46,5 @@ def run_tilize_matmul_test(M, K, N, device):
     assert passing_pcc
 
 
-@skip_for_blackhole("Hanging on BH, see #12349")
 def test_run_tilize_matmul_test(device):
     run_tilize_matmul_test(32, 32, 32, device)


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-llk-bh/pull/45 fixed #12539 #12599 #12601 #12602
While the hangs for #12599 are fixed, there are still test failures. Therefore the skip is still left for the relevant test and #13875 is created to deal with them.

### Problem description
BH llk repo updates fixed hangs in some tests

### What's changed
Remove the skip from these tests

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11384362576
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes
