### PR TITLE
#0: fix watcher error on cb ptr overflow

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -173,6 +173,10 @@ void MAIN {
                 reduce_tile(cb_ex_external, cb_scaler_global, 0, scaler0, dst0);
                 cb_pop_front(cb_ex_external, 1);
             }
+            if (use_two_stage_reduce && !is_second_stage_reader) {
+                cb_wait_front(cb_ex_external, num_blocks_second_stage - 1);
+                cb_pop_front(cb_ex_external, num_blocks_second_stage - 1);
+            }
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex);
@@ -287,6 +291,10 @@ void MAIN {
                 cb_wait_front(cb_ex_external2, 1);
                 reduce_tile(cb_ex_external2, cb_scaler_global, 0, scaler0, dst0);
                 cb_pop_front(cb_ex_external2, 1);
+            }
+            if (use_two_stage_reduce && !is_second_stage_reader) {
+                cb_wait_front(cb_ex_external2, num_blocks_second_stage - 1);
+                cb_pop_front(cb_ex_external2, num_blocks_second_stage - 1);
             }
             tile_regs_commit();
             tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -165,6 +165,7 @@ void kernel_main() {
                         }
 
                         // read data from other cores - second stage reduce
+                        cb_reserve_back(cb_external, num_blocks_second_stage - 1);
                         for(uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
                             noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
@@ -172,6 +173,9 @@ void kernel_main() {
                         }
                         l1_read_addr_ex += single_tile_size_bytes;
                         noc_async_read_barrier();
+                        cb_push_back(cb_external, num_blocks_second_stage - 1);
+                    } else {
+                        cb_reserve_back(cb_external, num_blocks_second_stage - 1);
                         cb_push_back(cb_external, num_blocks_second_stage - 1);
                     }
                 }
@@ -198,7 +202,7 @@ void kernel_main() {
         for (uint32_t block = 0; block < num_all_to_all_workers; ++block) {
             uint32_t num_tiles = block == num_all_to_all_workers - 1 ? num_tiles_per_worker_last : num_tiles_per_worker;
             cb_reserve_back(cb_ex_global, num_tiles);
-            noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, block+2);
+            noc_semaphore_wait_min(reduce_sender_semaphore_addr_ptr, block+2);
             cb_push_back(cb_ex_global, num_tiles);
         }
     };

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -137,6 +137,7 @@ void kernel_main() {
                 }
 
                 uint32_t curr_block_index = block_index_stride;
+                cb_reserve_back(cb_external, num_blocks_second_stage - 1);
                 for(uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                     uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | l1_read_addr_ex;
                     noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);


### PR DESCRIPTION


### Problem description
watcher assert err on cb_push_back, the wr_ptr overflows the CB limit, solution is to add extra push back for non-second-stage-reduce workers.

### Checklist
- [x] Post commit CI passes
- [x] custom dispatch test
