### PR TITLE
Bring tracy mem profiler back

### DIFF
--- a/tt_metal/common/utils.cpp
+++ b/tt_metal/common/utils.cpp
@@ -16,8 +16,8 @@ namespace utils
 {
     bool run_command(const string &cmd, const string &log_file, const bool verbose)
     {
-        ZoneScoped;
-        ZoneText( cmd.c_str(), cmd.length());
+        //ZoneScoped;
+        //ZoneText( cmd.c_str(), cmd.length());
         int ret;
         static std::mutex io_mutex;
         if (getenv("TT_METAL_BACKEND_DUMP_RUN_CMD") or verbose) {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -340,6 +340,7 @@ bool Buffer::is_dram() const {
 }
 bool Buffer::is_trace() const {
     return buffer_type() == BufferType::TRACE;
+
 }
 
 uint32_t Buffer::dram_channel_from_bank_id(uint32_t bank_id) const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -309,7 +309,7 @@ uint32_t Kernel::get_binary_text_size(Device *device, int index) const {
 }
 
 void DataMovementKernel::set_build_options(JitBuildOptions &build_options) const {
-    ZoneScoped;
+    //ZoneScoped;
     switch (this->config_.processor) {
         case DataMovementProcessor::RISCV_0: {
             build_options.brisc_defines = this->defines_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -29,9 +29,9 @@ namespace {
 std::atomic<bool> enable_persistent_kernel_cache = false;
 
 void GenerateBinaries(Device *device, JitBuildOptions &build_options, std::shared_ptr<Kernel> kernel) {
-    ZoneScoped;
-    const std::string tracyPrefix = "GenerateBinaries_";
-    ZoneName((tracyPrefix + build_options.name).c_str(), build_options.name.length() + tracyPrefix.length());
+    //ZoneScoped;
+    //const std::string tracyPrefix = "GenerateBinaries_";
+    //ZoneName((tracyPrefix + build_options.name).c_str(), build_options.name.length() + tracyPrefix.length());
     try {
         jit_build_genfiles_descriptors(device->build_env(), build_options);
         kernel->generate_binaries(device, build_options);
@@ -665,7 +665,7 @@ void detail::Program_::invalidate_circular_buffer_allocation() {
 void Program::invalidate_circular_buffer_allocation() { pimpl_->invalidate_circular_buffer_allocation(); }
 
 void detail::Program_::allocate_circular_buffers(const Device *device) {
-    ZoneScoped;
+    //ZoneScoped;
     if (not this->local_circular_buffer_allocation_needed_) {
         return;
     }
@@ -709,7 +709,7 @@ void detail::Program_::allocate_circular_buffers(const Device *device) {
 void Program::allocate_circular_buffers(const Device *device) { pimpl_->allocate_circular_buffers(device); }
 
 void detail::Program_::validate_circular_buffer_region(const Device *device) const {
-    ZoneScoped;
+    //ZoneScoped;
 
     // Banks are in lockstep so we only need to get lowest L1 address of one compute and storage core
     // Only compute with storage cores can have CBs and all compute with storage cores will have the same bank offset
@@ -802,7 +802,7 @@ std::vector<std::vector<CoreCoord>> detail::Program_::logical_cores() const {
 std::vector<std::vector<CoreCoord>> Program::logical_cores() const { return pimpl_->logical_cores(); }
 
 void detail::Program_::set_cb_data_fmt(Device *device, const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
-    ZoneScoped;
+    //ZoneScoped;
     for (auto logical_cr : crs) {
         auto cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
         for (auto circular_buffer : cbs_on_core) {
@@ -815,7 +815,7 @@ void detail::Program_::set_cb_data_fmt(Device *device, const std::vector<CoreRan
 }
 
 void detail::Program_::set_cb_tile_dims(Device *device, const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
-    ZoneScoped;
+    //ZoneScoped;
     for (const auto &logical_cr : crs) {
         auto cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
         for (const auto &circular_buffer : cbs_on_core) {
@@ -1310,7 +1310,7 @@ void detail::Program_::finalize(Device *device) {
 void Program::finalize(Device *device) { pimpl_->finalize(device); }
 
 void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
-    ZoneScoped;
+    //ZoneScoped;
     if (compiled_.contains(device->id())) {
         return;
     }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -480,7 +480,7 @@ void JitBuildState::compile_one(
     const JitBuildSettings* settings,
     const string& src,
     const string& obj) const {
-    ZoneScoped;
+    //ZoneScoped;
     fs::create_directories(out_dir);
 
     // Add kernel specific defines
@@ -517,7 +517,7 @@ void JitBuildState::compile_one(
 }
 
 void JitBuildState::compile(const string& log_file, const string& out_dir, const JitBuildSettings* settings) const {
-    ZoneScoped;
+    //ZoneScoped;
     std::vector<std::shared_future<void>> events;
     for (size_t i = 0; i < this->srcs_.size(); ++i) {
         launch_build_step(
@@ -534,7 +534,7 @@ void JitBuildState::compile(const string& log_file, const string& out_dir, const
 }
 
 void JitBuildState::link(const string& log_file, const string& out_dir) const {
-    ZoneScoped;
+    //ZoneScoped;
     string lflags = this->lflags_;
     if (tt::llrt::OptionsG.get_build_map_enabled()) {
         lflags += "-Wl,-Map=" + out_dir + "linker.map ";
@@ -564,7 +564,7 @@ void JitBuildState::link(const string& log_file, const string& out_dir) const {
 // same name don't result in duplicate symbols but B can reference A's symbols. Force the fw_export symbols to remain
 // strong so to propogate link addresses
 void JitBuildState::weaken(const string& log_file, const string& out_dir) const {
-    ZoneScoped;
+    //ZoneScoped;
 
     std::string pathname_in = out_dir + target_name_ + ".elf";
     std::string pathname_out = out_dir + target_name_ + "_weakened.elf";
@@ -577,7 +577,7 @@ void JitBuildState::weaken(const string& log_file, const string& out_dir) const 
 }
 
 void JitBuildState::extract_zone_src_locations(const string& log_file) const {
-    ZoneScoped;
+    //ZoneScoped;
     static std::atomic<bool> new_log = true;
     if (tt::tt_metal::getDeviceProfilerState()) {
         if (new_log.exchange(false) && std::filesystem::exists(tt::tt_metal::PROFILER_ZONE_SRC_LOCATIONS_LOG)) {
@@ -596,7 +596,7 @@ void JitBuildState::extract_zone_src_locations(const string& log_file) const {
 }
 
 void JitBuildState::build(const JitBuildSettings* settings) const {
-    ZoneScoped;
+    //ZoneScoped;
     string out_dir = (settings == nullptr)
                          ? this->out_path_ + this->target_name_ + "/"
                          : this->out_path_ + settings->get_full_kernel_name() + this->target_name_ + "/";
@@ -616,13 +616,13 @@ void JitBuildState::build(const JitBuildSettings* settings) const {
 }
 
 void jit_build(const JitBuildState& build, const JitBuildSettings* settings) {
-    ZoneScoped;
+    //ZoneScoped;
 
     build.build(settings);
 }
 
 void jit_build_set(const JitBuildStateSet& build_set, const JitBuildSettings* settings) {
-    ZoneScoped;
+    //ZoneScoped;
     std::vector<std::shared_future<void>> events;
     for (size_t i = 0; i < build_set.size(); ++i) {
         // Capture the necessary objects by reference

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -515,9 +515,9 @@ static void generate_math_approx_mode_descriptor(JitBuildOptions& options) {
 }
 
 void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& options) {
-    ZoneScoped;
-    const std::string tracyPrefix = "generate_descriptors_";
-    ZoneName((tracyPrefix + options.name).c_str(), options.name.length() + tracyPrefix.length());
+    //ZoneScoped;
+    //const std::string tracyPrefix = "generate_descriptors_";
+    //ZoneName((tracyPrefix + options.name).c_str(), options.name.length() + tracyPrefix.length());
     fs::create_directories(options.path);
     try {
         std::thread td( [&]() { generate_data_format_descriptors(options, env.get_arch()); } );

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -64,6 +64,7 @@ RunTimeOptions::RunTimeOptions() {
     profiler_enabled = false;
     profile_dispatch_cores = false;
     profiler_sync_enabled = false;
+    profiler_buffer_usage_enabled = false;
 #if defined(TRACY_ENABLE)
     const char *profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
     if (profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1') {
@@ -76,6 +77,10 @@ RunTimeOptions::RunTimeOptions() {
         if (profiler_enabled && profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
             profiler_sync_enabled = true;
         }
+    }
+    const char *profile_buffer_usage_str = std::getenv("TT_METAL_MEM_PROFILER");
+    if (profile_buffer_usage_str != nullptr && profile_buffer_usage_str[0] == '1') {
+        profiler_buffer_usage_enabled = true;
     }
 #endif
     TT_FATAL(

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -107,6 +107,7 @@ class RunTimeOptions {
     bool profiler_enabled = false;
     bool profile_dispatch_cores = false;
     bool profiler_sync_enabled = false;
+    bool profiler_buffer_usage_enabled = false;
 
     bool null_kernels = false;
 
@@ -255,6 +256,7 @@ class RunTimeOptions {
     inline bool get_profiler_enabled() { return profiler_enabled; }
     inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
     inline bool get_profiler_sync_enabled() { return profiler_sync_enabled; }
+    inline bool get_profiler_buffer_usage_enabled() { return profiler_buffer_usage_enabled; }
 
     inline void set_kernels_nullified(bool v) { null_kernels = v; }
     inline bool get_kernels_nullified() { return null_kernels; }


### PR DESCRIPTION
### Ticket
#6802 

### Problem description
Memory profiling with tracy was disabled due to more mem frees than news.

### What's changed
The profiling hooks were moved to Buffer class instead of the allocator class and no free vs. new discrepancy is observed.

Setting the env var`TT_METAL_MEM_PROFILER=1`  will enable buffer profiling in tracy. 

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11557294411
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11463494115
- [x] T3K Profiler https://github.com/tenstorrent/tt-metal/actions/runs/11557299950

![Screenshot 2024-10-21 at 10 50 22 AM](https://github.com/user-attachments/assets/33fc3b3c-5ef1-4574-aad7-0eb17b630cbd)
