### PR TITLE
#13268: Implement fold

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_fold.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_fold.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from loguru import logger
+from models.utility_functions import comp_allclose_and_pcc
+
+
+def run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype):
+    if dtype == torch.float:
+        torch_input = torch.randn(input_shape, dtype=dtype)
+    elif dtype == torch.bfloat16:
+        # Make bfloat16 input mostly positive by adding 1, thus making output result
+        # more positive and futher from 0 to avoid rounding precision problem with bfloat16
+        torch_input = torch.randn(input_shape, dtype=dtype) + 1
+    torch_fold = torch.nn.Fold(
+        output_size=output_size, kernel_size=kernel_size, dilation=dilation, padding=padding, stride=stride
+    )
+    expected = torch_fold(torch_input)
+
+    tt_dtype = ttnn.bfloat16 if dtype == torch.bfloat16 else ttnn.float32
+    tt_input = ttnn.from_torch(torch_input, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=tt_dtype)
+    tt_out = ttnn.operations.moreh.fold(tt_input, None, output_size, kernel_size, dilation, padding, stride)
+    actual = ttnn.to_torch(tt_out)
+    if dtype == torch.float:
+        passing, out = comp_allclose_and_pcc(expected, actual)
+    elif dtype == torch.bfloat16:
+        passing, out = comp_allclose_and_pcc(expected, actual, rtol=0.05, atol=0.05)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_size,kernel_size,dilation,padding,stride",
+    [
+        [(32, 32), (7, 11), (4, 4), (1, 1), (0, 0), (1, 1)],  # input single tile 2D
+        [(72, 900), (32, 32), (3, 3), (1, 1), (0, 0), (1, 1)],  # input multi tile 2D
+        [(128, 324), (32, 32), (4, 4), (2, 2), (5, 5), (2, 2)],  # input multi tile 2D with padding, dilation, stride
+        [(1, 32, 32), (7, 11), (4, 4), (1, 1), (0, 0), (1, 1)],  # input single tile
+        [(1, 32, 32), (5, 9), (2, 2), (1, 1), (0, 0), (1, 1)],  # input single tile
+        [(1, 32, 32), (5, 9), (2, 2), (2, 2), (2, 4), (2, 2)],  # input single tile with padding, dilation, stride
+        [(1, 9, 32), (6, 10), (3, 3), (1, 1), (0, 0), (1, 1)],  # small
+        [(32, 75, 784), (32, 32), (5, 5), (1, 1), (0, 0), (1, 1)],  # multi tile
+        [(32, 27, 100), (12, 12), (3, 3), (1, 1), (0, 0), (1, 1)],  # multi tile
+        [(5, 64, 36), (12, 12), (4, 4), (2, 2), (3, 3), (2, 2)],  # multi tile with padding, dilation, stride
+        [(5, 144, 42), (14, 16), (6, 6), (2, 2), (4, 4), (2, 2)],  # multi tile with padding, dilation, stride
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float,
+        torch.bfloat16,
+    ],
+)
+def test_fold(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype):
+    torch.manual_seed(2024)
+    run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype)
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_size,kernel_size,dilation,padding,stride",
+    [
+        [(1, 32, 32), (7, 11), (4, 4), (1, 1), (0, 0), (1, 1)],  # input single tile
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float,
+        torch.bfloat16,
+    ],
+)
+def test_fold_callback(
+    device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype, use_program_cache
+):
+    torch.manual_seed(0)
+    num_program_cache_entries_list = []
+    for i in range(2):
+        run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype)
+        # Add dummy tensor to make sure that created tensor in 2 iteration don't share the same addr
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -525,6 +525,10 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_fold/fold_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_fold/fold.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/index_fill/index_fill.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/index_fill/index_fill_pybind.cpp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fold_device_operation.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::moreh::moreh_fold {
+void MorehFoldOperation::validate_inputs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto& input = tensor_args.input;
+    auto input_shape = input.get_logical_shape();
+
+    TT_FATAL(input.get_layout() == Layout::ROW_MAJOR, "Fold: only support input in ROW_MAJOR");
+    TT_FATAL(operation_attributes.output_size.size() == 2, "Fold: output_size takes 2 elements");
+    TT_FATAL(operation_attributes.kernel_size.size() == 2, "Fold: kernel_size takes 2 elements");
+    TT_FATAL(operation_attributes.dilation.size() == 2, "Fold: dilation takes 2 elements");
+    TT_FATAL(operation_attributes.padding.size() == 2, "Fold: padding takes 2 elements");
+    TT_FATAL(operation_attributes.stride.size() == 2, "Fold: stride takes 2 elements");
+
+    uint32_t kernel_size_product = 1;
+    uint32_t l = 1;
+    for (uint32_t i = 0; i < 2; ++i) {
+        l *=
+            (((operation_attributes.output_size[i] + 2 * operation_attributes.padding[i] -
+               operation_attributes.dilation[i] * (operation_attributes.kernel_size[i] - 1) - 1) /
+              operation_attributes.stride[i]) +
+             1);
+        kernel_size_product *= operation_attributes.kernel_size[i];
+    }
+    auto input_rank = input.get_logical_shape().rank();
+
+    TT_FATAL((input_rank == 3) || (input_rank == 2), "Fold: Only support 3D or 2D input tensor");
+    TT_FATAL(input_shape[input_rank - 1] == l, "Fold: Invalid input tensor size");
+    TT_FATAL(input_shape[input_rank - 2] % kernel_size_product == 0, "Fold: Invalid input tensor size");
+
+    if (tensor_args.output) {
+        auto output_shape = tensor_args.output->get_logical_shape();
+        auto output_rank = tensor_args.output->get_logical_shape().rank();
+        TT_FATAL(
+            output_shape[output_rank - 3] == input_shape[input_rank - 2] / kernel_size_product,
+            "Fold: Invalid output tensor size");
+        TT_FATAL(
+            output_shape[output_rank - 2] == operation_attributes.output_size[0], "Fold: Invalid output shape size");
+        TT_FATAL(
+            output_shape[output_rank - 1] == operation_attributes.output_size[1], "Fold: Invalid output shape size");
+        TT_FATAL(output_rank == 4 || output_rank == 3, "Fold: Only support 4D and 3D output tensor");
+    }
+}
+
+MorehFoldOperation::program_factory_t MorehFoldOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return ProgramFactory{};
+};
+
+void MorehFoldOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_inputs(operation_attributes, tensor_args);
+};
+
+void MorehFoldOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_inputs(operation_attributes, tensor_args);
+};
+
+MorehFoldOperation::shape_return_value_t MorehFoldOperation::compute_output_shapes(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto input_tensor_shape = tensor_args.input.get_logical_shape();
+    auto input_tensor_rank = tensor_args.input.get_logical_shape().rank();
+    uint32_t kernel_size_product = operation_attributes.kernel_size[0] * operation_attributes.kernel_size[1];
+    if (input_tensor_rank == 3) {
+        uint32_t N = input_tensor_shape[0];
+        uint32_t C = input_tensor_shape[1] / kernel_size_product;
+        auto output_shape =
+            ttnn::SimpleShape{N, C, operation_attributes.output_size[0], operation_attributes.output_size[1]};
+        return output_shape;
+    }
+    // If input_tensor_rank == 2
+    uint32_t C = input_tensor_shape[0] / kernel_size_product;
+    auto output_shape = ttnn::SimpleShape{C, operation_attributes.output_size[0], operation_attributes.output_size[1]};
+    return output_shape;
+};
+
+MorehFoldOperation::tensor_return_value_t MorehFoldOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output.value();
+    }
+
+    const auto& output_shape = compute_output_shapes(operation_attributes, tensor_args);
+
+    return create_device_tensor(
+        output_shape,
+        tensor_args.input.get_dtype(),
+        tensor_args.input.get_layout(),
+        tensor_args.input.device(),
+        operation_attributes.memory_config);
+}
+
+std::tuple<MorehFoldOperation::operation_attributes_t, MorehFoldOperation::tensor_args_t> MorehFoldOperation::invoke(
+    const Tensor& input,
+    const std::optional<Tensor>& output,
+    const std::vector<uint32_t> output_size,
+    const std::vector<uint32_t> kernel_size,
+    const std::vector<uint32_t> dilation,
+    const std::vector<uint32_t> padding,
+    const std::vector<uint32_t> stride,
+    const std::optional<MemoryConfig>& memory_config) {
+    return {
+        operation_attributes_t{
+            output_size, kernel_size, dilation, padding, stride, memory_config.value_or(input.memory_config())},
+        tensor_args_t{input, output}};
+}
+}  // namespace ttnn::operations::moreh::moreh_fold

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::moreh::moreh_fold {
+
+struct MorehFoldOperation {
+    struct operation_attributes_t {
+        const std::vector<uint32_t> output_size;
+        const std::vector<uint32_t> kernel_size;
+        const std::vector<uint32_t> dilation;
+        const std::vector<uint32_t> padding;
+        const std::vector<uint32_t> stride;
+        const MemoryConfig memory_config;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input;
+        const std::optional<Tensor>& output;
+    };
+
+    using shape_return_value_t = SimpleShape;
+    using tensor_return_value_t = Tensor;
+
+    struct ProgramFactory {
+        struct shared_variables_t {
+            KernelHandle unary_reader_kernel_id;
+            KernelHandle unary_writer_kernel_id;
+            std::vector<CoreCoord> cores;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+
+    static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        const std::optional<Tensor>& output,
+        const std::vector<uint32_t> output_size,
+        const std::vector<uint32_t> kernel_size,
+        const std::vector<uint32_t> dilation,
+        const std::vector<uint32_t> padding,
+        const std::vector<uint32_t> stride,
+        const std::optional<MemoryConfig>& memory_config);
+};
+}  // namespace ttnn::operations::moreh::moreh_fold
+
+namespace ttnn::prim {
+constexpr auto moreh_fold =
+    ttnn::register_operation<"ttnn::prim::fold", ttnn::operations::moreh::moreh_fold::MorehFoldOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_program_factory_rm.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "fold_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+
+namespace ttnn::operations::moreh::moreh_fold {
+
+MorehFoldOperation::ProgramFactory::cached_program_t MorehFoldOperation::ProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& input = tensor_args.input;
+
+    auto output_size = operation_attributes.output_size;
+    auto kernel_size = operation_attributes.kernel_size;
+    auto dilation = operation_attributes.dilation;
+    auto padding = operation_attributes.padding;
+    auto stride = operation_attributes.stride;
+    auto output_shape = output.get_logical_shape();
+    auto output_shape_rank = output.get_logical_shape().rank();
+
+    uint32_t kernel_size_product = 1;
+    std::vector<uint32_t> ls;
+    uint32_t L = 1;
+    for (uint32_t i = 0; i < 2; ++i) {
+        uint32_t l = (((output_size[i] + 2 * padding[i] - dilation[i] * (kernel_size[i] - 1) - 1) / stride[i]) + 1);
+        L *= l;
+        ls.push_back(l);
+        kernel_size_product *= kernel_size[i];
+    }
+    uint32_t N = output_shape_rank == 4 ? output_shape[0] : 1;
+    uint32_t C = output_shape_rank == 4 ? output_shape[1] : output_shape[0];
+    uint32_t H = output_shape_rank == 4 ? output_shape[2] : output_shape[1];
+    uint32_t W = output_shape_rank == 4 ? output_shape[3] : output_shape[2];
+    uint32_t kernel_size_h = kernel_size[0];
+    uint32_t kernel_size_w = kernel_size[1];
+    uint32_t stride_h = stride[0];
+    uint32_t stride_w = stride[1];
+    uint32_t padding_h = padding[0];
+    uint32_t padding_w = padding[1];
+    uint32_t dilation_h = dilation[0];
+    uint32_t dilation_w = dilation[1];
+    uint32_t LH = ls[0];
+    uint32_t LW = ls[1];
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    Program program{};
+    Device* device = input.device();
+
+    uint32_t num_units = output.get_logical_volume() / output.get_logical_shape()[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_units);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+
+    uint32_t unit_size = input.element_size();
+    uint32_t input_cb_page_size = unit_size * input.get_logical_shape()[-1];
+    uint32_t output_cb_page_size = unit_size * output.get_logical_shape()[-1];
+
+    uint32_t aligned_input_cb_page_size = round_up_to_mul32(input_cb_page_size);
+    uint32_t aligned_output_cb_page_size = round_up_to_mul32(output_cb_page_size);
+
+    uint32_t input_cb_index = tt::CB::c_in0;    // input
+    uint32_t output_cb_index = tt::CB::c_out0;  // ouput
+
+    CircularBufferConfig input_cb_config =
+        CircularBufferConfig(aligned_input_cb_page_size * 2, {{input_cb_index, data_format}})
+            .set_page_size(input_cb_index, aligned_input_cb_page_size);
+    auto input_cb = CreateCircularBuffer(program, all_cores, input_cb_config);
+
+    CircularBufferConfig output_cb_config =
+        CircularBufferConfig(aligned_output_cb_page_size * 2, {{output_cb_index, data_format}})
+            .set_page_size(output_cb_index, aligned_output_cb_page_size);
+    auto output_cb = CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Kernels defines
+    ////////////////////////////////////////////////////////////////////////////
+    std::map<string, string> reader_defines;
+    std::map<string, string> writer_defines;
+
+    switch (input.get_dtype()) {
+        case DataType::BFLOAT16: reader_defines["DTYPE_BFLOAT16"] = "1"; break;
+        case DataType::FLOAT32: reader_defines["DTYPE_FLOAT32"] = "1"; break;
+        default: break;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    bool input_is_dram = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    bool output_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    const std::vector<uint32_t> reader_compile_time_args{
+        static_cast<uint32_t>(input_is_dram),
+        static_cast<uint32_t>(input_cb_index),
+        static_cast<uint32_t>(output_cb_index),
+    };
+
+    std::vector<uint32_t> writer_compile_time_args{
+        static_cast<uint32_t>(output_is_dram),
+        static_cast<uint32_t>(output_cb_index),
+    };
+
+    const auto reader_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp";
+    const auto writer_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp";
+
+    const auto reader_kernel_id = tt::operations::primary::CreateReadKernel(
+        program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
+    const auto writer_kernel_id = tt::operations::primary::CreateWriteKernel(
+        program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const auto input_addr = input.buffer()->address();
+    const auto output_addr = output.buffer()->address();
+
+    uint32_t start_id = 0;
+    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
+    uint32_t g1_numcores = core_group_1.num_cores();
+    for (uint32_t i = 0; i < cores.size(); ++i) {
+        const CoreCoord& core = cores.at(i);
+        uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
+
+        std::vector<uint32_t> reader_args = {
+            input.buffer()->address(),
+            N,
+            C,
+            H,
+            W,
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            dilation_h,
+            dilation_w,
+            LH,
+            LW,
+            aligned_input_cb_page_size,
+            aligned_output_cb_page_size,
+            start_id,
+            num_units_per_core};
+
+        std::vector<uint32_t> writer_args = {
+            output.buffer()->address(), aligned_output_cb_page_size, start_id, num_units_per_core};
+
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+        start_id += num_units_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, cores}};
+}
+
+void MorehFoldOperation::ProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto& cores = cached_program.shared_variables.cores;
+    auto input_buffer_address = tensor_args.input.buffer()->address();
+    auto output_buffer_address = output.buffer()->address();
+
+    for (const auto& core : cores) {
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = input_buffer_address;
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = output_buffer_address;
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_fold

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/reader_fold_rm.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    int i{0};
+    const uint32_t input_addr = get_arg_val<uint32_t>(0);
+    const uint32_t N = get_arg_val<uint32_t>(1);
+    const uint32_t C = get_arg_val<uint32_t>(2);
+    const uint32_t H = get_arg_val<uint32_t>(3);
+    const uint32_t W = get_arg_val<uint32_t>(4);
+    const uint32_t kernel_size_h = get_arg_val<uint32_t>(5);
+    const uint32_t kernel_size_w = get_arg_val<uint32_t>(6);
+    const uint32_t stride_h = get_arg_val<uint32_t>(7);
+    const uint32_t stride_w = get_arg_val<uint32_t>(8);
+    const uint32_t padding_h = get_arg_val<uint32_t>(9);
+    const uint32_t padding_w = get_arg_val<uint32_t>(10);
+    const uint32_t dilation_h = get_arg_val<uint32_t>(11);
+    const uint32_t dilation_w = get_arg_val<uint32_t>(12);
+    const uint32_t LH = get_arg_val<uint32_t>(13);
+    const uint32_t LW = get_arg_val<uint32_t>(14);
+    const uint32_t input_cb_page_size = get_arg_val<uint32_t>(15);
+    const uint32_t output_cb_page_size = get_arg_val<uint32_t>(16);
+    const uint32_t start_id = get_arg_val<uint32_t>(17);
+    const uint32_t num_units_per_core = get_arg_val<uint32_t>(18);
+
+    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t onetile = 1;
+
+    uint32_t P = kernel_size_h * kernel_size_w;
+    uint32_t l = LH * LW;
+
+    const InterleavedAddrGen<input_is_dram> s0 = {.bank_base_address = input_addr, .page_size = input_cb_page_size};
+
+    for (uint32_t row_id = start_id; row_id < start_id + num_units_per_core; row_id++) {
+        cb_reserve_back(output_cb_id, onetile);
+        for (uint32_t elem_id = 0; elem_id < W; elem_id++) {
+            uint32_t gid = row_id * W + elem_id;
+            uint32_t nch = gid / W;
+            uint32_t w = gid % W;
+            uint32_t nc = nch / H;
+            uint32_t h = nch % H;
+            uint32_t n = nc / C;
+            uint32_t c = nc % C;
+            float sum = 0.0f;
+            for (uint32_t ph = 0; ph < kernel_size_h; ++ph) {
+                for (uint32_t pw = 0; pw < kernel_size_w; ++pw) {
+                    uint32_t lhsh = h - ph * dilation_h + padding_h;
+                    uint32_t lwsw = w - pw * dilation_w + padding_w;
+                    if (lhsh % stride_h != 0)
+                        continue;
+                    if (lwsw % stride_w != 0)
+                        continue;
+                    uint32_t lh = lhsh / stride_h;
+                    uint32_t lw = lwsw / stride_w;
+                    if (lh < 0 || LH <= lh)
+                        continue;
+                    if (lw < 0 || LW <= lw)
+                        continue;
+
+                    // Input size is {N, C * kernel_size_h * kernel_size_w, LH * LW} or {C * kernel_size_h *
+                    // kernel_size_w, LH * LW}
+                    uint32_t input_row_id = n * C * P + (c * P + ph * kernel_size_w + pw);
+                    // Read entire row into input_cb
+                    cb_reserve_back(input_cb_id, onetile);
+                    uint32_t l1_write_addr = get_write_ptr(input_cb_id);
+                    uint64_t src_noc_addr = get_noc_addr(input_row_id, s0);
+                    noc_async_read(src_noc_addr, l1_write_addr, input_cb_page_size);
+                    noc_async_read_barrier();
+                    cb_push_back(input_cb_id, onetile);
+
+                    cb_wait_front(input_cb_id, onetile);
+#ifdef DTYPE_BFLOAT16
+                    uint16_t *input_cb_ptr_uint16 = reinterpret_cast<uint16_t *>(get_read_ptr(input_cb_id));
+                    uint16_t bfloat16_value = input_cb_ptr_uint16[lh * LW + lw];
+                    uint32_t float_value_as_int = static_cast<uint32_t>(bfloat16_value) << 16;
+                    auto tmp = reinterpret_cast<float *>(&float_value_as_int);
+                    float value_as_float = *tmp;
+                    sum += value_as_float;
+#endif
+#ifdef DTYPE_FLOAT32
+                    auto input_cb_ptr_float = reinterpret_cast<float *>(get_read_ptr(input_cb_id));
+                    sum += input_cb_ptr_float[lh * LW + lw];
+#endif
+                    cb_pop_front(input_cb_id, onetile);
+                }
+            }
+#ifdef DTYPE_BFLOAT16
+            uint16_t *output_cb_write_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(output_cb_id));
+            auto sum_ptr = reinterpret_cast<uint16_t *>(&sum) + 1;
+            output_cb_write_ptr[w] = *sum_ptr;
+#endif
+#ifdef DTYPE_FLOAT32
+            float *output_cb_write_ptr = reinterpret_cast<float *>(get_write_ptr(output_cb_id));
+            output_cb_write_ptr[w] = sum;
+#endif
+        }
+        cb_push_back(output_cb_id, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/kernels/writer_fold_rm.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t output_addr = get_arg_val<uint32_t>(0);
+    const uint32_t output_cb_page_size = get_arg_val<uint32_t>(1);
+    const uint32_t start_id = get_arg_val<uint32_t>(2);
+    const uint32_t num_units_per_core = get_arg_val<uint32_t>(3);
+    constexpr bool output_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);
+
+    constexpr int onetile = 1;
+
+    const InterleavedAddrGen<output_is_dram> s = {.bank_base_address = output_addr, .page_size = output_cb_page_size};
+
+    for (uint32_t i = start_id; i < start_id + num_units_per_core; i++) {
+        cb_wait_front(output_cb_id, onetile);
+        uint32_t l1_read_addr = get_read_ptr(output_cb_id);
+        uint64_t dst_noc_addr = get_noc_addr(i, s);
+        noc_async_write(l1_read_addr, dst_noc_addr, output_cb_page_size);
+        noc_async_write_barrier();
+        cb_pop_front(output_cb_id, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fold.hpp"
+
+#include "device/fold_device_operation.hpp"
+
+namespace ttnn::operations::moreh::moreh_fold {
+Tensor MorehFold::invoke(
+    const Tensor& input,
+    const std::optional<Tensor>& output,
+    const std::vector<uint32_t> output_size,
+    const std::vector<uint32_t> kernel_size,
+    const std::vector<uint32_t> dilation,
+    const std::vector<uint32_t> padding,
+    const std::vector<uint32_t> stride,
+    const std::optional<MemoryConfig>& memory_config) {
+    return ttnn::prim::moreh_fold(input, output, output_size, kernel_size, dilation, padding, stride, memory_config);
+}
+
+}  // namespace ttnn::operations::moreh::moreh_fold

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::moreh::moreh_fold {
+struct MorehFold {
+    static Tensor invoke(
+        const Tensor& input,
+        const std::optional<Tensor>& output,
+        const std::vector<uint32_t> output_size,
+        const std::vector<uint32_t> kernel_size,
+        const std::vector<uint32_t> dilation,
+        const std::vector<uint32_t> padding,
+        const std::vector<uint32_t> stride,
+        const std::optional<MemoryConfig>& memory_config);
+};
+}  // namespace ttnn::operations::moreh::moreh_fold
+
+namespace ttnn {
+constexpr auto moreh_fold =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_fold", ttnn::operations::moreh::moreh_fold::MorehFold>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold_pybind.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fold_pybind.hpp"
+
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/moreh/moreh_fold/fold.hpp"
+
+namespace ttnn::operations::moreh::moreh_fold {
+void bind_moreh_fold_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::moreh_fold,
+        "Moreh Fold Operation",
+        ttnn::pybind_arguments_t{
+            py::arg("input"),
+            py::arg("output") = std::nullopt,
+            py::arg("output_size"),
+            py::arg("kernel_size"),
+            py::arg("dilation") = std::vector<uint32_t>{1, 1},
+            py::arg("padding") = std::vector<uint32_t>{0, 0},
+            py::arg("stride") = std::vector<uint32_t>{1, 1},
+            py::arg("memory_config") = std::nullopt});
+}
+}  // namespace ttnn::operations::moreh::moreh_fold

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_fold {
+void bind_moreh_fold_operation(py::module& module);
+}  // namespace ttnn::operations::moreh::moreh_fold

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
@@ -9,9 +9,10 @@
 #include "ttnn/operations/moreh/moreh_arange/moreh_arange_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.hpp"
-#include "ttnn/operations/moreh/moreh_dot/moreh_dot_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_cumsum/moreh_cumsum_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_dot/moreh_dot_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_dot_backward/moreh_dot_backward_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_fold/fold_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_getitem/moreh_getitem_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_group_norm/moreh_group_norm_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward_pybind.hpp"
@@ -45,6 +46,7 @@ void bind_moreh_operations(py::module &module) {
     moreh_cumsum::bind_moreh_cumsum_operation(module);
     moreh_dot_backward::bind_moreh_dot_backward_operation(module);
     moreh_dot::bind_moreh_dot_operation(module);
+    moreh_fold::bind_moreh_fold_operation(module);
     moreh_getitem::bind_moreh_getitem_operation(module);
     moreh_group_norm_backward::bind_moreh_group_norm_backward_operation(module);
     moreh_group_norm::bind_moreh_group_norm_operation(module);
@@ -52,8 +54,8 @@ void bind_moreh_operations(py::module &module) {
     moreh_layer_norm::bind_moreh_layer_norm_operation(module);
     moreh_linear_backward::bind_moreh_linear_backward_operation(module);
     moreh_linear::bind_moreh_linear_operation(module);
-    moreh_matmul::bind_moreh_matmul_operation(module);
     moreh_matmul_backward::bind_moreh_matmul_backward_operation(module);
+    moreh_matmul::bind_moreh_matmul_operation(module);
     moreh_mean_backward::bind_moreh_mean_backward_operation(module);
     moreh_mean::bind_moreh_mean_operation(module);
     moreh_nll_loss_backward::bind_moreh_nll_loss_backward_operation(module);

--- a/ttnn/ttnn/operations/moreh.py
+++ b/ttnn/ttnn/operations/moreh.py
@@ -13,6 +13,7 @@ cumsum = ttnn._ttnn.operations.moreh.moreh_cumsum
 cumsum_backward = ttnn._ttnn.operations.moreh.moreh_cumsum_backward
 dot = ttnn._ttnn.operations.moreh.moreh_dot
 dot_backward = ttnn._ttnn.operations.moreh.moreh_dot_backward
+fold = ttnn._ttnn.operations.moreh.moreh_fold
 getitem = ttnn._ttnn.operations.moreh.moreh_getitem
 group_norm = ttnn._ttnn.operations.moreh.moreh_group_norm
 group_norm_backward = ttnn._ttnn.operations.moreh.moreh_group_norm_backward


### PR DESCRIPTION
### Ticket
Link to Github Issue: [#13268](https://github.com/tenstorrent/tt-metal/issues/13268)

### Problem description
The current fold implementation in tt-metal is incomplete as it doesn't support output_size, kernel_size, and dilation like pytorch fold.

### What's changed
I implemented a new fold operation in moreh_fold to support params exactly like pytorch.
I will clean up old fold implementation in later commits if possible. The current fold implementation is used in some tests and models (Like resnet) so it is hard to clean up.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11604992148
- [x] Blackhole Post commit (if applicable): NA
- [x] Model regression CI testing passes (if applicable): NA
- [x] Device performance regression CI testing passes (if applicable): NA
- [x] New/Existing tests provide coverage for changes: 15/15 tests passed
