### PR TITLE
reduction ops sweeps: argmax and topk

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -219,6 +219,8 @@ on:
           - eltwise.ternary.lerp
           - eltwise.ternary.where.where
           - eltwise.ternary.where.where_pytorch2
+          - reduction.topk.topk
+          - reduction.argmax.argmax
           - matmul.full.matmul_default_block_sharded
           - matmul.full.matmul_default_height_sharded
           - matmul.full.matmul_default_interleaved

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -8,6 +8,7 @@ from loguru import logger
 from itertools import product
 import torch
 import ttnn
+import math
 
 
 def sanitize_shape_rm(input_shape):
@@ -137,3 +138,17 @@ def gen_with_zeroes(size, probabilityzeroes=0.5, low=-100, high=100, dtype=torch
     ridx = torch.randperm(element_count)  # a random permutation of the entries
     mask = torch.reshape(raw[ridx], size)
     return mask
+
+
+# at the moment, topk only works on last dim
+# last dim must be a multiple of 64 and a pow of 2
+def santize_topk_shape(input_shape):
+    num_dims = len(input_shape)
+    last_dim = input_shape[num_dims - 1]
+    if not (last_dim & (last_dim - 1) == 0) and last_dim != 0:
+        last_dim = 2 ** math.ceil(math.log2(last_dim))
+        last_dim = last_dim + last_dim % 64
+
+    input_shape[num_dims - 1] = last_dim
+
+    return input_shape

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -31,7 +31,7 @@ parameters = {
         + gen_shapes([1, 1], [128, 128], [1, 1], 128),
         "dim": [0, 1, 2, 3, None],
         "input_a_dtype": [ttnn.bfloat16],
-        "input_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
@@ -51,6 +51,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["dim"] is not None:
         if test_vector["dim"] * (-1) > (len(test_vector["input_shape"])):
             return True, "Absolute value of dim must be less or equal than the rank of input tensor"
+    if test_vector["input_layout"] == ttnn.TILE_LAYOUT:
+        return True, "Tiled layout not supported"
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
     return False, None

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 30
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_shape": gen_shapes([1, 1, 1, 1], [2, 6, 128, 128], [1, 1, 1, 1], 128)
+        + gen_shapes([1, 1, 1], [6, 128, 128], [1, 1, 1], 128)
+        + gen_shapes([1, 1], [128, 128], [1, 1], 128),
+        "dim": [0, 1, 2, 3, None],
+        "input_a_dtype": [ttnn.bfloat16],
+        "input_layout": [ttnn.ROW_MAJOR_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_shape"][0] != 1:
+        return True, "dim 0 must be 1"
+    if test_vector["input_shape"][1] != 1:
+        return True, "dim 1 must be 1"
+    if test_vector["dim"] != 3:
+        return True, "Only argmax on last dim is supported"
+    if test_vector["dim"] is not None:
+        if test_vector["dim"] * (-1) > (len(test_vector["input_shape"])):
+            return True, "Absolute value of dim must be less or equal than the rank of input tensor"
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    dim,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    torch_output_tensor = torch.argmax(torch_input_tensor_a, dim=dim)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.argmax(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    e2e_perf = stop_measuring_time(start_time)
+
+    if dim:
+        output_tensor = ttnn.to_torch(output_tensor).squeeze(dim=dim - 1)
+    else:
+        ouptut_tensor = ttnn.to_torch(output_tensor).squeeze()
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -30,7 +30,7 @@ parameters = {
         + gen_shapes([1, 1, 1], [6, 128, 128], [1, 1, 1], 128)
         + gen_shapes([1, 1], [128, 128], [1, 1], 128),
         "dim": [0, 1, 2, 3, None],
-        "input_a_dtype": [ttnn.bfloat16],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -80,7 +80,8 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    torch_output_tensor = torch.argmax(torch_input_tensor_a, dim=dim)
+    golden_function = ttnn.get_golden_function(ttnn.argmax)
+    torch_output_tensor = golden_function(torch_input_tensor_a, dim=dim)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, santize_topk_shape
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_topk_simmilarity
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 30
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_shape": gen_shapes([1, 1, 32, 64], [6, 12, 256, 1024], [1, 1, 32, 64], 8),
+        "dim": [-1],
+        "largest": [True],
+        "k": [32],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
+        test_vector["grad_dtype"] == ttnn.bfloat8_b or test_vector["input_a_dtype"] == ttnn.bfloat8_b
+    ):
+        return True, "bfloat8_b is only supported on tiled layout"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    dim,
+    largest,
+    k,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    input_shape = santize_topk_shape(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    # golden_function = ttnn.get_golden_function(ttnn.topk)
+    torch_output_values, torch_output_indices = torch.topk(
+        torch_input_tensor_a, k, dim=dim, largest=largest, sorted=True
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    start_time = start_measuring_time()
+    output_values, output_indices = ttnn.topk(input_tensor_a, k=k, dim=dim, largest=largest, sorted=True)
+    e2e_perf = stop_measuring_time(start_time)
+
+    output_values, output_indices = ttnn.to_torch(output_values), ttnn.to_torch(output_indices).to(torch.int64)
+    output_gathered_values = torch.gather(torch_input_tensor_a, dim, output_indices)
+
+    passing, output_str = comp_topk_simmilarity(
+        [torch_output_values, torch_output_indices], [output_values, output_gathered_values]
+    )
+
+    return [(passing, output_str), e2e_perf]

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -95,6 +95,7 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
+    # topk golden function is not working, missing import torch
     # golden_function = ttnn.get_golden_function(ttnn.topk)
     # torch_output_values, torch_output_indices =golden_function(
     #    torch_input_tensor_a, k, dim=dim, largest=largest, sorted=True

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -15,7 +15,7 @@ from multiprocessing import Process, Queue
 from queue import Empty
 import subprocess
 from framework.statuses import TestStatus, VectorValidity, VectorStatus
-import framework.tt_smi_util
+import framework.tt_smi_util as tt_smi_util
 from elasticsearch import Elasticsearch, NotFoundError
 from framework.elastic_config import *
 from framework.sweeps_logger import sweeps_logger as logger


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11512

### Problem description
Missing sweeps for reduction ops:
1) topk
2) argmax

### What's changed
Added aforementioned sweeps to sweep_framework and to ttnn-run-sweeps.yaml.