### PR TITLE
#12815: update mish op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -321,8 +321,7 @@ def test_unary_composite_log1p_ttnn(input_shapes, device):
     ),
 )
 def test_unary_composite_mish_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -20, 100, device)
     output_tensor = ttnn.mish(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn.mish)
     golden_tensor = golden_function(in_data1)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -25,7 +25,6 @@ enum class UnaryCompositeOpType {
     DIGAMMA,
     LGAMMA,
     LOG1P,
-    MISH,
     MULTIGAMMALN,
     SINH,
     SOFTSIGN,
@@ -66,7 +65,6 @@ Tensor _cosh(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _digamma(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _lgamma(const Tensor&,  const std::optional<MemoryConfig>&);
 Tensor _log1p(const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _mish(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _multigammaln(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _sinh(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _softsign(const Tensor&, const std::optional<MemoryConfig>&);
@@ -189,13 +187,6 @@ template <>
 struct OpHandler<UnaryCompositeOpType::LOG1P> {
     static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
         return _log1p(t1, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<UnaryCompositeOpType::MISH> {
-    static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
-        return _mish(t1, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -153,6 +153,12 @@ struct ExecuteRdiv {
         std::optional<Tensor> optional_output_tensor = std::nullopt);
 };
 
+struct ExecuteMish {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+};
+
 }  // namespace unary
 }  // namespace operations
 
@@ -240,7 +246,7 @@ constexpr auto log1p = ttnn::register_operation_with_auto_launch_op<
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOG1P>>();
 constexpr auto mish = ttnn::register_operation_with_auto_launch_op<
     "ttnn::mish",
-    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MISH>>();
+    operations::unary::ExecuteMish>();
 constexpr auto multigammaln = ttnn::register_operation_with_auto_launch_op<
     "ttnn::multigammaln",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MULTIGAMMALN>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1844,7 +1844,7 @@ void py_module(py::module& module) {
            +----------------------------+---------------------------------+-------------------+
 
         )doc");
-    detail::bind_unary_composite(module, ttnn::mish, R"doc(Performs mish function on :attr:`input_tensor`, not supported for grayskull.)doc");
+    detail::bind_unary_composite(module, ttnn::mish, R"doc(Performs mish function on :attr:`input_tensor`, not supported for grayskull.)doc", "[supported range -20 to inf]");
     detail::bind_unary_composite(module, ttnn::multigammaln, R"doc(Performs multigammaln function on :attr:`input_tensor`.)doc", "[supported range 1.6 to inf]",
         R"doc(Supported dtypes, layouts, and ranks:
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #12815 

### Problem description
ttnn.mish operation takes too much time(Kernel duration) to compute

### What's changed
Updated the Mish op with Unary chain approach to improve the performance

### Analysis of unary Approach:
I’ve listed the performance metrics and limitations of the approach in the PDF attached below.
[Mish Analysis.pdf](https://github.com/user-attachments/files/17521603/Mish.Analysis.pdf)

<img width="321" alt="Screenshot 2024-10-25 at 5 19 54 PM" src="https://github.com/user-attachments/assets/5f67461f-d1b5-486a-a9a9-277daed25fed">

- The current Unary Chain Approach will experience a PCC drop for values less than -20.
### Checklist
- [x] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/11547309091)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
