### PR TITLE
#0: Seperate header & implementation in l1_banking_allocator

### DIFF
--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -9,7 +9,6 @@
 #include <functional>
 #include "common/core_coord.hpp"
 #include "hostdevcommon/common_values.hpp"
-#include "dev_mem_map.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -5,24 +5,25 @@
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 
 #include <algorithm>
-#include <cstddef>                        // for size_t
-#include <functional>                     // for function
-#include <iterator>                       // for back_insert_iterator, back_...
+#include <cstddef>
+#include <functional>
+#include <iterator>
 #include <optional>
 #include <random>
 #include <unordered_map>
 #include <vector>
 
-#include "tt_metal/impl/allocator/allocator.hpp"        // for Allocator, base_alloc, Bank...
-#include "tt_metal/impl/allocator/allocator_types.hpp"  // for AllocatorConfig, AllocCoreType
-#include "tt_metal/impl/buffers/buffer_constants.hpp"   // for BufferType
-#include "tt_metal/common/assert.hpp"                   // for TT_ASSERT, tt_throw, TT_THROW
-#include "tt_metal/common/core_coord.hpp"               // for CoreCoord
-#include "third_party/umd/device/xy_pair.h"             // for xy_pair, operator==, hash
-#include <fmt/base.h>                                   // for format_string
+#include "tt_metal/impl/allocator/allocator.hpp"
+#include "tt_metal/impl/allocator/allocator_types.hpp"
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/core_coord.hpp"
+#include "third_party/umd/device/xy_pair.h"
+#include <fmt/base.h>
 
-// FIXME: NEED TO ELIMINATE for ARCH_NAME, consider moving MEM_MAILBOX_BASE behind HAL
-#include "dev_mem_map.h"                                // for MEM_MAILBOX_BASE
+// FIXME: NEED TO ELIMINATE for ARCH_NAME
+// consider moving MEM_MAILBOX_BASE behind HAL
+#include "dev_mem_map.h"
 
 namespace tt {
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -5,12 +5,25 @@
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 
 #include <algorithm>
-#include <chrono>
-#include <cmath>
-#include <limits>
+#include <cstddef>                        // for size_t
+#include <functional>                     // for function
+#include <iterator>                       // for back_insert_iterator, back_...
+#include <optional>
 #include <random>
+#include <unordered_map>
+#include <vector>
 
-#include "tt_metal/impl/buffers/buffer.hpp"
+#include "tt_metal/impl/allocator/allocator.hpp"        // for Allocator, base_alloc, Bank...
+#include "tt_metal/impl/allocator/allocator_types.hpp"  // for AllocatorConfig, AllocCoreType
+#include "tt_metal/impl/buffers/buffer_constants.hpp"   // for BufferType
+#include "tt_metal/common/assert.hpp"                   // for TT_ASSERT, tt_throw, TT_THROW
+#include "tt_metal/common/core_coord.hpp"               // for CoreCoord
+#include "third_party/umd/device/xy_pair.h"             // for xy_pair, operator==, hash
+#include <fmt/base.h>                                   // for format_string
+
+// FIXME: NEED TO ELIMINATE for ARCH_NAME, consider moving MEM_MAILBOX_BASE behind HAL
+#include "dev_mem_map.h"                                // for MEM_MAILBOX_BASE
+
 namespace tt {
 
 namespace tt_metal {
@@ -70,8 +83,8 @@ void init_compute_and_storage_l1_bank_manager(Allocator &allocator, const Alloca
             logical_core.y,
             logical_core.x);
         CoreCoord noc_core({
-            static_cast<size_t>(alloc_config.worker_log_to_physical_routing_x.at(logical_core.x)),
-            static_cast<size_t>(alloc_config.worker_log_to_physical_routing_y.at(logical_core.y)),
+            static_cast<std::size_t>(alloc_config.worker_log_to_physical_routing_x.at(logical_core.x)),
+            static_cast<std::size_t>(alloc_config.worker_log_to_physical_routing_y.at(logical_core.y)),
             });
         TT_ASSERT (
             alloc_config.core_type_from_noc_coord_table.find(noc_core) != alloc_config.core_type_from_noc_coord_table.end(),

--- a/tt_metal/impl/allocator/l1_banking_allocator.hpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.hpp
@@ -5,18 +5,14 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
-#include <map>
-#include <unordered_map>
-#include <variant>
-#include <memory>
 
 #include "tt_metal/impl/allocator/allocator.hpp"
-#include "tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp"
 
 namespace tt {
 
 namespace tt_metal {
+
+struct AllocatorConfig;
 
 namespace allocator {
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
Get `dev_mem_map.h` out of public header file, reduce scope of ARCH_NAME include paths.

Follow up PR will be needed to move `MEM_MAILBOX_BASE` to Hal.

### What's changed
Ran pass of include what you use, to push header includes down towards implementation file.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11547227524
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
