### PR TITLE
#11178: add n300 reduce scatter post-commit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_N300_post_commit.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.test_reduce_scatter_post_commit import run_reduce_scatter_test
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (2, 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape, scatter_dim, layout",
+    [
+        ([1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 2048], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 768, 4096], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 768, 2048], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 768, 1024], 3, ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
+@pytest.mark.parametrize("enable_async", [True])
+def test_ring_reduce_scatter_post_commit(
+    n300_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    scatter_dim,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    num_iters=1,
+):
+    run_reduce_scatter_test(
+        n300_mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        scatter_dim,
+        num_links,
+        math_op,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        num_iters=num_iters,
+        enable_async=enable_async,
+    )

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -86,11 +86,14 @@ Tensor reduce_scatter(
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            TT_FATAL(input_tensors.size() >= 1, "Reduce scatter op expects an input tensor but it received none");
+
+            uint32_t num_devices = devices.size();
+            if (num_devices == 2){
+                topology = ttnn::ccl::Topology::Linear;
+            }
             bool is_linear = topology == ttnn::ccl::Topology::Linear;
 
             const auto& input_tensor = input_tensors.at(0);
-            uint32_t num_devices = devices.size();
             uint32_t device_index = 0; // Initialize device index
             std::optional<chip_id_t> receiver_device_id = std::nullopt; // Initialize receiver device ID
             std::optional<chip_id_t> sender_device_id = std::nullopt; // Initialize sender device ID


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11178)

### Problem description
No tests in post commit for line reduce scatter

### What's changed
Add some initial line reduce scatter tests on N300 in post-commit - a first line of defense. Adds about 20s total test time.

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11370476093
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
