### PR TITLE
Increased size of a trace buffer for llama demo

### DIFF
--- a/models/demos/wormhole/llama31_8b/demo/demo_trace.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_trace.py
@@ -585,7 +585,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
         "instruct_weights-3_batch",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 7860224, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 7943168, "num_command_queues": 2}], indirect=True)
 def test_llama_demo(
     device, use_program_cache, input_prompts, instruct_weights, is_ci_env, is_single_card_n300, num_batches
 ):


### PR DESCRIPTION
### Ticket
Issue #13478

### Problem description
After issue was closed, regression on single-card demos N300 happened. After adding new runtime args in binary reader kernel, trace buffer size has increased and that caused assertion.

### What's changed
Increased size of trace buffer.

### Checklist
- [x] Post commit CI passes
- [x] (Single-card) Demo tests
