### PR TITLE
#14076: Pin huggingface-hub to 0.25.2 to fix pipelines

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@ third_party/ @tt-rkim @TT-billteng
 MANIFEST.in @tt-rkim
 setup.py @tt-rkim
 pyproject.toml @tt-rkim @TT-billteng
-requirements*.txt @tt-rkim @TT-billteng
+requirements*.txt @tt-rkim @TT-billteng @ttmchiou
 setup_hugepages.py @tt-rkim @TT-billteng
 
 scripts/docker @TT-billteng
@@ -55,6 +55,7 @@ tt_metal/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema
 tt_metal/host_api.hpp @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @davorchap
 tt_metal/impl/device/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu
 tt_metal/distributed/ @cfjchu @aliuTT @tt-asaigal
+tt_metal/**/requirements*.txt @tt-rkim @TT-billteng @ttmchiou
 
 # metal - dispatch
 tt_metal/impl/dispatch/kernels/packet_* @ubcheema @aliuTT

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -58,3 +58,4 @@ docopt==0.6.2
 tabulate==0.9.0
 blobfile==2.1.1 # Required for llama3
 numpy>=1.24.4,<2
+huggingface-hub==0.25.2


### PR DESCRIPTION
### Ticket

#14076

### Problem description

Suddenly anything using `huggingface-hub` underneath started dying because they removed something from their API in a recent release.

### What's changed

We pin `huggingface-hub` to a version that contains this API, as for example our version of `diffusers` has a `huggingface-hub>=0.10`, so it just tries to pull in latest. SAD!

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
