### PR TITLE
#13994: Make CommandQueue type opaque

### DIFF
--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
 
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
 
     for (int device_id = 0; device_id < num_devices; device_id++) {
     try {

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
             ids.push_back(id);
         }
         tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
-        std::vector<Device*> devices = tt::DevicePool::instance().get_all_active_devices();
+        auto devices = tt::DevicePool::instance().get_all_active_devices();
         std::vector<Program> programs;
         std::set<uint32_t> build_keys;
         // kernel->binaries() returns 32B aligned binaries

--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -47,7 +47,7 @@ class DeviceFixture : public ::testing::Test {
         }
     }
 
-    std::vector<tt::tt_metal::Device*> devices_;
+    std::vector<tt::tt_metal::v1::DeviceKey> devices_;
     tt::ARCH arch_;
     size_t num_devices_;
 };
@@ -116,7 +116,7 @@ class GalaxyFixture : public ::testing::Test {
         this->devices_.clear();
     }
 
-    std::vector<tt::tt_metal::Device*> devices_;
+    std::vector<tt::tt_metal::v1::DeviceKey> devices_;
 
    private:
     std::map<chip_id_t, Device*> device_ids_to_devices_;

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -45,7 +45,7 @@ class N300DeviceFixture : public ::testing::Test {
         }
     }
 
-    std::vector<tt::tt_metal::Device*> devices_;
+    std::vector<tt::tt_metal::v1::DeviceKey> devices_;
     tt::ARCH arch_;
     size_t num_devices_;
 };

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/ring_gather_kernels.cpp
@@ -76,7 +76,7 @@ std::vector<int> get_hamiltonian_cycle(vector<vector<int>>& adj, int N, int s = 
     return {};
 }
 
-std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices) {
+std::vector<v1::DeviceKey> get_device_ring(std::vector<tt::tt_metal::v1::DeviceKey> devices) {
     std::vector<std::vector<int>> adj(devices.size(), std::vector<int>(devices.size(), 0));
     for (uint32_t i = 0; i < devices.size(); ++i) {
         const auto& device = devices[i];
@@ -90,7 +90,7 @@ std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices)
     }
 
     const auto& device_ring_idx = get_hamiltonian_cycle(adj, devices.size(), 0);
-    std::vector<Device*> device_ring;
+    std::vector<v1::DeviceKey> device_ring;
     device_ring.reserve(device_ring_idx.size());
     for (const auto& device_idx : device_ring_idx) {
         device_ring.push_back(devices[device_idx]);
@@ -99,7 +99,7 @@ std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices)
 }
 
 std::vector<std::tuple<Device*, Device*, CoreCoord, CoreCoord>> get_sender_receiver_cores(
-    std::vector<tt::tt_metal::Device*> device_ring) {
+    std::vector<tt::tt_metal::v1::DeviceKey> device_ring) {
     std::vector<std::tuple<Device*, Device*, CoreCoord, CoreCoord>> sender_receivers;
     sender_receivers.reserve(device_ring.size() - 1);
 
@@ -169,7 +169,7 @@ namespace unit_tests::erisc::kernels {
  *                                         ╚══════╝░░░╚═╝░░░╚═╝░░╚═╝
  */
 bool eth_direct_ring_gather_sender_receiver_kernels(
-    std::vector<tt::tt_metal::Device*> device_ring,
+    std::vector<tt::tt_metal::v1::DeviceKey> device_ring,
     const size_t& byte_size_per_device,
     const size_t& src_eth_l1_byte_address,
     const size_t& dst_eth_l1_byte_address,
@@ -313,7 +313,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
 }
 
 bool eth_interleaved_ring_gather_sender_receiver_kernels(
-    std::vector<tt::tt_metal::Device*> device_ring,
+    std::vector<tt::tt_metal::v1::DeviceKey> device_ring,
     const BankedConfig& cfg,
     const size_t& src_eth_l1_byte_address,
     const size_t& dst_eth_l1_byte_address,

--- a/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
@@ -80,14 +80,13 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     }
 
     ASSERT_TRUE(num_devices > 0);
-    std::vector<tt::tt_metal::Device *> devices;
     vector<chip_id_t> ids;
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
     }
@@ -100,14 +99,13 @@ TEST_P(DeviceParamFixture, DeviceLoadBlankKernels) {
         GTEST_SKIP();
     }
     ASSERT_TRUE(num_devices > 0);
-    std::vector<tt::tt_metal::Device *> devices;
     vector<chip_id_t> ids;
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(unit_tests_common::basic::test_device_init::load_all_blank_kernels(device));
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -48,7 +48,7 @@ public:
 
 protected:
     tt::ARCH arch_;
-    vector<tt::tt_metal::Device*> devices_;
+    vector<tt::tt_metal::v1::DeviceKey> devices_;
     bool slow_dispatch_;
     bool has_remote_devices_;
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/test_dispatch.cpp
@@ -9,7 +9,7 @@
 // Test sync w/ semaphores betweeen eth/tensix cores
 // Test will hang in the kernel if the sync doesn't work properly
 static void test_sems_across_core_types(CommonFixture *fixture,
-                                        vector<tt::tt_metal::Device*>& devices,
+                                        vector<tt::tt_metal::v1::DeviceKey>& devices,
                                         bool active_eth) {
     // just something unique...
     constexpr uint32_t eth_sem_init_val = 33;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_device_pool.cpp
@@ -20,7 +20,7 @@ TEST_F(FDBasicFixture, DevicePoolOpenClose) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<tt_metal::Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
@@ -48,7 +48,7 @@ TEST_F(FDBasicFixture, DevicePoolReconfigDevices) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
@@ -80,7 +80,7 @@ TEST_F(FDBasicFixture, DevicePoolAddDevices) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
@@ -114,7 +114,7 @@ TEST_F(FDBasicFixture, DevicePoolReduceDevices) {
     int l1_small_size = 1024;
     const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
       ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);

--- a/tt_metal/api/command_queue.hpp
+++ b/tt_metal/api/command_queue.hpp
@@ -12,9 +12,39 @@
 //                COMMAND QUEUE OPERATIONS
 //==================================================
 
+namespace tt::tt_metal {
 
-namespace tt::tt_metal{
+inline namespace v0 {
+
+class Program;
+class Event;
+
+}
+
 namespace v1 {
+
+/**
+ * @brief Get a handle to a command queue on a device.
+ *
+ * @param device The device to get the command queue from.
+ * @param id The id of the command queue to get.
+ * @return A handle to the command queue.
+ */
+CommandQueueHandle GetCommandQueue(DeviceHandle device, uint32_t id = 0);
+
+/**
+ * @brief Reads a buffer from the device.
+ *
+ * @param cq The command queue used to dispatch the command.
+ * @param buffer The device buffer to read from.
+ * @param dst The vector where the results that are read will be stored.
+ * @param blocking Indicates whether the operation is blocking.
+ */
+void EnqueueReadBuffer(
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<uint32_t> &dst,
+    bool blocking);
 
 /**
  * @brief Reads a buffer from the device.
@@ -25,9 +55,9 @@ namespace v1 {
  * @param blocking Indicates whether the operation is blocking.
  */
 void EnqueueReadBuffer(
-    CommandQueue cq,
-    Buffer buffer,
-    std::byte *dst,
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    void *dst,
     bool blocking);
 
 /**
@@ -39,11 +69,24 @@ void EnqueueReadBuffer(
  * @param blocking Indicates whether the operation is blocking.
  */
 void EnqueueWriteBuffer(
-    CommandQueue cq,
-    Buffer buffer,
-    const std::byte *src,
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<uint32_t> &src,
     bool blocking);
 
+/**
+ * @brief Writes data to a buffer on the device.
+ *
+ * @param cq The command queue used to dispatch the command.
+ * @param buffer The device buffer to write to.
+ * @param src Source data vector to write to the device.
+ * @param blocking Indicates whether the operation is blocking.
+ */
+void EnqueueWriteBuffer(
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    HostDataType src,
+    bool blocking);
 
 /**
  * @brief Writes a program to the device and launches it.
@@ -52,39 +95,41 @@ void EnqueueWriteBuffer(
  * @param program The program to execute on the device.
  * @param blocking Indicates whether the operation is blocking.
  */
-void EnqueueProgram(CommandQueue cq, Program program, bool blocking);
+void EnqueueProgram(CommandQueueHandle cq, v0::Program& program, bool blocking);
 
 /**
  * @brief Blocks until all previously dispatched commands on the device have completed.
  *
  * @param cq The command queue to wait on.
  */
-void Finish(CommandQueue cq);
-
-
-/**
- * @brief Sets the command queue mode to lazy or immediate.
- *
- * @param lazy If true, sets the command queue to lazy mode.
- */
-void SetLazyCommandQueueMode(bool lazy);
-
+void Finish(CommandQueueHandle cq);
 
 /**
- * @brief Retrieves the device associated with the command queue.
+ * @brief Enqueues a trace of previously generated commands and data.
  *
- * @param cq The command queue to query.
- * @return Device handle associated with the command queue.
+ * @param cq The command queue used to dispatch the command.
+ * @param trace_id A unique id representing an existing on-device trace, which has been
+ * instantiated via InstantiateTrace where the trace_id is returned
+ * @param blocking Indicates whether the operation is blocking.
  */
-Device GetDevice(class CommandQueue cq);
+void EnqueueTrace(CommandQueueHandle cq, uint32_t trace_id, bool blocking);
 
 /**
- * @brief Retrieves the ID of the command queue.
+ * @brief Enqueues a command to record an Event on the device for a given CQ, and updates the Event object for the user.
  *
- * @param cq The command queue to query.
- * @return ID of the command queue.
+ * @param cq The command queue used to dispatch the command.
+ * @param event An event that will be populated by this function, and inserted in CQ
  */
-uint32_t GetId(class CommandQueue cq);
+void EnqueueRecordEvent(CommandQueueHandle cq, const std::shared_ptr<Event> &event);
+
+/**
+ * @brief Enqueues a command on the device for a given CQ (non-blocking). The command on device will block and wait for completion of the specified event (which may be in another CQ).
+ *
+ * @param cq The command queue used to dispatch the command.
+ * @param event The event object that this CQ will wait on for completion.
+ */
+void EnqueueWaitForEvent(CommandQueueHandle cq, const std::shared_ptr<Event> &event);
 
 } // namespace v1
+
 } // namespace tt::tt_metal

--- a/tt_metal/api/metal.hpp
+++ b/tt_metal/api/metal.hpp
@@ -3,11 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "types.hpp"
-#include "buffer.hpp"
+
 #include "command_queue.hpp"
-#include "device.hpp"
-#include "event.hpp"
-#include "kernel.hpp"
-#include "program.hpp"
-#include "trace.hpp"

--- a/tt_metal/api/types.hpp
+++ b/tt_metal/api/types.hpp
@@ -4,33 +4,35 @@
 
 #pragma once
 
-#include "device/tt_cluster_descriptor_types.h"
-#include "hostdevcommon/common_values.hpp"
-#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
+#include <cstdint>
 
-namespace tt::tt_metal{
+namespace tt::tt_metal {
+inline namespace v0 {
+
+class CommandQueue;
+class Device;
+
+}  // namespace v0
 
 namespace v1 {
 
-// Opaque classes
-class Program;
-class Device;
-class CommandQueue;
-class Trace;
+struct DeviceHandle {
+    uint16_t key = 0;
 
-// Ideally these would be opaque but this work requires
-// completion of the prototype of the runtime args.
-class CircularBuffer;
-class Buffer;
+    bool is_valid() const { return key != 0; }
+};
 
-// Not likely going to be opaque, but pending review of
-// completion of the prototype of the runtime args.
-class Event;
-class RuntimeArgs;
-class RuntimeArgsData;
+struct CommandQueueHandle {
+    public:
+    operator v0::CommandQueue&() const { return command_queue; }
 
-}
+    private:
+    friend CommandQueueHandle GetCommandQueue(DeviceHandle, uint32_t);
+    CommandQueueHandle(v0::CommandQueue& queue) : command_queue(queue) {}
 
+    v0::CommandQueue& command_queue;
+};
 
+}  // namespace v1
 
-}
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/device/device_key.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3367,6 +3367,13 @@ void Device::generate_device_headers(const std::string &path) const
     );
 }
 
+namespace v1 {
+
+CommandQueueHandle GetCommandQueue(DeviceHandle device, uint32_t id) {
+    return CommandQueueHandle(DeviceKey(device)->command_queue(id));
+}
+
+}  // namespace v1
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3260,9 +3260,9 @@ void Device::enable_async(bool enable) {
     // This is required for checking if a call is made from an application thread or a worker thread.
     // See InWorkerThread().
     if (enable) {
-        tt::DevicePool::instance().register_worker_thread_for_device(this, this->work_executor.get_worker_thread_id());
+        tt::DevicePool::instance().register_worker_thread_for_device(tt::DevicePool::instance().get_handle(this), this->work_executor.get_worker_thread_id());
     } else {
-        tt::DevicePool::instance().unregister_worker_thread_for_device(this);
+        tt::DevicePool::instance().unregister_worker_thread_for_device(tt::DevicePool::instance().get_handle(this));
     }
 }
 

--- a/tt_metal/impl/device/device_key.cpp
+++ b/tt_metal/impl/device/device_key.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/device/device_key.hpp"
+
+#include "tt_metal/impl/device/device_pool.hpp"
+
+namespace tt::tt_metal {
+
+auto v1::DeviceKey::operator->() const -> Device * { return static_cast<Device *>(*this); }
+
+v1::DeviceKey::operator Device *() const {
+    const auto loc = this->index();
+    const auto &devices = DevicePool::instance().devices;
+    const auto size = devices.size();
+    TT_FATAL(loc < size, "Invalid Device key {}; Expected index less than {}", loc, size);
+    return devices[loc].get();
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_key.hpp
+++ b/tt_metal/impl/device/device_key.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_stl/slotmap.hpp"
+
+namespace tt::tt_metal {
+inline namespace v0 {
+
+class Device;
+
+}  // namespace v0
+
+namespace v1 {
+
+struct DeviceKey : stl::Key<std ::uint16_t, 12> {
+    using Key::Key;
+
+    // TODO remove with v0
+    auto operator->() const -> Device *;
+
+    // TODO remove with v0
+    operator Device *() const;
+};
+
+}  // namespace v1
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_key.hpp
+++ b/tt_metal/impl/device/device_key.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "tt_metal/api/types.hpp"
 #include "tt_stl/slotmap.hpp"
 
 namespace tt::tt_metal {
@@ -17,6 +18,8 @@ namespace v1 {
 
 struct DeviceKey : stl::Key<std ::uint16_t, 12> {
     using Key::Key;
+
+    DeviceKey(DeviceHandle handle) : Key(handle.key) {}
 
     // TODO remove with v0
     auto operator->() const -> Device *;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -7,6 +7,7 @@
 #include <numa.h>
 
 #include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/impl/device/device_key.hpp"
 
 namespace tt {
 
@@ -148,7 +149,8 @@ void DevicePool::initialize(
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
 }
 
-void DevicePool::initialize_device(Device* dev) const {
+void DevicePool::initialize_device(v1::DeviceKey key) const {
+    const auto dev = devices[key.index()].get();
     detail::ClearProfilerControlBuffer(dev);
 
     // Create system memory writer for this device to have an associated interface to hardware command queue (i.e.
@@ -254,7 +256,7 @@ void DevicePool::add_devices_to_pool(std::vector<chip_id_t> device_ids) {
     }
 }
 
-void DevicePool::register_worker_thread_for_device(Device* device, std::thread::id worker_thread_id) {
+void DevicePool::register_worker_thread_for_device(v1::DeviceKey device, std::thread::id worker_thread_id) {
     TT_FATAL(std::this_thread::get_id() == this->device_pool_creation_thread_id, "Worker threads can only be registered in the thread where the Device(s) were created");
     auto worker_thread_handle = this->device_to_worker_thread_id.find(device);
     if (worker_thread_handle != this->device_to_worker_thread_id.end()) {
@@ -267,7 +269,7 @@ void DevicePool::register_worker_thread_for_device(Device* device, std::thread::
     this->worker_thread_ids.insert(worker_thread_id);
 }
 
-void DevicePool::unregister_worker_thread_for_device(Device* device) {
+void DevicePool::unregister_worker_thread_for_device(v1::DeviceKey device) {
     TT_FATAL(std::this_thread::get_id() == this->device_pool_creation_thread_id, "Worker threads can only be unregistered in the thread where the Device(s) were created");
     auto worker_thread_handle = this->device_to_worker_thread_id.find(device);
     if (worker_thread_handle != this->device_to_worker_thread_id.end()) {
@@ -281,7 +283,8 @@ const std::unordered_set<std::thread::id>& DevicePool::get_worker_thread_ids() c
 }
 
 void DevicePool::init_firmware_on_active_devices() const {
-    for (const auto& dev : this->get_all_active_devices()) {
+    for (const auto& key : this->get_all_active_devices()) {
+        const auto dev = this->devices[key.index()].get();
         // For Galaxy init, we only need to loop over mmio devices
         const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
         if (mmio_device_id != dev->id()) {
@@ -304,14 +307,14 @@ void DevicePool::init_firmware_on_active_devices() const {
             tt::Cluster::instance().get_device_tunnel_depth(mmio_device_id));
 
         auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id);
-        this->initialize_device(dev);
+        this->initialize_device(key);
         if (not this->skip_remote_devices) {
             for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
                 // Need to create devices from farthest to the closest.
                 for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
                     uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
                     log_debug(tt::LogMetal, "Tunnel {} Device {} Tunnel Stop: {}", t, mmio_controlled_device_id, ts);
-                    this->initialize_device(this->devices[mmio_controlled_device_id].get());
+                    this->initialize_device({mmio_controlled_device_id, 0});
                 }
             }
         }
@@ -340,16 +343,16 @@ DevicePool::DevicePool(
     }
 }
 
-Device* DevicePool::get_active_device(chip_id_t device_id) const {
+v1::DeviceKey DevicePool::get_active_device(chip_id_t device_id) const {
     TT_ASSERT(this->is_device_active(device_id), "DevicePool does not contain active device {}", device_id);
-    return this->devices[device_id].get();
+    return {device_id, 0};
 }
 
-std::vector<Device*> DevicePool::get_all_active_devices() const {
-    std::vector<Device*> user_devices;
+std::vector<v1::DeviceKey> DevicePool::get_all_active_devices() const {
+    std::vector<v1::DeviceKey> user_devices;
     for (int id = 0; id < this->devices.size(); id++) {
         if (this->is_device_active(id)) {
-            user_devices.emplace_back(this->devices[id].get());
+            user_devices.emplace_back(id, 0);
         }
     }
     return user_devices;
@@ -365,7 +368,7 @@ bool DevicePool::close_device(chip_id_t device_id) {
             pass &= this->devices[mmio_controlled_device_id]->close();
             // When a device is closed, its worker thread is joined. Stop tracking this
             // worker thread.
-            this->unregister_worker_thread_for_device(this->devices[mmio_controlled_device_id].get());
+            this->unregister_worker_thread_for_device({mmio_controlled_device_id, 0});
         }
     }
     return pass;
@@ -381,6 +384,15 @@ DevicePool::~DevicePool() {
         }
     }
     this->devices.clear();
+}
+
+v1::DeviceKey DevicePool::get_handle(Device* device) const {
+    for (v1::DeviceKey::value_type index = 0; index < this->devices.size(); ++index) {
+        if (this->devices[index].get() == device) {
+            return {index, 0};
+        }
+    }
+    return {};
 }
 
 }  // namespace tt

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2983,6 +2983,61 @@ void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking) {
 
 }  // namespace v0
 
+namespace v1 {
+void EnqueueReadBuffer(
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<uint32_t>& dst,
+    bool blocking) {
+    v0::EnqueueReadBuffer(cq, buffer, dst, blocking);
+}
+
+void EnqueueReadBuffer(
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    void* dst,
+    bool blocking) {
+    v0::EnqueueReadBuffer(cq, buffer, dst, blocking);
+}
+
+void EnqueueWriteBuffer(
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<uint32_t>& src,
+    bool blocking) {
+    v0::EnqueueWriteBuffer(cq, buffer, src, blocking);
+}
+
+void EnqueueWriteBuffer(
+    CommandQueueHandle cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    HostDataType src,
+    bool blocking) {
+    v0::EnqueueWriteBuffer(cq, buffer, src, blocking);
+}
+
+void EnqueueProgram(CommandQueueHandle cq, Program& program, bool blocking) {
+    v0::EnqueueProgram(cq, program, blocking);
+}
+
+void Finish(CommandQueueHandle cq) {
+    v0::Finish(cq);
+}
+
+void EnqueueTrace(CommandQueueHandle cq, uint32_t trace_id, bool blocking) {
+    v0::EnqueueTrace(cq, trace_id, blocking);
+}
+
+void EnqueueRecordEvent(CommandQueueHandle cq, const std::shared_ptr<Event>& event) {
+    v0::EnqueueRecordEvent(cq, event);
+}
+
+void EnqueueWaitForEvent(CommandQueueHandle cq, const std::shared_ptr<Event>& event) {
+    v0::EnqueueWaitForEvent(cq, event);
+}
+
+}  // namespace v1
+
 void EnqueueReadBufferImpl(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -302,7 +302,7 @@ std::map<chip_id_t, Device *> CreateDevices(
     ZoneScoped;
     bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type);
-    std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
+    const auto devices = tt::DevicePool::instance().get_all_active_devices();
     std::map<chip_id_t, Device *> ret_devices;
     //Only include the mmio device in the active devices set returned to the caller if we are not running
     //on a Galaxy cluster.
@@ -329,7 +329,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         Synchronize(dev); // Synchronize device
     }
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-    std::map<chip_id_t, Device *> mmio_devices = {};
+    std::map<chip_id_t, v1::DeviceKey> mmio_devices = {};
     bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
 
     if (is_galaxy) {
@@ -346,7 +346,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
     } else {
         for (const auto &[device_id, dev] : devices) {
             if(dev->is_mmio_capable()) {
-                mmio_devices.insert({device_id, dev});
+                mmio_devices.insert({device_id, tt::DevicePool::instance().get_handle(dev)});
             }
         }
         for (const auto &[device_id, dev] : mmio_devices) {
@@ -366,7 +366,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
                     devices[t[ts]]->close();
                     // When a device is closed, its worker thread is joined. Stop tracking this
                     // worker thread.
-                    tt::DevicePool::instance().unregister_worker_thread_for_device(devices[t[ts]]);
+                    tt::DevicePool::instance().unregister_worker_thread_for_device(tt::DevicePool::instance().get_handle(devices[t[ts]]));
                 }
             }
         }


### PR DESCRIPTION
### Ticket
#13994 

### Problem description
In the metal API 1.0 we want to make user-visible types opaque.

### What's changed
This PR wraps a pointer to the CommandQueue with a strong CommandQueueHandle type, and this new type is exposed in the `host_api.hpp`.
