### PR TITLE
#14132: Add BFP8 unit tests for moreh dot

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_dot.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_dot.py
@@ -55,9 +55,6 @@ def run_moreh_dot_test(input_shape, npu_dtype, device, optional_output=False):
     torch_other = torch.reshape(torch_other, (torch_other.shape[-1],))
     torch_out = torch.matmul(torch_input, torch_other)
 
-    if optional_output == True:
-        print(tt_out)
-        print(torch_out)
     # test for equivalance
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out[0][0][0][0], pcc=0.999, rtol=rtol, atol=atol)

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -19,392 +19,484 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 
 
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[50, 32], 1],  # single tile
-        [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
-        [[5, 6, 32, 32], 3],  # multiple cores
-        [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
-        [[32, 32], 0],  # single tile
-        [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
-        [[5, 6, 32, 32], 2],  # multiple cores
-        [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_dev.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[2, 3, 32 * 4, 32 * 5], 3],
-        [[2, 3, 32 * 4, 32 * 5], 2],
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    strategy = (
-        ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.logsoftmax(
-        dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-    )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[1, 1, 10, 15], 3],  # single tile
-        [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
-        [[1, 1, 15, 10], 2],  # single tile
-        [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[1, 15, 32, 32], 1],  # single tile c
-        [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
-        [[109, 15, 32, 32], 1],  # mutiple tiles per cores
-        [[15, 1, 32, 32], 0],  # single tile n
-        [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
-        [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[32, 32], 1],  # single tile
-        [[3, 32, 32 * 2], 2],  # mutiple tile with dim W
-        [[5, 6, 32, 32], 3],  # multiple cores
-        [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
-        [[32, 32], 0],  # single tile
-        [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
-        [[5, 6, 32, 32], 2],  # multiple cores
-        [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[2, 3, 32 * 4, 32 * 5], 3],
-        [[2, 3, 32 * 4, 32 * 5], 2],
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    strategy = (
-        ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(
-        dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-    )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[1, 1, 10, 15], 3],  # single tile
-        [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
-        [[1, 1, 15, 10], 2],  # single tile
-        [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("200")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    (
-        [[1, 15, 32, 32], 1],  # single tile c
-        [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
-        [[109, 15, 32, 32], 1],  # mutiple tiles per cores
-        [[15, 1, 32, 32], 0],  # single tile n
-        [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
-        [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
-    ),
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    [
-        [[32, 32], 1],
-    ],  # single tile
-)
-@pytest.mark.parametrize(
-    "optional_output_tensor",
-    (True, False),
-)
-def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, device):
-    device.enable_program_cache()
-
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    # cpu calculation
-    tt_cpu = F.log_softmax(x, dim)
-
-    # npu calculation
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    if optional_output_tensor:
-        dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, output_tensor=dev_y)
-    else:
-        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    [
-        [[32, 32], 1],
-    ],  # single tile
-)
-@pytest.mark.parametrize(
-    "optional_output_tensor",
-    (True, False),
-)
-def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
-    device.enable_program_cache()
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    # cpu calculation
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    y.backward(dy)
-
-    # npu calculation
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    if optional_output_tensor:
-        dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-        tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
-    else:
-        tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[50, 32], 1],  # single tile
+#         [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
+#         [[5, 6, 32, 32], 3],  # multiple cores
+#         [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
+#         [[32, 32], 0],  # single tile
+#         [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
+#         [[5, 6, 32, 32], 2],  # multiple cores
+#         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+
+#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     tt_cpu = F.log_softmax(x, dim)
+#     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
+
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+#     assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
+#     tt_dev = tt_dev.to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.1
+#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[2, 3, 32 * 4, 32 * 5], 3],
+#         [[2, 3, 32 * 4, 32 * 5], 2],
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+
+#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#     tt_cpu = F.log_softmax(x, dim)
+#     strategy = (
+#         ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
+#         if dim == 3
+#         else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
+#     )
+#     tt_npu = ttnn.operations.moreh.logsoftmax(
+#         dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
+#     )
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.1
+#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[1, 1, 10, 15], 3],  # single tile
+#         [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
+#         [[1, 1, 15, 10], 2],  # single tile
+#         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+
+#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     tt_cpu = F.log_softmax(x, dim)
+#     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
+#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+#     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.1
+#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[1, 15, 32, 32], 1],  # single tile c
+#         [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
+#         [[109, 15, 32, 32], 1],  # mutiple tiles per cores
+#         [[15, 1, 32, 32], 0],  # single tile n
+#         [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
+#         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+
+#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     tt_cpu = F.log_softmax(x, dim)
+#     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
+#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+#     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.1
+#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[32, 32], 1],  # single tile
+#         [[3, 32, 32 * 2], 2],  # mutiple tile with dim W
+#         [[5, 6, 32, 32], 3],  # multiple cores
+#         [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
+#         [[32, 32], 0],  # single tile
+#         [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
+#         [[5, 6, 32, 32], 2],  # multiple cores
+#         [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+#     y = F.log_softmax(x, dim)
+#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#     y.backward(dy)
+#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.5
+#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[2, 3, 32 * 4, 32 * 5], 3],
+#         [[2, 3, 32 * 4, 32 * 5], 2],
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+#     y = F.log_softmax(x, dim)
+#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#     y.backward(dy)
+#     strategy = (
+#         ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
+#         if dim == 3
+#         else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
+#     )
+#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(
+#         dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
+#     )
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.5
+#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[1, 1, 10, 15], 3],  # single tile
+#         [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
+#         [[1, 1, 15, 10], 2],  # single tile
+#         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+#     y = F.log_softmax(x, dim)
+#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("200")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     y.backward(dy)
+#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
+#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+#     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.1
+#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     (
+#         [[1, 15, 32, 32], 1],  # single tile c
+#         [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
+#         [[109, 15, 32, 32], 1],  # mutiple tiles per cores
+#         [[15, 1, 32, 32], 0],  # single tile n
+#         [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
+#         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
+#     ),
+# )
+# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+# def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+#     y = F.log_softmax(x, dim)
+#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
+
+#     y.backward(dy)
+#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
+#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+#     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.5
+#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     [
+#         [[32, 32], 1],
+#     ],  # single tile
+# )
+# @pytest.mark.parametrize(
+#     "optional_output_tensor",
+#     (True, False),
+# )
+# def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, device):
+#     device.enable_program_cache()
+
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+
+#     # cpu calculation
+#     tt_cpu = F.log_softmax(x, dim)
+
+#     # npu calculation
+#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+#     if optional_output_tensor:
+#         dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, output_tensor=dev_y)
+#     else:
+#         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim)
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.05
+#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+#     logger.info(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim",
+#     [
+#         [[32, 32], 1],
+#     ],  # single tile
+# )
+# @pytest.mark.parametrize(
+#     "optional_output_tensor",
+#     (True, False),
+# )
+# def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
+#     device.enable_program_cache()
+#     shape, dim = shape_dim
+#     torch.manual_seed(0)
+
+#     # cpu calculation
+#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+#     y = F.log_softmax(x, dim)
+#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+#     y.backward(dy)
+
+#     # npu calculation
+#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#     if optional_output_tensor:
+#         dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+#         tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
+#     else:
+#         tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim)
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.05
+#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+#     logger.info(out)
+#     assert passing
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim_strategy",
+#     (
+#         [[50, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
+#         [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
+#         [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
+#         [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
+#         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
+#     ),
+# )
+# def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
+#     shape, dim, strategy = shape_dim_strategy
+#     torch.manual_seed(0)
+
+#     for i in range(2):
+#         x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100 + i
+#         tt_cpu = F.log_softmax(x, dim)
+#         dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+#         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
+#         if i == 0:
+#             num_program_cache_entries = device.num_program_cache_entries()
+#             assert num_program_cache_entries > 0
+#         else:
+#             assert device.num_program_cache_entries() == num_program_cache_entries
+#         torch_dummy = torch.randn([32, 32])
+#         tt_dummy = to_ttnn(torch_dummy, device=device)
+
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+#     assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
+#     tt_dev = tt_dev.to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.1
+#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
+
+
+# def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cache_entries=None):
+#     """
+#     Runs a single step of logsoftmax_backward and checks the program cache if needed.
+#     """
+#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
+
+#     if num_program_cache_entries is not None:
+#         assert device.num_program_cache_entries() == num_program_cache_entries
+#     else:
+#         num_program_cache_entries = device.num_program_cache_entries()
+#         assert num_program_cache_entries > 0
+
+#     torch_dummy = torch.randn([32, 32])
+#     tt_dummy = to_ttnn(torch_dummy, device=device)
+#     return tt_npu, num_program_cache_entries
+
+
+# @pytest.mark.parametrize(
+#     "shape_dim_strategy",
+#     (
+#         [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
+#         [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
+#         [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
+#         [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
+#         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
+#     ),
+# )
+# def test_logsoftmax_backward_callback(shape_dim_strategy, device, use_program_cache):
+#     shape, dim, strategy = shape_dim_strategy
+#     torch.manual_seed(0)
+
+#     num_program_cache_entries = None
+#     for i in range(2):
+#         x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+#         y = F.log_softmax(x, dim)
+#         dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#         dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+#         dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+#         y.backward(dy)
+
+#         tt_npu, num_program_cache_entries = logsoftmax_backward_step(
+#             dev_y, dev_dy, dim, strategy, device, num_program_cache_entries
+#         )
+
+#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+#     rtol = atol = 0.5
+#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+#     logger.debug(out)
+#     assert passing
 
 
 @pytest.mark.parametrize(
@@ -417,22 +509,16 @@ def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_t
         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
     ),
 )
-def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
+def test_logsoftmax_bfp8(shape_dim_strategy, device, use_program_cache):
+    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
+    pytest.skip(f"bfloat8_b is not supported in the kernel")
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
 
-    for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100 + i
-        tt_cpu = F.log_softmax(x, dim)
-        dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
-        if i == 0:
-            num_program_cache_entries = device.num_program_cache_entries()
-            assert num_program_cache_entries > 0
-        else:
-            assert device.num_program_cache_entries() == num_program_cache_entries
-        torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+    tt_cpu = F.log_softmax(x, dim)
+    dev_x = ttnn.from_torch(x, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
 
     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
     assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
@@ -440,60 +526,5 @@ def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cache_entries=None):
-    """
-    Runs a single step of logsoftmax_backward and checks the program cache if needed.
-    """
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-    if num_program_cache_entries is not None:
-        assert device.num_program_cache_entries() == num_program_cache_entries
-    else:
-        num_program_cache_entries = device.num_program_cache_entries()
-        assert num_program_cache_entries > 0
-
-    torch_dummy = torch.randn([32, 32])
-    tt_dummy = to_ttnn(torch_dummy, device=device)
-    return tt_npu, num_program_cache_entries
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    (
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
-        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
-        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
-        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
-    ),
-)
-def test_logsoftmax_backward_callback(shape_dim_strategy, device, use_program_cache):
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    num_program_cache_entries = None
-    for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-        y = F.log_softmax(x, dim)
-        dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-        dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        y.backward(dy)
-
-        tt_npu, num_program_cache_entries = logsoftmax_backward_step(
-            dev_y, dev_dy, dim, strategy, device, num_program_cache_entries
-        )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -19,484 +19,484 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 
 
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[50, 32], 1],  # single tile
-#         [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
-#         [[5, 6, 32, 32], 3],  # multiple cores
-#         [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
-#         [[32, 32], 0],  # single tile
-#         [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
-#         [[5, 6, 32, 32], 2],  # multiple cores
-#         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     tt_cpu = F.log_softmax(x, dim)
-#     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-#     assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
-#     tt_dev = tt_dev.to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.1
-#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[2, 3, 32 * 4, 32 * 5], 3],
-#         [[2, 3, 32 * 4, 32 * 5], 2],
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#     tt_cpu = F.log_softmax(x, dim)
-#     strategy = (
-#         ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
-#         if dim == 3
-#         else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
-#     )
-#     tt_npu = ttnn.operations.moreh.logsoftmax(
-#         dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-#     )
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.1
-#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[1, 1, 10, 15], 3],  # single tile
-#         [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
-#         [[1, 1, 15, 10], 2],  # single tile
-#         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     tt_cpu = F.log_softmax(x, dim)
-#     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-#     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.1
-#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[1, 15, 32, 32], 1],  # single tile c
-#         [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
-#         [[109, 15, 32, 32], 1],  # mutiple tiles per cores
-#         [[15, 1, 32, 32], 0],  # single tile n
-#         [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
-#         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     tt_cpu = F.log_softmax(x, dim)
-#     tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-#     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.1
-#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[32, 32], 1],  # single tile
-#         [[3, 32, 32 * 2], 2],  # mutiple tile with dim W
-#         [[5, 6, 32, 32], 3],  # multiple cores
-#         [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
-#         [[32, 32], 0],  # single tile
-#         [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
-#         [[5, 6, 32, 32], 2],  # multiple cores
-#         [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-#     y = F.log_softmax(x, dim)
-#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#     y.backward(dy)
-#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.5
-#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[2, 3, 32 * 4, 32 * 5], 3],
-#         [[2, 3, 32 * 4, 32 * 5], 2],
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-#     y = F.log_softmax(x, dim)
-#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#     y.backward(dy)
-#     strategy = (
-#         ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
-#         if dim == 3
-#         else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
-#     )
-#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(
-#         dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-#     )
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.5
-#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[1, 1, 10, 15], 3],  # single tile
-#         [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
-#         [[1, 1, 15, 10], 2],  # single tile
-#         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-#     y = F.log_softmax(x, dim)
-#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("200")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     y.backward(dy)
-#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-#     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.1
-#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     (
-#         [[1, 15, 32, 32], 1],  # single tile c
-#         [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
-#         [[109, 15, 32, 32], 1],  # mutiple tiles per cores
-#         [[15, 1, 32, 32], 0],  # single tile n
-#         [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
-#         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
-#     ),
-# )
-# @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-# def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-#     y = F.log_softmax(x, dim)
-#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-#     y.backward(dy)
-#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-#     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-#     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.5
-#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     [
-#         [[32, 32], 1],
-#     ],  # single tile
-# )
-# @pytest.mark.parametrize(
-#     "optional_output_tensor",
-#     (True, False),
-# )
-# def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, device):
-#     device.enable_program_cache()
-
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-#     # cpu calculation
-#     tt_cpu = F.log_softmax(x, dim)
-
-#     # npu calculation
-#     dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-#     if optional_output_tensor:
-#         dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, output_tensor=dev_y)
-#     else:
-#         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim)
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.05
-#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-#     logger.info(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim",
-#     [
-#         [[32, 32], 1],
-#     ],  # single tile
-# )
-# @pytest.mark.parametrize(
-#     "optional_output_tensor",
-#     (True, False),
-# )
-# def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
-#     device.enable_program_cache()
-#     shape, dim = shape_dim
-#     torch.manual_seed(0)
-
-#     # cpu calculation
-#     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-#     y = F.log_softmax(x, dim)
-#     dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-#     y.backward(dy)
-
-#     # npu calculation
-#     dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-#     dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#     if optional_output_tensor:
-#         dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-#         tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
-#     else:
-#         tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim)
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.05
-#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-#     logger.info(out)
-#     assert passing
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim_strategy",
-#     (
-#         [[50, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
-#         [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
-#         [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
-#         [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
-#         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
-#     ),
-# )
-# def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
-#     shape, dim, strategy = shape_dim_strategy
-#     torch.manual_seed(0)
-
-#     for i in range(2):
-#         x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100 + i
-#         tt_cpu = F.log_softmax(x, dim)
-#         dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-#         tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
-#         if i == 0:
-#             num_program_cache_entries = device.num_program_cache_entries()
-#             assert num_program_cache_entries > 0
-#         else:
-#             assert device.num_program_cache_entries() == num_program_cache_entries
-#         torch_dummy = torch.randn([32, 32])
-#         tt_dummy = to_ttnn(torch_dummy, device=device)
-
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-#     assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
-#     tt_dev = tt_dev.to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.1
-#     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
-
-
-# def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cache_entries=None):
-#     """
-#     Runs a single step of logsoftmax_backward and checks the program cache if needed.
-#     """
-#     tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-#     if num_program_cache_entries is not None:
-#         assert device.num_program_cache_entries() == num_program_cache_entries
-#     else:
-#         num_program_cache_entries = device.num_program_cache_entries()
-#         assert num_program_cache_entries > 0
-
-#     torch_dummy = torch.randn([32, 32])
-#     tt_dummy = to_ttnn(torch_dummy, device=device)
-#     return tt_npu, num_program_cache_entries
-
-
-# @pytest.mark.parametrize(
-#     "shape_dim_strategy",
-#     (
-#         [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
-#         [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
-#         [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
-#         [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
-#         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
-#     ),
-# )
-# def test_logsoftmax_backward_callback(shape_dim_strategy, device, use_program_cache):
-#     shape, dim, strategy = shape_dim_strategy
-#     torch.manual_seed(0)
-
-#     num_program_cache_entries = None
-#     for i in range(2):
-#         x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-#         y = F.log_softmax(x, dim)
-#         dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#         dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-#         dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-#         y.backward(dy)
-
-#         tt_npu, num_program_cache_entries = logsoftmax_backward_step(
-#             dev_y, dev_dy, dim, strategy, device, num_program_cache_entries
-#         )
-
-#     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-#     tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-#     rtol = atol = 0.5
-#     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-#     logger.debug(out)
-#     assert passing
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[50, 32], 1],  # single tile
+        [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
+        [[5, 6, 32, 32], 3],  # multiple cores
+        [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
+        [[32, 32], 0],  # single tile
+        [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
+        [[5, 6, 32, 32], 2],  # multiple cores
+        [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+
+    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_cpu = F.log_softmax(x, dim)
+    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
+
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_dev.to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.1
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[2, 3, 32 * 4, 32 * 5], 3],
+        [[2, 3, 32 * 4, 32 * 5], 2],
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+
+    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_cpu = F.log_softmax(x, dim)
+    strategy = (
+        ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
+        if dim == 3
+        else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
+    )
+    tt_npu = ttnn.operations.moreh.logsoftmax(
+        dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
+    )
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.1
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[1, 1, 10, 15], 3],  # single tile
+        [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
+        [[1, 1, 15, 10], 2],  # single tile
+        [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+
+    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_cpu = F.log_softmax(x, dim)
+    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
+    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.1
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[1, 15, 32, 32], 1],  # single tile c
+        [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
+        [[109, 15, 32, 32], 1],  # mutiple tiles per cores
+        [[15, 1, 32, 32], 0],  # single tile n
+        [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
+        [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
+
+    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_cpu = F.log_softmax(x, dim)
+    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
+    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.1
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[32, 32], 1],  # single tile
+        [[3, 32, 32 * 2], 2],  # mutiple tile with dim W
+        [[5, 6, 32, 32], 3],  # multiple cores
+        [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
+        [[32, 32], 0],  # single tile
+        [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
+        [[5, 6, 32, 32], 2],  # multiple cores
+        [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = F.log_softmax(x, dim)
+    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    y.backward(dy)
+    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.5
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[2, 3, 32 * 4, 32 * 5], 3],
+        [[2, 3, 32 * 4, 32 * 5], 2],
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = F.log_softmax(x, dim)
+    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    y.backward(dy)
+    strategy = (
+        ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
+        if dim == 3
+        else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
+    )
+    tt_npu = ttnn.operations.moreh.logsoftmax_backward(
+        dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
+    )
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.5
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[1, 1, 10, 15], 3],  # single tile
+        [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
+        [[1, 1, 15, 10], 2],  # single tile
+        [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = F.log_softmax(x, dim)
+    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
+
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("200")).to(ttnn.TILE_LAYOUT).to(device)
+
+    y.backward(dy)
+    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
+    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.1
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    (
+        [[1, 15, 32, 32], 1],  # single tile c
+        [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
+        [[109, 15, 32, 32], 1],  # mutiple tiles per cores
+        [[15, 1, 32, 32], 0],  # single tile n
+        [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
+        [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = F.log_softmax(x, dim)
+    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
+
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
+
+    y.backward(dy)
+    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
+    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.5
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        [[32, 32], 1],
+    ],  # single tile
+)
+@pytest.mark.parametrize(
+    "optional_output_tensor",
+    (True, False),
+)
+def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, device):
+    device.enable_program_cache()
+
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+
+    # cpu calculation
+    tt_cpu = F.log_softmax(x, dim)
+
+    # npu calculation
+    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    if optional_output_tensor:
+        dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, output_tensor=dev_y)
+    else:
+        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.05
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.info(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        [[32, 32], 1],
+    ],  # single tile
+)
+@pytest.mark.parametrize(
+    "optional_output_tensor",
+    (True, False),
+)
+def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
+    device.enable_program_cache()
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+
+    # cpu calculation
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = F.log_softmax(x, dim)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    y.backward(dy)
+
+    # npu calculation
+    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    if optional_output_tensor:
+        dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+        tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
+    else:
+        tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.05
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.info(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    (
+        [[50, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
+        [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
+        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
+        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
+        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
+    ),
+)
+def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    for i in range(2):
+        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100 + i
+        tt_cpu = F.log_softmax(x, dim)
+        dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
+        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_ttnn(torch_dummy, device=device)
+
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
+    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_dev.to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.1
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cache_entries=None):
+    """
+    Runs a single step of logsoftmax_backward and checks the program cache if needed.
+    """
+    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
+
+    if num_program_cache_entries is not None:
+        assert device.num_program_cache_entries() == num_program_cache_entries
+    else:
+        num_program_cache_entries = device.num_program_cache_entries()
+        assert num_program_cache_entries > 0
+
+    torch_dummy = torch.randn([32, 32])
+    tt_dummy = to_ttnn(torch_dummy, device=device)
+    return tt_npu, num_program_cache_entries
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    (
+        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
+        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
+        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
+        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
+        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
+    ),
+)
+def test_logsoftmax_backward_callback(shape_dim_strategy, device, use_program_cache):
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    num_program_cache_entries = None
+    for i in range(2):
+        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+        y = F.log_softmax(x, dim)
+        dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+        dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+        dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+        y.backward(dy)
+
+        tt_npu, num_program_cache_entries = logsoftmax_backward_step(
+            dev_y, dev_dy, dim, strategy, device, num_program_cache_entries
+        )
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.5
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
 
 
 @pytest.mark.parametrize(
@@ -526,5 +526,42 @@ def test_logsoftmax_bfp8(shape_dim_strategy, device, use_program_cache):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    (
+        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
+        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
+        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
+        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
+        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
+    ),
+)
+def test_logsoftmax_backward_bfp8(shape_dim_strategy, device):
+    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
+    pytest.skip(f"bfloat8_b is not supported in the kernel")
+    device.enable_program_cache()
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = F.log_softmax(x, dim)
+    dev_y = ttnn.from_torch(y, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttnn.from_torch(dy, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    y.backward(dy)
+    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.5
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing

--- a/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_logsoftmax.py
@@ -15,14 +15,124 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_ttnn,
 )
+
+
+def get_torch_dtype(dtype):
+    if dtype == ttnn.int32:
+        return torch.int32
+    elif dtype == ttnn.float32:
+        return torch.float32
+    else:
+        return torch.bfloat16
+
+
+def run_moreh_logsoftmax_test(
+    shape,
+    dim,
+    ttnn_dtype,
+    layout,
+    device,
+    rtol,
+    atol,
+    use_randint,
+    optional_output_tensor=False,
+    strategy=None,
+    compute_kernel_options=None,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
+    torch_dtype = get_torch_dtype(ttnn_dtype)
+    if use_randint == True:
+        torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
+    else:
+        torch_input = torch.rand(size=shape, dtype=torch_dtype) + 100
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=layout, device=device)
+
+    torch_output = F.log_softmax(torch_input, dim)
+
+    if optional_output_tensor == True:
+        optional_output = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=layout, device=device)
+        ttnn_output = ttnn.operations.moreh.logsoftmax(ttnn_input, dim, output_tensor=optional_output)
+    elif compute_kernel_options is not None:
+        compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+        if strategy is None:
+            ttnn_output = ttnn.operations.moreh.logsoftmax(ttnn_input, dim, compute_kernel_config=compute_kernel_config)
+        else:
+            ttnn_output = ttnn.operations.moreh.logsoftmax(
+                ttnn_input, dim, compute_kernel_config=compute_kernel_config, strategy=strategy
+            )
+    else:
+        ttnn_output = ttnn.operations.moreh.logsoftmax(ttnn_input, dim, strategy=strategy)
+
+    ttnn_output = ttnn.to_torch(ttnn_output).to(torch_dtype)
+
+    assert list(ttnn_output.shape) == list(torch_output.shape)
+
+    passing, out = comp_allclose_and_pcc(torch_output, ttnn_output, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+def run_moreh_logsoftmax_backward_test(
+    shape,
+    dim,
+    ttnn_dtype,
+    layout,
+    device,
+    rtol,
+    atol,
+    use_randint,
+    optional_output_tensor=False,
+    strategy=None,
+    compute_kernel_options=None,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
+    torch_dtype = get_torch_dtype(ttnn_dtype)
+    if use_randint == True:
+        torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
+        torch_dy = torch.randint(low=0, high=4, size=shape).to(torch_dtype)
+    else:
+        torch_x = torch.rand(size=shape, dtype=torch_dtype).requires_grad_(True)
+        torch_dy = torch.rand(size=shape, dtype=torch_dtype)
+
+    torch_y = F.log_softmax(torch_x, dim)
+
+    ttnn_y = ttnn.from_torch(torch_y, dtype=ttnn_dtype, layout=layout, device=device)
+    ttnn_dy = ttnn.from_torch(torch_dy, dtype=ttnn_dtype, layout=layout, device=device)
+
+    torch_y.backward(torch_dy)
+
+    if optional_output_tensor == True:
+        optional_output = ttnn.from_torch(torch_dy, dtype=ttnn_dtype, layout=layout, device=device)
+        ttnn_output = ttnn.operations.moreh.logsoftmax_backward(ttnn_y, ttnn_dy, dim, input_grad_tensor=optional_output)
+    elif compute_kernel_options is not None:
+        compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+        if strategy is None:
+            ttnn_output = ttnn.operations.moreh.logsoftmax_backward(
+                ttnn_y, ttnn_dy, dim, compute_kernel_config=compute_kernel_config
+            )
+        else:
+            ttnn_output = ttnn.operations.moreh.logsoftmax_backward(
+                ttnn_y, ttnn_dy, dim, compute_kernel_config=compute_kernel_config, strategy=strategy
+            )
+    else:
+        ttnn_output = ttnn.operations.moreh.logsoftmax_backward(ttnn_y, ttnn_dy, dim, strategy=strategy)
+
+    ttnn_output = ttnn.to_torch(ttnn_output).to(torch_dtype)
+
+    assert list(ttnn_output.shape) == list(torch_x.grad.shape)
+
+    passing, out = comp_allclose_and_pcc(torch_x.grad, ttnn_output, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
 
 
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        [[50, 32], 1],  # single tile
+        [[32, 32], 1],  # single tile
         [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
         [[5, 6, 32, 32], 3],  # multiple cores
         [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
@@ -32,30 +142,30 @@ from tests.ttnn.unit_tests.operations.test_utils import (
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-
+def test_logsoftmax_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_dev.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_logsoftmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -65,36 +175,29 @@ def test_logsoftmax_for_dim_hw(shape_dim, compute_kernel_options, device):
         [[2, 3, 32 * 4, 32 * 5], 2],
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
-
+def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    strategy = (
-        ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.logsoftmax(
-        dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-    )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_logsoftmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -106,29 +209,29 @@ def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options
         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
+def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_logsoftmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -142,29 +245,29 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_opti
         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
+def test_logsoftmax_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.log_softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_logsoftmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -180,32 +283,30 @@ def test_logsoftmax_for_dim_nc(shape_dim, compute_kernel_options, device):
         [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
+def test_logsoftmax_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_logsoftmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -215,39 +316,29 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, compute_kernel_options, devic
         [[2, 3, 32 * 4, 32 * 5], 2],
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-    device.enable_program_cache()
+def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    strategy = (
-        ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(
-        dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-    )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_logsoftmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -259,33 +350,30 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, compute_kerne
         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("200")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_logsoftmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -299,32 +387,30 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_ke
         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
     ),
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
+def test_logsoftmax_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
     rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_logsoftmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -334,36 +420,21 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, compute_kernel_options, devic
     ],  # single tile
 )
 @pytest.mark.parametrize(
-    "optional_output_tensor",
-    (True, False),
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
 )
-def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, device):
+def test_logsoftmax_optional_output_tensor(shape_dim, dtype, device):
     device.enable_program_cache()
 
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    # cpu calculation
-    tt_cpu = F.log_softmax(x, dim)
-
-    # npu calculation
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    if optional_output_tensor:
-        dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, output_tensor=dev_y)
-    else:
-        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
+
+    run_moreh_logsoftmax_test(
+        shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, optional_output_tensor=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -373,92 +444,51 @@ def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, de
     ],  # single tile
 )
 @pytest.mark.parametrize(
-    "optional_output_tensor",
-    (True, False),
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
 )
-def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
-    device.enable_program_cache()
+def test_logsoftmax_backward_optional_output_tensor(shape_dim, dtype, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    # cpu calculation
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    y.backward(dy)
-
-    # npu calculation
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    if optional_output_tensor:
-        dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-        tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
-    else:
-        tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
+
+    run_moreh_logsoftmax_backward_test(
+        shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, optional_output_tensor=True
+    )
 
 
 @pytest.mark.parametrize(
     "shape_dim_strategy",
     (
-        [[50, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
+        [[32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
         [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
         [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
         [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
     ),
 )
-def test_logsoftmax_callback(shape_dim_strategy, device, use_program_cache):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+def test_logsoftmax_callback(shape_dim_strategy, dtype, device, use_program_cache):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
+    rtol = atol = 0.1
 
     for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100 + i
-        tt_cpu = F.log_softmax(x, dim)
-        dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-        tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
+        run_moreh_logsoftmax_test(shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy)
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
-
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_dev.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cache_entries=None):
-    """
-    Runs a single step of logsoftmax_backward and checks the program cache if needed.
-    """
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-    if num_program_cache_entries is not None:
-        assert device.num_program_cache_entries() == num_program_cache_entries
-    else:
-        num_program_cache_entries = device.num_program_cache_entries()
-        assert num_program_cache_entries > 0
-
-    torch_dummy = torch.randn([32, 32])
-    tt_dummy = to_ttnn(torch_dummy, device=device)
-    return tt_npu, num_program_cache_entries
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
 
 
 @pytest.mark.parametrize(
@@ -471,97 +501,26 @@ def logsoftmax_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_c
         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
     ),
 )
-def test_logsoftmax_backward_callback(shape_dim_strategy, device, use_program_cache):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+def test_logsoftmax_backward_callback(shape_dim_strategy, dtype, device, use_program_cache):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
 
-    num_program_cache_entries = None
+    rtol = atol = 0.5
+
     for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-        y = F.log_softmax(x, dim)
-        dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-        dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        y.backward(dy)
-
-        tt_npu, num_program_cache_entries = logsoftmax_backward_step(
-            dev_y, dev_dy, dim, strategy, device, num_program_cache_entries
+        run_moreh_logsoftmax_backward_test(
+            shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy
         )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    (
-        [[50, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
-        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
-        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
-        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
-    ),
-)
-def test_logsoftmax_bfp8(shape_dim_strategy, device, use_program_cache):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    pytest.skip(f"bfloat8_b is not supported in the kernel")
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    x = torch.rand(size=shape).to(torch.bfloat16) + 100
-    tt_cpu = F.log_softmax(x, dim)
-    dev_x = ttnn.from_torch(x, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-    tt_npu = ttnn.operations.moreh.logsoftmax(dev_x, dim, strategy=strategy)
-
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_dev.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_npu = ttnn.to_torch(tt_npu)
-
-    rtol = atol = 0.1
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_npu, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    (
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
-        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
-        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
-        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
-    ),
-)
-def test_logsoftmax_backward_bfp8(shape_dim_strategy, device):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    pytest.skip(f"bfloat8_b is not supported in the kernel")
-    device.enable_program_cache()
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    x = torch.rand(size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.log_softmax(x, dim)
-    dev_y = ttnn.from_torch(y, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    dy = torch.rand(size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.from_torch(dy, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.logsoftmax_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_npu = ttnn.to_torch(tt_npu)
-
-    rtol = atol = 0.5
-    passing, out = comp_allclose_and_pcc(x.grad, tt_npu, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
@@ -504,3 +504,39 @@ def test_softmax_bfp8(shape_dim_strategy, device):
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    [
+        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
+        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
+        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
+        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
+        [[1, 1, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
+    ],
+)
+def test_softmax_backward_bfp8(shape_dim_strategy, device, use_program_cache):
+    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
+    pytest.skip(f"bfloat8_b is not supported in the kernel")
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+
+    y = torch.softmax(x, dim)
+    dev_y = ttnn.from_torch(y, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttnn.from_torch(dy, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    y.backward(dy)
+    tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, strategy=strategy)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.05
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmax.py
@@ -14,8 +14,118 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_ttnn,
 )
+
+
+def get_torch_dtype(dtype):
+    if dtype == ttnn.int32:
+        return torch.int32
+    elif dtype == ttnn.float32:
+        return torch.float32
+    else:
+        return torch.bfloat16
+
+
+def run_moreh_softmax_test(
+    shape,
+    dim,
+    ttnn_dtype,
+    layout,
+    device,
+    rtol,
+    atol,
+    use_randint,
+    use_optional_output_tensor=False,
+    strategy=None,
+    compute_kernel_options=None,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
+    torch_dtype = get_torch_dtype(ttnn_dtype)
+    if use_randint == True:
+        torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
+    else:
+        torch_input = torch.rand(size=shape, dtype=torch_dtype) + 100
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=layout, device=device)
+
+    torch_output = torch.softmax(torch_input, dim)
+
+    if use_optional_output_tensor == True:
+        optional_output = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=layout, device=device)
+        ttnn_output = ttnn.operations.moreh.softmax(ttnn_input, dim, output_tensor=optional_output)
+    elif compute_kernel_options is not None:
+        compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+        if strategy is None:
+            ttnn_output = ttnn.operations.moreh.softmax(ttnn_input, dim, compute_kernel_config=compute_kernel_config)
+        else:
+            ttnn_output = ttnn.operations.moreh.softmax(
+                ttnn_input, dim, compute_kernel_config=compute_kernel_config, strategy=strategy
+            )
+    else:
+        ttnn_output = ttnn.operations.moreh.softmax(ttnn_input, dim, strategy=strategy)
+
+    ttnn_output = ttnn.to_torch(ttnn_output).to(torch_dtype)
+
+    assert list(ttnn_output.shape) == list(torch_output.shape)
+
+    passing, out = comp_allclose_and_pcc(torch_output, ttnn_output, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
+
+
+def run_moreh_softmax_backward_test(
+    shape,
+    dim,
+    ttnn_dtype,
+    layout,
+    device,
+    rtol,
+    atol,
+    use_randint,
+    use_optional_output_tensor=False,
+    strategy=None,
+    compute_kernel_options=None,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
+    torch_dtype = get_torch_dtype(ttnn_dtype)
+    if use_randint == True:
+        torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
+        torch_dy = torch.randint(low=0, high=4, size=shape).to(torch_dtype)
+    else:
+        torch_x = torch.rand(size=shape, dtype=torch_dtype).requires_grad_(True)
+        torch_dy = torch.rand(size=shape, dtype=torch_dtype)
+
+    torch_y = torch.softmax(torch_x, dim)
+
+    ttnn_y = ttnn.from_torch(torch_y, dtype=ttnn_dtype, layout=layout, device=device)
+    ttnn_dy = ttnn.from_torch(torch_dy, dtype=ttnn_dtype, layout=layout, device=device)
+
+    torch_y.backward(torch_dy)
+
+    if use_optional_output_tensor == True:
+        optional_output = ttnn.from_torch(torch_dy, dtype=ttnn_dtype, layout=layout, device=device)
+        ttnn_output = ttnn.operations.moreh.softmax_backward(ttnn_y, ttnn_dy, dim, output_tensor=optional_output)
+    elif compute_kernel_options is not None:
+        compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+        if strategy is None:
+            ttnn_output = ttnn.operations.moreh.softmax_backward(
+                ttnn_y, ttnn_dy, dim, compute_kernel_config=compute_kernel_config
+            )
+        else:
+            ttnn_output = ttnn.operations.moreh.softmax_backward(
+                ttnn_y, ttnn_dy, dim, compute_kernel_config=compute_kernel_config, strategy=strategy
+            )
+    else:
+        ttnn_output = ttnn.operations.moreh.softmax_backward(ttnn_y, ttnn_dy, dim, strategy=strategy)
+
+    ttnn_output = ttnn.to_torch(ttnn_output).to(torch_dtype)
+
+    assert list(ttnn_output.shape) == list(torch_x.grad.shape)
+
+    passing, out = comp_allclose_and_pcc(torch_x.grad, ttnn_output, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing
 
 
 @pytest.mark.parametrize(
@@ -31,27 +141,29 @@ from tests.ttnn.unit_tests.operations.test_utils import (
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmax_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -61,33 +173,34 @@ def test_softmax_for_dim_hw(shape_dim, compute_kernel_options, device):
         [[2, 3, 32 * 4, 32 * 5], 2],
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmax_large_algorithm_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = torch.softmax(x, dim)
-
     strategy = (
         ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
         if dim == 3
         else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
     )
-    tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+        strategy=strategy,
+    )
 
 
 @pytest.mark.parametrize(
@@ -99,28 +212,29 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, d
         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -134,28 +248,29 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options
         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_for_dim_nc(shape_dim, compute_kernel_options, device):
+def test_softmax_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + 100
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("7")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -171,31 +286,31 @@ def test_softmax_for_dim_nc(shape_dim, compute_kernel_options, device):
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmax_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = torch.softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_softmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -205,39 +320,28 @@ def test_softmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
         [[2, 3, 32 * 4, 32 * 5], 2],
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = torch.softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-
-    strategy = (
-        ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.softmax_backward(
-        dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-    )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -249,32 +353,29 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_op
         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = torch.softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("20")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -288,31 +389,29 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kerne
         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
+def test_softmax_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = torch.softmax(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -326,32 +425,26 @@ def test_softmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
         [[1, 1, 32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
     ],
 )
-def test_softmax_callback(shape_dim_strategy, device, use_program_cache):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+def test_softmax_callback(shape_dim_strategy, dtype, device, use_program_cache):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
+    rtol = atol = 0.05
 
     for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-        dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        tt_cpu = torch.softmax(x, dim)
-        tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, strategy=strategy)
+        run_moreh_softmax_test(shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy)
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
 
 
 @pytest.mark.parametrize(
@@ -364,36 +457,28 @@ def test_softmax_callback(shape_dim_strategy, device, use_program_cache):
         [[1, 1, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
     ],
 )
-def test_softmax_backward_callback(shape_dim_strategy, device, use_program_cache):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+def test_softmax_backward_callback(shape_dim_strategy, dtype, device, use_program_cache):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
+    rtol = atol = 0.05
 
     for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-        y = torch.softmax(x, dim)
-        dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-        dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        y.backward(dy)
-        tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, strategy=strategy)
+        run_moreh_softmax_backward_test(
+            shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy
+        )
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
 
 
 @pytest.mark.parametrize(
@@ -403,34 +488,19 @@ def test_softmax_backward_callback(shape_dim_strategy, device, use_program_cache
     ],  # single tile
 )
 @pytest.mark.parametrize(
-    "optional_output_tensor",
-    [True, False],
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
 )
-def test_softmax_optional_output_tensor(shape_dim, optional_output_tensor, device):
+def test_softmax_optional_output_tensor(shape_dim, dtype, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    # cpu calculation
-    tt_cpu = torch.softmax(x, dim)
-
-    # npu calculation
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    if optional_output_tensor:
-        dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, output_tensor=dev_y)
-    else:
-        tt_npu = ttnn.operations.moreh.softmax(dev_x, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
+    run_moreh_softmax_test(
+        shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, use_optional_output_tensor=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -440,103 +510,16 @@ def test_softmax_optional_output_tensor(shape_dim, optional_output_tensor, devic
     ],  # single tile
 )
 @pytest.mark.parametrize(
-    "optional_output_tensor",
-    [True, False],
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
 )
-def test_softmax_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
+def test_softmax_backward_optional_output_tensor(shape_dim, dtype, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    # cpu calculation
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = torch.softmax(x, dim)
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    y.backward(dy)
-
-    # npu calculation
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    if optional_output_tensor:
-        dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-        tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
-    else:
-        tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    [
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
-        [[1, 1, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
-        [[1, 1, 32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
-    ],
-)
-def test_softmax_bfp8(shape_dim_strategy, device):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    pytest.skip(f"bfloat8_b is not supported in the kernel")
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    x = torch.rand(size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.from_torch(x, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttnn.operations.moreh.softmax(dev_x, dim, strategy=strategy)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_npu = ttnn.to_torch(tt_npu)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_npu, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    [
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
-        [[1, 1, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
-    ],
-)
-def test_softmax_backward_bfp8(shape_dim_strategy, device, use_program_cache):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    pytest.skip(f"bfloat8_b is not supported in the kernel")
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    x = torch.rand(size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = torch.softmax(x, dim)
-    dev_y = ttnn.from_torch(y, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    dy = torch.rand(size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.from_torch(dy, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmax_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_npu = ttnn.to_torch(tt_npu)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_npu, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmax_test(
+        shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, use_optional_output_tensor=True
+    )

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
@@ -482,3 +482,35 @@ def test_softmin_backward_callback(shape_dim_strategy, device, use_program_cache
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    [
+        [[32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
+        [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
+        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
+        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
+        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
+    ],
+)
+def test_softmin_bfp8(shape_dim_strategy, device):
+    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
+    pytest.skip(f"bfloat8_b is not supported in the kernel")
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+
+    dev_x = ttnn.from_torch(x, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_cpu = F.softmin(x, dim)
+    tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, strategy=strategy)
+
+    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.05
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.debug(out)
+    assert passing

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
@@ -500,7 +500,7 @@ def test_softmin_bfp8(shape_dim_strategy, device):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
 
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    x = torch.rand(size=shape).to(torch.bfloat16)
 
     dev_x = ttnn.from_torch(x, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -508,10 +508,10 @@ def test_softmin_bfp8(shape_dim_strategy, device):
     tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, strategy=strategy)
 
     assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+    tt_npu = ttnn.to_torch(tt_npu)
 
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_npu, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing
 
@@ -532,21 +532,21 @@ def test_softmin_backward_bfp8(shape_dim_strategy, device):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
 
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
+    x = torch.rand(size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.softmin(x, dim)
     dev_y = ttnn.from_torch(y, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dy = torch.rand(size=shape).to(torch.bfloat16)
     dev_dy = ttnn.from_torch(dy, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
     y.backward(dy)
     tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, strategy=strategy)
 
     assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+    tt_npu = ttnn.to_torch(tt_npu)
 
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    passing, out = comp_allclose_and_pcc(x.grad, tt_npu, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing

--- a/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_softmin.py
@@ -15,145 +15,116 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
-    to_ttnn,
 )
 
 
-@pytest.mark.parametrize(
-    "shape_dim",
-    [
-        [[32, 32], 1],  # single tile
-        [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
-        [[5, 6, 32, 32], 3],  # multiple cores
-        [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
-        [[32, 32], 0],  # single tile
-        [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
-        [[5, 6, 32, 32], 2],  # multiple cores
-        [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
-    ],
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_for_dim_hw(shape_dim, compute_kernel_options, device):
-    shape, dim = shape_dim
-    torch.manual_seed(0)
+def get_torch_dtype(dtype):
+    if dtype == ttnn.int32:
+        return torch.int32
+    elif dtype == ttnn.float32:
+        return torch.float32
+    else:
+        return torch.bfloat16
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+def run_moreh_softmin_test(
+    shape,
+    dim,
+    ttnn_dtype,
+    layout,
+    device,
+    rtol,
+    atol,
+    use_randint,
+    use_optional_output_tensor=False,
+    strategy=None,
+    compute_kernel_options=None,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
+    torch_dtype = get_torch_dtype(ttnn_dtype)
+    if use_randint == True:
+        torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
+    else:
+        torch_input = torch.rand(size=shape, dtype=torch_dtype) + 100
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=layout, device=device)
 
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    torch_output = F.softmin(torch_input, dim)
 
-    tt_cpu = F.softmin(x, dim)
-    tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
+    if use_optional_output_tensor == True:
+        optional_output = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=layout, device=device)
+        ttnn_output = ttnn.operations.moreh.softmin(ttnn_input, dim, output_tensor=optional_output)
+    elif compute_kernel_options is not None:
+        compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+        if strategy is None:
+            ttnn_output = ttnn.operations.moreh.softmin(ttnn_input, dim, compute_kernel_config=compute_kernel_config)
+        else:
+            ttnn_output = ttnn.operations.moreh.softmin(
+                ttnn_input, dim, compute_kernel_config=compute_kernel_config, strategy=strategy
+            )
+    else:
+        ttnn_output = ttnn.operations.moreh.softmin(ttnn_input, dim, strategy=strategy)
 
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+    ttnn_output = ttnn.to_torch(ttnn_output).to(torch_dtype)
 
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    assert list(ttnn_output.shape) == list(torch_output.shape)
+
+    passing, out = comp_allclose_and_pcc(torch_output, ttnn_output, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing
 
 
-@pytest.mark.parametrize(
-    "shape_dim",
-    [
-        [[2, 3, 32 * 4, 32 * 5], 3],
-        [[2, 3, 32 * 4, 32 * 5], 2],
-    ],
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
-    shape, dim = shape_dim
-    torch.manual_seed(0)
+def run_moreh_softmin_backward_test(
+    shape,
+    dim,
+    ttnn_dtype,
+    layout,
+    device,
+    rtol,
+    atol,
+    use_randint,
+    use_optional_output_tensor=False,
+    strategy=None,
+    compute_kernel_options=None,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
+    torch_dtype = get_torch_dtype(ttnn_dtype)
+    if use_randint == True:
+        torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
+        torch_dy = torch.randint(low=0, high=4, size=shape).to(torch_dtype)
+    else:
+        torch_x = torch.rand(size=shape, dtype=torch_dtype).requires_grad_(True)
+        torch_dy = torch.rand(size=shape, dtype=torch_dtype)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+    torch_y = F.softmin(torch_x, dim)
 
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    ttnn_y = ttnn.from_torch(torch_y, dtype=ttnn_dtype, layout=layout, device=device)
+    ttnn_dy = ttnn.from_torch(torch_dy, dtype=ttnn_dtype, layout=layout, device=device)
 
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    torch_y.backward(torch_dy)
 
-    tt_cpu = F.softmin(x, dim)
-    strategy = (
-        ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, strategy=strategy, compute_kernel_config=compute_kernel_config)
+    if use_optional_output_tensor == True:
+        optional_output = ttnn.from_torch(torch_dy, dtype=ttnn_dtype, layout=layout, device=device)
+        ttnn_output = ttnn.operations.moreh.softmin_backward(ttnn_y, ttnn_dy, dim, input_grad_tensor=optional_output)
+    elif compute_kernel_options is not None:
+        compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+        if strategy is None:
+            ttnn_output = ttnn.operations.moreh.softmin_backward(
+                ttnn_y, ttnn_dy, dim, compute_kernel_config=compute_kernel_config
+            )
+        else:
+            ttnn_output = ttnn.operations.moreh.softmin_backward(
+                ttnn_y, ttnn_dy, dim, compute_kernel_config=compute_kernel_config, strategy=strategy
+            )
+    else:
+        ttnn_output = ttnn.operations.moreh.softmin_backward(ttnn_y, ttnn_dy, dim, strategy=strategy)
 
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
+    ttnn_output = ttnn.to_torch(ttnn_output).to(torch_dtype)
 
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    assert list(ttnn_output.shape) == list(torch_x.grad.shape)
 
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    [
-        [[1, 1, 10, 15], 3],  # single tile
-        [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
-        [[1, 1, 15, 10], 2],  # single tile
-        [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
-    ],
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("nan")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.softmin(x, dim)
-    tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim",
-    [
-        [[1, 15, 32, 32], 1],  # single tile c
-        [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
-        [[109, 15, 32, 32], 1],  # mutiple tiles per cores
-        [[15, 1, 32, 32], 0],  # single tile n
-        [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
-        [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
-    ],
-)
-@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_for_dim_nc(shape_dim, compute_kernel_options, device):
-    shape, dim = shape_dim
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).pad_to_tile(float("7")).to(ttnn.TILE_LAYOUT).to(device)
-
-    tt_cpu = F.softmin(x, dim)
-    tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    passing, out = comp_allclose_and_pcc(torch_x.grad, ttnn_output, rtol=rtol, atol=atol)
     logger.debug(out)
     assert passing
 
@@ -171,31 +142,29 @@ def test_softmin_for_dim_nc(shape_dim, compute_kernel_options, device):
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmin_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.softmin(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmin_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -205,38 +174,28 @@ def test_softmin_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
         [[2, 3, 32 * 4, 32 * 5], 2],
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmin_large_algorithm_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.softmin(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    strategy = (
-        ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W
-        if dim == 3
-        else ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H
-    )
-    tt_npu = ttnn.operations.moreh.softmin_backward(
-        dev_y, dev_dy, dim, strategy=strategy, compute_kernel_config=compute_kernel_config
-    )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmin_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -248,32 +207,29 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_op
         [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
+def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.softmin(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("20")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+
+    run_moreh_softmin_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -287,31 +243,170 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kerne
         [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_softmin_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
+def test_softmin_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+    rtol = atol = 0.05
+
+    run_moreh_softmin_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        [[32, 32], 1],  # single tile
+        [[3, 32, 32 * 5], 2],  # mutiple tile with dim W
+        [[5, 6, 32, 32], 3],  # multiple cores
+        [[10, 20, 32 * 3, 32 * 5], 3],  # multiple tiles per core
+        [[32, 32], 0],  # single tile
+        [[3, 32 * 5, 32], 1],  # mutiple tile with dim H
+        [[5, 6, 32, 32], 2],  # multiple cores
+        [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+    rtol = atol = 0.05
+
+    run_moreh_softmin_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        [[2, 3, 32 * 4, 32 * 5], 3],
+        [[2, 3, 32 * 4, 32 * 5], 2],
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.softmin(x, dim)
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).pad_to_tile(float("10")).to(ttnn.TILE_LAYOUT).to(device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(shape)
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+    run_moreh_softmin_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        [[1, 1, 10, 15], 3],  # single tile
+        [[1, 1, 10, 32 * 2 + 10], 3],  # mutiple tile with dim
+        [[1, 1, 15, 10], 2],  # single tile
+        [[1, 1, 32 * 2 + 10, 32], 2],  # mutiple tile with dim
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+    rtol = atol = 0.05
+
+    run_moreh_softmin_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        [[1, 15, 32, 32], 1],  # single tile c
+        [[1, 15, 32 * 7, 32 * 5], 1],  # mutiple cores
+        [[109, 15, 32, 32], 1],  # mutiple tiles per cores
+        [[15, 1, 32, 32], 0],  # single tile n
+        [[15, 1, 32 * 7, 32 * 5], 0],  # mutiple cores
+        [[15, 109, 32 * 2, 32 * 2], 0],  # mutiple tiles per cores
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
+    shape, dim = shape_dim
+    torch.manual_seed(0)
+    rtol = atol = 0.05
+
+    run_moreh_softmin_backward_test(
+        shape,
+        dim,
+        dtype,
+        ttnn.TILE_LAYOUT,
+        device,
+        rtol,
+        atol,
+        True,
+        compute_kernel_options=compute_kernel_options,
+    )
 
 
 @pytest.mark.parametrize(
@@ -321,34 +416,19 @@ def test_softmin_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
     ],  # single tile
 )
 @pytest.mark.parametrize(
-    "optional_output_tensor",
-    [True, False],
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
 )
-def test_softmin_optional_output_tensor(shape_dim, optional_output_tensor, device):
+def test_softmin_optional_output_tensor(shape_dim, dtype, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-
-    # cpu calculation
-    tt_cpu = F.softmin(x, dim)
-
-    # npu calculation
-    dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    if optional_output_tensor:
-        dev_y = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, output_tensor=dev_y)
-    else:
-        tt_npu = ttnn.operations.moreh.softmin(dev_x, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
+
+    run_moreh_softmin_test(
+        shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, use_optional_output_tensor=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -358,37 +438,19 @@ def test_softmin_optional_output_tensor(shape_dim, optional_output_tensor, devic
     ],  # single tile
 )
 @pytest.mark.parametrize(
-    "optional_output_tensor",
-    [True, False],
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
 )
-def test_softmin_backward_optional_output_tensor(shape_dim, optional_output_tensor, device):
+def test_softmin_backward_optional_output_tensor(shape_dim, dtype, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
-
-    # cpu calculation
-    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.softmin(x, dim)
-    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-    y.backward(dy)
-
-    # npu calculation
-    dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-    dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-    if optional_output_tensor:
-        dev_dx = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-        tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, input_grad_tensor=dev_dx)
-    else:
-        tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
     rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
-    assert passing
+
+    run_moreh_softmin_backward_test(
+        shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, use_optional_output_tensor=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -401,50 +463,25 @@ def test_softmin_backward_optional_output_tensor(shape_dim, optional_output_tens
         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
     ],
 )
-def test_softmin_callback(shape_dim_strategy, device, use_program_cache):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+def test_softmin_callback(shape_dim_strategy, dtype, device, use_program_cache):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
-
+    rtol = atol = 0.05
     for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16) + i
-
-        dev_x = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        tt_cpu = F.softmin(x, dim)
-        tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, strategy=strategy)
+        run_moreh_softmin_test(shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy)
         if i == 0:
             num_program_cache_entries = device.num_program_cache_entries()
             assert num_program_cache_entries > 0
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
         torch_dummy = torch.randn([32, 32])
-        tt_dummy = to_ttnn(torch_dummy, device=device)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-def softmin_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cache_entries=None):
-    """
-    Runs a single step of softmin_backward and checks the program cache if needed.
-    """
-    tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-    if num_program_cache_entries is not None:
-        assert device.num_program_cache_entries() == num_program_cache_entries
-    else:
-        num_program_cache_entries = device.num_program_cache_entries()
-        assert num_program_cache_entries > 0
-
-    torch_dummy = torch.randn([32, 32])
-    tt_dummy = to_ttnn(torch_dummy, device=device)
-
-    return tt_npu, num_program_cache_entries
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)
 
 
 @pytest.mark.parametrize(
@@ -457,96 +494,25 @@ def softmin_backward_step(dev_y, dev_dy, dim, strategy, device, num_program_cach
         [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
     ],
 )
-def test_softmin_backward_callback(shape_dim_strategy, device, use_program_cache):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+def test_softmin_backward_callback(shape_dim_strategy, dtype, device, use_program_cache):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
-
+    rtol = atol = 0.05
     num_program_cache_entries = None
     for i in range(2):
-        x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
-        y = F.softmin(x, dim)
-        dev_y = ttnn.Tensor(y, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
-        dev_dy = ttnn.Tensor(dy, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
-
-        y.backward(dy)
-        tt_npu, num_program_cache_entries = softmin_backward_step(
-            dev_y, dev_dy, dim, strategy, device, num_program_cache_entries
+        run_moreh_softmin_backward_test(
+            shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy
         )
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_dev = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().to(torch.bfloat16)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    [
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.SMALL_H],
-        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_W],
-        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_H],
-        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxOpParallelizationStrategy.LARGE_C],
-    ],
-)
-def test_softmin_bfp8(shape_dim_strategy, device):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    pytest.skip(f"bfloat8_b is not supported in the kernel")
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    x = torch.rand(size=shape).to(torch.bfloat16)
-
-    dev_x = ttnn.from_torch(x, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    tt_cpu = F.softmin(x, dim)
-    tt_npu = ttnn.operations.moreh.softmin(dev_x, dim, strategy=strategy)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(tt_cpu.shape)
-    tt_npu = ttnn.to_torch(tt_npu)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(tt_cpu, tt_npu, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape_dim_strategy",
-    [
-        [[32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_W],
-        [[32, 32], 0, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.SMALL_H],
-        [[2, 3, 32 * 4, 32 * 5], 3, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_W],
-        [[2, 3, 32 * 4, 32 * 5], 2, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_H],
-        [[1, 15, 32, 32], 1, ttnn.operations.moreh.SoftmaxBackwardOpParallelizationStrategy.LARGE_C],
-    ],
-)
-def test_softmin_backward_bfp8(shape_dim_strategy, device):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    pytest.skip(f"bfloat8_b is not supported in the kernel")
-    shape, dim, strategy = shape_dim_strategy
-    torch.manual_seed(0)
-
-    x = torch.rand(size=shape).to(torch.bfloat16).requires_grad_(True)
-
-    y = F.softmin(x, dim)
-    dev_y = ttnn.from_torch(y, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    dy = torch.rand(size=shape).to(torch.bfloat16)
-    dev_dy = ttnn.from_torch(dy, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    y.backward(dy)
-    tt_npu = ttnn.operations.moreh.softmin_backward(dev_y, dev_dy, dim, strategy=strategy)
-
-    assert list(tt_npu.shape.with_tile_padding()) == list(x.grad.shape)
-    tt_npu = ttnn.to_torch(tt_npu)
-
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(x.grad, tt_npu, rtol=rtol, atol=atol)
-    logger.debug(out)
-    assert passing
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = ttnn.from_torch(torch_dummy, device=device)


### PR DESCRIPTION
### Ticket
Closes: https://github.com/tenstorrent/tt-metal/issues/14132

### Problem description
Some operations don't have unit tests for bfp8
These operations consist of:

- moreh_dot
- moreh_softmax
- moreh_softmax_backward

### What's changed
Added bfp8 tests

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
