### PR TITLE
#0: Map .at() -> .insert() for non-existent key in dispatch kernel defines map

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -715,7 +715,7 @@ void Device::configure_kernel_variant(
         {"FD_CORE_TYPE", std::to_string(programmable_core_type_index)},
     };
     if (force_watcher_no_inline) {
-        defines.at("WATCHER_NOINLINE") = std::to_string(force_watcher_no_inline);
+        defines.insert({"WATCHER_NOINLINE", std::to_string(force_watcher_no_inline)});
     }
     if (llrt::OptionsG.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Watcher is broken on main due to illegal map access

### What's changed
Insert NOINLINE define into map rather than accessing a non existent value

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
