### PR TITLE
#5560: `all_reduce` support (reduce_scatter + all_gather)

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
+import math
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from models.utility_functions import skip_for_grayskull
 
@@ -18,7 +19,7 @@ def is_unsupported_case(input_shape, math_op, mem_config, num_devices, num_links
     num_l1_banks = 64
     if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
         return True, "L1 buffer can't support large tensor sizes"
-    if input_shape[3] == 32 and input_dtype == ttnn.bfloat8_b:
+    if (input_shape[2] == 32 or input_shape[3] == 32) and input_dtype == ttnn.bfloat8_b:
         return True, "This combination is not supported for now"
 
     return False, ""
@@ -107,16 +108,14 @@ def run_all_reduce_test(
     tt_input_tensors = []
     input_tensors = []
 
-    numel = per_chip_output_shape[0] * per_chip_output_shape[1] * per_chip_output_shape[2] * per_chip_output_shape[3]
+    numel = math.prod(per_chip_output_shape)
     if debug:
         input_tensors[-1] = torch.arange(numel).reshape(per_chip_output_shape).bfloat16()
     for i in range(num_devices):
         input_tensor = torch.rand(per_chip_output_shape).bfloat16()
-        tt_input_tensors.append(
-            ttnn.Tensor(input_tensor, input_dtype)
-            .to(layout)
-            .to(mesh_device.get_device(mesh_device.get_device_ids()[i]), mem_config)
-        )
+        t = ttnn.from_torch(input_tensor, input_dtype, layout=layout)
+        t = t.to(mesh_device.get_device(mesh_device.get_device_ids()[i]), mem_config)
+        tt_input_tensors.append(t)
         input_tensor = input_tensor.view(1, -1, input_tensor.shape[2], input_tensor.shape[3])
         input_tensors.append(input_tensor)
 
@@ -146,7 +145,7 @@ def run_all_reduce_test(
     # Compare
     mismatch = False
     for i, t in enumerate(tt_out_tensors):
-        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        tt_output_tensor = ttnn.to_torch(t)
 
         eq, output = comp_pcc(tt_output_tensor, golden_canonical_out_tensor)
         mismatch = mismatch or not eq

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
@@ -10,6 +10,9 @@ import math
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from models.utility_functions import skip_for_grayskull
 
+TILE_HEIGHT = 32
+TILE_WIDTH = 32
+
 
 def is_unsupported_case(input_shape, math_op, mem_config, num_devices, num_links, input_dtype, layout):
     elem_size = 2 if input_dtype == ttnn.bfloat16 else 1
@@ -19,7 +22,7 @@ def is_unsupported_case(input_shape, math_op, mem_config, num_devices, num_links
     num_l1_banks = 64
     if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
         return True, "L1 buffer can't support large tensor sizes"
-    if (input_shape[2] == 32 or input_shape[3] == 32) and input_dtype == ttnn.bfloat8_b:
+    if (input_shape[-2] == TILE_HEIGHT or input_shape[-1] == TILE_WIDTH) and input_dtype == ttnn.bfloat8_b:
         return True, "This combination is not supported for now"
 
     return False, ""

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -137,6 +137,8 @@ struct AllGather {
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
 };
 
+namespace ccl{
+namespace all_gather_detail{
 AllGather create_all_gather_struct(
     const Tensor& input_tensor,
     const uint32_t dim,
@@ -147,6 +149,8 @@ AllGather create_all_gather_struct(
     const std::vector<Device*>& devices,
     const ccl::Topology topology
 );
+} // namespace all_gather_detail
+} // namespace ccl
 
 // All Gather Variants
 operation::ProgramWithCallbacks all_gather_full_shard_grid(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -24,26 +24,9 @@ ReduceScatter create_reduce_scatter_struct (
 ){
     uint32_t num_devices = devices.size();
 
-    bool is_linear = topology == ttnn::ccl::Topology::Linear;
+    auto [device_index, sender_device_id, receiver_device_id] =
+                get_device_index_and_sender_receiver_ids(input_tensor, devices, topology);
 
-    uint32_t device_index = 0; // Initialize device index
-    std::optional<chip_id_t> receiver_device_id = std::nullopt; // Initialize receiver device ID
-    std::optional<chip_id_t> sender_device_id = std::nullopt; // Initialize sender device ID
-    for (uint32_t i = 0; i < num_devices; ++i) {
-        if (devices.at(i) == input_tensor.device()) {
-
-            bool is_last_chip_in_clockwise_direction = is_linear && i == (num_devices - 1);
-            bool is_last_chip_in_counter_clockwise_direction = is_linear && i == 0;
-            device_index = i;
-            receiver_device_id = is_last_chip_in_clockwise_direction ?
-                std::nullopt :
-                std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
-            sender_device_id = is_last_chip_in_counter_clockwise_direction ?
-                std::nullopt :
-                std::optional<chip_id_t>(devices.at((i + num_devices - 1) % num_devices)->id());
-            break;
-        }
-    }
     TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be incorrect");
 
     return ttnn::ReduceScatter{
@@ -145,16 +128,7 @@ Tensor reduce_scatter(
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
 
-            uint32_t num_devices = devices.size();
-            if (num_devices == 2){
-                topology = ttnn::ccl::Topology::Linear;
-            }
-
             const auto& input_tensor = input_tensors.at(0);
-            auto [device_index, sender_device_id, receiver_device_id] =
-                get_device_index_and_sender_receiver_ids(input_tensor, devices, topology);
-
-            TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be incorrect");
 
             return operation::run(
                 ttnn::ccl::reduce_scatter_detail::create_reduce_scatter_struct(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -9,6 +9,55 @@
 
 namespace ttnn {
 
+ReduceScatter create_reduce_scatter_struct (
+    const Tensor& input_tensor,
+    const ttnn::operations::binary::BinaryOpType binary_op_type,
+    const uint32_t scatter_dim,
+    const uint32_t num_links,
+    const MemoryConfig output_mem_config,
+    const std::optional<size_t> user_defined_num_workers,
+    const std::optional<size_t> user_defined_num_buffers_per_channel,
+    const std::vector<Device*>& devices,
+    const ttnn::ccl::Topology topology
+){
+    uint32_t num_devices = devices.size();
+
+    bool is_linear = topology == ttnn::ccl::Topology::Linear;
+
+    uint32_t device_index = 0; // Initialize device index
+    std::optional<chip_id_t> receiver_device_id = std::nullopt; // Initialize receiver device ID
+    std::optional<chip_id_t> sender_device_id = std::nullopt; // Initialize sender device ID
+    for (uint32_t i = 0; i < num_devices; ++i) {
+        if (devices.at(i) == input_tensor.device()) {
+
+            bool is_last_chip_in_clockwise_direction = is_linear && i == (num_devices - 1);
+            bool is_last_chip_in_counter_clockwise_direction = is_linear && i == 0;
+            device_index = i;
+            receiver_device_id = is_last_chip_in_clockwise_direction ?
+                std::nullopt :
+                std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
+            sender_device_id = is_last_chip_in_counter_clockwise_direction ?
+                std::nullopt :
+                std::optional<chip_id_t>(devices.at((i + num_devices - 1) % num_devices)->id());
+            break;
+        }
+    }
+    TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be incorrect");
+
+    return ttnn::ReduceScatter{
+                    binary_op_type,
+                    scatter_dim,
+                    num_links,
+                    num_devices,
+                    device_index,
+                    receiver_device_id,
+                    sender_device_id,
+                    output_mem_config,
+                    topology,
+                    user_defined_num_workers,
+                    user_defined_num_buffers_per_channel};
+}
+
 void ReduceScatter::validate(const std::vector<Tensor>& input_tensors) const {
     for (auto const& t : input_tensors) {
         TT_FATAL(
@@ -77,10 +126,16 @@ Tensor reduce_scatter(
     ttnn::operations::binary::BinaryOpType binary_op_type = convert_reduce_type_to_eltwise_type(math_op);
     TT_FATAL(std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "reduce_scatter op is only supported for Fast Dispatch");
 
+    ttnn::ccl::Topology ccl_topology = topology;
     auto devices = input_tensor.get_workers();
+    uint32_t num_devices = devices.size();
+    if (num_devices == 2){
+        ccl_topology = ttnn::ccl::Topology::Linear;
+    }
+
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
-        [binary_op_type, scatter_dim, num_links, output_mem_config, topology, devices, user_defined_num_workers, user_defined_num_buffers_per_channel](
+        [binary_op_type, scatter_dim, num_links, output_mem_config, ccl_topology, devices, user_defined_num_workers, user_defined_num_buffers_per_channel](
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
@@ -97,18 +152,16 @@ Tensor reduce_scatter(
             TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be incorrect");
 
             return operation::run(
-                ttnn::ReduceScatter{
+                create_reduce_scatter_struct(
+                    input_tensor,
                     binary_op_type,
                     scatter_dim,
                     num_links,
-                    num_devices,
-                    device_index,
-                    receiver_device_id,
-                    sender_device_id,
                     output_mem_config,
-                    topology,
                     user_defined_num_workers,
-                    user_defined_num_buffers_per_channel},
+                    user_defined_num_buffers_per_channel,
+                    devices,
+                    ccl_topology),
                 {input_tensor});
         },
      {input_tensor},

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -49,6 +49,8 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
 }
 }; // namespace ccl
 
+namespace ccl{
+namespace reduce_scatter_detail{
 ReduceScatter create_reduce_scatter_struct (
     const Tensor& input_tensor,
     const ttnn::operations::binary::BinaryOpType binary_op_type,
@@ -60,6 +62,8 @@ ReduceScatter create_reduce_scatter_struct (
     const std::vector<Device*>& devices,
     const ttnn::ccl::Topology topology
 );
+} // namespace reduce_scatter_detail
+} // namespace ccl
 
 namespace operations{
 namespace ccl{

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -49,6 +49,18 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
 }
 }; // namespace ccl
 
+ReduceScatter create_reduce_scatter_struct (
+    const Tensor& input_tensor,
+    const ttnn::operations::binary::BinaryOpType binary_op_type,
+    const uint32_t scatter_dim,
+    const uint32_t num_links,
+    const MemoryConfig output_mem_config,
+    const std::optional<size_t> user_defined_num_workers,
+    const std::optional<size_t> user_defined_num_buffers_per_channel,
+    const std::vector<Device*>& devices,
+    const ttnn::ccl::Topology topology
+);
+
 namespace operations{
 namespace ccl{
 Tensor reduce_scatter(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -155,7 +155,7 @@ std::vector <ttnn::Tensor> all_gather_matmul(
             const auto& weight_tensor = input_tensors[1];
 
             /* AllGather setup */
-            ttnn::AllGather all_gather_struct = ttnn::create_all_gather_struct(input_tensor, dim, num_links, memory_config_ag, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, ttnn::ccl::Topology::Ring);
+            ttnn::AllGather all_gather_struct = ttnn::ccl::all_gather_detail::create_all_gather_struct(input_tensor, dim, num_links, memory_config_ag, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, ttnn::ccl::Topology::Ring);
 
             // Create the all gather output tensor used as input (activation) to the matmul
             ttnn::Tensor all_gather_out_tensor = all_gather_struct.create_output_tensors({input_tensor})[0];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -61,7 +61,7 @@ namespace operations{
 namespace experimental{
 namespace ccl{
 
-AllReduceStrategy choose_all_reduce_strategy(const Tensor& input_tensor, uint32_t num_devices, uint32_t num_links) {
+static AllReduceStrategy choose_all_reduce_strategy(const Tensor& input_tensor, uint32_t num_devices, uint32_t num_links) {
     auto shape = input_tensor.get_logical_shape();
     auto rank = shape.rank();
 
@@ -98,7 +98,7 @@ AllReduceStrategy choose_all_reduce_strategy(const Tensor& input_tensor, uint32_
 }
 
 
-Tensor all_gather_local_reduce(const Tensor& input_tensor, uint32_t num_devices, uint32_t num_links, const MemoryConfig& output_mem_config,
+static Tensor all_gather_local_reduce(const Tensor& input_tensor, uint32_t num_devices, uint32_t num_links, const MemoryConfig& output_mem_config,
                                const std::optional<size_t> user_defined_num_workers, const std::optional<size_t> user_defined_num_buffers_per_channel, const std::vector<Device*>& devices, const ttnn::ccl::Topology& topology) {
 
     auto shape = input_tensor.get_logical_shape();
@@ -125,7 +125,7 @@ Tensor all_gather_local_reduce(const Tensor& input_tensor, uint32_t num_devices,
     return ttnn::reshape(sum_tensor, shape);
 }
 
-Tensor reduce_scatter_all_gather(const Tensor& input_tensor, const ttnn::operations::binary::BinaryOpType binary_op_type, uint32_t num_devices, uint32_t num_links, const MemoryConfig& output_mem_config,
+static Tensor reduce_scatter_all_gather(const Tensor& input_tensor, const ttnn::operations::binary::BinaryOpType binary_op_type, uint32_t num_devices, uint32_t num_links, const MemoryConfig& output_mem_config,
                                  const std::optional<size_t> user_defined_num_workers, const std::optional<size_t> user_defined_num_buffers_per_channel, const std::vector<Device*>& devices, const ttnn::ccl::Topology& topology) {
     auto shape = input_tensor.get_logical_shape();
     auto rank = shape.rank();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -86,22 +86,43 @@ Tensor all_reduce(
 
             auto shape = input_tensor.get_logical_shape();
             auto rank = shape.rank();
+            uint32_t num_devices = devices.size();
 
             uint32_t merged_dim_size = 1;
             for (uint32_t i = 0; i <= rank - 3; ++i) {
                 merged_dim_size *= shape[i];
             }
 
-            ttnn::SmallVector<int32_t> new_shape{1, merged_dim_size, shape[rank - 2], shape[rank - 1]};
+            uint32_t all_reduce_dim = -1;
+            for (uint32_t i = 0; i < rank; ++i) {
+                if(shape[i] % num_devices == 0){
+                    all_reduce_dim = i;
+                }
+            }
+            TT_FATAL(all_reduce_dim != -1, "Atleast one dim should be divisible by num_devices {}", num_devices);
+
+            std::SmallVector<int32_t> new_shape{1, merged_dim_size, shape[rank - 2], shape[rank - 1]};
 
             auto reshaped_tensor = ttnn::reshape(input_tensor, new_shape);
 
-            const auto& gathered_tensor = operation::run(
-                create_all_gather_struct(reshaped_tensor, 0, num_links, output_mem_config, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, topology),
+            const auto& reduced_tensor = operation::run(
+                create_reduce_scatter_struct(
+                    reshaped_tensor,
+                    binary_op_type,
+                    all_reduce_dim,
+                    num_links,
+                    output_mem_config,
+                    user_defined_num_workers,
+                    user_defined_num_buffers_per_channel,
+                    devices,
+                    topology),
                 {reshaped_tensor});
 
-            auto sum_tensor = ttnn::sum(gathered_tensor.at(0), 0);
-            auto final_output = ttnn::reshape(sum_tensor, shape);
+            const auto& gathered_tensor = operation::run(
+                create_all_gather_struct(reduced_tensor.at(0), all_reduce_dim, num_links, output_mem_config, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, topology),
+                {reduced_tensor.at(0)});
+
+            auto final_output = ttnn::reshape(gathered_tensor.at(0), shape);
 
             return {final_output};
             },

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -69,7 +69,7 @@ Tensor all_reduce(
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel) {
     ttnn::operations::binary::BinaryOpType binary_op_type = convert_reduce_type_to_eltwise_type(math_op);
-    TT_FATAL(std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "This op is only supported for Fast Dispatch");
+    TT_FATAL(std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "All Reduce op is only supported for Fast Dispatch");
     TT_FATAL(topology == ttnn::ccl::Topology::Ring, "All Reduce op is currently supported only on Ring topology");
 
     auto devices = input_tensor.get_workers();
@@ -88,43 +88,69 @@ Tensor all_reduce(
             auto rank = shape.rank();
             uint32_t num_devices = devices.size();
 
-            uint32_t merged_dim_size = 1;
-            for (uint32_t i = 0; i <= rank - 3; ++i) {
-                merged_dim_size *= shape[i];
-            }
-
             uint32_t all_reduce_dim = -1;
+            bool optimized_version = false;
             for (uint32_t i = 0; i < rank; ++i) {
                 if(shape[i] % num_devices == 0){
                     all_reduce_dim = i;
+                    optimized_version = true;
                 }
             }
-            TT_FATAL(all_reduce_dim != -1, "Atleast one dim should be divisible by num_devices {}", num_devices);
+            if(shape[3] == tt::constants::TILE_WIDTH){
+                optimized_version = false; // Reduce scatter hangs for this shape
+            }
+            if (input_tensor.get_layout() == ttnn::TILE_LAYOUT){
+                if ((all_reduce_dim == 2 && shape[all_reduce_dim] % tt::constants::TILE_HEIGHT != 0) ||
+                    (all_reduce_dim == 3 && shape[all_reduce_dim] % tt::constants::TILE_WIDTH != 0)) {
+                    optimized_version = false;
+                }
+            }
 
-            std::SmallVector<int32_t> new_shape{1, merged_dim_size, shape[rank - 2], shape[rank - 1]};
 
-            auto reshaped_tensor = ttnn::reshape(input_tensor, new_shape);
+            if(optimized_version){
+                const auto& reduced_tensor = operation::run(
+                    create_reduce_scatter_struct(
+                        input_tensor,
+                        binary_op_type,
+                        all_reduce_dim,
+                        num_links,
+                        output_mem_config,
+                        user_defined_num_workers,
+                        user_defined_num_buffers_per_channel,
+                        devices,
+                        topology),
+                    {input_tensor});
 
-            const auto& reduced_tensor = operation::run(
-                create_reduce_scatter_struct(
-                    reshaped_tensor,
-                    binary_op_type,
-                    all_reduce_dim,
-                    num_links,
-                    output_mem_config,
-                    user_defined_num_workers,
-                    user_defined_num_buffers_per_channel,
-                    devices,
-                    topology),
-                {reshaped_tensor});
+                const auto& gathered_tensor = operation::run(
+                    create_all_gather_struct(reduced_tensor.at(0), all_reduce_dim, num_links, output_mem_config, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, topology),
+                    {reduced_tensor.at(0)});
 
-            const auto& gathered_tensor = operation::run(
-                create_all_gather_struct(reduced_tensor.at(0), all_reduce_dim, num_links, output_mem_config, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, topology),
-                {reduced_tensor.at(0)});
+                auto final_output = gathered_tensor.at(0);
+                return {final_output};
+            }
+            else{
+                log_warning(
+                    tt::LogOp,
+                    "Falling back to unoptimized version (all_gather + local reduce) as the input tensor shape {} is not handled by optimized version", shape);
 
-            auto final_output = ttnn::reshape(gathered_tensor.at(0), shape);
+                uint32_t merged_dim_size = 1;
+                for (uint32_t i = 0; i <= rank - 3; ++i) {
+                    merged_dim_size *= shape[i];
+                }
 
-            return {final_output};
+                std::vector<int32_t> new_shape{1, merged_dim_size, shape[rank - 2], shape[rank - 1]};
+                auto reshaped_tensor = ttnn::reshape(input_tensor, new_shape);
+
+                const auto& gathered_tensor = operation::run(
+                    create_all_gather_struct(reshaped_tensor, 0, num_links, output_mem_config, user_defined_num_workers, user_defined_num_buffers_per_channel, devices, topology),
+                    {reshaped_tensor});
+
+                auto sum_tensor = ttnn::sum(gathered_tensor.at(0), 0);
+                auto final_output = ttnn::reshape(sum_tensor, shape);
+                return {final_output};
+
+            }
+
             },
      {input_tensor},
      output_tensors);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
@@ -11,6 +11,13 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 namespace ttnn {
 
+enum class AllReduceStrategy {
+    AllGatherLocalReduce,
+    ReduceScatterAllGather,
+    //Fused,
+    Invalid
+};
+
 struct AllReduce {
     const ttnn::operations::binary::BinaryOpType binary_op_type;
     const uint32_t num_links;


### PR DESCRIPTION
### Ticket
Tracking Issue : #5560 

### Problem description
Provide support for `all_gather` with help of `reduce_scatter` and `all_gather`

### What's changed
Created `create_reduce_scatter_struct` to use it in `all_reduce` to avoid reusing of code

@SeanNijjar: This PR enables an optimized implementation of all-reduce to be used. This more optimal implementation reduces the amount of data communication between chips by first running a reduce scatter and then running an all-gather operation. For the time being, this optimization will only apply if atleast one of the dimensions of the input tensor (per chip) is both divisible by the number of chips in the all-reduce (as well as TILE DIM if the selected dim is Y or X and layout == TILE). 

Future work will improve test coverage (sweeps) and will also provide a fused all-reduce implementation to avoid launch overhead related issues caused by a composite op implementation.


### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11460286768
- [x] T3K Pipelines - https://github.com/tenstorrent/tt-metal/actions/runs/11460290044
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
