### PR TITLE
#0: Remove unused includes in tt_memory.cpp

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -66,6 +66,7 @@ foreach (TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
     )
     set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal/perf_microbenchmark/${TEST_DIR})
     target_compile_options(${TEST_TARGET} PUBLIC ${COMPILE_OPTIONS})
+    target_compile_options(${TEST_TARGET} PRIVATE "-include${PROJECT_SOURCE_DIR}/tt_metal/common/test_common.hpp")
     list(APPEND PERF_MICROBENCH_TEST_TARGETS ${TEST_TARGET})
 endforeach()
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tunnel_2cq.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tunnel_2cq.cpp
@@ -2,12 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include "tt_metal/common/test_common.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
 

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
+#include "tt_metal/common/test_common.hpp"
 
 #include "llrt/llrt.hpp"
 

--- a/tt_metal/impl/debug/sanitize_noc_host.hpp
+++ b/tt_metal/impl/debug/sanitize_noc_host.hpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "tensix.h" // RISCV_DEBUG_REG_SOFT_RESET_0
 #include "noc/noc_parameters.h"
 #include "noc/noc_overlay_parameters.h"
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -3,21 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <algorithm>
-#include <filesystem>
-#include <functional>
-#include <iostream>
-#include <random>
-#include <tuple>
+
+#include <cstdint>
+#include <vector>
 
 // clang-format off
 #include "llrt/tt_cluster.hpp"
-#include "tensix.h"
 #include "tt_metal/third_party/umd/device/device_api_metal.h"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
 #include "llrt_common/tiles.hpp"
 #include "llrt/tt_memory.h"
-#include "hostdevcommon/common_runtime_address_map.h"
 #include "jit_build/build.hpp"
 #include "dev_msgs.h"
 // clang-format on

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -4,22 +4,32 @@
 
 #include "tt_cluster.hpp"
 
-#include <immintrin.h>
-
+#include <cstdint>
+#include <cstdlib> // getenv
 #include <filesystem>
-#include <iomanip>
 #include <iostream>
+#include <set>
 #include <string>
+#include <tuple> // tie, make_tuple
+#include <unordered_set>
+#include <vector>
+#include <stdexcept>
 
-#include "hostdevcommon/dprint_common.h"
 #include "rtoptions.hpp"
-#include "third_party/umd/device/tt_silicon_driver_common.hpp"
+#include "third_party/umd/device/device_api_metal.h"
+#include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"
 #include "third_party/umd/device/simulation/tt_simulation_device.h"
+#include "third_party/umd/device/tt_cluster_descriptor_types.h" // chip_id_t
+#include "tt_metal/third_party/umd/device/tt_xy_pair.h" // tt_xy_pair, tt_cxy_pair
 #include "tools/profiler/profiler.hpp"
 #include "tt_metal/impl/debug/sanitize_noc_host.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
 #include "tt_metal/llrt/tlb_config.hpp"
 #include "tt_metal/common/core_coord.h"
+
+#include "common/test_common.hpp" // get_core_description_file
+#include "tt_metal/common/assert.hpp" // TT_FATAL
+#include "tt_metal/common/logger.hpp" // log_info
 
 static constexpr uint32_t HOST_MEM_CHANNELS = 4;
 static constexpr uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;
@@ -55,7 +65,7 @@ Cluster::Cluster() {
 void Cluster::detect_arch_and_target() {
     if(std::getenv("TT_METAL_SIMULATOR_EN")) {
         this->target_type_ = TargetDevice::Simulator;
-        auto arch_env = getenv("ARCH_NAME");
+        auto arch_env = std::getenv("ARCH_NAME");
         TT_FATAL(arch_env, "ARCH_NAME env var needed for VCS");
         this->arch_ = tt::get_arch_from_string(arch_env);
     }else {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -4,19 +4,17 @@
 
 #pragma once
 
-#include <chrono>
 #include <functional>
+#include <vector>
 
 #include "common/base.hpp"
 #include "common/metal_soc_descriptor.h"
-#include "common/test_common.hpp"
-#include "common/tt_backend_api_types.hpp"
-#include "host_mem_address_map.h"
-#include "hostdevcommon/common_runtime_address_map.h"
+#include "host_mem_address_map.h" // Comes from UMD, architecture specific, FIXME
 #include "third_party/umd/device/device_api_metal.h"
 #include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
 
+// FIXME: Need to get rid of these, because they are architecture specific
 // clang-format off
 #include "noc/noc_parameters.h"
 #include "eth_interface.h"
@@ -80,9 +78,9 @@ class Cluster {
     void deassert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const;
     void assert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const;
 
-    void write_dram_vec(vector<uint32_t> &vec, tt_target_dram dram, uint64_t addr, bool small_access = false) const;
+    void write_dram_vec(std::vector<uint32_t> &vec, tt_target_dram dram, uint64_t addr, bool small_access = false) const;
     void read_dram_vec(
-        vector<uint32_t> &vec,
+        std::vector<uint32_t> &vec,
         uint32_t size_in_bytes,
         tt_target_dram dram,
         uint64_t addr,
@@ -94,7 +92,7 @@ class Cluster {
     void read_core(
         void *mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
     void read_core(
-        vector<uint32_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
+        std::vector<uint32_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair &target) const {
         chip_id_t mmio_device_id = device_to_mmio_device_.at(target.chip);

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -4,14 +4,15 @@
 
 #include "tt_memory.h"
 
-#include <cassert>
 #include <cstdio>
-#include <fstream>
+#include <cstdint>
+#include <cstring>
+#include <functional>
 #include <limits>
-#include <stdexcept>
+#include <string>
+#include <span> // FIXME: No C++20 desired in tt_metal
+#include <vector>
 
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tensix.h"
 #include "tt_elffile.hpp"
 #include "tt_metal/common/assert.hpp"
 

--- a/tt_metal/llrt/tt_memory.h
+++ b/tt_metal/llrt/tt_memory.h
@@ -4,15 +4,11 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
-#include <cassert>
 #include <cstdint>
-#include <istream>
-#include <sstream>
 #include <string>
 #include <vector>
-
-// #include "command_assembler/memory.h"
 
 namespace ll_api {
 


### PR DESCRIPTION
### Ticket
#11830 

### Problem description
We are eliminating the header file `common_runtime_address_map.h`.
However there are several unnecessary references to it.
I am trying to sweep these occurrences using clang-tidy.

### What's changed
Header files.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11470200080 (LATEST CODE)
https://github.com/tenstorrent/tt-metal/actions/runs/11468303022
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
