### PR TITLE
#0: update perf times for distillbert, vgg16 and vgg11

### DIFF
--- a/models/demos/distilbert/tests/test_perf_distilbert.py
+++ b/models/demos/distilbert/tests/test_perf_distilbert.py
@@ -154,7 +154,7 @@ def test_distilbert_perf_device(batch_size, test, reset_seeds):
     if is_grayskull():
         expected_perf = 40.8772
     elif is_wormhole_b0():
-        expected_perf = 19.80
+        expected_perf = 90.2505
 
     command = f"pytest tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert.py::test_distilbert_for_question_answering[sequence_size=768-batch_size=8-model_name=distilbert-base-uncased-distilled-squad]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/vgg/tests/test_perf_vgg.py
+++ b/models/demos/vgg/tests/test_perf_vgg.py
@@ -137,10 +137,10 @@ def test_perf_device_bare_metal_vgg(batch_size, model_name):
     margin = 0.03
 
     if model_name == "ttnn_vgg11":
-        expected_perf = 132.2436 if is_grayskull() else 105.7
+        expected_perf = 132.2436 if is_grayskull() else 272.8989
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg11.py"
     else:
-        expected_perf = 116.1459 if is_grayskull() else 92.6
+        expected_perf = 116.1459 if is_grayskull() else 194.4063
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg16.py"
 
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]


### PR DESCRIPTION
### Ticket
Need to update device perf after improvements from transpose change (removal of autoformat which would untilize before transposing)

### Problem description
Device perf cannot be stale

### What's changed
Model perf before my change:
https://github.com/tenstorrent/tt-metal/actions/runs/11377171481/job/31651204183
Model perf with my change:
https://github.com/tenstorrent/tt-metal/actions/runs/11379280921/job/31656952467
VGG16 is .2s better e2e, distillbert is .9s better and VGG11 is about .06s worse. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
