### PR TITLE
Assert on sharded+tiled HC transpose inputs

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -58,7 +58,11 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
         } else {
             TT_FATAL(C % TILE_HEIGHT == 0, "Error");
         }
-        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
+        TT_FATAL(
+            input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
+        TT_FATAL(
+            !(input_tensor.is_sharded() && input_tensor.get_layout() == Layout::TILE),
+            "HC transpose does not support sharded+tilized inputs");
     } else if (this->dim == TransposeOpDim::CW) {
         TT_FATAL(C % TILE_WIDTH == 0, "Error");
         TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");


### PR DESCRIPTION
### Summary 

Sharded and tiled inputs are not currently supported in HC transpose. Previously, this condition was not checked and the operation produced garbage outputs.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11553497840
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/11553501183