### PR TITLE
Update MaxPool2D to Support Width and Block Sharding

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/test_maxpool2d.py
@@ -23,6 +23,7 @@ def run_max_pool(
     device,
     dtype,
     memory_config=None,
+    shard_scheme=None,
 ):
     in_n, in_c, in_h, in_w = act_shape
     kernel_h, kernel_w = kernel_size
@@ -30,22 +31,37 @@ def run_max_pool(
     stride_h, stride_w = stride
     dilation_h, dilation_w = dilation
 
-    if 2 * pad_h > kernel_h or 2 * pad_w > kernel_w:
-        pytest.skip("Invalid case")
-
-    if (kernel_h == 3 and pad_h != 1) or (kernel_h == 2 and pad_h != 0):
-        pytest.skip("kernel size and padding combination not supported")
+    if shard_scheme != ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+        if 2 * pad_h > kernel_h or 2 * pad_w > kernel_w:
+            pytest.skip("Invalid case")
+        if (kernel_h == 3 and pad_h != 1) or (kernel_h == 2 and pad_h != 0):
+            pytest.skip("kernel size and padding combination not supported")
 
     out_h = math.floor((in_h + 2 * pad_h - (dilation_h * kernel_h - 1) - 1) / stride_h) + 1
     out_w = math.floor((in_w + 2 * pad_w - (dilation_w * kernel_w - 1) - 1) / stride_w) + 1
-    if in_c % 16 != 0:
-        pytest.skip("Current maxpool writer needs nchannels to be multiple of 16!")
+    cores_x = device.core_grid.x
+    cores_y = device.core_grid.y
+    max_cores = cores_x * cores_y
 
-    if in_c == 16 and dtype == ttnn.bfloat8_b and in_n * in_h * in_w > 600000:
-        pytest.skip("This case runs out of memory on Grayskull")
+    if shard_scheme == ttnn.TensorMemoryLayout.HEIGHT_SHARDED or shard_scheme is None:
+        if in_c % 16 != 0:
+            pytest.skip("Current maxpool writer needs nchannels to be multiple of 16!")
+        if in_c == 16 and dtype == ttnn.bfloat8_b and in_n * in_h * in_w > 600000:
+            pytest.skip("This case runs out of memory on Grayskull")
+        if in_n > 16 and in_c > 64 and dtype == ttnn.bfloat8_b and is_wormhole_b0():
+            pytest.skip("This case runs out of memory on Wormhole b0")
 
-    if in_n > 16 and in_c > 64 and dtype == ttnn.bfloat8_b and is_wormhole_b0():
-        pytest.skip("This case runs out of memory on Wormhole b0")
+    if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED:
+        if in_c < max_cores:
+            pytest.skip("Width sharding requires channles >= cores")
+        if in_c / max_cores < 16:
+            pytest.skip("Width sharding requires large enough channels to shard (at least 16 per core)")
+
+    if shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
+        if in_c < cores_x:
+            pytest.skip("Block sharding requires channles >= cores")
+        if in_c / cores_x < 16:
+            pytest.skip("Block sharding requires large enough channels to shard (at least 16 per core)")
 
     torch.manual_seed(0)
     torch.set_printoptions(precision=3, sci_mode=False, linewidth=500, threshold=10000, edgeitems=32)
@@ -72,12 +88,15 @@ def run_max_pool(
     if dtype == ttnn.bfloat8_b:
         if (in_h * in_w) % 32 != 0:
             pytest.skip("For BFP8_B datatype, input height * width should be multiple of 32")
+        if shard_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED and (in_c / max_cores) % 32 != 0:
+            pytest.skip("For BFP8_B datatype, input channels / max_cores should be multiple of 32")
+        if shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED and (in_c / cores_x) % 32 != 0:
+            pytest.skip("For BFP8_B datatype, input channels / cores_x should be multiple of 32")
         ttact = ttnn.from_torch(act_reshaped, dtype, layout=ttnn.TILE_LAYOUT)
     else:
         ttact = ttnn.from_torch(act_reshaped, dtype)
 
-    pre_shard = True
-    # pre_shard = False
+    pre_shard = shard_scheme == None
 
     ttact_device = ttnn.to_device(ttact, device)
     if pre_shard:
@@ -109,6 +128,7 @@ def run_max_pool(
         padding=[pad_h, pad_w],
         dilation=[dilation_h, dilation_w],
         memory_config=memory_config,
+        applied_shard_scheme=shard_scheme,
     )
 
     output_host = output.cpu()
@@ -247,6 +267,141 @@ def test_run_max_pool_mem_config(
     use_program_cache,
 ):
     run_max_pool(act_shape, (3, 3), (1, 1), (2, 2), (1, 1), device, ttnn.bfloat16, memory_config=memory_config)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "act_shape",  ## NCHW
+    (
+        (
+            [1, 512, 28, 28],
+            [1, 512, 14, 14],
+            [1, 1024, 6, 6],
+            [1, 2048, 6, 6],
+            [1, 4096, 6, 6],
+            [4, 1024, 40, 40],
+            [2, 2048, 40, 40],
+            [8, 4096, 10, 16],
+        )
+    ),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        (2, 2),
+        (3, 3),
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (0, 0),
+        (1, 1),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((2, 2),),
+)
+@pytest.mark.parametrize("dilation", ((1, 1),))  ## default
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_run_max_pool_width_shard(
+    act_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    dtype,
+    use_program_cache,
+):
+    run_max_pool(
+        act_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        dtype,
+        shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "act_shape",  ## NCHW
+    (
+        (
+            [1, 256, 56, 56],
+            [1, 256, 28, 28],
+            [1, 256, 14, 14],
+            [1, 256, 10, 14],
+            [1, 512, 8, 6],
+            [1, 1024, 6, 6],
+            [1, 2048, 4, 6],
+            [4, 512, 40, 40],
+            [2, 1024, 40, 40],
+            [8, 2048, 10, 16],
+            ## resnet shapes
+            [1, 64, 112, 112],
+            [4, 64, 112, 112],
+            [8, 64, 112, 112],
+            [16, 64, 112, 112],
+            ## hpr shapes
+            [8, 32, 132, 20],
+            [16, 32, 132, 20],
+            [32, 32, 132, 20],
+            [64, 32, 132, 20],
+            [128, 32, 132, 20],
+            [8, 32, 264, 40],
+            [16, 32, 264, 40],
+            [32, 32, 264, 40],
+            [4, 16, 1056, 160],
+            [8, 16, 528, 80],
+            [16, 16, 528, 80],
+        )
+    ),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        (2, 2),
+        (3, 3),
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (0, 0),
+        (1, 1),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    ((2, 2),),
+)
+@pytest.mark.parametrize("dilation", ((1, 1),))  ## default
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_run_max_pool_block_shard(
+    act_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    dtype,
+    use_program_cache,
+):
+    run_max_pool(
+        act_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        dtype,
+        shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+    )
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -102,7 +102,9 @@ ParallelConfig determine_parallel_config(
         }
         grid = num_cores_to_corerange_set(num_cores_nhw, grid_size, true);
     } else if (shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        num_cores_nhw = find_closest_largest_divisor_with_num_padding(out_nhw_ntiles, grid_size.x);
+        uint32_t start_divisor =
+                block_shard_orientation == ShardOrientation::COL_MAJOR ? grid_size.x : grid_size.y;
+        num_cores_nhw = find_closest_largest_divisor_with_num_padding(out_nhw_ntiles, start_divisor);
         uint32_t num_cores_c = find_closest_common_largest_divisor(out_c_ntiles, std::ceil((float)input_channels / effective_tile_width), block_shard_orientation == ShardOrientation::COL_MAJOR ? grid_size.y : grid_size.x);
         uint32_t cores_x = block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_nhw : num_cores_c;
         uint32_t cores_y = block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_c : num_cores_nhw;

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.cpp
@@ -26,10 +26,15 @@ void validate_maxpool(const Tensor& input, const sliding_window::SlidingWindowCo
     TT_FATAL(is_pow2, "Row size (nchannels * bytes = {}) should be power of 2 ({}).", in_nbytes_c, is_pow2);
 
     TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
-    TT_FATAL(input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Only height sharded tensors are supported.");
-
     TT_FATAL(out_mem_config.is_sharded(), "Output memory config needs to be sharded");
-    TT_FATAL(out_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Only height sharded tensors are supported.");
+
+    // check that C dimnenion is a multiple of num_shards_c for all but height sharding
+    TensorMemoryLayout in_memory_layout = input.memory_config().memory_layout;
+    if (in_memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t num_shards_c = sliding_window_config.num_cores_c;
+        const tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
+        TT_FATAL(input_shape[3] % num_shards_c == 0, "For width and block sharding, input channels should be divisible by num_shards");
+    }
 }
 
 void MaxPool2D::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
@@ -83,7 +88,7 @@ MaxPool2D::tensor_return_value_t MaxPool2D::create_output_tensors(const operatio
     Shape output_shape = compute_output_shapes(op_attr, tensors);
     auto mem_config = out_mem_config;
     if (mem_config.shard_spec.has_value()) {
-        mem_config.shard_spec->shape[1] = output_shape[3];
+        mem_config.shard_spec->shape[1] = input.shard_spec()->shape[1];
     } else {
         uint32_t ncores = input.shard_spec().value().num_cores();
         TT_FATAL(ncores == sliding_window_config.num_cores_nhw, "Number of cores should match");

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -4,6 +4,7 @@
 
 #include "max_pool2d.hpp"
 
+#include "impl/buffers/buffer_constants.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "tt_metal/common/math.hpp"
@@ -12,8 +13,17 @@
 namespace ttnn {
 namespace operations::pool {
 
-Tensor MaxPool2DOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t channels, std::array<uint32_t, 2> kernel_size, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> padding, std::array<uint32_t, 2> dilation, const std::optional<const MemoryConfig> memory_config) {
-
+Tensor MaxPool2DOp::invoke(uint8_t queue_id,
+                           const Tensor& input_tensor,
+                           uint32_t batch_size,
+                           uint32_t input_h, uint32_t input_w,
+                           uint32_t channels,
+                           std::array<uint32_t, 2> kernel_size,
+                           std::array<uint32_t, 2> stride,
+                           std::array<uint32_t, 2> padding,
+                           std::array<uint32_t, 2> dilation,
+                           const std::optional<const MemoryConfig> memory_config,
+                           const std::optional<const TensorMemoryLayout> applied_shard_scheme) {
     sliding_window::SlidingWindowConfig sliding_window_config{
             .batch_size = batch_size,
             .input_hw = {input_h, input_w},
@@ -22,7 +32,7 @@ Tensor MaxPool2DOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32_
             .pad_hw = {padding.at(0), padding.at(1)},
             .dilation_hw = {dilation.at(0), dilation.at(1)}
     };
-    auto output_shape = sliding_window_config.get_output_shape();
+    auto output_shape = sliding_window_config.get_output_shape();   // last dim/width is 0
     auto input_tensor_sharded = input_tensor;
 
     // maxpool output is row major
@@ -32,38 +42,50 @@ Tensor MaxPool2DOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32_
     sliding_window::ParallelConfig parallel_config;
     MemoryConfig out_memory_config = input_tensor_sharded.memory_config();
     uint32_t num_cores_nhw = 0;
+    uint32_t num_cores_c = 0;
 
+    TensorMemoryLayout shard_layout = TensorMemoryLayout::HEIGHT_SHARDED; // default to height sharding
     if (!out_memory_config.shard_spec.has_value()) {
         // Input is not sharded. Perform sharding.
+        if (applied_shard_scheme.has_value()) {
+            TT_FATAL((applied_shard_scheme.value() == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                     (applied_shard_scheme.value() == TensorMemoryLayout::WIDTH_SHARDED) ||
+                     (applied_shard_scheme.value() == TensorMemoryLayout::BLOCK_SHARDED),
+                     "Only height, width, or block sharding strategies are supported.");
+            shard_layout = applied_shard_scheme.value();
+        }
         parallel_config = conv::conv2d::determine_parallel_config(
-                                            TensorMemoryLayout::HEIGHT_SHARDED,
+                                            shard_layout,
                                             batch_size,
-                                            0,          // in_channels -- not used
+                                            channels,
                                             output_shape[1],
                                             output_shape[2],
-                                            0,          // out_channels -- not used
+                                            channels,
                                             input_tensor.device(),
                                             ShardOrientation::ROW_MAJOR,
                                             false);
         num_cores_nhw = conv::conv2d::get_num_cores_nhw_from_parallel_config(parallel_config);
+        num_cores_c = conv::conv2d::get_num_cores_channels_from_parallel_config(parallel_config);
         auto sharded_mem_config = conv::conv2d::create_sharded_memory_config_from_parallel_config(input_tensor_sharded.shape(), parallel_config, is_in_tiled ? tt::constants::TILE_HEIGHT : 1);
-        input_tensor_sharded = ttnn::to_memory_config(input_tensor_sharded, sharded_mem_config, std::nullopt);
+        input_tensor_sharded = ttnn::to_memory_config(input_tensor_sharded, sharded_mem_config, std::nullopt); // this converts interleaved to sharded
         out_memory_config = input_tensor_sharded.memory_config();
     } else {
         // input is already sharded, use it as is
         const auto shard_grid = out_memory_config.shard_spec.value().grid;
         const auto shard_scheme = out_memory_config.memory_layout;
         const auto shard_orientation = out_memory_config.shard_spec.value().orientation;
-        TT_FATAL(shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED, "Only height sharded tensors are supported.");
+        TT_FATAL(!applied_shard_scheme.has_value(), "A sharding scheme should not be specified for a sharded input tensor.");
         TT_FATAL(shard_orientation == ShardOrientation::ROW_MAJOR, "Only row major orientation is supported.");
         parallel_config.grid = shard_grid;
         parallel_config.shard_scheme = shard_scheme;
         parallel_config.shard_orientation = shard_orientation;
         num_cores_nhw = conv::conv2d::get_num_cores_nhw_from_parallel_config(parallel_config);
+        num_cores_c = conv::conv2d::get_num_cores_channels_from_parallel_config(parallel_config);
     }
+
     // update the shard spec to match the output shape
     auto shard_spec = out_memory_config.shard_spec.value();
-    uint32_t output_shard_width_padded = input_tensor.dtype() == DataType::BFLOAT8_B ? tt::round_up(output_shape[3], tt::constants::TILE_WIDTH) : tt::round_up(output_shape[3] * tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())), tt::constants::TILE_WIDTH);
+    uint32_t output_shard_width_padded = input_tensor.dtype() == DataType::BFLOAT8_B ? tt::round_up(channels / num_cores_c, tt::constants::TILE_WIDTH) : tt::round_up(channels / num_cores_c * tt::datum_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype())), tt::constants::TILE_WIDTH);
     uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
     uint32_t output_nhw_padded = tt::round_up(output_nhw, num_cores_nhw * (is_out_tiled ? tt::constants::TILE_HEIGHT : 1));
     uint32_t output_shard_height_padded = output_nhw_padded / num_cores_nhw;
@@ -78,6 +100,7 @@ Tensor MaxPool2DOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32_
             .pad_hw = {padding.at(0), padding.at(1)},
             .dilation_hw = {dilation.at(0), dilation.at(1)},
             .num_cores_nhw = num_cores_nhw,
+            .num_cores_c = num_cores_c,
             .core_range_set = parallel_config.grid,
             .snap_to_tile = false
     };

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.hpp
@@ -16,7 +16,17 @@ namespace ttnn {
 namespace operations::pool {
 
 struct MaxPool2DOp {
-    static Tensor invoke(uint8_t queue_id, const Tensor& input_tensor, uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t channels, std::array<uint32_t, 2> kernel_size, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> padding, std::array<uint32_t, 2> dilation, const std::optional<const MemoryConfig> memory_config = std::nullopt);
+    static Tensor invoke(uint8_t queue_id,
+                         const Tensor& input_tensor,
+                         uint32_t batch_size,
+                         uint32_t input_h, uint32_t input_w,
+                         uint32_t channels,
+                         std::array<uint32_t, 2> kernel_size,
+                         std::array<uint32_t, 2> stride,
+                         std::array<uint32_t, 2> padding,
+                         std::array<uint32_t, 2> dilation,
+                         const std::optional<const MemoryConfig> memory_config,
+                         const std::optional<const TensorMemoryLayout> applied_shard_scheme);
 
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d_pybind.cpp
@@ -19,24 +19,59 @@ void bind_max_pool2d_operation(py::module& module) {
         module,
         ttnn::max_pool2d,
         R"doc(
-        Max Pool 2D
-        +-------------------+-------------------------------+---------------+-------------+----------+
-        | Argument          | Description                   | Data type     | Valid range | Required |
-        +===================+===============================+===============+=============+==========+
-        | input             | Input activations tensor      | Tensor        |             | Yes      |
-        | in_n              | Input nbatch                  | Tensor        |             | Yes      |
-        | in_h              | Input height                  | Tensor        |             | Yes      |
-        | in_w              | Input width                   | Tensor        |             | Yes      |
-        | kernel_h          | kernel window height          | uint32_t      |             | Yes      |
-        | kernel_w          | kernel window width           | uint32_t      |             | Yes      |
-        | stride_h          | stride in height dim          | uint32_t      |             | No       |
-        | stride_w          | stride in width dim           | uint32_t      |             | No       |
-        | pad_h             | padding in height dim         | uint32_t      |             | No       |
-        | pad_w             | padding in width dim          | uint32_t      |             | No       |
-        | dilation_h        | kernel dilation in height dim | uint32_t      |             | No       |
-        | dilation_w        | kernel dilation in width dim  | uint32_t      |             | No       |
-        | memory_config     | Output memory config          | MemoryConfig  |             | No       |
-        +-------------------+-------------------------------+---------------+-------------+----------+
+        Applies a max pool convolution to the input tensor. The resulting output Tensor will contain the maximum
+        value for each channel within a kernel window. The input tensor is expected to be in [NHW, C] format and
+        should be on the device. Height, width and block sharding schemes are supported.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the tensor to be convolved.
+            batch_size (int): the number of batches (N in a [N, C, H, W] shaped tensor).
+            input_h (int): the height of the input tensor (H in a [N, C, H, W] shaped tensor).
+            input_w (int): the width of the input tensor (W in a [N, C, H, W] shaped tensor).
+            channels (int): the number of channels (C in a [N, C, H, W] shaped tensor).
+            kernel_size (List of [int]): the (h, w) size of the kernel window.
+            stride (List of [int]): the (h, w) stride of the kernel window.
+            padding (List of [int]): the (h, w) padding of the input tensor.
+            dilation (List of [int]): the (h, w) dilation of the kernel window.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
+            applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
+            queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the max pool convolved output tensor.
+
+        Example:
+            >>> import ttnn
+            >>> import torch
+            >>> device = ttnn.CreateDevice(0, l1_small_size=8192)
+            >>> kernel_h, kernel_w = 2, 2
+            >>> stride_h, stride_w = 1, 1
+            >>> pad_h, pad_w = 0, 0
+            >>> dilation_h, dilation_w = 1, 1
+            >>> nchw_shape = (4, 256, 40, 40)
+            >>> in_N, in_C, in_H, in_W = nchw_shape
+            >>> input_shape = (1, 1, in_N * in_H * in_W, in_C)
+            >>> input = torch.randn(nchw_shape, dtype=torch.bfloat16)
+            >>> input_perm = torch.permute(input, (0, 2, 3, 1)) # this op expects a [N, H, W, C] format
+            >>> input_reshape = input_perm.reshape(input_shape)
+            >>> tt_input= ttnn.from_torch(input_reshape, ttnn.bfloat16)
+            >>> tt_input_dev = ttnn.to_device(tt_input, device)
+            >>> tt_output = ttnn.max_pool2d(
+                                input_tensor=tt_input_dev,
+                                batch_size=in_N,
+                                input_h=in_H,
+                                input_w=in_W,
+                                channels=in_C,
+                                kernel_size=[kernel_h, kernel_w],
+                                stride=[stride_h, stride_w],
+                                padding=[pad_h, pad_w],
+                                dilation=[dilation_h, dilation_w],
+                                memory_config=None,
+                                applied_shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                            )
+
         )doc",
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::max_pool2d)& self, const ttnn::Tensor& input_tensor,
@@ -48,19 +83,21 @@ void bind_max_pool2d_operation(py::module& module) {
                 std::array<uint32_t, 2> stride,
                 std::array<uint32_t, 2> padding,
                 std::array<uint32_t, 2> dilation,
-                const std::optional<const MemoryConfig>& memory_config,
+                const std::optional<const MemoryConfig> memory_config,
+                const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
                 const uint8_t& queue_id)
                 -> ttnn::Tensor { return self(queue_id,
-                                            input_tensor,
-                                            batch_size,
-                                            input_h,
-                                            input_w,
-                                            channels,
-                                            kernel_size,
-                                            stride,
-                                            padding,
-                                            dilation,
-                                            memory_config); },
+                                              input_tensor,
+                                              batch_size,
+                                              input_h,
+                                              input_w,
+                                              channels,
+                                              kernel_size,
+                                              stride,
+                                              padding,
+                                              dilation,
+                                              memory_config,
+                                              applied_shard_scheme); },
                 py::arg("input_tensor"),
                 py::arg("batch_size"),
                 py::arg("input_h"),
@@ -72,6 +109,7 @@ void bind_max_pool2d_operation(py::module& module) {
                 py::arg("dilation"),
                 py::kw_only(),
                 py::arg("memory_config") = std::nullopt,
+                py::arg("applied_shard_scheme") = std::nullopt,
                 py::arg("queue_id") = 0});
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -33,6 +33,7 @@ Tensor HaloTensorCreation(const Tensor &input){
     int input_height = input.get_legacy_shape()[1];
     int input_width = input.get_legacy_shape()[2];
     int num_cores_nhw = input.shard_spec().value().num_cores();
+    int num_cores_c = 1;
 
     ttnn::Tensor input_tensor = input;  // tensor to return
     SlidingWindowConfig sliding_window_config = SlidingWindowConfig(
@@ -43,6 +44,7 @@ Tensor HaloTensorCreation(const Tensor &input){
             {1, 0}, //padding
             {1, 1}, //dilation
             num_cores_nhw,
+            num_cores_c,
             input_tensor.memory_config().shard_spec.value().grid,
             false, true);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -45,6 +45,7 @@ struct SlidingWindowConfig {
 
     // parallel configuration
     uint32_t num_cores_nhw = 1;        // num cores along collapsed height nhw
+    uint32_t num_cores_c = 1;          // num cores along width c
     CoreRangeSet core_range_set = std::set{CoreRange({0, 0}, {0, 0})};   // active cores
 
     bool snap_to_tile = false;
@@ -80,7 +81,7 @@ std::vector<std::pair<uint32_pair_t, uint32_pair_t>> generate_shard_boundaries(c
 std::vector<std::pair<bool, uint32_pair_t>> generate_tensor_metadata(const std::vector<bool>& pad_metadata, const SlidingWindowConfig& config, uint32_t reshard_num_cores_nhw = 0, bool is_in_tiled = true);
 uint32_t generate_max_out_nsticks_per_core(const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries);
 std::tuple<std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tensors(const std::vector<std::pair<bool, uint32_pair_t>>& tensor_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool is_block_sharded, bool transpose_mcast, bool remote_read, Device* device);
-std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(const std::vector<uint32_t>& op_trace_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool pad_tile = false, bool pad_last_core = false);
+std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(const std::vector<uint32_t>& op_trace_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool pad_tile = false, bool pad_cores = false);
 std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input);
 Tensor construct_on_host_config_tensor(const std::vector<std::vector<uint16_t>>& config, const SlidingWindowConfig& sw_config, const ParallelConfig& p_config);
 Tensor move_config_tensor_to_device(const Tensor& config_tensor, const ParallelConfig& p_config, bool is_block_sharded, Device* device);


### PR DESCRIPTION
### Ticket
#13077 
#13078 

### Problem description
This PR updates MaxPool2D to support both width and block sharding.

### What's changed
A default parameter `applied_shard_scheme` has been added to `ttnn.max_pool2d`.  When not specified, MaxPool2D will use height sharding.  But, if either width or block sharding is specified, MaxPool2D will use that shard scheme instead.

This was primarily achieved by:
- scaling the references to the channel dimensions of the activation matrix in the program factory by the number of shards in the channel dimension
- adjusting the sliding window config calculation to pad the top left index shards to ensure all cores' shards have uniform length
- fixing a bug in `determine_parallel_conig` to compute the number of NHW cores variably depending on that shard orientation

### Checklist
- [x] Post commit CI passes
- [N/A] Blackhole Post commit (if applicable)
- [N/A] Model regression CI testing passes (if applicable)
- [N/A] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
