### PR TITLE
#13707: Update TT_ASSERT in reshape op to use padded shape

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -351,14 +351,15 @@ Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const ttnn::SimpleShap
 Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) {
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::reshape", input_tensor, new_shape);
+    const auto& new_padded_shape = new_shape.padded_shape();
     TT_ASSERT(
-        input_tensor.volume() == new_shape.padded_shape().volume(),
+        input_tensor.volume() == new_padded_shape.volume(),
         "{} != {}",
         input_tensor.volume(),
-        new_shape.padded_shape().volume());
+        new_padded_shape.volume());
     if (input_tensor.get_layout() == Layout::TILE) {
         TT_ASSERT(
-            new_shape[-2] % constants::TILE_HEIGHT == 0 && new_shape[-1] % constants::TILE_WIDTH == 0 &&
+            new_padded_shape[-2] % constants::TILE_HEIGHT == 0 && new_padded_shape[-1] % constants::TILE_WIDTH == 0 &&
             "Expected a multiple of 32 for H, W (or -1 evaluating to such) in Tensor::reshape()!");
     }
     auto output = std::visit(


### PR DESCRIPTION
### Ticket
Minor bug fix.

### Problem description
One of the `TT_ASSERT` in reshape was broken in debug build with this test: 
```
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_min_max.py::test_min_max_for_dim_hw[layout0-min-shape_dim6]
```

### What's changed
Switch to padded shape for tile checks.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11443858947
  - NOTE: This pipeline doesn't actually test this change since it's built in release. I verified failing test is passing locally with debug build.
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
