### PR TITLE
#14253: resolve multi-link line reduce scatter PCC issues

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
@@ -208,7 +208,7 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
 @pytest.mark.parametrize(
     "num_devices, num_links, per_chip_output_shape, dim, layout",
     [
-        (4, 1, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
+        (4, 2, [1, 4, 32, 2304], 1, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
@@ -270,8 +270,8 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
 @pytest.mark.parametrize(
     "num_devices, num_links, per_chip_output_shape, dim, layout",
     [
-        (8, 1, [1, 8, 32, 1280], 1, ttnn.TILE_LAYOUT),
-        (8, 1, [8, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (8, 2, [1, 8, 32, 1280], 1, ttnn.TILE_LAYOUT),
+        (8, 2, [8, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -339,7 +339,7 @@ static std::pair<CoreRangeSet, std::optional<CoreRangeSet>> select_worker_cores_
     auto const& lower_half_of_cores =
         CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(workers_per_direction - 1, num_links - 1)));
     auto const& upper_half_of_cores = CoreRangeSet(
-        CoreRange(CoreCoord(workers_per_direction, 0), CoreCoord(num_edm_channels - 1, num_links - 1)));
+        CoreRange(CoreCoord(0, num_links), CoreCoord(workers_per_direction - 1, (2 * num_links) - 1)));
     if (topology_config.ring_index == 0) {
         log_trace(tt::LogOp, "Start of line, putting CCL send cores in lower half");
         return {upper_half_of_cores, lower_half_of_cores};
@@ -650,7 +650,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
 
     std::function<bool(uint32_t)> is_worker_in_clockwise_direction_fn = [is_linear, enable_bidirectional, num_edm_channels_per_link](std::size_t x) {
                 static constexpr std::size_t bidirectional_directions = 2;
-                return is_linear ? (x < (num_edm_channels_per_link / bidirectional_directions)):
+                return is_linear ? ((x % num_edm_channels_per_link) < (num_edm_channels_per_link / bidirectional_directions)):
                     enable_bidirectional ? (x % bidirectional_directions == 0) : true;
             };
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/host/reduce_scatter_common.cpp
@@ -93,18 +93,20 @@ std::vector<WorkerAttributes> build_worker_attributes(
         worker_receiver_semaphore_id :
         worker_receiver_semaphore_id_second_core_range;
 
+    std::array<size_t, 2> worker_slice_index = {0, 0};
+
     for (std::size_t l = 0; l < num_links; l++) {
         for (std::size_t i = 0; i < workers_per_slice; i++) {
             auto worker_id = get_global_worker_id(l, i, num_channels_per_link);
             TT_ASSERT(worker_cores_idx < worker_cores_list.size());
-
+            auto direction = is_buffer_in_clockwise_direction_fn(worker_id) ? Direction::CLOCKWISE : Direction::COUNTER_CLOCKWISE;
             worker_attributes.push_back(
                 {
                     l,
                     i,
-                    i,
-                    is_buffer_in_clockwise_direction_fn(worker_id) ? Direction::CLOCKWISE : Direction::COUNTER_CLOCKWISE,
-                    first_workers_list[worker_cores_idx],
+                    worker_slice_index[static_cast<size_t>(direction)]++,
+                    direction,
+                    first_workers_list.at(worker_cores_idx),
                     first_send_to_edm_sem_id,
                     first_read_from_edm_sem_id
                 }
@@ -118,14 +120,15 @@ std::vector<WorkerAttributes> build_worker_attributes(
                 TT_ASSERT(second_vec_index < second_workers_list.value().size());
                 std::size_t my_logical_index = workers_per_slice + i;
                 std::size_t my_idx = worker_attributes.size();
+                auto direction = is_buffer_in_clockwise_direction_fn(my_logical_index) ?
+                            Direction::CLOCKWISE : Direction::COUNTER_CLOCKWISE;
                 worker_attributes.push_back(
                     {
                         l,
                         my_logical_index,
-                        i,
-                        is_buffer_in_clockwise_direction_fn(my_logical_index) ?
-                            Direction::CLOCKWISE : Direction::COUNTER_CLOCKWISE,
-                        second_workers_list.value()[second_vec_index],
+                        worker_slice_index[static_cast<size_t>(direction)]++,
+                        direction,
+                        second_workers_list.value().at(second_vec_index),
                         second_send_to_edm_sem_id,
                         second_read_from_edm_sem_id
                     }
@@ -149,9 +152,10 @@ std::vector<WorkerAttributes> build_worker_attributes(
     // Log worker attributes
     log_trace(tt::LogOp, "Worker Attributes:");
     for (const auto &wa : worker_attributes) {
-        log_trace(tt::LogOp, "\tAttributes: link={}, index={}, core_logical=(x={},y={}), direction={}, associated_core=(x={},y={}), associated_index={}",
+        log_trace(tt::LogOp, "\tAttributes: link={}, chan_index={}, slice_index: {}, core_logical=(x={},y={}), direction={}, associated_core=(x={},y={}), associated_index={}",
             wa.link,
             wa.channel,
+            wa.index_in_slice,
             wa.location_logical.x,
             wa.location_logical.y,
             wa.direction == Direction::CLOCKWISE ? "CLOCKWISE": "COUNTER-CLOCKWISE",


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14253)

### Problem description
(line) Reduce scatter had multiple issues when multiple links were enabled:
- PCC issue
- Host program building failure (due to inccorect kernel-id/worker core mapping

### What's changed
Resolved PCC issue for mult-link case. Also added some test cases where we reshard within the reduce scatter while it's in flight. 

This PR is not intended to have comprehensive test coverage and is primarily intended to unblock model development

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/11532030389
- [x] TG nightly: https://github.com/tenstorrent/tt-metal/actions/runs/11527643303
- [x] T3000 nightly, frequent, demo, model perf: https://github.com/tenstorrent/tt-metal/actions/runs/11532008612
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
