### PR TITLE
#12652: switch all-gather to worker initiated edm termination mode

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -13,6 +13,7 @@ void kernel_main() {
     volatile uint32_t *receiver_read_sem_addr = reinterpret_cast<volatile uint32_t *>(get_semaphore(get_compile_time_arg_val(1)));
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(2);
     constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(3);
+    constexpr ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode = static_cast<ttnn::ccl::EriscDataMoverTerminationMode>(get_compile_time_arg_val(4));
 
     uint32_t arg_idx = 0;
     const uint32_t eth_receiver_l1_base_addr = get_arg_val<uint32_t>(arg_idx++);
@@ -28,7 +29,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
-    ccl::edm::WorkerToEdmReader<ttnn::ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED> reader(
+    ccl::edm::WorkerToEdmReader<edm_termination_mode> reader(
         ttnn::ccl::WorkerXY(eth_receiver_noc_x, eth_receiver_noc_y),
         eth_receiver_l1_base_addr,
         num_buffers_per_channel,
@@ -36,16 +37,23 @@ void kernel_main() {
         (num_full_chunks > 0 ? num_pages_per_full_chunk : rem_num_pages) * page_size,
         receiver_read_sem_addr);
 
+    bool last_message = false;
     for (uint32_t i = 0; i < num_transfers; ++i) {
         if (num_full_chunks > 0) {
             for (uint32_t c = 0; c < num_full_chunks; ++c) {
                 reader.wait_for_payload_available();
-                reader.fetch_payload_blocking(cb_id_in0, num_pages_per_full_chunk, page_size, false);
+                if constexpr (edm_termination_mode == ttnn::ccl::EriscDataMoverTerminationMode::WORKER_INITIATED) {
+                    last_message = (i == num_transfers - 1 && c == num_full_chunks - 1 && rem_num_pages == 0);
+                }
+                reader.fetch_payload_blocking(cb_id_in0, num_pages_per_full_chunk, page_size, last_message);
             }
         }
         if (rem_num_pages > 0) {
+            if constexpr (edm_termination_mode == ttnn::ccl::EriscDataMoverTerminationMode::WORKER_INITIATED) {
+                last_message = (i == num_transfers - 1);
+            }
             reader.wait_for_payload_available();
-            reader.fetch_payload_blocking(cb_id_in0, rem_num_pages, page_size, false);
+            reader.fetch_payload_blocking(cb_id_in0, rem_num_pages, page_size, last_message);
             ASSERT(num_pages_per_full_chunk == 0 || num_pages_per_full_chunk > rem_num_pages);
             ASSERT(half_cb_n_pages > rem_num_pages);
             push_filler_pages_to_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -171,5 +171,7 @@ void kernel_main() {
         }
     }
 
-    sender.close();
+    if (num_transfers > 0 && (num_full_chunks > 0 || rem_num_pages > 0)) {
+        sender.close();
+    }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -55,18 +55,19 @@ void kernel_main() {
     volatile uint32_t *const writer_send_sem_ptr = reinterpret_cast<volatile uint32_t *const >(get_semaphore(get_compile_time_arg_val(4)));
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(5);
     constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(6);
+    constexpr ttnn::ccl::EriscDataMoverTerminationMode edm_termination_mode = static_cast<ttnn::ccl::EriscDataMoverTerminationMode>(get_compile_time_arg_val(7));
 
     ASSERT(half_cb_n_pages > rem_num_pages);
 
     #ifdef SHARDED_MEM_LAYOUT
-    constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(7));
-    constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(8);
-    constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(9);
-    constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(10);
-    constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(11);
-    constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(12);
-    constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(13);
-    constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(14) != 0;
+    constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(8));
+    constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(9);
+    constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(10);
+    constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(11);
+    constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(12);
+    constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(13);
+    constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(14);
+    constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(15) != 0;
     #endif
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
@@ -118,7 +119,7 @@ void kernel_main() {
         #endif
     #endif
 
-    ccl::edm::WorkerToEdmSender<ttnn::ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED> sender(
+    ccl::edm::WorkerToEdmSender<edm_termination_mode> sender(
         ttnn::ccl::WorkerXY(eth_sender_noc_x, eth_sender_noc_y),
         eth_sender_l1_base_addr,
         num_buffers_per_channel,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -738,7 +738,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                     auto &sender_edm_builder = is_buffer_in_clockwise_direction(b) ? clockwise_edm_builders.at(i) : counter_clockwise_edm_builders.at(i);
                     log_trace(tt::LogOp, "Adding sender EDM channel");
                     EriscDatamoverBuilder::ChannelBufferInterface const& sender_channel_buffer_info =
-                        sender_edm_builder.add_sender_channel(sender_worker_writer_semaphore_id, 1, sender_worker_coords);
+                        sender_edm_builder.add_sender_channel(sender_worker_writer_semaphore_id, (num_full_chunks_per_worker.at(b) + rem_pages_per_worker.at(b)) > 0 ? 1 : 0, sender_worker_coords);
                     if (is_channel_shrinkable.at(b) && largest_packets_per_channel.at(b) > 0) {
                         TT_ASSERT(largest_packets_per_channel.at(b) > 0);
                         log_trace(tt::LogOp, "\tsetting channel_max_size to {} for channel {}", largest_packets_per_channel.at(b), b);
@@ -758,7 +758,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                     auto &receiver_edm_builder = is_buffer_in_clockwise_direction(b) ? counter_clockwise_edm_builders.at(i) : clockwise_edm_builders.at(i);
                     log_trace(tt::LogOp, "Adding receiver EDM channel");
                     EriscDatamoverBuilder::ChannelBufferInterface const& receiver_channel_buffer_info =
-                        receiver_edm_builder.add_receiver_channel(receiver_worker_semaphore_id, 1, receiver_worker_coords);
+                        receiver_edm_builder.add_receiver_channel(receiver_worker_semaphore_id, (num_full_chunks_per_worker.at(b) + rem_pages_per_worker.at(b)) > 0 ? 1 : 0, receiver_worker_coords);
                     if (is_channel_shrinkable.at(b) && largest_packets_per_channel.at(b) > 0) {
                         TT_ASSERT(largest_packets_per_channel.at(b) > 0);
                         log_trace(tt::LogOp, "\tsetting channel_max_size to {} for channel {}", largest_packets_per_channel.at(b), b);

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp
@@ -91,7 +91,6 @@ struct WorkerToEdmSender{
         buffer_size_bytes(buffer_size_bytes),
         buffer_index(0)
     {
-        ASSERT(buffer_size_bytes > 0);
     }
 
     FORCE_INLINE void wait_for_empty_write_slot() const {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_async_datamover.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_async_datamover.hpp
@@ -146,6 +146,7 @@ class ChannelBuffer final {
             }
         } else {
             ASSERT(TERMINATION_MODE != ttnn::ccl::EriscDataMoverTerminationMode::WORKER_INITIATED);
+            DPRINT << "CHANNEL BUFFER: " << eth_transaction_channel << " is not active\n";
             goto_state(STATE::DONE);
         }
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues//12652)

### Problem description
This change isn't _strictly_ required. However, making this change will simplify some follow-up changes.

### What's changed
This is a purely tactical/refactoring change that will simplify some follow up all-gather changes. Namely:
- We will be able to start deleting explicit message counting/computation code on host
- We will be able to migrate All-gather to improved CCL infra (like the slicing infra that reduce scatter uses) - commonizing it further
  - We'll be better setup to use the same tensor iterating code as reduce scatter
- This will reduce amount of code change needed to support merged sender/receiver workers for all-gather


### Checklist
- [ ] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11452923662
- [ ] TG frequent, model perf: https://github.com/tenstorrent/tt-metal/actions/runs/11452926992
- [ ] TG nightly: https://github.com/tenstorrent/tt-metal/actions/runs/11452928580
- [ ] T3k frequent, nightly, model perf, demo: https://github.com/tenstorrent/tt-metal/actions/runs/11452930897
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
