### PR TITLE
Remove do while(0) from assert.hpp

### DIFF
--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -151,10 +151,10 @@ void tt_assert(
 #ifdef DEBUG
 #ifndef TT_ASSERT
 #define TT_ASSERT(condition, ...)                                                                           \
-    do {                                                                                                    \
+    {                                                                                                    \
         if (not(condition)) [[unlikely]]                                                                    \
             tt::assert::tt_assert(__FILE__, __LINE__, "TT_ASSERT", (condition), #condition, ##__VA_ARGS__); \
-    } while (0)
+    }
 #endif
 #else
 #define TT_ASSERT(condition, ...)
@@ -166,10 +166,10 @@ void tt_assert(
 
 #ifndef TT_FATAL
 #define TT_FATAL(condition, message, ...)                                                             \
-    do {                                                                                              \
+    {                                                                                              \
         if (not(condition)) [[unlikely]] {                                                            \
             tt::assert::tt_throw(__FILE__, __LINE__, "TT_FATAL", #condition, message, ##__VA_ARGS__); \
             __builtin_unreachable();                                                                  \
         }                                                                                             \
-    } while (0)
+    }
 #endif


### PR DESCRIPTION
### Ticket
None

### Problem description
We use do while in TT_FATAL and TT_ASSERT
This is to ensure that macro correctly acts as a single statement even inside other if statements.

Imagine
```
if (condition)
    TT_FATAL(some_condition, "Error occurred");
else
    do_something();
```
without it, macro expands into
```
if (condition)
    if (!(some_condition)) {
        tt::assert::tt_throw(...);
        __builtin_unreachable();
    }
else
    do_something();
```

### What's changed
Replace do while with { } block to not confuse clang tidy.
This makes macro expand into its own block, isolating it from the outside context

```
if (condition)
{
    if (!(some_condition)) {
        tt::assert::tt_throw(...);
        __builtin_unreachable();
    }
}
else
    do_something();
```

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11370868935
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
