### PR TITLE
#13864: Add forward support for maximum  and minimum with tensor, scalar variant

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -147,6 +147,29 @@ def test_binary_maximum_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
+@pytest.mark.parametrize(
+    "scalar",
+    {random.randint(-100, 100) + 0.5 for _ in range(5)},
+)
+def test_binary_maximum_scalar_ttnn(input_shapes, scalar, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.maximum(input_tensor1, scalar)
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden_tensor = golden_function(in_data1, torch.tensor(scalar))
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
 def test_binary_atan2_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -127,6 +127,29 @@ def test_binary_minimum_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
+@pytest.mark.parametrize(
+    "scalar",
+    {-82.5, -45.7, 0.0, 12.5, 66.4, 96, 8},
+)
+def test_binary_minimum_scalar_ttnn(input_shapes, scalar, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.minimum(input_tensor1, scalar)
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden_tensor = golden_function(in_data1, torch.full(input_shapes, scalar))
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
 def test_binary_maximum_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
@@ -149,14 +172,14 @@ def test_binary_maximum_ttnn(input_shapes, device):
 )
 @pytest.mark.parametrize(
     "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
+    {-82.5, -45.7, 0.0, 12.5, 66.4, 96, 8},
 )
 def test_binary_maximum_scalar_ttnn(input_shapes, scalar, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.maximum(input_tensor1, scalar)
     golden_function = ttnn.get_golden_function(ttnn.maximum)
-    golden_tensor = golden_function(in_data1, torch.tensor(scalar))
+    golden_tensor = golden_function(in_data1, torch.full(input_shapes, scalar))
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -229,6 +229,20 @@ struct ExecuteMaximum
 
 };
 
+struct ExecuteMinimum
+{
+    static Tensor invoke(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        float scalar,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
+};
+
 } // namespace binary
 }  // namespace operations
 
@@ -240,7 +254,7 @@ constexpr auto xlogy = ttnn::register_operation_with_auto_launch_op<
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>();
 constexpr auto minimum = ttnn::register_operation_with_auto_launch_op<
     "ttnn::minimum",
-    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MINIMUM>>();
+    operations::binary::ExecuteMinimum>();
 constexpr auto maximum = ttnn::register_operation_with_auto_launch_op<
     "ttnn::maximum",
     operations::binary::ExecuteMaximum>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -215,6 +215,20 @@ struct ExecuteGCD {
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
+struct ExecuteMaximum
+{
+    static Tensor invoke(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        float scalar,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
+};
+
 } // namespace binary
 }  // namespace operations
 
@@ -229,7 +243,7 @@ constexpr auto minimum = ttnn::register_operation_with_auto_launch_op<
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MINIMUM>>();
 constexpr auto maximum = ttnn::register_operation_with_auto_launch_op<
     "ttnn::maximum",
-    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MAXIMUM>>();
+    operations::binary::ExecuteMaximum>();
 constexpr auto atan2 = ttnn::register_operation_with_auto_launch_op<
     "ttnn::atan2",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -332,7 +332,7 @@ void bind_binary_composite_with_rtol_atol(py::module& module, const binary_opera
 }
 
 template <typename binary_operation_t>
-void bind_div_like_ops(py::module& module, const binary_operation_t& operation, const std::string& description) {
+void bind_binary_composite_overload(py::module& module, const binary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
         R"doc(
             {2}
@@ -965,13 +965,6 @@ void py_module(py::module& module) {
 
     detail::bind_binary_composite(
         module,
-        ttnn::maximum,
-        R"doc(Compute maximum :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
-        R"doc(\mathrm{output\_tensor}_i = \text{max}\left(\mathrm{input\_tensor\_a}_i , \mathrm{input\_tensor\_b}_i\right)
-        )doc");
-
-    detail::bind_binary_composite(
-        module,
         ttnn::atan2,
         R"doc(Compute atan2 :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{output\_tensor}_i = \arctan\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)
@@ -1080,15 +1073,20 @@ void py_module(py::module& module) {
         R"doc(\mathrm{output}_i = \begin{cases} \mathrm{\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{None} \\ \mathrm{\text{floor}\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{floor} \\ \mathrm{\text{trunc}\left(\frac{\mathrm{input\_tensor\_a}_i}{\mathrm{input\_tensor\_b}_i}\right)}, & \text{if } \mathrm{round\_mode} = \mathrm{trunc} \end{cases}
         )doc");
 
-    detail::bind_div_like_ops(
+    detail::bind_binary_composite_overload(
         module,
         ttnn::div_no_nan,
         R"doc(Compute div_no_nan :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
 
-    detail::bind_div_like_ops(
+    detail::bind_binary_composite_overload(
         module,
         ttnn::floor_div,
         R"doc(Compute floor division :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
+
+    detail::bind_binary_composite_overload(
+        module,
+        ttnn::maximum,
+        R"doc(Compute maximum :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
 
     detail::bind_binary_composite(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -956,12 +956,10 @@ void py_module(py::module& module) {
         R"doc(\mathrm{output\_tensor}_i = \begin{cases} \mathrm{next\_float}(\mathrm{input\_tensor\_a}_i, \mathrm{input\_tensor\_b}_i), & \text{if } \mathrm{input\_tensor\_a}_i \neq \mathrm{input\_tensor\_b}_i \\ \mathrm{input\_tensor\_a}_i, & \text{if } \mathrm{input\_tensor\_a}_i = \mathrm{input\_tensor\_b}_i \end{cases}
         )doc");
 
-    detail::bind_binary_composite(
+    detail::bind_binary_composite_overload(
         module,
         ttnn::minimum,
-        R"doc(Compute minimum :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
-        R"doc(\mathrm{output\_tensor}_i = \text{min}\left(\mathrm{input\_tensor\_a}_i , \mathrm{input\_tensor\_b}_i\right)
-        )doc");
+        R"doc(Compute minimum :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
 
     detail::bind_binary_composite(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -106,9 +106,15 @@ Tensor _isclose(
 }
 
 // minimum(a,b) = a - (a - b > 0 )*(a-b)
-Tensor _minimum(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+Tensor ExecuteMinimum::invoke(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor t_diff = ttnn::subtract(input_a, input_b, std::nullopt, output_mem_config);
     Tensor result = ttnn::where(t_diff, input_b, input_a);
+    return result;
+}
+
+Tensor ExecuteMinimum::invoke(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor t_diff = ttnn::subtract(input_a, value, std::nullopt, output_mem_config);
+    Tensor result = ttnn::where(t_diff, value, input_a);
     return result;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -113,9 +113,15 @@ Tensor _minimum(const Tensor& input_a, const Tensor& input_b, const std::optiona
 }
 
 // maximum(a,b) = a + (b - a > 0 )*(b-a)
-Tensor _maximum(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+Tensor ExecuteMaximum::invoke(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor t_diff = ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config);
     Tensor result = ttnn::where(t_diff, input_b, input_a);
+    return result;
+}
+
+Tensor ExecuteMaximum::invoke(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor t_diff = ttnn::rsub(input_a, value, output_mem_config);
+    Tensor result = ttnn::where(t_diff, value, input_a);
     return result;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -20,7 +20,6 @@ enum class BinaryCompositeOpType {
     SUBALPHA,
     NEXTAFTER,
     ISCLOSE,
-    MINIMUM,
     ATAN2,
     DIV_NO_NAN,
     FLOOR_DIV,
@@ -31,7 +30,6 @@ enum class BinaryCompositeOpType {
 
 Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _xlogy(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _minimum(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _atan2(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
@@ -68,13 +66,6 @@ template <>
 struct OpHandler<BinaryCompositeOpType::NEXTAFTER> {
     static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
         return _nextafter(t1, t2, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<BinaryCompositeOpType::MINIMUM> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
-        return _minimum(t1, t2, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -21,7 +21,6 @@ enum class BinaryCompositeOpType {
     NEXTAFTER,
     ISCLOSE,
     MINIMUM,
-    MAXIMUM,
     ATAN2,
     DIV_NO_NAN,
     FLOOR_DIV,
@@ -33,7 +32,6 @@ enum class BinaryCompositeOpType {
 Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _xlogy(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _minimum(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _maximum(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _atan2(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
@@ -77,13 +75,6 @@ template <>
 struct OpHandler<BinaryCompositeOpType::MINIMUM> {
     static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
         return _minimum(t1, t2, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<BinaryCompositeOpType::MAXIMUM> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
-        return _maximum(t1, t2, mem_cfg);
     }
 };
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #13864 

### What's changed

- Added forward support for maximum  and minimum with tensor, scalar variant

### Checklist
- [x] [All Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/11515952889)