### PR TITLE
#13782: Update .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,4 +4,8 @@ Checks: >
   modernize-*,
   readability-*,
   cppcoreguidelines-*
+  -modernize-use-trailing-return-type
 
+CheckOptions:
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: 'x|y|z|i|j|k|t|it|ix|itr|a|b'

--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -154,7 +154,7 @@ void tt_assert(
     do {                                                                                                    \
         if (not(condition)) [[unlikely]]                                                                    \
             tt::assert::tt_assert(__FILE__, __LINE__, "TT_ASSERT", (condition), #condition, ##__VA_ARGS__); \
-    } while (0)
+    } while (0) // NOLINT(cppcoreguidelines-macro-usage)
 #endif
 #else
 #define TT_ASSERT(condition, ...)
@@ -171,5 +171,5 @@ void tt_assert(
             tt::assert::tt_throw(__FILE__, __LINE__, "TT_FATAL", #condition, message, ##__VA_ARGS__); \
             __builtin_unreachable();                                                                  \
         }                                                                                             \
-    } while (0)
+    } while (0) // NOLINT(cppcoreguidelines-macro-usage)
 #endif


### PR DESCRIPTION
### Ticket
#13782 

### Problem description
Current warnings are too strict

### What's changed
Relax readability constraint about short variable names.
Disable modernize rule about using trailing return type.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
