### PR TITLE
#0: remove sweeps workflow codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,6 @@
 # precedence.
 
 .github/ @tt-rkim @ttmchiou @TT-billteng @blozano-tt @afuller-TT
-.github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT
 
 /infra/ @tt-rkim
 


### PR DESCRIPTION
### Ticket

### Problem description
We require review for every addition to this workflow, when it is just adding options to the dropdown in 99% of cases. We have a workflow in post-commit to make sure this happens, so we shouldn't need to review.

### What's changed
Remove codeowners from the `ttnn-run-sweeps.yaml` file. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
