### PR TITLE
#0: Ensure libc++ used across both projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,9 @@ endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG=DEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DDEBUG=DEBUG")
-set(CMAKE_CXX_FLAGS_CI "-O3 -DDEBUG=DEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_CI "-O3 -DDEBUG")
 
 # Set default values for variables/options
 set(UMD_HOME "${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,14 +268,7 @@ target_compile_options(compiler_flags INTERFACE -DARCH_${ARCH_NAME_DEF})
 
 add_library(metal_header_directories INTERFACE)
 target_include_directories(metal_header_directories INTERFACE ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc)
-target_include_directories(
-    metal_header_directories
-    SYSTEM
-    INTERFACE
-        ${reflect_SOURCE_DIR}
-        ${flatbuffers_include_dir}
-        ${nng_include_dir}
-)
+target_include_directories(metal_header_directories SYSTEM INTERFACE ${reflect_SOURCE_DIR})
 foreach(lib ${BoostPackages})
     target_include_directories(metal_header_directories INTERFACE ${Boost${lib}_SOURCE_DIR}/include)
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,10 +130,7 @@ if(ENABLE_BUILD_TIME_TRACE)
         message(STATUS "Adding compile option: -ftime-trace")
         add_compile_options("-ftime-trace")
     else()
-        message(
-            FATAL
-            "ENABLE_BUILD_TIME_TRACE is only supported with Clang"
-        )
+        message(FATAL_ERROR "ENABLE_BUILD_TIME_TRACE is only supported with Clang")
     endif()
 endif()
 
@@ -198,7 +195,6 @@ target_link_libraries(
 )
 
 # Note on flags:
-#   DFMT_HEADER_ONLY must be for every target or else they won't interact with the header only fmt as intended
 #   ttnn and tt_lib will break if built with LTO, so leaving -fno-lto in compile options
 add_library(linker_flags INTERFACE)
 
@@ -229,7 +225,6 @@ target_compile_options(
     INTERFACE
         -mavx2
         -fPIC
-        -DFMT_HEADER_ONLY
         -fvisibility-inlines-hidden
         -fno-lto
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(
         gtest
         gtest_main
         magic_enum
-        fmt
+        fmt::fmt-header-only
         span
 )
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(
         gtest
         gtest_main
         magic_enum
-        fmt
+        fmt::fmt-header-only
         span
 )
 target_include_directories(

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -26,10 +26,10 @@ target_link_libraries(
     tt_metal
     PUBLIC
         metal_header_directories
-        umd_device
+        umd::device
         metal_common_libs
         magic_enum
-        fmt
+        fmt::fmt-header-only
         span
 )
 

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
         compiler_flags
         metal_header_directories
         magic_enum
-        fmt
+        fmt::fmt-header-only
         span
 )
 

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -18,5 +18,10 @@ set(LLRT_SRC
 )
 
 add_library(llrt OBJECT ${LLRT_SRC})
-target_link_libraries(llrt PUBLIC common umd_device)
+target_link_libraries(
+    llrt
+    PUBLIC
+        common
+        umd::device
+)
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -18,5 +18,5 @@ set(LLRT_SRC
 )
 
 add_library(llrt OBJECT ${LLRT_SRC})
-target_link_libraries(llrt PUBLIC common)
+target_link_libraries(llrt PUBLIC common umd_device)
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -30,7 +30,7 @@ class ElfFile {
         offset_t bss = 0;                  // words of BSS
 
        public:
-        constexpr Segment(std::span<word_t const> contents, address_t addr, offset_t bss) :
+         inline Segment(std::span<word_t const> contents, address_t addr, offset_t bss) :
             contents(contents), address(addr), bss(bss) {}
     };
 

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
@@ -566,7 +566,7 @@ constexpr auto build_sharded_addr_gen(
 
 template <TensorMemoryLayout layout>
 struct DeviceShardSpecTypeGetter {
-    using type = nullptr_t;
+    using type = std::nullptr_t;
 };
 template <>
 struct DeviceShardSpecTypeGetter<TensorMemoryLayout::WIDTH_SHARDED> {


### PR DESCRIPTION
### Ticket
NA

### Problem description
Fix linker problem
UMD does not ingest `stdlib` interface library from `tt-metal` anymore.
Need to get the two projects to use same version of C++ standard library.
Solution is to adjust `CXX_FLAGS`.

### What's changed
Remove `stdlib` interface library, use `CXX_FLAGS`.
Also removed `DFMT_HEADER_ONLY` define since it comes for free, when you link the right target.
Had to fix a couple tangential issues that popped up.

### Extra info
Compiler warning (werror) -> error popped up for the below.
I don't know why it popped up, but this is illegal in C++17, so I removed constexpr.
```
old:        constexpr Segment(std::span<word_t const> contents, address_t addr, offset_t bss) :
new:         inline Segment(std::span<word_t const> contents, address_t addr, offset_t bss) :
```

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/11610163942
- [x] Blackhole Post commit (if applicable) : Not needed, just a build system change
- [x] Model regression CI testing passes (if applicable): Not needed, just a build system change
- [x] Device performance regression CI testing passes (if applicable) : Not needed, just a build system change
- [x] New/Existing tests provide coverage for changes : Not needed 
