### PR TITLE
#0: Update host_api.hpp - unnecessary include

### DIFF
--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -7,7 +7,6 @@
 #include <variant>
 #include <vector>
 
-#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/impl/kernels/runtime_args_data.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/device/device.hpp"


### PR DESCRIPTION
### Ticket
NA

### Problem description
I am trying to cut down on internal implementation details we expose to customers.
This header file can be removed with no impact on the build.
It does not provide public types to client.

### What's changed
Remove include from host_api.h

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11375623001
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
