### PR TITLE
#14010: fix caching issues with moreh_adam and moreh_adamw

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_adam.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_adam.py
@@ -189,3 +189,19 @@ def test_moreh_adam_caching(params, device, use_program_cache):
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     for i in range(1, 4):
         assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]
+
+    num_program_cache_entries_list = []
+    for i in range(4):
+        shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en = params
+
+        # generate a random lr between (0, 1)
+        lr = torch.rand(1).item()
+
+        test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en, device)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    for i in range(1, 4):
+        assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]

--- a/tests/ttnn/unit_tests/operations/test_moreh_adamw.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_adamw.py
@@ -240,11 +240,25 @@ def test_moreh_adamw_compute_kernel_options(
 @pytest.mark.parametrize("eps", [1e-08])
 @pytest.mark.parametrize("weight_decay", [0.3])
 @pytest.mark.parametrize("amsgrad", [True])
-def test_moreh_adamw_step_cache(shape, lr, betas, eps, weight_decay, amsgrad, device, use_program_cache):
+def test_moreh_adamw_cache(shape, lr, betas, eps, weight_decay, amsgrad, device, use_program_cache):
     torch.manual_seed(2024)
     num_program_cache_entries_list = []
     for step in range(1, 5):
         run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    for i in range(1, 4):
+        assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]
+
+    num_program_cache_entries_list = []
+    for _ in range(4):
+        # generate a new lr between (0, 1)
+        lr = torch.rand(1).item()
+
+        run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, 8, device)
         torch_dummy = torch.randn([32, 32])
         tt_dummy = to_ttnn(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())

--- a/tests/ttnn/unit_tests/operations/test_moreh_adamw.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_adamw.py
@@ -229,3 +229,26 @@ def test_moreh_adamw_compute_kernel_options(
 ):
     torch.manual_seed(0)
     run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device, compute_kernel_options)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[32, 32]],  # single
+)
+@pytest.mark.parametrize("lr", [1e-2])
+@pytest.mark.parametrize("betas", [[0.5, 0.555]])
+@pytest.mark.parametrize("eps", [1e-08])
+@pytest.mark.parametrize("weight_decay", [0.3])
+@pytest.mark.parametrize("amsgrad", [True])
+def test_moreh_adamw_step_cache(shape, lr, betas, eps, weight_decay, amsgrad, device, use_program_cache):
+    torch.manual_seed(2024)
+    num_program_cache_entries_list = []
+    for step in range(1, 5):
+        run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+        num_program_cache_entries_list.append(device.num_program_cache_entries())
+    logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    assert num_program_cache_entries_list[0] > 0
+    for i in range(1, 4):
+        assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -156,4 +156,14 @@ std::tuple<MorehAdamOperation::operation_attributes_t, MorehAdamOperation::tenso
             max_exp_avg_sq_in,
             {param_out, exp_avg_out, exp_avg_sq_out, max_exp_avg_sq_out}}};
 }
+auto MorehAdamOperation::compute_program_hash(
+    const MorehAdamOperation::operation_attributes_t& operation_attributes,
+    const MorehAdamOperation::tensor_args_t& tensor_args) -> tt::stl::hash::hash_t {
+    // For hash we'll set `step` to 0
+    auto operation_attributes_without_step = operation_attributes;
+    operation_attributes_without_step.step = 0;
+
+    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes_without_step, tensor_args);
+}
+
 }  // namespace ttnn::operations::moreh::moreh_adam

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "ttnn/operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -159,11 +160,25 @@ std::tuple<MorehAdamOperation::operation_attributes_t, MorehAdamOperation::tenso
 auto MorehAdamOperation::compute_program_hash(
     const MorehAdamOperation::operation_attributes_t& operation_attributes,
     const MorehAdamOperation::tensor_args_t& tensor_args) -> tt::stl::hash::hash_t {
-    // For hash we'll set `step` to 0
-    auto operation_attributes_without_step = operation_attributes;
-    operation_attributes_without_step.step = 0;
-
-    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes_without_step, tensor_args);
+    return operation::hash_operation<MorehAdamOperation>(
+        operation_attributes.beta1,
+        operation_attributes.beta2,
+        operation_attributes.eps,
+        operation_attributes.amsgrad,
+        operation_attributes.weight_decay,
+        operation_attributes.memory_config,
+        operation_attributes.compute_kernel_config,
+        tensor_args.param_in.memory_config(),
+        tensor_args.param_in.dtype(),
+        tensor_args.grad.memory_config(),
+        tensor_args.grad.dtype(),
+        tensor_args.exp_avg_in.memory_config(),
+        tensor_args.exp_avg_in.dtype(),
+        tensor_args.exp_avg_sq_in.memory_config(),
+        tensor_args.exp_avg_sq_in.dtype(),
+        tensor_args.max_exp_avg_sq_in.has_value() ? tensor_args.max_exp_avg_sq_in.value().memory_config()
+                                                  : MemoryConfig{},
+        tensor_args.max_exp_avg_sq_in.has_value() ? tensor_args.max_exp_avg_sq_in.value().dtype() : DataType::INVALID);
 }
 
 }  // namespace ttnn::operations::moreh::moreh_adam

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 #include <vector>
 
+#include "common/core_coord.h"
 #include "ttnn/decorators.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -42,6 +43,10 @@ struct MorehAdamOperation {
         struct shared_variables_t {
             KernelHandle unary_reader_kernel_id;
             KernelHandle unary_writer_kernel_id;
+            KernelHandle compute_kernel_group1_id;
+            KernelHandle compute_kernel_group2_id;
+            CoreRangeSet core_group_1;
+            CoreRangeSet core_group_2;
             std::size_t num_cores;
             std::size_t num_cores_y;
         };
@@ -90,6 +95,8 @@ struct MorehAdamOperation {
 
         const std::optional<ttnn::MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
+
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::moreh::moreh_adam
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -5,7 +5,6 @@
 #include <variant>
 #include <vector>
 
-#include "common/core_coord.h"
 #include "ttnn/decorators.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
@@ -280,6 +280,13 @@ void MorehAdamOperation::ProgramFactory::override_runtime_arguments(
     auto num_cores = cached_program.shared_variables.num_cores;
     auto num_cores_y = cached_program.shared_variables.num_cores_y;
 
+    union {
+        float f;
+        uint32_t u;
+    } f2u_lr;
+
+    f2u_lr.f = operation_attributes.lr;
+
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         {
@@ -291,6 +298,7 @@ void MorehAdamOperation::ProgramFactory::override_runtime_arguments(
             if (max_exp_avg_sq_in_buffer != nullptr) {
                 runtime_args[4] = max_exp_avg_sq_in_buffer->address();
             }
+            runtime_args[5] = f2u_lr.u;
             runtime_args[10] = operation_attributes.step;
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -150,4 +150,13 @@ MorehAdamWDeviceOperation::invoke(
             max_exp_avg_sq_out}};
 }
 
+tt::stl::hash::hash_t MorehAdamWDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // For hash we'll set `step` to 0
+    auto operation_attributes_without_step = operation_attributes;
+    operation_attributes_without_step.step = 0;
+
+    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes_without_step, tensor_args);
+}
+
 }  // namespace ttnn::operations::moreh::moreh_adamw

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -152,11 +152,24 @@ MorehAdamWDeviceOperation::invoke(
 
 tt::stl::hash::hash_t MorehAdamWDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // For hash we'll set `step` to 0
-    auto operation_attributes_without_step = operation_attributes;
-    operation_attributes_without_step.step = 0;
-
-    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes_without_step, tensor_args);
+    return operation::hash_operation<MorehAdamWDeviceOperation>(
+        operation_attributes.beta1,
+        operation_attributes.beta2,
+        operation_attributes.eps,
+        operation_attributes.amsgrad,
+        operation_attributes.weight_decay,
+        operation_attributes.memory_config,
+        operation_attributes.compute_kernel_config,
+        tensor_args.param_in.memory_config(),
+        tensor_args.param_in.dtype(),
+        tensor_args.grad.memory_config(),
+        tensor_args.grad.dtype(),
+        tensor_args.exp_avg_in.memory_config(),
+        tensor_args.exp_avg_in.dtype(),
+        tensor_args.exp_avg_sq_in.memory_config(),
+        tensor_args.exp_avg_sq_in.dtype(),
+        tensor_args.max_exp_avg_sq_in.has_value() ? tensor_args.max_exp_avg_sq_in.value().memory_config()
+                                                  : MemoryConfig{},
+        tensor_args.max_exp_avg_sq_in.has_value() ? tensor_args.max_exp_avg_sq_in.value().dtype() : DataType::INVALID);
 }
-
 }  // namespace ttnn::operations::moreh::moreh_adamw

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -49,6 +49,10 @@ struct MorehAdamWDeviceOperation {
         struct shared_variables_t {
             KernelHandle unary_reader_kernel_id;
             KernelHandle unary_writer_kernel_id;
+            KernelHandle compute_kernel_group1_id;
+            KernelHandle compute_kernel_group2_id;
+            CoreRangeSet core_group_1;
+            CoreRangeSet core_group_2;
             std::size_t num_cores;
             std::size_t num_cores_y;
         };
@@ -102,8 +106,9 @@ struct MorehAdamWDeviceOperation {
         const std::optional<Tensor>& max_exp_avg_sq_out,
         const std::optional<ttnn::MemoryConfig>& memory_config,
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config);
-};
 
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
 }  // namespace ttnn::operations::moreh::moreh_adamw
 
 // Register the operation with the ttnn::register_operation API to make it available to the user as

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -270,6 +270,13 @@ void MorehAdamWDeviceOperation::MultiCore::override_runtime_arguments(
     const uint32_t max_exp_avg_sq_out_addr =
         operation_attributes.amsgrad ? tensor_return_value.at(3).value().buffer()->address() : 0;
 
+    union {
+        float f;
+        uint32_t u;
+    } f2u_lr;
+
+    f2u_lr.f = operation_attributes.lr;
+
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         {
@@ -279,6 +286,7 @@ void MorehAdamWDeviceOperation::MultiCore::override_runtime_arguments(
             runtime_args[2] = exp_avg_in_addr;
             runtime_args[3] = exp_avg_sq_in_addr;
             runtime_args[4] = max_exp_avg_sq_in_addr;
+            runtime_args[5] = f2u_lr.u;
             runtime_args[10] = operation_attributes.step;
         }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -4,8 +4,8 @@
 
 #include "moreh_matmul_device_operation.hpp"
 #include "tt_metal/common/work_split.hpp"
-#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_matmul {
 
@@ -473,15 +473,6 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
             {output.buffer()->address(), num_tiles_written, num_output_tiles_per_core});
         num_tiles_written += num_output_tiles_per_core;
     }
-
-    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, num_cores_y](
-                                              const void *operation,
-                                              Program &program,
-                                              const std::vector<Tensor> &input_tensors,
-                                              const std::vector<std::optional<const Tensor>> &optional_input_tensors,
-                                              const std::vector<Tensor> &output_tensors) {
-
-    };
 
     return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
 }


### PR DESCRIPTION
### Ticket
Closes #14010 

### Problem description
`adam` and `adamw` specified the `step` operation attribute that is provided at runtime as a non-cacheable argument. As such when the `step` changes the cache is always regenerated even though the cache item is valid if the argument is overriden accordingly

### What's changed
- Override `compute_program_hash` with custom hash implementation that does not use the `step` argument
- Update `override_runtime_arguments` with new item for `step`

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
