### PR TITLE
#0: Remove unused/invalid import from add_different_memory_configs sweep

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/binary/add/add_different_memory_configs.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/add/add_different_memory_configs.py
@@ -8,7 +8,6 @@ from functools import partial
 import torch
 import random
 import ttnn
-from tests.sweep_framework.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time


### PR DESCRIPTION
### Ticket

### Problem description
https://github.com/tenstorrent/tt-metal/actions/runs/11448607158/job/31853143869

### What's changed
Removed unused import that is incorrect after #12943 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
