### PR TITLE
#0: Put Bash strict mode in place

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -127,6 +127,8 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
+            set -euo pipefail # basic bash hygiene
+
             # /tmp is a tmpfs; more efficient than persisted storage
             mkdir -p /tmp/ccache
             export CCACHE_TEMPDIR=/tmp/ccache

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -77,9 +77,9 @@ jobs:
       - in-service
     steps:
       - name: Verify ccache availability
-        shell: bash
+        # shell: bash
         run: |
-          Confirm theory: does GHA have set -e active by default when bash shell is chosen?
+          Confirm theory: does GHA have set -e active by default when bash shell is NOT chosen?
           if [ ! -d "/mnt/MLPerf/ccache" ]; then
             echo "::error title=ccache-mlperf-not-mounted::NFS drive is not mounted; build machine not properly provisioned."
             exit 1

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -79,6 +79,7 @@ jobs:
       - name: Verify ccache availability
         shell: bash
         run: |
+          Confirm theory: does GHA have set -e active by default when bash shell is chosen?
           if [ ! -d "/mnt/MLPerf/ccache" ]; then
             echo "::error title=ccache-mlperf-not-mounted::NFS drive is not mounted; build machine not properly provisioned."
             exit 1
@@ -127,7 +128,9 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            set -euo pipefail # basic bash hygiene
+            Confirm theory: does GHA have set -e active by default when no shell is set?
+
+            # set -euo pipefail # basic bash hygiene
 
             # /tmp is a tmpfs; more efficient than persisted storage
             mkdir -p /tmp/ccache

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -127,7 +127,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            set -euo pipefail # basic bash hygiene
+            set -eu # basic bash hygiene
             Confirm theory: does GHA have set -e active by default when no shell is set?
 
             # /tmp is a tmpfs; more efficient than persisted storage

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -127,8 +127,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
-            set -eu # basic bash hygiene
-            Confirm theory: does GHA have set -e active by default when no shell is set?
+            set -eu # basic shell hygiene
 
             # /tmp is a tmpfs; more efficient than persisted storage
             mkdir -p /tmp/ccache

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -77,9 +77,8 @@ jobs:
       - in-service
     steps:
       - name: Verify ccache availability
-        # shell: bash
+        shell: bash
         run: |
-          Confirm theory: does GHA have set -e active by default when bash shell is NOT chosen?
           if [ ! -d "/mnt/MLPerf/ccache" ]; then
             echo "::error title=ccache-mlperf-not-mounted::NFS drive is not mounted; build machine not properly provisioned."
             exit 1

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -127,9 +127,8 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
             -w ${{ github.workspace }}
           run: |
+            set -euo pipefail # basic bash hygiene
             Confirm theory: does GHA have set -e active by default when no shell is set?
-
-            # set -euo pipefail # basic bash hygiene
 
             # /tmp is a tmpfs; more efficient than persisted storage
             mkdir -p /tmp/ccache

--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -31,6 +31,7 @@ std::ostream& operator<<(std::ostream& os, tt::OStreamJoin<A, B> const& join) {
 }
 }  // namespace tt
 
+force a build failure.  Right here.  Right now.
 namespace tt::assert {
 
 static std::string demangle(const char* str) {

--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -31,7 +31,6 @@ std::ostream& operator<<(std::ostream& os, tt::OStreamJoin<A, B> const& join) {
 }
 }  // namespace tt
 
-force a build failure.  Right here.  Right now.
 namespace tt::assert {
 
 static std::string demangle(const char* str) {


### PR DESCRIPTION
This was missing.  We want it to fail if there's an error.