### PR TITLE
#12349: Disable mismatching transpose test on BH

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -610,6 +610,7 @@ def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, u
     assert device.num_program_cache_entries() == 3
 
 
+@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "shape, swap_dims",
     [


### PR DESCRIPTION
### Ticket
#12349 

### Problem description
Transpose bfloat8 test was mismatching on BH

### What's changed
Disable test

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
