### PR TITLE
#13626: Update doc for lgamma, normalize_global, normalize_hw, mish

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/lgamma.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/lgamma.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -14,10 +13,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
@@ -28,18 +23,18 @@ parameters = {
         "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 32)
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 32)
         + gen_shapes([1, 1], [256, 256], [1, 1], 32),
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "input_dtype": [ttnn.bfloat16],
+        "input_layout": [ttnn.TILE_LAYOUT],
+        "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
     "xfail": {
         "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 4)
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 4)
         + gen_shapes([1, 1], [256, 256], [1, 1], 4),
-        "input_a_dtype": [ttnn.bfloat8_b],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "input_dtype": [ttnn.bfloat8_b],
+        "input_layout": [ttnn.TILE_LAYOUT],
+        "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
@@ -51,34 +46,33 @@ parameters = {
 # If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_a_layout,
-    input_a_memory_config,
+    input_dtype,
+    input_layout,
+    input_memory_config,
     output_memory_config,
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
-    torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=0.0001, high=100, dtype=torch.float32), input_a_dtype
+    torch_input_tensor = gen_func_with_cast_tt(
+        partial(torch_random, low=0.0001, high=100, dtype=torch.float32), input_dtype
     )(input_shape)
-    torch_output_tensor = torch.lgamma(torch_input_tensor_a)
+    golden_function = ttnn.get_golden_function(ttnn.lgamma)
+    torch_output_tensor = golden_function(torch_input_tensor)
 
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=input_a_dtype,
-        layout=input_a_layout,
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=input_dtype,
+        layout=input_layout,
         device=device,
-        memory_config=input_a_memory_config,
+        memory_config=input_memory_config,
     )
 
     start_time = start_measuring_time()
-    result = ttnn.lgamma(input_tensor_a, memory_config=output_memory_config)
+    result = ttnn.lgamma(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 
     pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    # print(f"pcc {pcc}")
     return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/mish.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/mish.py
@@ -7,7 +7,6 @@ from functools import partial
 
 import os
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -15,10 +14,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
@@ -30,11 +25,20 @@ parameters = {
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 16)
         + gen_shapes([1, 1], [256, 256], [1, 1], 16),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_a_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
+    return False, None
 
 
 def mesh_device_fixture():
@@ -59,15 +63,14 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    mish = torch.nn.Mish()
-    torch_output_tensor = mish(torch_input_tensor_a)
+    golden_function = ttnn.get_golden_function(ttnn.mish)
+    torch_output_tensor = golden_function(torch_input_tensor_a)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/sweep_framework/sweeps/eltwise/unary/normalize_global/normalize_global.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/normalize_global/normalize_global.py
@@ -6,18 +6,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -27,12 +21,21 @@ random.seed(0)
 parameters = {
     "nightly": {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 64),
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is not supported"
+    return False, None
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -41,35 +44,32 @@ parameters = {
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
-    input_a_dtype,
-    input_a_layout,
-    input_a_memory_config,
+    input_dtype,
+    input_layout,
+    input_memory_config,
     output_memory_config,
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
-    torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-1, high=1, dtype=torch.float32), input_a_dtype
-    )(input_shape)
+    torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-1, high=1, dtype=torch.float32), input_dtype)(
+        input_shape
+    )
 
-    mean_global = torch.mean(torch_input_tensor_a, list(range(0, len(input_shape))), keepdim=True)
-    std_global = torch.std(torch_input_tensor_a, list(range(0, len(input_shape))), keepdim=True)
+    golden_function = ttnn.get_golden_function(ttnn.normalize_global)
+    torch_output_tensor = golden_function(torch_input_tensor)
 
-    torch_output_tensor = (torch_input_tensor_a - mean_global) / std_global
-
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=input_a_dtype,
-        layout=input_a_layout,
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=input_dtype,
+        layout=input_layout,
         device=device,
-        memory_config=input_a_memory_config,
+        memory_config=input_memory_config,
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.normalize_global(input_tensor_a, memory_config=output_memory_config)
+    output_tensor = ttnn.normalize_global(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/unary/normalize_hw/normalize_hw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/normalize_hw/normalize_hw.py
@@ -6,18 +6,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -27,12 +21,21 @@ random.seed(0)
 parameters = {
     "nightly": {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 64),
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_a_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is not supported"
+    return False, None
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -48,22 +51,16 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-10, high=10, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
     torch_output_tensor = torch_input_tensor_a.clone()
-    mean_hw = torch.mean(torch_output_tensor, [-2, -1], keepdim=True)
-    std_hw = torch.std(torch_output_tensor, [-2, -1], keepdim=True)
 
-    for i in range(torch_output_tensor.shape[0]):
-        for j in range(torch_output_tensor.shape[1]):
-            torch_output_tensor[i, j, :, :] = (torch_output_tensor[i, j, :, :] - mean_hw[i, j, :, :]) / std_hw[
-                i, j, :, :
-            ]
+    golden_function = ttnn.get_golden_function(ttnn.normalize_global)
+    torch_output_tensor = golden_function(torch_output_tensor)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -24,7 +24,16 @@ namespace unary {
 namespace detail {
 
 template <typename unary_operation_t>
-void bind_unary_composite_optional_floats_with_default(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, std::optional<float> parameter_a_value, const std::string& parameter_name_b, const std::string& parameter_b_doc, std::optional<float> parameter_b_value, const std::string& description) {
+void bind_unary_composite_optional_floats_with_default(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    std::optional<float> parameter_a_value,
+    const std::string& parameter_name_b,
+    const std::string& parameter_b_doc,
+    std::optional<float> parameter_b_value,
+    const std::string& description) {
     auto doc = fmt::format(
         R"doc(
         {8}
@@ -192,8 +201,6 @@ void bind_unary_operation_overload_complex_return_complex(py::module& module, co
         R"doc(
         Applies {0} to :attr:`input_tensor` element-wise.
 
-        {2}
-
         .. math::
             \mathrm{{output\_tensor}}_i = {0}(\mathrm{{input\_tensor}}_i)
 
@@ -207,6 +214,9 @@ void bind_unary_operation_overload_complex_return_complex(py::module& module, co
 
         Returns:
             ttnn.Tensor: the output tensor.
+
+        Note:
+            {2}
 
         Example:
             >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
@@ -305,7 +315,7 @@ void bind_unary_operation_with_float_parameter(
     const std::string& parameter_name,
     const std::string& parameter_doc,
     const std::string& info_doc,
-    const std::string& note=" ") {
+    const std::string& note = "") {
     auto doc = fmt::format(
         R"doc(
         Applies {0} to :attr:`input_tensor` element-wise with {2}.
@@ -484,7 +494,16 @@ void bind_unary_operation_with_dim_parameter(
 }
 
 template <typename unary_operation_t>
-void bind_unary_rdiv(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, const std::string& parameter_name_b, const std::string& parameter_b_doc, const std::string parameter_b_value, const std::string& description, const std::string& note = " ") {
+void bind_unary_rdiv(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    const std::string& parameter_name_b,
+    const std::string& parameter_b_doc,
+    const std::string parameter_b_value,
+    const std::string& description,
+    const std::string& note = " ") {
     auto doc = fmt::format(
         R"doc(
         {7}
@@ -854,7 +873,13 @@ void bind_unary_composite(py::module& module, const unary_operation_t& operation
 
 //OpHandler_1int
 template <typename unary_operation_t>
-void bind_unary_composite_int_with_default(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, int32_t parameter_a_value, const std::string& description) {
+void bind_unary_composite_int_with_default(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    int32_t parameter_a_value,
+    const std::string& description) {
     auto doc = fmt::format(
         R"doc(
         {5}
@@ -899,7 +924,16 @@ void bind_unary_composite_int_with_default(py::module& module, const unary_opera
 
 //OpHandler_two_float_with_default
 template <typename unary_operation_t>
-void bind_unary_composite_floats_with_default(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, float parameter_a_value, const std::string& parameter_name_b, const std::string& parameter_b_doc, float parameter_b_value, const std::string& note = "") {
+void bind_unary_composite_floats_with_default(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    float parameter_a_value,
+    const std::string& parameter_name_b,
+    const std::string& parameter_b_doc,
+    float parameter_b_value,
+    const std::string& info_doc = "") {
     auto doc = fmt::format(
         R"doc(
         Performs {0} function on :attr:`input_tensor`, :attr:`{2}`, :attr:`{5}`.
@@ -930,7 +964,7 @@ void bind_unary_composite_floats_with_default(py::module& module, const unary_op
         parameter_name_b,
         parameter_b_doc,
         parameter_b_value,
-        note);
+        info_doc);
 
     bind_registered_operation(
         module,
@@ -996,7 +1030,14 @@ void bind_unary_composite_int(py::module& module, const unary_operation_t& opera
 
 //OpHandler_two_float_with_default
 template <typename unary_operation_t>
-void bind_unary_composite_floats(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc,  const std::string& parameter_name_b, const std::string& parameter_b_doc, const std::string& description) {
+void bind_unary_composite_floats(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    const std::string& parameter_name_b,
+    const std::string& parameter_b_doc,
+    const std::string& description) {
     auto doc = fmt::format(
         R"doc(
         {6}
@@ -1093,7 +1134,13 @@ void bind_unary_composite_operation(py::module& module, const unary_operation_t&
 
 //OpHandler_float_with_default
 template <typename unary_operation_t>
-void bind_unary_composite_float_with_default(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, float parameter_a_value, const std::string& note = "") {
+void bind_unary_composite_float_with_default(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    float parameter_a_value,
+    const std::string& info_doc = "") {
     auto doc = fmt::format(
         R"doc(
         Performs {0} function on :attr:`input_tensor`, :attr:`{2}`.
@@ -1120,7 +1167,7 @@ void bind_unary_composite_float_with_default(py::module& module, const unary_ope
         parameter_name_a,
         parameter_a_doc,
         parameter_a_value,
-        note);
+        info_doc);
 
     bind_registered_operation(
         module,
@@ -1140,20 +1187,30 @@ void bind_unary_composite_float_with_default(py::module& module, const unary_ope
 }
 
 template <typename unary_operation_t>
-void bind_unary_composite_float(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, const std::string& description) {
+void bind_unary_composite_float(
+    py::module& module,
+    const unary_operation_t& operation,
+    const std::string& parameter_name_a,
+    const std::string& parameter_a_doc,
+    const std::string& description,
+    const std::string& range,
+    const std::string& info_doc = "") {
     auto doc = fmt::format(
         R"doc(
         {4}
 
         Args:
-            input_tensor (ttnn.Tensor): the input tensor.
-            {2}
+            input_tensor (ttnn.Tensor): the input tensor. {5}
+            {2} (float): {3}
 
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
+
+        Note:
+            {6}
 
         Example:
             >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
@@ -1163,7 +1220,9 @@ void bind_unary_composite_float(py::module& module, const unary_operation_t& ope
         operation.python_fully_qualified_name(),
         parameter_name_a,
         parameter_a_doc,
-        description);
+        description,
+        range,
+        info_doc);
     bind_registered_operation(
         module,
         operation,
@@ -1543,7 +1602,16 @@ void py_module(py::module& module) {
            +----------------------------+---------------------------------+-------------------+
         )doc");
 
-    detail::bind_unary_operation_overload_complex_return_complex(module, ttnn::reciprocal);
+    detail::bind_unary_operation_overload_complex_return_complex(module, ttnn::reciprocal,
+        R"doc(Supported dtypes, layouts, and ranks:
+
+           +----------------------------+---------------------------------+-------------------+
+           |     Dtypes                 |         Layouts                 |     Ranks         |
+           +----------------------------+---------------------------------+-------------------+
+           |    BFLOAT16                |          TILE                   |      2, 3, 4      |
+           +----------------------------+---------------------------------+-------------------+
+        )doc");
+
     detail::bind_unary_operation(module, ttnn::relu, R"doc(\mathrm{{output\_tensor}}_i = relu(\mathrm{{input\_tensor}}_i))doc");
     detail::bind_unary_operation(module, ttnn::relu6, R"doc(\mathrm{{output\_tensor}}_i = relu6(\mathrm{{input\_tensor}}_i))doc");
     detail::bind_unary_operation(module, ttnn::sigmoid, R"doc(\mathrm{{output\_tensor}}_i = sigmoid(\mathrm{{input\_tensor}}_i))doc");
@@ -1574,7 +1642,9 @@ void py_module(py::module& module) {
            +----------------------------+---------------------------------+-------------------+
 
         )doc");
-    detail::bind_unary_operation(module, ttnn::bitwise_not, R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_not|(\mathrm{{input\_tensor}}_i))doc", "Input tensor needs to be in the range [-2147483647, 2147483647], INT32 dtype. Support provided only for Wormhole_B0.");
+    detail::bind_unary_operation(module, ttnn::bitwise_not,
+    R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_not|(\mathrm{{input\_tensor}}_i))doc",
+    "Input tensor needs to be in the range [-2147483647, 2147483647], INT32 dtype. Support provided only for Wormhole_B0.");
 
     //  Unaries with fast_and_approximate_mode
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::exp,
@@ -1618,7 +1688,8 @@ void py_module(py::module& module) {
            +----------------------------+---------------------------------+-------------------+
         )doc");
 
-    detail::bind_unary_operation_with_float_parameter(module, ttnn::rsub, "value", "subtrahent value which is actually calculated as minuend", "Returns tensor with respective elements of the input tensor subtracted from the value.",
+    detail::bind_unary_operation_with_float_parameter(module, ttnn::rsub, "value", "subtrahent value which is actually calculated as minuend",
+        "Returns tensor with respective elements of the input tensor subtracted from the value.",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1653,7 +1724,8 @@ void py_module(py::module& module) {
 
         )doc");
 
-    detail::bind_unary_operation_with_float_parameter(module, ttnn::fill, "fill_value", "The value to be filled in the output tensor", "This will create a tensor of same shape as input reference tensor with fill_value. Support provided for bfloat16, float32 dtypes in Wormhole_B0; Support provided for bfloat16 in Grayskull.",
+    detail::bind_unary_operation_with_float_parameter(module, ttnn::fill, "fill_value", "The value to be filled in the output tensor",
+        "This will create a tensor of same shape as input reference tensor with fill_value. Support provided for bfloat16, float32 dtypes in Wormhole_B0; Support provided for bfloat16 in Grayskull.",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+-------------------+
@@ -1668,7 +1740,8 @@ void py_module(py::module& module) {
 
         )doc");
 
-    detail::bind_unary_operation_with_float_parameter(module, ttnn::relu_max, "upper_limit", "The max value for ReLU function", "This function caps off the input to a max value and a min value of 0",
+    detail::bind_unary_operation_with_float_parameter(module, ttnn::relu_max, "upper_limit", "The max value for ReLU function",
+        "This function caps off the input to a max value and a min value of 0",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1680,7 +1753,8 @@ void py_module(py::module& module) {
            System memory is not supported.
 
         )doc");
-    detail::bind_unary_operation_with_float_parameter(module, ttnn::relu_min, "lower_limit", "The min value for ReLU function", "This will carry out ReLU operation at min value instead of the standard 0",
+    detail::bind_unary_operation_with_float_parameter(module, ttnn::relu_min, "lower_limit", "The min value for ReLU function",
+        "This will carry out ReLU operation at min value instead of the standard 0",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1702,7 +1776,12 @@ void py_module(py::module& module) {
 
 
     // Unary ops with dim parameter
-    detail::bind_unary_operation_with_dim_parameter(module, ttnn::glu, "dim", "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)", "Split the tensor into two parts, apply the GLU function on the second tensor, and then perform multiplication with the first tensor.",
+    detail::bind_unary_operation_with_dim_parameter(
+        module,
+        ttnn::glu,
+        "dim",
+        "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)",
+        "Split the tensor into two parts, apply the GLU function on the second tensor, and then perform multiplication with the first tensor.",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1717,7 +1796,12 @@ void py_module(py::module& module) {
 
         )doc");
 
-    detail::bind_unary_operation_with_dim_parameter(module, ttnn::reglu, "dim", "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)", "Split the tensor into two parts, apply the ReLU function on the second tensor, and then perform multiplication with the first tensor.",
+    detail::bind_unary_operation_with_dim_parameter(
+        module,
+        ttnn::reglu,
+        "dim",
+        "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)",
+        "Split the tensor into two parts, apply the ReLU function on the second tensor, and then perform multiplication with the first tensor.",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1732,7 +1816,12 @@ void py_module(py::module& module) {
 
         )doc");
 
-    detail::bind_unary_operation_with_dim_parameter(module, ttnn::geglu, "dim", "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)", "Split the tensor into two parts, apply the GELU function on the second tensor, and then perform multiplication with the first tensor.",
+    detail::bind_unary_operation_with_dim_parameter(
+        module,
+        ttnn::geglu,
+        "dim",
+        "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)",
+        "Split the tensor into two parts, apply the GELU function on the second tensor, and then perform multiplication with the first tensor.",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1747,7 +1836,12 @@ void py_module(py::module& module) {
 
         )doc");
 
-    detail::bind_unary_operation_with_dim_parameter(module, ttnn::swiglu, "dim", "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)", "Split the tensor into two parts, apply the SiLU function on the second tensor, and then perform multiplication with the first tensor.",
+    detail::bind_unary_operation_with_dim_parameter(
+        module,
+        ttnn::swiglu,
+        "dim",
+        "Dimension to split input tensor. Supported only for last dimension (dim = -1 or 3)",
+        "Split the tensor into two parts, apply the SiLU function on the second tensor, and then perform multiplication with the first tensor.",
         R"doc(Supported dtypes, layouts, and ranks:
 
            +----------------------------+---------------------------------+-------------------+
@@ -1853,7 +1947,18 @@ void py_module(py::module& module) {
            +----------------------------+---------------------------------+-------------------+
 
         )doc");
-    detail::bind_unary_composite(module, ttnn::mish, R"doc(Performs mish function on :attr:`input_tensor`, not supported for grayskull.)doc", "[supported range -20 to inf]");
+    detail::bind_unary_composite(module, ttnn::mish, R"doc(Performs mish function on :attr:`input_tensor`.)doc", "[supported range -20 to inf]",
+        R"doc(Supported dtypes, layouts, and ranks:
+
+           +----------------------------+---------------------------------+-------------------+
+           |     Dtypes                 |         Layouts                 |     Ranks         |
+           +----------------------------+---------------------------------+-------------------+
+           |    BFLOAT16, BFLOAT8_B     |          TILE                   |      2, 3, 4      |
+           +----------------------------+---------------------------------+-------------------+
+
+           Not supported on Grayskull.
+
+        )doc");
     detail::bind_unary_composite(module, ttnn::multigammaln, R"doc(Performs multigammaln function on :attr:`input_tensor`.)doc", "[supported range 1.6 to inf]",
         R"doc(Supported dtypes, layouts, and ranks:
 
@@ -2054,8 +2159,20 @@ void py_module(py::module& module) {
     detail::bind_unary_composite_float(
         module,
         ttnn::rpow,
-        "exponent", "exponent value",
-        R"doc(Performs rpow function on :attr:`input_tensor`, :attr:`exponent`.)doc");
+        "exponent", "exponent value. Non-positive values are not supported.",
+        R"doc(Performs rpow function on :attr:`input_tensor`, :attr:`exponent`.)doc",
+        R"doc(Supported for input range upto 25)doc",
+        R"doc(Supported dtypes and layouts:
+
+           +----------------------------+---------------------------------+-------------------+
+           |     Dtypes                 |         Layouts                 |     Ranks         |
+           +----------------------------+---------------------------------+-------------------+
+           |    BFLOAT16                |       TILE                      |      2, 3, 4      |
+           +----------------------------+---------------------------------+-------------------+
+
+           System memory is not supported.
+
+        )doc");
 
     detail::bind_unary_rdiv(
     module,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1879,9 +1879,27 @@ void py_module(py::module& module) {
     detail::bind_unary_composite(module, ttnn::swish, R"doc(Performs swish function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::var_hw, R"doc(Performs var_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::std_hw, R"doc(Performs std_hw function on :attr:`input_tensor`.)doc");
-    detail::bind_unary_composite(module, ttnn::normalize_hw, R"doc(Performs normalize_hw function on :attr:`input_tensor`.)doc");
+    detail::bind_unary_composite(module, ttnn::normalize_hw, R"doc(Performs normalize_hw function on :attr:`input_tensor`.)doc", "",
+        R"doc(Supported dtypes, layouts, and ranks:
+
+           +----------------------------+---------------------------------+-------------------+
+           |     Dtypes                 |         Layouts                 |     Ranks         |
+           +----------------------------+---------------------------------+-------------------+
+           |    BFLOAT16                |          ROW MAJOR, TILE        |      4            |
+           +----------------------------+---------------------------------+-------------------+
+
+        )doc");
     detail::bind_unary_composite(module, ttnn::logical_not_, R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc");
-    detail::bind_unary_composite(module, ttnn::normalize_global, R"doc(Performs normalize_global function on :attr:`input_tensor`.)doc");
+    detail::bind_unary_composite(module, ttnn::normalize_global, R"doc(Performs normalize_global function on :attr:`input_tensor`.)doc", "",
+        R"doc(Supported dtypes, layouts, and ranks:
+
+           +----------------------------+---------------------------------+-------------------+
+           |     Dtypes                 |         Layouts                 |     Ranks         |
+           +----------------------------+---------------------------------+-------------------+
+           |    BFLOAT16                |          ROW MAJOR, TILE        |      4            |
+           +----------------------------+---------------------------------+-------------------+
+
+        )doc");
     detail::bind_unary_composite(module, ttnn::frac, R"doc(Performs frac function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite_operation(module, ttnn::trunc, R"doc(Not supported for grayskull.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -2161,7 +2161,7 @@ void py_module(py::module& module) {
         ttnn::rpow,
         "exponent", "exponent value. Non-positive values are not supported.",
         R"doc(Performs rpow function on :attr:`input_tensor`, :attr:`exponent`.)doc",
-        R"doc(Supported for input range upto 25)doc",
+        R"doc(Supported for input range upto 28)doc",
         R"doc(Supported dtypes and layouts:
 
            +----------------------------+---------------------------------+-------------------+

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1833,7 +1833,16 @@ void py_module(py::module& module) {
 
         )doc");
     detail::bind_unary_composite(module, ttnn::digamma, R"doc(Performs digamma function on :attr:`input_tensor`.)doc", "[supported for value greater than 0]");
-    detail::bind_unary_composite(module, ttnn::lgamma, R"doc(Performs lgamma function on :attr:`input_tensor`.)doc", "[supported for value greater than 0]");
+    detail::bind_unary_composite(module, ttnn::lgamma, R"doc(Performs lgamma function on :attr:`input_tensor`.)doc", "[supported for value greater than 0]",
+        R"doc(Supported dtypes, layouts, and ranks:
+
+           +----------------------------+---------------------------------+-------------------+
+           |     Dtypes                 |         Layouts                 |     Ranks         |
+           +----------------------------+---------------------------------+-------------------+
+           |    BFLOAT16                |          TILE                   |      2, 3, 4      |
+           +----------------------------+---------------------------------+-------------------+
+
+        )doc");
     detail::bind_unary_composite(module, ttnn::log1p, R"doc(Performs log1p function on :attr:`input_tensor`.)doc", "[supported range -1 to 1]",
         R"doc(Supported dtypes, layouts, and ranks:
 

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -676,6 +676,22 @@ def _golden_function_normalize_global(input_tensor_a, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.normalize_global, golden_function=_golden_function_normalize_global)
 
 
+def _golden_function_normalize_hw(input_tensor_a, *args, **kwargs):
+    import torch
+
+    mean_hw = torch.mean(input_tensor_a, [-2, -1], keepdim=True)
+    std_hw = torch.std(input_tensor_a, [-2, -1], keepdim=True)
+
+    for i in range(input_tensor_a.shape[0]):
+        for j in range(input_tensor_a.shape[1]):
+            input_tensor_a[i, j, :, :] = (input_tensor_a[i, j, :, :] - mean_hw[i, j, :, :]) / std_hw[i, j, :, :]
+
+    return input_tensor_a
+
+
+ttnn.attach_golden_function(ttnn.normalize_hw, golden_function=_golden_function_normalize_hw)
+
+
 def _golden_function_rpow(input_tensor_a, dim, *args, **kwargs):
     import torch
 


### PR DESCRIPTION
### Ticket
#13626 
#13682 
#3309 
#8156 

### Problem description
Documentation on supported params incomplete

### List of Ops
- [x] lgamma
- [x] normalize_global
- [x] normalize_hw 
- [x] rpow
- [x] reciprocal
- [x] mish

### What's changed
- Updated doc to include supported dtypes, layouts and ranks
- Updated sweep tests to include invalidate function and golden function; removed timeout parameter

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11594267041) - PASSED
- [x] Run Sweeps