### PR TITLE
#14038: Remove global BUFFER_MAP and make the tracking of buffers local to an allocator

### DIFF
--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -276,7 +276,7 @@ inline namespace v0 {
 
         void SetLazyCommandQueueMode(bool lazy);
 
-        DeviceAddr AllocateBuffer(const Buffer* buffer, bool bottom_up);
+        DeviceAddr AllocateBuffer(Buffer* buffer);
 
         void DeallocateBuffer(Buffer *buffer);
     }  // namespace detail

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -27,12 +27,12 @@ bool GraphTracker::add_hook(const std::shared_ptr<IGraphHooks>& new_hook) {
     return true;
 }
 
-void GraphTracker::track_allocate(const Buffer* buffer, bool bottom_up) {
+void GraphTracker::track_allocate(const Buffer* buffer) {
     if (processors.empty()) {
         return;
     }
     for (auto& it : processors) {
-        it->track_allocate(buffer, bottom_up);
+        it->track_allocate(buffer);
     }
 }
 
@@ -73,11 +73,11 @@ void GraphTracker::track_program(Program* program) {
     }
 }
 
-bool GraphTracker::hook_allocate(const Buffer* buffer, bool bottom_up) {
+bool GraphTracker::hook_allocate(const Buffer* buffer) {
     if (hook == nullptr)
         return false;
 
-    return hook->hook_allocate(buffer, bottom_up);
+    return hook->hook_allocate(buffer);
 }
 
 bool GraphTracker::hook_deallocate(Buffer* buffer) {

--- a/tt_metal/graph/graph_tracking.hpp
+++ b/tt_metal/graph/graph_tracking.hpp
@@ -28,7 +28,7 @@ inline namespace v0 {
 
         IGraphProcessor() = default;
 
-        virtual void track_allocate(const tt::tt_metal::Buffer* buffer, bool bottom_up) {};
+        virtual void track_allocate(const tt::tt_metal::Buffer* buffer) {};
 
         virtual void track_deallocate(tt::tt_metal::Buffer* buffer) {};
 
@@ -54,7 +54,7 @@ inline namespace v0 {
     class IGraphHooks {
     public:
         IGraphHooks() = default;
-        virtual bool hook_allocate(const tt::tt_metal::Buffer* buffer, bool bottom_up) = 0;
+        virtual bool hook_allocate(const tt::tt_metal::Buffer* buffer) = 0;
 
         virtual bool hook_deallocate(tt::tt_metal::Buffer* buffer) = 0;
 
@@ -77,7 +77,7 @@ inline namespace v0 {
 
         bool add_hook(const std::shared_ptr<IGraphHooks>& hook);
 
-        void track_allocate(const Buffer* buffer, bool bottom_up);
+        void track_allocate(const Buffer* buffer);
 
         void track_deallocate(Buffer* buffer);
 
@@ -118,7 +118,7 @@ inline namespace v0 {
             }
         }
 
-        bool hook_allocate(const Buffer* buffer, bool bottom_up);
+        bool hook_allocate(const Buffer* buffer);
 
         bool hook_deallocate(Buffer* buffer);
 

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -377,38 +377,45 @@ void verify_safe_allocation(Allocator& allocator) {
     }
 }
 
-uint64_t allocate_buffer(
-    Allocator &allocator,
-    DeviceAddr size,
-    DeviceAddr page_size,
-    const BufferType &buffer_type,
-    bool bottom_up,
-    std::optional<uint32_t> num_shards) {
-    uint64_t address = 0;
+const std::unordered_set<Buffer *> &get_allocated_buffers(const Allocator &allocator) { return allocator.allocated_buffers; }
+
+DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, Buffer *buffer) {
+    DeviceAddr address = 0;
+    auto page_size = buffer->page_size();
+    auto buffer_type = buffer->buffer_type();
+    auto bottom_up = buffer->bottom_up();
+    auto num_shards = buffer->num_cores();
     verify_safe_allocation(allocator);
     switch (buffer_type) {
         case BufferType::DRAM:
-            return allocator.descriptor.dram.alloc(
+            address = allocator.descriptor.dram.alloc(
                 allocator.config, allocator.dram_manager, size, page_size, bottom_up, num_shards);
+            break;
         case BufferType::L1:
-            return allocator.descriptor.l1.alloc(
+            address = allocator.descriptor.l1.alloc(
                 allocator.config, allocator.l1_manager, size, page_size, bottom_up, num_shards);
+            break;
         case BufferType::L1_SMALL: {
             TT_FATAL(num_shards.has_value(), "L1_SMALL only supports sharded allocations, see validate_num_banks");
-            return allocator.descriptor.l1.alloc(
+            address = allocator.descriptor.l1.alloc(
                 allocator.config, allocator.l1_small_manager, size, page_size, bottom_up, num_shards);
-            case BufferType::TRACE:
-                return allocator.descriptor.dram.alloc(
-                    allocator.config, allocator.trace_buffer_manager, size, page_size, bottom_up, num_shards);
+            break;
         }
+        case BufferType::TRACE:
+            address = allocator.descriptor.dram.alloc(
+                allocator.config, allocator.trace_buffer_manager, size, page_size, bottom_up, num_shards);
+            break;
         default: {
             TT_THROW("Unsupported buffer type!");
         }
     }
+    allocator.allocated_buffers.insert(buffer);
     return address;
 }
 
-void deallocate_buffer(Allocator &allocator, DeviceAddr address, const BufferType &buffer_type) {
+void deallocate_buffer(Allocator &allocator, Buffer *buffer) {
+    auto address = buffer->address();
+    auto buffer_type = buffer->buffer_type();
     switch (buffer_type) {
         case BufferType::DRAM: allocator.dram_manager.deallocate_buffer(address); break;
         case BufferType::L1: allocator.l1_manager.deallocate_buffer(address); break;
@@ -418,6 +425,7 @@ void deallocate_buffer(Allocator &allocator, DeviceAddr address, const BufferTyp
             TT_THROW("Unsupported buffer type!");
         }
     }
+    allocator.allocated_buffers.erase(buffer);
 }
 
 void deallocate_buffers(Allocator &allocator) {
@@ -425,6 +433,7 @@ void deallocate_buffers(Allocator &allocator) {
     allocator.l1_manager.deallocate_all();
     allocator.l1_small_manager.deallocate_all();
     allocator.trace_buffer_manager.deallocate_all();
+    allocator.allocated_buffers.clear();
 }
 
 void clear(Allocator &allocator) {
@@ -432,6 +441,7 @@ void clear(Allocator &allocator) {
     allocator.l1_manager.clear();
     allocator.l1_small_manager.clear();
     allocator.trace_buffer_manager.clear();
+    allocator.allocated_buffers.clear();
 }
 
 }  // namespace allocator
@@ -460,6 +470,7 @@ void Allocator::reset() {
     l1_manager.clear();
     l1_small_manager.clear();
     trace_buffer_manager.clear();
+    allocated_buffers.clear();
     config.reset();
 }
 

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -19,6 +19,12 @@ namespace tt {
 
 namespace tt_metal {
 
+inline namespace v0 {
+
+class Buffer;
+
+}  // namespace v0
+
 // Fwd declares
 enum class BufferType;
 struct Allocator;
@@ -99,14 +105,16 @@ std::optional<DeviceAddr> lowest_occupied_l1_address(const Allocator &allocator,
 
 DeviceAddr base_alloc(const AllocatorConfig & config, BankManager &bank_manager, DeviceAddr size, DeviceAddr page_size, bool bottom_up, std::optional<uint32_t> num_shards);
 
-DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, DeviceAddr page_size, const BufferType &buffer_type, bool bottom_up, std::optional<uint32_t> num_shards = std::nullopt);
+DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, Buffer *buffer);
 
 void mark_allocations_unsafe(Allocator &allocator);
 
 void mark_allocations_safe(Allocator &allocator);
 
-void deallocate_buffer(Allocator &allocator, DeviceAddr address, const BufferType &buffer_type);
+void deallocate_buffer(Allocator &allocator, Buffer *buffer);
 void deallocate_buffers(Allocator &allocator);
+
+const std::unordered_set<Buffer *> &get_allocated_buffers(const Allocator &allocator);
 
 void clear(Allocator &allocatator);
 
@@ -127,6 +135,7 @@ struct Allocator {
     std::unordered_map<uint32_t, std::vector<uint32_t>> dram_channel_to_bank_ids;
     std::unordered_map<uint32_t, CoreCoord> bank_id_to_logical_core;
     std::unordered_map<BufferType, std::unordered_map<CoreCoord, std::vector<uint32_t>>> logical_core_to_bank_ids;
+    std::unordered_set<Buffer *> allocated_buffers;
 
     AllocatorConfig config;
     // Callbacks to invoke during initialization and allocation

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2949,10 +2949,8 @@ bool Device::close() {
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);
     // After device close, no buffers on this device should be used
-    for (const auto &[buf_attr, buf] : detail::BUFFER_MAP.value()) {
-        if (std::get<0>(buf_attr) == this->id()) {
-            DeallocateBuffer(*buf);
-        }
+    for (const auto &buf : this->get_allocated_buffers()) {
+        DeallocateBuffer(*buf);
     }
 
     this->compute_cores_.clear();
@@ -3172,6 +3170,11 @@ size_t Device::get_l1_small_size() const {
 void Device::dump_memory_blocks(const BufferType &buffer_type, std::ofstream &out) const {
     this->check_allocator_is_initialized();
     return allocator::dump_memory_blocks(*this->allocator_, buffer_type, out);
+}
+
+const std::unordered_set<Buffer *> &Device::get_allocated_buffers() const {
+    this->check_allocator_is_initialized();
+    return allocator::get_allocated_buffers(*this->allocator_);
 }
 
 void Device::deallocate_buffers(){

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -197,6 +197,8 @@ class Device {
     uint32_t get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& physical_core) const;
     uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& physical_cores) const;
 
+    const std::unordered_set<Buffer *> &get_allocated_buffers() const;
+
     void deallocate_buffers();
 
     // machine epsilon

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -478,9 +478,6 @@ using CompletionReaderQueue = LockFreeQueue<CompletionReaderVariant>;
 struct AllocBufferMetadata {
     Buffer* buffer;
     std::reference_wrapper<Allocator> allocator;
-    BufferType buffer_type;
-    uint32_t device_address;
-    bool bottom_up;
 };
 
 struct RuntimeArgsMetadata {

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -90,7 +90,7 @@ GraphProcessor::GraphProcessor(RunMode mode) : run_mode(mode) {
     end_function_any_map[typeid(std::reference_wrapper<Tensor>)] = [ptr = this] (const std::any& val) mutable {ptr->end_function_process_tensor(val);};
 
 }
-void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer, bool bottom_up) {
+void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
     const std::lock_guard<std::mutex> lock(mutex);
     auto buf_id = add_buffer(buffer);
 
@@ -478,7 +478,7 @@ nlohmann::json GraphProcessor::end_graph_capture() {
         return res;
 }
 
-bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer, bool bottom_up) {
+bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer) {
     return do_block;
 }
 

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -22,7 +22,7 @@ namespace ttnn::graph {
 
     public:
         ProcessorHooks() = default;
-        bool hook_allocate(const tt::tt_metal::Buffer* buffer, bool bottom_up) override;
+        bool hook_allocate(const tt::tt_metal::Buffer* buffer) override;
 
         bool hook_deallocate(tt::tt_metal::Buffer* buffer) override;
 
@@ -40,7 +40,7 @@ namespace ttnn::graph {
         GraphProcessor(tt::tt_metal::IGraphProcessor::RunMode mode);
         ~GraphProcessor() override;
 
-        void track_allocate(const tt::tt_metal::Buffer* buffer, bool bottom_up) override;
+        void track_allocate(const tt::tt_metal::Buffer* buffer) override;
 
         void track_deallocate(tt::tt_metal::Buffer* buffer) override;
 

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include "tt_metal/impl/buffers/buffer.hpp"
+#include "tt_metal/impl/device/device_pool.hpp"
 
 namespace ttnn {
 
@@ -64,49 +65,52 @@ struct BufferInfo {
 
 std::vector<BufferInfo> get_buffers() {
     std::vector<BufferInfo> buffer_infos;
-    for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
-        auto [device_id, address] = key;
-        auto device = buffer->device();
+    for (const auto &device : tt::DevicePool::instance().get_all_active_devices()) {
+        for (const auto &buffer : device->get_allocated_buffers()) {
+            auto device_id = device->id();
+            auto address = buffer->address();
 
-        auto num_pages = buffer->num_pages();
-        auto page_size = buffer->page_size();
-        auto num_banks = device->num_banks(buffer->buffer_type());
+            auto num_pages = buffer->num_pages();
+            auto page_size = buffer->page_size();
+            auto num_banks = device->num_banks(buffer->buffer_type());
 
-        std::map<uint32_t, uint32_t> bank_to_num_pages;
-        if (buffer->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
-            uint32_t bank_id = 0;
-            for (int page_index = 0; page_index < num_pages; page_index++) {
-                if (bank_to_num_pages.find(bank_id) == bank_to_num_pages.end()) {
-                    bank_to_num_pages[bank_id] = 0;
+            std::map<uint32_t, uint32_t> bank_to_num_pages;
+            if (buffer->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
+                uint32_t bank_id = 0;
+                for (int page_index = 0; page_index < num_pages; page_index++) {
+                    if (bank_to_num_pages.find(bank_id) == bank_to_num_pages.end()) {
+                        bank_to_num_pages[bank_id] = 0;
+                    }
+                    bank_to_num_pages[bank_id]++;
+                    bank_id = (bank_id + 1) % num_banks;
                 }
-                bank_to_num_pages[bank_id]++;
-                bank_id = (bank_id + 1) % num_banks;
-            }
-        } else {
-            const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();
-            for (int page_index = 0; page_index < num_pages; page_index++) {
-                auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
-                auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
-                auto bank_id = device->bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
+            } else {
+                const auto &buffer_page_mapping = *buffer->get_buffer_page_mapping();
+                for (int page_index = 0; page_index < num_pages; page_index++) {
+                    auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
+                    auto core =
+                        buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
+                    auto bank_id = device->bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
 
-                if (bank_to_num_pages.find(bank_id) == bank_to_num_pages.end()) {
-                    bank_to_num_pages[bank_id] = 0;
+                    if (bank_to_num_pages.find(bank_id) == bank_to_num_pages.end()) {
+                        bank_to_num_pages[bank_id] = 0;
+                    }
+                    bank_to_num_pages[bank_id]++;
                 }
-                bank_to_num_pages[bank_id]++;
             }
+
+            auto max_num_pages =
+                std::max_element(bank_to_num_pages.begin(), bank_to_num_pages.end(), [](const auto &a, const auto &b) {
+                    return a.second < b.second;
+                });
+
+            BufferInfo buffer_info = {};
+            buffer_info.device_id = device_id;
+            buffer_info.address = address;
+            buffer_info.max_size_per_bank = (*max_num_pages).second * page_size;
+            buffer_info.buffer_type = buffer->buffer_type();
+            buffer_infos.push_back(buffer_info);
         }
-
-        auto max_num_pages =
-            std::max_element(bank_to_num_pages.begin(), bank_to_num_pages.end(), [](const auto &a, const auto &b) {
-                return a.second < b.second;
-            });
-
-        BufferInfo buffer_info = {};
-        buffer_info.device_id = device_id;
-        buffer_info.address = address;
-        buffer_info.max_size_per_bank = (*max_num_pages).second * page_size;
-        buffer_info.buffer_type = buffer->buffer_type();
-        buffer_infos.push_back(buffer_info);
     }
     return buffer_infos;
 }
@@ -125,23 +129,35 @@ struct BufferPageInfo {
 
 std::vector<BufferPageInfo> get_buffer_pages() {
     std::vector<BufferPageInfo> buffer_page_infos;
-    for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
-        if (not buffer->is_l1()) {
-            continue;
-        }
+    for (const auto &device : tt::DevicePool::instance().get_all_active_devices()) {
+        for (const auto &buffer : device->get_allocated_buffers()) {
+            if (not buffer->is_l1()) {
+                continue;
+            }
 
-        auto [device_id, address] = key;
-        auto device = buffer->device();
+            auto device_id = device->id();
+            auto address = buffer->address();
 
-        uint32_t page_size = buffer->page_size();
-        auto num_pages = buffer->num_pages();
-        auto num_banks = device->num_banks(buffer->buffer_type());
+            auto page_size = buffer->page_size();
+            auto num_pages = buffer->num_pages();
+            auto num_banks = device->num_banks(buffer->buffer_type());
 
-        if (buffer->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
             uint32_t bank_id = 0;
             for (int page_index = 0; page_index < num_pages; page_index++) {
-                auto page_address = buffer->page_address(bank_id, page_index);
-                auto core = buffer->logical_core_from_bank_id(bank_id);
+                CoreCoord core;
+                DeviceAddr page_address = 0;
+
+                if (buffer->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
+                    page_address = buffer->page_address(bank_id, page_index);
+                    core = buffer->logical_core_from_bank_id(bank_id);
+                    bank_id = (bank_id + 1) % num_banks;
+                } else {
+                    const auto &buffer_page_mapping = *buffer->get_buffer_page_mapping();
+                    auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
+                    core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
+                    bank_id = device->bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
+                    page_address = buffer->sharded_page_address(bank_id, dev_page_index);
+                }
 
                 BufferPageInfo buffer_page_info = {};
                 buffer_page_info.device_id = device_id;
@@ -153,28 +169,7 @@ std::vector<BufferPageInfo> get_buffer_pages() {
                 buffer_page_info.page_address = page_address;
                 buffer_page_info.page_size = page_size;
                 buffer_page_info.buffer_type = buffer->buffer_type();
-                buffer_page_infos.push_back(buffer_page_info);
 
-                bank_id = (bank_id + 1) % num_banks;
-            }
-        } else {
-            const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();
-            for (int page_index = 0; page_index < num_pages; page_index++) {
-                auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
-                auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
-                auto bank_id = device->bank_ids_from_logical_core(buffer->buffer_type(), core)[0];
-                auto page_address = buffer->sharded_page_address(bank_id, dev_page_index);
-
-                BufferPageInfo buffer_page_info = {};
-                buffer_page_info.device_id = device_id;
-                buffer_page_info.address = address;
-                buffer_page_info.core_y = core.y;
-                buffer_page_info.core_x = core.x;
-                buffer_page_info.bank_id = bank_id;
-                buffer_page_info.page_index = page_index;
-                buffer_page_info.page_address = page_address;
-                buffer_page_info.page_size = page_size;
-                buffer_page_info.buffer_type = buffer->buffer_type();
                 buffer_page_infos.push_back(buffer_page_info);
             }
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14038

### Problem description
We had a global BUFFER_MAP that tracked buffers by device/address. This was bugged since it doesn't distinguish between buffer types, as different buffer types can have the same address. The two users of this map are device, which uses it to deallocate all buffers on device close, and ttnn for dumping buffer statistics. Discussion with @tt-asaigal was that for distributed work in the future, the allocation won't be by device, so we will have the allocator track its own allocated buffers, and device can query this.

### What's changed
Make buffer map local to the allocator object.
Update apis related to allocate/deallocate to not need to pass `bottom_up` separately and make them pass around the buffer ptr, instead of extracting fields at the higher level. This simplifies the api and also needed for tracking the buffers in the allocator.
There is a dependency on #14023 to make buffers thread safe, which would enable the change to pass buffer ptrs around.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
