### PR TITLE
#14052: Remove C++20 span dependency

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,12 +7,11 @@ set(ENV{CPM_SOURCE_CACHE} "${PROJECT_SOURCE_DIR}/.cpmcache")
 
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
 
-add_library(span INTERFACE)
-if(CMAKE_CXX_STANDARD LESS 20)
-  fetch_boost_library(core)
-  target_link_libraries(span INTERFACE Boost::core)
-endif()
+fetch_boost_library(core)
 fetch_boost_library(smart_ptr)
+
+add_library(span INTERFACE)
+target_link_libraries(span INTERFACE Boost::core)
 
 ############################################################################################################################
 # yaml-cpp


### PR DESCRIPTION
### Ticket
#14052

### Problem description
tt_metal project must compile with C++17 so it cannot depend on C++20 headers or features

### What's changed
Remove the preprocessor branches that check for C++20 support and always depend on Boost::core

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11444812825)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
