### PR TITLE
#13127: Add compute_output_specs and make create_output_tensors optional

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
@@ -22,8 +22,7 @@ struct SliceDeviceOperation {
 
 
     void validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp
@@ -23,8 +23,7 @@ struct Transpose {
     const MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     TransposeOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
@@ -30,8 +30,7 @@ struct Reduce {
     ttnn::DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     ReduceOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const;
 };

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -17,6 +17,11 @@ namespace tt::tt_metal {
 namespace operation {
 
 using ttnn::operations::experimental::auto_format::FormatParams;
+
+// TODO: create_output_tensors should become a fully manual path with no dependency on infra
+// - Pass output shapes directly
+// - Move default values for output_dtype and output_mem_config inside ops
+// - This function becomes just a regular helper function
 template <typename ConcreteOperation>
 auto generic_create_output_tensors(
     const ConcreteOperation& operation,

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -368,5 +368,6 @@ bool validate_worker_modes(const std::vector<Device *> &workers);
 namespace ttnn {
 
 using Tensor = tt::tt_metal::Tensor;
+using TensorSpec = std::pair<ttnn::SimpleShape, tt::tt_metal::TensorLayout>;
 
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Switching `compute_output_shapes` to return `SimpleShape` does not capture cases where OP manually carries over padding that cannot be automatically determined (eg. padding along non-height or width dims).

### What's changed
Added new `compute_output_specs` that returns a `TensorSpec`, which is a pair of `SimpleShape` and `TensorLayout`. With this function, OP infra can now fully handle tensor creation (including optional output tensors) without needing an explicit `create_output_tensors`. So `create_output_tensors` is now optional and OP Infra asserts are updated to enable this.
- NOTE: You should only implement one of `compute_output_shape` or `compute_output_specs`. If you implement `compute_output_shape`, then `create_output_tensors` is still needed.

OPs updated as examples: reduce, transpose, slice

### Checklist
- [x] Post commit CI passes:
  - post-commit all: https://github.com/tenstorrent/tt-metal/actions/runs/11731339722
  - nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/11731337943
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
