### PR TITLE
#14238: Add missing dependency in tt_metal/hw/CMakeLists.txt

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -186,6 +186,8 @@ foreach(ARCH IN LISTS ARCHS)
                 ${CMAKE_COMMAND} -E make_directory ${HW_LIB_DIR}
             COMMAND
                 ${GPP_CMD} ${GPP_FLAGS} ${GPP_DEFINES} ${GPP_INCLUDES} -c -o ${HW_LIB_DIR}/${HWLIB}.o ${${HWLIB}_SOURCE}
+            DEPENDS
+                ${${HWLIB}_SOURCE}
             COMMENT "Building hw lib ${HWLIB}.o"
             VERBATIM
         )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14238

### Problem description
Stale build was causing errors in compiling kernels after modifying a toolchain file

### What's changed
Add missing dependency to tt_metal/hw/CMakeLists.txt

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
