### PR TITLE
Revert "Fix Hanging Reshape"

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -293,9 +293,6 @@ def test_reshape_tile_layout_only_change_shape(device):
         ((1, 1445, 192), (1445, 192)),
         ((1, 256), (1, 1, 256)),
         ((16, 1, 32), (16, 1, 32)),
-        ((32,), (1, 1, 1, 32)),
-        ((16,), (1, 1, 1, 16)),
-        ((48,), (1, 1, 1, 48)),
     ],
 )
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -59,7 +59,7 @@ ttnn::Tensor convert_tensor_to_rm_reshape_convert_back_to_orig_layout(const ttnn
     //Constraint in device kernel
     uint32_t ROW_MAJOR_WIDTH = 8;
     ttnn::Tensor reshaped_rm_tensor;
-    if((tensor_shape[-1] % ROW_MAJOR_WIDTH == 0 && shape[-1] % ROW_MAJOR_WIDTH == 0) and tensor_shape.rank() == 4) {
+    if((tensor_shape[-1] % ROW_MAJOR_WIDTH == 0 && shape[-1] % ROW_MAJOR_WIDTH == 0)) {
         auto rm_tensor = ttnn::to_layout(tensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device *)nullptr);
         if (rm_tensor.is_contiguous()) {
             // Page size depends on the width, so only modify the shape if the width is the same


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#14120


The original PR for cases where untilize would hang on device we would move it to host to untilize and reshape.

The untilize is used to remove padding for padded tiled shapes. I think the check (tensor_shape.rank() != 4) is too liberal a check and too many cases fell in the host fallback causing a major perf regression. I'll refine this check to be more selective to catch the untilize hangs (and only the untilize hangs). Will require more of a thorough diagnosis on why untilize is hanging. 

Failing Perf Regression before Revert: 
https://github.com/tenstorrent/tt-metal/actions/runs/11503988229/attempts/1

Passing Perf Regression:
https://github.com/tenstorrent/tt-metal/actions/runs/11522581361