### PR TITLE
#7957: update doc- zeros, empty, zeros_like

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -14,6 +14,9 @@ on:
           - ccl.line_all_gather
           - ccl.all_gather_n300
           - ccl.all_gather_n300_focused
+          - creation.zeros.zeros
+          - creation.empty.empty
+          - creation.zeros_like.zeros_like
           - eltwise.unary.abs.abs_pytorch2
           - eltwise.unary.relu.relu
           - eltwise.unary.relu.relu_pytorch2

--- a/tests/sweep_framework/sweeps/creation/empty/empty.py
+++ b/tests/sweep_framework/sweeps/creation/empty/empty.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "batch_sizes": [(1, 2), (3, 6)],
+        "height": [384, 1024],
+        "width": [1024, 4096],
+        "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "Skipped as ROW_MAJOR_LAYOUT and ttnn.bfloat8_b not supported"
+    return False, None
+
+
+def check_output(torch_output_tensor, output_tensor):
+    status = list(torch_output_tensor.shape) == list(output_tensor.shape)
+    msg = ""
+    msg = "pass" if status else "fail"
+
+    return status, msg
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    input_shape = (*batch_sizes, height, width)
+
+    torch_output_tensor = torch.empty(input_shape)
+
+    start_time = start_measuring_time()
+
+    output_tensor = ttnn.empty(input_shape, input_dtype, layout, device=device, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_output(torch_output_tensor, output_tensor), e2e_perf]

--- a/tests/sweep_framework/sweeps/creation/zeros/zeros.py
+++ b/tests/sweep_framework/sweeps/creation/zeros/zeros.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "batch_sizes": [(1, 2), (3, 6)],
+        "height": [384, 1024],
+        "width": [1024, 4096],
+        "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+        "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "Skipped as ROW_MAJOR_LAYOUT and ttnn.bfloat8_b not supported"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    input_shape = (*batch_sizes, height, width)
+
+    torch_output_tensor = torch.zeros(input_shape)
+
+    start_time = start_measuring_time()
+
+    output_tensor = ttnn.zeros(input_shape, input_dtype, layout, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/creation/zeros_like/zeros_like.py
+++ b/tests/sweep_framework/sweeps/creation/zeros_like/zeros_like.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import ttnn
+from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_shape": gen_shapes([1, 1, 32, 32], [2, 6, 256, 256], [1, 1, 320, 320], 128),
+        "input_dtype": [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "Skipped as bfloat8_b dtype not supported"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_dtype,
+    input_a_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    torch_output_tensor = torch.zeros_like(torch_input_tensor_a)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.zeros_like(input_tensor_a, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]


### PR DESCRIPTION
### Ticket
Link to Github Issue #7957

### Problem description
Need to Update documentation with supported layout and dtype

### What's changed
Updated documentation with supported layout and dtype
Added sweeps

<img width="1125" alt="Screenshot 2024-10-23 at 2 07 26 AM" src="https://github.com/user-attachments/assets/944e9ce6-899b-40c0-837f-640b59ea49ba">

**Doc:** 
<img width="1129" alt="Screenshot 2024-10-23 at 11 40 03 AM" src="https://github.com/user-attachments/assets/6d73f46e-01d9-45a2-91d8-40e4fd825fda">

<img width="1149" alt="Screenshot 2024-10-23 at 11 40 16 AM" src="https://github.com/user-attachments/assets/2b41539f-dc75-4893-be71-de643541ecfe">

<img width="1144" alt="Screenshot 2024-10-23 at 11 39 49 AM" src="https://github.com/user-attachments/assets/75795655-e9f2-4ff5-ab65-344fee46f210">

### Checklist
- [x] Post commit CI passes  https://github.com/tenstorrent/tt-metal/actions/runs/11468254188
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
