### PR TITLE
#13918: add ShortNamespaceLines to calng format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -55,6 +55,7 @@ DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
+ShortNamespaceLines: 0
 ForEachMacros:
   - foreach
   - Q_FOREACH

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -97,4 +97,4 @@ namespace ttnn::prim {
 constexpr auto moreh_adam = ttnn::register_operation_with_auto_launch_op<
     "ttnn::prim::moreh_adam",
     ttnn::operations::moreh::moreh_adam::MorehAdamOperation>();
-}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/moreh_adam.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/moreh_adam.hpp
@@ -57,4 +57,4 @@ struct MorehAdam {
 namespace ttnn {
 constexpr auto moreh_adam =
     ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_adam", ttnn::operations::moreh::moreh_adam::MorehAdam>();
-}
+}  // namespace ttnn


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13918

### Problem description
It seems that in Tenstorrent's coding style, it's standard to add a comment at the end of a namespace.
However, `ttnn` code has many short namespaces, and clang-format does not automatically add comments for short namespaces.
Pointing out this issue during every PR review is causing unnecessary time waste for both the developer and the reviewer.


ex)
```C++
namespace ttnn::operations::expand {
void bind_expand_operation(py::module& module);
}
->
namespace ttnn::operations::expand {
void bind_expand_operation(py::module& module);
}  // namespace ttnn::operations::moreh::expand
```

### What's changed
 To resolve this, I will add the ShortNamespaceLines option to clang-format so that the issue is automatically addressed.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
