### PR TITLE
#14001: Ignore reformatting commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# CMake formatting
+0be480e4450b902174f8c1f03559a8fc6eebb827


### PR DESCRIPTION
Follow-up to #14117 to ignore the final commit ID for blames.