### PR TITLE
#13931: Implement index fill

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_index_fill.py
+++ b/tests/ttnn/unit_tests/operations/test_index_fill.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import ttnn
+import torch
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+def run_index_fill_test(shape, dim, value, dtype, device):
+    if len(shape) - 1 < dim:
+        pytest.skip("Given dim is higher than tensor rank")
+
+    if dtype == torch.int32:
+        torch_input = torch.randint(0, 100, shape, dtype=torch.int32)
+    else:
+        torch_input = torch.rand(shape, dtype=dtype)
+    torch_index = torch.tensor([0, 2])
+    torch_output = torch.index_fill(torch_input, dim, torch_index, value)
+
+    tt_input = ttnn.from_torch(torch_input, device=device)
+    tt_index = ttnn.from_torch(torch_index, device=device)
+
+    ttnn_output = ttnn.index_fill(tt_input, dim, tt_index, value)
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert assert_equal(ttnn_output, torch_output)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [32, 32],  # multiple of 32
+        [12, 24],  # not multiple of 32
+        [23, 41, 32],  # multiple of 32
+        [9, 5, 38],  # not multiple of 32
+        [3, 4, 5, 32],  # multiple of 32
+        [41, 21, 33, 34],  # not multiple of 32,
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    [
+        0,
+        1,
+        2,
+        3,
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        2.5,
+        1.72,
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float32,
+        torch.bfloat16,
+    ],
+)
+def test_index_fill_float(shape, dim, value, dtype, device):
+    torch.manual_seed(2024)
+
+    run_index_fill_test(shape, dim, value, dtype, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [32, 32],  # multiple of 32
+        [12, 23],  # not multiple of 32
+        [27, 12, 32],  # multiple of 32
+        [61, 3, 6],  # not multiple of 32
+        [6, 3, 7, 32],  # multiple of 32
+        [13, 15, 22, 13],  # not multiple of 32
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    [
+        0,
+        1,
+        2,
+        3,
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        15,
+        12,
+    ],
+)
+def test_index_fill_int(shape, dim, value, device):
+    torch.manual_seed(2024)
+
+    run_index_fill_test(shape, dim, value, torch.int32, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [32, 32],  # multiple of 32
+        [12, 23],  # not multiple of 32
+        [27, 12, 32],  # multiple of 32
+        [61, 3, 6],  # not multiple of 32
+        [4, 3, 7, 32],  # multiple of 32
+        [13, 15, 22, 13],  # not multiple of 32
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    [
+        0,
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        2002,
+    ],
+)
+def test_index_fill_callback(shape, dim, value, device, use_program_cache):
+    torch.manual_seed(2024)
+    for i in range(2):
+        run_index_fill_test(shape, dim, value, torch.int32, device)
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -519,6 +519,11 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/index_fill/index_fill.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/index_fill/index_fill_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
 )
 
 #Split src and python bindings

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -29,6 +29,7 @@
 #include "ttnn/operations/experimental/experimental_pybind.hpp"
 #include "ttnn/operations/full/full_pybind.hpp"
 #include "ttnn/operations/full_like/full_like_pybind.hpp"
+#include "ttnn/operations/index_fill/index_fill_pybind.hpp"
 #include "ttnn/operations/kv_cache/kv_cache_pybind.hpp"
 #include "ttnn/operations/loss/loss_pybind.hpp"
 #include "ttnn/operations/matmul/matmul_pybind.hpp"
@@ -148,6 +149,9 @@ void py_module(py::module& module) {
 
     auto m_uniform = module.def_submodule("uniform", "uniform operations");
     uniform::bind_uniform_operation(m_uniform);
+
+    auto m_index_fill = module.def_submodule("index_fill", "index_fill operation");
+    index_fill::bind_index_fill_operation(m_index_fill);
 }
 }  // namespace operations
 

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "index_fill_device_operation.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::index_fill {
+IndexFillOperation::program_factory_t IndexFillOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return MultiCore{};
+}
+
+void IndexFillOperation::validate(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    const auto& index = tensor_args.index;
+    const uint32_t dim = operation_attributes.dim;
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Index fill: Input must be on device");
+    TT_FATAL(input.buffer() != nullptr, "Index fill: Input must be allocated in buffer on device");
+    TT_FATAL(
+        input.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Index fill: Not currently supporting sharding");
+    TT_FATAL(
+        operation_attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Index fill: Not currently supporting sharding");
+    TT_FATAL(index.get_logical_shape().rank() == 1,
+        "Index fill: Index tensor must be 1D!");
+    TT_FATAL(
+        dim < input.get_logical_shape().rank() && dim >= 0,
+        "Index fill: Invalid dimension");
+    TT_FATAL(index.get_logical_shape().rank() == 1,
+        "Index fill: Index tensor must be 1D!");
+}
+void IndexFillOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate(operation_attributes, tensor_args);
+}
+void IndexFillOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate(operation_attributes, tensor_args);
+}
+IndexFillOperation::shape_return_value_t IndexFillOperation::compute_output_shapes(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return tensor_args.input.get_logical_shape();
+}
+IndexFillOperation::tensor_return_value_t IndexFillOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
+    const auto& input = tensor_args.input;
+    return create_device_tensor(
+        output_shape,
+        input.tensor_attributes->dtype,
+        input.tensor_attributes->layout,
+        input.device(),
+        operation_attributes.memory_config);
+}
+std::tuple<IndexFillOperation::operation_attributes_t, IndexFillOperation::tensor_args_t> IndexFillOperation::invoke(
+    const Tensor& input,
+    const uint32_t dim,
+    const Tensor& index,
+    const std::variant<float, int> value,
+    const std::optional<MemoryConfig>& memory_config) {
+    return {
+        operation_attributes_t{dim, value, memory_config.value_or(input.memory_config())}, tensor_args_t{input, index}};
+}
+}  // namespace ttnn::operations::index_fill

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <optional>
+#include <variant>
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+namespace ttnn::operations::index_fill {
+struct IndexFillOperation {
+    struct operation_attributes_t {
+        const uint32_t dim;
+        const std::variant<float, int> value;
+        const MemoryConfig memory_config;
+    };
+    struct tensor_args_t {
+        const Tensor& input;
+        const Tensor& index;
+    };
+    using shape_return_value_t = SimpleShape;
+    using tensor_return_value_t = Tensor;
+    struct MultiCore {
+        struct shared_variables_t {
+            KernelHandle reader_kernel_id;
+            KernelHandle writer_kernel_id;
+            std::size_t num_cores;
+            std::size_t num_cores_y;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+    using program_factory_t = std::variant<MultiCore>;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate(const operation_attributes_t&, const tensor_args_t&);
+    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        const uint32_t dim,
+        const Tensor& index,
+        const std::variant<float, int> value,
+        const std::optional<MemoryConfig>& memory_config);
+};
+}  // namespace ttnn::operations::index_fill
+namespace ttnn::prim {
+constexpr auto index_fill =
+    ttnn::register_operation<"ttnn::prim::index_fill", ttnn::operations::index_fill::IndexFillOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "host_api.hpp"
+#include "impl/buffers/circular_buffer_types.hpp"
+#include "index_fill_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "tt_metal/host_api.hpp"
+#include "ttnn/tensor/types.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+using namespace tt::constants;
+using namespace tt::tt_metal::detail;
+
+union datatype {
+    uint32_t u32;
+    float f32;
+} u_fill_value;
+
+namespace ttnn::operations::index_fill {
+IndexFillOperation::MultiCore::cached_program_t IndexFillOperation::MultiCore::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    const Tensor& index = tensor_args.index;
+    const Tensor& input = tensor_args.input;
+    uint32_t dim = operation_attributes.dim;
+
+    auto dtype = input.get_dtype();
+
+    const auto input_shape = input.get_logical_shape();
+    const auto n = input_shape.rank();
+
+    uint32_t num_rows_to_fill_per_index = 1;
+    for (int i = n - 2; i > dim; i--) {
+        num_rows_to_fill_per_index *= input_shape[i];
+    }
+
+    auto fill_value = operation_attributes.value;
+    if (std::holds_alternative<int>(fill_value)) {
+        u_fill_value.u32 = std::get<int>(fill_value);
+    } else if (std::holds_alternative<float>(fill_value)) {
+        u_fill_value.f32 = std::get<float>(fill_value);
+    }
+
+    auto num_rows = input.volume() / input.get_logical_shape()[-1];
+    Program program{};
+    Device* device = input.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows);
+
+    auto input_data_format = datatype_to_dataformat_converter(dtype);
+    auto index_data_format = datatype_to_dataformat_converter(index.get_dtype());
+    auto output_data_format = datatype_to_dataformat_converter(output.get_dtype());
+
+    uint32_t input_unit_size = input.get_logical_shape()[-1] * input.element_size();
+    uint32_t rounded_input_unit_size = round_up_to_mul32(input_unit_size);
+
+    uint32_t index_unit_size = index.volume() * index.element_size();
+    uint32_t rounded_index_unit_size = round_up_to_mul32(index_unit_size);
+
+    uint32_t output_unit_size = output.get_logical_shape()[-1] * output.element_size();
+    uint32_t rounded_output_unit_size = round_up_to_mul32(output_unit_size);
+
+    auto src_cb_index = CB::c_in0;
+    CircularBufferConfig cb_src_config =
+        CircularBufferConfig(rounded_input_unit_size, {{src_cb_index, input_data_format}})
+            .set_page_size(src_cb_index, rounded_input_unit_size);
+    auto cb_src = CreateCircularBuffer(program, all_cores, cb_src_config);
+    std::map<string, string> reader_defines;
+
+    switch (dtype) {
+        case DataType::BFLOAT16: reader_defines["OUTPUT_DTYPE_BFLOAT16"] = "1"; break;
+        case DataType::INT32: reader_defines["OUTPUT_DTYPE_INT32"] = "1"; break;
+        case DataType::FLOAT32: reader_defines["OUTPUT_DTYPE_FLOAT32"] = "1"; break;
+        default:
+            TT_FATAL(false, "Unsupported datatype");
+            break;
+    }
+
+    auto index_cb_index = CB::c_in1;
+    CircularBufferConfig cb_index_config =
+        CircularBufferConfig(rounded_index_unit_size, {{index_cb_index, index_data_format}})
+            .set_page_size(index_cb_index, rounded_index_unit_size);
+    auto cb_index = CreateCircularBuffer(program, all_cores, cb_index_config);
+
+    auto dst_cb_index = CB::c_out0;
+    CircularBufferConfig dst_cb_config =
+        CircularBufferConfig(rounded_output_unit_size, {{dst_cb_index, output_data_format}})
+            .set_page_size(dst_cb_index, rounded_output_unit_size);
+    auto cb_dst = CreateCircularBuffer(program, all_cores, dst_cb_config);
+
+    bool in_is_dram = input.buffer()->is_dram();
+    bool index_is_dram = index.buffer()->is_dram();
+    bool out_is_dram = output.buffer()->is_dram();
+
+    // Create Kernels
+    // reader
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)in_is_dram,
+        (std::uint32_t)index_is_dram,
+        (std::uint32_t)src_cb_index,
+        (std::uint32_t)index_cb_index,
+        (std::uint32_t)(dim == n - 1)};
+
+    auto reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp",
+        all_cores,
+        ReaderDataMovementConfig(reader_compile_time_args));
+
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)out_is_dram};
+
+    auto writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp",
+        all_cores,
+        WriterDataMovementConfig(writer_compile_time_args));
+
+    uint32_t unit_offset = 0;
+    for (uint32_t i = 0; i < num_cores; i++) {
+        const CoreCoord core(i / num_cores_y, i % num_cores_y);
+
+        uint32_t num_rows_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_FATAL(false, "Core not in specified core ranges");
+        }
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             index.buffer()->address(),
+             u_fill_value.u32,
+             input_unit_size,
+             index_unit_size,
+             unit_offset,
+             num_rows_per_core,
+             input_shape[-1],
+             index.volume(),
+             num_rows_to_fill_per_index,
+             input_shape[dim]});
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {output.buffer()->address(), num_rows_per_core, unit_offset, output_unit_size});
+
+        unit_offset += num_rows_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
+}
+
+void IndexFillOperation::MultiCore::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;
+    auto& num_cores = cached_program.shared_variables.num_cores;
+    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    auto src_buffer = tensor_args.input.buffer()->address();
+    auto index_buffer = tensor_args.index.buffer()->address();
+    auto output_buffer = output.buffer()->address();
+
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_buffer;
+            runtime_args[1] = index_buffer;
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = output_buffer;
+        }
+    }
+}
+
+}  // namespace ttnn::operations::index_fill

--- a/ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+typedef union {
+    float f;
+    uint32_t u;
+} value;
+
+bool is_in_indices(uint32_t *index_ptr, uint32_t size, uint32_t row_id) {
+    for (uint32_t i = 0; i < size; i++) {
+        if (row_id == index_ptr[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void kernel_main() {
+    uint32_t input_addr = get_arg_val<uint32_t>(0);
+    uint32_t index_addr = get_arg_val<uint32_t>(1);
+    uint32_t fill_value = get_arg_val<uint32_t>(2);
+    uint32_t input_page_size = get_arg_val<uint32_t>(3);
+    uint32_t index_page_size = get_arg_val<uint32_t>(4);
+    uint32_t start_row_id = get_arg_val<uint32_t>(5);
+    uint32_t num_rows_per_core = get_arg_val<uint32_t>(6);
+    uint32_t row_size = get_arg_val<uint32_t>(7);
+    uint32_t index_size = get_arg_val<uint32_t>(8);
+    uint32_t num_rows_to_fill_per_index = get_arg_val<uint32_t>(9);
+    uint32_t dim = get_arg_val<uint32_t>(10);
+
+    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool index_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t index_cb_id = get_compile_time_arg_val(3);
+    constexpr bool is_last_dim = get_compile_time_arg_val(4) == 1;
+
+    constexpr uint32_t onetile = 1;
+
+    const InterleavedAddrGen<input_is_dram> s0 = {.bank_base_address = input_addr, .page_size = input_page_size};
+
+    const InterleavedAddrGen<index_is_dram> s1 = {.bank_base_address = index_addr, .page_size = index_page_size};
+
+    value val;
+    val.u = fill_value;
+
+    cb_reserve_back(index_cb_id, onetile);
+
+    uint32_t index_cb_reader = get_write_ptr(index_cb_id);
+    uint64_t index_noc_addr = get_noc_addr(0, s1);
+    noc_async_read(index_noc_addr, index_cb_reader, index_page_size);
+    noc_async_read_barrier();
+    uint32_t *index_ptr = reinterpret_cast<uint32_t *>(index_cb_reader);
+
+    if (is_last_dim) {
+        for (uint32_t row_id = start_row_id; row_id < start_row_id + num_rows_per_core; row_id++) {
+            cb_reserve_back(src_cb_id, onetile);
+            uint32_t src_cb_reader = get_write_ptr(src_cb_id);
+            uint64_t input_noc_addr = get_noc_addr(row_id, s0);
+            noc_async_read(input_noc_addr, src_cb_reader, input_page_size);
+            noc_async_read_barrier();
+
+            uint32_t *input_ptr = reinterpret_cast<uint32_t *>(src_cb_reader);
+
+            for (uint32_t i = 0; i < index_page_size / 4; i++) {
+                uint32_t current_index = index_ptr[i];
+                input_ptr[current_index] = fill_value;
+            }
+
+            cb_push_back(src_cb_id, onetile);
+        }
+    } else {
+        for (uint32_t row_id = start_row_id; row_id < start_row_id + num_rows_per_core; row_id++) {
+            cb_reserve_back(src_cb_id, onetile);
+            uint32_t src_cb_reader = get_write_ptr(src_cb_id);
+            uint64_t input_noc_addr = get_noc_addr(row_id, s0);
+            noc_async_read(input_noc_addr, src_cb_reader, input_page_size);
+            noc_async_read_barrier();
+
+            if (is_in_indices(index_ptr, index_page_size / 4, row_id / num_rows_to_fill_per_index % dim)) {
+#ifdef OUTPUT_DTYPE_BFLOAT16
+                auto ptr = reinterpret_cast<uint16_t *>(write_addr);
+                for (uint32_t i = 0; i < input_page_size / 4; ++i) {
+                    ptr[i] = val.u >> 16;
+                }
+#endif
+#ifdef OUTPUT_DTYPE_INT32
+                auto ptr = reinterpret_cast<uint32_t *>(write_addr);
+                for (uint32_t i = 0; i < input_page_size / 4; ++i) {
+                    ptr[i] = fill_value;
+                }
+#endif
+#ifdef OUTPUT_DTYPE_FLOAT32
+                auto ptr = reinterpret_cast<float *>(write_addr);
+                for (uint32_t i = 0; i < input_page_size / 4; ++i) {
+                    ptr[i] = val.f;
+                }
+#endif
+            }
+            cb_push_back(src_cb_id, onetile);
+        }
+    }
+    cb_push_back(index_cb_id, onetile);
+}

--- a/ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/kernels/writer_index_fill.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
+    uint32_t num_rows_per_core = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t output_unit_size = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t dst_cb_id = tt::CB::c_out0;
+    constexpr uint32_t src_cb_id = tt::CB::c_in0;
+    constexpr bool output_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr uint32_t onetile = 1;
+
+    const InterleavedAddrGen<output_is_dram> s = {
+        .bank_base_address = output_buffer_address,
+        .page_size = output_unit_size,
+    };
+    for (uint32_t i = start_id; i < start_id + num_rows_per_core; i++) {
+        cb_wait_front(src_cb_id, onetile);
+
+        uint32_t writer_ptr = get_read_ptr(src_cb_id);
+        uint64_t output_noc_addr = get_noc_addr(i, s);
+        noc_async_write(writer_ptr, output_noc_addr, output_unit_size);
+        noc_async_write_barrier();
+
+        cb_pop_front(src_cb_id, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/index_fill/index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/index_fill.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "index_fill.hpp"
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/index_fill/device/index_fill_device_operation.hpp"
+
+namespace ttnn::operations::index_fill {
+
+Tensor IndexFill::invoke(
+    const Tensor &input,
+    const uint32_t dim,
+    const Tensor &index,
+    const std::variant<float, int> value,
+    const std::optional<MemoryConfig> &memory_config) {
+    return ttnn::prim::index_fill(input, dim, index, value, memory_config);
+}
+
+}  // namespace ttnn::operations::index_fill

--- a/ttnn/cpp/ttnn/operations/index_fill/index_fill.hpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/index_fill.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::index_fill {
+
+struct IndexFill {
+    static Tensor invoke(
+        const Tensor &input,
+        const uint32_t dim,
+        const Tensor &index,
+        const std::variant<float, int> value,
+        const std::optional<MemoryConfig> &memory_config);
+};
+}  // namespace ttnn::operations::index_fill
+
+namespace ttnn {
+constexpr auto index_fill =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::index_fill", ttnn::operations::index_fill::IndexFill>();
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/index_fill/index_fill_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/index_fill_pybind.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "index_fill_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "index_fill.hpp"
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/index_fill/device/index_fill_device_operation.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::index_fill {
+
+void bind_index_fill_operation(py::module& module) {
+    auto doc =
+        R"doc(index_fill(input: Tensor, dim: uint32, index: Tensor, value: int or float, memory_config: MemoryConfig) -> Tensor
+    Create or fill a tensor with the given value, with the specified `memory_config`.
+    This operation only supports ROW_MAJOR_LAYOUT for now.
+    Args:
+        * :attr:`input`: The tensor that we will operate on
+        * :attr:`dim`: The dimension that we need to fill the value along.
+        * :attr:`index`: The index that we need to fill the value in.
+        * :attr:`value`: The value which will be used to fill the output tensor
+        * :attr:`memory_config`: The memory configuration for the output tensor.
+    )doc";
+
+    bind_registered_operation(
+        module,
+        ttnn::index_fill,
+        doc,
+        ttnn::pybind_arguments_t{
+            py::arg("input"),
+            py::arg("dim"),
+            py::arg("index"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+}  // namespace ttnn::operations::index_fill

--- a/ttnn/cpp/ttnn/operations/index_fill/index_fill_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/index_fill_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::index_fill {
+void bind_index_fill_operation(py::module& module);
+}


### PR DESCRIPTION
### Ticket
Closes: https://github.com/tenstorrent/tt-metal/issues/13931

### Problem description
tt-metal currently does not support the exact version of index fill operation in pytorch

### What's changed
I implemented index fill operation to support exactly like pytorch. (Having input_tensor, index_tensor, dim, value).
Added tests to cover cases:
* All dimension will be tested to fill
* Int and float will be tested accordingly with bfloat16, float32, int32 data type
* Shapes of both multiple and not multiple of 32

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable) - NA
- [x] Model regression CI testing passes (if applicable) - NA
- [x] Device performance regression CI testing passes (if applicable) - NA
- [x] New/Existing tests provide coverage for changes
