### PR TITLE
#11886: Refactoring moreh group norm forward

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -27,21 +27,25 @@ def find_mismatched_indices_and_values(tensor1, tensor2, rtol, atol):
     mismatched_indices = torch.nonzero(difference, as_tuple=False)
 
     # get different value
-    mismatched_values = [
+    mismatched_idx_and_values = [
         (idx.tolist(), tensor1[tuple(idx)].item(), tensor2[tuple(idx)].item()) for idx in mismatched_indices
     ]
 
-    return mismatched_indices, mismatched_values
+    return mismatched_idx_and_values
 
 
 def print_mismatched_elements(golden, calculated, rtol, atol):
-    indicies, values = find_mismatched_indices_and_values(golden, calculated, rtol=rtol, atol=atol)
+    index_and_values = find_mismatched_indices_and_values(golden, calculated, rtol=rtol, atol=atol)
 
     MAX_PRINT_CNT = 10
-    logger.debug("Number of different elements {}", len(indicies))
-    cnt = min(MAX_PRINT_CNT, len(indicies))
-    for i in range(cnt):
-        logger.debug("Different idx and values {}", values[i])
+    mismatched_cnt = len(index_and_values)
+    logger.debug("Number of different elements {}", mismatched_cnt)
+    display_cnt = min(MAX_PRINT_CNT, mismatched_cnt)
+    for i in range(display_cnt):
+        logger.debug("Different idx and values {}", index_and_values[i])
+
+    if len(index_and_values) > MAX_PRINT_CNT:
+        logger.debug("More indices are mismatched and only MAX_PRINT_CNT={} Displayed.", MAX_PRINT_CNT)
 
 
 ### Math operations ###

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -415,6 +415,8 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_2d_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_3d_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
@@ -26,6 +26,14 @@
 #include "compute_kernel_api/mask.h"
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/transpose_wh_dest.h"
+
+constexpr uint32_t div_up(uint32_t n, uint32_t d) { return (n + d - 1) / d; }
+
+constexpr uint32_t round_down(uint32_t a, uint32_t b) { return a / b * b; }
+
+constexpr uint32_t round_up(uint32_t a, uint32_t b) { return b * div_up(a, b); }
 
 
 // Deprecated
@@ -143,6 +151,14 @@ ALWI void reduce_init_delta_with_dt(uint32_t ocb = 16, uint32_t icb0 = 0, uint32
         reconfig_data_format(icb0, icb1);
     #endif
     reduce_init_delta<at_start, reduce_type, reduce_dim>(ocb, icb0, icb1);
+}
+
+ALWI void transpose_wh_init_short_with_dt(uint32_t icb)
+{
+    #if defined FP32_DEST_ACC_EN
+        reconfig_data_format_srca(icb);
+    #endif
+    transpose_wh_init_short(icb);
 }
 
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
@@ -27,7 +27,6 @@
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/transpose_wh.h"
-#include "compute_kernel_api/transpose_wh_dest.h"
 
 constexpr uint32_t div_up(uint32_t n, uint32_t d) { return (n + d - 1) / d; }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_2d.cpp
@@ -1,0 +1,474 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // runtime args
+    int i{0};
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
+    const auto unit_offset = get_arg_val<uint32_t>(i++);
+
+    // compile-time args
+    constexpr uint32_t num_units_per_core = get_compile_time_arg_val(0);
+    constexpr bool gamma_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr bool beta_has_value = get_compile_time_arg_val(2) == 1;
+    constexpr bool mean_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr bool rstd_has_value = get_compile_time_arg_val(4) == 1;
+
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+
+    constexpr auto cb_x = tt::CB::c_in0;       // input
+    constexpr auto cb_scaler = tt::CB::c_in1;  // scaler
+    constexpr auto cb_eps = tt::CB::c_in2;     // epsilon
+    constexpr auto cb_gamma = tt::CB::c_in3;   // gamma
+    constexpr auto cb_beta = tt::CB::c_in4;    // beta
+    constexpr auto cb_mask = tt::CB::c_in5;    // mask
+    constexpr auto cb_zeros = tt::CB::c_in6;   // zeros
+
+    constexpr auto cb_output = tt::CB::c_out0;  // output
+    constexpr auto cb_mean = tt::CB::c_out1;    // mean
+    constexpr auto cb_rstd = tt::CB::c_out2;    // rstd
+
+    constexpr auto cb_ex = tt::CB::c_intermed0;          // E[x]
+    constexpr auto cb_xmm = tt::CB::c_intermed1;         // x - E[x]
+    constexpr auto cb_xmm2 = tt::CB::c_intermed2;        // (x - E[x])^2
+    constexpr auto cb_xmm2sum = tt::CB::c_intermed3;     // Sum[(x - E[x])^2]
+    constexpr auto cb_var = tt::CB::c_intermed4;         // E[(x - E[x])^2] = Var[x]
+    constexpr auto cb_recip_std = tt::CB::c_intermed5;   // 1.0/(sqrt(Var[x] + eps))
+    constexpr auto cb_gamma_beta = tt::CB::c_intermed6;  // p * gamm + beta
+    constexpr auto cb_xsum = tt::CB::c_intermed7;        // Sum[x]
+
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    cb_wait_front(cb_scaler, onetile);  // comes from the reader
+    cb_wait_front(cb_eps, onetile);     // comes from the reader
+    cb_wait_front(cb_zeros, onetile);   // comes from the reader
+
+    for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; outer_idx++) {
+        // input[N, C]
+        // reshaped_input[N, num_groups, C / num_groups]
+        auto unit_idx = unit_offset + outer_idx;
+        auto group_idx = unit_idx % num_groups;
+
+        uint32_t c_size_per_unit = C / num_groups;
+        uint32_t c_start = c_size_per_unit * group_idx;
+        uint32_t c_end = c_size_per_unit * (group_idx + 1);
+
+        {
+            uint32_t read_start = c_start;
+            uint32_t read_end = c_start;
+            bool first_iter = true;
+            for (;;) {
+                // compute read start
+                read_start = read_end;
+                // compute read end
+                read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+                if (read_start >= c_end) {
+                    break;
+                }
+
+                bool is_tile_end = (read_end % TILE_WIDTH == 0);
+                bool is_last = (read_end == c_end);
+                if (is_tile_end || is_last) {
+                    /*
+                     * Sum[x]
+                     * cb_xsum
+                     */
+                    if (first_iter) {
+                        cb_reserve_back(cb_xsum, onetile);
+                        cb_wait_front(cb_x, onetile);
+
+                        tile_regs_acquire();
+                        copy_tile_init_with_dt(cb_x);
+                        copy_tile(cb_x, 0, dst0);
+
+                        bool mask_required = (read_start % TILE_WIDTH != 0) || (read_end % TILE_WIDTH != 0);
+                        if (mask_required) {
+                            cb_wait_front(cb_mask, onetile);
+
+                            copy_tile_init_with_dt(cb_mask);
+                            copy_tile(cb_mask, 0, dst1);
+
+                            mask_tile_init();
+                            mask_tile(dst0, dst1);
+
+                            cb_pop_front(cb_mask, onetile);
+                        }
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_xsum);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_x, onetile);
+                        cb_push_back(cb_xsum, onetile);
+                    } else {
+                        // I use cb_ex temporarily.
+                        constexpr auto cb_tmp = cb_ex;
+                        cb_reserve_back(cb_tmp, onetile);
+                        cb_wait_front(cb_x, onetile);
+
+                        copy_tile_init_with_dt(cb_x);
+                        copy_tile(cb_x, 0, dst0);  // input
+
+                        bool mask_required = (read_start % TILE_WIDTH != 0) || (read_end % TILE_WIDTH != 0);
+                        if (mask_required) {
+                            cb_wait_front(cb_mask, onetile);
+
+                            copy_tile_init_with_dt(cb_mask);
+                            copy_tile(cb_mask, 0, dst1);
+
+                            mask_tile_init();
+                            mask_tile(dst0, dst1);
+                        }
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_tmp);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_x, onetile);
+                        cb_push_back(cb_tmp, onetile);
+
+                        // add_tiles
+                        cb_wait_front(cb_xsum, onetile);
+                        cb_wait_front(cb_tmp, onetile);
+
+                        tile_regs_acquire();
+                        add_tiles_init_with_dt(cb_xsum, cb_tmp);
+                        add_tiles(cb_xsum, cb_tmp, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        cb_pop_front(cb_xsum, onetile);
+                        cb_pop_front(cb_tmp, onetile);
+
+                        cb_reserve_back(cb_xsum, onetile);
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_xsum);
+                        tile_regs_release();
+
+                        cb_push_back(cb_xsum, onetile);
+                    }
+                }  // if (is_tile_end || is_last)
+
+                first_iter = false;
+            }
+        }
+
+        /*
+         * E[x]
+         * cb_ex
+         */
+        cb_wait_front(cb_xsum, onetile);
+        cb_reserve_back(cb_ex, onetile);
+        if (mean_has_value) {
+            cb_reserve_back(cb_mean, onetile);
+        }
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_ex, cb_xsum, cb_scaler);
+        reduce_tile(cb_xsum, cb_scaler, 0, 0, dst0);
+        reduce_revert_delta(cb_ex);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_ex);
+        if (mean_has_value) {
+            pack_tile_with_dt(dst0, cb_mean);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_xsum, onetile);
+        cb_push_back(cb_ex, onetile);
+        if (mean_has_value) {
+            cb_push_back(cb_mean, onetile);
+        }
+
+        // mean
+        {
+            uint32_t read_start = c_start;
+            uint32_t read_end = c_start;
+            bool first_iter = true;
+            for (;;) {
+                // compute read start
+                read_start = read_end;
+                // compute read end
+                read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+                if (read_start >= c_end) {
+                    break;
+                }
+
+                bool is_tile_end = (read_end % TILE_WIDTH == 0);
+                bool is_last = (read_end == c_end);
+                if (is_tile_end || is_last) {
+                    /*
+                     * x - E[x]
+                     * xmm
+                     */
+                    cb_reserve_back(cb_xmm, onetile);
+                    cb_wait_front(cb_x, onetile);
+                    cb_wait_front(cb_ex, onetile);
+
+                    tile_regs_acquire();
+                    sub_bcast_cols_init_short_with_dt(cb_x, cb_ex);
+                    sub_tiles_bcast_cols(cb_x, cb_ex, 0, 0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xmm);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_x, onetile);
+                    cb_push_back(cb_xmm, onetile);
+
+                    /*
+                     * (x - E[x])^2
+                     * cb_xmm2
+                     */
+                    cb_wait_front(cb_xmm, onetile);
+                    cb_reserve_back(cb_xmm2, onetile);
+
+                    tile_regs_acquire();
+                    mul_tiles_init_with_dt(cb_xmm, cb_xmm);
+                    mul_tiles(cb_xmm, cb_xmm, 0, 0, dst0);
+                    bool mask_required = (read_start % TILE_WIDTH != 0) || (read_end % TILE_WIDTH != 0);
+                    if (mask_required) {
+                        cb_wait_front(cb_mask, onetile);
+
+                        copy_tile_init_with_dt(cb_mask);
+                        copy_tile(cb_mask, 0, dst1);
+
+                        mask_tile_init();
+                        mask_tile(dst0, dst1);
+
+                        cb_pop_front(cb_mask, onetile);
+                    }
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xmm2);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_xmm, onetile);
+                    cb_push_back(cb_xmm2, onetile);
+
+                    /*
+                     * Sum[(x-E[x])^2]
+                     * cb_xmm2sum
+                     */
+                    if (first_iter) {
+                        cb_reserve_back(cb_xmm2sum, onetile);
+                        cb_wait_front(cb_xmm2, onetile);
+                        cb_wait_front(cb_zeros, onetile);
+
+                        tile_regs_acquire();
+                        add_tiles_init_with_dt(cb_xmm2, cb_zeros);
+                        add_tiles(cb_xmm2, cb_zeros, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_xmm2sum);
+                        tile_regs_release();
+
+                        cb_push_back(cb_xmm2sum, onetile);
+                        cb_pop_front(cb_xmm2, onetile);
+                    } else {
+                        cb_wait_front(cb_xmm2sum, onetile);
+                        cb_wait_front(cb_xmm2, onetile);
+
+                        tile_regs_acquire();
+                        add_tiles_init_with_dt(cb_xmm2sum, cb_xmm2);
+                        add_tiles(cb_xmm2sum, cb_xmm2, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        cb_pop_front(cb_xmm2sum, onetile);
+
+                        cb_reserve_back(cb_xmm2sum, onetile);
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_xmm2sum);
+                        tile_regs_release();
+
+                        cb_push_back(cb_xmm2sum, onetile);
+                        cb_pop_front(cb_xmm2, onetile);
+                    }
+                    first_iter = false;
+                }  // if (is_tile_end || is_last)
+            }
+        }
+
+        /*
+         * E[(x-E[x])^2 = Var[x]
+         * cb_var
+         */
+        cb_wait_front(cb_xmm2sum, onetile);
+        cb_reserve_back(cb_var, onetile);
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_var, cb_xmm2sum, cb_scaler);
+        reduce_tile(cb_xmm2sum, cb_scaler, 0, 0, dst0);
+        reduce_revert_delta(cb_var);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_var);
+        tile_regs_release();
+
+        cb_pop_front(cb_xmm2sum, onetile);
+        cb_push_back(cb_var, onetile);
+
+        /*
+         * 1.0/(sqrt(E[(x-E[x])^2] + eps))
+         * cb_recip_std
+         */
+        cb_wait_front(cb_var, onetile);
+        cb_reserve_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_reserve_back(cb_rstd, onetile);
+        }
+
+        tile_regs_acquire();
+        add_tiles_init_with_dt(cb_var, cb_eps);
+        add_tiles(cb_var, cb_eps, 0, 0, dst0);
+
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_recip_std);
+        if (rstd_has_value) {
+            pack_tile_with_dt(dst0, cb_rstd);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_var, onetile);
+        cb_push_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_push_back(cb_rstd, onetile);
+        }
+
+        /*
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps))) * gamma + beta
+         * cb_output
+         */
+        {
+            uint32_t read_start = c_start;
+            uint32_t read_end = c_start;
+            for (;;) {
+                // compute read start
+                read_start = read_end;
+                // compute read end
+                read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+                if (read_start >= c_end) {
+                    break;
+                }
+
+                bool is_tile_end = (read_end % TILE_WIDTH == 0);
+                bool is_last = (read_end == c_end);
+                if (is_tile_end || is_last) {
+                    /*
+                     * x - E[x]
+                     * cb_reuse(==cb_xmm)
+                     */
+                    constexpr auto cb_reuse = cb_xmm;
+
+                    cb_wait_front(cb_x, onetile);
+                    cb_wait_front(cb_ex, onetile);
+                    cb_reserve_back(cb_reuse, onetile);
+
+                    tile_regs_acquire();
+                    sub_bcast_cols_init_short_with_dt(cb_x, cb_ex);
+                    sub_tiles_bcast_cols(cb_x, cb_ex, 0, 0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_reuse);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_x, onetile);
+                    cb_push_back(cb_reuse, onetile);
+
+                    /*
+                     * (x - E[x]) * 1.0/sqrt(Var[x] + eps)
+                     * cb_gamma_beta_or_output
+                     */
+                    constexpr auto cb_gamma_beta_or_output =
+                        (gamma_has_value || beta_has_value) ? cb_gamma_beta : cb_output;
+                    cb_wait_front(cb_reuse, onetile);
+                    cb_wait_front(cb_recip_std, onetile);
+                    cb_reserve_back(cb_gamma_beta_or_output, onetile);
+
+                    tile_regs_acquire();
+                    mul_bcast_cols_init_short_with_dt(cb_reuse, cb_recip_std);
+                    mul_tiles_bcast_cols(cb_reuse, cb_recip_std, 0, 0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_gamma_beta_or_output);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_reuse, onetile);
+                    cb_push_back(cb_gamma_beta_or_output, onetile);
+
+                    // * gamma
+                    if (gamma_has_value) {
+                        constexpr auto cb_gamma_output = beta_has_value ? cb_gamma_beta : cb_output;
+                        cb_wait_front(cb_gamma_beta_or_output, onetile);
+                        cb_wait_front(cb_gamma, onetile);
+                        cb_reserve_back(cb_gamma_output, onetile);
+
+                        tile_regs_acquire();
+                        mul_bcast_rows_init_short_with_dt(cb_gamma_beta_or_output, cb_gamma);
+                        mul_tiles_bcast_rows(cb_gamma_beta_or_output, cb_gamma, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_gamma_output);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_gamma_beta_or_output, onetile);
+                        cb_pop_front(cb_gamma, onetile);
+                        cb_push_back(cb_gamma_output, onetile);
+                    }  // if (gamma_has_value)
+
+                    // + beta
+                    if (beta_has_value) {
+                        cb_wait_front(cb_gamma_beta, onetile);
+                        cb_wait_front(cb_beta, onetile);
+                        cb_reserve_back(cb_output, onetile);
+
+                        tile_regs_acquire();
+                        add_bcast_rows_init_short_with_dt(cb_gamma_beta, cb_beta);
+                        add_tiles_bcast_rows(cb_gamma_beta, cb_beta, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_output);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_gamma_beta, onetile);
+                        cb_pop_front(cb_beta, onetile);
+                        cb_push_back(cb_output, onetile);
+                    }  // if (beta_has_value)
+                }  // if (is_tile_end || is_last)
+            }  // for(;;)
+        }  // cb_out
+
+        cb_pop_front(cb_recip_std, onetile);
+        cb_pop_front(cb_ex, onetile);
+    }
+
+}  // void MAIN
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_3d.cpp
@@ -1,0 +1,574 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // runtime args
+    int i{0};
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto W = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
+    const auto unit_offset = get_arg_val<uint32_t>(i++);
+
+    // compile-time args
+    constexpr uint32_t num_units_per_core = get_compile_time_arg_val(0);
+    constexpr bool gamma_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr bool beta_has_value = get_compile_time_arg_val(2) == 1;
+    constexpr bool mean_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr bool rstd_has_value = get_compile_time_arg_val(4) == 1;
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+
+    constexpr auto cb_x = tt::CB::c_in0;       // input
+    constexpr auto cb_scaler = tt::CB::c_in1;  // scaler
+    constexpr auto cb_eps = tt::CB::c_in2;     // epsilon
+    constexpr auto cb_gamma = tt::CB::c_in3;   // gamma
+    constexpr auto cb_beta = tt::CB::c_in4;    // beta
+    constexpr auto cb_mask_h = tt::CB::c_in5;  // mask_h
+    constexpr auto cb_mask_w = tt::CB::c_in6;  // mask_w
+    constexpr auto cb_zeros = tt::CB::c_in7;   // zeros
+
+    constexpr auto cb_output = tt::CB::c_out0;  // output
+    constexpr auto cb_mean = tt::CB::c_out1;    // mean
+    constexpr auto cb_rstd = tt::CB::c_out2;    // rstd
+
+    constexpr auto cb_ex = tt::CB::c_intermed0;          // E[x]
+    constexpr auto cb_xmm = tt::CB::c_intermed1;         // x - E[x]
+    constexpr auto cb_xmm2 = tt::CB::c_intermed2;        // (x - E[x])^2
+    constexpr auto cb_xmm2sum = tt::CB::c_intermed3;     // Sum[(x - E[x])^2]
+    constexpr auto cb_var = tt::CB::c_intermed4;         // E[(x - E[x])^2] = Var[x]
+    constexpr auto cb_recip_std = tt::CB::c_intermed5;   // 1.0/(sqrt(Var[x] + eps))
+    constexpr auto cb_gamma_beta = tt::CB::c_intermed6;  // p * gamm + beta
+    constexpr auto cb_xsum = tt::CB::c_intermed7;        // Sum[x]
+
+    const auto Wt = div_up(W, TILE_WIDTH);
+
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    cb_wait_front(cb_scaler, onetile);  // comes from the reader
+    cb_wait_front(cb_eps, onetile);     // comes from the reader
+    cb_wait_front(cb_zeros, onetile);   // comes from the reader
+
+    for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; outer_idx++) {
+        // input[N, C, W]
+        // reshaped_input[N, num_groups, C / num_groups, W]
+        auto unit_idx = unit_offset + outer_idx;
+        auto group_idx = unit_idx % num_groups;
+        uint32_t n = unit_idx / num_groups;
+
+        uint32_t c_size_per_unit = C / num_groups;
+        uint32_t c_start = c_size_per_unit * group_idx;
+        uint32_t c_end = c_size_per_unit * (group_idx + 1);
+
+        {
+            uint32_t read_start = c_start;
+            uint32_t read_end = c_start;
+            bool first_iter = true;
+            for (;;) {
+                // compute read start
+                read_start = read_end;
+                // compute read end
+                read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+                if (read_start >= c_end) {
+                    break;
+                }
+
+                bool is_tile_end = (read_end % TILE_WIDTH == 0);
+                bool is_last = (read_end == c_end);
+                if (is_tile_end || is_last) {
+                    bool mask_h_required = (read_start % TILE_WIDTH != 0) || (read_end % TILE_WIDTH != 0);
+                    /*
+                     * Sum[x]
+                     * cb_xsum
+                     */
+
+                    for (uint32_t wt = 0; wt < Wt; wt++) {
+                        if (first_iter) {
+                            cb_reserve_back(cb_xsum, onetile);
+                            cb_wait_front(cb_x, onetile);
+
+                            tile_regs_acquire();
+                            copy_tile_init_with_dt(cb_x);
+                            copy_tile(cb_x, 0, dst0);
+
+                            if (mask_h_required) {
+                                cb_wait_front(cb_mask_h, onetile);
+
+                                copy_tile_init_with_dt(cb_mask_h);
+                                copy_tile(cb_mask_h, 0, dst1);
+
+                                mask_tile_init();
+                                mask_tile(dst0, dst1);
+                            }
+
+                            bool mask_w_required = (wt + 1 == Wt) && (W % TILE_WIDTH != 0);
+                            if (mask_w_required) {
+                                cb_wait_front(cb_mask_w, onetile);
+
+                                copy_tile_init_with_dt(cb_mask_w);
+                                copy_tile(cb_mask_w, 0, dst1);
+
+                                mask_tile_init();
+                                mask_tile(dst0, dst1);
+
+                                cb_pop_front(cb_mask_w, onetile);
+                            }
+
+                            tile_regs_commit();
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_xsum);
+                            tile_regs_release();
+
+                            cb_pop_front(cb_x, onetile);
+                            cb_push_back(cb_xsum, onetile);
+                            first_iter = false;
+                        } else {
+                            // I use cb_ex temporarily.
+                            constexpr auto cb_tmp = cb_ex;
+                            cb_reserve_back(cb_tmp, onetile);
+                            cb_wait_front(cb_x, onetile);
+
+                            tile_regs_acquire();
+                            copy_tile_init_with_dt(cb_x);
+                            copy_tile(cb_x, 0, dst0);
+
+                            if (mask_h_required) {
+                                cb_wait_front(cb_mask_h, onetile);
+
+                                copy_tile_init_with_dt(cb_mask_h);
+                                copy_tile(cb_mask_h, 0, dst1);
+
+                                mask_tile_init();
+                                mask_tile(dst0, dst1);
+                            }
+
+                            bool mask_w_required = (wt + 1 == Wt) && (W % TILE_WIDTH != 0);
+                            if (mask_w_required) {
+                                cb_wait_front(cb_mask_w, onetile);
+
+                                copy_tile_init_with_dt(cb_mask_w);
+                                copy_tile(cb_mask_w, 0, dst1);
+
+                                mask_tile_init();
+                                mask_tile(dst0, dst1);
+
+                                cb_pop_front(cb_mask_w, onetile);
+                            }
+                            tile_regs_commit();
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_tmp);
+                            tile_regs_release();
+
+                            cb_pop_front(cb_x, onetile);
+                            cb_push_back(cb_tmp, onetile);
+
+                            // add_tiles
+                            cb_wait_front(cb_xsum, onetile);
+                            cb_wait_front(cb_tmp, onetile);
+
+                            tile_regs_acquire();
+                            add_tiles_init_with_dt(cb_xsum, cb_tmp);
+                            add_tiles(cb_xsum, cb_tmp, 0, 0, dst0);
+                            tile_regs_commit();
+
+                            cb_pop_front(cb_xsum, onetile);
+                            cb_pop_front(cb_tmp, onetile);
+
+                            cb_reserve_back(cb_xsum, onetile);
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_xsum);
+                            tile_regs_release();
+
+                            cb_push_back(cb_xsum, onetile);
+                        }
+                    }  // for (uint32_t wt = 0; wt < Wt; wt++)
+
+                    if (mask_h_required) {
+                        cb_pop_front(cb_mask_h, onetile);
+                    }
+                }  // if (is_tile_end || is_last)
+            }  // for (;;)
+        }
+
+        /*
+         * E[x]
+         * cb_ex
+         */
+        cb_wait_front(cb_xsum, onetile);
+        cb_reserve_back(cb_ex, onetile);
+        if (mean_has_value) {
+            cb_reserve_back(cb_mean, onetile);
+        }
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_ex, cb_xsum, cb_scaler);
+        reduce_tile(cb_xsum, cb_scaler, 0, 0, dst0);
+        reduce_revert_delta(cb_ex);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_ex);
+        if (mean_has_value) {
+            pack_tile_with_dt(dst0, cb_mean);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_xsum, onetile);
+        cb_push_back(cb_ex, onetile);
+
+        if (mean_has_value) {
+            cb_push_back(cb_mean, onetile);
+        }
+
+        {
+            uint32_t read_start = c_start;
+            uint32_t read_end = c_start;
+            bool first_iter = true;
+            for (;;) {
+                // compute read start
+                read_start = read_end;
+                // compute read end
+                read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+                if (read_start >= c_end) {
+                    break;
+                }
+
+                bool is_tile_end = (read_end % TILE_WIDTH == 0);
+                bool is_last = (read_end == c_end);
+                if (is_tile_end || is_last) {
+                    bool mask_h_required = (read_start % TILE_WIDTH != 0) || (read_end % TILE_WIDTH != 0);
+
+                    for (uint32_t wt = 0; wt < Wt; wt++) {
+                        /*
+                         * x - E[x]
+                         * xmm
+                         */
+                        cb_reserve_back(cb_xmm, onetile);
+                        cb_wait_front(cb_x, onetile);
+                        cb_wait_front(cb_ex, onetile);
+
+                        tile_regs_acquire();
+                        sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                        sub_tiles_bcast_scalar(cb_x, cb_ex, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_xmm);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_x, onetile);
+                        cb_push_back(cb_xmm, onetile);
+
+                        /*
+                         * (x - E[x])^2
+                         * cb_xmm2
+                         */
+                        cb_wait_front(cb_xmm, onetile);
+                        cb_reserve_back(cb_xmm2, onetile);
+
+                        tile_regs_acquire();
+                        mul_tiles_init_with_dt(cb_xmm, cb_xmm);
+                        mul_tiles(cb_xmm, cb_xmm, 0, 0, dst0);
+
+                        if (mask_h_required) {
+                            cb_wait_front(cb_mask_h, onetile);
+
+                            copy_tile_init_with_dt(cb_mask_h);
+                            copy_tile(cb_mask_h, 0, dst1);
+
+                            mask_tile_init();
+                            mask_tile(dst0, dst1);
+                        }
+
+                        bool mask_w_required = (wt + 1 == Wt) && (W % TILE_WIDTH != 0);
+                        if (mask_w_required) {
+                            cb_wait_front(cb_mask_w, onetile);
+
+                            copy_tile_init_with_dt(cb_mask_w);
+                            copy_tile(cb_mask_w, 0, dst1);
+
+                            mask_tile_init();
+                            mask_tile(dst0, dst1);
+
+                            cb_pop_front(cb_mask_w, onetile);
+                        }
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_xmm2);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_xmm, onetile);
+                        cb_push_back(cb_xmm2, onetile);
+
+                        /*
+                         * Sum[(x-E[x])^2]
+                         * cb_xmm2sum
+                         */
+
+                        if (first_iter) {
+                            cb_reserve_back(cb_xmm2sum, onetile);
+                            cb_wait_front(cb_xmm2, onetile);
+                            cb_wait_front(cb_zeros, onetile);
+
+                            tile_regs_acquire();
+                            add_tiles_init_with_dt(cb_xmm2, cb_zeros);
+                            add_tiles(cb_xmm2, cb_zeros, 0, 0, dst0);
+                            tile_regs_commit();
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_xmm2sum);
+                            tile_regs_release();
+
+                            cb_push_back(cb_xmm2sum, onetile);
+                            cb_pop_front(cb_xmm2, onetile);
+                            first_iter = false;
+                        } else {
+                            cb_wait_front(cb_xmm2sum, onetile);
+                            cb_wait_front(cb_xmm2, onetile);
+
+                            tile_regs_acquire();
+                            add_tiles_init_with_dt(cb_xmm2sum, cb_xmm2);
+                            add_tiles(cb_xmm2sum, cb_xmm2, 0, 0, dst0);
+                            tile_regs_commit();
+
+                            cb_pop_front(cb_xmm2sum, onetile);
+                            cb_pop_front(cb_xmm2, onetile);
+
+                            cb_reserve_back(cb_xmm2sum, onetile);
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_xmm2sum);
+                            tile_regs_release();
+
+                            cb_push_back(cb_xmm2sum, onetile);
+                        }
+                    }  // for (uint32_t wt = 0; wt < Wt; wt++)
+
+                    if (mask_h_required) {
+                        cb_pop_front(cb_mask_h, onetile);
+                    }
+                }  // if (is_tile_end || is_last)
+            }  // for (;;)
+        }
+
+        /*
+         * E[(x-E[x])^2 = Var[x]
+         * cb_var
+         */
+        cb_wait_front(cb_xmm2sum, onetile);
+        cb_reserve_back(cb_var, onetile);
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_var, cb_xmm2sum, cb_scaler);
+        reduce_tile(cb_xmm2sum, cb_scaler, 0, 0, dst0);
+        reduce_revert_delta(cb_var);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_var);
+        tile_regs_release();
+
+        cb_pop_front(cb_xmm2sum, onetile);
+        cb_push_back(cb_var, onetile);
+
+        /*
+         * 1.0/(sqrt(E[(x-E[x])^2] + eps))
+         * cb_recip_std
+         */
+        cb_wait_front(cb_var, onetile);
+        cb_reserve_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_reserve_back(cb_rstd, onetile);
+        }
+
+        tile_regs_acquire();
+        add_tiles_init_with_dt(cb_var, cb_eps);
+        add_tiles(cb_var, cb_eps, 0, 0, dst0);
+
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_recip_std);
+        if (rstd_has_value) {
+            pack_tile_with_dt(dst0, cb_rstd);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_var, onetile);
+        cb_push_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_push_back(cb_rstd, onetile);
+        }
+
+        /*
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps))) * gamma + beta
+         * cb_output
+         */
+        {
+            uint32_t read_start = c_start;
+            uint32_t read_end = c_start;
+            bool first_iter = true;
+            for (;;) {
+                // compute read start
+                read_start = read_end;
+                // compute read end
+                read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+                if (read_start >= c_end) {
+                    break;
+                }
+
+                bool is_tile_end = (read_end % TILE_WIDTH == 0);
+                bool is_last = (read_end == c_end);
+                if (is_tile_end || is_last) {
+                    for (uint32_t wt = 0; wt < Wt; wt++) {
+                        /*
+                         * x - E[x]
+                         * cb_reuse(==cb_xmm)
+                         */
+                        constexpr auto cb_reuse = cb_xmm;
+
+                        cb_wait_front(cb_x, onetile);
+                        cb_wait_front(cb_ex, onetile);
+                        cb_reserve_back(cb_reuse, onetile);
+
+                        tile_regs_acquire();
+                        sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                        sub_tiles_bcast_scalar(cb_x, cb_ex, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_reuse);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_x, onetile);
+                        cb_push_back(cb_reuse, onetile);
+
+                        /*
+                         * (x - E[x]) * 1.0/sqrt(Var[x] + eps)
+                         * cb_gamma_beta_or_output
+                         */
+                        constexpr auto cb_gamma_beta_or_output =
+                            (gamma_has_value || beta_has_value) ? cb_gamma_beta : cb_output;
+                        cb_wait_front(cb_reuse, onetile);
+                        cb_wait_front(cb_recip_std, onetile);
+                        cb_reserve_back(cb_gamma_beta_or_output, onetile);
+
+                        tile_regs_acquire();
+                        mul_tiles_bcast_scalar_init_short_with_dt(cb_reuse, cb_recip_std);
+                        mul_tiles_bcast_scalar(cb_reuse, cb_recip_std, 0, 0, dst0);
+                        tile_regs_commit();
+
+                        tile_regs_wait();
+                        pack_tile_with_dt(dst0, cb_gamma_beta_or_output);
+                        tile_regs_release();
+
+                        cb_pop_front(cb_reuse, onetile);
+                        cb_push_back(cb_gamma_beta_or_output, onetile);
+
+                        if (gamma_has_value) {
+                            // transpose
+                            cb_reserve_back(cb_reuse, onetile);
+                            cb_wait_front(cb_gamma, onetile);
+
+                            tile_regs_acquire();
+                            transpose_wh_init_short_with_dt(cb_gamma);
+                            transpose_wh_tile(cb_gamma, 0, dst0);
+                            tile_regs_commit();
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_reuse);
+                            tile_regs_release();
+
+                            cb_push_back(cb_reuse, onetile);
+
+                            // mult
+                            constexpr auto cb_gamma_output = beta_has_value ? cb_gamma_beta : cb_output;
+                            cb_wait_front(cb_gamma_beta_or_output, onetile);
+                            cb_wait_front(cb_reuse, onetile);
+
+                            tile_regs_acquire();
+                            mul_bcast_cols_init_short_with_dt(cb_gamma_beta_or_output, cb_reuse);
+                            mul_tiles_bcast_cols(cb_gamma_beta_or_output, cb_reuse, 0, 0, dst0);
+                            tile_regs_commit();
+
+                            cb_pop_front(cb_gamma_beta_or_output, onetile);
+                            cb_pop_front(cb_reuse, onetile);
+
+                            cb_reserve_back(cb_gamma_output, onetile);
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_gamma_output);
+                            tile_regs_release();
+
+                            cb_push_back(cb_gamma_output, onetile);
+                        }  // if (gamma_has_value)
+
+                        if (beta_has_value) {
+                            // transpose beta
+                            cb_reserve_back(cb_reuse, onetile);
+                            cb_wait_front(cb_beta, onetile);
+
+                            tile_regs_acquire();
+                            transpose_wh_init_short_with_dt(cb_beta);
+                            transpose_wh_tile(cb_beta, 0, dst0);
+                            tile_regs_commit();
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_reuse);
+                            tile_regs_release();
+
+                            cb_push_back(cb_reuse, onetile);
+
+                            // add beta
+                            cb_reserve_back(cb_output, onetile);
+                            cb_wait_front(cb_reuse, onetile);
+                            cb_wait_front(cb_gamma_beta, onetile);
+
+                            tile_regs_acquire();
+                            add_bcast_cols_init_short_with_dt(cb_gamma_beta, cb_reuse);
+                            add_tiles_bcast_cols(cb_gamma_beta, cb_reuse, 0, 0, dst0);
+                            tile_regs_commit();
+
+                            tile_regs_wait();
+                            pack_tile_with_dt(dst0, cb_output);
+                            tile_regs_release();
+
+                            cb_pop_front(cb_gamma_beta, onetile);
+                            cb_pop_front(cb_reuse, onetile);
+                            cb_push_back(cb_output, onetile);
+                        }  // if (beta_has_value)
+
+                    }  // for (uint32_t wt = 0; wt < Wt; wt++)
+
+                    if (gamma_has_value) {
+                        cb_pop_front(cb_gamma, onetile);
+                    }
+
+                    if (beta_has_value) {
+                        cb_pop_front(cb_beta, onetile);
+                    }
+
+                }  // if (is_tile_end || is_last)
+            }  // for (;;)
+        }
+
+        cb_pop_front(cb_recip_std, onetile);
+        cb_pop_front(cb_ex, onetile);
+    }  // for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; outer_idx++)
+
+}  // void MAIN
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_large_kernel.cpp
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+ALWI bool need_to_do_mask_h(uint32_t w_idx, uint32_t origin_num_h_tiles, uint32_t origin_num_w_tiles) {
+    return ((w_idx / origin_num_w_tiles) + 1) % origin_num_h_tiles == 0;
+}
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t origin_H = get_compile_time_arg_val(1);
+    constexpr uint32_t origin_W = get_compile_time_arg_val(2);
+    constexpr uint32_t num_inner = get_compile_time_arg_val(3);
+    constexpr uint32_t block_size = get_compile_time_arg_val(4);
+    constexpr bool gamma_has_value = get_compile_time_arg_val(5) == 1;
+    constexpr bool beta_has_value = get_compile_time_arg_val(6) == 1;
+    constexpr bool mean_has_value = get_compile_time_arg_val(7) == 1;
+    constexpr bool rstd_has_value = get_compile_time_arg_val(8) == 1;
+
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+
+    constexpr auto cb_x = tt::CB::c_in0;       // input
+    constexpr auto cb_scaler = tt::CB::c_in1;  // scaler
+    constexpr auto cb_eps = tt::CB::c_in2;     // epsilon
+    constexpr auto cb_gamma = tt::CB::c_in3;   // gamma
+    constexpr auto cb_beta = tt::CB::c_in4;    // beta
+    constexpr auto cb_mask_h = tt::CB::c_in5;  // mask_h
+    constexpr auto cb_mask_w = tt::CB::c_in6;  // mask_w
+    constexpr auto cb_zeros = tt::CB::c_in7;   // zeros
+
+    constexpr auto cb_out = tt::CB::c_out0;   // output
+    constexpr auto cb_mean = tt::CB::c_out1;  // mean
+    constexpr auto cb_rstd = tt::CB::c_out2;  // rstd
+
+    constexpr auto cb_ex = tt::CB::c_intermed0;          // E[x]
+    constexpr auto cb_xmm = tt::CB::c_intermed1;         // x - E[x]
+    constexpr auto cb_xmm2 = tt::CB::c_intermed2;        // (x - E[x])^2
+    constexpr auto cb_xmm2sum = tt::CB::c_intermed3;     // Sum[(x - E[x])^2]
+    constexpr auto cb_var = tt::CB::c_intermed4;         // E[(x - E[x])^2] = Var[x]
+    constexpr auto cb_recip_std = tt::CB::c_intermed5;   // 1.0/(sqrt(Var[x] + eps))
+    constexpr auto cb_gamma_beta = tt::CB::c_intermed6;  // p * gamm + beta
+    constexpr auto cb_xsum = tt::CB::c_intermed7;        // Sum[x]
+
+    constexpr uint32_t onetile = 1;
+
+    cb_wait_front(cb_scaler, onetile);  // comes from the reader
+    cb_wait_front(cb_eps, onetile);     // comes from the reader
+    cb_wait_front(cb_zeros, onetile);   // comes from the reader
+
+    constexpr bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
+    constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
+
+    if (do_mask_h) {
+        cb_wait_front(cb_mask_h, onetile);
+    }
+    if (do_mask_w) {
+        cb_wait_front(cb_mask_w, onetile);
+    }
+
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t first_tile = 0;
+
+    constexpr uint32_t origin_Ht = div_up(origin_H, TILE_HEIGHT);
+    constexpr uint32_t origin_Wt = div_up(origin_W, TILE_WIDTH);
+
+    for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; outer_idx++) {
+        /*
+         * Sum[x]
+         * cb_xsum
+         */
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
+            cb_wait_front(cb_x, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                const uint32_t w_idx = inner_idx + j;
+                if (w_idx == 0) {
+                    cb_reserve_back(cb_xsum, onetile);
+
+                    tile_regs_acquire();
+                    copy_tile_init_with_dt(cb_x);
+                    copy_tile(cb_x, first_tile, dst0);  // input
+
+                    if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
+                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile(cb_mask_h, first_tile, dst1);  // mask_h
+                        mask_tile_init();
+                        mask_tile(dst0, dst1);
+                    }
+
+                    if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
+                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile(cb_mask_w, first_tile, dst1);  // mask_w
+                        mask_tile_init();
+                        mask_tile(dst0, dst1);
+                    }
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xsum);
+                    tile_regs_release();
+                    cb_push_back(cb_xsum, onetile);
+                } else {
+                    // I use cb_ex temporarily.
+                    constexpr auto cb_tmp = cb_ex;
+                    cb_reserve_back(cb_tmp, onetile);
+
+                    tile_regs_acquire();
+                    copy_tile_init_with_dt(cb_x);
+                    copy_tile(cb_x, j, j);  // input
+
+                    const uint32_t mask_dst = j < 4 ? j + 1 : 0;
+
+                    if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
+                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
+                        mask_tile_init();
+                        mask_tile(j, mask_dst);
+                    }
+
+                    if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
+                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
+                        mask_tile_init();
+                        mask_tile(j, mask_dst);
+                    }
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(j, cb_tmp);
+                    tile_regs_release();
+
+                    cb_push_back(cb_tmp, onetile);
+
+                    cb_wait_front(cb_tmp, onetile);
+                    cb_wait_front(cb_xsum, onetile);
+                    cb_reserve_back(cb_xsum, onetile);
+
+                    tile_regs_acquire();
+                    add_tiles_init_with_dt(cb_xsum, cb_tmp);
+                    add_tiles(cb_xsum, cb_tmp, first_tile, first_tile, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xsum);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_tmp, onetile);
+                    cb_pop_front(cb_xsum, onetile);
+                    cb_push_back(cb_xsum, onetile);
+                }
+            }  // block_size loop
+            cb_pop_front(cb_x, block_size);
+        }  // num_inner loop
+
+        /*
+         * E[x]
+         * cb_ex
+         */
+        cb_wait_front(cb_xsum, onetile);
+        cb_reserve_back(cb_ex, onetile);
+        if (mean_has_value) {
+            cb_reserve_back(cb_mean, onetile);
+        }
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_ex, cb_xsum, cb_scaler);
+        reduce_tile(cb_xsum, cb_scaler, first_tile, first_tile, dst0);
+        reduce_revert_delta(cb_ex);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_ex);
+        if (mean_has_value) {
+            pack_tile_with_dt(dst0, cb_mean);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_xsum, onetile);
+        cb_push_back(cb_ex, onetile);
+
+        if (mean_has_value) {
+            cb_push_back(cb_mean, onetile);
+        }
+        // We don't pop cb_ex here.
+
+        /*
+         * x - E[x]
+         * xmm
+         */
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
+            cb_wait_front(cb_x, block_size);
+            cb_wait_front(cb_ex, onetile);
+            cb_reserve_back(cb_xmm, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                tile_regs_acquire();
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                sub_tiles_bcast_scalar(cb_x, cb_ex, j, first_tile, j);
+
+                const uint32_t mask_dst = j < 4 ? j + 1 : 0;
+                const uint32_t w_idx = inner_idx + j;
+
+                if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
+                    copy_tile_init_with_dt(cb_mask_h);
+                    copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
+                    mask_tile_init();
+                    mask_tile(j, mask_dst);
+                }
+
+                if (do_mask_w && (w_idx + 1) % origin_Wt == 0) {
+                    copy_tile_init_with_dt(cb_mask_w);
+                    copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
+                    mask_tile_init();
+                    mask_tile(j, mask_dst);
+                }
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(j, cb_xmm);
+                tile_regs_release();
+            }  // block_size loop
+            cb_pop_front(cb_x, block_size);
+            cb_push_back(cb_xmm, block_size);
+
+            /*
+             * (x - E[x])^2
+             * cb_xmm2
+             */
+            cb_wait_front(cb_xmm, block_size);
+            cb_reserve_back(cb_xmm2, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                tile_regs_acquire();
+                mul_tiles_init_with_dt(cb_xmm, cb_xmm);
+                mul_tiles(cb_xmm, cb_xmm, j, j, j);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(j, cb_xmm2);
+                tile_regs_release();
+            }  // block_size loop
+            cb_pop_front(cb_xmm, block_size);
+            cb_push_back(cb_xmm2, block_size);
+
+            /*
+             * Sum[(x-E[x])^2]
+             * cb_xmm2sum
+             */
+            cb_wait_front(cb_xmm2, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                if (inner_idx == 0 && j == 0) {
+                    cb_reserve_back(cb_xmm2sum, onetile);
+
+                    tile_regs_acquire();
+                    add_tiles_init_with_dt(cb_xmm2, cb_zeros);
+                    add_tiles(cb_xmm2, cb_zeros, first_tile, first_tile, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xmm2sum);
+                    tile_regs_release();
+
+                    cb_push_back(cb_xmm2sum, onetile);
+                } else {
+                    cb_wait_front(cb_xmm2sum, onetile);
+                    cb_reserve_back(cb_xmm2sum, onetile);
+
+                    tile_regs_acquire();
+                    add_tiles_init_with_dt(cb_xmm2sum, cb_xmm2);
+                    add_tiles(cb_xmm2sum, cb_xmm2, first_tile, j, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xmm2sum);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_xmm2sum, onetile);
+                    cb_push_back(cb_xmm2sum, onetile);
+                }
+            }  // block_size loop
+            cb_pop_front(cb_xmm2, block_size);
+        }  // num_inner loop
+        // Do not pop cb_ex here, we need it later.
+
+        /*
+         * E[(x-E[x])^2 = Var[x]
+         * cb_var
+         */
+        cb_wait_front(cb_xmm2sum, onetile);
+        cb_reserve_back(cb_var, onetile);
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_var, cb_xmm2sum, cb_scaler);
+        reduce_tile(cb_xmm2sum, cb_scaler, first_tile, first_tile, dst0);
+        reduce_revert_delta(cb_var);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_var);
+        tile_regs_release();
+
+        cb_pop_front(cb_xmm2sum, onetile);
+        cb_push_back(cb_var, onetile);
+
+        /*
+         * 1.0/(sqrt(E[(x-E[x])^2] + eps))
+         * cb_recip_std
+         */
+        cb_wait_front(cb_var, onetile);
+        cb_reserve_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_reserve_back(cb_rstd, onetile);
+        }
+
+        tile_regs_acquire();
+        add_tiles_init_with_dt(cb_var, cb_eps);
+        add_tiles(cb_var, cb_eps, first_tile, first_tile, dst0);
+
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_recip_std);
+        if (rstd_has_value) {
+            pack_tile_with_dt(dst0, cb_rstd);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_var, onetile);
+        cb_push_back(cb_recip_std, onetile);
+
+        if (rstd_has_value) {
+            cb_push_back(cb_rstd, onetile);
+        }
+
+        /*
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps))) * gamma + beta
+         * cb_out
+         */
+        constexpr auto cb_reuse = cb_xmm;
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
+            /*
+             * x - E[x]
+             * cb_reuse(==cb_xmm)
+             */
+            cb_wait_front(cb_x, block_size);
+            cb_reserve_back(cb_reuse, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                tile_regs_acquire();
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                sub_tiles_bcast_scalar(cb_x, cb_ex, j, first_tile, j);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(j, cb_reuse);
+                tile_regs_release();
+            }  // block_size loop
+            cb_pop_front(cb_x, block_size);
+            cb_push_back(cb_reuse, block_size);
+
+            /*
+             * (x - E[x]) * 1.0/sqrt(Var[x] + eps)
+             * cb_gamma_beta_or_out
+             */
+            constexpr auto cb_gamma_beta_or_out = (gamma_has_value || beta_has_value) ? cb_gamma_beta : cb_out;
+            cb_wait_front(cb_reuse, block_size);
+
+            cb_wait_front(cb_recip_std, onetile);
+            cb_reserve_back(cb_gamma_beta_or_out, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                tile_regs_acquire();
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_reuse, cb_recip_std);
+                mul_tiles_bcast_scalar(cb_reuse, cb_recip_std, j, first_tile, j);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(j, cb_gamma_beta_or_out);
+                tile_regs_release();
+            }  // block_size loop
+            cb_pop_front(cb_reuse, block_size);
+            cb_push_back(cb_gamma_beta_or_out, block_size);
+
+            // * gamma
+            if (gamma_has_value) {
+                constexpr auto cb_outg = beta_has_value ? cb_gamma_beta : cb_out;
+                cb_wait_front(cb_gamma_beta_or_out, block_size);
+                cb_wait_front(cb_gamma, block_size);
+                cb_reserve_back(cb_outg, block_size);
+                for (uint32_t j = 0; j < block_size; j++) {
+                    tile_regs_acquire();
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                    mul_tiles_bcast_scalar(cb_gamma_beta_or_out, cb_gamma, j, j, j);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(j, cb_outg);
+                    tile_regs_release();
+                }  // block_size loop
+                cb_pop_front(cb_gamma_beta_or_out, block_size);
+                cb_pop_front(cb_gamma, block_size);
+                cb_push_back(cb_outg, block_size);
+            }
+
+            // + beta
+            if (beta_has_value) {
+                cb_wait_front(cb_gamma_beta, block_size);
+                cb_wait_front(cb_beta, block_size);
+                cb_reserve_back(cb_out, block_size);
+                for (uint32_t j = 0; j < block_size; j++) {
+                    tile_regs_acquire();
+                    add_bcast_scalar_init_short_with_dt(cb_gamma_beta, cb_beta);
+                    add_tiles_bcast_scalar(cb_gamma_beta, cb_beta, j, j, j);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(j, cb_out);
+                    tile_regs_release();
+                }  // block_size loop
+                cb_pop_front(cb_gamma_beta, block_size);
+                cb_pop_front(cb_beta, block_size);
+                cb_push_back(cb_out, block_size);
+            }
+        }  // num_inner loop
+        cb_pop_front(cb_recip_std, onetile);
+        cb_pop_front(cb_ex, onetile);
+    }  // num_rows_per_core loop
+    cb_pop_front(cb_scaler, onetile);
+    cb_pop_front(cb_eps, onetile);
+
+    if (do_mask_h) {
+        cb_pop_front(cb_mask_h, onetile);
+    }
+    if (do_mask_w) {
+        cb_pop_front(cb_mask_w, onetile);
+    }
+}  // void MAIN
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_small_kernel.cpp
@@ -1,0 +1,413 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+ALWI bool need_to_do_mask_h(uint32_t w_idx, uint32_t origin_num_h_tiles, uint32_t origin_num_w_tiles) {
+    return ((w_idx / origin_num_w_tiles) + 1) % origin_num_h_tiles == 0;
+}
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t origin_H = get_compile_time_arg_val(1);
+    constexpr uint32_t origin_W = get_compile_time_arg_val(2);
+    constexpr uint32_t num_inner = get_compile_time_arg_val(3);
+    constexpr uint32_t block_size = get_compile_time_arg_val(4);
+    constexpr bool gamma_has_value = get_compile_time_arg_val(5) == 1;
+    constexpr bool beta_has_value = get_compile_time_arg_val(6) == 1;
+    constexpr bool mean_has_value = get_compile_time_arg_val(7) == 1;
+    constexpr bool rstd_has_value = get_compile_time_arg_val(8) == 1;
+
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+
+    constexpr auto cb_x = tt::CB::c_in0;       // input
+    constexpr auto cb_scaler = tt::CB::c_in1;  // scaler
+    constexpr auto cb_eps = tt::CB::c_in2;     // epsilon
+    constexpr auto cb_gamma = tt::CB::c_in3;   // gamma
+    constexpr auto cb_beta = tt::CB::c_in4;    // beta
+    constexpr auto cb_mask_h = tt::CB::c_in5;  // mask_h
+    constexpr auto cb_mask_w = tt::CB::c_in6;  // mask_w
+    constexpr auto cb_zeros = tt::CB::c_in7;   // zeros
+
+    constexpr auto cb_out = tt::CB::c_out0;   // output
+    constexpr auto cb_mean = tt::CB::c_out1;  // mean
+    constexpr auto cb_rstd = tt::CB::c_out2;  // rstd
+
+    constexpr auto cb_ex = tt::CB::c_intermed0;          // E[x]
+    constexpr auto cb_xmm = tt::CB::c_intermed1;         // x - E[x]
+    constexpr auto cb_xmm2 = tt::CB::c_intermed2;        // (x - E[x])^2
+    constexpr auto cb_xmm2sum = tt::CB::c_intermed3;     // Sum[(x - E[x])^2]
+    constexpr auto cb_var = tt::CB::c_intermed4;         // E[(x - E[x])^2] = Var[x]
+    constexpr auto cb_recip_std = tt::CB::c_intermed5;   // 1.0/(sqrt(Var[x] + eps))
+    constexpr auto cb_gamma_beta = tt::CB::c_intermed6;  // p * gamm + beta
+    constexpr auto cb_xsum = tt::CB::c_intermed7;        // Sum[x]
+
+    constexpr uint32_t onetile = 1;
+
+    cb_wait_front(cb_scaler, onetile);  // comes from the reader
+    cb_wait_front(cb_eps, onetile);     // comes from the reader
+    cb_wait_front(cb_zeros, onetile);   // comes from the reader
+
+    constexpr bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
+    constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
+
+    if (do_mask_h) {
+        cb_wait_front(cb_mask_h, onetile);
+    }
+    if (do_mask_w) {
+        cb_wait_front(cb_mask_w, onetile);
+    }
+
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t first_tile = 0;
+
+    constexpr uint32_t origin_Ht = div_up(origin_H, TILE_HEIGHT);
+    constexpr uint32_t origin_Wt = div_up(origin_W, TILE_WIDTH);
+
+    for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; outer_idx++) {
+        /*
+         * Sum[x]
+         * cb_xsum
+         */
+        cb_wait_front(cb_x, num_inner);
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
+            for (uint32_t j = 0; j < block_size; j++) {
+                const uint32_t w_idx = inner_idx + j;
+                if (w_idx == 0) {
+                    cb_reserve_back(cb_xsum, onetile);
+
+                    tile_regs_acquire();
+                    copy_tile_init_with_dt(cb_x);
+                    copy_tile(cb_x, first_tile, dst0);  // input
+
+                    if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
+                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile(cb_mask_h, first_tile, dst1);  // mask_h
+
+                        mask_tile_init();
+                        mask_tile(dst0, dst1);
+                    }
+
+                    if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
+                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile(cb_mask_w, first_tile, dst1);  // mask_w
+
+                        mask_tile_init();
+                        mask_tile(dst0, dst1);
+                    }
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xsum);
+                    tile_regs_release();
+                    cb_push_back(cb_xsum, onetile);
+                } else {
+                    // I use cb_ex temporarily.
+                    constexpr auto cb_tmp = cb_ex;
+                    cb_reserve_back(cb_tmp, onetile);
+
+                    tile_regs_acquire();
+                    copy_tile_init_with_dt(cb_x);
+                    copy_tile(cb_x, inner_idx + j, dst0);  // input
+
+                    const uint32_t mask_dst = dst0 < 4 ? dst0 + 1 : 0;
+
+                    if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
+                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
+
+                        mask_tile_init();
+                        mask_tile(dst0, mask_dst);
+                    }
+
+                    if (do_mask_w && ((w_idx + 1) % origin_Wt == 0)) {
+                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
+
+                        mask_tile_init();
+                        mask_tile(dst0, mask_dst);
+                    }
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_tmp);
+                    tile_regs_release();
+
+                    cb_push_back(cb_tmp, onetile);
+
+                    cb_wait_front(cb_tmp, onetile);
+                    cb_wait_front(cb_xsum, onetile);
+                    cb_reserve_back(cb_xsum, onetile);
+
+                    tile_regs_acquire();
+                    add_tiles_init_with_dt(cb_xsum, cb_tmp);
+                    add_tiles(cb_xsum, cb_tmp, first_tile, first_tile, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(dst0, cb_xsum);
+                    tile_regs_release();
+
+                    cb_pop_front(cb_tmp, onetile);
+                    cb_pop_front(cb_xsum, onetile);
+                    cb_push_back(cb_xsum, onetile);
+                }
+            }  // block_size loop
+        }  // num_inner loop
+        // We don't pop cb_x until we compute xmm.
+
+        /*
+         * E[x]
+         * cb_ex
+         */
+        cb_wait_front(cb_xsum, onetile);
+        cb_reserve_back(cb_ex, onetile);
+        if (mean_has_value) {
+            cb_reserve_back(cb_mean, onetile);
+        }
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_ex, cb_xsum, cb_scaler);
+        reduce_tile(cb_xsum, cb_scaler, first_tile, first_tile, dst0);
+        reduce_revert_delta(cb_ex);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_ex);
+        if (mean_has_value) {
+            pack_tile_with_dt(dst0, cb_mean);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_xsum, onetile);
+        cb_push_back(cb_ex, onetile);
+        if (mean_has_value) {
+            cb_push_back(cb_mean, onetile);
+        }
+        // We don't pop cb_ex here.
+
+        /*
+         * x - E[x]
+         * xmm
+         */
+        cb_wait_front(cb_ex, onetile);
+        cb_reserve_back(cb_xmm, num_inner);
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
+            for (uint32_t j = 0; j < block_size; j++) {
+                const uint32_t w_idx = inner_idx + j;
+                tile_regs_acquire();
+                sub_tiles_bcast_scalar_init_short_with_dt(cb_x, cb_ex);
+                sub_tiles_bcast_scalar(cb_x, cb_ex, w_idx, first_tile, j);
+                // mask xmm
+                if (do_mask_h || do_mask_w) {
+                    const uint32_t mask_dst = j < 15 ? j + 1 : 0;
+                    if (do_mask_h && need_to_do_mask_h(w_idx, origin_Ht, origin_Wt)) {
+                        copy_tile_init_with_dt(cb_mask_h);
+                        copy_tile(cb_mask_h, first_tile, mask_dst);  // mask_h
+
+                        mask_tile_init();
+                        mask_tile(j, mask_dst);
+                    }
+                    if (do_mask_w && (w_idx + 1) % origin_Wt == 0) {
+                        copy_tile_init_with_dt(cb_mask_w);
+                        copy_tile(cb_mask_w, first_tile, mask_dst);  // mask_w
+
+                        mask_tile_init();
+                        mask_tile(j, mask_dst);
+                    }
+                }
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(j, cb_xmm);
+                tile_regs_release();
+            }  // block_size loop
+            cb_push_back(cb_xmm, block_size);
+        }  // num_inner loop
+        cb_pop_front(cb_ex, onetile);
+        cb_pop_front(cb_x, num_inner);
+
+        /*
+         * Sum[(x - E[x])^2]
+         * cb_xmm2sum
+         */
+        cb_wait_front(cb_xmm, num_inner);
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx++) {
+            cb_reserve_back(cb_xmm2, onetile);
+
+            tile_regs_acquire();
+            mul_tiles_init_with_dt(cb_xmm, cb_xmm);
+            mul_tiles(cb_xmm, cb_xmm, inner_idx, inner_idx, dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_with_dt(dst0, cb_xmm2);
+            tile_regs_release();
+
+            cb_push_back(cb_xmm2, onetile);
+            if (inner_idx == 0) {
+                cb_wait_front(cb_xmm2, onetile);
+                cb_reserve_back(cb_xmm2sum, onetile);
+
+                tile_regs_acquire();
+                add_tiles_init_with_dt(cb_xmm2, cb_zeros);
+                add_tiles(cb_xmm2, cb_zeros, 0, 0, dst0);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(dst0, cb_xmm2sum);
+                tile_regs_release();
+
+                cb_pop_front(cb_xmm2, onetile);
+                cb_push_back(cb_xmm2sum, onetile);
+            } else {
+                cb_wait_front(cb_xmm2sum, onetile);
+                cb_wait_front(cb_xmm2, onetile);
+                cb_reserve_back(cb_xmm2sum, onetile);
+
+                tile_regs_acquire();
+                add_tiles_init_with_dt(cb_xmm2sum, cb_xmm2);
+                add_tiles(cb_xmm2sum, cb_xmm2, first_tile, first_tile, dst0);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(dst0, cb_xmm2sum);
+                tile_regs_release();
+
+                cb_pop_front(cb_xmm2sum, onetile);
+                cb_pop_front(cb_xmm2, onetile);
+                cb_push_back(cb_xmm2sum, onetile);
+            }
+        }  // num_inner loop
+        // We don't pop cb_xmm here.
+
+        /*
+         * E[(x-E[x])^2 = Var[x]
+         * cb_var
+         */
+        cb_wait_front(cb_xmm2sum, onetile);
+        cb_reserve_back(cb_var, onetile);
+
+        tile_regs_acquire();
+        reduce_init_delta_with_dt<false>(cb_var, cb_xmm2sum, cb_scaler);
+        reduce_tile(cb_xmm2sum, cb_scaler, first_tile, first_tile, dst0);
+        reduce_revert_delta(cb_var);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_var);
+        tile_regs_release();
+
+        cb_pop_front(cb_xmm2sum, onetile);
+        cb_push_back(cb_var, onetile);
+
+        /*
+         * 1.0/(sqrt(E[(x-E[x])^2] + eps))
+         * cb_recip_std
+         */
+        cb_wait_front(cb_var, onetile);
+        cb_reserve_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_reserve_back(cb_rstd, onetile);
+        }
+
+        tile_regs_acquire();
+        add_tiles_init_with_dt(cb_var, cb_eps);
+        add_tiles(cb_var, cb_eps, first_tile, first_tile, dst0);
+
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_recip_std);
+        if (rstd_has_value) {
+            pack_tile_with_dt(dst0, cb_rstd);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_var, onetile);
+        cb_push_back(cb_recip_std, onetile);
+        if (rstd_has_value) {
+            cb_push_back(cb_rstd, onetile);
+        }
+
+        /*
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
+         * (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps))) * gamma + beta
+         * cb_out
+         */
+        cb_wait_front(cb_recip_std, onetile);
+        constexpr auto cb_gamma_beta_or_out = (gamma_has_value || beta_has_value) ? cb_gamma_beta : cb_out;
+        for (uint32_t inner_idx = 0; inner_idx < num_inner; inner_idx += block_size) {
+            cb_reserve_back(cb_gamma_beta_or_out, block_size);
+            for (uint32_t j = 0; j < block_size; j++) {
+                tile_regs_acquire();
+                mul_tiles_bcast_scalar_init_short_with_dt(cb_xmm, cb_recip_std);
+                mul_tiles_bcast_scalar(cb_xmm, cb_recip_std, inner_idx + j, first_tile, j);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(j, cb_gamma_beta_or_out);
+                tile_regs_release();
+            }  // block_size loop
+            cb_push_back(cb_gamma_beta_or_out, block_size);
+
+            // * gamma
+            if (gamma_has_value) {
+                constexpr auto cb_outg = beta_has_value ? cb_gamma_beta : cb_out;
+                cb_wait_front(cb_gamma_beta_or_out, block_size);
+                cb_wait_front(cb_gamma, block_size);
+                cb_reserve_back(cb_outg, block_size);
+                for (uint32_t j = 0; j < block_size; j++) {
+                    tile_regs_acquire();
+                    mul_tiles_bcast_scalar_init_short_with_dt(cb_gamma_beta_or_out, cb_gamma);
+                    mul_tiles_bcast_scalar(cb_gamma_beta_or_out, cb_gamma, j, j, j);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(j, cb_outg);
+                    tile_regs_release();
+                }  // block_size loop
+                cb_pop_front(cb_gamma_beta_or_out, block_size);
+                cb_pop_front(cb_gamma, block_size);
+                cb_push_back(cb_outg, block_size);
+            }  // if (gamma_has_value)
+
+            // + beta
+            if (beta_has_value) {
+                cb_wait_front(cb_gamma_beta, block_size);
+                cb_wait_front(cb_beta, block_size);
+                cb_reserve_back(cb_out, block_size);
+                for (uint32_t j = 0; j < block_size; j++) {
+                    tile_regs_acquire();
+                    add_bcast_scalar_init_short_with_dt(cb_gamma_beta, cb_beta);
+                    add_tiles_bcast_scalar(cb_gamma_beta, cb_beta, j, j, j);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_with_dt(j, cb_out);
+                    tile_regs_release();
+                }  // block_size loop
+                cb_pop_front(cb_gamma_beta, block_size);
+                cb_pop_front(cb_beta, block_size);
+                cb_push_back(cb_out, block_size);
+            }  // if (beta_has_value)
+        }  // num_inner loop
+        cb_pop_front(cb_recip_std, onetile);
+        cb_pop_front(cb_xmm, num_inner);
+    }  // num_rows_per_core loop
+    cb_pop_front(cb_scaler, onetile);
+    cb_pop_front(cb_eps, onetile);
+
+    if (do_mask_h) {
+        cb_pop_front(cb_mask_h, onetile);
+    }
+    if (do_mask_w) {
+        cb_pop_front(cb_mask_w, onetile);
+    }
+}  // void MAIN
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_2d.cpp
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+/**
+ * @brief Generates a mask with bits set inside the valid range [start, end).
+ *
+ * This function modifies the `cb_mask` by setting bits that correspond to values
+ * within the valid range [start, end). The values outside this range are considered
+ * invalid and will not have their corresponding bits set.
+ *
+ * @param cb_mask The mask to be modified. Bits outside the range [start, end) will be set.
+ * @param start The start of the valid range (inclusive).
+ * @param end The end of the valid range (exclusive).
+ */
+FORCE_INLINE void generate_mask_w(uint32_t cb_mask, uint32_t start, uint32_t end) {
+    start = start % TILE_WIDTH;
+    end = (end + TILE_WIDTH - 1) % TILE_WIDTH + 1;
+    Scalar one;
+    Scalar zero;
+
+    one.f = 1.0f;
+    zero.f = 0.0f;
+
+    uint16_t u16_one = uint16_t(one.u >> 16);
+    uint16_t u16_zero = uint16_t(zero.u >> 16);
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t h = 0; h < FACE_HEIGHT; h++) {
+        // sub tile 0
+        {
+            uint32_t offset = h * FACE_WIDTH;
+            if (start >= FACE_WIDTH) {
+                for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+            } else {
+                for (uint32_t w = 0; w < start; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+                uint32_t w_end = std::min(end, FACE_WIDTH);
+                for (uint32_t w = start; w < w_end; w++) {
+                    // valid
+                    ptr[offset + w] = u16_one;
+                }
+
+                for (uint32_t w = w_end; w < FACE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t offset = h * FACE_WIDTH + 256 - FACE_WIDTH;
+
+            if (end <= FACE_WIDTH) {
+                for (uint32_t w = FACE_WIDTH; w < TILE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+            } else {
+                for (uint32_t w = FACE_WIDTH; w < start; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+                uint32_t w_start = std::max(start, FACE_WIDTH);
+                for (uint32_t w = w_start; w < end; w++) {
+                    // valid
+                    ptr[offset + w] = u16_one;
+                }
+
+                for (uint32_t w = end; w < TILE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t offset = h * FACE_WIDTH + 512;
+
+            if (start >= FACE_WIDTH) {
+                for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+            } else {
+                for (uint32_t w = 0; w < start; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+                uint32_t w_end = std::min(end, FACE_WIDTH);
+                for (uint32_t w = start; w < w_end; w++) {
+                    // valid
+                    ptr[offset + w] = u16_one;
+                }
+
+                for (uint32_t w = w_end; w < FACE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t offset = h * FACE_WIDTH + 768 - FACE_WIDTH;
+
+            if (end <= FACE_WIDTH) {
+                for (uint32_t w = FACE_WIDTH; w < TILE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+            } else {
+                for (uint32_t w = FACE_WIDTH; w < start; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+
+                uint32_t w_start = std::max(start, FACE_WIDTH);
+                for (uint32_t w = w_start; w < end; w++) {
+                    // valid
+                    ptr[offset + w] = u16_one;
+                }
+
+                for (uint32_t w = end; w < TILE_WIDTH; w++) {
+                    // invalid
+                    ptr[offset + w] = u16_zero;
+                }
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
+template <typename T>
+FORCE_INLINE void read_input(
+    uint32_t cb_id, T addrgen, uint32_t read_start, uint32_t read_end, uint32_t nt, uint32_t Ct, uint32_t N) {
+    constexpr uint32_t onetile = 1;
+    const auto elem_size = get_tile_size(cb_id) >> 10;
+
+    cb_reserve_back(cb_id, onetile);
+    auto l1_write_addr = get_write_ptr(cb_id);
+
+    uint32_t ct = read_start / TILE_WIDTH;
+    auto noc_id = nt * Ct + ct;
+    auto noc_addr = get_noc_addr(noc_id, addrgen);
+
+    // read left face
+    if (read_start % TILE_WIDTH < FACE_WIDTH) {
+        // read [tile_start, tile_end)
+        uint32_t tile_start = read_start;
+        uint32_t tile_end = std::min(round_down(read_start, TILE_WIDTH) + FACE_WIDTH, read_end);
+
+        // n loop
+        uint32_t n_start = nt * TILE_HEIGHT;
+        uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+
+        auto noc_read_size = (tile_end - tile_start) * elem_size;
+        for (uint32_t n = n_start; n < n_end; n++) {
+            uint32_t tilized_idx = get_tilized_idx(n, tile_start);
+            uint32_t offset = tilized_idx * elem_size;
+
+            noc_async_read(noc_addr + offset, l1_write_addr + offset, noc_read_size);
+        }  // n loop
+
+    }  // read left face
+
+    // read right face
+    if ((read_end + TILE_WIDTH - 1) % TILE_WIDTH >= FACE_WIDTH) {
+        // read [tile_start, tile_end)
+        uint32_t tile_start = std::max(round_down(read_start, TILE_WIDTH) + FACE_WIDTH, read_start);
+        uint32_t tile_end = read_end;
+
+        // n loop
+        uint32_t n_start = nt * TILE_HEIGHT;
+        uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+        auto noc_read_size = (tile_end - tile_start) * elem_size;
+        for (uint32_t n = n_start; n < n_end; n++) {
+            uint32_t tilized_idx = get_tilized_idx(n, tile_start);
+            uint32_t offset = tilized_idx * elem_size;
+
+            noc_async_read(noc_addr + offset, l1_write_addr + offset, noc_read_size);
+        }  // n loop
+
+    }  // read right face
+
+    noc_async_read_barrier();
+
+    cb_push_back(cb_id, onetile);
+}
+
+template <typename T, typename U, typename V>
+void read_all_tiles(
+    uint32_t cb_input,
+    T input_addrgen,
+    uint32_t cb_gamma,
+    U gamma_addrgen,
+    uint32_t cb_beta,
+    V beta_addrgen,
+    uint32_t c_start,
+    uint32_t c_end,
+    uint32_t nt,
+    uint32_t Ct,
+    uint32_t N,
+    uint32_t cb_mask,
+    bool read_gamma,
+    bool read_beta,
+    bool create_mask) {
+    uint32_t read_start = c_start;
+    uint32_t read_end = c_start;
+
+    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+
+    for (;;) {
+        // compute read range in tiles
+        read_start = read_end;
+        read_end = std::min(round_up(read_start + 1, TILE_WIDTH), c_end);
+
+        if (read_start >= c_end) {
+            break;
+        }
+
+        // read [read_start, read_end]
+        bool is_tile_end = (read_end % TILE_WIDTH == 0);
+        bool is_last = (read_end == c_end);
+        if (is_tile_end || is_last) {
+            read_input(cb_input, input_addrgen, read_start, read_end, nt, Ct, N);
+
+            // generate mask
+            bool mask_required = create_mask && ((read_start % TILE_WIDTH != 0) || (read_end % TILE_WIDTH != 0));
+            if (mask_required) {
+                generate_mask_w(cb_mask, read_start, read_end);
+            }
+
+            uint32_t ct = read_start / TILE_WIDTH;
+            // gamma[1, C]
+            if (read_gamma) {
+                uint32_t noc_id = ct;
+                read_tile(cb_gamma, gamma_addrgen, noc_id, gamma_tile_bytes);
+            }
+
+            // beta[1, C]
+            if (read_beta) {
+                uint32_t noc_id = ct;
+                read_tile(cb_beta, beta_addrgen, noc_id, beta_tile_bytes);
+            }
+        }
+    }
+}
+
+void kernel_main() {
+    int i{0};
+    const auto input_addr = get_arg_val<uint32_t>(i++);
+    const auto gamma_addr = get_arg_val<uint32_t>(i++);
+    const auto beta_addr = get_arg_val<uint32_t>(i++);
+
+    const auto scaler = get_arg_val<uint32_t>(i++);
+    const auto eps = get_arg_val<uint32_t>(i++);
+
+    const auto unit_offset = get_arg_val<uint32_t>(i++);
+    const auto num_units_per_core = get_arg_val<uint32_t>(i++);
+
+    const auto N = get_arg_val<uint32_t>(i++);
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
+
+    // compile-time args
+    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool gamma_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr bool gamma_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool beta_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr bool beta_is_dram = get_compile_time_arg_val(4) == 1;
+
+    constexpr uint32_t onetile = 1;
+
+    const auto Nt = div_up(N, TILE_HEIGHT);
+    const auto Ct = div_up(C, TILE_WIDTH);
+
+    uint32_t cb_id = tt::CB::c_in0;
+    const auto cb_input = cb_id++;
+    const auto cb_scaler = cb_id++;
+    const auto cb_eps = cb_id++;
+    const auto cb_gamma = cb_id++;
+    const auto cb_beta = cb_id++;
+    const auto cb_mask = cb_id++;
+    const auto cb_zeros = cb_id++;
+
+    fill_cb_with_value(cb_scaler, scaler);
+    fill_cb_with_value(cb_eps, eps);
+    fill_cb_with_zeros(cb_zeros);
+
+    // input
+    const uint32_t input_tile_bytes = get_tile_size(cb_input);
+    const auto input_data_format = get_dataformat(cb_input);
+    const auto input_elem_size = get_tile_size(cb_input) >> 10;
+
+    const InterleavedAddrGenFast<input_is_dram> input_addrgen = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+
+    // gamma
+    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+    const auto gamma_data_format = get_dataformat(cb_gamma);
+    const InterleavedAddrGenFast<gamma_is_dram> gamma_addrgen = {
+        .bank_base_address = gamma_addr, .page_size = gamma_tile_bytes, .data_format = gamma_data_format};
+
+    // beta
+    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+    const auto beta_data_format = get_dataformat(cb_beta);
+    const InterleavedAddrGenFast<beta_has_value> beta_addrgen = {
+        .bank_base_address = beta_addr, .page_size = beta_tile_bytes, .data_format = beta_data_format};
+
+    for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; ++outer_idx) {
+        // input[N, C]
+        // reshaped_input[N, num_groups, C / num_groups]
+        auto unit_idx = unit_offset + outer_idx;
+        auto group_idx = unit_idx % num_groups;
+        auto nt = unit_idx / num_groups;
+
+        // read range [c_start, c_end)
+        uint32_t c_size_per_unit = C / num_groups;
+        uint32_t c_start = c_size_per_unit * group_idx;
+        uint32_t c_end = c_size_per_unit * (group_idx + 1);
+
+        // read x For E[x]
+        read_all_tiles(
+            cb_input,
+            input_addrgen,
+            cb_gamma,
+            gamma_addrgen,
+            cb_beta,
+            beta_addrgen,
+            c_start,
+            c_end,
+            nt,
+            Ct,
+            N,
+            cb_mask,
+            false,
+            false,
+            true);
+
+        // read x for x - E[x]
+        read_all_tiles(
+            cb_input,
+            input_addrgen,
+            cb_gamma,
+            gamma_addrgen,
+            cb_beta,
+            beta_addrgen,
+            c_start,
+            c_end,
+            nt,
+            Ct,
+            N,
+            cb_mask,
+            false,
+            false,
+            true);
+
+        // read x for (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
+        read_all_tiles(
+            cb_input,
+            input_addrgen,
+            cb_gamma,
+            gamma_addrgen,
+            cb_beta,
+            beta_addrgen,
+            c_start,
+            c_end,
+            nt,
+            Ct,
+            N,
+            cb_mask,
+            gamma_has_value,
+            beta_has_value,
+            false);
+
+    }  // num_units_per_core
+
+}  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_3d.cpp
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+/**
+ * @brief Generates a mask with bits set inside the valid range [start, end).
+ *
+ * This function modifies the `cb_mask` by setting bits that correspond to values
+ * within the valid range [start, end). The values outside this range are considered
+ * invalid and will not have their corresponding bits set.
+ *
+ * @param cb_mask The mask to be modified. Bits outside the range [start, end) will be set.
+ * @param start The start of the valid range (inclusive).
+ * @param end The end of the valid range (exclusive).
+ */
+FORCE_INLINE void generate_mask_h(uint32_t cb_mask, uint32_t start, uint32_t end) {
+    start = start % TILE_WIDTH;
+    end = (end + TILE_WIDTH - 1) % TILE_WIDTH + 1;
+    Scalar one;
+    Scalar zero;
+
+    one.f = 1.0f;
+    zero.f = 0.0f;
+
+    uint16_t u16_one = uint16_t(one.u >> 16);
+    uint16_t u16_zero = uint16_t(zero.u >> 16);
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    uint32_t h = 0;
+
+    // invalid
+    for (; h < start; h++) {
+        uint32_t offset = get_tilized_idx(h, 0);
+        for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+            ptr[offset + w] = u16_zero;
+        }
+
+        offset = get_tilized_idx(h, FACE_WIDTH);
+        for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+            ptr[offset + w] = u16_zero;
+        }
+    }
+
+    // valid
+    for (; h < end; h++) {
+        uint32_t offset = get_tilized_idx(h, 0);
+        for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+            ptr[offset + w] = u16_one;
+        }
+
+        offset = get_tilized_idx(h, FACE_WIDTH);
+        for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+            ptr[offset + w] = u16_one;
+        }
+    }
+
+    // invalid
+    for (; h < TILE_HEIGHT; h++) {
+        uint32_t offset = get_tilized_idx(h, 0);
+        for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+            ptr[offset + w] = u16_zero;
+        }
+
+        offset = get_tilized_idx(h, FACE_WIDTH);
+        for (uint32_t w = 0; w < FACE_WIDTH; w++) {
+            ptr[offset + w] = u16_zero;
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
+template <typename T>
+FORCE_INLINE void read_input(
+    uint32_t cb_id,
+    T addrgen,
+    uint32_t read_start,
+    uint32_t read_end,
+    uint32_t n,
+    uint32_t wt,
+    uint32_t Ct,
+    uint32_t Wt) {
+    constexpr uint32_t onetile = 1;
+    const auto elem_size = get_tile_size(cb_id) >> 10;
+
+    cb_reserve_back(cb_id, onetile);
+    auto l1_write_addr = get_write_ptr(cb_id);
+
+    // input[N, C, W]
+    // reshaped_input[N, num_groups, C / num_groups, W]
+    uint32_t ct = read_start / TILE_HEIGHT;
+    auto noc_id = n * Ct * Wt + ct * Wt + wt;
+    auto noc_addr = get_noc_addr(noc_id, addrgen);
+
+    uint32_t c_start = read_start;
+    uint32_t c_end = read_end;
+    auto noc_read_size = FACE_WIDTH * elem_size;
+
+    for (uint32_t c = c_start; c < c_end; c++) {
+        uint32_t tilized_idx = get_tilized_idx(c, 0);
+        uint32_t offset = tilized_idx * elem_size;
+
+        noc_async_read(noc_addr + offset, l1_write_addr + offset, noc_read_size);
+
+        tilized_idx = get_tilized_idx(c, FACE_WIDTH);
+        offset = tilized_idx * elem_size;
+        noc_async_read(noc_addr + offset, l1_write_addr + offset, noc_read_size);
+    }  // for (uint32_t c = c_start; c < c_end; c++)
+
+    noc_async_read_barrier();
+
+    cb_push_back(cb_id, onetile);
+}
+
+template <typename T, typename U, typename V>
+void read_all_tiles(
+    uint32_t cb_input,
+    T input_addrgen,
+    uint32_t cb_gamma,
+    U gamma_addrgen,
+    uint32_t cb_beta,
+    V beta_addrgen,
+    uint32_t c_start,
+    uint32_t c_end,
+    uint32_t n,
+    uint32_t Ct,
+    uint32_t Wt,
+    uint32_t W,
+    uint32_t cb_mask_h,
+    uint32_t cb_mask_w,
+    bool read_gamma,
+    bool read_beta,
+    bool create_mask) {
+    uint32_t read_start = c_start;
+    uint32_t read_end = c_start;
+
+    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+    const uint32_t beta_tile_bytes = get_tile_size(cb_gamma);
+
+    for (;;) {
+        // compute read range in tiles
+        read_start = read_end;
+        read_end = std::min(round_up(read_start + 1, TILE_HEIGHT), c_end);
+
+        if (read_start >= c_end) {
+            break;
+        }
+
+        // read [read_start, read_end]
+        bool is_tile_end = (read_end % TILE_HEIGHT == 0);
+        bool is_last = (read_end == c_end);
+        if (is_tile_end || is_last) {
+            // generate mask
+            bool mask_h_required = create_mask && ((read_start % TILE_HEIGHT != 0) || (read_end % TILE_HEIGHT != 0));
+            if (mask_h_required) {
+                generate_mask_h(cb_mask_h, read_start, read_end);
+            }
+
+            uint32_t ct = read_start / TILE_WIDTH;
+            // gamma[1, C]
+            if (read_gamma) {
+                uint32_t noc_id = ct;
+                read_tile(cb_gamma, gamma_addrgen, noc_id, gamma_tile_bytes);
+            }
+
+            // beta[1, C]
+            if (read_beta) {
+                uint32_t noc_id = ct;
+                read_tile(cb_beta, beta_addrgen, noc_id, beta_tile_bytes);
+            }
+
+            for (uint32_t wt = 0; wt < Wt; wt++) {
+                read_input(cb_input, input_addrgen, read_start, read_end, n, wt, Ct, Wt);
+
+                bool mask_w_required = create_mask && ((wt + 1 == Wt) && (W % TILE_WIDTH != 0));
+                if (mask_w_required) {
+                    generate_mask_w(cb_mask_w, W % TILE_WIDTH);
+                }
+            }
+        }
+    }
+}
+
+void kernel_main() {
+    int i{0};
+    const auto input_addr = get_arg_val<uint32_t>(i++);
+    const auto gamma_addr = get_arg_val<uint32_t>(i++);
+    const auto beta_addr = get_arg_val<uint32_t>(i++);
+
+    const auto scaler = get_arg_val<uint32_t>(i++);
+    const auto eps = get_arg_val<uint32_t>(i++);
+
+    const auto unit_offset = get_arg_val<uint32_t>(i++);
+    const auto num_units_per_core = get_arg_val<uint32_t>(i++);
+
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto W = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
+
+    // compile-time args
+    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool gamma_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr bool gamma_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool beta_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr bool beta_is_dram = get_compile_time_arg_val(4) == 1;
+
+    constexpr uint32_t onetile = 1;
+
+    uint32_t Ct = div_up(C, TILE_HEIGHT);
+    uint32_t Wt = div_up(W, TILE_WIDTH);
+
+    uint32_t cb_id = tt::CB::c_in0;
+    const auto cb_input = cb_id++;
+    const auto cb_scaler = cb_id++;
+    const auto cb_eps = cb_id++;
+    const auto cb_gamma = cb_id++;
+    const auto cb_beta = cb_id++;
+    const auto cb_mask_h = cb_id++;
+    const auto cb_mask_w = cb_id++;
+    const auto cb_zeros = cb_id++;
+
+    fill_cb_with_value(cb_scaler, scaler);
+    fill_cb_with_value(cb_eps, eps);
+    fill_cb_with_zeros(cb_zeros);
+
+    // input
+    const uint32_t input_tile_bytes = get_tile_size(cb_input);
+    const auto input_data_format = get_dataformat(cb_input);
+    const InterleavedAddrGenFast<input_is_dram> input_addrgen = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+
+    // gamma
+    const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
+    const auto gamma_data_format = get_dataformat(cb_gamma);
+    const InterleavedAddrGenFast<gamma_is_dram> gamma_addrgen = {
+        .bank_base_address = gamma_addr, .page_size = gamma_tile_bytes, .data_format = gamma_data_format};
+
+    // beta
+    const uint32_t beta_tile_bytes = get_tile_size(cb_beta);
+    const auto beta_data_format = get_dataformat(cb_beta);
+    const InterleavedAddrGenFast<beta_has_value> beta_addrgen = {
+        .bank_base_address = beta_addr, .page_size = beta_tile_bytes, .data_format = beta_data_format};
+
+    for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; ++outer_idx) {
+        // input[N, C, W]
+        // reshaped_input[N, num_groups, C / num_groups, W]
+        auto unit_idx = unit_offset + outer_idx;
+        auto group_idx = unit_idx % num_groups;
+        uint32_t n = unit_idx / num_groups;
+
+        // read range [c_start, c_end)
+        uint32_t c_size_per_unit = C / num_groups;
+        uint32_t c_start = c_size_per_unit * group_idx;
+        uint32_t c_end = c_size_per_unit * (group_idx + 1);
+
+        // read x For E[x]
+        read_all_tiles(
+            cb_input,
+            input_addrgen,
+            cb_gamma,
+            gamma_addrgen,
+            cb_beta,
+            beta_addrgen,
+            c_start,
+            c_end,
+            n,
+            Ct,
+            Wt,
+            W,
+            cb_mask_h,
+            cb_mask_w,
+            false,
+            false,
+            true);
+
+        // read x for x - E[x]
+        read_all_tiles(
+            cb_input,
+            input_addrgen,
+            cb_gamma,
+            gamma_addrgen,
+            cb_beta,
+            beta_addrgen,
+            c_start,
+            c_end,
+            n,
+            Ct,
+            Wt,
+            W,
+            cb_mask_h,
+            cb_mask_w,
+            false,
+            false,
+            true);
+
+        // read x for (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
+        read_all_tiles(
+            cb_input,
+            input_addrgen,
+            cb_gamma,
+            gamma_addrgen,
+            cb_beta,
+            beta_addrgen,
+            c_start,
+            c_end,
+            n,
+            Ct,
+            Wt,
+            W,
+            cb_mask_h,
+            cb_mask_w,
+            gamma_has_value,
+            beta_has_value,
+            false);
+
+    }  // num_units_per_core
+
+}  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_small.cpp
@@ -23,25 +23,23 @@ void kernel_main() {
     const auto tile_offset = get_arg_val<uint32_t>(i++);
     const auto num_rows_per_core = get_arg_val<uint32_t>(i++);
     const auto num_inner_tiles = get_arg_val<uint32_t>(i++);
-    const auto num_channels = get_arg_val<uint32_t>(i++);
+    const auto c_inner_tiles = get_arg_val<uint32_t>(i++);
 
-    const auto origin_h = get_arg_val<uint32_t>(i++);
-    const auto origin_w = get_arg_val<uint32_t>(i++);
+    const auto N = get_arg_val<uint32_t>(i++);
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto H = get_arg_val<uint32_t>(i++);
+    const auto W = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
     const auto block_size = get_arg_val<uint32_t>(i++);
 
     constexpr uint32_t onetile = 1;
 
-    constexpr uint32_t TILE_H = 32;
-    constexpr uint32_t TILE_W = 32;
-
-    const auto Ht = (origin_h + TILE_H - 1) / TILE_H;
-    const auto Wt = (origin_w + TILE_W - 1) / TILE_W;
+    const auto Ht = div_up(H, TILE_HEIGHT);
+    const auto Wt = div_up(W, TILE_WIDTH);
 
     const auto HtWt = Ht * Wt;
 
-    const auto C = num_channels;
-
-    uint32_t cb_id{0};
+    uint32_t cb_id = tt::CB::c_in0;
     const auto cb_id_input = cb_id++;
     const auto cb_id_scaler = cb_id++;
     const auto cb_id_eps = cb_id++;
@@ -49,15 +47,17 @@ void kernel_main() {
     const auto cb_id_beta = cb_id++;
     const auto cb_id_mask_h = cb_id++;
     const auto cb_id_mask_w = cb_id++;
+    const auto cb_zeros = cb_id++;
 
     fill_cb_with_value(cb_id_scaler, scaler);
     fill_cb_with_value(cb_id_eps, eps);
+    fill_cb_with_zeros(cb_zeros);
 
-    const bool do_mask_h = (origin_h % TILE_H) != 0;
-    const auto mask_h = do_mask_h ? origin_h % TILE_H : TILE_H;
+    const bool do_mask_h = (H % TILE_HEIGHT) != 0;
+    const auto mask_h = do_mask_h ? H % TILE_HEIGHT : TILE_HEIGHT;
 
-    const bool do_mask_w = (origin_w % TILE_W) != 0;
-    const auto mask_w = do_mask_w ? origin_w % TILE_W : TILE_W;
+    const bool do_mask_w = (W % TILE_WIDTH) != 0;
+    const auto mask_w = do_mask_w ? W % TILE_WIDTH : TILE_WIDTH;
 
     if (do_mask_h) {
         generate_mask_h(cb_id_mask_h, mask_h);
@@ -99,62 +99,40 @@ void kernel_main() {
     const auto input_l1_write_ptr = get_write_ptr(cb_id_input);
     uint32_t input_tile_idx;
     for (uint32_t outer_idx = 0; outer_idx < num_rows_per_core; ++outer_idx) {
-        // For E[x]
-        for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
-            cb_reserve_back(cb_id_input, block_size);
-            for (uint32_t r = 0; r < block_size; r++) {
-                input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
-                if (input_is_dram) {
-                    noc_async_read_tile(input_tile_idx, dram_input_addrg, input_l1_write_ptr + r * input_tile_bytes);
-                } else {
-                    noc_async_read_tile(input_tile_idx, l1_input_addrg, input_l1_write_ptr + r * input_tile_bytes);
-                }
+        cb_reserve_back(cb_id_input, num_inner_tiles);
+        for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; ++inner_idx) {
+            cb_reserve_back(cb_id_input, num_inner_tiles);
+            input_tile_idx = (tile_offset + outer_idx) * num_inner_tiles + inner_idx;
+            if (input_is_dram) {
+                noc_async_read_tile(
+                    input_tile_idx, dram_input_addrg, input_l1_write_ptr + inner_idx * input_tile_bytes);
+            } else {
+                noc_async_read_tile(input_tile_idx, l1_input_addrg, input_l1_write_ptr + inner_idx * input_tile_bytes);
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_input, block_size);
         }  // inner_idx loop
+        noc_async_read_barrier();
+        cb_push_back(cb_id_input, num_inner_tiles);
 
-        // For Var[x]
+        // input (N, C, *, H, W)
+        // gamma (1, C)
         for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
-            cb_reserve_back(cb_id_input, block_size);
-            for (uint32_t r = 0; r < block_size; r++) {
-                input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
-                if (input_is_dram) {
-                    noc_async_read_tile(input_tile_idx, dram_input_addrg, input_l1_write_ptr + r * input_tile_bytes);
-                } else {
-                    noc_async_read_tile(input_tile_idx, l1_input_addrg, input_l1_write_ptr + r * input_tile_bytes);
-                }
-            }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_input, block_size);
-        }  // inner_idx loop
-
-        // For (x - E[x]) * (1.0/(sqrt(E[(x-E[x])^2] + eps)))
-        for (uint32_t inner_idx = 0; inner_idx < num_inner_tiles; inner_idx += block_size) {
-            cb_reserve_back(cb_id_input, block_size);
-            for (uint32_t r = 0; r < block_size; r++) {
-                input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
-                if (input_is_dram) {
-                    noc_async_read_tile(input_tile_idx, dram_input_addrg, input_l1_write_ptr + r * input_tile_bytes);
-                } else {
-                    noc_async_read_tile(input_tile_idx, l1_input_addrg, input_l1_write_ptr + r * input_tile_bytes);
-                }
-            }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_input, block_size);
-
-            // input (N, C, H, W)
-            // input_tile_idx = n * C * Ht * Wt + c * Ht * Wt + h * Wt + w
-            // n * C + c = input_tile_idx / (Ht * Wt)
-            // c = (input_tile_idx / (Ht * Wt)) % C
-            // gamma (1, 1, 1, C)
             if (gamma_has_value) {
+                // unit_idx = n * num_groups
+                uint32_t unit_idx = outer_idx + tile_offset;
+                uint32_t n = unit_idx / num_groups;
+                uint32_t group_idx = unit_idx % num_groups;
+
+                uint32_t c_per_groups = C / num_groups;
+                uint32_t c_offset = group_idx * c_per_groups;
+
                 uint32_t gamma_tile_idx;
                 const auto gamma_l1_write_ptr = get_write_ptr(cb_id_gamma);
                 cb_reserve_back(cb_id_gamma, block_size);
                 for (uint32_t r = 0; r < block_size; r++) {
-                    input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
-                    gamma_tile_idx = get_gamma_beta_tile_idx(input_tile_idx, HtWt, C, TILE_W);
+                    input_tile_idx = inner_idx + r;
+                    uint32_t c = (input_tile_idx / c_inner_tiles) + c_offset;
+                    gamma_tile_idx = c / TILE_WIDTH;
+
                     if (gamma_is_dram) {
                         noc_async_read_tile(
                             gamma_tile_idx, dram_gamma_addrg, gamma_l1_write_ptr + r * gamma_tile_bytes);
@@ -166,9 +144,10 @@ void kernel_main() {
 
                 uint32_t tilized_gamma_idx_in_tile;
                 for (uint32_t q = 0; q < block_size; q++) {
-                    input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + q;
-                    tilized_gamma_idx_in_tile =
-                        get_tilized_gamma_beta_idx_in_tile(input_tile_idx, HtWt, C, TILE_H, TILE_W);
+                    input_tile_idx = inner_idx + q;
+                    uint32_t c = (input_tile_idx / c_inner_tiles) + c_offset;
+                    tilized_gamma_idx_in_tile = get_tilized_idx(0, c);
+
                     if (tilized_gamma_idx_in_tile != 0) {
                         auto gamma_ptr = reinterpret_cast<uint16_t *>(gamma_l1_write_ptr + q * gamma_tile_bytes);
                         gamma_ptr[0] = gamma_ptr[tilized_gamma_idx_in_tile];
@@ -177,14 +156,23 @@ void kernel_main() {
                 cb_push_back(cb_id_gamma, block_size);
             }
 
-            // beta (1, 1, 1, C)
+            // beta (1, C)
             if (beta_has_value) {
+                // unit_idx = n * num_groups
+                uint32_t unit_idx = outer_idx + tile_offset;
+                uint32_t n = unit_idx / num_groups;
+                uint32_t group_idx = unit_idx % num_groups;
+
+                uint32_t c_per_groups = C / num_groups;
+                uint32_t c_offset = group_idx * c_per_groups;
+
                 uint32_t beta_tile_idx;
                 const auto beta_l1_write_ptr = get_write_ptr(cb_id_beta);
                 cb_reserve_back(cb_id_beta, block_size);
                 for (uint32_t r = 0; r < block_size; r++) {
-                    input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + r;
-                    beta_tile_idx = get_gamma_beta_tile_idx(input_tile_idx, HtWt, C, TILE_W);
+                    input_tile_idx = inner_idx + r;
+                    uint32_t c = (input_tile_idx / c_inner_tiles) + c_offset;
+                    beta_tile_idx = c / TILE_WIDTH;
                     if (beta_is_dram) {
                         noc_async_read_tile(beta_tile_idx, dram_beta_addrg, beta_l1_write_ptr + r * beta_tile_bytes);
                     } else {
@@ -195,9 +183,9 @@ void kernel_main() {
 
                 uint32_t tilized_beta_idx_in_tile;
                 for (uint32_t q = 0; q < block_size; q++) {
-                    input_tile_idx = tile_offset + outer_idx * num_inner_tiles + inner_idx + q;
-                    tilized_beta_idx_in_tile =
-                        get_tilized_gamma_beta_idx_in_tile(input_tile_idx, HtWt, C, TILE_H, TILE_W);
+                    input_tile_idx = inner_idx + q;
+                    uint32_t c = (input_tile_idx / c_inner_tiles) + c_offset;
+                    tilized_beta_idx_in_tile = get_tilized_idx(0, c);
                     if (tilized_beta_idx_in_tile != 0) {
                         auto beta_ptr = reinterpret_cast<uint16_t *>(beta_l1_write_ptr + q * beta_tile_bytes);
                         beta_ptr[0] = beta_ptr[tilized_beta_idx_in_tile];

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm_2d.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+template <typename T>
+FORCE_INLINE void write_output(
+    uint32_t cb_id, T addrgen, uint32_t write_start, uint32_t write_end, uint32_t nt, uint32_t Ct, uint32_t N) {
+    constexpr uint32_t onetile = 1;
+    const auto elem_size = get_tile_size(cb_id) >> 10;
+
+    cb_wait_front(cb_id, onetile);
+    auto l1_read_addr = get_read_ptr(cb_id);
+
+    uint32_t ct = write_start / TILE_WIDTH;
+    auto noc_id = nt * Ct + ct;
+    auto noc_addr = get_noc_addr(noc_id, addrgen);
+
+    // write left face
+    if (write_start % TILE_WIDTH < FACE_WIDTH) {
+        // write [tile_start, tile_end)
+        uint32_t tile_start = write_start;
+        uint32_t tile_end = std::min(round_down(write_start, TILE_WIDTH) + FACE_WIDTH, write_end);
+
+        uint32_t n_start = 0;
+        uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+        auto noc_write_size = (tile_end - tile_start) * elem_size;
+        for (uint32_t n = n_start; n < n_end; n++) {
+            uint32_t tilized_idx = get_tilized_idx(n, tile_start);
+            uint32_t offset = tilized_idx * elem_size;
+
+            noc_async_write(l1_read_addr + offset, noc_addr + offset, noc_write_size);
+        }
+    }  // write left face
+
+    // write right face
+    if ((write_end + TILE_WIDTH - 1) % TILE_WIDTH >= FACE_WIDTH) {
+        // write [tile_start, tile_end)
+        uint32_t tile_start = std::max(round_down(write_start, TILE_WIDTH) + FACE_WIDTH, write_start);
+        uint32_t tile_end = write_end;
+
+        uint32_t n_start = 0;
+        uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+        auto noc_write_size = (tile_end - tile_start) * elem_size;
+        for (uint32_t n = n_start; n < n_end; n++) {
+            uint32_t tilized_idx = get_tilized_idx(n, tile_start);
+            uint32_t offset = tilized_idx * elem_size;
+
+            noc_async_write(l1_read_addr + offset, noc_addr + offset, noc_write_size);
+        }
+    }  // write right face
+
+    noc_async_write_barrier();
+
+    cb_pop_front(cb_id, onetile);
+}
+
+void kernel_main() {
+    int i{0};
+    const auto output_addr = get_arg_val<uint32_t>(i++);
+    const auto mean_addr = get_arg_val<uint32_t>(i++);
+    const auto rstd_addr = get_arg_val<uint32_t>(i++);
+
+    const auto unit_offset = get_arg_val<uint32_t>(i++);
+    const auto num_units_per_core = get_arg_val<uint32_t>(i++);
+
+    const auto N = get_arg_val<uint32_t>(i++);
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
+
+    // compile-time args
+    constexpr bool output_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool mean_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr bool mean_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool rstd_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr bool rstd_is_dram = get_compile_time_arg_val(4) == 1;
+
+    uint32_t cb_id = tt::CB::c_out0;
+    const auto cb_output = cb_id++;
+    const auto cb_mean = cb_id++;
+    const auto cb_rstd = cb_id++;
+
+    const auto Ct = div_up(C, TILE_WIDTH);
+
+    // output
+    const uint32_t output_tile_bytes = get_tile_size(cb_output);
+    const auto output_data_format = get_dataformat(cb_output);
+    const auto output_elem_size = get_tile_size(cb_output) >> 10;
+
+    const InterleavedAddrGenFast<output_is_dram> output_addrgen = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    constexpr uint32_t onetile = 1;
+
+    for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; ++outer_idx) {
+        // input[N, C]
+        // reshaped_input[N, num_groups, C / num_groups]
+
+        auto unit_idx = unit_offset + outer_idx;
+        auto group_idx = unit_idx % num_groups;
+        auto nt = unit_idx / num_groups;
+
+        uint32_t c_size_per_unit = C / num_groups;
+        uint32_t c_start = c_size_per_unit * group_idx;
+        uint32_t c_end = c_size_per_unit * (group_idx + 1);
+
+        uint32_t write_start = c_start;
+        uint32_t write_end = c_start;
+        for (;;) {
+            // write range [c_start, c_end)
+            write_start = write_end;
+            write_end = std::min(round_up(write_start + 1, TILE_WIDTH), c_end);
+
+            if (write_start >= c_end) {
+                break;
+            }
+
+            bool is_tile_end = (write_end % TILE_WIDTH == 0);
+            bool is_last = (write_end == c_end);
+            if (is_tile_end || is_last) {
+                write_output(cb_output, output_addrgen, write_start, write_end, nt, Ct, N);
+            }
+        }
+
+        // mean
+        // shape: [N, num_groups]
+        if (mean_has_value) {
+            const uint32_t mean_tile_bytes = get_tile_size(cb_mean);
+            const auto mean_data_format = get_dataformat(cb_mean);
+            const auto mean_dtype_bytes = mean_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
+
+            const InterleavedAddrGenFast<mean_is_dram> mean_addrg = {
+                .bank_base_address = mean_addr, .page_size = mean_tile_bytes, .data_format = mean_data_format};
+
+            cb_wait_front(cb_mean, onetile);
+            const auto mean_l1_read_ptr = get_read_ptr(cb_mean);
+
+            // shift [n, 0] -> [n, group_idx]
+            if (group_idx % TILE_WIDTH != 0) {
+                auto mean_ptr = reinterpret_cast<uint16_t *>(mean_l1_read_ptr);
+                uint32_t n_start = 0;
+                uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+                for (uint32_t n = n_start; n < n_end; n++) {
+                    uint32_t src_idx = get_tilized_idx(n, 0);
+                    uint32_t dst_idx = get_tilized_idx(n, group_idx);
+
+                    mean_ptr[dst_idx] = mean_ptr[src_idx];
+                }
+            }
+
+            uint32_t noc_id = nt * div_up(num_groups, TILE_WIDTH) + (group_idx / TILE_WIDTH);
+            const auto mean_noc_addr = get_noc_addr(noc_id, mean_addrg);
+            uint32_t n_start = 0;
+            uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+
+            for (uint32_t n = n_start; n < n_end; n++) {
+                uint32_t dst_idx = get_tilized_idx(n, group_idx);
+                noc_async_write(
+                    mean_l1_read_ptr + dst_idx * mean_dtype_bytes,
+                    mean_noc_addr + dst_idx * mean_dtype_bytes,
+                    mean_dtype_bytes);
+            }
+            noc_async_write_barrier();
+            cb_pop_front(cb_mean, onetile);
+        }
+
+        // rstd
+        // shape: [N, num_groups]
+        if (rstd_has_value) {
+            const uint32_t rstd_tile_bytes = get_tile_size(cb_rstd);
+            const auto rstd_data_format = get_dataformat(cb_rstd);
+            const auto rstd_dtype_bytes = rstd_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
+
+            const InterleavedAddrGenFast<rstd_is_dram> rstd_addrg = {
+                .bank_base_address = rstd_addr, .page_size = rstd_tile_bytes, .data_format = rstd_data_format};
+
+            cb_wait_front(cb_rstd, onetile);
+            const auto rstd_l1_read_ptr = get_read_ptr(cb_rstd);
+
+            // shift [n, 0] -> [n, group_idx]
+            if (group_idx % TILE_WIDTH != 0) {
+                auto rstd_ptr = reinterpret_cast<uint16_t *>(rstd_l1_read_ptr);
+                uint32_t n_start = 0;
+                uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+                for (uint32_t n = n_start; n < n_end; n++) {
+                    uint32_t src_idx = get_tilized_idx(n, 0);
+                    uint32_t dst_idx = get_tilized_idx(n, group_idx);
+
+                    rstd_ptr[dst_idx] = rstd_ptr[src_idx];
+                }
+            }
+
+            uint32_t noc_id = nt * div_up(num_groups, TILE_WIDTH) + (group_idx / TILE_WIDTH);
+            const auto rstd_noc_addr = get_noc_addr(noc_id, rstd_addrg);
+            uint32_t n_start = 0;
+            uint32_t n_end = std::min((nt + 1) * TILE_HEIGHT, N);
+
+            for (uint32_t n = n_start; n < n_end; n++) {
+                uint32_t dst_idx = get_tilized_idx(n, group_idx);
+                noc_async_write(
+                    rstd_l1_read_ptr + dst_idx * rstd_dtype_bytes,
+                    rstd_noc_addr + dst_idx * rstd_dtype_bytes,
+                    rstd_dtype_bytes);
+            }
+            noc_async_write_barrier();
+            cb_pop_front(cb_rstd, onetile);
+        }
+    }
+}  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm_3d.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+template <typename T>
+FORCE_INLINE void write_output(
+    uint32_t cb_id,
+    T addrgen,
+    uint32_t write_start,
+    uint32_t write_end,
+    uint32_t n,
+    uint32_t wt,
+    uint32_t Ct,
+    uint32_t Wt) {
+    constexpr uint32_t onetile = 1;
+    const auto elem_size = get_tile_size(cb_id) >> 10;
+
+    cb_wait_front(cb_id, onetile);
+    auto l1_read_addr = get_read_ptr(cb_id);
+
+    // output[N, C, W]
+    uint32_t ct = write_start / TILE_HEIGHT;
+    auto noc_id = n * Ct * Wt + ct * Wt + wt;
+    auto noc_addr = get_noc_addr(noc_id, addrgen);
+
+    uint32_t c_start = write_start;
+    uint32_t c_end = write_end;
+    auto noc_write_size = FACE_WIDTH * elem_size;
+    for (uint32_t c = c_start; c < c_end; c++) {
+        uint32_t tilized_idx = get_tilized_idx(c, 0);
+        uint32_t offset = tilized_idx * elem_size;
+        noc_async_write(l1_read_addr + offset, noc_addr + offset, noc_write_size);
+
+        tilized_idx = get_tilized_idx(c, FACE_WIDTH);
+        offset = tilized_idx * elem_size;
+        noc_async_write(l1_read_addr + offset, noc_addr + offset, noc_write_size);
+    }
+
+    noc_async_write_barrier();
+
+    cb_pop_front(cb_id, onetile);
+}
+
+void kernel_main() {
+    int i{0};
+    const auto output_addr = get_arg_val<uint32_t>(i++);
+    const auto mean_addr = get_arg_val<uint32_t>(i++);
+    const auto rstd_addr = get_arg_val<uint32_t>(i++);
+
+    const auto unit_offset = get_arg_val<uint32_t>(i++);
+    const auto num_units_per_core = get_arg_val<uint32_t>(i++);
+
+    const auto C = get_arg_val<uint32_t>(i++);
+    const auto W = get_arg_val<uint32_t>(i++);
+    const auto num_groups = get_arg_val<uint32_t>(i++);
+
+    // compile-time args
+    constexpr bool output_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool mean_has_value = get_compile_time_arg_val(1) == 1;
+    constexpr bool mean_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool rstd_has_value = get_compile_time_arg_val(3) == 1;
+    constexpr bool rstd_is_dram = get_compile_time_arg_val(4) == 1;
+
+    uint32_t cb_id = tt::CB::c_out0;
+    const auto cb_output = cb_id++;
+    const auto cb_mean = cb_id++;
+    const auto cb_rstd = cb_id++;
+
+    uint32_t Ct = div_up(C, TILE_HEIGHT);
+    uint32_t Wt = div_up(W, TILE_WIDTH);
+
+    // output
+    const uint32_t output_tile_bytes = get_tile_size(cb_output);
+    const auto output_data_format = get_dataformat(cb_output);
+    const auto output_elem_size = get_tile_size(cb_output) >> 10;
+
+    const InterleavedAddrGenFast<output_is_dram> output_addrgen = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    constexpr uint32_t onetile = 1;
+
+    for (uint32_t outer_idx = 0; outer_idx < num_units_per_core; ++outer_idx) {
+        // input[N, C, W]
+        // reshaped_input[N, num_groups, C / num_groups, W]
+        auto unit_idx = unit_offset + outer_idx;
+        auto group_idx = unit_idx % num_groups;
+        auto n = unit_idx / num_groups;
+
+        uint32_t c_size_per_unit = C / num_groups;
+        uint32_t c_start = c_size_per_unit * group_idx;
+        uint32_t c_end = c_size_per_unit * (group_idx + 1);
+
+        uint32_t write_start = c_start;
+        uint32_t write_end = c_start;
+
+        for (;;) {
+            // write range [c_start, c_end)
+            write_start = write_end;
+            write_end = std::min(round_up(write_start + 1, TILE_WIDTH), c_end);
+
+            if (write_start >= c_end) {
+                break;
+            }
+
+            bool is_tile_end = (write_end % TILE_WIDTH == 0);
+            bool is_last = (write_end == c_end);
+            if (is_tile_end || is_last) {
+                for (uint32_t wt = 0; wt < Wt; wt++) {
+                    write_output(cb_output, output_addrgen, write_start, write_end, n, wt, Ct, Wt);
+                }
+            }
+        }
+
+        // mean
+        // shape: [N, num_groups]
+        if (mean_has_value) {
+            const uint32_t mean_tile_bytes = get_tile_size(cb_mean);
+            const auto mean_data_format = get_dataformat(cb_mean);
+            const auto mean_dtype_bytes = mean_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
+
+            const InterleavedAddrGenFast<mean_is_dram> mean_addrg = {
+                .bank_base_address = mean_addr, .page_size = mean_tile_bytes, .data_format = mean_data_format};
+
+            cb_wait_front(cb_mean, onetile);
+            const auto mean_l1_read_ptr = get_read_ptr(cb_mean);
+
+            // shift [0, 0] -> [n, group_idx]
+            auto mean_ptr = reinterpret_cast<uint16_t *>(mean_l1_read_ptr);
+            uint32_t src_idx = 0;
+            uint32_t dst_idx = get_tilized_idx(n, group_idx);
+
+            mean_ptr[dst_idx] = mean_ptr[src_idx];
+
+            uint32_t nt = n / TILE_HEIGHT;
+            uint32_t noc_id = nt * div_up(num_groups, TILE_WIDTH) + (group_idx / TILE_WIDTH);
+            const auto mean_noc_addr = get_noc_addr(noc_id, mean_addrg);
+
+            noc_async_write(
+                mean_l1_read_ptr + dst_idx * mean_dtype_bytes,
+                mean_noc_addr + dst_idx * mean_dtype_bytes,
+                mean_dtype_bytes);
+
+            noc_async_write_barrier();
+            cb_pop_front(cb_mean, onetile);
+        }  // if (mean_has_value)
+
+        // rstd
+        // shape: [N, num_groups]
+        if (rstd_has_value) {
+            const uint32_t rstd_tile_bytes = get_tile_size(cb_rstd);
+            const auto rstd_data_format = get_dataformat(cb_rstd);
+            const auto rstd_dtype_bytes = rstd_tile_bytes / (TILE_HEIGHT * TILE_WIDTH);
+
+            const InterleavedAddrGenFast<rstd_is_dram> rstd_addrg = {
+                .bank_base_address = rstd_addr, .page_size = rstd_tile_bytes, .data_format = rstd_data_format};
+
+            cb_wait_front(cb_rstd, onetile);
+            const auto rstd_l1_read_ptr = get_read_ptr(cb_rstd);
+
+            // shift [0, 0] -> [n, group_idx]
+            auto rstd_ptr = reinterpret_cast<uint16_t *>(rstd_l1_read_ptr);
+            uint32_t src_idx = 0;
+            uint32_t dst_idx = get_tilized_idx(n, group_idx);
+
+            rstd_ptr[dst_idx] = rstd_ptr[src_idx];
+
+            uint32_t nt = n / TILE_HEIGHT;
+            uint32_t noc_id = nt * div_up(num_groups, TILE_WIDTH) + (group_idx / TILE_WIDTH);
+            const auto rstd_noc_addr = get_noc_addr(noc_id, rstd_addrg);
+
+            noc_async_write(
+                rstd_l1_read_ptr + dst_idx * rstd_dtype_bytes,
+                rstd_noc_addr + dst_idx * rstd_dtype_bytes,
+                rstd_dtype_bytes);
+
+            noc_async_write_barrier();
+            cb_pop_front(cb_rstd, onetile);
+        }  // if (rstd_has_value)
+    }
+
+}  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_2d_program_factory.cpp
@@ -6,19 +6,9 @@
 #include "tt_metal/common/work_split.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
-inline uint32_t get_block_size(uint32_t num_tiles, uint32_t max_block_size) {
-    uint32_t block_size{1};
-    for (uint32_t current_block_size = max_block_size; current_block_size >= 1; current_block_size >>= 1) {
-        if (num_tiles % current_block_size == 0) {
-            block_size = current_block_size;
-            break;
-        }
-    }
-    return block_size;
-}
-
 namespace ttnn::operations::moreh::moreh_group_norm {
-MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormOperation::MorehGroupNormFactory::create(
+MorehGroupNormOperation::MorehGroupNorm2DFactory::cached_program_t
+MorehGroupNormOperation::MorehGroupNorm2DFactory::create(
     const operation_attributes_t &operation_attributes,
     const tensor_args_t &tensor_args,
     tensor_return_value_t &outputs) {
@@ -29,8 +19,8 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     const auto &input = tensor_args.input;
     auto gamma = tensor_args.gamma;
     auto beta = tensor_args.beta;
-    auto mean = outputs[1];
-    auto rstd = outputs[2];
+    const std::optional<const Tensor> mean = outputs[1];
+    const std::optional<const Tensor> rstd = outputs[2];
 
     auto &output = outputs[0].value();
 
@@ -51,38 +41,13 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
 
     const auto n = input_shape[0];
     const auto c = input_shape[1];
-    const auto h = input_shape[-2];
-    const auto w = input_shape[-1];
 
-    const bool do_mask_h = (h % TILE_HEIGHT) != 0;
-    const auto mask_h = do_mask_h ? h % TILE_HEIGHT : TILE_HEIGHT;
-
-    const bool do_mask_w = (w % TILE_WIDTH) != 0;
-    const auto mask_w = do_mask_w ? w % TILE_WIDTH : TILE_WIDTH;
-
-    const auto Ht = div_up(h, TILE_HEIGHT);
-    const auto Wt = div_up(w, TILE_WIDTH);
-
-    const auto num_units = n * num_groups;
-    const auto num_inner_tiles = input.get_logical_volume() / n / h / w * Ht * Wt / num_groups;
-    const auto c_inner_tiles = num_inner_tiles * num_groups / c;
-
-    auto scaler = 1.0f / static_cast<float>(sqrt(input.get_logical_volume() / n / num_groups));
+    const auto nt = div_up(n, TILE_HEIGHT);
 
     const bool gamma_has_value = gamma.has_value();
     const bool beta_has_value = beta.has_value();
     const bool mean_has_value = mean.has_value();
     const bool rstd_has_value = rstd.has_value();
-
-    auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(arch, compute_kernel_config);
-
-    uint32_t MAX_BLOCK_SIZE = 4;
-    if (fp32_dest_acc_en) {
-        MAX_BLOCK_SIZE = 2;
-    }
-    const uint32_t block_size = get_block_size(num_inner_tiles, MAX_BLOCK_SIZE);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
@@ -90,62 +55,52 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     auto grid = device->compute_with_storage_grid_size();
     const auto num_cores_y = grid.y;
 
+    const auto num_units = nt * num_groups;
+
     const auto
         [num_cores_to_be_used,
          all_cores,
          core_group_1,
          core_group_2,
          num_units_per_core_group_1,
-         num_units_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_units);
+         num_units_per_core_group_2] = split_work_to_cores(grid, num_units);
 
     log_debug(LogTest, "num_cores_to_be_used: {}", num_cores_to_be_used);
     log_debug(LogTest, "num_units_per_core_group_1: {}", num_units_per_core_group_1);
     log_debug(LogTest, "num_units_per_core_group_2: {}", num_units_per_core_group_2);
-    log_debug(LogTest, "block_size: {}", block_size);
+
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(arch, compute_kernel_config);
+
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
-    uint32_t in0_t = num_inner_tiles;                         // input
-    const uint32_t in1_t = 1;                                 // scaler
-    const uint32_t in2_t = 1;                                 // epsilon
-    const uint32_t in3_t = gamma_has_value ? block_size : 0;  // gamma
-    const uint32_t in4_t = beta_has_value ? block_size : 0;   // beta
-    const uint32_t in5_t = do_mask_h ? 1 : 0;                 // mask_h
-    const uint32_t in6_t = do_mask_w ? 1 : 0;                 // mask_w
-    const uint32_t in7_t = 1;                                 // zeros
+    uint32_t in0_t = 1;                              // input
+    const uint32_t in1_t = 1;                        // scaler
+    const uint32_t in2_t = 1;                        // epsilon
+    const uint32_t in3_t = gamma_has_value ? 1 : 0;  // gamma
+    const uint32_t in4_t = beta_has_value ? 1 : 0;   // beta
+    const uint32_t in5_t = 1;                        // mask_w
+    const uint32_t in6_t = 1;                        // zeros
 
-    const uint32_t out0_t = block_size;              // output
+    const uint32_t out0_t = 1;                       // output
     const uint32_t out1_t = mean_has_value ? 1 : 0;  // mean
     const uint32_t out2_t = rstd_has_value ? 1 : 0;  // rstd
 
-    const uint32_t im0_t = 1;                                                         // E[x]
-    uint32_t im1_t = num_inner_tiles;                                                 // x - E[x]
-    uint32_t im2_t = 1;                                                               // (x - E[x])^2
-    const uint32_t im3_t = 1;                                                         // Sum[(x - E[x])^2]
-    const uint32_t im4_t = 1;                                                         // E[(x - E[x])^2] = Var[x]
-    const uint32_t im5_t = 1;                                                         // 1.0/(sqrt(Var[x] + eps))
-    const uint32_t im6_t = (gamma_has_value || beta_has_value) ? 2 * block_size : 0;  // x * gamm + beta
-    const uint32_t im7_t = 2;                                                         // Sum[x]
+    const uint32_t im0_t = 1;                                                // E[x]
+    uint32_t im1_t = 1;                                                      // x - E[x]
+    uint32_t im2_t = 1;                                                      // (x - E[x])^2
+    const uint32_t im3_t = 1;                                                // Sum[(x - E[x])^2]
+    const uint32_t im4_t = 1;                                                // E[(x - E[x])^2] = Var[x]
+    const uint32_t im5_t = 1;                                                // 1.0/(sqrt(Var[x] + eps))
+    const uint32_t im6_t = (gamma_has_value || beta_has_value) ? 2 * 1 : 0;  // x * gamm + beta
+    const uint32_t im7_t = 2;                                                // Sum[x]
 
-    const auto cb_data_format = datatype_to_dataformat_converter(input.get_dtype());
+    const auto cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
     const auto single_tile_size = tt_metal::detail::TileSize(cb_data_format);
-    auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
-    const auto intermed_single_tile_size = tt::tt_metal::detail::TileSize(intermed_data_format);
-
-    const auto cb_usage = (in0_t + in3_t + in4_t + in5_t + in6_t + out0_t + out1_t + out2_t) * single_tile_size +
-                          (in1_t + in2_t + in7_t + im0_t + im1_t + im2_t + im3_t + im4_t + im5_t + im6_t + im7_t) *
-                              intermed_single_tile_size;
-    const auto available_L1 = device->l1_size_per_core() - device->get_base_allocator_addr(HalMemType::L1);
-    const bool use_large_algorithm = cb_usage >= available_L1;
-
-    if (use_large_algorithm) {
-        log_info(LogTest, "Large moreh_group_norm algorithm is selected.");
-        in0_t = block_size;
-        im1_t = 2 * block_size;
-        im2_t = 2 * block_size;
-    } else {
-        log_info(LogTest, "Small moreh_group_norm algorithm is selected.");
-    }
+    const auto intermed_single_tile_size = tt_metal::detail::TileSize(intermed_data_format);
 
     CreateCircularBuffer(
         program,
@@ -157,9 +112,8 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
             {CB::c_in2, in2_t, intermed_data_format},        // eps
             {CB::c_in3, in3_t},                              // gamma
             {CB::c_in4, in4_t},                              // beta
-            {CB::c_in5, in5_t},                              // mask_h
-            {CB::c_in6, in6_t},                              // mask_w
-            {CB::c_in7, in7_t, intermed_data_format},        // zeros
+            {CB::c_in5, in5_t},                              // mask
+            {CB::c_in6, in6_t, intermed_data_format},        // zeros
             {CB::c_out0, out0_t},                            // output
             {CB::c_out1, out1_t},                            // mean
             {CB::c_out2, out2_t},                            // rstd
@@ -170,64 +124,67 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
             {CB::c_intermed4, im4_t, intermed_data_format},  // E[(x - E[x])^2] = Var[x]
             {CB::c_intermed5, im5_t, intermed_data_format},  // 1.0/(sqrt(Var[x] + eps))
             {CB::c_intermed6, im6_t, intermed_data_format},  // y * gamm + beta
-            {CB::c_intermed7, im7_t, intermed_data_format},  // Sum[x]
+            {CB::c_intermed7, im7_t, intermed_data_format}   // Sum[x]
         });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto reader_kernel_file = use_large_algorithm ? "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/"
-                                                          "kernels/reader_moreh_group_norm_large.cpp"
-                                                        : "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/"
-                                                          "kernels/reader_moreh_group_norm_small.cpp";
+    const std::vector<uint32_t> reader_compile_time_args{
+        static_cast<uint32_t>(is_dram(input)),
+        static_cast<uint32_t>(gamma_has_value),
+        static_cast<uint32_t>(is_dram(gamma)),
+        static_cast<uint32_t>(beta_has_value),
+        static_cast<uint32_t>(is_dram(beta))};
+    const std::vector<uint32_t> writer_compile_time_args{
+        static_cast<uint32_t>(is_dram(output)),
+        static_cast<uint32_t>(mean_has_value),
+        static_cast<uint32_t>(is_dram(mean)),
+        static_cast<uint32_t>(rstd_has_value),
+        static_cast<uint32_t>(is_dram(rstd))};
 
-    const std::string writer_kernel_file(
-        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm.cpp");
+    const auto reader_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_2d.cpp";
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores);
+    const auto writer_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm_2d.cpp";
+
+    std::map<string, string> reader_defines{};
+    std::map<string, string> writer_defines{};
+
+    const auto reader_kernels_id =
+        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
+    const auto writer_kernels_id =
+        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
     std::map<std::string, std::string> compute_defines{};
     compute_defines["REDUCE_OP"] = "PoolType::SUM";
-    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_SCALAR";
+    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
     if (fp32_dest_acc_en) {
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
     const auto compute_kernel_file =
-        use_large_algorithm
-            ? "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_large_kernel.cpp"
-            : "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_small_kernel.cpp";
+        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_2d.cpp";
 
     const std::vector<uint32_t> compute_args_group_1{
         num_units_per_core_group_1,
-        h,
-        w,
-        num_inner_tiles,
-        block_size,
         static_cast<uint32_t>(gamma_has_value),
         static_cast<uint32_t>(beta_has_value),
         static_cast<uint32_t>(mean_has_value),
-        static_cast<uint32_t>(rstd_has_value),
-    };
+        static_cast<uint32_t>(rstd_has_value)};
 
     const std::vector<uint32_t> compute_args_group_2{
         num_units_per_core_group_2,
-        h,
-        w,
-        num_inner_tiles,
-        block_size,
         static_cast<uint32_t>(gamma_has_value),
         static_cast<uint32_t>(beta_has_value),
         static_cast<uint32_t>(mean_has_value),
-        static_cast<uint32_t>(rstd_has_value),
-    };
+        static_cast<uint32_t>(rstd_has_value)};
 
     vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-
     auto compute_kernel_ids = CreateComputeKernel(
         program,
         compute_kernel_file,
@@ -255,14 +212,23 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0;
     const auto beta_addr = beta_has_value ? beta.value().buffer()->address() : 0;
 
-    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+    union {
+        float f;
+        uint32_t u;
+    } scaler;
+
+    scaler.f = 1.0f / (static_cast<float>(c) / num_groups);
+
+    for (uint32_t i = 0, unit_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
-        uint32_t num_rows_per_core;
+        uint32_t num_units_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
-            num_rows_per_core = num_units_per_core_group_1;
+            num_units_per_core = num_units_per_core_group_1;
+            SetRuntimeArgs(program, compute_kernel_ids[0], core, {c, num_groups, unit_offset});
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            num_rows_per_core = num_units_per_core_group_2;
+            num_units_per_core = num_units_per_core_group_2;
+            SetRuntimeArgs(program, compute_kernel_ids[1], core, {c, num_groups, unit_offset});
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
@@ -270,53 +236,38 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
         // reader
         const std::vector<uint32_t> reader_runtime_args{
             input_addr,
-            static_cast<uint32_t>(is_dram(input)),
             gamma_addr,
-            static_cast<uint32_t>(is_dram(gamma)),
-            static_cast<uint32_t>(gamma_has_value),
             beta_addr,
-            static_cast<uint32_t>(is_dram(beta)),
-            static_cast<uint32_t>(beta_has_value),
-            *reinterpret_cast<uint32_t *>(&scaler),
+            scaler.u,
             *reinterpret_cast<uint32_t *>(&eps),
-            tile_offset,
-            num_rows_per_core,
-            num_inner_tiles,
-            c_inner_tiles,
+            unit_offset,
+            num_units_per_core,
             n,
             c,
-            h,
-            w,
             num_groups,
-            block_size,
         };
         SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
 
         // writer
         const std::vector<uint32_t> writer_runtime_args{
             output_addr,
-            static_cast<uint32_t>(is_dram(output)),
             mean_addr,
-            static_cast<uint32_t>(mean_has_value ? is_dram(mean.value()) : 1),
-            static_cast<uint32_t>(mean_has_value),
             rstd_addr,
-            static_cast<uint32_t>(rstd_has_value ? is_dram(rstd.value()) : 1),
-            static_cast<uint32_t>(rstd_has_value),
-            tile_offset,
-            num_rows_per_core,
-            num_inner_tiles,
+            unit_offset,
+            num_units_per_core,
+            n,
+            c,
             num_groups,
-            block_size,
         };
         SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
 
-        tile_offset += num_rows_per_core;
+        unit_offset += num_units_per_core;
     }
 
     return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
 }
 
-void MorehGroupNormOperation::MorehGroupNormFactory::override_runtime_arguments(
+void MorehGroupNormOperation::MorehGroupNorm2DFactory::override_runtime_arguments(
     cached_program_t &cached_program,
     const operation_attributes_t &operation_attributes,
     const tensor_args_t &tensor_args,
@@ -341,10 +292,10 @@ void MorehGroupNormOperation::MorehGroupNormFactory::override_runtime_arguments(
             auto &runtime_args = GetRuntimeArgs(cached_program.program, reader_kernels_id, core);
             runtime_args[0] = input_buffer->address();
             if (gamma_buffer != nullptr) {
-                runtime_args[2] = gamma_buffer->address();
+                runtime_args[1] = gamma_buffer->address();
             }
             if (beta_buffer != nullptr) {
-                runtime_args[5] = beta_buffer->address();
+                runtime_args[2] = beta_buffer->address();
             }
         }
 
@@ -352,10 +303,10 @@ void MorehGroupNormOperation::MorehGroupNormFactory::override_runtime_arguments(
             auto &runtime_args = GetRuntimeArgs(cached_program.program, writer_kernels_id, core);
             runtime_args[0] = ouput_buffer->address();
             if (mean_buffer != nullptr) {
-                runtime_args[2] = mean_buffer->address();
+                runtime_args[1] = mean_buffer->address();
             }
             if (rstd_buffer != nullptr) {
-                runtime_args[5] = rstd_buffer->address();
+                runtime_args[2] = rstd_buffer->address();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_3d_program_factory.cpp
@@ -6,19 +6,9 @@
 #include "tt_metal/common/work_split.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
-inline uint32_t get_block_size(uint32_t num_tiles, uint32_t max_block_size) {
-    uint32_t block_size{1};
-    for (uint32_t current_block_size = max_block_size; current_block_size >= 1; current_block_size >>= 1) {
-        if (num_tiles % current_block_size == 0) {
-            block_size = current_block_size;
-            break;
-        }
-    }
-    return block_size;
-}
-
 namespace ttnn::operations::moreh::moreh_group_norm {
-MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormOperation::MorehGroupNormFactory::create(
+MorehGroupNormOperation::MorehGroupNorm3DFactory::cached_program_t
+MorehGroupNormOperation::MorehGroupNorm3DFactory::create(
     const operation_attributes_t &operation_attributes,
     const tensor_args_t &tensor_args,
     tensor_return_value_t &outputs) {
@@ -29,8 +19,8 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     const auto &input = tensor_args.input;
     auto gamma = tensor_args.gamma;
     auto beta = tensor_args.beta;
-    auto mean = outputs[1];
-    auto rstd = outputs[2];
+    const std::optional<const Tensor> mean = outputs[1];
+    const std::optional<const Tensor> rstd = outputs[2];
 
     auto &output = outputs[0].value();
 
@@ -51,44 +41,21 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
 
     const auto n = input_shape[0];
     const auto c = input_shape[1];
-    const auto h = input_shape[-2];
-    const auto w = input_shape[-1];
-
-    const bool do_mask_h = (h % TILE_HEIGHT) != 0;
-    const auto mask_h = do_mask_h ? h % TILE_HEIGHT : TILE_HEIGHT;
-
-    const bool do_mask_w = (w % TILE_WIDTH) != 0;
-    const auto mask_w = do_mask_w ? w % TILE_WIDTH : TILE_WIDTH;
-
-    const auto Ht = div_up(h, TILE_HEIGHT);
-    const auto Wt = div_up(w, TILE_WIDTH);
-
-    const auto num_units = n * num_groups;
-    const auto num_inner_tiles = input.get_logical_volume() / n / h / w * Ht * Wt / num_groups;
-    const auto c_inner_tiles = num_inner_tiles * num_groups / c;
-
-    auto scaler = 1.0f / static_cast<float>(sqrt(input.get_logical_volume() / n / num_groups));
+    const auto w = input_shape[2];
 
     const bool gamma_has_value = gamma.has_value();
     const bool beta_has_value = beta.has_value();
     const bool mean_has_value = mean.has_value();
     const bool rstd_has_value = rstd.has_value();
 
-    auto arch = input.device()->arch();
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(arch, compute_kernel_config);
-
-    uint32_t MAX_BLOCK_SIZE = 4;
-    if (fp32_dest_acc_en) {
-        MAX_BLOCK_SIZE = 2;
-    }
-    const uint32_t block_size = get_block_size(num_inner_tiles, MAX_BLOCK_SIZE);
-
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
     auto grid = device->compute_with_storage_grid_size();
+
     const auto num_cores_y = grid.y;
+
+    const auto num_units = n * num_groups;
 
     const auto
         [num_cores_to_be_used,
@@ -96,56 +63,45 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
          core_group_1,
          core_group_2,
          num_units_per_core_group_1,
-         num_units_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_units);
+         num_units_per_core_group_2] = split_work_to_cores(grid, num_units);
 
     log_debug(LogTest, "num_cores_to_be_used: {}", num_cores_to_be_used);
     log_debug(LogTest, "num_units_per_core_group_1: {}", num_units_per_core_group_1);
     log_debug(LogTest, "num_units_per_core_group_2: {}", num_units_per_core_group_2);
-    log_debug(LogTest, "block_size: {}", block_size);
+
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(arch, compute_kernel_config);
+
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
-    uint32_t in0_t = num_inner_tiles;                         // input
-    const uint32_t in1_t = 1;                                 // scaler
-    const uint32_t in2_t = 1;                                 // epsilon
-    const uint32_t in3_t = gamma_has_value ? block_size : 0;  // gamma
-    const uint32_t in4_t = beta_has_value ? block_size : 0;   // beta
-    const uint32_t in5_t = do_mask_h ? 1 : 0;                 // mask_h
-    const uint32_t in6_t = do_mask_w ? 1 : 0;                 // mask_w
-    const uint32_t in7_t = 1;                                 // zeros
+    uint32_t in0_t = 1;                              // input
+    const uint32_t in1_t = 1;                        // scaler
+    const uint32_t in2_t = 1;                        // epsilon
+    const uint32_t in3_t = gamma_has_value ? 1 : 0;  // gamma
+    const uint32_t in4_t = beta_has_value ? 1 : 0;   // beta
+    const uint32_t in5_t = 1;                        // mask_h
+    const uint32_t in6_t = 1;                        // mask_w
+    const uint32_t in7_t = 1;                        // zeros
 
-    const uint32_t out0_t = block_size;              // output
+    const uint32_t out0_t = 1;                       // output
     const uint32_t out1_t = mean_has_value ? 1 : 0;  // mean
     const uint32_t out2_t = rstd_has_value ? 1 : 0;  // rstd
 
-    const uint32_t im0_t = 1;                                                         // E[x]
-    uint32_t im1_t = num_inner_tiles;                                                 // x - E[x]
-    uint32_t im2_t = 1;                                                               // (x - E[x])^2
-    const uint32_t im3_t = 1;                                                         // Sum[(x - E[x])^2]
-    const uint32_t im4_t = 1;                                                         // E[(x - E[x])^2] = Var[x]
-    const uint32_t im5_t = 1;                                                         // 1.0/(sqrt(Var[x] + eps))
-    const uint32_t im6_t = (gamma_has_value || beta_has_value) ? 2 * block_size : 0;  // x * gamm + beta
-    const uint32_t im7_t = 2;                                                         // Sum[x]
+    const uint32_t im0_t = 1;                                                // E[x]
+    uint32_t im1_t = 1;                                                      // x - E[x]
+    uint32_t im2_t = 1;                                                      // (x - E[x])^2
+    const uint32_t im3_t = 1;                                                // Sum[(x - E[x])^2]
+    const uint32_t im4_t = 1;                                                // E[(x - E[x])^2] = Var[x]
+    const uint32_t im5_t = 1;                                                // 1.0/(sqrt(Var[x] + eps))
+    const uint32_t im6_t = (gamma_has_value || beta_has_value) ? 2 * 1 : 0;  // x * gamm + beta
+    const uint32_t im7_t = 2;                                                // Sum[x]
 
-    const auto cb_data_format = datatype_to_dataformat_converter(input.get_dtype());
+    const auto cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    const auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
     const auto single_tile_size = tt_metal::detail::TileSize(cb_data_format);
-    auto intermed_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : cb_data_format;
-    const auto intermed_single_tile_size = tt::tt_metal::detail::TileSize(intermed_data_format);
-
-    const auto cb_usage = (in0_t + in3_t + in4_t + in5_t + in6_t + out0_t + out1_t + out2_t) * single_tile_size +
-                          (in1_t + in2_t + in7_t + im0_t + im1_t + im2_t + im3_t + im4_t + im5_t + im6_t + im7_t) *
-                              intermed_single_tile_size;
-    const auto available_L1 = device->l1_size_per_core() - device->get_base_allocator_addr(HalMemType::L1);
-    const bool use_large_algorithm = cb_usage >= available_L1;
-
-    if (use_large_algorithm) {
-        log_info(LogTest, "Large moreh_group_norm algorithm is selected.");
-        in0_t = block_size;
-        im1_t = 2 * block_size;
-        im2_t = 2 * block_size;
-    } else {
-        log_info(LogTest, "Small moreh_group_norm algorithm is selected.");
-    }
+    const auto intermed_single_tile_size = tt_metal::detail::TileSize(intermed_data_format);
 
     CreateCircularBuffer(
         program,
@@ -176,16 +132,32 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const auto reader_kernel_file = use_large_algorithm ? "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/"
-                                                          "kernels/reader_moreh_group_norm_large.cpp"
-                                                        : "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/"
-                                                          "kernels/reader_moreh_group_norm_small.cpp";
+    const std::vector<uint32_t> reader_compile_time_args{
+        static_cast<uint32_t>(is_dram(input)),
+        static_cast<uint32_t>(gamma_has_value),
+        static_cast<uint32_t>(is_dram(gamma)),
+        static_cast<uint32_t>(beta_has_value),
+        static_cast<uint32_t>(is_dram(beta))};
+    const std::vector<uint32_t> writer_compile_time_args{
+        static_cast<uint32_t>(is_dram(output)),
+        static_cast<uint32_t>(mean_has_value),
+        static_cast<uint32_t>(is_dram(mean)),
+        static_cast<uint32_t>(rstd_has_value),
+        static_cast<uint32_t>(is_dram(rstd))};
 
-    const std::string writer_kernel_file(
-        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm.cpp");
+    const auto reader_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/reader_moreh_group_norm_3d.cpp";
 
-    const auto reader_kernels_id = CreateReadKernel(program, reader_kernel_file, all_cores);
-    const auto writer_kernels_id = CreateWriteKernel(program, writer_kernel_file, all_cores);
+    const auto writer_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/writer_moreh_group_norm_3d.cpp";
+
+    std::map<string, string> reader_defines{};
+    std::map<string, string> writer_defines{};
+
+    const auto reader_kernels_id =
+        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
+    const auto writer_kernels_id =
+        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, writer_defines);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
@@ -198,36 +170,23 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     }
 
     const auto compute_kernel_file =
-        use_large_algorithm
-            ? "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_large_kernel.cpp"
-            : "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_small_kernel.cpp";
+        "ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/kernels/moreh_group_norm_3d.cpp";
 
     const std::vector<uint32_t> compute_args_group_1{
         num_units_per_core_group_1,
-        h,
-        w,
-        num_inner_tiles,
-        block_size,
         static_cast<uint32_t>(gamma_has_value),
         static_cast<uint32_t>(beta_has_value),
         static_cast<uint32_t>(mean_has_value),
-        static_cast<uint32_t>(rstd_has_value),
-    };
+        static_cast<uint32_t>(rstd_has_value)};
 
     const std::vector<uint32_t> compute_args_group_2{
         num_units_per_core_group_2,
-        h,
-        w,
-        num_inner_tiles,
-        block_size,
         static_cast<uint32_t>(gamma_has_value),
         static_cast<uint32_t>(beta_has_value),
         static_cast<uint32_t>(mean_has_value),
-        static_cast<uint32_t>(rstd_has_value),
-    };
+        static_cast<uint32_t>(rstd_has_value)};
 
     vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-
     auto compute_kernel_ids = CreateComputeKernel(
         program,
         compute_kernel_file,
@@ -255,14 +214,23 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     const auto gamma_addr = gamma_has_value ? gamma.value().buffer()->address() : 0;
     const auto beta_addr = beta_has_value ? beta.value().buffer()->address() : 0;
 
-    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+    union {
+        float f;
+        uint32_t u;
+    } scaler;
+
+    scaler.f = 1.0f / sqrt(static_cast<float>(c) / num_groups * w);
+
+    for (uint32_t i = 0, unit_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
-        uint32_t num_rows_per_core;
+        uint32_t num_units_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
-            num_rows_per_core = num_units_per_core_group_1;
+            num_units_per_core = num_units_per_core_group_1;
+            SetRuntimeArgs(program, compute_kernel_ids[0], core, {c, w, num_groups, unit_offset});
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            num_rows_per_core = num_units_per_core_group_2;
+            num_units_per_core = num_units_per_core_group_2;
+            SetRuntimeArgs(program, compute_kernel_ids[1], core, {c, w, num_groups, unit_offset});
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
@@ -270,53 +238,38 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
         // reader
         const std::vector<uint32_t> reader_runtime_args{
             input_addr,
-            static_cast<uint32_t>(is_dram(input)),
             gamma_addr,
-            static_cast<uint32_t>(is_dram(gamma)),
-            static_cast<uint32_t>(gamma_has_value),
             beta_addr,
-            static_cast<uint32_t>(is_dram(beta)),
-            static_cast<uint32_t>(beta_has_value),
-            *reinterpret_cast<uint32_t *>(&scaler),
+            scaler.u,
             *reinterpret_cast<uint32_t *>(&eps),
-            tile_offset,
-            num_rows_per_core,
-            num_inner_tiles,
-            c_inner_tiles,
-            n,
+            unit_offset,
+            num_units_per_core,
             c,
-            h,
             w,
             num_groups,
-            block_size,
         };
         SetRuntimeArgs(program, reader_kernels_id, core, reader_runtime_args);
 
         // writer
         const std::vector<uint32_t> writer_runtime_args{
             output_addr,
-            static_cast<uint32_t>(is_dram(output)),
             mean_addr,
-            static_cast<uint32_t>(mean_has_value ? is_dram(mean.value()) : 1),
-            static_cast<uint32_t>(mean_has_value),
             rstd_addr,
-            static_cast<uint32_t>(rstd_has_value ? is_dram(rstd.value()) : 1),
-            static_cast<uint32_t>(rstd_has_value),
-            tile_offset,
-            num_rows_per_core,
-            num_inner_tiles,
+            unit_offset,
+            num_units_per_core,
+            c,
+            w,
             num_groups,
-            block_size,
         };
         SetRuntimeArgs(program, writer_kernels_id, core, writer_runtime_args);
 
-        tile_offset += num_rows_per_core;
+        unit_offset += num_units_per_core;
     }
 
     return {std::move(program), {reader_kernels_id, writer_kernels_id, num_cores_to_be_used, num_cores_y}};
 }
 
-void MorehGroupNormOperation::MorehGroupNormFactory::override_runtime_arguments(
+void MorehGroupNormOperation::MorehGroupNorm3DFactory::override_runtime_arguments(
     cached_program_t &cached_program,
     const operation_attributes_t &operation_attributes,
     const tensor_args_t &tensor_args,
@@ -341,10 +294,10 @@ void MorehGroupNormOperation::MorehGroupNormFactory::override_runtime_arguments(
             auto &runtime_args = GetRuntimeArgs(cached_program.program, reader_kernels_id, core);
             runtime_args[0] = input_buffer->address();
             if (gamma_buffer != nullptr) {
-                runtime_args[2] = gamma_buffer->address();
+                runtime_args[1] = gamma_buffer->address();
             }
             if (beta_buffer != nullptr) {
-                runtime_args[5] = beta_buffer->address();
+                runtime_args[2] = beta_buffer->address();
             }
         }
 
@@ -352,10 +305,10 @@ void MorehGroupNormOperation::MorehGroupNormFactory::override_runtime_arguments(
             auto &runtime_args = GetRuntimeArgs(cached_program.program, writer_kernels_id, core);
             runtime_args[0] = ouput_buffer->address();
             if (mean_buffer != nullptr) {
-                runtime_args[2] = mean_buffer->address();
+                runtime_args[1] = mean_buffer->address();
             }
             if (rstd_buffer != nullptr) {
-                runtime_args[5] = rstd_buffer->address();
+                runtime_args[2] = rstd_buffer->address();
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
@@ -30,6 +30,50 @@ struct MorehGroupNormOperation {
     using shape_return_value_t = std::vector<std::optional<SimpleShape>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
+    struct MorehGroupNorm2DFactory {
+        struct shared_variables_t {
+            KernelHandle reader_kernels_id;
+            KernelHandle writer_kernels_id;
+            uint32_t num_cores_to_be_used;
+            std::size_t num_cores_y;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& outputs);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& outputs);
+    };
+
+    struct MorehGroupNorm3DFactory {
+        struct shared_variables_t {
+            KernelHandle reader_kernels_id;
+            KernelHandle writer_kernels_id;
+            uint32_t num_cores_to_be_used;
+            std::size_t num_cores_y;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& outputs);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& outputs);
+    };
+
     struct MorehGroupNormFactory {
         struct shared_variables_t {
             KernelHandle reader_kernels_id;
@@ -52,7 +96,7 @@ struct MorehGroupNormOperation {
             tensor_return_value_t& outputs);
     };
 
-    using program_factory_t = std::variant<MorehGroupNormFactory>;
+    using program_factory_t = std::variant<MorehGroupNorm2DFactory, MorehGroupNorm3DFactory, MorehGroupNormFactory>;
 
     static void validate_tensors(const operation_attributes_t&, const tensor_args_t&);
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.hpp
@@ -45,4 +45,4 @@ namespace ttnn {
 constexpr auto moreh_group_norm = ttnn::register_operation_with_auto_launch_op<
     "ttnn::moreh_group_norm",
     ttnn::operations::moreh::moreh_group_norm::MorehGroupNorm>();
-}
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -203,6 +203,33 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     return compute_kernel_id;
 }
 
+[[maybe_unused]] KernelHandle CreateComputeKernel(
+    Program &program, const std::string &file_name, ComputeKernelArg arg, ComputeConfig config) {
+    KernelHandle compute_kernel_id{0};
+    if (arg.num_tile_per_core_group > 0) {
+        compute_kernel_id = CreateKernel(
+            program,
+            file_name,
+            arg.core_spec,
+            config);
+    }
+    return compute_kernel_id;
+}
+
+
+[[maybe_unused]] std::vector<KernelHandle> CreateComputeKernel(
+    Program &program, const std::string &file_name, std::vector<ComputeKernelArg> args, ComputeConfig config)
+{
+    std::vector<KernelHandle> compute_kernel_ids{};
+    KernelHandle compute_kernel_id{};
+    for (auto arg : args) {
+        config.compile_args = arg.compile_args;
+        compute_kernel_id = CreateComputeKernel(program, file_name, arg, config);
+        compute_kernel_ids.push_back(compute_kernel_id);
+    }
+    return compute_kernel_ids;
+}
+
 [[maybe_unused]] std::vector<CBHandle> CreateCircularBuffer(
     Program &program,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_range,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.hpp
@@ -117,6 +117,12 @@ struct ComputeKernelConfig {
 [[maybe_unused]] KernelHandle CreateComputeKernel(
     Program &program, const std::string &file_name, ComputeKernelArg arg, ComputeKernelConfig config);
 
+[[maybe_unused]] KernelHandle CreateComputeKernel(
+    Program &program, const std::string &file_name, ComputeKernelArg arg, ComputeConfig config);
+
+[[maybe_unused]] std::vector<KernelHandle> CreateComputeKernel(
+    Program &program, const std::string &file_name, std::vector<ComputeKernelArg> args, ComputeConfig config);
+
 struct CircularBufferArg {
     uint32_t buffer_index;
     uint32_t num_tiles;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11886

### Problem description
`moreh_groupnorm` needs refactoring as it currently does not support 
1. n-dimensional tensors 
2. optional output
3. fp32 dest accum

### What's changed
For this task, since the amount of code being modified is large, I plan to create separate PRs for the forward and backward operations.

refactoring `moreh_group_norm` forward
   1. add fp32_dest_acc_en support
   2. support non 4d tensor
   3. support optional output tensor

I am adding a new feature to the utility function.
1. Now, functions like `comp_allclose` will output both the index and the value that cause the failure when they fail.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
