### PR TITLE
#10428: Type-erase RuntimeArgs

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,6 +7,11 @@ set(ENV{CPM_SOURCE_CACHE} "${PROJECT_SOURCE_DIR}/.cpmcache")
 
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
 
+add_library(span INTERFACE)
+if(CMAKE_CXX_STANDARD LESS 20)
+  fetch_boost_library(core)
+  target_link_libraries(span INTERFACE Boost::core)
+endif()
 fetch_boost_library(smart_ptr)
 
 ############################################################################################################################

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -1,7 +1,7 @@
 Runtime Arguments
 ==================
 
-.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, const std::vector<uint32_t> &runtime_args)
+.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, stl::Span<const uint32_t> runtime_args)
 
 .. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args)
 
@@ -13,6 +13,6 @@ Runtime Arguments
 
 .. doxygenfunction:: GetRuntimeArgs(const Program &program, KernelHandle kernel_id)
 
-.. doxygenfunction:: SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args)
+.. doxygenfunction:: SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args)
 
 .. doxygenfunction:: GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 enable_testing()
 include(GoogleTest)
 add_library(test_common_libs INTERFACE)
-target_link_libraries(test_common_libs INTERFACE pthread gtest gtest_main magic_enum fmt)
+target_link_libraries(test_common_libs INTERFACE pthread gtest gtest_main magic_enum fmt span)
 
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
 
                 CoreCoord adjacent_core_noc = device->worker_core_from_logical_core(adjacent_core_logical);
 
-                vector<uint32_t> noc_runtime_args = {
+                const std::array noc_runtime_args = {
                     (uint32_t)adjacent_core_noc.x,
                     (uint32_t)adjacent_core_noc.y,
                     cb_src1_addr,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
                 uint32_t core_index = i * num_cores_c + j;
                 uint32_t l1_buffer_addr = l1_buffer.address();
 
-                vector<uint32_t> noc_runtime_args = {core_index, l1_buffer_addr, num_tiles, num_cores_r * num_cores_c};
+                const std::array noc_runtime_args = {core_index, l1_buffer_addr, num_tiles, num_cores_r * num_cores_c};
                 SetRuntimeArgs(program, noc_kernel, core, noc_runtime_args);
             }
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -419,7 +419,7 @@ bool assign_runtime_args_to_program(
             TT_ASSERT(false, "Core not in specified core ranges");
         }
         uint32_t num_blocks = num_tiles_per_core / num_reqs_at_a_time;
-        std::vector<uint32_t> kernel_args = {
+        const std::array kernel_args = {
             (std::uint32_t)input_buffer_addr,
             (std::uint32_t)(num_tiles_used),
             (std::uint32_t)num_blocks,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
@@ -163,11 +163,11 @@ int main(int argc, char** argv) {
                     CoreCoord core = {(std::size_t)j, (std::size_t)i};
                     int core_index = i * num_cores_c + j;
 
-                    vector<uint32_t> reader_runtime_args;
-                    vector<uint32_t> writer_runtime_args;
+                    std::array<uint32_t, 255> reader_runtime_args;
+                    std::array<uint32_t, 255> writer_runtime_args;
                     for (uint32_t k = 0; k < 255; ++k) {
-                        reader_runtime_args.push_back(core_index + k);
-                        writer_runtime_args.push_back(core_index + k);
+                        reader_runtime_args[k] = core_index + k;
+                        writer_runtime_args[k] = core_index + k;
                     }
 
                     SetRuntimeArgs(program, writer_kernel, core, writer_runtime_args);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -142,7 +142,7 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
             }
         }
 
-        std::vector<uint32_t> rt_args = {
+        const std::array rt_args = {
             (std::uint32_t) bank_id,
             (std::uint32_t) vc
         };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -165,7 +165,7 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
             }
         }
 
-        std::vector<uint32_t> reader_rt_args = {
+        const std::array reader_rt_args = {
             (std::uint32_t) bank_id,
             (std::uint32_t) vc
         };
@@ -177,7 +177,7 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
         auto writer_core = all_l1_writer_cores_ordered[i];
         auto writer_core_phy = device->worker_core_from_logical_core(writer_core);
 
-        std::vector<uint32_t> writer_rt_args = {
+        const std::array writer_rt_args = {
             (std::uint32_t) (vc + 2) & 0x3,
             (std::uint32_t) writer_core_phy.x,
             (std::uint32_t) writer_core_phy.y

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -276,9 +276,7 @@ int main(int argc, char **argv) {
                                           worker_g,
                                           tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default, .defines = defines});
         if (page_size_as_runtime_arg_g) {
-            vector<uint32_t> args;
-            args.push_back(page_size_g);
-            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_coord, args);
+            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_coord, {page_size_g});
         }
 
         std::shared_ptr<Event> sync_event = std::make_shared<Event>();

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -36,8 +36,8 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::Program program = tt_metal::CreateProgram();
         CoreCoord core = {0, 0};
-        std::vector<uint32_t> first_runtime_args = {101, 202};
-        std::vector<uint32_t> second_runtime_args = {303, 606};
+        constexpr std::array<uint32_t, 2> first_runtime_args = {101, 202};
+        constexpr std::array<uint32_t, 2> second_runtime_args = {303, 606};
 
         tt_metal::KernelHandle add_two_ints_kernel = tt_metal::CreateKernel(
             program, "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp", core,

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
         EnqueueWriteBuffer(cq, input_dram_buffer, input_vec, false);
 
-        const std::vector<uint32_t> runtime_args = {
+        const std::array<uint32_t, 8> runtime_args = {
             l1_buffer->address(),
             input_dram_buffer->address(),
             static_cast<uint32_t>(input_dram_buffer->noc_coordinates().x),

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -162,7 +162,7 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
     tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
     // Reader kernel on all cores reads from same location in DRAM
-    std::vector<uint32_t> reader_rt_args = {
+    const std::array reader_rt_args = {
         src_dram_buffer->address(),
         (std::uint32_t)dram_src_noc_xy.x,
         (std::uint32_t)dram_src_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
         CoreCoord core_end = {core_start.x + (grid_size.x - 1), core_start.y + (grid_size.y - 1)};
         auto core_start_physical = device->worker_core_from_logical_core(core_start);
         auto core_end_physical = device->worker_core_from_logical_core(core_end);
-        std::vector<uint32_t> mcast_reader_args = {
+        const std::array mcast_reader_args = {
             (std::uint32_t)dram_buffer_addr,
             (std::uint32_t)dram_noc_xy.x,
             (std::uint32_t)dram_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
         CoreCoord core_end = {core_start.x + (grid_size.x - 1), core_start.y + (grid_size.y - 1)};
         auto core_start_physical = device->worker_core_from_logical_core(core_start);
         auto core_end_physical = device->worker_core_from_logical_core(core_end);
-        std::vector<uint32_t> mcast_reader_args = {
+        const std::array mcast_reader_args = {
             (std::uint32_t)dram_buffer_addr,
             (std::uint32_t)dram_noc_xy.x,
             (std::uint32_t)dram_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
 
             EnqueueWriteBuffer(cq, std::ref(src1_dram_buffer), src1_vec, false);
 
-            vector<uint32_t> reader_args = {
+            const std::array<uint32_t, 9> reader_args = {
                 dram_buffer_src0_addr,
                 (std::uint32_t)dram_src0_noc_xy.x,
                 (std::uint32_t)dram_src0_noc_xy.y,
@@ -171,7 +171,7 @@ int main(int argc, char** argv) {
                 num_tiles,
                 0};
 
-            vector<uint32_t> writer_args = {
+            const std::array<uint32_t, 4> writer_args = {
                 dram_buffer_dst_addr, (std::uint32_t)dram_dst_noc_xy.x, (std::uint32_t)dram_dst_noc_xy.y, num_tiles};
 
             SetRuntimeArgs(program, unary_writer_kernel, core, writer_args);

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
         auto source_addresses_in_l1 = CreateBuffer(l1_config);
         auto source_addresses_in_l1_addr = source_addresses_in_l1->address();
 
-        std::vector<uint32_t> generic_binary_reader_args {
+        const std::array generic_binary_reader_args {
             src0_dram_buffer->address(),
             (uint32_t)dram_src0_noc_xy.x,
             (uint32_t)dram_src0_noc_xy.y,
@@ -270,7 +270,7 @@ int main(int argc, char **argv) {
             core,
             tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
-        std::vector<uint32_t> writer_rt_args{
+        const std::array writer_rt_args{
             dst_dram_buffer->address(),
             (std::uint32_t)dram_dst_noc_xy.x,
             (std::uint32_t)dram_dst_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
@@ -254,7 +254,7 @@ bool test_matmul_large_block(tt_metal::Device *device, bool activations_rm, bool
         auto dram_src1_noc_xy = src1_dram_buffer->noc_coordinates();
         auto dram_dst_noc_xy = dst_dram_buffer->noc_coordinates();
 
-        std::vector<uint32_t> mm_reader_rt_args{
+        const std::array mm_reader_rt_args{
             src0_dram_buffer->address(),
             (std::uint32_t)dram_src0_noc_xy.x,
             (std::uint32_t)dram_src0_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
@@ -256,7 +256,7 @@ bool write_runtime_args_to_device(
             auto core_start_physical = device->worker_core_from_logical_core(core_start);
             auto core_end_physical = device->worker_core_from_logical_core(core_end);
 
-            std::vector<uint32_t> mm_reader_args = {
+            const std::array mm_reader_args = {
                 (std::uint32_t) in0_dram_addr, // in0_tensor_addr
                 (std::uint32_t)  K * per_core_M * core_idx_y, // in0_tensor_start_tile_id
                 (std::uint32_t)  1, // in0_tensor_stride_w
@@ -290,7 +290,7 @@ bool write_runtime_args_to_device(
                 in0_mcast_receiver_semaphore_addr
             };
 
-            std::vector<uint32_t> writer_args = {
+            const std::array writer_args = {
                 (std::uint32_t) out_dram_addr, // out_tensor_addr
                 (std::uint32_t) core_idx_x * per_core_N + core_idx_y * per_core_M * N, // out_tensor_start_tile_id
                 (std::uint32_t) 1, // out_tensor_stride_w

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -300,7 +300,7 @@ bool write_runtime_args_to_device(
             auto top_core_physical = device->worker_core_from_logical_core(top_core);
             auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
             auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
-            std::vector<uint32_t> mm_reader_args = {
+            const std::array mm_reader_args = {
                 (std::uint32_t) in0_dram_addr, // in0_tensor_addr
                 (std::uint32_t)  K * per_core_M * core_idx_y, // in0_tensor_start_tile_id
                 (std::uint32_t)  1, // in0_tensor_stride_w
@@ -343,7 +343,7 @@ bool write_runtime_args_to_device(
                 (std::uint32_t)  in1_mcast_sender_semaphore_addr,
                 (std::uint32_t)  in1_mcast_receiver_semaphore_addr
             };
-            std::vector<uint32_t> writer_args = {
+            const std::array writer_args = {
                 (std::uint32_t) out_dram_addr, // out_tensor_addr
                 (std::uint32_t) core_idx_x * per_core_N + core_idx_y * per_core_M * N, // out_tensor_start_tile_id
                 (std::uint32_t) 1, // out_tensor_stride_w

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
@@ -255,7 +255,7 @@ bool write_runtime_args_to_device(
             auto core_start_physical = device->worker_core_from_logical_core(core_start);
             auto core_end_physical = device->worker_core_from_logical_core(core_end);
 
-            std::vector<uint32_t> mm_reader_args = {
+            const std::array mm_reader_args = {
                 (std::uint32_t) in0_dram_addr, // in0_tensor_addr
                 (std::uint32_t)  K * per_core_M * core_idx_y, // in0_tensor_start_tile_id
                 (std::uint32_t)  1, // in0_tensor_stride_w
@@ -288,7 +288,7 @@ bool write_runtime_args_to_device(
                 (std::uint32_t)  in1_mcast_sender_semaphore_addr,
                 (std::uint32_t)  in1_mcast_receiver_semaphore_addr
             };
-            std::vector<uint32_t> writer_args = {
+            const std::array writer_args = {
                 (std::uint32_t) out_dram_addr, // out_tensor_addr
                 (std::uint32_t) core_idx_x * per_core_N + core_idx_y * per_core_M * N, // out_tensor_start_tile_id
                 (std::uint32_t) 1, // out_tensor_stride_w

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
                 auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
                 pass &= tt_metal::detail::WriteToDeviceDRAMChannel(device, dram_src1_channel_id, dram_buffer_src1_addr, weights);
 
-                std::vector<uint32_t> mm_reader_args = {
+                const std::array mm_reader_args = {
                     (std::uint32_t) dram_buffer_src0_addr,
                     (std::uint32_t) dram_src0_noc_xy.x,
                     (std::uint32_t) dram_src0_noc_xy.y,
@@ -374,7 +374,7 @@ int main(int argc, char **argv) {
                     (std::uint32_t) per_core_M * in0_block_w * single_tile_size, // input 0 block bytes
                     (std::uint32_t) per_core_N * in0_block_w * single_tile_size};
 
-                std::vector<uint32_t> writer_args = {
+                const std::array writer_args = {
                     (std::uint32_t) dram_buffer_dst_addr,
                     (std::uint32_t) dram_dst_noc_xy.x,
                     (std::uint32_t) dram_dst_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
             .set_page_size(ouput_cb_index, single_tile_size);
         auto cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
 
-        std::vector<uint32_t> mm_reader_rt_args{
+        const std::array mm_reader_rt_args{
             src0_dram_buffer->address(),
             (std::uint32_t)dram_src0_noc_xy.x,
             (std::uint32_t)dram_src0_noc_xy.y,
@@ -251,7 +251,7 @@ int main(int argc, char **argv) {
             M * in0_block_w * single_tile_size, // input 0 block bytes
             N * in0_block_w * single_tile_size}; // input 1 block bytes
 
-        std::vector<uint32_t> writer_rt_args{
+        const std::array writer_rt_args{
             dst_dram_buffer->address(),
             (std::uint32_t)dram_dst_noc_xy.x,
             (std::uint32_t)dram_dst_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
             .set_page_size(ouput_cb_index, single_tile_size);
         auto cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
 
-        std::vector<uint32_t> mm_reader_rt_args{
+        const std::array mm_reader_rt_args{
             src0_dram_buffer->address(),
             (std::uint32_t)dram_src0_noc_xy.x,
             (std::uint32_t)dram_src0_noc_xy.y,
@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
             M * in0_block_w * single_tile_size, // input 0 block bytes
             N * in0_block_w * single_tile_size}; // input 1 block bytes
 
-        std::vector<uint32_t> writer_rt_args{
+        const std::array writer_rt_args{
             dst_dram_buffer->address(),
             (std::uint32_t)dram_dst_noc_xy.x,
             (std::uint32_t)dram_dst_noc_xy.y,

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -87,7 +87,7 @@ void compile_and_configure_program(
 
 }
 
-void set_rt_args(tt_metal::Program &program, tt_metal::KernelHandle kernel, const CoreRange &core_range, const std::vector<uint32_t> &rt_args) {
+void set_rt_args(tt_metal::Program &program, tt_metal::KernelHandle kernel, const CoreRange &core_range, const std::array<uint32_t, 4> &rt_args) {
     for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
         for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
             CoreCoord core = CoreCoord(x, y);
@@ -109,13 +109,13 @@ void write_same_runtime_args_to_device(
     auto dram_src_noc_xy = src_dram_buffer.noc_coordinates();
     auto dram_dst_noc_xy = dst_dram_buffer.noc_coordinates();
 
-    std::vector<uint32_t> unary_reader_args{
+    const std::array unary_reader_args{
     (std::uint32_t)src_dram_buffer.address(),
     (std::uint32_t)dram_src_noc_xy.x,
     (std::uint32_t)dram_src_noc_xy.y,
     (std::uint32_t)num_tiles};
 
-    std::vector<uint32_t> unary_writer_args{
+    const std::array unary_writer_args{
     (std::uint32_t)dst_dram_buffer.address(),
     (std::uint32_t)dram_dst_noc_xy.x,
     (std::uint32_t)dram_dst_noc_xy.y,
@@ -144,25 +144,25 @@ void write_unique_writer_runtime_args_to_device(
     auto dram_dst_noc_xy = dst_dram_buffer_1.noc_coordinates();
 
     // Same readers args because all kernels read from same src
-    std::vector<uint32_t> unary_reader_args{
+    const std::array unary_reader_args{
         (std::uint32_t)src_dram_buffer.address(),
         (std::uint32_t)dram_src_noc_xy.x,
         (std::uint32_t)dram_src_noc_xy.y,
         (std::uint32_t)num_tiles};
 
-    std::vector<uint32_t> unary_writer_args_1{
+    const std::array unary_writer_args_1{
         dst_dram_buffer_1.address(),
         (std::uint32_t)dram_dst_noc_xy.x,
         (std::uint32_t)dram_dst_noc_xy.y,
         (std::uint32_t)num_tiles};
 
-    std::vector<uint32_t> unary_writer_args_2{
+    const std::array unary_writer_args_2{
         dst_dram_buffer_2.address(),
         (std::uint32_t)dram_dst_noc_xy.x,
         (std::uint32_t)dram_dst_noc_xy.y,
         (std::uint32_t)num_tiles};
 
-    std::vector<uint32_t> unary_writer_args_3{
+    const std::array unary_writer_args_3{
         dst_dram_buffer_3.address(),
         (std::uint32_t)dram_dst_noc_xy.x,
         (std::uint32_t)dram_dst_noc_xy.y,
@@ -170,7 +170,7 @@ void write_unique_writer_runtime_args_to_device(
 
     set_rt_args(program, reader_kernel_id, core_range, unary_reader_args);
     int core_range_idx = 0;
-    std::vector<std::vector<uint32_t>> rt_args = {unary_writer_args_1, unary_writer_args_2, unary_writer_args_3};
+    const std::array rt_args = {unary_writer_args_1, unary_writer_args_2, unary_writer_args_3};
     for (auto core_range : core_blocks.ranges()) {
         set_rt_args(program, writer_kernel_id, core_range, rt_args.at(core_range_idx++));
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -30,7 +30,7 @@ set(UNIT_TESTS_COMMON_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp
 )
 add_library(unit_tests_common_o OBJECT ${UNIT_TESTS_COMMON_SRC})
-target_link_libraries(unit_tests_common_o PUBLIC compiler_flags metal_header_directories gtest gtest_main magic_enum fmt)
+target_link_libraries(unit_tests_common_o PUBLIC compiler_flags metal_header_directories gtest gtest_main magic_enum fmt span)
 target_include_directories(unit_tests_common_o PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
@@ -184,7 +184,7 @@ bool matmul_large_block(CommonFixture *fixture, tt_metal::Device *device, bool a
     auto dram_src1_noc_xy = src1_dram_buffer->noc_coordinates();
     auto dram_dst_noc_xy = dst_dram_buffer->noc_coordinates();
 
-    std::vector<uint32_t> mm_reader_rt_args{
+    const std::array mm_reader_rt_args{
         src0_dram_buffer->address(),
         (std::uint32_t)dram_src0_noc_xy.x,
         (std::uint32_t)dram_src0_noc_xy.y,

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_X_dram.cpp
@@ -229,7 +229,7 @@ bool matmul_multi_core_single_dram(tt_metal::Device *device){
             auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
             pass &= tt_metal::detail::WriteToDeviceDRAMChannel(device, dram_src1_channel_id, dram_buffer_src1_addr, weights);
 
-            std::vector<uint32_t> mm_reader_args = {
+            const std::array mm_reader_args = {
                 (std::uint32_t) dram_buffer_src0_addr,
                 (std::uint32_t) dram_src0_noc_xy.x,
                 (std::uint32_t) dram_src0_noc_xy.y,
@@ -242,7 +242,7 @@ bool matmul_multi_core_single_dram(tt_metal::Device *device){
                 (std::uint32_t) per_core_M * in0_block_w * single_tile_size, // input 0 block bytes
                 (std::uint32_t) per_core_N * in0_block_w * single_tile_size};
 
-            std::vector<uint32_t> writer_args = {
+            const std::array writer_args = {
                 (std::uint32_t) dram_buffer_dst_addr,
                 (std::uint32_t) dram_dst_noc_xy.x,
                 (std::uint32_t) dram_dst_noc_xy.y,
@@ -321,7 +321,7 @@ bool assign_runtime_args_to_program(
         for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
             CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
 
-            std::vector<uint32_t> mm_reader_args = {
+            const std::array mm_reader_args = {
                 (std::uint32_t)in0_dram_addr,                // in0_tensor_addr
                 (std::uint32_t)K * per_core_M * core_idx_y,  // in0_tensor_start_tile_id
                 (std::uint32_t)1,                            // in0_tensor_stride_w
@@ -345,7 +345,7 @@ bool assign_runtime_args_to_program(
                 (std::uint32_t)K / in0_block_w               // num_blocks
             };
 
-            std::vector<uint32_t> writer_args = {
+            const std::array writer_args = {
                 (std::uint32_t)out_dram_addr,                                          // out_tensor_addr
                 (std::uint32_t)core_idx_x * per_core_N + core_idx_y * per_core_M * N,  // out_tensor_start_tile_id
                 (std::uint32_t)1,                                                      // out_tensor_stride_w

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TT_METAL_OBJECTS
 
 add_library(tt_metal ${TT_METAL_OBJECTS})
 
-target_link_libraries(tt_metal PUBLIC metal_header_directories umd_device metal_common_libs magic_enum fmt)
+target_link_libraries(tt_metal PUBLIC metal_header_directories umd_device metal_common_libs magic_enum fmt span)
 
 target_precompile_headers(tt_metal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tracy/public/tracy/Tracy.hpp

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -8,7 +8,7 @@ set(COMMON_SRCS
 
 add_library(common OBJECT ${COMMON_SRCS})
 target_link_libraries(common PRIVATE yaml-cpp::yaml-cpp)
-target_link_libraries(common PUBLIC compiler_flags metal_header_directories magic_enum fmt)
+target_link_libraries(common PUBLIC compiler_flags metal_header_directories magic_enum fmt span)
 
 target_include_directories(common PUBLIC
     ${UMD_HOME}

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -10,6 +10,7 @@
 #include "tt_metal/impl/kernels/runtime_args_data.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/tt_stl/span.hpp"
 
 /** @file */
 
@@ -307,13 +308,13 @@ using RuntimeArgs = std::vector<std::variant<Buffer *, uint32_t>>;
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
- * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> &                          |                                                                     | Yes      |
+ * | runtime_args | The runtime args to be written                                         | stl::Span<const uint32_t>                              |                                                                     | Yes      |
  */
 void SetRuntimeArgs(
     const Program &program,
     KernelHandle kernel,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
-    const std::vector<uint32_t> &runtime_args);
+    stl::Span<const uint32_t> runtime_args);
 
 /**
  * Set multiple runtime arguments of a kernel at once during runtime, each mapping to a specific core. The runtime args for each core may be unique.
@@ -381,9 +382,9 @@ void SetRuntimeArgs(
  * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
- * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> &                          |                                                                     | Yes      |
+ * | runtime_args | The runtime args to be written                                         | stl::Span<const uint32_t>                              |                                                                     | Yes      |
  */
-void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args);
+void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args);
 
 /**
  * Get the runtime args for a kernel.

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -221,7 +221,7 @@ void Kernel::validate_runtime_args_size(
     }
 }
 
-void Kernel::set_runtime_args(const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args) {
+void Kernel::set_runtime_args(const CoreCoord &logical_core, stl::Span<const uint32_t> runtime_args) {
     // TODO (abhullar): If we don't include this check then user can write runtime args to a core that the kernel is not
     // placed on.
     //                  Should this check only be enabled in debug mode?
@@ -241,7 +241,7 @@ void Kernel::set_runtime_args(const CoreCoord &logical_core, const std::vector<u
             core_with_max_runtime_args_ = logical_core;
         }
         this->validate_runtime_args_size(runtime_args.size(), this->common_runtime_args_.size(), logical_core);
-        set_rt_args = runtime_args;
+        set_rt_args.assign(runtime_args.begin(), runtime_args.end());
         this->core_to_runtime_args_data_[logical_core.x][logical_core.y] =
             RuntimeArgsData{set_rt_args.data(), set_rt_args.size()};
         this->core_with_runtime_args_.insert(logical_core);
@@ -256,14 +256,14 @@ void Kernel::set_runtime_args(const CoreCoord &logical_core, const std::vector<u
     }
 }
 
-void Kernel::set_common_runtime_args(const std::vector<uint32_t> &common_runtime_args) {
+void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_args) {
     auto &set_rt_args = this->common_runtime_args_;
     TT_FATAL(
         set_rt_args.empty(),
         "Illegal Common Runtime Args: Can only set common runtime args once. Get and modify args in place instead.");
     this->validate_runtime_args_size(
         max_runtime_args_per_core_, common_runtime_args.size(), core_with_max_runtime_args_);
-    set_rt_args = common_runtime_args;
+    set_rt_args.assign(common_runtime_args.begin(), common_runtime_args.end());
     this->common_runtime_args_data_ = RuntimeArgsData{set_rt_args.data(), set_rt_args.size()};
 }
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -14,6 +14,7 @@
 #include "common/base_types.hpp"
 #include "tt_metal/impl/kernels/kernel_types.hpp"
 #include "tt_metal/llrt/tt_memory.h"
+#include "tt_metal/tt_stl/span.hpp"
 #include "runtime_args_data.hpp"
 
 namespace tt {
@@ -110,8 +111,8 @@ class Kernel : public JitBuildSettings {
     virtual void read_binaries(Device *device) = 0;
 
     void validate_runtime_args_size(size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core);
-    void set_runtime_args(const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args);
-    void set_common_runtime_args(const std::vector<uint32_t> &runtime_args);
+    void set_runtime_args(const CoreCoord &logical_core, stl::Span<const uint32_t> runtime_args);
+    void set_common_runtime_args(stl::Span<const uint32_t> runtime_args);
 
     int get_watcher_kernel_id() { return watcher_kernel_id_; }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -158,7 +158,7 @@ std::optional<uint32_t> get_semaphore_id(const Program &program, const CoreRange
 }
 
 inline void SetRuntimeArgsImpl(
-    const Program &program, KernelHandle kernel_id, const CoreCoord &c, const std::vector<uint32_t> &runtime_args) {
+    const Program &program, KernelHandle kernel_id, const CoreCoord &c, stl::Span<const uint32_t> runtime_args) {
     if (runtime_args.size() != 0) {
         detail::GetKernel(program, kernel_id)->set_runtime_args(c, runtime_args);
     }
@@ -168,7 +168,7 @@ inline void SetRuntimeArgsImpl(
     const Program &program,
     KernelHandle kernel_id,
     const CoreRange &core_range,
-    const std::vector<uint32_t> &runtime_args) {
+    stl::Span<const uint32_t> runtime_args) {
     if (runtime_args.size() != 0) {
         auto kernel = detail::GetKernel(program, kernel_id);
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
@@ -183,7 +183,7 @@ inline void SetRuntimeArgsImpl(
     const Program &program,
     KernelHandle kernel_id,
     const CoreRangeSet &core_range_set,
-    const std::vector<uint32_t> &runtime_args) {
+    stl::Span<const uint32_t> runtime_args) {
     if (runtime_args.size() != 0) {
         auto kernel = detail::GetKernel(program, kernel_id);
         for (const auto &core_range : core_range_set.ranges()) {
@@ -1115,7 +1115,7 @@ void SetRuntimeArgs(
     const Program &program,
     KernelHandle kernel_id,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
-    const std::vector<uint32_t> &runtime_args) {
+    stl::Span<const uint32_t> runtime_args) {
     ZoneScoped;
     TT_FATAL(
         not CommandQueue::async_mode_set(),
@@ -1166,7 +1166,7 @@ void SetRuntimeArgs(
     SetRuntimeArgsImpl(device->command_queue(), kernel, core_spec, runtime_args, false);
 }
 
-void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args) {
+void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, stl::Span<const uint32_t> runtime_args) {
     ZoneScoped;
     TT_FATAL(
         not CommandQueue::async_mode_set(),

--- a/tt_metal/tt_stl/span.hpp
+++ b/tt_metal/tt_stl/span.hpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ranges>
+#include <span>
+
+namespace tt::stl {
+
+using std::dynamic_extent;
+
+namespace detail {
+
+using std::span;
+
+template <class T, std::size_t Extent>
+class SpanBase : public span<T, Extent> {
+   public:
+    using span<T, Extent>::span;
+};
+
+template <class T, std::size_t Extent>
+class SpanBase<const T, Extent> : public span<const T, Extent> {
+   public:
+    using span<const T>::span;
+
+    // expose constructor from initializer_list for const-qualified element_type
+    explicit(Extent != dynamic_extent) constexpr SpanBase(std::initializer_list<T> il) noexcept : span<const T>(il) {}
+};
+
+}  // namespace detail
+
+template <class T, std::size_t Extent = dynamic_extent>
+class Span : detail::SpanBase<T, Extent> {
+    using base = detail::SpanBase<T, Extent>;
+
+   public:
+    // Member types
+    using typename base::const_pointer;
+    using typename base::const_reference;
+    using typename base::difference_type;
+    using typename base::element_type;
+    using typename base::iterator;
+    using typename base::pointer;
+    using typename base::reference;
+    using typename base::reverse_iterator;
+    using typename base::size_type;
+    using typename base::value_type;
+
+    // Member constants
+    using base::extent;
+
+    using base::base;
+    using base::operator=;
+
+    // Iterators
+    using base::begin;
+    using base::end;
+    using base::rbegin;
+    using base::rend;
+
+    // Element access
+    using base::back;
+    using base::front;
+    using base::operator[];
+    using base::data;
+
+    // Observers
+    using base::empty;
+    using base::size;
+    using base::size_bytes;
+
+    // Subviews
+    using base::first;
+    using base::last;
+    using base::subspan;
+};
+
+template <class It, class EndOrSize>
+Span(It, EndOrSize) -> Span<std::remove_reference_t<std::iter_reference_t<It>>>;
+
+template <class T, std::size_t N>
+Span(T (&)[N]) -> Span<T, N>;
+
+template <class T, std::size_t N>
+Span(std::array<T, N> &) -> Span<T, N>;
+
+template <class T, std::size_t N>
+Span(const std::array<T, N> &) -> Span<const T, N>;
+
+template <class R>
+Span(R &&) -> Span<std::remove_reference_t<std::ranges::range_reference_t<R>>>;
+
+}  // namespace tt::stl
+
+template <class T, std::size_t Extent>
+constexpr bool std::ranges::enable_borrowed_range<tt::stl::Span<T, Extent>> = true;
+
+template <class T, std::size_t Extent>
+constexpr bool std::ranges::enable_view<tt::stl::Span<T, Extent>> = true;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
@@ -119,9 +119,13 @@ operation::ProgramWithCallbacks bcast_multi_core_h(const Tensor &a, const Tensor
 		} else if (core_group_2.core_coord_in_core_ranges(core)) {
 			Ht_per_core = Ht_per_core_group_2;
 		} else {
-			tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(15, 0));
-			tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
-			tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(9, 0));
+			constexpr std::array<uint32_t, 15> binary_reader_kernel_args{0};
+			constexpr std::array<uint32_t, 3> bcast_kernel_args{0};
+			constexpr std::array<uint32_t, 9> unary_writer_kernel_args{0};
+
+			tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, binary_reader_kernel_args);
+			tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, bcast_kernel_args);
+			tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, unary_writer_kernel_args);
 			continue;
 		}
 		uint32_t num_tensor_tiles_per_core = NC * Ht_per_core * Wt;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -157,9 +157,13 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_2;
         } else {
-            tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
-            tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, {1, 1, 0});
-            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
+            constexpr std::array<uint32_t, 7> binary_reader_kernel_args{0};
+			constexpr std::array<uint32_t, 3> bcast_kernel_args{1, 1, 0};
+			constexpr std::array<uint32_t, 3> unary_writer_kernel_args{0};
+
+            tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, binary_reader_kernel_args);
+            tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, bcast_kernel_args);
+            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, unary_writer_kernel_args);
             continue;
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
@@ -118,9 +118,13 @@ operation::ProgramWithCallbacks bcast_multi_core_w(const Tensor &a, const Tensor
 		} else if (core_group_2.core_coord_in_core_ranges(core)) {
 			Wt_per_core = Wt_per_core_group_2;
 		} else {
-			tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(16, 0));
-			tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
-			tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(9, 0));
+			constexpr std::array<uint32_t, 16> binary_reader_kernel_args{0};
+			constexpr std::array<uint32_t, 3> bcast_kernel_args{0};
+			constexpr std::array<uint32_t, 9> unary_writer_kernel_args{0};
+
+			tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, binary_reader_kernel_args);
+			tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, bcast_kernel_args);
+			tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, unary_writer_kernel_args);
 			continue;
 		}
         uint32_t num_tensor_tiles_per_core = NC*Ht*Wt_per_core;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_single_core_program_factory.cpp
@@ -96,7 +96,7 @@ Fold::SingleCore::cached_program_t fold_single_core(
     SetRuntimeArgs(program, reader_kernel_id, core, {src_buffer->address(), pixel_size, num_pixels, 0});
 
     // Writer run-time args
-    std::vector<uint32_t> writer_kernel_args = {
+    const std::array writer_kernel_args = {
         dst_buffer->address(),
         dst_pixel_size,
         scratch_buffer->address(),

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
@@ -98,7 +98,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids,
         uint32_t local_b = (i<B) ? b : 0;
         uint32_t local_batch_size_in_sticks = (i<B) ? batch_size_in_sticks : 0;
 
-        std::vector<uint32_t> reader_runtime_args = {
+        const std::array reader_runtime_args = {
                                                     batch_ids.buffer()->address(),
                                                     local_b,
                                                     input_a.buffer()->address(),
@@ -108,7 +108,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids,
                                                     i
         };
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        std::vector<uint32_t> writer_runtime_args = {
+        const std::array writer_runtime_args = {
                                                     output.buffer()->address(),
                                                     page_size,
                                                     local_batch_size_in_sticks,
@@ -135,7 +135,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids,
         for (const auto &core : cores) {
             uint32_t local_b = (core_id<B) ? b : 0;
             uint32_t local_batch_size_in_sticks = (core_id<B) ? batch_size_in_sticks : 0;
-            std::vector<uint32_t> reader_runtime_args = {
+            const std::array reader_runtime_args = {
                                                     batch_ids.buffer()->address(),
                                                     local_b,
                                                     input_a.buffer()->address(),
@@ -146,7 +146,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids,
             };
             tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
 
-            std::vector<uint32_t> writer_runtime_args = {
+            const std::array writer_runtime_args = {
                                                     output.buffer()->address(),
                                                     page_size,
                                                     local_batch_size_in_sticks,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -250,7 +250,7 @@ operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor& input, Ten
         shard_grid,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1, .compile_args = reader_compile_time_args});
-    std::vector<uint32_t> runtime_args = {
+    const std::array runtime_args = {
         total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
     SetRuntimeArgs(program, kernel_id, shard_grid, runtime_args);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.cpp
@@ -75,7 +75,7 @@ operation::ProgramWithCallbacks non_zero_indices_single_core(const Tensor &input
         (std::uint32_t) out_is_dram_1,
     };
 
-    std::vector<uint32_t> run_time_args = {
+    const std::array run_time_args = {
         (std::uint32_t) input.buffer()->address(),
         (std::uint32_t) out_num_indices.buffer()->address(),
         (std::uint32_t) out_indices.buffer()->address(),

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -107,7 +107,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
 
     uint32_t start_src_stick_id = 0;
     uint32_t start_dst_stick_id = 0;
-    vector<uint32_t> reader_rt_args = {src0_buffer->address(),
+    const std::array reader_rt_args = {src0_buffer->address(),
                                        dst_buffer->address(),
                                        a.get_legacy_shape()[0],
                                        output_shape[0],
@@ -125,17 +125,17 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
                                        packed_pad_value,
                                        start_src_stick_id,
                                        start_dst_stick_id,
-                                       0,
-                                       0,
-                                       0,
+                                       std::uint32_t{0},
+                                       std::uint32_t{0},
+                                       std::uint32_t{0},
                                        output_shape[2],
                                        a.get_legacy_shape()[2],
                                        unpadded_row_size_nbytes,
                                        padded_row_size_nbytes,
-                                       0,
+                                       std::uint32_t{0},
                                        output.get_legacy_shape()[0]
                                        };
-    vector<uint32_t> writer_rt_args = reader_rt_args;
+    const auto &writer_rt_args = reader_rt_args;
     tt::tt_metal::SetRuntimeArgs(program,
                    reader_kernel_id,
                    cores,
@@ -247,7 +247,7 @@ operation::ProgramWithCallbacks pad_rm_opt(const Tensor &a,
     }
     #endif
 
-    vector<uint32_t> reader_rt_args = {src0_buffer->address(),
+    const std::array reader_rt_args = {src0_buffer->address(),
                                        dst_buffer->address(),
                                        a.get_legacy_shape()[0],
                                        output_shape[0],
@@ -321,7 +321,7 @@ operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Sh
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
-    vector<uint32_t> reader_kernel_args = {
+    const std::array reader_kernel_args = {
         src0_buffer->address(),
         dst_buffer->address(),
         a.get_legacy_shape()[0],
@@ -445,11 +445,12 @@ operation::ProgramWithCallbacks pad_tile(const Tensor &a, Tensor& output, const 
 
     uint32_t num_unpadded_tiles = a.volume() / TILE_HW;
 
-    vector<uint32_t> reader_kernel_args = {
+    const std::array reader_kernel_args = {
         src0_buffer->address(),
-        num_unpadded_tiles, 0
+        num_unpadded_tiles,
+        std::uint32_t{0},
     };
-    vector<uint32_t> writer_kernel_args = {
+    const std::array writer_kernel_args = {
         dst_buffer->address(),
         num_unpadded_W,
         num_padded_Wt,
@@ -785,7 +786,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
                     curr_stick_diff_nbytes = dst_nbytes_per_core_w - curr_stick_size_nbytes;
                     rem_src_stick_size_nbytes = 0;
                 }
-                vector<uint32_t> reader_rt_args = {src0_buffer->address(),
+                const std::array reader_rt_args = {src0_buffer->address(),
                                                     dst_buffer->address(),
                                                     a.get_legacy_shape()[0],
                                                     output_shape[0],
@@ -822,7 +823,7 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
                 //     log_debug("{} :: nbatch_per_core_h: {}", core.y, nbatch_per_core_h);
                 //     log_debug("{} :: ncores_per_batch_h: {}", core.y, ncores_per_batch_h);
                 // }
-                vector<uint32_t> writer_rt_args = reader_rt_args;
+                const auto &writer_rt_args = reader_rt_args;
                 tt::tt_metal::SetRuntimeArgs(program,
                                 reader_kernel_id,
                                 core,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -812,7 +812,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
         }
 
         if constexpr (initialize_args) {
-            vector<uint32_t> writer_kernel_args = {output_buffer->address(), num_tiles_per_core, num_tiles_written};
+            const std::array writer_kernel_args = {output_buffer->address(), num_tiles_per_core, num_tiles_written};
             tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
         } else {
             auto& writer_kernel_args = writer_kernel_args_by_core[core.x][core.y];

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -52,7 +52,7 @@ void setup_runtime(
                     uint32_t reader_core_id = id_c * per_core_tiles_y;
                     reader_core_id += id_r_reader;
 
-                    std::vector<uint32_t> reader_runtime_args = {
+                    const std::array reader_runtime_args = {
                         (std::uint32_t)reader_core_id,
                         (std::uint32_t)(in0_buffer->address()),  // in0_tensor_addr
                         (std::uint32_t)0                         // split on last dim
@@ -66,7 +66,7 @@ void setup_runtime(
 
                     uint32_t writer_core_id = id_c_inner * per_core_tiles_y + (id_r_writer);
 
-                    std::vector<uint32_t> writer_runtime_args = {
+                    const std::array writer_runtime_args = {
                         writer_core_id,
                         (std::uint32_t)out0_buffer->address(),  // first base addr
                         (std::uint32_t)out1_buffer->address(),  // second base addr

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.cpp
@@ -80,7 +80,7 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& outp
                                 .set_page_size(output_cb_index, output_single_tile_size);
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
-    vector<uint32_t> reader_kernel_args = {
+    const std::array reader_kernel_args = {
         src0_buffer->address(),
         num_sticks,
         stick_size,
@@ -89,7 +89,7 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& outp
         num_full_blocks_in_row,
         num_leftover_tiles,
         leftover_width_in_row,
-        0  // row_start_id
+        std::uint32_t{0},  // row_start_id
     };
 
     // Reader compile-time args
@@ -236,19 +236,19 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
         const CoreCoord& core = cores[i];
 
         // reader runtime args
-        vector<uint32_t> reader_rt_args = {
+        const std::array reader_rt_args = {
             src0_buffer->address(),
             nblocks_per_core * TILE_HEIGHT,
             block_size_nbytes,
             ntiles_per_block,
             block_size_nbytes,
-            1,  // full blocks in row
-            0,  // num leftover tiles
-            0,  // leftover width in row
+            std::uint32_t{1},  // full blocks in row
+            std::uint32_t{0},  // num leftover tiles
+            std::uint32_t{0},  // leftover width in row
             row_start_id};
 
         // writer runtime args
-        vector<uint32_t> writer_rt_args = {
+        const std::array writer_rt_args = {
             dst_buffer->address(),
             ntiles_per_block * nblocks_per_core,  // ntiles per core
             tile_start_id                         // start id
@@ -265,19 +265,19 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, T
         const CoreCoord& core = cores.back();
 
         // reader runtime args
-        vector<uint32_t> reader_rt_args = {
+        const std::array reader_rt_args = {
             src0_buffer->address(),
             nblocks_per_core_cliff * TILE_HEIGHT,
             block_size_nbytes,
             ntiles_per_block,
             block_size_nbytes,
-            1,  // full blocks in row
-            0,  // num leftover tiles
-            0,  // leftover width in row
+            std::uint32_t{1},  // full blocks in row
+            std::uint32_t{0},  // num leftover tiles
+            std::uint32_t{0},  // leftover width in row
             row_start_id};
 
         // writer runtime args
-        vector<uint32_t> writer_rt_args = {
+        const std::array writer_rt_args = {
             dst_buffer->address(),
             ntiles_per_block * nblocks_per_core_cliff,  // ntiles per core
             tile_start_id                               // start id

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.cpp
@@ -116,7 +116,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
-    vector<uint32_t> reader_kernel_args = {
+    const std::array reader_kernel_args = {
         src0_buffer->address(),
         input_w,
         padded_W_diff_blocks,
@@ -315,7 +315,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
         uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
 
         // writer runtime args
-        vector<uint32_t> writer_rt_args = {dst_buffer->address(), num_tiles_per_core, tile_start_id};
+        const std::array writer_rt_args = {dst_buffer->address(), num_tiles_per_core, tile_start_id};
 
         SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
         SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
@@ -447,7 +447,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
-    vector<uint32_t> reader_rt_args = {
+    const std::array reader_rt_args = {
         num_input_rows,
         input_shard_width_bytes,
         (num_input_rows / num_batches) * input_shard_width_bytes,
@@ -457,7 +457,7 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
         packed_pad_value};
     tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, reader_rt_args);
 
-    vector<uint32_t> writer_rt_args = {ntiles_per_core};
+    const std::array writer_rt_args = {ntiles_per_core};
     tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, writer_rt_args);
 
     auto override_runtime_arguments_callback = [reader_kernel_id = unary_reader_kernel_id,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -188,22 +188,20 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
             continue;
         }
         // reader runtime args
-        vector<uint32_t> reader_rt_args;
         auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
-        reader_rt_args = {
+        const std::array reader_rt_args = {
             src0_buffer->address(),               // src_addr
             ntiles_per_core,  // ntiles
             tile_start_id                         // start_id
         };
 
-        std::vector<uint32_t> writer_rt_args;
-        writer_rt_args = {
+        const std::array writer_rt_args = {
             dst_buffer->address(),           // dst_addr
             nsticks_per_core,  // nsticks
             stick_size,               // block_size_nbytes
             ntiles_per_core,                // ntiles_per_core
             TILE_WIDTH * output.element_size(),               // tile_width_size
-            0, //start stick id = 0, since parallelizing on height
+            std::uint32_t{0}, //start stick id = 0, since parallelizing on height
             offset_within_stick
         };
 
@@ -218,22 +216,20 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
         CoreCoord core = row_major ? CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x}
                                    : CoreCoord{ncores_full / ncores_y, ncores_full % ncores_y};
         // reader runtime args
-        std::vector<uint32_t> reader_rt_args;
         auto ntiles_per_core_cliff = ntiles_per_block * nblocks_per_core_cliff;
-        reader_rt_args = {
+        const std::array reader_rt_args = {
             src0_buffer->address(),               // src_addr
             ntiles_per_core_cliff,  // ntiles
             tile_start_id                         // start_id
         };
 
-        std::vector<uint32_t> writer_rt_args;
-        writer_rt_args = {
+        const std::array writer_rt_args = {
             dst_buffer->address(),           // dst_addr
             nsticks_per_core,  // nsticks
             stick_size,               // block_size_nbytes
             ntiles_per_core_cliff,                // ntiles_per_core
             TILE_WIDTH * output.element_size(),               // tile_width_size
-            0, //start stick id = 0, since parallelizing on height
+            std::uint32_t{0}, //start stick id = 0, since parallelizing on height
             offset_within_stick
         };
         tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
@@ -754,7 +750,7 @@ operation::ProgramWithCallbacks untilize_single_core(
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
     // Writer compile-time args
-    vector<uint32_t> writer_kernel_args = {
+    const std::array writer_kernel_args = {
         dst_buffer->address(),
         num_sticks,
         stick_size,
@@ -763,7 +759,7 @@ operation::ProgramWithCallbacks untilize_single_core(
         num_full_blocks_in_row,
         num_leftover_tiles,
         leftover_width_in_row,
-        0};
+        std::uint32_t{0}};
 
     bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram};

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -111,7 +111,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
                                 .set_page_size(output_cb_index, output_single_tile_size);
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
-    vector<uint32_t> writer_kernel_args = {
+    const std::array writer_kernel_args = {
         dst_buffer->address(),
         output_w,
         padded_W_diff_blocks,
@@ -336,7 +336,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
         uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
 
         // reader runtime args
-        vector<uint32_t> reader_rt_args = {src0_buffer->address(), num_tiles_per_core, tile_start_id};
+        const std::array reader_rt_args = {src0_buffer->address(), num_tiles_per_core, tile_start_id};
 
         SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
         SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
@@ -522,7 +522,7 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
         ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
 
     // reader runtime args
-    vector<uint32_t> reader_rt_args = {
+    const std::array reader_rt_args = {
         ntiles_per_block * nblocks_per_core  // ntiles
     };
     tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, reader_rt_args);
@@ -550,7 +550,6 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
             CoreCoord& core = cores[i];
 
             // writer runtime args
-            vector<uint32_t> writer_rt_args;
             uint32_t block_start_row_offset;
             uint32_t block_start_row_id_offset;
             uint32_t row_size_unpadded = block_row_size;
@@ -605,13 +604,13 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
                 }
             }
 
-            writer_rt_args = {
+            const std::array writer_rt_args = {
                 dst_buffer->address(),  // dst_addr
                 num_rows_block,
                 block_row_size,
-                1,
-                1,
-                1,
+                std::uint32_t{1},
+                std::uint32_t{1},
+                std::uint32_t{1},
                 output_row_size,
                 row_size_unpadded,
                 num_rows_unpadded,


### PR DESCRIPTION
### Ticket
#10428

### Problem description
SetRuntimeArgs currently accepts a vector which forces the user to allocate in order to call the API function.

### What's changed
Accept an stl::Span which is a non-owning contiguous range, and can be constructed from vector or initializer_list (so it's backwards compatible), and additionally, array, or any other contiguous ranges. Refactored some tests and ttnn ops to show how this enables unnecessary allocation to be avoided.

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11407490155)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
