### PR TITLE
#13499: Split runtime_args_data into header and implementation

### DIFF
--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -7,6 +7,7 @@ set(IMPL_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/kernels/runtime_args_data.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/allocator/algorithms/free_list.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/allocator/allocator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/allocator/basic_allocator.cpp

--- a/tt_metal/impl/kernels/runtime_args_data.cpp
+++ b/tt_metal/impl/kernels/runtime_args_data.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/kernels/runtime_args_data.hpp" // Public API Header
+
+#include "tt_metal/common/assert.hpp"
+
+namespace tt::tt_metal {
+
+std::uint32_t & RuntimeArgsData::operator[](std::size_t index) {
+    TT_ASSERT(index < rt_args_count, "Index specified is larger than runtime args size");
+    return this->rt_args_data[index];
+}
+
+const std::uint32_t & RuntimeArgsData::operator[](std::size_t index) const {
+    TT_ASSERT(index < rt_args_count, "Index specified is larger than runtime args size");
+    return this->rt_args_data[index];
+}
+
+std::uint32_t & RuntimeArgsData::at(std::size_t index) {
+    TT_FATAL(index < rt_args_count, "Index specified is larger than runtime args size");
+    return this->rt_args_data[index];
+}
+
+const std::uint32_t & RuntimeArgsData::at(std::size_t index) const {
+    TT_FATAL(index < rt_args_count, "Index specified is larger than runtime args size");
+    return this->rt_args_data[index];
+}
+
+std::uint32_t * RuntimeArgsData::data() noexcept {
+    return rt_args_data;
+}
+
+const std::uint32_t * RuntimeArgsData::data() const noexcept {
+    return rt_args_data;
+}
+
+std::size_t RuntimeArgsData::size() const noexcept {
+    return rt_args_count;
+}
+
+}
+

--- a/tt_metal/impl/kernels/runtime_args_data.hpp
+++ b/tt_metal/impl/kernels/runtime_args_data.hpp
@@ -16,19 +16,19 @@ struct RuntimeArgsData {
     std::uint32_t * rt_args_data;
     std::size_t rt_args_count;
 
-    inline std::uint32_t & operator[](std::size_t index);
+    std::uint32_t & operator[](std::size_t index);
 
-    inline const std::uint32_t& operator[](std::size_t index) const;
+    const std::uint32_t& operator[](std::size_t index) const;
 
-    inline std::uint32_t & at(std::size_t index);
+    std::uint32_t & at(std::size_t index);
 
-    inline const std::uint32_t& at(std::size_t index) const;
+    const std::uint32_t& at(std::size_t index) const;
 
-    inline std::uint32_t * data() noexcept;
+    std::uint32_t * data() noexcept;
 
-    inline const std::uint32_t * data() const noexcept;
+    const std::uint32_t * data() const noexcept;
 
-    inline std::size_t size() const noexcept;
+    std::size_t size() const noexcept;
 };
 
 }

--- a/tt_metal/impl/kernels/runtime_args_data.hpp
+++ b/tt_metal/impl/kernels/runtime_args_data.hpp
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include "tt_metal/common/assert.hpp"
+#include <cstddef>
+#include <cstdint>
 
 namespace tt::tt_metal {
 // RuntimeArgsData provides an indirection to the runtime args
@@ -12,34 +13,22 @@ namespace tt::tt_metal {
 // After generation, this points into the cq cmds so that runtime args API calls
 // update the data directly in the command
 struct RuntimeArgsData {
-    uint32_t * rt_args_data;
-    size_t rt_args_count;
+    std::uint32_t * rt_args_data;
+    std::size_t rt_args_count;
 
-    inline uint32_t & operator[](size_t index) {
-        TT_ASSERT(index < rt_args_count, "Index specified is larger than runtime args size");
-        return this->rt_args_data[index];
-    }
-    inline const uint32_t& operator[](size_t index) const {
-        TT_ASSERT(index < rt_args_count, "Index specified is larger than runtime args size");
-        return this->rt_args_data[index];
-    }
-    inline uint32_t & at(size_t index) {
-        TT_FATAL(index < rt_args_count, "Index specified is larger than runtime args size");
-        return this->rt_args_data[index];
-    }
-    inline const uint32_t& at(size_t index) const {
-        TT_FATAL(index < rt_args_count, "Index specified is larger than runtime args size");
-        return this->rt_args_data[index];
-    }
-    inline uint32_t * data() noexcept {
-        return rt_args_data;
-    }
-    inline const uint32_t * data() const noexcept {
-        return rt_args_data;
-    }
-    inline size_t size() const noexcept{
-        return rt_args_count;
-    }
+    inline std::uint32_t & operator[](std::size_t index);
+
+    inline const std::uint32_t& operator[](std::size_t index) const;
+
+    inline std::uint32_t & at(std::size_t index);
+
+    inline const std::uint32_t& at(std::size_t index) const;
+
+    inline std::uint32_t * data() noexcept;
+
+    inline const std::uint32_t * data() const noexcept;
+
+    inline std::size_t size() const noexcept;
 };
 
-};
+}


### PR DESCRIPTION
### Ticket
#13499 

### Problem description
This is a public header file as it defines a class that is part of the public interface.
It exposes our internal assert header file, and transitively `<fmt>`.
We don't need to expose these internals to client.

### What's changed
Split `runtime_args_data.hpp` into header and implementation.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11378062521
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
