### PR TITLE
#11178: add sharding support to line reduce scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_N300_post_commit.py
@@ -7,7 +7,10 @@ import pytest
 from loguru import logger
 import ttnn
 from models.utility_functions import skip_for_grayskull
-from tests.ttnn.unit_tests.operations.test_reduce_scatter_post_commit import run_reduce_scatter_test
+from tests.ttnn.unit_tests.operations.test_reduce_scatter_post_commit import (
+    run_reduce_scatter_test,
+    run_reduce_scatter_sharded_test,
+)
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
@@ -45,7 +48,7 @@ from tests.ttnn.unit_tests.operations.test_reduce_scatter_post_commit import run
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("enable_async", [True])
-def test_ring_reduce_scatter_post_commit(
+def test_ring_reduce_scatter_n300_post_commit(
     n300_mesh_device,
     num_devices,
     per_chip_output_shape,
@@ -74,4 +77,84 @@ def test_ring_reduce_scatter_post_commit(
         function_level_defaults,
         num_iters=num_iters,
         enable_async=enable_async,
+    )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (2, 1),
+    ],
+)
+@pytest.mark.parametrize("dim", [3])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape,output_shard_shape,shard_grid,tensor_mem_layout",
+    (
+        (
+            (1, 1, 32, 1792),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        (
+            (1, 1, 1792, 32),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        (
+            (1, 1, 224, 256),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ),
+    ),
+)
+@pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
+@pytest.mark.parametrize("enable_async", [True])
+def test_width_sharded_reduce_scatter_N300_post_commit(
+    t3k_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    output_shard_shape,
+    dim,
+    num_links,
+    math_op,
+    shard_grid,
+    orientation,
+    input_dtype,
+    tensor_layout,
+    tensor_mem_layout,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    num_iters=5,
+):
+    run_reduce_scatter_sharded_test(
+        t3k_mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        output_shard_shape,
+        dim,
+        num_links,
+        math_op,
+        shard_grid,
+        orientation,
+        input_dtype,
+        tensor_layout,
+        tensor_mem_layout,
+        use_program_cache=use_program_cache,
+        function_level_defaults=function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
     )

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -348,6 +348,8 @@ def run_reduce_scatter_sharded_test(
             f"Not enough devices on machine to implement test case. Wanted {num_devices} but found {len(t3k_mesh_device.get_device_ids())}"
         )
 
+    logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}, scatter_dim: {scatter_dim}")
+
     debug = False
 
     t3k_mesh_device.enable_async(enable_async)

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -455,10 +455,9 @@ FORCE_INLINE void read_wrapped_chunk_from_output_tensor_to_address(
   #ifdef INTERLEAVED_MEM_LAYOUT
         uint64_t src_noc_addr = get_noc_addr(curr_page_idx, s);
         noc_async_read(src_noc_addr, local_l1_read_addr, page_size);
-    #elif defined SHARDED_MEM_LAYOUT
+  #elif defined SHARDED_MEM_LAYOUT
         ASSERT(false);  // unimplemented
-    #endif
-    ASSERT(false);  // unimplemented
+  #endif
 #elif defined TILED_LAYOUT
     #ifdef INTERLEAVED_MEM_LAYOUT
         noc_async_read_tile(curr_page_idx, s, local_l1_read_addr);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
@@ -157,10 +157,76 @@ static constexpr uint32_t output_tensor_shard_pages_per_shard_x = 0;
 static constexpr bool output_tensor_shard_grid_transposed = 0;
 #endif
 
+struct sharded_tensor_ct_args_t {
+    const uint32_t tensor_shard_grid_height;
+    const uint32_t tensor_shard_grid_width;
+    const uint32_t tensor_shard_grid_start_y_logical;
+    const uint32_t tensor_shard_grid_start_x_logical;
+    const uint32_t tensor_shard_pages_per_shard_y;
+    const uint32_t tensor_shard_pages_per_shard_x;
+    const bool tensor_shard_grid_transposed;
+};
+
+static constexpr auto input_sharded_tensor_ct_args = sharded_tensor_ct_args_t{
+    input_tensor_shard_grid_height,
+    input_tensor_shard_grid_width,
+    input_tensor_shard_grid_start_y_logical,
+    input_tensor_shard_grid_start_x_logical,
+    input_tensor_shard_pages_per_shard_y,
+    input_tensor_shard_pages_per_shard_x,
+    input_tensor_shard_grid_transposed
+};
+
+static constexpr auto output_sharded_tensor_ct_args = sharded_tensor_ct_args_t{
+    output_tensor_shard_grid_height,
+    output_tensor_shard_grid_width,
+    output_tensor_shard_grid_start_y_logical,
+    output_tensor_shard_grid_start_x_logical,
+    output_tensor_shard_pages_per_shard_y,
+    output_tensor_shard_pages_per_shard_x,
+    output_tensor_shard_grid_transposed
+};
+
+struct sharded_tensor_rt_args_t {
+    uint32_t shard_grid_nrows;
+    const uint32_t* shard_grid_row_map;
+    uint32_t shard_grid_ncols;
+    const uint32_t* shard_grid_col_map;
+
+    static sharded_tensor_rt_args_t from_args(std::size_t& arg_idx) {
+        sharded_tensor_rt_args_t args;
+        args.shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);
+        args.shard_grid_row_map = reinterpret_cast<const uint32_t*>(get_arg_addr(arg_idx));
+        arg_idx += args.shard_grid_nrows;
+        args.shard_grid_ncols = get_arg_val<uint32_t>(arg_idx++);
+        args.shard_grid_col_map = reinterpret_cast<const uint32_t*>(get_arg_addr(arg_idx));
+        arg_idx += args.shard_grid_ncols;
+        return args;
+    }
+};
+
 
 
 template <tt::tt_metal::TensorMemoryLayout tensor_memory_layout, bool tensor_is_dram>
-auto build_source_address_generator(std::size_t &arg_idx, reduce_scatter_reader_common_args_t const& args, uint32_t tensor_base_addr) -> typename source_tensor_addrgen<input_tensor_memory_layout, src_is_dram>::type {
+auto build_sharded_tensor_address_generator(sharded_tensor_ct_args_t const& ct_args, sharded_tensor_rt_args_t const &sharded_tensor_rt_args, reduce_scatter_reader_common_args_t const& args, uint32_t tensor_base_addr) -> typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type {
+    ASSERT(is_sharded_mode);
+    return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type(
+        tt::tt_metal::address_generators::HarvestedWormholeWorkerToNocLookup(
+            sharded_tensor_rt_args.shard_grid_nrows, sharded_tensor_rt_args.shard_grid_row_map, sharded_tensor_rt_args.shard_grid_ncols, sharded_tensor_rt_args.shard_grid_col_map),
+        typename tt::tt_metal::address_generators::DeviceShardSpecTypeGetter<tensor_memory_layout>::type(
+            ct_args.tensor_shard_pages_per_shard_y,
+            ct_args.tensor_shard_pages_per_shard_x,
+            ct_args.tensor_shard_grid_height,
+            ct_args.tensor_shard_grid_width,
+            ct_args.tensor_shard_grid_start_y_logical,
+            ct_args.tensor_shard_grid_start_x_logical,
+            ct_args.tensor_shard_grid_transposed),
+        args.page_size,
+        tensor_base_addr);
+}
+
+template <tt::tt_metal::TensorMemoryLayout tensor_memory_layout, bool tensor_is_dram>
+auto build_source_address_generator(std::size_t &arg_idx, reduce_scatter_reader_common_args_t const& args, uint32_t tensor_base_addr) -> typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type {
     if constexpr (tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
         if constexpr (row_major_layout) {
             return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type{tensor_base_addr, args.page_size};
@@ -172,28 +238,34 @@ auto build_source_address_generator(std::size_t &arg_idx, reduce_scatter_reader_
         tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
         tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
         ASSERT(is_sharded_mode);
-        uint32_t input_shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);
-        const uint32_t* const input_shard_grid_row_map =
-            reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
-        arg_idx += input_shard_grid_nrows;
-        uint32_t input_shard_grid_ncols = get_arg_val<uint32_t>(arg_idx++);
-        const uint32_t* const input_shard_grid_col_map =
-            reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
-        arg_idx += input_shard_grid_ncols;
+        auto sharded_tensor_rt_args = sharded_tensor_rt_args_t::from_args(arg_idx);
 
-        return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type(
-            tt::tt_metal::address_generators::HarvestedWormholeWorkerToNocLookup(
-                input_shard_grid_nrows, input_shard_grid_row_map, input_shard_grid_ncols, input_shard_grid_col_map),
-            typename tt::tt_metal::address_generators::DeviceShardSpecTypeGetter<tensor_memory_layout>::type(
-                input_tensor_shard_pages_per_shard_y,
-                input_tensor_shard_pages_per_shard_x,
-                input_tensor_shard_grid_height,
-                input_tensor_shard_grid_width,
-                input_tensor_shard_grid_start_y_logical,
-                input_tensor_shard_grid_start_x_logical,
-                input_tensor_shard_grid_transposed),
-            args.page_size,
-            tensor_base_addr);
+        return build_sharded_tensor_address_generator<tensor_memory_layout, tensor_is_dram>(input_sharded_tensor_ct_args, sharded_tensor_rt_args, args, tensor_base_addr);
+    } else {
+        ASSERT(false);
+    }
+}
+
+template <tt::tt_metal::TensorMemoryLayout tensor_memory_layout, bool tensor_is_dram>
+auto build_dest_address_generator(std::size_t &arg_idx, reduce_scatter_reader_common_args_t const& args, uint32_t tensor_base_addr) -> typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type {
+    if constexpr (tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
+        if constexpr (row_major_layout) {
+            return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type{tensor_base_addr, args.page_size};
+        } else {
+            return typename source_tensor_addrgen<tensor_memory_layout, tensor_is_dram>::type{tensor_base_addr, args.page_size, args.in0_df};
+        }
+    } else if constexpr (
+        tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+        tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
+        tensor_memory_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+        ASSERT(is_sharded_mode);
+
+        sharded_tensor_rt_args_t sharded_tensor_rt_args;
+        if constexpr (is_line_reduce_scatter) {
+            sharded_tensor_rt_args = sharded_tensor_rt_args_t::from_args(arg_idx);
+        }
+
+        return build_sharded_tensor_address_generator<tensor_memory_layout, tensor_is_dram>(output_sharded_tensor_ct_args, sharded_tensor_rt_args, args, tensor_base_addr);
     } else {
         ASSERT(false);
     }
@@ -251,7 +323,11 @@ struct signal_receiver {
 
     FORCE_INLINE static signal_receiver build(bool requires_last_input_from_other_sender, std::size_t &arg_idx) {
         if constexpr (connected_to_producer) {
-            return {requires_last_input_from_other_sender, reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)))};
+            if (requires_last_input_from_other_sender) {
+                return {requires_last_input_from_other_sender, reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)))};
+            } else {
+                return {requires_last_input_from_other_sender, 0};
+            }
         } else {
             return {requires_last_input_from_other_sender, 0};
         }
@@ -278,7 +354,7 @@ void kernel_main() {
 
     auto s = build_source_address_generator<input_tensor_memory_layout, src_is_dram>(arg_idx, args, args.input_tensor_addr);
 
-    auto d = build_source_address_generator<output_tensor_memory_layout, dest_is_dram>(arg_idx, args, args.output_tensor_addr);
+    auto d = build_dest_address_generator<output_tensor_memory_layout, dest_is_dram>(arg_idx, args, args.output_tensor_addr);
 
 
     bool width_sliced = args.tensor_slice_shape.x <= args.input_tensor_shape.x;
@@ -376,6 +452,7 @@ void kernel_main() {
         }
 
         for (uint32_t i = 1; i < args.num_transfers; ++i) {
+
             bool last_transfer = i == args.num_transfers - 1;
             uint32_t offset_into_worker_slice = 0;
             std::tie(args.my_ring_idx, curr_ring_slice_start_page_offset) = advance_to_next_transfer_slice(
@@ -385,7 +462,7 @@ void kernel_main() {
                 args.input_tensor_shape,
                 args.tensor_slice_shape,
                 args.is_clockwise_direction);
-            ASSERT(last_page_of_worker);
+            ASSERT(is_line_reduce_scatter || last_page_of_worker);
             last_page_of_worker = false;
             curr_tile_id = curr_ring_slice_start_page_offset + worker_relative_start_offset_into_slice;
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp
@@ -97,7 +97,6 @@ void kernel_main() {
     uint32_t total_eltwise_kernel_num_pages = get_arg_val<uint32_t>(arg_idx++);
 
     auto readback_accumulation_signaler = reader_signaler<is_line_reduce_scatter>::build(arg_idx);
-    arg_idx += readback_accumulation_signaler.get_args_consumed();
 
     #ifdef SHARDED_MEM_LAYOUT
     uint32_t output_shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -17,8 +17,6 @@ void ReduceScatter::validate(const std::vector<Tensor>& input_tensors) const {
         TT_FATAL(
             t.get_legacy_shape()[this->scatter_dim] % this->ring_size == 0,
             "Reduce scatter input tensor shape on dim {} must be divisible by ring size", this->scatter_dim);
-
-        TT_FATAL(this->topology != ccl::Topology::Linear || !t.is_sharded(), "Sharded tensors are not supported for reduce scatter on a linear topology");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_worker_builder.cpp
@@ -146,10 +146,10 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_receiver_kernel_ct
         // TODO: rangeify
         auto const& input_sharded_tensor_args = ShardedAddrGenArgBuilder::emit_ct_args(local_input_tensor);
         std::copy(input_sharded_tensor_args.begin(), input_sharded_tensor_args.end(), std::back_inserter(args));
+        ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_input_tensor, "input");
+
         auto const& output_sharded_tensor_args = ShardedAddrGenArgBuilder::emit_ct_args(local_output_tensor);
         std::copy(output_sharded_tensor_args.begin(), output_sharded_tensor_args.end(), std::back_inserter(args));
-
-        ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_input_tensor, "input");
         ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(local_output_tensor, "output");
     }
 
@@ -632,6 +632,10 @@ std::vector<uint32_t> ReduceScatterWorkerArgBuilder::generate_line_start_sender_
         static_cast<uint32_t>(this->edm_termination_mode), // (EDM) termination mode
         static_cast<uint32_t>(tt::CB::c_in0) // cb_id
     };
+
+    auto const& input_tensor = this->op_config.get_input_tensor(0);
+    auto const& addr_gen_rt_args = ttnn::ccl::emit_address_generator_compile_time_args(input_tensor);
+    std::ranges::copy(addr_gen_rt_args, std::back_inserter(args));
 
     return args;
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11178)

### Problem description
Line reduce scatter was missing support for sharded tensors

### What's changed
It's added now although only with limited tests. For the time being the desired outcome with these changes are to improve performance for TG llama

More tests to be added in the near future (t3k and sweeps).

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11395719337
- [x] t3k frequent + model perf: https://github.com/tenstorrent/tt-metal/actions/runs/11393945436
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
