### PR TITLE
#13981: add write flush to BH matmul kernels and remove skips from tests

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py
@@ -15,7 +15,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
-from models.utility_functions import is_wormhole_b0, skip_for_blackhole
+from models.utility_functions import is_wormhole_b0
 
 shapes_mm = [
     # Single core (won't be hit after padding is added for multicast)
@@ -47,7 +47,6 @@ if is_wormhole_b0():
     del shapes_mm[1:]
 
 
-@skip_for_blackhole("Hanging configs on BH, see #12349")
 @pytest.mark.parametrize("input_shapes", shapes_mm)
 @pytest.mark.parametrize(
     "dtype",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_bert_ops.py
@@ -531,7 +531,6 @@ def not_fit_l1(M, K, N, fp32):
     return (M * K + K * N > 5000000) and (fp32 == True)
 
 
-@pytest.mark.skipif(is_blackhole(), reason="Hanging on Blackhole, see #12349")
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize("fp32_acc_mode", [True, False], ids=["fp32", "no_fp32"])
@@ -605,7 +604,6 @@ def test_bert_linear_batch4(
             logger.warning("L1 cannot fit large tensors in fp32 mode")
 
 
-@pytest.mark.skipif(is_blackhole(), reason="Hangs on BH, see #12349")
 @pytest.mark.skipif(is_grayskull(), reason="not tested for GS")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -18,7 +18,6 @@ from tt_lib.utils import (
     untilize,
     is_close,
 )
-from models.utility_functions import skip_for_blackhole
 
 
 def find_max_subblock(out_block_h, out_block_w):
@@ -452,7 +451,6 @@ def test_matmul_in1_dram_sharded_with_mm_chain(
     )
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(
     "fp32_acc_mode",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1068,7 +1068,6 @@ def test_sharded_program_cache(device, use_program_cache, function_level_default
     assert eq
 
 
-@skip_for_blackhole("Hanging on BH, see #12349")
 @pytest.mark.parametrize("in0_sharded", [True, False], ids=["in0_sharded", "in0_unsharded"])
 @pytest.mark.parametrize("out_sharded", [True, False], ids=["out_sharded", "out_unsharded"])
 @pytest.mark.parametrize("M", [1600])
@@ -1278,8 +1277,6 @@ def test_sharded_matmul_2d_transposed(
     compute_grid_size = device.compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
         pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
-    if activations_dtype != weights_dtype and is_wormhole_b0():
-        pytest.skip("WH does not work with mixed precision")
 
     interleaved_mem_config = ttnn.MemoryConfig(
         memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
@@ -1338,7 +1335,6 @@ def test_sharded_matmul_2d_transposed(
     assert passing
 
 
-@skip_for_blackhole("Hanging on BH, see #12349")
 def test_resharded_binary_to_matmul(device, function_level_defaults):
     grid_size_binary = device.compute_with_storage_grid_size()
     num_cores_binary = 98
@@ -1996,7 +1992,6 @@ def test_sharded_matmul_1d_in0(
 
 
 # Have at least one example of 1d matmul with in1 mcasted that runs on WH
-@skip_for_blackhole("Hangs on BH, see #12349")
 def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
     M = 4096
     K = 64

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -187,6 +187,11 @@ void kernel_main() {
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+            // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
+            // latency which means data could be changed before write is issued.
+            noc_async_writes_flushed();
+#endif
 
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_block_sharded.cpp
@@ -130,6 +130,11 @@ void kernel_main() {
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+            // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
+            // latency which means data could be changed before write is issued.
+            noc_async_writes_flushed();
+#endif
 
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -365,6 +365,11 @@ void kernel_main() {
                 in3_start_address, in3_multicast_data_addr, in3_block_size_bytes, in1_mcast_num_cores, true, true);
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
+#ifdef ARCH_BLACKHOLE
+            // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
+            // latency which means data could be changed before write is issued.
+            noc_async_writes_flushed();
+#endif
 
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/13981

### Problem description
BH requires write flushes for `noc_async_write_multicast` followed by `noc_semaphore_set_multicast` and modifying data due to higher RISC to L1 latency.

### What's changed
- add in the flushes
- remove the skips from tests that now pass on BH
- remove a skip for WH for one of the tests that was fixed a long time ago

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11406363773
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11406368778/job/31742078350 no worse than main https://github.com/tenstorrent/tt-metal/actions/runs/11405205673/job/31736893926
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes
