### PR TITLE
#12979: erisc linker script cleanup (part 1/n)

### DIFF
--- a/tt_metal/hw/firmware/src/erisc-crt0.cc
+++ b/tt_metal/hw/firmware/src/erisc-crt0.cc
@@ -22,7 +22,7 @@ static void do_erisc_exit();
 // The function relies on optimization to avoid unexpected register
 // usage.
 
-extern "C" __attribute__((section("erisc_l1_code.0"), naked, optimize("Os"))) void ApplicationHandler(void) {
+extern "C" [[gnu::section(".start"), gnu::naked, gnu::optimize("Os")]] void _start(void) {
     // Save callee saves.
     __asm__ volatile(
         "addi sp, sp, -13 * 4\n\t"

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -34,7 +34,7 @@ uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 uint32_t tt_l1_ptr *sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
-void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
+void __attribute__((noinline)) Application(void) {
     WAYPOINT("I");
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -23,7 +23,7 @@
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 
-void __attribute__((section("erisc_l1_code"))) kernel_launch(uint32_t) {
+void kernel_launch(uint32_t) {
     DeviceZoneScopedMainChildN("ERISC-KERNEL");
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 

--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -11,17 +11,15 @@
 OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
 	      "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
-ENTRY(ApplicationHandler)
+ENTRY(_start)
 SECTIONS
 {
-  /* Read-only sections, merged into text segment: */
-  PROVIDE (__executable_start = __firmware_start);
   PROVIDE (__global_pointer$ = __firmware_global_pointer);
   PROVIDE (__erisc_jump_table = ORIGIN(ERISC_JUMPTABLE));
 
-  erisc_l1_code :
+  .start :
   {
-    *(SORT(erisc_l1_code.*))
+    *(.start)
   } > REGION_APP_CODE
   code_l1 :
   {
@@ -45,10 +43,6 @@ SECTIONS
     *(.gnu.warning)
   } > REGION_APP_IRAM_CODE AT > ERISC_OVERLAY*/
 
-
-  PROVIDE (__etext = .);
-  PROVIDE (_etext = .);
-  PROVIDE (etext = .);
   .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_CODE
   .rodata1        : { *(.rodata1) } > REGION_APP_CODE
   .sdata2         :
@@ -56,12 +50,9 @@ SECTIONS
     *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
   } > REGION_APP_DATA
   .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) } > REGION_APP_DATA
-  /* Adjust the address for the data segment.  We want to adjust up to
-     the same address within the page on the next page up.  */
-  . = DATA_SEGMENT_ALIGN (CONSTANT (MAXPAGESIZE), CONSTANT (COMMONPAGESIZE));
-  .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_DATA
+
+.data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_DATA
   .dynamic        : { *(.dynamic) } > REGION_APP_DATA
-  . = DATA_SEGMENT_RELRO_END (0, .);
   .data           :
   {
     *(.data .data.* .gnu.linkonce.d.*)
@@ -69,8 +60,6 @@ SECTIONS
   } > REGION_APP_DATA
 
   . = ALIGN(4); /* startup code will use word writes to zero bss */
-  _edata = .; PROVIDE (edata = .);
-  . = .;
   __l1_bss_start = .;
   .sbss           :
   {
@@ -97,11 +86,6 @@ SECTIONS
    __ldm_bss_end = .;
   } > REGION_APP_DATA
   . = ALIGN(32 / 8);
-  . = SEGMENT_START("ldata-segment", .);
-  . = ALIGN(32 / 8);
-  _end = .; PROVIDE (end = .);
-  . = DATA_SEGMENT_END (.);
-
 
   .stack :
   {

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -22,8 +22,6 @@ OUTPUT_ARCH(riscv)
 ENTRY(_start)
 SECTIONS
 {
-  /* Read-only sections, merged into text segment: */
-  PROVIDE (__executable_start = __firmware_start);
   PROVIDE (__global_pointer$ = __firmware_global_pointer);
   PROVIDE (__erisc_jump_table = ORIGIN(ERISC_JUMPTABLE));
 
@@ -48,10 +46,6 @@ SECTIONS
   } > REGION_APP_KERNEL_CODE
 
 
-  PROVIDE (__etext = .);
-  _etext = .; PROVIDE (_etext = .);
-
-  PROVIDE (etext = .);
   .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_KERNEL_CODE
   .rodata1        : { *(.rodata1) } > REGION_APP_KERNEL_CODE
   .sdata2         :
@@ -74,8 +68,6 @@ SECTIONS
   } > REGION_APP_KERNEL_DATA
 
   . = ALIGN(4); /* startup code will use word writes to zero bss */
-  _edata = .; PROVIDE (edata = .);
-  . = .;
   __l1_bss_start = .;
   .sbss           :
   {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12979

### Problem description
The erisc linker scripts are bespoke, rather then an instantiation of the more general scripts. This starts cleaning them up to progress their merging.

### What's changed
1) Use the more usual `_start` entry name and a .start section
2) remove a bunch of unneeded symbols inherited from the generic unix-like origin.
3) add some more logging the the elf loader, and diagnostics on error
4) remove a check about section placement -- I forgot about NOBITS sections there, and it's not really necessary to pedantically verify a well formed ELF.

### Checklist
- [ YES ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [NA] Model regression CI testing passes (if applicable)
- [ NA] Device performance regression CI testing passes (if applicable)
- [YES] New/Existing tests provide coverage for changes
