### PR TITLE
Minor modifications to vllm llama70b initialization for configuring seq len and batch size

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -62,15 +62,15 @@ class TtLlamaModelForGeneration:
         del state_dict
 
     @classmethod
-    def initialize_vllm_model(cls, hf_config, t3k_mesh_device):
+    def initialize_vllm_model(cls, hf_config, t3k_mesh_device, max_batch_size):
         # TODO: pass in model args and tt args as parameters from vllm
         @dataclass
         class ModelArgs:
             llama_version: str = None
             ckpt_dir: str = None
-            max_batch_size: int = 32
+            max_batch_size: int = 32  # overwritten by max_num_seqs from vllm
             num_layers: int = 80
-            max_kv_context_len: int = 4096
+            max_kv_context_len: int = 131072
 
         @dataclass
         class TTArgs:
@@ -85,7 +85,7 @@ class TtLlamaModelForGeneration:
         check_mesh_device(t3k_mesh_device, model_config)
 
         # initialize arg classes
-        model_args = ModelArgs(llama_version=llama_version, ckpt_dir=ckpt_dir)
+        model_args = ModelArgs(llama_version=llama_version, ckpt_dir=ckpt_dir, max_batch_size=max_batch_size)
         tt_args = TTArgs(mesh_device=t3k_mesh_device, cache_path=cache_path)
 
         # load state dict
@@ -107,6 +107,10 @@ class TtLlamaModelForGeneration:
         return cls(
             configuration=configuration, state_dict=state_dict, model_args=model_args, tt_args=tt_args, vllm=True
         )
+
+    @property
+    def cache_path(self):
+        return self.tt_model.cache_path
 
     def forward(self, tokens: torch.Tensor, start_pos: int, page_table=None, kv_cache=None, prompt_lens=None):
         _, seq_len = tokens.shape

--- a/models/demos/t3000/llama2_70b/tt/model_config.py
+++ b/models/demos/t3000/llama2_70b/tt/model_config.py
@@ -69,6 +69,7 @@ def get_model_config(llama_version="llama3", max_batch_size=32, max_context_len=
         "ALL_GATHER_NUM_LINKS": 1,
         "MAX_BATCH_SIZE": max_batch_size,
         "MAX_CONTEXT_LEN": max_context_len,
+        "MAX_PREFILL_SEQ_LEN": 32768,  # TODO: remove once larger seq lens can be prefilled via decode in TtLlamaModelForGeneration
         "NUM_DEVICES": num_devices,
         "llama3-tg": MAX_SEQ_LEN_LLAMA3,
         "llama3.1-tg": MAX_SEQ_LEN_LLAMA3_1,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The max kv context length and batch size in `initialize_vllm_model` were not set properly to support larger sequence lengths
- There was no assert for the maximum prefill length allowed in llama70b

### What's changed
- Set the max kv context length to 128*1024 for the vLLM model and add an argument for the max batch size
- Added an assert for the max prefill seq len (currently 32k) in llama70b

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
