### PR TITLE
Reduce code size with TT_METAL_WATCHER_NOINLINE=1 in stress test pipeline

### DIFF
--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -30,6 +30,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
       TT_METAL_WATCHER: 60
+      TT_METAL_WATCHER_NOINLINE: 1
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}


### PR DESCRIPTION
### Problem description
Stress test pipeline was erroring out due to code size issues with some kernels when watcher is enabled

### What's changed
@tt-dma recommended that I try using `TT_METAL_WATCHER_NOINLINE=1` to avoid code size issues.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
