### PR TITLE
#12955: cleanup device close

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2946,8 +2946,6 @@ bool Device::close() {
         }
     }
 
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);
     // After device close, no buffers on this device should be used

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "tt_metal/host_api.hpp"
 #include "impl/debug/dprint_server.hpp"
 #include "impl/debug/noc_logging.hpp"
 #include "impl/debug/watcher_server.hpp"
@@ -45,6 +46,7 @@ class DevicePool {
     v1::DeviceHandle get_active_device(chip_id_t device_id) const;
     std::vector<v1::DeviceHandle> get_all_active_devices() const;
     bool close_device(chip_id_t device_id);
+    void close_devices(const std::vector<Device *> &devices);
     bool is_device_active(chip_id_t id) const;
     void register_worker_thread_for_device(v1::DeviceHandle device, std::thread::id worker_thread_id);
     void unregister_worker_thread_for_device(v1::DeviceHandle device);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -909,56 +909,58 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
     // TODO: initialize devices if user does not
     // Must initialize remote chips first, then mmio chips since once mmio chips are doing fd routing
     // we do not always context switch to base FW
-    const routing_info_t routing_info_disabled = {
-        .routing_enabled = 0,
-        .src_sent_valid_cmd = 0,
-        .dst_acked_valid_cmd = 0,
-    };
-    const routing_info_t routing_info_enabled = {
-        .routing_enabled = 1,
-        .src_sent_valid_cmd = 0,
-        .dst_acked_valid_cmd = 0,
-    };
+    std::vector<chip_id_t> mmio_devices;
+    mmio_devices.reserve(this->devices_grouped_by_assoc_mmio_device_.size());
+    std::vector<chip_id_t> non_mmio_devices;
     for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
+        mmio_devices.emplace_back(assoc_mmio_device);
         for (const auto &chip_id : devices) {
+            non_mmio_devices.emplace_back(chip_id);
+        }
+    }
+
+    if (enable_internal_routing) {
+        const routing_info_t routing_info_enabled = {
+            .routing_enabled = 1,
+            .src_sent_valid_cmd = 0,
+            .dst_acked_valid_cmd = 0,
+        };
+        for (const auto &chip_id : non_mmio_devices) {
             for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
                 tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
-                if (chip_id == assoc_mmio_device and not enable_internal_routing) {
-                    // Disable internal ethernet routing for mmio devices
-                    write_core(
-                        (void *)&routing_info_disabled,
-                        sizeof(routing_info_t),
-                        eth_phys_core,
-                        routing_info_addr,
-                        false);
-                } else if (chip_id != assoc_mmio_device and enable_internal_routing) {
-                    // Enable internal ethernet routing for non-mmio devices
-                    write_core(
-                        (void *)&routing_info_enabled, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
-
-                } else {
-                    continue;
-                }
+                // Enable internal ethernet routing for non-mmio devices
+                write_core(
+                    (void *)&routing_info_enabled, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
             }
         }
-        for (const auto &chip_id : devices) {
+        for (const auto &chip_id : mmio_devices) {
             for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
                 tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
-                if (chip_id != assoc_mmio_device and not enable_internal_routing) {
-                    // Disable internal ethernet routing for non-mmio devices
-                    write_core(
-                        (void *)&routing_info_disabled,
-                        sizeof(routing_info_t),
-                        eth_phys_core,
-                        routing_info_addr,
-                        false);
-                } else if (chip_id == assoc_mmio_device and enable_internal_routing) {
-                    // Enable internal ethernet routing for mmio devices
-                    write_core(
-                        (void *)&routing_info_enabled, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
-                } else {
-                    continue;
-                }
+                // Enable internal ethernet routing for mmio devices
+                write_core(
+                    (void *)&routing_info_enabled, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+            }
+        }
+    } else {
+        const routing_info_t routing_info_disabled = {
+            .routing_enabled = 0,
+            .src_sent_valid_cmd = 0,
+            .dst_acked_valid_cmd = 0,
+        };
+        for (const auto &chip_id : mmio_devices) {
+            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+                tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                // Disable internal ethernet routing for mmio devices
+                write_core(
+                    (void *)&routing_info_disabled, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+            }
+        }
+        for (const auto &chip_id : non_mmio_devices) {
+            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+                tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                // Disable internal ethernet routing for non-mmio devices
+                write_core(
+                    (void *)&routing_info_disabled, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
             }
         }
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12955)
### Problem description
Close devices needs some cleanup.

### What's changed
Move CloseDevices functionality to DevicePool. Setup better control for device close.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
