### PR TITLE
#11178: fix line reduce scatter override args behaviour

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -326,6 +326,8 @@ def get_devices(request):
         devices = request.getfixturevalue("pcie_devices")
     elif "mesh_device" in request.fixturenames:
         devices = request.getfixturevalue("mesh_device").get_devices()
+    elif "n300_mesh_device" in request.fixturenames:
+        devices = request.getfixturevalue("n300_mesh_device").get_devices()
     elif "t3k_mesh_device" in request.fixturenames:
         devices = request.getfixturevalue("t3k_mesh_device").get_devices()
     elif "pcie_mesh_device" in request.fixturenames:

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_N300_post_commit.py
@@ -58,7 +58,7 @@ def test_ring_reduce_scatter_post_commit(
     use_program_cache,
     function_level_defaults,
     enable_async,
-    num_iters=1,
+    num_iters=5,
 ):
     run_reduce_scatter_test(
         n300_mesh_device,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11178)

### Problem description
RT args werren't correctly being updated for line reduce scatter on reruns

### What's changed
Updated args properly for CCL send kernel now

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11387556056
- [x] t3k frequent: https://github.com/tenstorrent/tt-metal/actions/runs/11387569029
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
