### PR TITLE
#14087: Add unit tests BFP8 for ttnn operations 

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_arange.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_arange.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc
-from tests.ttnn.unit_tests.operations.test_utils import to_ttnn, get_lib_dtype
+from tests.ttnn.unit_tests.operations.test_utils import get_lib_dtype
 
 
 def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
@@ -16,7 +16,13 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
     # Prepare inputs
     start, end, step = start_end_step
     if (dtype == "int32") and (start != int(start) or end != int(end) or step != int(step)):
-        pytest.skip(f"start/end/step must be integer when using int32 dtype")
+        pytest.skip(f"start, end, and step must be integers when using int32 dtype")
+    if dtype == "bfloat8_b" and not tilized:
+        pytest.skip(f"bfloat8_b requires TILE_LAYOUT")
+
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if dtype == "bfloat8_b":
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
 
     # Compute using torch
     torch_dtype = get_lib_dtype(torch, dtype)
@@ -28,24 +34,25 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
     ttnn_dtype = get_lib_dtype(ttnn, dtype)
     if ttnn_dtype is None:
         ttnn_dtype = ttnn.bfloat16
-    any_cpu = torch.ones(1024)
-    any_npu = ttnn.from_torch(any_cpu, dtype=ttnn_dtype, device=device)
-    if tilized:
-        L = expected_output.shape[0]
-    if optional_output:
-        output_cpu = torch.empty_like(expected_output)
-        if tilized:
-            output_npu = (
-                ttnn.from_torch(output_cpu, ttnn_dtype)
-                .reshape([1, L])
-                .pad_to_tile(float("nan"))
-                .to(ttnn.TILE_LAYOUT)
-                .to(device)
-            )
-        else:
-            output_npu = ttnn.from_torch(output_cpu, dtype=ttnn_dtype, device=device)
-    else:
-        output_npu = None
+    any_cpu = torch.randn([32, 32])
+    any_npu = ttnn.from_torch(
+        any_cpu,
+        device=device,
+        dtype=ttnn_dtype,
+        layout=ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT,
+    )
+    L = expected_output.shape[0]
+    output_npu = (
+        ttnn.from_torch(
+            torch.empty([1, L]),
+            device=device,
+            dtype=ttnn_dtype,
+            layout=ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT,
+        )
+        if optional_output
+        else None
+    )
+
     output_npu = ttnn.operations.moreh.arange(
         start,
         end,
@@ -55,10 +62,7 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
         untilize_out=not tilized,
         dtype=get_lib_dtype(ttnn, dtype),
     )
-    if tilized:
-        actual_output = output_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile((1, L)).to_torch().reshape((L))
-    else:
-        actual_output = output_npu.cpu().to_torch()
+    actual_output = ttnn.to_torch(output_npu).reshape([L])
 
     # Assert shape and value comparison
     assert actual_output.shape == expected_output.shape
@@ -86,7 +90,7 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [None, "bfloat16", "int32", "float32"],
+    [None, "bfloat8_b", "bfloat16", "int32", "float32"],
 )
 @pytest.mark.parametrize(
     "tilized",
@@ -109,7 +113,7 @@ def test_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [None, "bfloat16", "int32", "float32"],
+    [None, "bfloat8_b", "bfloat16", "int32", "float32"],
 )
 def test_arange_callback(start_end_step, optional_output, dtype, device, use_program_cache):
     """Test arange functionality with callback and program cache validation."""
@@ -118,7 +122,7 @@ def test_arange_callback(start_end_step, optional_output, dtype, device, use_pro
     for i in range(2):
         run_moreh_arange(start_end_step, optional_output, dtype, True, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0

--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -8,7 +8,6 @@ import torch.nn.functional as F
 from loguru import logger
 
 import ttnn
-from tests.ttnn.unit_tests.operations.test_moreh_matmul import get_tensors
 from models.utility_functions import comp_allclose_and_pcc
 
 from tests.ttnn.unit_tests.operations.test_utils import (
@@ -16,6 +15,53 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_options,
     compute_kernel_ids,
 )
+
+
+def create_ttnn_tilized_tensor(torch_tensor, device, dtype):
+    return ttnn.from_torch(torch_tensor, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+
+def get_tensors(
+    input_shape,
+    mat2_shape,
+    output_shape,
+    require_input_grad,
+    require_mat2_grad,
+    device,
+):
+    torch_dtype = torch.float32
+    ttnn_dtype = ttnn.bfloat16
+
+    torch_input = torch.rand(input_shape, dtype=torch_dtype)
+    torch_mat2 = torch.rand(mat2_shape, dtype=torch_dtype)
+    torch_output = torch.rand(output_shape, dtype=torch_dtype)
+
+    ttnn_input = create_ttnn_tilized_tensor(torch_input, device, ttnn_dtype)
+    ttnn_mat2 = create_ttnn_tilized_tensor(torch_mat2, device, ttnn_dtype)
+    ttnn_output = create_ttnn_tilized_tensor(torch_output, device, ttnn_dtype)
+
+    ttnn_output_grad = torch_output_grad = ttnn_input_grad = ttnn_mat2_grad = None
+    if require_input_grad or require_mat2_grad:
+        torch_output_grad = torch.rand(output_shape, dtype=torch_dtype)
+        ttnn_output_grad = create_ttnn_tilized_tensor(torch_output_grad, device, ttnn_dtype)
+        if require_input_grad:
+            torch_input_grad = torch.full(input_shape, float("nan"), dtype=torch_dtype)
+            ttnn_input_grad = create_ttnn_tilized_tensor(torch_input_grad, device, ttnn_dtype)
+        if require_mat2_grad:
+            torch_mat2_grad = torch.full(mat2_shape, float("nan"), dtype=torch_dtype)
+            ttnn_mat2_grad = create_ttnn_tilized_tensor(torch_mat2_grad, device, ttnn_dtype)
+
+    return (
+        ttnn_input,
+        ttnn_mat2,
+        ttnn_output,
+        ttnn_output_grad,
+        ttnn_input_grad,
+        ttnn_mat2_grad,
+        torch_input,
+        torch_mat2,
+        torch_output_grad,
+    )
 
 
 def run_moreh_bmm(shape, optional_output, compute_kernel_options, device):
@@ -41,7 +87,7 @@ def run_moreh_bmm(shape, optional_output, compute_kernel_options, device):
         input,
         mat2,
         _,
-    ) = get_tensors(input_shape, mat2_shape, output_shape, False, False, False, device)
+    ) = get_tensors(input_shape, mat2_shape, output_shape, False, False, device)
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     # Perform PyTorch BMM
@@ -57,7 +103,9 @@ def run_moreh_bmm(shape, optional_output, compute_kernel_options, device):
     actual_output = ttnn.to_torch(ttnn_output)
 
     # Compare results for equivalence
-    passing, output_pcc = comp_allclose_and_pcc(output, actual_output, pcc=0.999)
+    rtol = atol = 0.1
+    pcc = 0.998 if compute_kernel_options else 0.97
+    passing, output_pcc = comp_allclose_and_pcc(output, actual_output, pcc=pcc, rtol=rtol, atol=atol)
     logger.debug(f"Out passing={passing}")
     logger.debug(f"Output pcc={output_pcc}")
     assert passing
@@ -87,7 +135,7 @@ def run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
         input,
         mat2,
         output_grad,
-    ) = get_tensors(input_shape, mat2_shape, output_shape, require_input_grad, require_mat2_grad, False, device)
+    ) = get_tensors(input_shape, mat2_shape, output_shape, require_input_grad, require_mat2_grad, device)
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     # Perform PyTorch BMM (backward)
@@ -107,16 +155,17 @@ def run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
 
     # Compare results for equivalence
     rtol = atol = 0.1
+    pcc = 0.998 if compute_kernel_options else 0.97
     if require_input_grad:
         actual_input_grad = ttnn.to_torch(ttnn_input_grad)
-        passing, output_pcc = comp_allclose_and_pcc(input.grad, actual_input_grad, pcc=0.999, rtol=rtol, atol=atol)
+        passing, output_pcc = comp_allclose_and_pcc(input.grad, actual_input_grad, pcc=pcc, rtol=rtol, atol=atol)
         logger.debug(f"input_grad passing={passing}")
         logger.debug(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_mat2_grad:
         actual_mat2_grad = ttnn.to_torch(ttnn_mat2_grad)
-        passing, output_pcc = comp_allclose_and_pcc(mat2.grad, actual_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
+        passing, output_pcc = comp_allclose_and_pcc(mat2.grad, actual_mat2_grad, pcc=pcc, rtol=rtol, atol=atol)
         logger.debug(f"mat2_grad passing={passing}")
         logger.debug(f"mat2_grad pcc={output_pcc}")
         assert passing
@@ -127,26 +176,41 @@ def run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
     [
         [1, 31, 639, 31],
         [5, 95, 415, 65],
+        [10, 77, 320, 320],
         [10, 191, 447, 159],
     ],
 )
-@pytest.mark.parametrize("optional_output", [False, True])
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_bmm(shape, optional_output, compute_kernel_options, device):
+def test_moreh_bmm_shape(shape, device):
     """
     PyTest wrapper for running BMM tests with multiple configurations.
     """
     torch.manual_seed(2024)
-    run_moreh_bmm(shape, optional_output, compute_kernel_options, device)
+    run_moreh_bmm(shape, True, True, device)
+
+
+@pytest.mark.parametrize("optional_output", [False, True])
+def test_moreh_bmm_optional_output(optional_output, device):
+    """
+    PyTest wrapper for running BMM tests with multiple configurations.
+    """
+    torch.manual_seed(2024)
+    run_moreh_bmm([10, 191, 447, 159], optional_output, True, device)
+
+
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm_compute_kernel_options(compute_kernel_options, device):
+    """
+    PyTest wrapper for running BMM tests with multiple configurations.
+    """
+    torch.manual_seed(2024)
+    run_moreh_bmm([10, 191, 447, 159], True, compute_kernel_options, device)
 
 
 @pytest.mark.parametrize(
     "shape",
     [[10, 191, 447, 159]],
 )
-@pytest.mark.parametrize("optional_output", [False, True])
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_bmm_callback(shape, optional_output, compute_kernel_options, device, use_program_cache):
+def test_moreh_bmm_callback(shape, device, use_program_cache):
     """
     PyTest wrapper for running BMM tests with multiple configurations.
     AssertionError: If the number of program cache entries differs between runs with the same settings.
@@ -154,9 +218,9 @@ def test_moreh_bmm_callback(shape, optional_output, compute_kernel_options, devi
     torch.manual_seed(2024)
     num_program_cache_entries_list = []
     for i in range(2):
-        run_moreh_bmm(shape, optional_output, compute_kernel_options, device)
+        run_moreh_bmm(shape, True, True, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
+        ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0
@@ -168,30 +232,18 @@ def test_moreh_bmm_callback(shape, optional_output, compute_kernel_options, devi
     [
         [1, 32, 32, 32],
         [3, 31, 31, 31],
+        [10, 77, 320, 320],
         [7, 511, 313, 765],
     ],
 )
-@pytest.mark.parametrize(
-    "requires_grad",
-    [
-        [True, False],
-        [False, True],
-        [True, True],
-    ],
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device):
+def test_moreh_bmm_backward_shape(shape, device):
     """
     PyTest wrapper for running BMM backward tests with multiple configurations.
     """
     torch.manual_seed(2024)
-    run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
+    run_moreh_bmm_backward(shape, [True, True], True, device)
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [[7, 511, 313, 765]],
-)
 @pytest.mark.parametrize(
     "requires_grad",
     [
@@ -200,8 +252,32 @@ def test_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device
         [True, True],
     ],
 )
+def test_moreh_bmm_backward_requires_grad(requires_grad, device):
+    """
+    PyTest wrapper for running BMM backward tests with multiple configurations.
+    """
+    torch.manual_seed(2024)
+    run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, True, device)
+
+
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_bmm_backward_callback(shape, requires_grad, compute_kernel_options, device, use_program_cache):
+def test_moreh_bmm_backward_compute_kernel_options(compute_kernel_options, device):
+    """
+    PyTest wrapper for running BMM backward tests with multiple configurations.
+    """
+    torch.manual_seed(2024)
+    run_moreh_bmm_backward([7, 511, 313, 765], [True, True], compute_kernel_options, device)
+
+
+@pytest.mark.parametrize(
+    "requires_grad",
+    [
+        [True, False],
+        [False, True],
+        [True, True],
+    ],
+)
+def test_moreh_bmm_backward_callback(requires_grad, device, use_program_cache):
     """
     PyTest wrapper for running BMM backward tests with multiple configurations.
     AssertionError: If the number of program cache entries differs between runs with the same settings.
@@ -209,9 +285,9 @@ def test_moreh_bmm_backward_callback(shape, requires_grad, compute_kernel_option
     torch.manual_seed(2024)
     num_program_cache_entries_list = []
     for i in range(2):
-        run_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device)
+        run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, True, device)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
+        ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0

--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from loguru import logger
 
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc
+from models.utility_functions import comp_allclose_and_pcc, is_grayskull
 
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
@@ -219,7 +219,7 @@ def test_moreh_bmm_shape(shape, device):
     PyTest wrapper for running BMM tests with multiple configurations.
     """
     torch.manual_seed(2024)
-    run_moreh_bmm(shape, True, True, device)
+    run_moreh_bmm(shape, True, False if is_grayskull() else True, device)
 
 
 @pytest.mark.parametrize("optional_output", [False, True])
@@ -228,7 +228,7 @@ def test_moreh_bmm_optional_output(optional_output, device):
     PyTest wrapper for running BMM tests with multiple configurations.
     """
     torch.manual_seed(2024)
-    run_moreh_bmm([10, 191, 447, 159], optional_output, True, device)
+    run_moreh_bmm([10, 191, 447, 159], optional_output, False if is_grayskull() else True, device)
 
 
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
@@ -249,7 +249,7 @@ def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     if ttnn_dtype == ttnn.bfloat8_b:
         pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch.manual_seed(2024)
-    run_moreh_bmm([10, 191, 447, 159], True, True, device, ttnn_dtype=ttnn_dtype)
+    run_moreh_bmm([10, 191, 447, 159], True, False if is_grayskull() else True, device, ttnn_dtype=ttnn_dtype)
 
 
 @pytest.mark.parametrize(
@@ -264,7 +264,7 @@ def test_moreh_bmm_callback(shape, device, use_program_cache):
     torch.manual_seed(2024)
     num_program_cache_entries_list = []
     for i in range(2):
-        run_moreh_bmm(shape, True, True, device)
+        run_moreh_bmm(shape, True, False if is_grayskull() else True, device)
         torch_dummy = torch.randn([32, 32])
         ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
@@ -287,7 +287,7 @@ def test_moreh_bmm_backward_shape(shape, device):
     PyTest wrapper for running BMM backward tests with multiple configurations.
     """
     torch.manual_seed(2024)
-    run_moreh_bmm_backward(shape, [True, True], True, device)
+    run_moreh_bmm_backward(shape, [True, True], False if is_grayskull() else True, device)
 
 
 @pytest.mark.parametrize(
@@ -303,7 +303,7 @@ def test_moreh_bmm_backward_requires_grad(requires_grad, device):
     PyTest wrapper for running BMM backward tests with multiple configurations.
     """
     torch.manual_seed(2024)
-    run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, True, device)
+    run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, False if is_grayskull() else True, device)
 
 
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
@@ -324,7 +324,9 @@ def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     if ttnn_dtype == ttnn.bfloat8_b:
         pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch.manual_seed(2024)
-    run_moreh_bmm_backward([7, 511, 313, 765], [True, True], True, device, ttnn_dtype=ttnn_dtype)
+    run_moreh_bmm_backward(
+        [7, 511, 313, 765], [True, True], False if is_grayskull() else True, device, ttnn_dtype=ttnn_dtype
+    )
 
 
 @pytest.mark.parametrize(
@@ -343,7 +345,7 @@ def test_moreh_bmm_backward_callback(requires_grad, device, use_program_cache):
     torch.manual_seed(2024)
     num_program_cache_entries_list = []
     for i in range(2):
-        run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, True, device)
+        run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, False if is_grayskull() else True, device)
         torch_dummy = torch.randn([32, 32])
         ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())

--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -123,8 +123,8 @@ def run_moreh_bmm(
     rtol = atol = 0.1
     pcc = 0.998 if compute_kernel_options else 0.97
     passing, output_pcc = comp_allclose_and_pcc(output, actual_output, pcc=pcc, rtol=rtol, atol=atol)
-    logger.debug(f"Out passing={passing}")
-    logger.debug(f"Output pcc={output_pcc}")
+    logger.info(f"Out passing={passing}")
+    logger.info(f"Output pcc={output_pcc}")
     assert passing
 
 
@@ -193,15 +193,15 @@ def run_moreh_bmm_backward(
     if require_input_grad:
         actual_input_grad = ttnn.to_torch(ttnn_input_grad)
         passing, output_pcc = comp_allclose_and_pcc(input.grad, actual_input_grad, pcc=pcc, rtol=rtol, atol=atol)
-        logger.debug(f"input_grad passing={passing}")
-        logger.debug(f"input_grad pcc={output_pcc}")
+        logger.info(f"input_grad passing={passing}")
+        logger.info(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_mat2_grad:
         actual_mat2_grad = ttnn.to_torch(ttnn_mat2_grad)
         passing, output_pcc = comp_allclose_and_pcc(mat2.grad, actual_mat2_grad, pcc=pcc, rtol=rtol, atol=atol)
-        logger.debug(f"mat2_grad passing={passing}")
-        logger.debug(f"mat2_grad pcc={output_pcc}")
+        logger.info(f"mat2_grad passing={passing}")
+        logger.info(f"mat2_grad pcc={output_pcc}")
         assert passing
 
 

--- a/tests/ttnn/unit_tests/operations/test_moreh_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_norm.py
@@ -13,18 +13,18 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_torch,
-    to_ttnn,
     compute_output_shape,
-    TILE_HEIGHT,
-    TILE_WIDTH,
     check_dim,
 )
 
 
-def make_cpu_tensors(input_shape, dim, keepdim=False):
+def create_ttnn_tilized_tensor(torch_tensor, device, dtype):
+    return ttnn.from_torch(torch_tensor, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+
+def make_torch_tensors(input_shape, dim, keepdim=False):
     """
-    Creates random CPU tensors for input and gradient output based on the input shape and dimension.
+    Creates random tensors for input and gradient output based on the input shape and dimension.
 
     Args:
         input_shape (tuple): The shape of the input tensor.
@@ -33,22 +33,22 @@ def make_cpu_tensors(input_shape, dim, keepdim=False):
 
     Returns:
         tuple: A tuple containing two tensors:
-            - `cpu_input`: Random input tensor on CPU with `requires_grad=True`.
-            - `cpu_output_grad`: Random gradient tensor with the shape corresponding to the output.
+            - `torch_input`: Random input tensor on CPU with `requires_grad=True`.
+            - `torch_output_grad`: Random gradient tensor with the shape corresponding to the output.
     """
     torch_output_shape, _ = compute_output_shape(input_shape, dim, keepdim=keepdim)
-    cpu_input = torch.empty(input_shape, dtype=torch.float32).uniform_(-1, 1).requires_grad_()
-    cpu_output_grad = torch.empty(torch_output_shape, dtype=torch.float32).uniform_(-1, 1)
-    return cpu_input, cpu_output_grad
+    torch_input = torch.empty(input_shape, dtype=torch.float32).uniform_(-1, 1).requires_grad_()
+    torch_output_grad = torch.empty(torch_output_shape, dtype=torch.float32).uniform_(-1, 1)
+    return torch_input, torch_output_grad
 
 
-def torch_norm(cpu_x, cpu_dy, *, p=2.0, dim=None, keepdim=False, do_backward=False):
+def torch_norm(torch_input, torch_output_grad, *, p=2.0, dim=None, keepdim=False, do_backward=False):
     """
-    Computes the norm of a tensor using PyTorch and optionally performs backpropagation.
+    Computes the norm of a tensor using torch and optionally performs backpropagation.
 
     Args:
-        cpu_x (torch.Tensor): Input tensor.
-        cpu_dy (torch.Tensor): Gradient tensor for backpropagation.
+        torch_input (torch.Tensor): Input tensor.
+        torch_output_grad (torch.Tensor): Gradient output tensor for backpropagation.
         p (float, optional): The order of the norm. Defaults to 2.0.
         dim (int or tuple of int, optional): Dimension(s) over which to compute the norm.
         keepdim (bool, optional): Whether to keep the dimensions of the output. Defaults to False.
@@ -56,20 +56,20 @@ def torch_norm(cpu_x, cpu_dy, *, p=2.0, dim=None, keepdim=False, do_backward=Fal
 
     Returns:
         tuple: A tuple containing:
-            - `cpu_y`: The result of the norm operation.
-            - `cpu_dx`: The gradient of the input tensor (if `do_backward=True`), otherwise None.
+            - `torch_output`: The result of the norm operation.
+            - `torch_input_grad`: The gradient of the input tensor (if `do_backward=True`), otherwise None.
     """
-    cpu_y = torch.norm(cpu_x, p=p, dim=dim, keepdim=keepdim)
-    cpu_dx = None
+    torch_output = torch.norm(torch_input, p=p, dim=dim, keepdim=keepdim)
+    torch_input_grad = None
     if do_backward:
-        cpu_y.backward(cpu_dy)
-        cpu_dx = cpu_x.grad
-    return cpu_y, cpu_dx
+        torch_output.backward(torch_output_grad)
+        torch_input_grad = torch_input.grad
+    return torch_output, torch_input_grad
 
 
-def tt_norm(
-    cpu_x,
-    cpu_dy,
+def ttnn_norm(
+    torch_input,
+    torch_output_grad,
     *,
     p=2.0,
     dim=None,
@@ -79,11 +79,11 @@ def tt_norm(
     device=None,
 ):
     """
-    Computes the norm of a tensor using Tenstorrent's custom backend and optionally performs backpropagation.
+    Computes the norm of a tensor using ttnn's custom backend and optionally performs backpropagation.
 
     Args:
-        cpu_x (torch.Tensor): Input tensor on CPU.
-        cpu_dy (torch.Tensor): Gradient tensor for backpropagation on CPU.
+        torch_input (torch.Tensor): Input tensor.
+        torch_output_grad (torch.Tensor): Gradient output tensor for backpropagation.
         p (float, optional): The order of the norm. Defaults to 2.0.
         dim (int or tuple of int, optional): Dimension(s) over which to compute the norm.
         keepdim (bool, optional): Whether to keep the dimensions of the output. Defaults to False.
@@ -93,47 +93,47 @@ def tt_norm(
 
     Returns:
         tuple: A tuple containing:
-            - `npu_y`: The result of the norm operation.
-            - `npu_dx`: The gradient of the input tensor (if `do_backward=True`), otherwise None.
+            - `ttnn_output`: The result of the norm operation.
+            - `ttnn_input_grad`: The gradient of the input tensor (if `do_backward=True`), otherwise None.
     """
-    _, tt_output_shape = compute_output_shape(cpu_x.shape, dim, keepdim=keepdim)
-    npu_x = to_ttnn(cpu_x.bfloat16(), device=device)
+    ttnn_dtype = ttnn.bfloat16
+    _, ttnn_output_shape = compute_output_shape(torch_input.shape, dim, keepdim=keepdim)
+    ttnn_input = create_ttnn_tilized_tensor(torch_input, device, ttnn_dtype)
     if do_backward:
-        npu_dy = to_ttnn(cpu_dy.reshape(tt_output_shape).bfloat16(), device=device)
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-    if do_backward:
-        npu_y = to_ttnn(
-            torch.norm(cpu_x, p=p, dim=dim, keepdim=keepdim).bfloat16().reshape(tt_output_shape), device=device
-        )
+        torch_output = torch.norm(torch_input, p=p, dim=dim, keepdim=keepdim)
+        ttnn_output = create_ttnn_tilized_tensor(torch_output, device, ttnn_dtype)
     else:
-        npu_y = to_ttnn(torch.empty(tt_output_shape), device=device)
+        ttnn_output = create_ttnn_tilized_tensor(torch.empty(ttnn_output_shape), device, ttnn_dtype)
         ttnn.operations.moreh.norm(
-            npu_x, p=p, dim=dim, keepdim=keepdim, output=npu_y, compute_kernel_config=compute_kernel_config
-        )
-
-    npu_dx = None
-    if do_backward:
-        npu_dx = to_ttnn(torch.empty_like(cpu_x), device=device)
-
-        ttnn.operations.moreh.norm_backward(
-            npu_x,
-            npu_y,
-            npu_dy,
+            ttnn_input,
             p=p,
             dim=dim,
             keepdim=keepdim,
-            input_grad=npu_dx,
-            compute_kernel_config=compute_kernel_config,
+            output=ttnn_output,
+            compute_kernel_config=get_compute_kernel_options(compute_kernel_options),
         )
-        npu_dx = to_torch(npu_dx, shape=cpu_x.shape)
-
-    npu_y = to_torch(npu_y, shape=tt_output_shape)
-    return npu_y, npu_dx
+    ttnn_input_grad = None
+    if do_backward:
+        ttnn_output_grad = create_ttnn_tilized_tensor(torch_output_grad, device, ttnn_dtype)
+        ttnn_input_grad = create_ttnn_tilized_tensor(torch.empty_like(torch_input), device, ttnn_dtype)
+        ttnn.operations.moreh.norm_backward(
+            ttnn_input,
+            ttnn_output,
+            ttnn_output_grad,
+            p=p,
+            dim=dim,
+            keepdim=keepdim,
+            input_grad=ttnn_input_grad,
+            compute_kernel_config=get_compute_kernel_options(compute_kernel_options),
+        )
+        ttnn_input_grad = ttnn.to_torch(ttnn_input_grad)
+    ttnn_output = ttnn.to_torch(ttnn_output)
+    return ttnn_output, ttnn_input_grad
 
 
 def run_moreh_norm(input_shape, p, dim, rtol, atol, device, keepdim=False, compute_kernel_options=None):
     """
-    Runs the norm operation using both PyTorch and Tenstorrent's custom implementation and compares the outputs.
+    Runs the norm operation using both torch and ttnn's implementation and compares the outputs.
 
     Args:
         input_shape (tuple): The shape of the input tensor.
@@ -146,17 +146,14 @@ def run_moreh_norm(input_shape, p, dim, rtol, atol, device, keepdim=False, compu
         compute_kernel_options: Configuration options for the compute kernel.
 
     Raises:
-        AssertionError: If the computed norm values from Tenstorrent's implementation and PyTorch are not close.
+        AssertionError: If the computed norm values from ttnn's implementation and torch are not close.
     """
-    if dim in (None, [], [0, 1, 2, 3]) and p == 2.5 and is_wormhole_b0():
-        pytest.skip("TODO: Check why comp_allclose result is poor on WH_B0.")
     check_dim(input_shape, dim, keepdim)
-    cpu_x, cpu_dy = make_cpu_tensors(input_shape, dim, keepdim=keepdim)
-
-    expected_y, _ = torch_norm(cpu_x, cpu_dy, p=p, dim=dim, keepdim=keepdim, do_backward=False)
-    actual_y, _ = tt_norm(
-        cpu_x,
-        cpu_dy,
+    torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim)
+    expected_output, _ = torch_norm(torch_input, torch_output_grad, p=p, dim=dim, keepdim=keepdim, do_backward=False)
+    actual_output, _ = ttnn_norm(
+        torch_input,
+        torch_output_grad,
         p=p,
         dim=dim,
         keepdim=keepdim,
@@ -164,16 +161,14 @@ def run_moreh_norm(input_shape, p, dim, rtol, atol, device, keepdim=False, compu
         device=device,
         do_backward=False,
     )
-    actual_y = actual_y if keepdim else actual_y.reshape(expected_y.shape)
-
-    pass_y, out_y = comp_allclose(expected_y, actual_y, rtol=rtol, atol=atol)
-    logger.debug(f"output's {out_y}")
-    assert pass_y
+    passing, out = comp_allclose(expected_output, actual_output, rtol=rtol, atol=atol)
+    logger.debug(f"output's {out}")
+    assert passing
 
 
 def run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, keepdim=False, compute_kernel_options=None):
     """
-    Runs the norm operation with backpropagation using both PyTorch and Tenstorrent's custom implementation and compares the gradients.
+    Runs the norm operation with backpropagation using both torch and ttnn's custom implementation and compares the gradients.
 
     Args:
         input_shape (tuple): The shape of the input tensor.
@@ -186,16 +181,14 @@ def run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, keepdim=Fal
         compute_kernel_options: Configuration options for the compute kernel.
 
     Raises:
-        AssertionError: If the computed gradients from Tenstorrent's implementation and PyTorch are not close.
+        AssertionError: If the computed gradients from ttnn's implementation and torch are not close.
     """
     check_dim(input_shape, dim, keepdim)
-
-    cpu_x, cpu_dy = make_cpu_tensors(input_shape, dim, keepdim=keepdim)
-
-    _, expected_dx = torch_norm(cpu_x, cpu_dy, p=p, dim=dim, keepdim=keepdim, do_backward=True)
-    _, actual_dx = tt_norm(
-        cpu_x,
-        cpu_dy,
+    torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim)
+    _, expected_input_grad = torch_norm(torch_input, torch_output_grad, p=p, dim=dim, keepdim=keepdim, do_backward=True)
+    _, actual_input_grad = ttnn_norm(
+        torch_input,
+        torch_output_grad,
         p=p,
         dim=dim,
         keepdim=keepdim,
@@ -203,10 +196,9 @@ def run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, keepdim=Fal
         device=device,
         do_backward=True,
     )
-
-    pass_dx, out_dx = comp_allclose(expected_dx, actual_dx, rtol=rtol, atol=atol)
-    logger.debug(f"input_grad's {out_dx}")
-    assert pass_dx
+    passing, out = comp_allclose(expected_input_grad, actual_input_grad, rtol=rtol, atol=atol)
+    logger.debug(f"input_grad's {out}")
+    assert passing
 
 
 @pytest.mark.parametrize("p", [2.0, 2.5, -2.5])
@@ -250,25 +242,14 @@ def run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, keepdim=Fal
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [TILE_HEIGHT, TILE_WIDTH],
-        [2, 2, 2 * TILE_HEIGHT + 13, 2 * TILE_WIDTH + 13],
+        [32, 32],
+        [5, 8, 78, 77],
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_moreh_norm(input_shape, p, dim_rtol_atol, keepdim, device):
     """
-    Parametrized test for Tenstorrent's norm operation. Compares the output of Tenstorrent's norm with PyTorch's norm
-    for various input shapes, dimensions, norms, and keepdim settings.
-
-    Args:
-        input_shape (list of int): Shape of the input tensor.
-        p (float): The order of the norm.
-        dim_rtol_atol (list): List containing the dimension(s), relative tolerance, and absolute tolerance for the comparison.
-        keepdim (bool): Whether to retain the reduced dimensions in the output.
-        device: The device to run the computation on.
-
-    Raises:
-        AssertionError: If the computed outputs from Tenstorrent's implementation and PyTorch are not close.
+    Parametrized test for ttnn's norm operation. Compares the output of ttnn's norm with torch's norm.
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
@@ -287,77 +268,57 @@ def test_moreh_norm(input_shape, p, dim_rtol_atol, keepdim, device):
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [10, TILE_HEIGHT, TILE_WIDTH],
+        [10, 32, 32],
     ],
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_norm_compute_kernel_options(input_shape, p, dim_rtol_atol, compute_kernel_options, device):
     """
-    Parametrized test for Tenstorrent's norm operation with various kernel compute options. Compares the output of Tenstorrent's norm
-    with PyTorch's norm for different input shapes, dimensions, norms, and compute kernel configurations.
-
-    Args:
-        input_shape (list of int): Shape of the input tensor.
-        p (float): The order of the norm.
-        dim_rtol_atol (list): List containing the dimension(s), relative tolerance, and absolute tolerance for the comparison.
-        compute_kernel_options: Configuration options for the compute kernel.
-        device: The device to run the computation on.
-
-    Raises:
-        AssertionError: If the computed outputs from Tenstorrent's implementation and PyTorch are not close.
+    Parametrized test for ttnn's norm operation. Compares the output of ttnn's norm with torch's norm.
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
-    run_moreh_norm(input_shape, p, dim, rtol, atol, device, compute_kernel_options=compute_kernel_options)
+    run_moreh_norm(
+        input_shape,
+        p,
+        dim,
+        rtol,
+        atol,
+        device,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
-@pytest.mark.parametrize("p", [2.0])
 @pytest.mark.parametrize(
     "dim_rtol_atol",
     [
-        [[0, 1, 2, 3], 0.2, 0.2],
+        [[1, 3], 0.1, 0.1],
+        [0, 0.1, 0.1],
+        [1, 0.1, 0.1],
+        [2, 0.1, 0.1],
+        [3, 0.1, 0.1],
     ],
-    ids=[
-        "NCHW",
-    ],
-)
-@pytest.mark.parametrize(
-    "input_shape",
-    [
-        [TILE_HEIGHT, TILE_WIDTH],
-        [2, 2, 2 * TILE_HEIGHT + 13, 2 * TILE_WIDTH + 13],
-    ],
+    ids=["CW", "N", "C", "H", "W"],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_moreh_norm_callback(input_shape, p, dim_rtol_atol, keepdim, device, use_program_cache):
+def test_moreh_norm_callback(dim_rtol_atol, keepdim, device, use_program_cache):
     """
-    Test the norm operation in Tenstorrent's implementation with and without the program cache.
-    Verifies that the number of program cache entries remains consistent when running norm operations.
-
-    Args:
-        input_shape (list of int): Shape of the input tensor.
-        p (float): The order of the norm.
-        dim_rtol_atol (list): List containing the dimension(s), relative tolerance, and absolute tolerance for the comparison.
-        device: The device to run the computation on.
-        use_program_cache: Use the program cache.
-
-    Raises:
-        AssertionError: If the number of program cache entries differs between runs with the same settings.
+    Parametrized test for ttnn's norm operation. Compares the output of ttnn's norm with torch's norm.
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
     num_program_cache_entries_list = []
     for i in range(2):
-        run_moreh_norm(input_shape, p, dim, rtol, atol, device, keepdim=keepdim)
+        run_moreh_norm([5, 8, 78, 77], 2.0, dim, rtol, atol, device, keepdim=keepdim)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
+        ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-@pytest.mark.parametrize("p", [2.0])
+@pytest.mark.parametrize("p", [2.0, 2.5, -2.5])
 @pytest.mark.parametrize(
     "dim_rtol_atol",
     [
@@ -398,25 +359,14 @@ def test_moreh_norm_callback(input_shape, p, dim_rtol_atol, keepdim, device, use
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [TILE_HEIGHT, TILE_WIDTH],
-        [2, 2, 2 * TILE_HEIGHT + 13, 2 * TILE_WIDTH + 13],
+        [32, 32],
+        [5, 8, 78, 77],
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_moreh_norm_backward(input_shape, p, dim_rtol_atol, keepdim, device):
     """
-    Parametrized test for Tenstorrent's norm operation with backward propagation.
-    Compares the output gradient of Tenstorrent's norm with PyTorch's norm across various configurations.
-
-    Args:
-        input_shape (list of int): Shape of the input tensor.
-        p (float): The order of the norm.
-        dim_rtol_atol (list): List containing the dimension(s), relative tolerance, and absolute tolerance for the comparison.
-        keepdim (bool): Whether to retain the reduced dimensions in the output.
-        device: The device to run the computation on.
-
-    Raises:
-        AssertionError: If the computed gradients from Tenstorrent's implementation and PyTorch are not close.
+    Parametrized test for ttnn's norm backward operation. Compares the output of ttnn's norm backward with torch's norm backward.
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
@@ -435,70 +385,50 @@ def test_moreh_norm_backward(input_shape, p, dim_rtol_atol, keepdim, device):
 @pytest.mark.parametrize(
     "input_shape",
     [
-        [10, TILE_HEIGHT, TILE_WIDTH],
+        [10, 32, 32],
     ],
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_norm_backward_compute_kernel_options(input_shape, p, dim_rtol_atol, compute_kernel_options, device):
     """
-    Parametrized test for Tenstorrent's norm backward operation with various kernel compute options.
-    Compares the output gradient of Tenstorrent's norm with PyTorch's norm across different compute kernel configurations.
-
-    Args:
-        input_shape (list of int): Shape of the input tensor.
-        p (float): The order of the norm.
-        dim_rtol_atol (list): List containing the dimension(s), relative tolerance, and absolute tolerance for the comparison.
-        compute_kernel_options: Configuration options for the compute kernel.
-        device: The device to run the computation on.
-
-    Raises:
-        AssertionError: If the computed gradients from Tenstorrent's implementation and PyTorch are not close.
+    Parametrized test for ttnn's norm backward operation. Compares the output of ttnn's norm backward with torch's norm backward.
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
-    run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, compute_kernel_options=compute_kernel_options)
+    run_moreh_norm_backward(
+        input_shape,
+        p,
+        dim,
+        rtol,
+        atol,
+        device,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
-@pytest.mark.parametrize("p", [2.0])
 @pytest.mark.parametrize(
     "dim_rtol_atol",
     [
-        [[0, 1, 2, 3], 0.2, 0.2],
+        [[1, 3], 0.1, 0.1],
+        [0, 0.1, 0.1],
+        [1, 0.1, 0.1],
+        [2, 0.1, 0.1],
+        [3, 0.1, 0.1],
     ],
-    ids=[
-        "NCHW",
-    ],
-)
-@pytest.mark.parametrize(
-    "input_shape",
-    [
-        [TILE_HEIGHT, TILE_WIDTH],
-        [2, 2, 2 * TILE_HEIGHT + 13, 2 * TILE_WIDTH + 13],
-    ],
+    ids=["CW", "N", "C", "H", "W"],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_moreh_norm_backward_callback(input_shape, p, dim_rtol_atol, keepdim, device, use_program_cache):
+def test_moreh_norm_backward_callback(dim_rtol_atol, keepdim, device, use_program_cache):
     """
-    Test the norm backward operation in Tenstorrent's implementation with and without the program cache.
-    Verifies that the number of program cache entries remains consistent when running backward norm operations.
-
-    Args:
-        input_shape (list of int): Shape of the input tensor.
-        p (float): The order of the norm.
-        dim_rtol_atol (list): List containing the dimension(s), relative tolerance, and absolute tolerance for the comparison.
-        device: The device to run the computation on.
-        use_program_cache: Use the program cache.
-
-    Raises:
-        AssertionError: If the number of program cache entries differs between runs with the same settings.
+    Parametrized test for ttnn's norm backward operation. Compares the output of ttnn's norm backward with torch's norm backward.
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
     num_program_cache_entries_list = []
     for i in range(2):
-        run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, keepdim=keepdim)
+        run_moreh_norm_backward([5, 8, 78, 77], 2.0, dim, rtol, atol, device, keepdim=keepdim)
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
+        ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0

--- a/tests/ttnn/unit_tests/operations/test_moreh_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_norm.py
@@ -178,7 +178,7 @@ def run_moreh_norm(
         dtype=ttnn_dtype,
     )
     passing, out = comp_allclose(expected_output, actual_output, rtol=rtol, atol=atol)
-    logger.debug(f"output's {out}")
+    logger.info(f"output's {out}")
     assert passing
 
 
@@ -228,7 +228,7 @@ def run_moreh_norm_backward(
         dtype=ttnn_dtype,
     )
     passing, out = comp_allclose(expected_input_grad, actual_input_grad, rtol=rtol, atol=atol)
-    logger.debug(f"input_grad's {out}")
+    logger.info(f"input_grad's {out}")
     assert passing
 
 

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -165,14 +165,17 @@ def get_lib_dtype(lib, dtype):
     lib: library module (e.g., torch, ttnn)
         The library for which the dtype mapping is required.
     dtype: str
-        The string representation of the data type (e.g., 'bfloat16', 'float32', 'int32').
+        The string representation of the data type (e.g., 'bfloat16', 'float32', 'int32', 'bfloat8_b').
 
     Returns:
     Corresponding library-specific dtype or None if not found.
     """
-    dtype_map = {
-        "bfloat16": lib.bfloat16,
-        "float32": lib.float32,
-        "int32": lib.int32,
-    }
-    return dtype_map.get(dtype, None)
+    if hasattr(lib, "bfloat8_b") and dtype == "bfloat8_b":
+        return lib.bfloat8_b
+    else:
+        dtype_map = {
+            "bfloat16": lib.bfloat16,
+            "float32": lib.float32,
+            "int32": lib.int32,
+        }
+        return dtype_map.get(dtype, None)

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -12,11 +12,9 @@ TILE_HEIGHT = 32
 TILE_WIDTH = 32
 
 
-compute_kernel_options = [
-    False,  # for grayskull
-]
+compute_kernel_options = [False]
 compute_kernel_ids = ["fp32_dest_acc_en=False"]
-if is_wormhole_b0:
+if is_wormhole_b0():
     compute_kernel_options.append(True)
     compute_kernel_ids.append("fp32_dest_acc_en=True")
 
@@ -34,7 +32,7 @@ def get_compute_kernel_options(compute_kernel_options):
             packer_l1_acc=packer_l1_acc,
         )
     else:
-        # Grayskull doesn't support fp32 but test passing a GS config is ok
+        # Grayskull doesn't support FP32, but passing a Grayskull config in the test is OK.
         compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi4,
             math_approx_mode=True,


### PR DESCRIPTION
### Ticket
Link to Github Issue: [14087](https://github.com/tenstorrent/tt-metal/issues/14087)

### Problem description
- Add unit tests for the BFP8 data type, covering all operations.
- Compare BFP8 results with BF16/FP32 results from PyTorch for validation.
- Use allclose for accuracy checks, allowing for more relaxed tolerance where necessary due to precision differences.
- Ensure tests include cases where the last two dimensions are not multiples of the tile size (32x32).
- Include corner cases in testing to ensure the robustness of the implementation.


### What's changed
These operations are included:
- moreh_arange
- moreh_bmm
- moreh_bmm_backward
- moreh_norm
- moreh_norm_backward

**test_utils.py:**
- Support `bfloat8_b` dtype in `get_lib_dtype`.
- Enable Wormhole B0 compute kernel configuration in unit testing properly

**test_moreh_arange.py:**
- Remove `to_ttnn`. Use `ttnn.to_torch` and `ttnn.from_torch` instead.
- Add `bfloat8_b` as a dtype for `ttnn.operations.moreh.arange`.

**test_moreh_bmm.py:**
- Remove `to_ttnn`, `unpad_from_tile`, and `to_torch`. Use `ttnn.to_torch` and `ttnn.from_torch` instead.
- Add `bfloat8_b` as a dtype for `ttnn.operations.moreh.bmm/bmm_backward`.
- Refactor `get_tensors`: The previous implementation always created tensors with integer values at the beginning, which seemed unfair. So I created a new one (the old one was reused from `test_moreh_matmul`). The new one:
  + Supports `torch_dtype` and `ttnn_dtype`.
  + Creates random float tensors in the range [0, 1).
- Of course, the PCC changed slightly compared to the previous one: from 0.999 to 0.998, as some test cases now fall below 0.999 (when fp32_dest_acc_en=True). When fp32_dest_acc_en=False, the PCC is set to 0.97.

**test_moreh_norm.py:**
- Revise naming. Resolve some minor errors like unnecessary reshaping.
- Remove `to_ttnn` and `unpad_from_tile`. Use `ttnn.to_torch` and `ttnn.from_torch` instead.
- Add `bfloat8_b` as a dtype for `ttnn.operations.moreh.norm/norm_backward`.

All tests for `ttnn.bfloat8_b` failed as it is not yet supported in the kernel. I added TODO comments in the unit test files. Reviewers, please check if my approach is correct.


### Checklist
- [x] Post commit CI passes: [All post-commit tests #18430](https://github.com/tenstorrent/tt-metal/actions/runs/11484314361)
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] Device performance regression CI testing passes (if applicable): N/A
- [x] New/Existing tests provide coverage for changes: N/A
