### PR TITLE
Add nonzero sweep

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -258,6 +258,7 @@ on:
           - data_movement.index_select.index_select_pytorch2
           - data_movement.split.split_with_sizes_pytorch2
           - data_movement.repeat.repeat
+          - data_movement.nonzero.nonzero
           - conv2d.full.conv2d_misc
           - conv2d.full.conv2d_sharding
           - conv2d.full.conv2d_sliding_window

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -129,6 +129,8 @@ def gen_rand_bitwise_left_shift(size, shift_bits=None, low=-2147483647, high=214
 
 def gen_with_zeroes(size, probabilityzeroes=0.5, low=-100, high=100, dtype=torch.bfloat16):
     element_count = 1
+    if probabilityzeroes == "random":
+        probabilityzeroes = random.uniform(0.0, 0.9)
     for i in size:
         element_count = element_count * i
     raw = torch.zeros(element_count).to(dtype)

--- a/tests/sweep_framework/sweeps/data_movement/nonzero/nonzero.py
+++ b/tests/sweep_framework/sweeps/data_movement/nonzero/nonzero.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Optional, Tuple
 from functools import partial
 

--- a/tests/sweep_framework/sweeps/data_movement/nonzero/nonzero.py
+++ b/tests/sweep_framework/sweeps/data_movement/nonzero/nonzero.py
@@ -1,0 +1,93 @@
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import ttnn
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm, gen_with_zeroes
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 30
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_shape": gen_shapes([1, 1, 1, 1], [1, 1, 1, 256], [1, 1, 1, 1], 16),
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    },
+    "xfail": {
+        "input_shape": gen_shapes([1, 1, 1, 1], [1, 1, 1, 256], [1, 1, 1, 1], 16),
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+}
+
+
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_layout"] == ttnn.TILE_LAYOUT:
+        return True, "Input tensor must be in row major layout"
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+    return False, None
+
+
+def run(
+    input_shape,
+    input_a_dtype,
+    input_layout,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(gen_with_zeroes, probabilityzeroes="random", low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    torch_output_tensor = torch.nonzero(torch_input_tensor_a, as_tuple=False)
+    torch_num_nonzero = torch_output_tensor.shape[0]
+    torch_output_tensor = torch_output_tensor[:, 3].reshape(-1, 1)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    start_time = start_measuring_time()
+    output_indices, output_tensor = ttnn.nonzero(input_tensor_a, memory_config=output_memory_config)
+    e2e_perf = stop_measuring_time(start_time)
+
+    num_nonzero = ttnn.to_torch(output_indices)[0, 0, 0, 0].item()
+    output_tensor = ttnn.to_torch(output_tensor)[0, 0, 0, :num_nonzero].reshape(-1, 1)
+
+    if num_nonzero != torch_num_nonzero:
+        return [
+            (False, f"Expected num of non-zero: {torch_num_nonzero}, actual num of non_zero: {num_nonzero}"),
+            e2e_perf,
+        ]
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11512

### Problem description
Missing sweeps for reduction ops:
1) nonzero

### What's changed
Added aforementioned sweeps to sweep_framework and to ttnn-run-sweeps.yaml