### PR TITLE
#11606: Add non-blocking CB space/tiles available APIs

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_available_at_front.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_available_at_front.rst
@@ -1,4 +1,4 @@
 cb_pages_available_at_front
-============
+===========================
 
 .. doxygenfunction:: cb_pages_available_at_front(int32_t operand, int32_t num_pages)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_available_at_front.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_available_at_front.rst
@@ -1,0 +1,4 @@
+cb_pages_available_at_front
+============
+
+.. doxygenfunction:: cb_pages_available_at_front(int32_t operand, int32_t num_pages)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_reservable_at_back.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_reservable_at_back.rst
@@ -1,0 +1,4 @@
+cb_pages_reservable_at_back
+============
+
+.. doxygenfunction:: cb_pages_reservable_at_back(int32_t operand, int32_t num_pages)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_reservable_at_back.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/cb_pages_reservable_at_back.rst
@@ -1,4 +1,4 @@
 cb_pages_reservable_at_back
-============
+===========================
 
 .. doxygenfunction:: cb_pages_reservable_at_back(int32_t operand, int32_t num_pages)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/circular_buffers.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/circular_buffers/circular_buffers.rst
@@ -4,7 +4,9 @@ Circular Buffer APIs
 Circular buffers are used for communication between threads of the Tensix core. They act as limited capacity double-ended queues with producers pushing tiles to the back of the queue and consumers popping tiles off the front of the queue.
 
 .. toctree::
+  cb_pages_available_at_front
   cb_wait_front
+  cb_pages_reservable_at_back
   cb_reserve_back
   cb_push_back
   cb_pop_front

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_master_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_master_test_kernel.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/hw/inc/dataflow_api.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <array>
+
+
+/*
+ * This kernel enumerates over all the CBs and pushes a page at a time. For every page, it checks to see if the
+ * non-blocking call to `cb_pages_reservable_at_back` to get the result. It stores the result for the element
+ * corresponding to that iteration index, into the output buffer associated with that CB. The buffer can
+ * later be readback by host for comparison and checking.
+ */
+void kernel_main() {
+    constexpr int32_t n_cbs = get_compile_time_arg_val(0);
+    constexpr int32_t n_pages = get_compile_time_arg_val(1);
+
+    size_t arg_idx = 0;
+
+    auto master_sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
+    auto slave_sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
+
+    std::array<uint32_t, n_cbs> output_buffer_addrs;
+    for (size_t i = 0; i < n_cbs; i++) {
+        output_buffer_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    auto get_idx = [n_pages](size_t i, size_t j) -> size_t {
+        return i * n_pages + j;
+    };
+
+    for (int32_t i = 0; i < n_cbs; i++) {
+        auto *const output_buffer = reinterpret_cast<uint8_t*>(output_buffer_addrs[i]);
+        for (int32_t j = 0; j < n_pages; j++) {
+
+            if (j > 0) {
+                // Induce some memory load to the CB, indicating that fewer pages are available
+                // for reservation (writer) and that more are available for popping (reader)
+                cb_reserve_back(i, j);
+                cb_push_back(i, j);
+            }
+
+            noc_semaphore_set(master_sem_addr, 1);
+            noc_semaphore_wait(slave_sem_addr, 1);
+            // noc_semaphore_set(slave_sem_addr, 0);
+            for (int32_t k = 0; k < n_pages; k++) {
+                bool result = cb_pages_reservable_at_back(i, k);
+                output_buffer[get_idx(j,k)] = static_cast<uint8_t>(result);
+            }
+
+            // Notify that reader can expect the appropriate number of pages to be available
+            noc_semaphore_set(master_sem_addr, 2);
+            noc_semaphore_wait(slave_sem_addr, 2);
+            noc_semaphore_set(slave_sem_addr, 0);
+
+            // snap back to alignment
+            if (j > 0) {
+                cb_reserve_back(i, n_pages - j);
+                cb_push_back(i, n_pages - j);
+            }
+
+        }
+
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_slave_test_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_slave_test_kernel.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/hw/inc/dataflow_api.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <array>
+
+
+/*
+ * This kernel enumerates over all the CBs and pushes a page at a time. For every page, it checks to see if the
+ * non-blocking call to `cb_pages_reservable_at_back` to get the result. It stores the result for the element
+ * corresponding to that iteration index, into the output buffer associated with that CB. The buffer can
+ * later be readback by host for comparison and checking.
+ */
+void kernel_main() {
+    constexpr int32_t n_cbs = get_compile_time_arg_val(0);
+    constexpr int32_t n_pages = get_compile_time_arg_val(1);
+
+    size_t arg_idx = 0;
+
+    auto master_sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
+    auto slave_sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
+
+    std::array<uint32_t, n_cbs> output_buffer_addrs;
+    for (size_t i = 0; i < n_cbs; i++) {
+        output_buffer_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    auto get_idx = [n_pages](size_t i, size_t j) -> size_t {
+        return i * n_pages + j;
+    };
+
+    for (int32_t i = 0; i < n_cbs; i++) {
+        auto *const output_buffer = reinterpret_cast<uint8_t*>(output_buffer_addrs[i]);
+        for (int32_t j = 0; j < n_pages; j++) {
+            // First level signal indicates the writer has pushed new pages to the CB
+            noc_semaphore_wait(master_sem_addr, 1);
+            noc_semaphore_set(slave_sem_addr, 1);
+
+            for (int32_t k = 0; k < n_pages; k++) {
+                auto result = cb_pages_available_at_front(i, k);
+                output_buffer[get_idx(j,k)] = static_cast<uint8_t>(result);
+            }
+            noc_semaphore_wait(master_sem_addr, 2);
+            noc_semaphore_set(master_sem_addr, 0);
+            if (j > 0) {
+                cb_wait_front(i, j);
+                cb_pop_front(i, j);
+            }
+            // Second level signal indicates "alignment pages". We signal back that we are
+            // done processing this step
+            noc_semaphore_set(slave_sem_addr, 2);
+
+            if (j > 0) {
+                // snap back to alignment
+                cb_wait_front(i, n_pages - j);
+                cb_pop_front(i, n_pages - j);
+            }
+
+        }
+
+    }
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer/test_simple_l1_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/circular_buffer/test_CircularBuffer_allocation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/circular_buffer/test_CircularBuffer_creation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/circular_buffer/test_CircularBuffer_non_blocking.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_golden_impls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_reduce.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_single_core_binary_compute.cpp

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "circular_buffer_test_utils.hpp"
+#include "device_fixture.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/buffers/circular_buffer.hpp"
+
+#include "gtest/gtest.h"
+
+#include <iostream>
+#include <algorithm>
+#include <cstddef>
+
+using namespace tt::tt_metal;
+
+
+constexpr CoreCoord worker_core = {0, 0};
+constexpr size_t cb_n_pages = 32;
+constexpr size_t cb_page_size = 16;
+constexpr size_t n_cbs = 32;
+constexpr size_t data_buffer_size = cb_n_pages * cb_n_pages;
+
+std::vector<std::shared_ptr<Buffer>> create_output_buffers(Program &program, Device *device) {
+    std::vector<std::shared_ptr<Buffer>> output_buffers;
+    output_buffers.reserve(n_cbs);
+    for (size_t i = 0; i < n_cbs; i++) {
+        // Bootleg way to put a single buffer on a single core
+        auto const& buffer_config = ShardedBufferConfig {
+            device,
+            data_buffer_size,
+            data_buffer_size,
+            BufferType::L1,
+            TensorMemoryLayout::WIDTH_SHARDED,
+            ShardSpecBuffer(
+                CoreRangeSet({worker_core}),
+                {cb_n_pages,cb_n_pages},
+                ShardOrientation::ROW_MAJOR,
+                false,
+                {cb_n_pages,cb_n_pages},
+                {1,1}
+            ),
+            true
+        };
+        output_buffers.push_back(CreateBuffer(buffer_config));
+    }
+    return output_buffers;
+}
+
+std::vector<uint32_t> generate_rt_args(uint32_t master_semaphore, uint32_t slave_semaphore, std::vector<std::shared_ptr<Buffer>> const& data_buffers) {
+    std::vector<uint32_t> rt_args;
+    rt_args.reserve(2 + n_cbs);
+    rt_args.push_back(master_semaphore);
+    rt_args.push_back(slave_semaphore);
+    std::transform(data_buffers.begin(), data_buffers.end(), std::back_inserter(rt_args), [](auto const& buffer) { return buffer->address(); });
+    return rt_args;
+}
+
+TEST_F(DeviceFixture, TestCircularBufferNonBlockingAPIs) {
+    Program program;
+    Device *device = devices_.at(0);
+
+    auto const master_semaphore = CreateSemaphore(program, worker_core, 0, CoreType::WORKER);
+    auto const slave_semaphore = CreateSemaphore(program, worker_core, 0, CoreType::WORKER);
+
+    std::vector<CBHandle> cbs;
+    cbs.reserve(n_cbs);
+    for (size_t i = 0; i < n_cbs; i++) {
+        CircularBufferConfig cb_config = CircularBufferConfig(cb_n_pages * cb_page_size, {{i, tt::DataFormat::Float16_b}}).set_page_size(i, cb_page_size);
+        cbs.push_back(CreateCircularBuffer(program, worker_core, cb_config));
+    }
+
+    auto const& master_data_buffers = create_output_buffers(program, device);
+    auto const& slave_data_buffers = create_output_buffers(program, device);
+
+    std::vector<uint32_t> const& kernel_ct_args{
+        n_cbs,
+        cb_n_pages
+    };
+
+    auto const master_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_master_test_kernel.cpp",
+        worker_core,
+        tt::tt_metal::ReaderDataMovementConfig{kernel_ct_args});
+    auto const slave_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_non_blocking_slave_test_kernel.cpp",
+        worker_core,
+        tt::tt_metal::WriterDataMovementConfig{kernel_ct_args});
+
+    auto const& master_rt_args = generate_rt_args(master_semaphore, slave_semaphore, master_data_buffers);
+    auto const& slave_rt_args = generate_rt_args(master_semaphore, slave_semaphore, slave_data_buffers);
+
+    tt::tt_metal::SetRuntimeArgs(
+        program,
+        master_kernel_id,
+        worker_core,
+        master_rt_args);
+    tt::tt_metal::SetRuntimeArgs(
+        program,
+        slave_kernel_id,
+        worker_core,
+        slave_rt_args);
+
+    tt::tt_metal::detail::CompileProgram(device, program);
+    tt::tt_metal::detail::LaunchProgram(device, program, true);
+
+    std::vector<uint32_t> out_buf(data_buffer_size);
+    for (size_t i = 0; i < n_cbs; i++) {
+        tt::tt_metal::detail::ReadFromBuffer(master_data_buffers[i], out_buf, false);
+
+        uint8_t const* raw_data = reinterpret_cast<uint8_t *>(out_buf.data());
+        for (size_t pages_pushed = 0; pages_pushed < cb_n_pages; pages_pushed++) {
+            for (size_t requested_pages_free = 0; requested_pages_free < cb_n_pages; requested_pages_free++) {
+                ASSERT_EQ(static_cast<bool>(raw_data[pages_pushed * cb_n_pages + requested_pages_free]), requested_pages_free <= (cb_n_pages - pages_pushed));
+            }
+        }
+    }
+
+    for (size_t i = 0; i < n_cbs; i++) {
+        tt::tt_metal::detail::ReadFromBuffer(slave_data_buffers[i], out_buf, true);
+
+        uint8_t const* raw_data = reinterpret_cast<uint8_t *>(out_buf.data());
+        for (size_t pages_pushed = 0; pages_pushed < cb_n_pages; pages_pushed++) {
+            for (size_t filled_pages_requested = 0; filled_pages_requested < cb_n_pages; filled_pages_requested++) {
+                ASSERT_EQ(static_cast<bool>(raw_data[pages_pushed * cb_n_pages + filled_pages_requested]), filled_pages_requested <= pages_pushed);
+            }
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_non_blocking.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_non_blocking.cpp
@@ -10,6 +10,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
 
+#include "tt_metal/common/core_coord.hpp"
+
 #include "gtest/gtest.h"
 
 #include <iostream>
@@ -37,7 +39,7 @@ std::vector<std::shared_ptr<Buffer>> create_output_buffers(Program &program, Dev
             BufferType::L1,
             TensorMemoryLayout::WIDTH_SHARDED,
             ShardSpecBuffer(
-                CoreRangeSet({worker_core}),
+                CoreRangeSet(CoreRange(worker_core)),
                 {cb_n_pages,cb_n_pages},
                 ShardOrientation::ROW_MAJOR,
                 false,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11606)

### Problem description
Current APIs do not let callers query for CB readiness (space or data availability), which prevents optimizations from being written - particularly for CCL around prefetching.

### What's changed
New non-blocking (brisc/ncrisc based) CB APIs (the names could probably use some workshopping - suggestions welcome)
`cb_pages_reservable_at_back`
* return true if atleast specified number of pages are free in CB `cb_pages_available_at_front`
* return true if atleast specified number of pages are pushed to CB

Similar to their corresponding blocking `cb_reserve_back` and `cb_wait_front` functions in that for a given set of arguments at a given timestep, if any of the blocking functions would return, the corresponding non-blocking query function would return true.

### What's not included:
The current set of changes are not tested or necessarily expected to work with CBs between trisc cores operating as unpack, pack, and math.


### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11450936615; https://github.com/tenstorrent/tt-metal/actions/runs/11508378808
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
