### PR TITLE
#13644: test arith binary scalar with unary sfpu

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -18,9 +18,33 @@ def test_add_1D_tensor_and_scalar(device, scalar, size):
     torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor + scalar
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = input_tensor + scalar
     output_tensor = ttnn.to_torch(output_tensor, torch_rank=1)
+
+    print("torch_output_tensor", torch_output_tensor)
+    print("output_tensor", output_tensor)
+    print(ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor))
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99964
+    assert output_tensor.shape == (size,)
+
+
+@pytest.mark.parametrize("scalar", [3])
+@pytest.mark.parametrize("size", [64])
+def test_add_1D_tensor_and_scalar_float(device, scalar, size):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((size,), dtype=torch.float)
+    torch_output_tensor = torch_input_tensor + scalar
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = input_tensor + scalar
+    output_tensor = ttnn.to_torch(output_tensor, torch_rank=1)
+
+    print("torch_output_tensor", torch_output_tensor)
+    print("output_tensor", output_tensor)
+    print(ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor))
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988
     assert output_tensor.shape == (size,)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_scalar.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_scalar.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("scalar", [3])
+@pytest.mark.parametrize("size", [64])
+def test_div_1D_tensor_and_scalar(device, scalar, size):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor / scalar
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.divide(input_tensor, scalar)
+    output_tensor = ttnn.to_torch(output_tensor, torch_rank=1)
+
+    print("torch_output_tensor", torch_output_tensor)
+    print("output_tensor", output_tensor)
+    print(ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor))
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.9999
+    assert output_tensor.shape == (size,)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
@@ -23,6 +23,21 @@ def test_sub_scalar(device, s, h, w):
     output_tensor = input_tensor - s
     output_tensor = ttnn.to_torch(output_tensor)
 
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
+
+
+@pytest.mark.parametrize("s", [3])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_sub_scalar_float(device, s, h, w):
+    torch_input_tensor = torch.rand((h, w), dtype=torch.float)
+    torch_output_tensor = torch_input_tensor - s
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = input_tensor - s
+    output_tensor = ttnn.to_torch(output_tensor)
+
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9998)
 
 
@@ -31,6 +46,23 @@ def test_sub_scalar(device, s, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_rsub_scalar(device, s, h, w):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_output_tensor = s - torch_input_tensor
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # TODO : add Tensor.__rsub__ eventually
+    output_tensor = ttnn.mul(input_tensor, -1.0)
+    output_tensor = ttnn.add(output_tensor, s)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
+
+
+@pytest.mark.parametrize("s", [3])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_rsub_scalar_float(device, s, h, w):
+    torch_input_tensor = torch.rand((h, w), dtype=torch.float)
     torch_output_tensor = s - torch_input_tensor
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Profiling (main): 
- add_unary:  ttnn.add_unary,800,0.042,0.044,0.115,0.014
- sub_unary:  ttnn.sub_unary,800,0.041,0.044,0.115,0.014
- mul_unary:  ttnn.mul_unary,800,0.043,0.047,0.115,0.015

### What's changed
**Profiling : 
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)**

- ttnn.add_unary,800,0.038,0.042,0.105,0.01
- ttnn.mul_unary,800,0.037,0.039,0.108,0.01
- ttnn.sub_unary,800,0.037,0.039,0.105,0.009


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
