### PR TITLE
#14297: Remove API single card FD nightly tests because they don't exist anymore

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -55,27 +55,6 @@ jobs:
               timeout: 40
             },
             {
-              name: "API tests GS",
-              arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
-              cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
-              timeout: 10
-            },
-            {
-              name: "API tests N300 WH B0",
-              arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
-              cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
-              timeout: 10
-            },
-            {
-              name: "API tests N150 WH B0",
-              arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
-              cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
-              timeout: 10
-            },
-            {
               name: "[Unstable] N150 models",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N150", "in-service"],

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -79,12 +79,6 @@ run_frequent_api_pipeline_tests() {
         TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_frequent
         echo "Running Python API unit tests in SD for frequent..."
         ./tests/scripts/run_python_api_unit_tests.sh
-    else
-        if [[ $tt_arch == "wormhole_b0" ]]; then
-            pytest -n auto tests/ttnn/unit_tests/operations/test_all_gather.py -k nightly
-        else
-            echo "API tests are not available for fast dispatch because they're already covered in post-commit"
-        fi
     fi
 }
 


### PR DESCRIPTION
…

### Ticket

#14297

### Problem description

Nightly is failing because the tests don't exist.

### What's changed

Delete the tests.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
