### PR TITLE
#0: Update runtime_args_data.hpp to not use TT_FATAL

### DIFF
--- a/tt_metal/impl/kernels/runtime_args_data.hpp
+++ b/tt_metal/impl/kernels/runtime_args_data.hpp
@@ -4,7 +4,12 @@
 
 #pragma once
 
-#include "tt_metal/common/assert.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace tt::tt_metal {
 // RuntimeArgsData provides an indirection to the runtime args
@@ -12,32 +17,46 @@ namespace tt::tt_metal {
 // After generation, this points into the cq cmds so that runtime args API calls
 // update the data directly in the command
 struct RuntimeArgsData {
-    uint32_t * rt_args_data;
-    size_t rt_args_count;
+    std::uint32_t * rt_args_data;
+    std::size_t rt_args_count;
 
-    inline uint32_t & operator[](size_t index) {
-        TT_ASSERT(index < rt_args_count, "Index specified is larger than runtime args size");
+    inline bool in_bounds(std::size_t index) {
+        if(index >= rt_args_count) [[unlikely]] {
+            std::cerr << "TT_FATAL: Index " << index << " is larger than runtime args size " 
+                      << rt_args_count << " at " << __FILE__ << ":" << __LINE__ << std::endl;
+            throw std::out_of_range(
+                "Index " + std::to_string(index) + " is larger than runtime args size " + std::to_string(rt_args_count)
+            );
+            std::unreachable();
+        }
+        return true;
+    }
+
+    inline std::uint32_t & operator[](std::size_t index) noexcept {
         return this->rt_args_data[index];
     }
-    inline const uint32_t& operator[](size_t index) const {
-        TT_ASSERT(index < rt_args_count, "Index specified is larger than runtime args size");
+    inline const std::uint32_t& operator[](std::size_t index) const noexcept {
         return this->rt_args_data[index];
     }
-    inline uint32_t & at(size_t index) {
-        TT_FATAL(index < rt_args_count, "Index specified is larger than runtime args size");
-        return this->rt_args_data[index];
+    inline std::uint32_t & at(std::size_t index) {
+        if (in_bounds(index)) [[likely]] {
+            return this->rt_args_data[index];
+        }
+        std::unreachable();
     }
-    inline const uint32_t& at(size_t index) const {
-        TT_FATAL(index < rt_args_count, "Index specified is larger than runtime args size");
-        return this->rt_args_data[index];
+    inline const std::uint32_t& at(std::size_t index) const {
+        if (in_bounds(index)) [[likely]] {
+            return this->rt_args_data[index];
+        }
+        std::unreachable();
     }
-    inline uint32_t * data() noexcept {
+    inline std::uint32_t * data() noexcept {
         return rt_args_data;
     }
-    inline const uint32_t * data() const noexcept {
+    inline const std::uint32_t * data() const noexcept {
         return rt_args_data;
     }
-    inline size_t size() const noexcept{
+    inline std::size_t size() const noexcept{
         return rt_args_count;
     }
 };

--- a/tt_metal/impl/kernels/runtime_args_data.hpp
+++ b/tt_metal/impl/kernels/runtime_args_data.hpp
@@ -20,7 +20,7 @@ struct RuntimeArgsData {
     std::uint32_t * rt_args_data;
     std::size_t rt_args_count;
 
-    inline bool in_bounds(std::size_t index) {
+    inline bool in_bounds(std::size_t index) const {
         if(index >= rt_args_count) [[unlikely]] {
             std::cerr << "TT_FATAL: Index " << index << " is larger than runtime args size " 
                       << rt_args_count << " at " << __FILE__ << ":" << __LINE__ << std::endl;

--- a/tt_metal/impl/kernels/runtime_args_data.hpp
+++ b/tt_metal/impl/kernels/runtime_args_data.hpp
@@ -27,7 +27,7 @@ struct RuntimeArgsData {
             throw std::out_of_range(
                 "Index " + std::to_string(index) + " is larger than runtime args size " + std::to_string(rt_args_count)
             );
-            std::unreachable();
+            __builtin_unreachable();
         }
         return true;
     }
@@ -42,13 +42,13 @@ struct RuntimeArgsData {
         if (in_bounds(index)) [[likely]] {
             return this->rt_args_data[index];
         }
-        std::unreachable();
+        __builtin_unreachable();
     }
     inline const std::uint32_t& at(std::size_t index) const {
         if (in_bounds(index)) [[likely]] {
             return this->rt_args_data[index];
         }
-        std::unreachable();
+        __builtin_unreachable();
     }
     inline std::uint32_t * data() noexcept {
         return rt_args_data;


### PR DESCRIPTION
### Ticket
NA

### Problem description
Don't infect customer code with TT_FATAL and incur them our `<fmt>` dependency.

### What's changed
Remove TT_FATAL for public API header.
Don't do bounds checking during `operator []`.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11390831277
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
