### PR TITLE
#14200: add bfp8_b tests for moreh_dot_backward

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_dot_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_dot_backward.py
@@ -12,14 +12,26 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
     compute_kernel_ids,
+    get_ttnn_torch_dtype,
 )
 
 
 def get_tensors(
-    input_shape, other_shape, output_shape, require_input_grad, require_other_grad, is_1d, device, use_randint=True
+    input_shape,
+    other_shape,
+    output_shape,
+    require_input_grad,
+    require_other_grad,
+    is_1d,
+    device,
+    npu_dtype=ttnn.bfloat16,
+    use_randint=True,
 ):
-    npu_dtype = ttnn.bfloat16
-    cpu_dtype = torch.bfloat16
+    cpu_dtype = get_ttnn_torch_dtype(npu_dtype)
+    if cpu_dtype is None:
+        # panic
+        assert False
+
     npu_layout = ttnn.TILE_LAYOUT
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
 
@@ -33,9 +45,9 @@ def get_tensors(
         other = torch.rand(other_shape, dtype=cpu_dtype)
         output = torch.rand(output_shape, dtype=cpu_dtype)
 
-    tt_input = ttnn.Tensor(input, npu_dtype).pad_to_tile(float(1)).to(npu_layout).to(device)
-    tt_other = ttnn.Tensor(other, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    tt_output = ttnn.Tensor(output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_input = ttnn.from_torch(input, npu_dtype, layout=npu_layout, device=device)
+    tt_other = ttnn.from_torch(other, npu_dtype, layout=npu_layout, device=device)
+    tt_output = ttnn.from_torch(output, npu_dtype, layout=npu_layout, device=device)
 
     torch_input = input.reshape(-1) if is_1d else input
     torch_other = other.reshape(-1) if is_1d else other
@@ -44,25 +56,16 @@ def get_tensors(
     output_grad = tt_output_grad = torch_output_grad = tt_input_grad = tt_other_grad = None
     if require_input_grad or require_other_grad:
         output_grad = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
-        # tt_output_grad = ttnn.Tensor(output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-        tt_output_grad = ttnn.Tensor(output_grad, npu_dtype).pad_to_tile(float(-1)).to(npu_layout).to(device)
+        tt_output_grad = ttnn.from_torch(output_grad, npu_dtype, layout=npu_layout, device=device)
         torch_output_grad = output_grad[0][0][0][0] if is_1d else output_grad
 
         if require_input_grad:
             input_grad = torch.full(input_shape, float("nan"), dtype=cpu_dtype)
-            tt_input_grad = ttnn.Tensor(input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+            tt_input_grad = ttnn.from_torch(input_grad, npu_dtype, layout=npu_layout, device=device)
 
         if require_other_grad:
             other_grad = torch.full(other_shape, float("nan"), dtype=cpu_dtype)
-            tt_other_grad = (
-                ttnn.Tensor(
-                    other_grad,
-                    npu_dtype,
-                )
-                .pad_to_tile(float("nan"))
-                .to(npu_layout)
-                .to(device)
-            )
+            tt_other_grad = ttnn.from_torch(other_grad, npu_dtype, layout=npu_layout, device=device)
 
     return (
         tt_input,
@@ -77,24 +80,7 @@ def get_tensors(
     )
 
 
-@pytest.mark.parametrize(
-    "input_shape",
-    (
-        [1, 1, 1, 10],  # test not mutiple of 32 case
-        [1, 1, 1, 32],  # test single tile
-        [1, 1, 1, 352],  # test multiple tiles
-        [1, 1, 1, 323],  # test multiple tiles, not a multiple of 32
-    ),
-)
-@pytest.mark.parametrize(
-    "requires_grad",
-    (
-        (True, False),
-        (False, True),
-        (True, True),
-    ),
-)
-def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
+def run_moreh_dot_backward(input_shape, requires_grad, device, dtype=ttnn.bfloat16, use_randint=True):
     torch.manual_seed(3072)
     require_input_grad, require_other_grad = requires_grad
     output_shape = [1, 1, 1, 1]
@@ -109,7 +95,9 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
         torch_input,
         torch_other,
         torch_output_grad,
-    ) = get_tensors(input_shape, input_shape, output_shape, require_input_grad, require_other_grad, True, device)
+    ) = get_tensors(
+        input_shape, input_shape, output_shape, require_input_grad, require_other_grad, True, device, dtype, use_randint
+    )
     # torch matmul
     torch_out = torch.matmul(
         torch_input.requires_grad_(require_input_grad), torch_other.requires_grad_(require_other_grad)
@@ -125,7 +113,7 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
     rtol = atol = 0.1
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     if require_input_grad:
-        ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
+        ttcpu_input_grad = ttnn.to_torch(tt_input_grad)
 
         passing, output_pcc = comp_allclose_and_pcc(
             torch_input.grad, ttcpu_input_grad.reshape(-1), pcc=0.999, rtol=rtol, atol=atol
@@ -135,7 +123,7 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
         assert passing
 
     if require_other_grad:
-        ttcpu_other_grad = tt_other_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
+        ttcpu_other_grad = ttnn.to_torch(tt_other_grad)
 
         passing, output_pcc = comp_allclose_and_pcc(
             torch_other.grad, ttcpu_other_grad.reshape(-1), pcc=0.999, rtol=rtol, atol=atol
@@ -143,3 +131,61 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
         logger.debug(f"other_grad passing={passing}")
         logger.debug(f"other_grad pcc={output_pcc}")
         assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        [1, 1, 1, 10],  # test not mutiple of 32 case
+        [1, 1, 1, 32],  # test single tile
+        [1, 1, 1, 352],  # test multiple tiles
+        [1, 1, 1, 323],  # test multiple tiles, not a multiple of 32
+    ),
+)
+@pytest.mark.parametrize(
+    "requires_grad",
+    (
+        [True, False],
+        [False, True],
+        [True, True],
+    ),
+)
+@pytest.mark.parametrize("use_randint", (True, False))
+@pytest.mark.parametrize("dtype", ([ttnn.bfloat16, ttnn.bfloat8_b]))
+def test_moreh_dot_backward(input_shape, requires_grad, dtype, use_randint, device):
+    run_moreh_dot_backward(input_shape, requires_grad, device, dtype, use_randint)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        [1, 1, 1, 10],  # test not mutiple of 32 case
+        [1, 1, 1, 32],  # test single tile
+        [1, 1, 1, 352],  # test multiple tiles
+        [1, 1, 1, 323],  # test multiple tiles, not a multiple of 32
+    ),
+)
+@pytest.mark.parametrize(
+    "requires_grad",
+    (
+        [True, False],
+        [False, True],
+        [True, True],
+    ),
+)
+def test_moreh_dot_backward_callback(
+    input_shape,
+    requires_grad,
+    device,
+    use_program_cache,
+):
+    num_program_in_cache = []
+    for i in range(2):
+        run_moreh_dot_backward(input_shape, requires_grad, device)
+        num_program_in_cache.append(device.num_program_cache_entries())
+        dummy = torch.randn([32, 32])
+        tt_dummy = ttnn.from_torch(dummy, device=device)
+
+    logger.info(f"num_program_in_cache={num_program_in_cache}")
+    assert num_program_in_cache[0] > 0
+    assert num_program_in_cache[0] == num_program_in_cache[1]

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+import torch
 from models.utility_functions import is_wormhole_b0
 import copy
 import pytest
@@ -177,3 +178,22 @@ def get_lib_dtype(lib, dtype):
             "int32": lib.int32,
         }
         return dtype_map.get(dtype, None)
+
+
+def get_ttnn_torch_dtype(ttnn_dtype: ttnn.DataType) -> torch.dtype:
+    """
+    Maps a ttnn.DataType to the corresponding torch dtype that can handle them.
+    Parameters:
+    ttnn_dtype: ttnn.DataType
+        The ttnn data type to be mapped.
+    Returns:
+    torch.dtype or None
+        The corresponding torch dtype if the mapping exists, otherwise None.
+    """
+    dtype_map = {
+        ttnn.bfloat16: torch.bfloat16,
+        ttnn.float32: torch.float32,
+        ttnn.bfloat8_b: torch.bfloat16,
+        ttnn.int32: torch.int32,
+    }
+    return dtype_map.get(ttnn_dtype, None)


### PR DESCRIPTION
### Ticket
Closes #14200 

### Problem description
`moreh_dot_backward` supports `bfloat8_b` as an input type, but it is missing an unit test for that

### What's changed
- Added unit tests for `bfp8_b`
- Disable integer-only prng tests

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
