### PR TITLE
#0: Cleanup public vs private header files for buffer.hpp

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -10,13 +10,13 @@
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/device/device.hpp"
 
-#include <mutex>                                  // for unique_lock
 #include <algorithm>                              // for min
+#include <mutex>                                  // for unique_lock
 #include <string>                                 // for basic_string
 #include <utility>                                // for move
-#include "tt_metal/impl/buffers/buffer_constants.hpp"
 #include "tt_metal/common/base.hpp"               // for align
-#include "device/tt_soc_descriptor.h"             // for CoreType
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "third_party/umd/device/tt_soc_descriptor.h" // for CoreType
 #include "fmt/base.h"                             // for format_string
 #include "tt_stl/reflection.hpp"                  // for from_json
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -10,15 +10,15 @@
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/device/device.hpp"
 
-#include <algorithm>                              // for min
-#include <mutex>                                  // for unique_lock
-#include <string>                                 // for basic_string
-#include <utility>                                // for move
-#include "tt_metal/common/base.hpp"               // for align
+#include <algorithm>
+#include <mutex>
+#include <string>
+#include <utility>
+#include "tt_metal/common/base.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
-#include "third_party/umd/device/tt_soc_descriptor.h" // for CoreType
-#include "fmt/base.h"                             // for format_string
-#include "tt_stl/reflection.hpp"                  // for from_json
+#include "third_party/umd/device/tt_soc_descriptor.h"
+#include "fmt/base.h"
+#include "tt_stl/reflection.hpp"
 
 namespace tt {
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -4,13 +4,21 @@
 
 #include "tt_metal/impl/buffers/buffer.hpp"
 
-#include "llrt/llrt.hpp"
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/math.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
-#include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/device/device.hpp"
+
+#include <mutex>                                  // for unique_lock
+#include <algorithm>                              // for min
+#include <string>                                 // for basic_string
+#include <utility>                                // for move
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/common/base.hpp"               // for align
+#include "device/tt_soc_descriptor.h"             // for CoreType
+#include "fmt/base.h"                             // for format_string
+#include "tt_stl/reflection.hpp"                  // for from_json
 
 namespace tt {
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -6,10 +6,10 @@
 
 #include <array>
 #include <atomic>
-#include <cstdint>                                              // for uint32_t
+#include <cstdint>
 #include <condition_variable>
 #include <map>
-#include <memory>                                               // for shared_ptr
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <tuple>
@@ -20,11 +20,11 @@
 #include "common/bfloat16.hpp"
 #include "common/core_coord.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // For CoreType
-#include "third_party/umd/device/xy_pair.h"                     // for hash
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
+#include "third_party/umd/device/xy_pair.h"
 #include "tt_metal/tt_stl/concepts.hpp"
-#include "tt_metal/common/assert.hpp"                           // for TT_ASSERT
-#include "third_party/json/json.hpp"                            // for json
+#include "tt_metal/common/assert.hpp"
+#include "third_party/json/json.hpp"
 
 #include "llrt/hal.hpp"
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -4,22 +4,28 @@
 
 #pragma once
 
-#include <map>
-#include <mutex>
+#include <array>
+#include <atomic>
+#include <cstdint>                                              // for uint32_t
 #include <condition_variable>
+#include <map>
+#include <memory>                                               // for shared_ptr
+#include <mutex>
 #include <optional>
+#include <tuple>
+#include <unordered_map>
+#include <variant>
+#include <vector>
 
 #include "common/bfloat16.hpp"
 #include "common/core_coord.hpp"
-#include "common/tt_backend_api_types.hpp"
-#include "hostdevcommon/common_values.hpp"
-#include "tt_metal/common/constants.hpp"
-#include "tt_metal/common/math.hpp"
-#include "tt_metal/impl/allocator/allocator_types.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // For CoreType
+#include "third_party/umd/device/xy_pair.h"                     // for hash
 #include "tt_metal/tt_stl/concepts.hpp"
-#include "tt_metal/tt_stl/reflection.hpp"
+#include "tt_metal/common/assert.hpp"                           // for TT_ASSERT
+#include "third_party/json/json.hpp"                            // for json
+
 #include "llrt/hal.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -31,8 +31,6 @@ using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
 
 }  // namespace v0
 
-struct Allocator;
-
 // Only contains the types of commands which are enqueued onto the device
 enum class EnqueueCommandType {
     ENQUEUE_READ_BUFFER,
@@ -476,11 +474,6 @@ using CompletionReaderVariant = std::variant<std::monostate, ReadBufferDescripto
 using CompletionReaderQueue = LockFreeQueue<CompletionReaderVariant>;
 }  // namespace detail
 
-struct AllocBufferMetadata {
-    Buffer* buffer;
-    std::reference_wrapper<Allocator> allocator;
-};
-
 struct RuntimeArgsMetadata {
     CoreCoord core_coord;
     std::shared_ptr<RuntimeArgs> runtime_args_ptr;
@@ -588,7 +581,6 @@ struct CommandInterface {
     std::optional<bool> blocking;
     std::optional<std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>> buffer;
     Program* program;
-    std::optional<AllocBufferMetadata> alloc_md;
     std::optional<RuntimeArgsMetadata> runtime_args_md;
     std::optional<const Buffer*> shadow_buffer;
     std::optional<HostDataType> src;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -31,6 +31,8 @@ using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
 
 }  // namespace v0
 
+struct Allocator;
+
 // Only contains the types of commands which are enqueued onto the device
 enum class EnqueueCommandType {
     ENQUEUE_READ_BUFFER,


### PR DESCRIPTION
### Ticket
NA

### Problem description
ttnn and other consumers are directly exposed to `buffer.hpp` which is currently a public header file.
This was directly exposing those targets to ARCH_NAME via `allocator_types.hpp` inclusion -> `dev_mem_map.h`.
So I did a pass of `include-what-you-use` and cleaned up private from public header files for buffer.hpp and buffer.cpp.

### What's changed
Removed unnecessary header inclusions.
Moved some header inclusions from header file to implementation file
Added missing header inclusions.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11536938501
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
