### PR TITLE
#12979: Remove unused l1_memory section

### DIFF
--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -86,12 +86,6 @@ SECTIONS
   } > REGION_APP_DATA :data
   . = ALIGN(32 / 8);
 
-  l1_memory :
-  {
-    *(l1_memory)
-    *(l1_memory_const) /* gcc complains about const and non-const data in the same segment. */
-  } > ETH_L1
-
   .riscv.attributes 0 : { *(.riscv.attributes) } :attributes
 
   /* Stabs debugging sections.  */

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -98,12 +98,6 @@ SECTIONS
    __ldm_bss_end = .;
   } > REGION_APP_KERNEL_DATA :data
 
-  l1_memory :
-  {
-    *(l1_memory)
-    *(l1_memory_const) /* gcc complains about const and non-const data in the same segment. */
-  } > ETH_L1
-
   .riscv.attributes 0 : { *(.riscv.attributes) } :attributes
 
   /* Stabs debugging sections.  */


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12979

### Problem description
The l1_memory section is unused:
*) ASSERTING the output section size is zero never fails
*) Grepping sources finds no occurrence of `l1_memory{,_const}`, other than the occurrences here.

### What's changed
Delete the output section.

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [NA] Model regression CI testing passes (if applicable)
- [NA] Device performance regression CI testing passes (if applicable)
- [NA] New/Existing tests provide coverage for changes
