### PR TITLE
#13782: Update .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,10 +1,24 @@
-Checks: >
-  bugprone-*,
-  performance-*,
-  modernize-*,
-  readability-*,
-  cppcoreguidelines-*
-  -modernize-use-trailing-return-type
+Checks: "*,
+        -abseil-*,
+        -altera-*,
+        -android-*,
+        -fuchsia-*,
+        -google-*,
+        -llvm*,
+        -modernize-use-trailing-return-type,
+        -zircon-*,
+        -readability-else-after-return,
+        -readability-static-accessed-through-instance,
+        -readability-avoid-const-params-in-decls,
+        -cppcoreguidelines-non-private-member-variables-in-classes,
+        -misc-non-private-member-variables-in-classes,
+        -include-what-you-use,
+        -cppcoreguidelines-avoid-magic-numbers,
+        -readability-magic-numbers,
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle:     none
 
 CheckOptions:
   - key: readability-identifier-length.IgnoredVariableNames


### PR DESCRIPTION
### Ticket
#13782 

### Problem description
`.clang-tidy` was too generic

### What's changed
Stole settings from @dmakoviichuk-tt 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
