### PR TITLE
#596: Disconnect test cases from runtime ARCH_NAME ENV

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -5,6 +5,25 @@
 #pragma once
 #include "common/utils.hpp"
 
+#include "third_party/umd/device/device_api_metal.h"
+
+#include <string>
+
+namespace {
+
+std::string get_string_lowercase(tt::ARCH arch) {
+    switch (arch) {
+        case tt::ARCH::GRAYSKULL: return "grayskull"; break;
+        case tt::ARCH::WORMHOLE: return "wormhole"; break;
+        case tt::ARCH::WORMHOLE_B0: return "wormhole_b0"; break;
+        case tt::ARCH::BLACKHOLE: return "blackhole"; break;
+        case tt::ARCH::Invalid: return "invalid"; break;
+        default: return "invalid"; break;
+    }
+}
+
+}
+
 namespace tt {
 namespace test_utils {
 inline std::string get_env_arch_name() {
@@ -18,5 +37,30 @@ inline std::string get_env_arch_name() {
     }
     return arch_name;
 }
+
+inline std::string get_umd_arch_name() {
+
+    if(std::getenv("TT_METAL_SIMULATOR_EN")) {
+        return get_env_arch_name();
+    }
+
+    std::vector<chip_id_t> physical_mmio_device_ids = tt_SiliconDevice::detect_available_device_ids();
+    tt::ARCH arch = detect_arch(physical_mmio_device_ids.at(0));
+    for (int dev_index = 1; dev_index < physical_mmio_device_ids.size(); dev_index++) {
+        chip_id_t device_id = physical_mmio_device_ids.at(dev_index);
+        tt::ARCH detected_arch = detect_arch(device_id);
+        TT_FATAL(
+            arch == detected_arch,
+            "Expected all devices to be {} but device {} is {}",
+            get_string_lowercase(arch),
+            device_id,
+            get_string_lowercase(detected_arch));
+    }
+
+    return get_string_lowercase(arch); 
+
+}
+
+
 }  // namespace test_utils
 }  // namespace tt

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -34,7 +34,7 @@ using namespace tt::test_utils::df;
 class N300TestDevice {
    public:
     N300TestDevice() : device_open(false) {
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() >= 2 and
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
         log_trace(tt::LogTest, "channel_counts[{}]: {}", i, channel_counts.back());
     }
 
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 2) {
         log_trace(tt::LogTest, "Need at least 2 devices to run this test");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -42,7 +42,7 @@ class T3000TestDevice {
         if (slow_dispatch) {
             TT_THROW("This suite can only be run without TT_METAL_SLOW_DISPATCH_MODE set");
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 8 and
@@ -368,7 +368,7 @@ int main (int argc, char** argv) {
     // concurrent samples
     // hop counts
     // Early exit if invalid test setup
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices != 8) {
         log_trace(tt::LogTest, "Need at least 2 devices to run this test");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -35,7 +35,7 @@ using namespace tt::test_utils::df;
 class N300TestDevice {
    public:
     N300TestDevice() : device_open(false) {
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() >= 2 and
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
         log_trace(tt::LogTest, "channel_counts[{}]: {}", i, channel_counts.back());
     }
 
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 2) {
         log_info(tt::LogTest, "Need at least 2 devices to run this test");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
@@ -32,7 +32,7 @@ class N300TestDevice {
         if (not slow_dispatch) {
             TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and
@@ -304,7 +304,7 @@ int main(int argc, char** argv) {
     const bool source_is_dram = std::stoi(argv[7]) == 1;
     const bool dest_is_dram = std::stoi(argv[8]) == 1;
     const uint32_t precomputed_source_addresses_buffer_size = std::stoi(argv[9]);
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices != 2) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
@@ -30,7 +30,7 @@ class N300TestDevice {
         if (not slow_dispatch) {
             TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and
@@ -234,7 +234,7 @@ int main(int argc, char** argv) {
     bool source_is_dram = true;
     bool dest_is_dram = true;
 
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices != 2) {
         std::cout << "Need at least 2 devices to run this test" << std::endl;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -36,7 +36,7 @@ class N300TestDevice {
         if (not slow_dispatch) {
             TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and
@@ -575,7 +575,7 @@ int main(int argc, char** argv) {
     const bool dest_is_dram = std::stoi(argv[10]) == 1;
     const uint32_t precomputed_source_addresses_buffer_size = std::stoi(argv[9]);
 
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices != 2) {
         std::cout << "Need at least 2 devices to run this test" << std::endl;

--- a/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
@@ -83,7 +83,7 @@ bool dram_ping(
 }  // namespace unit_tests::basic::device
 
 TEST_F(BasicFixture, SingleDeviceHarvestingPrints) {
-    auto arch = tt::get_arch_from_string(get_env_arch_name());
+    auto arch = tt::get_arch_from_string(get_umd_arch_name());
     tt::tt_metal::Device* device;
     const unsigned int device_id = 0;
     device = tt::tt_metal::CreateDevice(device_id);
@@ -93,7 +93,7 @@ TEST_F(BasicFixture, SingleDeviceHarvestingPrints) {
         case tt::ARCH::WORMHOLE_B0: unharvested_logical_grid_size = CoreCoord(8, 10); break;
         case tt::ARCH::BLACKHOLE: unharvested_logical_grid_size = CoreCoord(14, 10); break;
         default:
-            TT_THROW("Unsupported arch {}", get_env_arch_name());
+            TT_THROW("Unsupported arch {}", get_umd_arch_name());
     }
     auto logical_grid_size = device->logical_grid_size();
     if (logical_grid_size == unharvested_logical_grid_size) {

--- a/tests/tt_metal/tt_metal/unit_tests/basic/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/test_noc.cpp
@@ -74,7 +74,7 @@ void read_translation_table (Device* device, CoreCoord logical_node, std::vector
 
 
 TEST_F(BasicFixture, VerifyNocNodeIDs) {
-    auto arch = tt::get_arch_from_string(get_env_arch_name());
+    auto arch = tt::get_arch_from_string(get_umd_arch_name());
     tt::tt_metal::Device* device;
     const unsigned int device_id = 0;
     device = tt::tt_metal::CreateDevice(device_id);
@@ -97,7 +97,7 @@ TEST_F(BasicFixture, VerifyNocNodeIDs) {
     ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
 }
 TEST_F(BasicFixture, VerifyNocIdentityTranslationTable) {
-    auto arch = tt::get_arch_from_string(get_env_arch_name());
+    auto arch = tt::get_arch_from_string(get_umd_arch_name());
     if (arch == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP();
     }

--- a/tests/tt_metal/tt_metal/unit_tests/basic/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/test_soc_descriptor.cpp
@@ -47,7 +47,7 @@ namespace unit_tests::basic::soc_desc {
 TEST_F(BasicFixture, ValidateLogicalToPhysicalCoreCoordHostMapping) {
     size_t num_devices = tt_metal::GetNumAvailableDevices();
     ASSERT_TRUE(num_devices > 0);
-    tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     num_devices = (arch == tt::ARCH::GRAYSKULL) ? 1 : num_devices;
     for (int device_id = 0; device_id < num_devices; device_id++) {
         tt_metal::Device *device = tt_metal::CreateDevice(device_id);

--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -19,7 +19,7 @@ class DeviceFixture : public ::testing::Test {
             TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
             GTEST_SKIP();
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
 
@@ -61,7 +61,7 @@ class DeviceSingleCardFixture : public ::testing::Test {
             TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
             GTEST_SKIP();
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         const chip_id_t mmio_device_id = 0;
         reserved_devices_ = tt::tt_metal::detail::CreateDevices({mmio_device_id});
@@ -83,7 +83,7 @@ class GalaxyFixture : public ::testing::Test {
    protected:
     void SkipTestSuiteIfNotGalaxyMotherboard()
     {
-        const tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        const tt::ARCH arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         if (!(arch == tt::ARCH::WORMHOLE_B0 && num_devices >= 32))
         {

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -19,7 +19,7 @@ class N300DeviceFixture : public ::testing::Test {
             TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
             GTEST_SKIP();
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_broadcast.cpp
@@ -90,7 +90,7 @@ std::vector<tt::test_utils::df::bfloat16> gold_broadcast(std::vector<tt::test_ut
     uint16_t srcb_fid_mask = 0xFFFF;
 
     std::vector<tt::test_utils::df::bfloat16> golden(num_cols * num_rows);
-    auto arch = get_arch_from_string(get_env_arch_name());
+    auto arch = get_arch_from_string(get_umd_arch_name());
 
     switch (math_fidelity) {
         case MathFidelity::HiFi4:

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
@@ -78,7 +78,7 @@ float get_scaler(const ReduceConfig &test_config) {
 }
 
 void set_math_fid_masks_binary(uint16_t &srca_fid_mask, uint16_t &srcb_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
-    auto arch = get_arch_from_string(get_env_arch_name());
+    auto arch = get_arch_from_string(get_umd_arch_name());
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: { break; }

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_single_core_binary_compute.cpp
@@ -51,7 +51,7 @@ struct SingleCoreBinaryConfig {
 };
 
 void set_math_fid_masks(uint16_t &srca_fid_mask, uint16_t &srcb_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
-    auto arch = get_arch_from_string(get_env_arch_name());
+    auto arch = get_arch_from_string(get_umd_arch_name());
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: { break; }

--- a/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
@@ -23,7 +23,7 @@ using namespace tt::test_utils;
 
 class DeviceParamFixture : public ::testing::TestWithParam<int> {
    protected:
-    tt::ARCH arch = tt::get_arch_from_string(get_env_arch_name());
+    tt::ARCH arch = tt::get_arch_from_string(get_umd_arch_name());
 };
 
 namespace unit_tests_common::basic::test_device_init {

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -64,7 +64,7 @@ protected:
         }
 
         // Set up all available devices
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         auto num_devices = tt::tt_metal::GetNumAvailableDevices();
         auto num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
         // An extra flag for if we have remote devices, as some tests are disabled for fast

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_X_tile.cpp
@@ -71,7 +71,7 @@ void create_test_stimuli(MatmulTileStimuli &stimuli, uint32_t M, uint32_t K, uin
 
 // This function creates bit masks to model math fidelity phases. This will mask the result only.
 void set_math_fid_masks(uint16_t &math_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
-    auto arch = get_arch_from_string(get_env_arch_name());
+    auto arch = get_arch_from_string(get_umd_arch_name());
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: { break; }

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
@@ -22,7 +22,7 @@ using namespace tt::test_utils;
 namespace unit_tests_common::matmul::test_matmul_large_block {
 
 void set_math_fid_masks(uint16_t &math_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
-    auto arch = get_arch_from_string(get_env_arch_name());
+    auto arch = get_arch_from_string(get_umd_arch_name());
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: { break; }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -19,7 +19,7 @@ class CommandQueueFixture : public ::testing::Test {
             tt::log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             GTEST_SKIP();
         }
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         const int device_id = 0;
 
@@ -43,7 +43,7 @@ class CommandQueueMultiDeviceFixture : public ::testing::Test {
             TT_THROW("This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             GTEST_SKIP();
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (num_devices_ < 2 ) {
@@ -78,7 +78,7 @@ class CommandQueueSingleCardFixture : public ::testing::Test {
             GTEST_SKIP();
         }
         auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
         const chip_id_t mmio_device_id = 0;
@@ -121,7 +121,7 @@ protected:
                 GTEST_SKIP();
             }
         }
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         const int device_id = 0;
         const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
         const chip_id_t mmio_device_id = 0;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/streams/test_autonomous_relay_streams.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/streams/test_autonomous_relay_streams.cpp
@@ -649,7 +649,7 @@ void build_and_run_autonomous_stream_test(
 }  // namespace tt
 
 TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreams) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
         log_info(tt::LogTest, "Test must be run on WH");
@@ -692,7 +692,7 @@ TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreams) {
 }
 
 TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsSmallPackets) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
         log_info(tt::LogTest, "Test must be run on WH");
@@ -735,7 +735,7 @@ TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsSmallPackets) {
 }
 
 TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsLoopingShort) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
         log_info(tt::LogTest, "Test must be run on WH");
@@ -781,7 +781,7 @@ TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsLoopingShort) {
 // so we just enable a couple of the unit tests to ensure nobody accidentally introduces compile errors
 // or anything like that
 TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsLoopingRandomShort) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     // if (num_devices != 8) {
     //     log_info(tt::LogTest, "Need at least 2 devices to run this test");
@@ -836,7 +836,7 @@ TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsLoopingRandomShor
 // so we just enable a couple of the unit tests to ensure nobody accidentally introduces compile errors
 // or anything like that
 TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsLoopingLong) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     // if (num_devices != 8) {
     //     log_info(tt::LogTest, "Need at least 2 devices to run this test");
@@ -886,7 +886,7 @@ TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsLoopingLong) {
 // so we just enable a couple of the unit tests to ensure nobody accidentally introduces compile errors
 // or anything like that
 TEST_F(CommandQueueFixture, DISABLED_TestAutonomousRelayStreamsSweep) {
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
         log_info(tt::LogTest, "Test must be run on WH");

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
@@ -24,7 +24,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             TT_THROW("This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
             if (!tt::tt_metal::IsGalaxyCluster()) {
@@ -56,7 +56,7 @@ class MultiCommandQueueMultiDeviceFixture : public ::testing::Test {
             TT_THROW("This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
         }
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
 
         DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
@@ -104,7 +104,7 @@ protected:
                 GTEST_SKIP();
             }
         }
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         const int device_id = 0;
         this->device_ = tt::tt_metal::CreateDevice(device_id, num_hw_cqs, 0, buffer_size);;
     }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -59,7 +59,7 @@ void set_edm_runtime_args(
 class N300TestDevice {
    public:
     N300TestDevice() : device_open(false) {
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() >= 2 and
@@ -681,7 +681,7 @@ int TestEntrypoint(
     // argv[1]: buffer_size_bytes
     // argv[2]: num_loops
 
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 2) {
         log_info("This test can only be run on n300 devices");

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -34,7 +34,7 @@ Tensor dispatch_ops_to_device(Device* dev, Tensor input_tensor, uint8_t cq_id) {
 
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
     // 8 devices with 2 CQs. Enable this test on T3K only.
-    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_env_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP();
     }
 
@@ -84,7 +84,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
 
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
     // 8 devices with 2 CQs. Enable this test on T3K only.
-    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_env_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP();
     }
 
@@ -135,7 +135,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
 
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
     // 8 devices with 2 CQs. Enable this test on T3K only.
-    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_env_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP();
     }
 

--- a/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
@@ -15,7 +15,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
    protected:
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (slow_dispatch) {
             GTEST_SKIP() << "Skipping Multi CQ test suite, since it can only be run in Fast Dispatch Mode.";
@@ -42,7 +42,7 @@ class MultiCommandQueueT3KFixture : public ::testing::Test {
    protected:
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
         if (slow_dispatch) {
             GTEST_SKIP() << "Skipping Multi CQ test suite, since it can only be run in Fast Dispatch Mode.";

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -26,7 +26,7 @@ class TTNNFixture : public ::testing::Test {
 
     void SetUp() override {
         std::srand(0);
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
     }
 
@@ -59,7 +59,7 @@ class T3kMultiDeviceFixture : public ::testing::Test {
    protected:
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        const auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
         if (slow_dispatch) {
             GTEST_SKIP() << "Skipping Multi-Device test suite, since it can only be run in Fast Dispatch Mode.";


### PR DESCRIPTION
### Ticket
#596 

### Problem description
Reduce usage of ARCH_NAME env in tests

### What's changed
Use UMD to query the system platform

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11448355045
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
