### PR TITLE
Add more tests to TensorLayout

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -12,9 +12,11 @@ set(TTNN_CCL_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/ccl/test_erisc_data_mover_with_workers.cpp
 )
 set(TTNN_TENSOR_UNIT_TESTS_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/tensor/common_tensor_test_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_create_tensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_tensor_layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_create_tensor_with_layout.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_vector_base.cpp
 )
 
 add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})

--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common_tensor_test_utils.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/async_runtime.hpp"
+
+#include "gtest/gtest.h"
+
+namespace test_utils {
+
+void test_tensor_on_device(const ttnn::SimpleShape& input_shape, const TensorLayout& layout, tt::tt_metal::Device* device) {
+    using namespace tt::tt_metal;
+
+    const uint32_t io_cq = 0;
+
+    const auto input_buf_size_bytes = layout.get_packed_buffer_size_bytes(input_shape);
+    const auto host_buffer_datum_size_bytes = sizeof(uint32_t);
+    const auto input_buf_size = input_buf_size_bytes / host_buffer_datum_size_bytes;
+
+    auto host_data = std::make_shared<uint32_t[]>(input_buf_size);
+    auto readback_data = std::make_shared<uint32_t[]>(input_buf_size);
+
+    const auto random_prime_number = 4051;
+    for (int i = 0; i < input_buf_size; i++) {
+        host_data[i] = i % random_prime_number;
+    }
+
+    auto tensor = tt::tt_metal::create_device_tensor(input_shape, layout, device);
+    ttnn::queue_synchronize(device->command_queue(io_cq));
+
+    ttnn::write_buffer(io_cq, tensor, {host_data});
+    ttnn::queue_synchronize(device->command_queue(io_cq));
+
+    ttnn::read_buffer(io_cq, tensor, {readback_data});
+    ttnn::queue_synchronize(device->command_queue(io_cq));
+
+    for (int i = 0; i < input_buf_size; i++) {
+        EXPECT_EQ(host_data[i], readback_data[i]);
+    }
+
+    EXPECT_EQ(tensor.get_padded_shape(), layout.get_padded_shape(input_shape));
+    tensor.deallocate();
+}
+
+void test_tensor_on_device(const ttnn::SimpleShape& input_shape, const tt::tt_metal::TensorLayout& layout) {
+    tt::tt_metal::Device* device =  tt::tt_metal::CreateDevice(0);
+
+    test_tensor_on_device(input_shape, layout, device);
+
+    tt::tt_metal::CloseDevice(device);
+}
+
+} // namespace test_utils

--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor_layout.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace test_utils {
+void test_tensor_on_device(const ttnn::SimpleShape& input_shape, const tt::tt_metal::TensorLayout& layout, tt::tt_metal::Device* device);
+void test_tensor_on_device(const ttnn::SimpleShape& input_shape, const tt::tt_metal::TensorLayout& layout);
+}

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -485,8 +485,6 @@ TEST(TensorLayoutTests, TensorLayout_TinyTiles) {
         TensorLayout layout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, Tile({16, 32})), DefaultMemoryConfig);
         ttnn::SimpleShape shape({2, 3, 10, 16});
         EXPECT_EQ(layout.get_packed_buffer_size_bytes(shape), 3264); // 32 * 16 * 3 * 2 + (32 * 16 * 3 * 2)/16
-
-        //test_utils::test_tensor_on_device(shape, layout);
     }
 
     {
@@ -494,7 +492,5 @@ TEST(TensorLayoutTests, TensorLayout_TinyTiles) {
         Tile tile({16, 16});
         TensorLayout layout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), DefaultMemoryConfig);
         EXPECT_EQ(layout.get_packed_buffer_size_bytes(shape), 2228224); // 256 * 256 * 4 * 8 + (256 * 256 * 4 * 8)/16
-
-        //test_utils::test_tensor_on_device(shape, layout);
     }
 }

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_base.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_base.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <exception>
+#include "gtest/gtest.h"
+
+#include "ttnn/tensor/vector_base.hpp"
+
+
+TEST(TensorVectorBaseTests, General4D) {
+    tt::tt_metal::VectorBase vec({20, 30, 40, 50});
+    EXPECT_EQ(vec.view().size(), vec.as_vector().size());
+    EXPECT_EQ(vec.view().size(), 4);
+    EXPECT_EQ(vec[0], 20);
+    EXPECT_EQ(vec[1],30);
+    EXPECT_EQ(vec[2], 40);
+    EXPECT_EQ(vec[3], 50);
+    EXPECT_THROW(vec[4], std::exception);
+    EXPECT_EQ(vec[-1], vec[3]);
+    EXPECT_EQ(vec[-2], vec[2]);
+    EXPECT_EQ(vec[-3], vec[1]);
+    EXPECT_EQ(vec[-4], vec[0]);
+    EXPECT_THROW(vec[-5], std::exception);
+}
+
+TEST(TensorVectorBaseTests, General5D) {
+
+    tt::tt_metal::VectorBase vec({20, 30, 40, 50, 60});
+    EXPECT_EQ(vec.view().size(), vec.as_vector().size());
+    EXPECT_EQ(vec.view().size(), 5);
+    EXPECT_EQ(vec[4], 60);
+    EXPECT_THROW(vec[5], std::exception);
+    EXPECT_EQ(vec[-1], vec[4]);
+    EXPECT_EQ(vec[-2], vec[3]);
+    EXPECT_EQ(vec[-3], vec[2]);
+    EXPECT_EQ(vec[-4], vec[1]);
+    EXPECT_EQ(vec[-5], vec[0]);
+    EXPECT_THROW(vec[-6], std::exception);
+}
+
+TEST(TensorVectorBaseTests, Empty)
+{
+    tt::tt_metal::VectorBase vec({});
+    EXPECT_EQ(vec.view().size(), vec.as_vector().size());
+    EXPECT_EQ(vec.view().size(), 0);
+    EXPECT_THROW(vec[0], std::exception);
+    EXPECT_THROW(vec[1], std::exception);
+    EXPECT_THROW(vec[2], std::exception);
+    EXPECT_THROW(vec[3], std::exception);
+    EXPECT_THROW(vec[4], std::exception);
+    EXPECT_EQ(vec[-1], 1);
+    EXPECT_EQ(vec[-2], 1);
+    EXPECT_EQ(vec[-3], 1);
+    EXPECT_EQ(vec[-4], 1);
+    EXPECT_THROW(vec[-5], std::exception);
+}
+
+TEST(TensorVectorBaseTests, SingleElement) {
+    tt::tt_metal::VectorBase vec({20});
+    EXPECT_EQ(vec.view().size(), vec.as_vector().size());
+    EXPECT_EQ(vec.view().size(), 1);
+    EXPECT_EQ(vec[0], 20);
+    EXPECT_THROW(vec[1], std::exception);
+    EXPECT_EQ(vec[-1], vec[0]);
+    EXPECT_EQ(vec[-2], 1);
+    EXPECT_EQ(vec[-3], 1);
+    EXPECT_EQ(vec[-4], 1);
+    EXPECT_THROW(vec[-5], std::exception);
+}
+
+TEST(TensorVectorBaseTests, TwoElements) {
+    tt::tt_metal::VectorBase vec({20, 30});
+    EXPECT_EQ(vec.view().size(), vec.as_vector().size());
+    EXPECT_EQ(vec.view().size(), 2);
+    EXPECT_EQ(vec[0], 20);
+    EXPECT_EQ(vec[1], 30);
+    EXPECT_THROW(vec[2], std::exception);
+    EXPECT_EQ(vec[-1], vec[1]);
+    EXPECT_EQ(vec[-2], vec[0]);
+    EXPECT_EQ(vec[-3], 1);
+    EXPECT_EQ(vec[-4], 1);
+    EXPECT_THROW(vec[-5], std::exception);
+}

--- a/ttnn/cpp/ttnn/tensor/alignment.cpp
+++ b/ttnn/cpp/ttnn/tensor/alignment.cpp
@@ -13,7 +13,7 @@ bool Alignment::operator==(const std::vector<uint32_t> &other) const {
 }
 
 size_t Alignment::size() const {
-    return this->m_value.size();
+    return this->m_original_size;
 }
 
 std::ostream &operator<<(std::ostream &os, const tt::tt_metal::Alignment &alignment) {

--- a/ttnn/cpp/ttnn/tensor/alignment.cpp
+++ b/ttnn/cpp/ttnn/tensor/alignment.cpp
@@ -12,10 +12,6 @@ bool Alignment::operator==(const std::vector<uint32_t> &other) const {
     return this->m_value == other;
 }
 
-size_t Alignment::size() const {
-    return this->m_original_size;
-}
-
 std::ostream &operator<<(std::ostream &os, const tt::tt_metal::Alignment &alignment) {
     os << "Alignment([";
     for (size_t i = 0; i < alignment.size(); ++i) {

--- a/ttnn/cpp/ttnn/tensor/alignment.hpp
+++ b/ttnn/cpp/ttnn/tensor/alignment.hpp
@@ -15,6 +15,7 @@ public:
     using tt::tt_metal::VectorBase::cbegin;
     using tt::tt_metal::VectorBase::cend;
     using tt::tt_metal::VectorBase::as_vector;
+    using tt::tt_metal::VectorBase::size;
 
     template<std::size_t N>
     bool operator==(const std::array<uint32_t, N> &other) const {
@@ -24,9 +25,6 @@ public:
 
     bool operator==(const Alignment &other) const;
     bool operator==(const std::vector<uint32_t> &other) const;
-
-    [[nodiscard]] size_t size() const;
-
 
     // Needed for reflect / fmt
     static constexpr auto attribute_names = std::forward_as_tuple("value");

--- a/ttnn/cpp/ttnn/tensor/page_config.hpp
+++ b/ttnn/cpp/ttnn/tensor/page_config.hpp
@@ -13,22 +13,22 @@ namespace tt::tt_metal {
 
 class RowMajorPageConfig {
 public:
-    Alignment create_default_alignment(DataType dataType) const;
-    void validate_alignment(const Alignment& alignment, DataType dataType) const;
+    Alignment create_default_alignment(DataType dtype) const;
+    void validate_alignment(const Alignment& alignment, DataType dtype) const;
 
-    Size get_page_shape(const Size& physical_size, const MemoryConfig& memoryConfig) const;
-    size_t get_page_size_bytes(const Size& page_size, DataType dataType) const;
+    Size get_page_shape(const Size& physical_size, const MemoryConfig& memory_config) const;
+    size_t get_page_size_bytes(const Size& page_size, DataType dtype) const;
 };
 
 class TilePageConfig {
 public:
     TilePageConfig(const Tile& tile = Tile());
 
-    Alignment create_default_alignment(DataType dataType) const;
-    void validate_alignment(const Alignment& alignment, DataType dataType) const;
+    Alignment create_default_alignment(DataType dtype) const;
+    void validate_alignment(const Alignment& alignment, DataType dtype) const;
 
-    Size get_page_shape(const Size& physical_size, const MemoryConfig& memoryConfig) const;
-    size_t get_page_size_bytes(const Size& page_size, DataType dataType) const;
+    Size get_page_shape(const Size& physical_size, const MemoryConfig& memory_config) const;
+    size_t get_page_size_bytes(const Size& page_size, DataType dtype) const;
 
     const Tile& get_tile() const;
 
@@ -44,11 +44,11 @@ public:
     PageConfig(Layout layout);
     PageConfig(Layout layout, const std::optional<Tile>& tile);
 
-    Alignment create_default_alignment(DataType dataType) const;
-    void validate_alignment(const Alignment& alignment, DataType dataType) const;
+    Alignment create_default_alignment(DataType dtype) const;
+    void validate_alignment(const Alignment& alignment, DataType dtype) const;
 
-    Size get_page_shape(const Size& physical_size, const MemoryConfig& memoryConfig) const;
-    size_t get_page_size_bytes(const Size& page_size, DataType dataType) const;
+    Size get_page_shape(const Size& physical_size, const MemoryConfig& memory_config) const;
+    size_t get_page_size_bytes(const Size& page_size, DataType dtype) const;
 
     std::optional<Tile> get_tile() const;
 

--- a/ttnn/cpp/ttnn/tensor/shape.cpp
+++ b/ttnn/cpp/ttnn/tensor/shape.cpp
@@ -13,7 +13,7 @@ bool SimpleShape::operator==(const std::vector<uint32_t> &other) const {
 }
 
 size_t SimpleShape::rank() const {
-    return this->m_value.size();
+    return this->m_original_size;
 }
 
 uint64_t SimpleShape::volume() const {

--- a/ttnn/cpp/ttnn/tensor/shape.cpp
+++ b/ttnn/cpp/ttnn/tensor/shape.cpp
@@ -13,7 +13,7 @@ bool SimpleShape::operator==(const std::vector<uint32_t> &other) const {
 }
 
 size_t SimpleShape::rank() const {
-    return this->m_original_size;
+    return this->size();
 }
 
 uint64_t SimpleShape::volume() const {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -431,6 +431,8 @@ std::string to_string(const BufferType& buffer, const tt::tt_metal::LegacyShape&
         }
     } else if (layout == Layout::TILE) {
         switch (shape.rank()) {
+            case 0: print_datum(ss, buffer[0]); break;
+            case 1: ss << "Unsupported Rank (1) for printing tensor with TILE_LAYOUT!";
             case 2: to_string_tile<BufferType, 2>(ss, buffer, shape, 0, 0); break;
             case 3: to_string_tile<BufferType, 3>(ss, buffer, shape, 0, 0); break;
             case 4: to_string_tile<BufferType, 4>(ss, buffer, shape, 0, 0); break;

--- a/ttnn/cpp/ttnn/tensor/vector_base.cpp
+++ b/ttnn/cpp/ttnn/tensor/vector_base.cpp
@@ -33,10 +33,15 @@ int32_t normalized_index(int32_t index, size_t original_size, size_t container_s
 void VectorBase::init() {
     m_original_size = m_value.size();
     const size_t min_internal_size = 4;
+
     if(m_original_size < min_internal_size) {
         std::vector<uint32_t> ones(min_internal_size - m_original_size, 1);
         m_value.insert(m_value.begin(), ones.begin(), ones.end());
     }
+}
+
+size_t VectorBase::size() const {
+    return m_original_size;
 }
 
 std::span<const uint32_t> VectorBase::view() const {

--- a/ttnn/cpp/ttnn/tensor/vector_base.cpp
+++ b/ttnn/cpp/ttnn/tensor/vector_base.cpp
@@ -3,40 +3,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "vector_base.hpp"
+#include <stdexcept>
+#include "fmt/color.h"
+#include "tt_metal/common/assert.hpp"
 
 namespace tt::tt_metal {
 
 namespace {
-int32_t normalized_index(int32_t index, size_t container_size) {
-    int32_t size = static_cast<int32_t>(container_size);
 
-    if (index < 0) {
-        index += size;
+int32_t normalized_index(int32_t index, size_t original_size, size_t container_size) {
+    int32_t orig_size = static_cast<int32_t>(original_size);
+    int32_t full_size = static_cast<int32_t>(container_size);
+
+    int fixed_index = index;
+    if (fixed_index < 0) {
+        fixed_index += full_size;
+    } else {
+        fixed_index += full_size - orig_size;
     }
 
-    if (index < 0 || index >= size) {
-        throw std::out_of_range("SimpleShape index out of range.");
+    if (fixed_index < 0 || fixed_index >= full_size) {
+        TT_THROW("VectorBase[] index out of range. {} not in [{}, {})", index, -full_size, full_size);
     }
 
-    return index;
+    return fixed_index;
 }
 }
 
-bool VectorBase::operator==(const VectorBase &other) const {
-    return this->m_value == other.m_value;
+void VectorBase::init() {
+    m_original_size = m_value.size();
+    const size_t min_internal_size = 4;
+    if(m_original_size < min_internal_size) {
+        std::vector<uint32_t> new_value(min_internal_size, 1);
+        std::copy(m_value.begin(), m_value.end(), new_value.begin() + (min_internal_size - m_original_size));
+        m_value = std::move(new_value);
+    }
 }
+
+std::span<const uint32_t> VectorBase::view() const {
+    return std::span<const uint32_t>(cbegin(), cend());
+}
+
+std::vector<uint32_t> VectorBase::as_vector() const {
+    auto original_view = view();
+    return std::vector<uint32_t>(original_view.begin(), original_view.end());
+}
+
+bool VectorBase::operator==(const VectorBase &other) const = default;
 
 bool VectorBase::operator==(const std::vector<uint32_t> &other) const {
-    return this->m_value == other;
+    auto original_view = view();
+    return std::equal(original_view.begin(), original_view.end(), other.begin(), other.end());
 }
 
 uint32_t VectorBase::operator[](int32_t index) const {
-    auto norm_index = normalized_index(index, m_value.size());
+    auto norm_index = normalized_index(index, m_original_size, m_value.size());
     return m_value[norm_index];
 }
 
 uint32_t& VectorBase::operator[](int32_t index) {
-    auto norm_index = normalized_index(index, m_value.size());
+    auto norm_index = normalized_index(index, m_original_size, m_value.size());
     return m_value[norm_index];
 }
 

--- a/ttnn/cpp/ttnn/tensor/vector_base.cpp
+++ b/ttnn/cpp/ttnn/tensor/vector_base.cpp
@@ -34,9 +34,8 @@ void VectorBase::init() {
     m_original_size = m_value.size();
     const size_t min_internal_size = 4;
     if(m_original_size < min_internal_size) {
-        std::vector<uint32_t> new_value(min_internal_size, 1);
-        std::copy(m_value.begin(), m_value.end(), new_value.begin() + (min_internal_size - m_original_size));
-        m_value = std::move(new_value);
+        std::vector<uint32_t> ones(min_internal_size - m_original_size, 1);
+        m_value.insert(m_value.begin(), ones.begin(), ones.end());
     }
 }
 
@@ -64,6 +63,14 @@ uint32_t VectorBase::operator[](int32_t index) const {
 uint32_t& VectorBase::operator[](int32_t index) {
     auto norm_index = normalized_index(index, m_original_size, m_value.size());
     return m_value[norm_index];
+}
+
+VectorBase::Container::const_iterator VectorBase::cbegin() const {
+    return this->m_value.cbegin() + (m_value.size() - m_original_size);
+}
+
+VectorBase::Container::const_iterator VectorBase::cend() const {
+    return this->m_value.cend();
 }
 
 }

--- a/ttnn/cpp/ttnn/tensor/vector_base.hpp
+++ b/ttnn/cpp/ttnn/tensor/vector_base.hpp
@@ -12,6 +12,8 @@ namespace tt::tt_metal {
 // Container wrapper that allows negative indexing
 class VectorBase {
 public:
+    using Container = std::vector<uint32_t>;
+
     VectorBase() = default;
     explicit VectorBase(const std::vector<uint32_t>& shape) : m_value(shape) { init(); }
     explicit VectorBase(std::vector<uint32_t>&& shape) : m_value(std::move(shape)) { init(); }
@@ -31,9 +33,8 @@ public:
     uint32_t operator[](int32_t index) const;
     uint32_t &operator[](int32_t index);
 
-
-    auto cbegin() const { return this->m_value.cbegin() + (m_value.size() - m_original_size); }
-    auto cend() const { return this->m_value.cend(); }
+    Container::const_iterator cbegin() const;
+    Container::const_iterator cend() const;
 
     std::span<const uint32_t> view() const;
 
@@ -44,7 +45,7 @@ protected:
     void init();
 
     size_t m_original_size = 0;
-    std::vector<uint32_t> m_value;
+    Container m_value;
 };
 
 }

--- a/ttnn/cpp/ttnn/tensor/vector_base.hpp
+++ b/ttnn/cpp/ttnn/tensor/vector_base.hpp
@@ -43,9 +43,12 @@ public:
 
 protected:
     void init();
+    size_t size() const;
 
-    size_t m_original_size = 0;
     Container m_value;
+
+private:
+    size_t m_original_size = 0;
 };
 
 }

--- a/ttnn/cpp/ttnn/tensor/vector_base.hpp
+++ b/ttnn/cpp/ttnn/tensor/vector_base.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <vector>
+#include <span>
 
 namespace tt::tt_metal {
 
@@ -12,11 +13,11 @@ namespace tt::tt_metal {
 class VectorBase {
 public:
     VectorBase() = default;
-    explicit VectorBase(const std::vector<uint32_t>& shape) : m_value(shape) {}
-    explicit VectorBase(std::vector<uint32_t>&& shape) : m_value(std::move(shape)) {}
-    explicit VectorBase(std::initializer_list<uint32_t> ilist) : m_value(ilist) {}
+    explicit VectorBase(const std::vector<uint32_t>& shape) : m_value(shape) { init(); }
+    explicit VectorBase(std::vector<uint32_t>&& shape) : m_value(std::move(shape)) { init(); }
+    explicit VectorBase(std::initializer_list<uint32_t> ilist) : m_value(ilist) { init(); }
     template<std::size_t N>
-    explicit VectorBase(const std::array<uint32_t, N>& arr) : m_value(arr.begin(), arr.end()) {}
+    explicit VectorBase(const std::array<uint32_t, N>& arr) : m_value(arr.begin(), arr.end()) { init(); }
 
     template<std::size_t N>
     bool operator==(const std::array<uint32_t, N> &other) const {
@@ -31,12 +32,18 @@ public:
     uint32_t &operator[](int32_t index);
 
 
-    auto cbegin() const { return this->m_value.cbegin(); }
+    auto cbegin() const { return this->m_value.cbegin() + (m_value.size() - m_original_size); }
     auto cend() const { return this->m_value.cend(); }
 
-    [[nodiscard]] const std::vector<uint32_t>& as_vector() const { return this->m_value; }
+    std::span<const uint32_t> view() const;
+
+    [[deprecated("Use view() instead")]]
+    std::vector<uint32_t> as_vector() const;
 
 protected:
+    void init();
+
+    size_t m_original_size = 0;
     std::vector<uint32_t> m_value;
 };
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Wanted to add tests to verify not only the layout but also the creation of Tensor

### What's changed
* Make every TensorLayout test check tensor creation and data loopback
* Changed the behavior of VectorBase to return 1 when the index is out of range

### Important note
* I fully realize this is not the best behavior.
* I realize that I add another allocation here for shapes < 4
* It is a concision tradeoff
* I am open to suggestions on how to make it better
* I go this way mainly because:
  * Our current codebase assumes >0 rank all over the place and does shape[-1] and shape[-2] w/o rank check
  * We must bridge TensorLayout change with the rest of the codebase
  * I don't see changing the rest of the codebase a) nor practical b) nor desirable (convolutes the code)
  * I believe we will switch to small_vector soon, so the allocation concern must go away
  * I can't just return 1, because of **uint32_t&** operator[] (reference)

### Checklist
Merge into a feature branch
- [x] Local tests pass