### PR TITLE
#0: Add upload_data option to produce data workflow so we can upload if we want and add ttnn sweeps and BH post-commit to collection

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -12,6 +12,10 @@ on:
         description: "Run attempt of the workflow run"
         default: 1
         type: number
+      upload_data:
+        description: "Upload data to datastore cluster for our dashboard"
+        default: false
+        type: boolean
   workflow_run:
     workflows:
       - "All post-commit tests"
@@ -113,7 +117,7 @@ jobs:
         run: ls -hal
       - name: Upload cicd data
         uses: ./.github/actions/upload-data-via-sftp
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_run' || inputs.upload_data }}
         with:
           ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/cicd_data_batchfile.txt

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -33,6 +33,8 @@ on:
       - "(TGG) TGG unit tests"
       - "(TGG) TGG demo tests"
       - "(TGG) TGG frequent tests"
+      - "ttnn - Run sweeps"
+      - "Blackhole post-commit tests"
     types:
       - completed
 


### PR DESCRIPTION
### Ticket

Quick additions.

### Problem description

We want to:
- upload data if we choose to on dispatch, not only on workflow_run: trigger
- add ttnn sweeps and BH PC to collection

### What's changed

Add the above.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
