### PR TITLE
#0: Temporarily disable clang-tidy in all-static-checks.yaml for PR

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -68,7 +68,8 @@ jobs:
       pull-requests: write
       # OPTIONAL: auto-closing conversations requires the `contents` permission
       contents: write
-    if: github.event_name == 'pull_request'  # Only run this job on pull request events
+    # if: github.event_name == 'pull_request'  # Only run this job on pull request events
+    if : false
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
### Ticket
NA

### Problem description
clang-tidy comments are too noisy right now.
Need to improve `.clang-tidy` and then re-enable.

### What's changed
Disable job in CI.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
