### PR TITLE
#14111: Add option to run post-commit in different build modes (`Debug` etc), while still in `Release` on main

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -14,7 +14,7 @@ on:
           - RelWithDebInfo
           - CI
   push:
-    branches: ["main", "rkim/14111-debug"]
+    branches: ["main"]
 
 permissions:
   actions: read

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -3,6 +3,16 @@ name: "All post-commit tests"
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      build-type:
+        required: false
+        default: Release
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - CI
   push:
     branches: ["main"]
 
@@ -54,12 +64,14 @@ jobs:
     secrets: inherit
     with:
       build-docker: false
+      build-type: ${{ inputs.build-type || 'Release' }}
   build-artifact-profiler:
     needs: build-docker-image-2004
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
       build-docker: false
+      build-type: ${{ inputs.build-type || 'Release' }}
     secrets: inherit
   # UMD Unit Tests
   umd-unit-tests:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -14,7 +14,7 @@ on:
           - RelWithDebInfo
           - CI
   push:
-    branches: ["main"]
+    branches: ["main", "rkim/14111-debug"]
 
 permissions:
   actions: read


### PR DESCRIPTION
### Ticket

#14111 

### Problem description

Devs have requested that we be able to run post-commit in different build types on branches to support their work.

### What's changed

Add a workflow dispatch option to do so.

this could also lay some ground-work for doing a scheduled nightly debug build or something like that.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
