### PR TITLE
#14022: Fix package and release workflow by using `build_metal.sh` underneath in `setup.py`

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -25,6 +25,7 @@ show_help() {
     echo "  --development                    Set the build type as RelWithDebInfo."
     echo "  --debug                          Set the build type as Debug."
     echo "  --clean                          Remove build workspaces."
+    echo "  --build-static-libs              Build tt_metal (not ttnn) as a static lib (BUILD_SHARED_LIBS=OFF)"
 }
 
 clean() {
@@ -47,11 +48,12 @@ build_ttnn_tests="OFF"
 build_metal_tests="OFF"
 build_umd_tests="OFF"
 build_programming_examples="OFF"
+build_static_libs="OFF"
 
 declare -a cmake_args
 
 OPTIONS=h,e,c,t,a,m,s,u,b:,p
-LONGOPTIONS=help,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,release,development,debug,clean
+LONGOPTIONS=help,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,build-static-libs,release,development,debug,clean
 
 # Parse the options
 PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTIONS --name "$0" -- "$@")
@@ -97,6 +99,8 @@ while true; do
             build_umd_tests="ON";;
         --build-programming-examples)
             build_programming_examples="ON";;
+        --build-static-libs)
+            build_static_libs="ON";;
         --release)
             build_type="Release";;
         --development)
@@ -211,6 +215,10 @@ fi
 
 if [ "$build_programming_examples" = "ON" ]; then
     cmake_args+=("-DBUILD_PROGRAMMING_EXAMPLES=ON")
+fi
+
+if [ "$build_static_libs" = "ON" ]; then
+    cmake_args+=("-DBUILD_SHARED_LIBS=OFF")
 fi
 
 # Create and link the build directory

--- a/setup.py
+++ b/setup.py
@@ -127,23 +127,22 @@ class CMakeBuild(build_ext):
             ).exists(), "The precompiled option is selected via `TT_FROM_PRECOMPILED` \
             env var. Please place files into `build/lib` and `runtime` folders."
         else:
+            build_dir = source_dir / "build_Release"
             # We indirectly set a wheel build for our CMake build by using BUILD_SHARED_LIBS. This does the following things:
             # - Bundles (most) of our libraries into a static library to deal with a potential singleton bug error with tt_cluster (to fix)
-            build_script_args = ["--build-static-libs"]
+            build_script_args = ["--build-static-libs", "--release"]
 
-            subprocess.check_call(
-                ["./build_metal.sh", *build_script_args], cwd=source_dir, env=build_env
-            )
+            subprocess.check_call(["./build_metal.sh", *build_script_args], cwd=source_dir, env=build_env)
 
         # Some verbose sanity logging to see what files exist in the outputs
         subprocess.check_call(["ls", "-hal"], cwd=source_dir, env=build_env)
-        subprocess.check_call(["ls", "-hal", "build/lib"], cwd=source_dir, env=build_env)
+        subprocess.check_call(["ls", "-hal", str(build_dir / "lib")], cwd=source_dir, env=build_env)
         subprocess.check_call(["ls", "-hal", "runtime"], cwd=source_dir, env=build_env)
 
         # Copy needed C++ shared libraries and runtime assets into wheel (sfpi, FW etc)
         dest_ttnn_build_dir = self.build_lib + "/ttnn/build"
         os.makedirs(dest_ttnn_build_dir, exist_ok=True)
-        self.copy_tree(source_dir / "build/lib", dest_ttnn_build_dir + "/lib")
+        self.copy_tree(build_dir / "lib", dest_ttnn_build_dir + "/lib")
         self.copy_tree(source_dir / "runtime", self.build_lib + "/runtime")
 
         # Encode ARCH_NAME into package for later use so user doesn't have to provide


### PR DESCRIPTION
### Ticket

#14022 

### Problem description

Recent CMake refactoring by @blozano-tt now means that we no longer arbitrarily set `CMAKE_INSTALL_PREFIX` and instead take it in from the user. This is more idiomatic in the CMake world.

However, we relied on this variable being set for us even if we call CMake directly, rather than using the packaged `build_metal.sh`.

### What's changed

Use `build_metal.sh` directly.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
