### PR TITLE
Multiple Reshapes in a Row Unit Test

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -290,6 +290,7 @@ def test_reshape_tile_layout_only_change_shape(device):
         ((1, 256, 16), (16, 256)),
         ((1, 256, 1024), (1, 256, 16, 64)),
         ((16, 16), (32, 8)),
+        ((32,), (1, 1, 1, 32)),
     ],
 )
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
@@ -324,39 +325,3 @@ def test_reshape_host(input_shape, output_shape, device):
     output = ttnn.to_torch(ttnn_output)
 
     assert_with_pcc(torch_result, output, 0.9999)
-
-
-@pytest.mark.parametrize(
-    "reshape_pair",
-    [
-        ([((12), (1, 1, 1, 12)), ((32), (1, 1, 1, 32)), ((1, 7), (1, 1, 1, 7))]),
-        ([((12), (1, 1, 1, 12)), ((5), (1, 1, 1, 5)), ((32), (1, 1, 1, 32)), ((1, 7), (1, 1, 1, 7))]),
-        ([((12), (1, 1, 1, 12)), ((32), (1, 1, 1, 32)), ((5), (1, 1, 1, 5)), ((1, 7), (1, 1, 1, 7))]),
-        (
-            [
-                ((12), (1, 1, 1, 12)),
-                ((32), (1, 1, 1, 32)),
-                ((32), (1, 1, 1, 32)),
-            ]
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float16, torch.float32],
-)
-def test_reshape_mlir_multiple_reshape(reshape_pair, dtype, device):
-    for pair in reshape_pair:
-        input_shape = pair[0]
-        output_shape = pair[1]
-        torch_input_tensor = torch.randn(input_shape, dtype=dtype)
-        torch_result = torch_input_tensor.reshape(output_shape)
-
-        input_tensor = ttnn.from_torch(
-            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )
-        ttnn_output = ttnn.reshape(input_tensor, output_shape)
-
-        output = ttnn.to_torch(ttnn_output)
-
-        assert_with_pcc(torch_result, output, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -57,7 +57,7 @@ ttnn::Tensor row_major_reshape(const ttnn::Tensor& tensor, const ttnn::Shape& sh
     //Constraint in device kernel
     uint32_t ROW_MAJOR_WIDTH = 8;
     ttnn::Tensor reshaped_rm_tensor;
-    if((tensor_shape[-1] % ROW_MAJOR_WIDTH == 0 && shape[-1] % ROW_MAJOR_WIDTH == 0)) {
+    if((tensor_shape[-1] % ROW_MAJOR_WIDTH == 0 && shape[-1] % ROW_MAJOR_WIDTH == 0) and tensor_shape.rank() == 4) {
         auto rm_tensor = ttnn::to_layout(tensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
         if (rm_tensor.is_contiguous()) {
             // Page size depends on the width, so only modify the shape if the width is the same


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13961)

### Problem description
MLIR team has cases of multiple reshapes in a row. Previously they thought there was a hang with the case, but that was due to type casting outside of reshape (not dependent on the op). We should have the unit test as a reference for their team. 

### What's changed
Adds multiple reshapes in a row for shapes observed by the MLIR Team

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
