### PR TITLE
#14225: Do not use a log driver to save logs to disk as we'll likely not need it

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -65,6 +65,8 @@ runs:
         # for newly created files.
         # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which
         # may not be writable by the RUNNER_UID user.
+        # --log-driver none: Do not save logs to disk as we're printing them to GitHub
+        # and it takes up space
         options: |
           -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
           --rm
@@ -73,8 +75,6 @@ runs:
           -v /etc/bashrc:/etc/bashrc:ro
           -v ${{ github.workspace }}:${{ github.workspace }}
           --net=host
-          # Do not save logs to disk as we're printing them to GitHub
-          # and it takes up space
           --log-driver none
           ${{ inputs.docker_opts }}
           -e LOGURU_LEVEL=${{ env.LOGURU_LEVEL }}

--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -38,7 +38,7 @@ runs:
       uses: ./.github/actions/generate-docker-tag
       with:
         image: ${{ inputs.docker_os_arch }}
-    - name: Set 
+    - name: Set
       shell: bash
       run: |
         echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
@@ -63,7 +63,7 @@ runs:
         # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
         # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
         # for newly created files.
-        # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which 
+        # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which
         # may not be writable by the RUNNER_UID user.
         options: |
           -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
@@ -73,6 +73,9 @@ runs:
           -v /etc/bashrc:/etc/bashrc:ro
           -v ${{ github.workspace }}:${{ github.workspace }}
           --net=host
+          # Do not save logs to disk as we're printing them to GitHub
+          # and it takes up space
+          --log-driver none
           ${{ inputs.docker_opts }}
           -e LOGURU_LEVEL=${{ env.LOGURU_LEVEL }}
           -e PYTHONPATH=${{ github.workspace }}


### PR DESCRIPTION
…

### Ticket

#14225

### Problem description

Docker logs are saved to disk and when a job dumps out stuff it can cause bad things to happen. Read above

We should be wary though if we need `docker logs` on the runner if we need to debug a live test. @ttmchiou @TT-billteng @dimitri-tenstorrent thoughts?

### What's changed

Use no log driver

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
