### PR TITLE
#13822: Add program cache test for embedding backwards

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_embedding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_embedding.py
@@ -66,3 +66,59 @@ def test_embedding_bw(input_dtype, output_dtype, batch_size, seq_len, embedding_
 
     logger.debug(comp_out)
     assert comp_pass
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "batch_size, seq_len, embedding_dim, num_embeddings",
+    [
+        (2, 64, 160, 96),
+    ],
+)
+@pytest.mark.parametrize(
+    "output_dtype",
+    [
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.uint32,
+    ],
+)
+def test_embedding_bw_with_program_cache(
+    input_dtype, output_dtype, batch_size, seq_len, embedding_dim, num_embeddings, device, use_program_cache
+):
+    torch.manual_seed(1234)
+
+    input_shape = (batch_size, seq_len)
+    weights_shape = (num_embeddings, embedding_dim)
+    grad_shape = (1, 1, batch_size * seq_len, embedding_dim)
+
+    for _ in range(2):
+        input_index = torch.randint(0, num_embeddings, input_shape)
+        input_tensor = ttnn.from_torch(input_index, dtype=input_dtype, device=device)
+
+        weights = torch.randn(weights_shape, requires_grad=True)
+        weights_ttnn = ttnn.from_torch(weights, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+        grad_data = torch.randn(grad_shape, requires_grad=True)
+        grad_tensor = ttnn.from_torch(grad_data, dtype=output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+        tt_output_tensor_on_device = ttnn.embedding_bw(input_tensor, weights_ttnn, grad_tensor, dtype=output_dtype)
+        tt_output_tensor = ttnn.to_torch(tt_output_tensor_on_device)
+
+        # PyTorch reference
+        weights.retain_grad()
+        pyt_y = torch.nn.functional.embedding(input_index, weights).reshape(grad_shape)
+        pyt_y.backward(gradient=grad_data)
+        golden_output_tensor = weights.grad
+
+        comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
+
+        logger.debug(comp_out)
+        assert comp_pass
+
+    assert device.num_program_cache_entries() == 1

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -165,8 +165,9 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
                                               const Program &program,
                                               const std::vector<Buffer *> &input_buffers,
                                               const std::vector<Buffer *> &output_buffers) {
-        auto grad_dram_buffer = input_buffers.at(1);
+
         auto index_dram_buffer = input_buffers.at(0);
+        auto grad_dram_buffer = input_buffers.at(1);
         auto output_dram_buffer = output_buffers.at(0);
 
         auto &runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13822)

### Problem description
Bug with `embedding_bw` program cache.

### What's changed
Previous [PR](https://github.com/tenstorrent/tt-metal/pull/13907) added the quick fix. This one adds a proper unit test for it.

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11388622872
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
