### PR TITLE
#13541: Fix regression from #01940051

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -159,14 +159,7 @@ void py_bind_conv2d(py::module& module) {
            uint32_t height,
            uint32_t width,
            uint32_t in_channels,
-           uint32_t out_channels,
-           std::array<uint32_t, 2> kernel_size,
-           std::array<uint32_t, 2> stride,
-           std::array<uint32_t, 2> padding,
-           std::array<uint32_t, 2> dilation,
-           uint32_t weights_width,
-           uint32_t input_width,
-           uint32_t groups) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool, bool> {
+           uint32_t out_channels) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool, bool> {
             return ttnn::operations::conv::conv2d::get_conv_padded_input_shape_and_mem_config<MeshDevice>(
                 device,
                 input_tensor,
@@ -185,14 +178,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("height"),
         py::arg("width"),
         py::arg("in_channels"),
-        py::arg("out_channels"),
-        py::arg("kernel_size"),
-        py::arg("stride"),
-        py::arg("padding"),
-        py::arg("dilation"),
-        py::arg("weights_width"),
-        py::arg("input_width"),
-        py::arg("groups"));
+        py::arg("out_channels"));
 
     module.def(
         "convert_conv_weight_tensor_to_tiled_layout",


### PR DESCRIPTION
Previous change for conv2d auto sharded didn't properly adjust python biding for get_conv_padded_input_shape_and_mem_config in template version of the function for MeshDevice. get_conv_padded_input_shape_and_mem_config that is template on Device, was properly adjusted and now with this change they are the same.
