### PR TITLE
Multiple op hang issue

### DIFF
--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_add_hang.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_add_hang.py
@@ -42,7 +42,7 @@ test_sweep_args = [
     (
         [(150, 72), (150, 72)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         17799073,
@@ -50,7 +50,7 @@ test_sweep_args = [
     (
         [(3, 201, 228), (3, 201, 228)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         3121221,
@@ -58,7 +58,7 @@ test_sweep_args = [
     (
         [(6, 6, 230, 138), (6, 6, 230, 138)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         10286194,

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_exp_hang.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_exp_hang.py
@@ -40,7 +40,7 @@ test_sweep_args = [
     (
         [(150, 72)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         17799073,
@@ -48,7 +48,7 @@ test_sweep_args = [
     (
         [(3, 201, 228)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         3121221,
@@ -56,7 +56,7 @@ test_sweep_args = [
     (
         [(6, 6, 230, 138)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         10286194,

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_gelu_hang.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_gelu_hang.py
@@ -40,7 +40,7 @@ test_sweep_args = [
     (
         [(150, 72)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         17799073,
@@ -48,7 +48,7 @@ test_sweep_args = [
     (
         [(3, 201, 228)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         3121221,
@@ -56,7 +56,7 @@ test_sweep_args = [
     (
         [(6, 6, 230, 138)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         10286194,

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_mul_hang.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_mul_hang.py
@@ -40,25 +40,25 @@ def run_eltwise_mul_tests(input_shape, dtype, dlayout, in_mem_config, output_mem
 
 test_sweep_args = [
     (
-        [(150, 72), (150, 72)],
+        [(160, 96), (160, 96)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         17799073,
     ),
     (
-        [(3, 201, 228), (3, 201, 228)],
+        [(3, 224, 256), (3, 224, 256)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         3121221,
     ),
     (
-        [(6, 6, 230, 138), (6, 6, 230, 138)],
+        [(6, 6, 256, 160), (6, 6, 256, 160)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         10286194,

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_sub_hang.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_sub_hang.py
@@ -42,7 +42,7 @@ test_sweep_args = [
     (
         [(150, 72), (150, 72)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         17799073,
@@ -50,7 +50,7 @@ test_sweep_args = [
     (
         [(3, 201, 228), (3, 201, 228)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         3121221,
@@ -58,7 +58,7 @@ test_sweep_args = [
     (
         [(6, 6, 230, 138), (6, 6, 230, 138)],
         [ttnn.bfloat16, ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         10286194,

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_tanh_hang.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_tanh_hang.py
@@ -40,7 +40,7 @@ test_sweep_args = [
     (
         [(150, 72)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         17799073,
@@ -48,7 +48,7 @@ test_sweep_args = [
     (
         [(3, 201, 228)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         3121221,
@@ -56,7 +56,7 @@ test_sweep_args = [
     (
         [(6, 6, 230, 138)],
         [ttnn.bfloat16],
-        [ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.ttnn.TILE_LAYOUT],
         (ttnn.DRAM_MEMORY_CONFIG),
         (ttnn.DRAM_MEMORY_CONFIG),
         10286194,


### PR DESCRIPTION
### Ticket
#4702 

### Problem description
- Test was hanging and Row Major layout was used
- Few ops like, mul, add, sub, exp, gelu, tanh was hanging and failed as Row Major Layout was used. 

### What's changed
- Updated the layout of the test to TILE Layout 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11552992090)
