### PR TITLE
#596: Update test_eth_EnqueueProgram.cpp

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_EnqueueProgram.cpp
@@ -589,7 +589,6 @@ TEST_F(CommandQueueSingleCardFixture, EthKernelsNocWriteNoReceive) {
 }
 
 TEST_F(CommandQueueMultiDeviceFixture, EthKernelsDirectSendAllConnectedChips) {
-    tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
     const size_t src_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
     const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
     for (const auto& sender_device : devices_) {
@@ -640,7 +639,6 @@ TEST_F(CommandQueueMultiDeviceFixture, EthKernelsDirectSendAllConnectedChips) {
 }
 
 TEST_F(CommandQueueMultiDeviceFixture, EthKernelsSendDramBufferAllConnectedChips) {
-    tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
     for (const auto& sender_device : devices_) {
         for (const auto& receiver_device : devices_) {
             if (sender_device->id() >= receiver_device->id()) {
@@ -673,7 +671,6 @@ TEST_F(CommandQueueMultiDeviceFixture, EthKernelsSendDramBufferAllConnectedChips
 }
 
 TEST_F(CommandQueueMultiDeviceFixture, EthKernelsSendInterleavedBufferAllConnectedChips) {
-    tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
     for (const auto& sender_device : devices_) {
         for (const auto& receiver_device : devices_) {
             if (sender_device->id() >= receiver_device->id()) {


### PR DESCRIPTION
Seems like no need for ARCH_NAME runtime ENV here, unused variable anyways

### Ticket
#596 

### Problem description
Need to get rid of ARCH_NAME at runtime

### What's changed
Remove dead code

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11433008789
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
