### PR TITLE
#14267: Move sender receiver computation to ccl_common.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -25,7 +25,7 @@ AllGather create_all_gather_struct(
 ) {
     uint32_t num_devices = devices.size();
     auto [device_index, sender_device_id, receiver_device_id] =
-                getDeviceIndexAndSenderReceiverIDs(input_tensor, devices, topology);
+                get_device_index_and_sender_receiver_ids(input_tensor, devices, topology);
 
     return ttnn::AllGather{
         dim, num_links, num_devices, device_index, user_defined_num_workers, user_defined_num_buffers_per_channel, receiver_device_id, sender_device_id, memory_config.value_or(input_tensor.memory_config()), topology};

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -12,7 +12,7 @@
 namespace ttnn {
 namespace ccl {
 
-std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> getDeviceIndexAndSenderReceiverIDs(
+std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_device_index_and_sender_receiver_ids(
     const Tensor& input_tensor,
     const std::vector<Device*>& devices,
     const ttnn::ccl::Topology& topology) {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -18,6 +18,11 @@
 namespace ttnn {
 namespace ccl {
 
+std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> getDeviceIndexAndSenderReceiverIDs(
+    const Tensor& input_tensor,
+    const std::vector<Device*>& devices,
+    const ttnn::ccl::Topology& topology);
+
 // Eventual home: ccl_topology_descriptors
 struct RingTopology {
     RingTopology(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -18,7 +18,7 @@
 namespace ttnn {
 namespace ccl {
 
-std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> getDeviceIndexAndSenderReceiverIDs(
+std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_device_index_and_sender_receiver_ids(
     const Tensor& input_tensor,
     const std::vector<Device*>& devices,
     const ttnn::ccl::Topology& topology);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -89,27 +89,11 @@ Tensor reduce_scatter(
             if (num_devices == 2){
                 topology = ttnn::ccl::Topology::Linear;
             }
-            bool is_linear = topology == ttnn::ccl::Topology::Linear;
 
             const auto& input_tensor = input_tensors.at(0);
-            uint32_t device_index = 0; // Initialize device index
-            std::optional<chip_id_t> receiver_device_id = std::nullopt; // Initialize receiver device ID
-            std::optional<chip_id_t> sender_device_id = std::nullopt; // Initialize sender device ID
-            for (uint32_t i = 0; i < num_devices; ++i) {
-                if (devices.at(i) == input_tensor.device()) {
+            auto [device_index, sender_device_id, receiver_device_id] =
+                getDeviceIndexAndSenderReceiverIDs(input_tensor, devices, topology);
 
-                    bool is_last_chip_in_clockwise_direction = is_linear && i == (num_devices - 1);
-                    bool is_last_chip_in_counter_clockwise_direction = is_linear && i == 0;
-                    device_index = i;
-                    receiver_device_id = is_last_chip_in_clockwise_direction ?
-                        std::nullopt :
-                        std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
-                    sender_device_id = is_last_chip_in_counter_clockwise_direction ?
-                        std::nullopt :
-                        std::optional<chip_id_t>(devices.at((i + num_devices - 1) % num_devices)->id());
-                    break;
-                }
-            }
             TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be incorrect");
 
             return operation::run(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -92,7 +92,7 @@ Tensor reduce_scatter(
 
             const auto& input_tensor = input_tensors.at(0);
             auto [device_index, sender_device_id, receiver_device_id] =
-                getDeviceIndexAndSenderReceiverIDs(input_tensor, devices, topology);
+                get_device_index_and_sender_receiver_ids(input_tensor, devices, topology);
 
             TT_FATAL(receiver_device_id != std::nullopt || sender_device_id != std::nullopt, "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be incorrect");
 


### PR DESCRIPTION
### Ticket
#14267 

### Problem description
Structure change needed to avoid code duplication across CCL ops

### What's changed
Move sender and receiver computation to ccl_common.cpp

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11515650377
- [ ] T3K Pipelines - https://github.com/tenstorrent/tt-metal/actions/runs/11515653457
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
