### PR TITLE
Fix Bug in Reshape where Output Tensor is Different Layout than Input Tensor

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -290,6 +290,9 @@ def test_reshape_tile_layout_only_change_shape(device):
         ((1, 256, 16), (16, 256)),
         ((1, 256, 1024), (1, 256, 16, 64)),
         ((16, 16), (32, 8)),
+        ((1, 1445, 192), (1445, 192)),
+        ((1, 256), (1, 1, 256)),
+        ((16, 1, 32), (16, 1, 32)),
     ],
 )
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
@@ -299,7 +302,7 @@ def test_reshape_tile_with_padding(input_shape, output_shape, layout, device):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, dtype=ttnn.bfloat16, device=device)
     ttnn_output = ttnn.reshape(input_tensor, output_shape)
-
+    assert layout == ttnn_output.layout
     output = ttnn.to_torch(ttnn_output)
 
     assert_with_pcc(torch_result, output, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -50,7 +50,7 @@ ttnn::Tensor host_reshape(const ttnn::Tensor& tensor, const ttnn::Shape& shape) 
     return device_tensor;
 }
 
-ttnn::Tensor row_major_reshape(const ttnn::Tensor& tensor, const ttnn::Shape& shape) {
+ttnn::Tensor convert_tensor_to_rm_reshape_convert_back_to_orig_layout(const ttnn::Tensor& tensor, const ttnn::Shape& shape) {
     const auto layout = tensor.get_layout();
     auto shape_with_padding = shape.padded_shape();
     auto tensor_shape = tensor.get_shape();
@@ -124,7 +124,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn
 
     // Catch-all
     // Do the reshape in row-major
-    return detail::row_major_reshape(tensor, shape);
+    return detail::convert_tensor_to_rm_reshape_convert_back_to_orig_layout(tensor, shape);
 }
 
 ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn::SimpleShape& shape) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -64,7 +64,7 @@ ttnn::Tensor row_major_reshape(const ttnn::Tensor& tensor, const ttnn::Shape& sh
         if (rm_tensor.is_contiguous()) {
             // Page size depends on the width, so only modify the shape if the width is the same
             if (tensor_shape_with_padding[-1] == shape_with_padding[-1]) {
-                return rm_tensor.reshape(shape);
+                reshaped_rm_tensor =  rm_tensor.reshape(shape);
             }
             //Different page width, going to use device kernel that does transpose
             else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13891)

### Problem description
In cases where reshape needs to just use an untilize to remove padding and then do a host side no op reshape view, the returned tensor was in ROW-MAJOR even if the input tensor is TILE.

### What's changed
The reshape op was early returning the tensor before converting to the input layout. Removed the early exit. 

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11486977263)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
