### PR TITLE
#13925: Fix bad optional access errors in OPs

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear/moreh_linear.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear/moreh_linear.cpp
@@ -10,7 +10,7 @@ Tensor MorehLinear::invoke(
     const Tensor& input,
     const Tensor& weight,
     const std::optional<Tensor>& bias,
-    std::optional<Tensor>& output,
+    const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
     return ttnn::moreh_matmul(input, weight, false, true, output, bias, memory_config, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear/moreh_linear.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear/moreh_linear.hpp
@@ -13,7 +13,7 @@ struct MorehLinear {
         const Tensor& input,
         const Tensor& weight,
         const std::optional<Tensor>& bias,
-        std::optional<Tensor>& output,
+        const std::optional<Tensor>& output,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig> compute_kernel_config);
 };

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.cpp
@@ -51,6 +51,11 @@ MorehBiasAddBackwardOperation::shape_return_value_t MorehBiasAddBackwardOperatio
 
 MorehBiasAddBackwardOperation::tensor_return_value_t MorehBiasAddBackwardOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.bias_grad.has_value()) {
+        return tensor_args.bias_grad.value();
+    }
+
+    TT_FATAL(tensor_args.bias.has_value(), "bias tensor should not be std::nullopt");
     const auto& output_shape = compute_output_shapes(operation_attributes, tensor_args);
     auto dtype = tensor_args.bias.value().get_dtype();
     Layout layout{Layout::TILE};
@@ -58,9 +63,6 @@ MorehBiasAddBackwardOperation::tensor_return_value_t MorehBiasAddBackwardOperati
 
     auto bias_grad_memory_config = operation_attributes.bias_grad_memory_config;
 
-    if (tensor_args.bias_grad.has_value()) {
-        return tensor_args.bias_grad.value();
-    }
     return create_device_tensor(output_shape, dtype, layout, device, bias_grad_memory_config);
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
@@ -188,6 +188,7 @@ std::vector<std::optional<Tensor>> MorehLinearBackward::invoke(
     }
 
     if (bias_required_grad) {
+        TT_FATAL(bias_grad.has_value(), "bias_grad tensor should not be std::nullopt");
         Tensor output_tensor = ttnn::prim::moreh_bias_add_backward(
             output_grad, bias, bias_grad, bias_grad_memory_config, compute_kernel_config);
         result[2] = std::make_optional(output_tensor);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -97,18 +97,23 @@ void MorehSumBackwardOperation::validate_on_program_cache_hit(
 
 MorehSumBackwardOperation::shape_return_value_t MorehSumBackwardOperation::compute_output_shapes(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tensor_args.output_grad.get_shape();
+    return tensor_args.input->get_shape();
 };
 
 MorehSumBackwardOperation::tensor_return_value_t MorehSumBackwardOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto input_grad = tensor_args.input_grad;
+    if (input_grad.has_value()) {
+            return input_grad.value();
+    }
     auto input = tensor_args.input;
+    TT_FATAL(input.has_value(), "input tensor should not be std::nullopt." );
+
     auto dtype = input->dtype();
     Layout layout{Layout::TILE};
     auto device = input->device();
     auto memory_config = operation_attributes.memory_config;
-    return input_grad.value_or(create_device_tensor(input->shape(), dtype, layout, device, memory_config));
+    return create_device_tensor(input->shape(), dtype, layout, device, memory_config);
 }
 
 std::tuple<MorehSumBackwardOperation::operation_attributes_t, MorehSumBackwardOperation::tensor_args_t>


### PR DESCRIPTION
### Ticket
Link to Github Issue ([#13925](https://github.com/tenstorrent/tt-metal/issues/13925))

### Problem description
There are bad optional access errors in OPs (moreh_sum_backward, moreh_linear_backward).

### What's changed
- Modifications to the create_output_tensors method
- Added an assert to check for std::nullopt tensors before accessing them
-

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11380524129)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
