### PR TITLE
#0: Ensure that trace region in DRAM respects alignment constraints

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -223,8 +223,8 @@ void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size
          .worker_grid_size = this->logical_grid_size(),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
          .storage_core_bank_size = get_storage_core_bank_size(id_, num_hw_cqs_, dispatch_core_type),
-         .l1_small_size = l1_small_size,
-         .trace_region_size = trace_region_size,
+         .l1_small_size = align(l1_small_size, hal.get_alignment(HalMemType::L1)),
+         .trace_region_size = align(trace_region_size, hal.get_alignment(HalMemType::DRAM)),
          .core_type_from_noc_coord_table = {},  // Populated later
          .worker_log_to_physical_routing_x = soc_desc.worker_log_to_physical_routing_x,
          .worker_log_to_physical_routing_y = soc_desc.worker_log_to_physical_routing_y,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Trace region size is passed in my the user and may not respect DRAM alignment constraints by default. This can cause hangs since data structures allocated below the trace region will not respect DRAM alignment.

### What's changed
Align the trace region size in device init, when creating the allocator config.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
