### PR TITLE
#0: Move SynchronizeWorkerThreads to tt_metal::detail namespace

### DIFF
--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -279,5 +279,7 @@ inline namespace v0 {
         DeviceAddr AllocateBuffer(Buffer* buffer);
 
         void DeallocateBuffer(Buffer *buffer);
+
+        void SynchronizeWorkerThreads(const std::vector<Device*>& workers);
     }  // namespace detail
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14310

### Problem description
Hang in `repeat_interleave` test using async mode seen after reshapes were being done on host. The commit performing reshapes on host has since been reverted, but an issue with the `tensor.cpu()` was exposed.

### What's changed
  - Reshape on host changes exposed a deadlock when calling `cpu()` in a worker thread
  - Resolve deadlock, by early exiting synchronize cal when in a worker thread
  - SynchronizeWorkerThread is a core tt_metal API and shouldn't be in tensor_ops. Move this to `tt_metal::detail` namespace

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
