### PR TITLE
#12979: Explict phdrs, enforce ordering

### DIFF
--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -12,6 +12,13 @@ OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
 	      "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
+
+PHDRS {
+  attributes 0x70000003;
+  text PT_LOAD;
+  data PT_LOAD;
+}
+
 SECTIONS
 {
   PROVIDE (__global_pointer$ = __firmware_global_pointer);
@@ -27,29 +34,29 @@ SECTIONS
     *(.text .stub .text.* .gnu.linkonce.t.*)
     /* .gnu.warning sections are handled specially by elf32.em.  */
     *(.gnu.warning)
-  } > REGION_APP_CODE
+  } > REGION_APP_CODE :text
   .init.fini :
   {
     /* We don't use .init/.fini (this isn't the '90s), make sure there aren't any.  */
     KEEP (*(.init .fini))
     ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections present");
-  } > REGION_APP_CODE
+  } > REGION_APP_CODE :text
 
-  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_CODE
-  .rodata1        : { *(.rodata1) } > REGION_APP_CODE
+  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_CODE :text
+  .rodata1        : { *(.rodata1) } > REGION_APP_CODE :text
   .sdata2         :
   {
     *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
-  } > REGION_APP_DATA
-  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) } > REGION_APP_DATA
+  } > REGION_APP_DATA :data
+  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) } > REGION_APP_DATA :data
 
-.data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_DATA
-  .dynamic        : { *(.dynamic) } > REGION_APP_DATA
+.data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_DATA :data
+  .dynamic        : { *(.dynamic) } > REGION_APP_DATA :data
   .data           :
   {
     *(.data .data.* .gnu.linkonce.d.*)
     SORT(CONSTRUCTORS)
-  } > REGION_APP_DATA
+  } > REGION_APP_DATA :data
 
   . = ALIGN(4); /* startup code will use word writes to zero bss */
   __l1_bss_start = .;
@@ -58,7 +65,7 @@ SECTIONS
     *(.dynsbss)
     *(.sbss .sbss.* .gnu.linkonce.sb.*)
     *(.scommon)
-  } > REGION_APP_DATA
+  } > REGION_APP_DATA :data
   . = ALIGN(4);
   __l1_bss_end = .;
 
@@ -76,24 +83,16 @@ SECTIONS
       pad the .data section.  */
    . = ALIGN(4);
    __ldm_bss_end = .;
-  } > REGION_APP_DATA
+  } > REGION_APP_DATA :data
   . = ALIGN(32 / 8);
-
-  .stack :
-  {
-   . = ALIGN(16);
-   __stack_bottom = .;
-   . += __firmware_stack_size;
-   __stack_top = .;
-   __freertos_irq_stack_top = .;
-   . += 4;
-  } > REGION_LDM
 
   l1_memory :
   {
     *(l1_memory)
     *(l1_memory_const) /* gcc complains about const and non-const data in the same segment. */
   } > ETH_L1
+
+  .riscv.attributes 0 : { *(.riscv.attributes) } :attributes
 
   /* Stabs debugging sections.  */
   .stab          0 : { *(.stab) }

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ * SPDX-FileCopyrightText: © 2023, 2024 Tenstorrent Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,52 +20,56 @@ OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
 	      "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
+
+PHDRS {
+  attributes 0x70000003;
+  text PT_LOAD;
+  data PT_LOAD;
+}
+
 SECTIONS
 {
   PROVIDE (__global_pointer$ = __firmware_global_pointer);
   PROVIDE (__erisc_jump_table = ORIGIN(ERISC_JUMPTABLE));
 
-  .start __firmware_start :
+  .text __firmware_start :
   {
     *(.start)
-  } > REGION_APP_KERNEL_CODE
-  code_l1 :
-  {
-    *(code_l1)
-  } > REGION_APP_KERNEL_CODE
-  PROVIDE (__ecode_l1 = .);
-  .text :
-
-  {
     *(.text.unlikely .text.*_unlikely .text.unlikely.*)
     *(.text.exit .text.exit.*)
     *(.text.startup .text.startup.*)
     *(.text.hot .text.hot.*)
     *(.text .stub .text.* .gnu.linkonce.t.*)
+    /* .gnu.warning sections are handled specially by elf32.em.  */
     *(.gnu.warning)
-  } > REGION_APP_KERNEL_CODE
+  } > REGION_APP_KERNEL_CODE :text
 
+  .init.fini :
+  {
+    /* We don't use .init/.fini (this isn't the '90s), make sure there aren't any.  */
+    KEEP (*(.init .fini))
+    ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections present");
+  } > REGION_APP_KERNEL_CODE :text
 
-  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_KERNEL_CODE
-  .rodata1        : { *(.rodata1) } > REGION_APP_KERNEL_CODE
+  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_KERNEL_CODE :text
+  .rodata1        : { *(.rodata1) } > REGION_APP_KERNEL_CODE :text
+
   .sdata2         :
   {
     *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
-  } > REGION_APP_KERNEL_DATA
-  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) } > REGION_APP_KERNEL_DATA
+  } > REGION_APP_KERNEL_DATA :data
+  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) } > REGION_APP_KERNEL_DATA :data
   /* Adjust the address for the data segment.  We want to adjust up to
      the same address within the page on the next page up.  */
-  . = DATA_SEGMENT_ALIGN (CONSTANT (MAXPAGESIZE), CONSTANT (COMMONPAGESIZE));
-  .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_KERNEL_DATA
-  .dynamic        : { *(.dynamic) } > REGION_APP_KERNEL_DATA
-  . = DATA_SEGMENT_RELRO_END (0, .);
+  .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_KERNEL_DATA :data
+  .dynamic        : { *(.dynamic) } > REGION_APP_KERNEL_DATA :data
   .data           :
   {
     . = ALIGN(16);
     *(.data .data.* .gnu.linkonce.d.*)
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata .srodata.*)
     SORT(CONSTRUCTORS)
-  } > REGION_APP_KERNEL_DATA
+  } > REGION_APP_KERNEL_DATA :data
 
   . = ALIGN(4); /* startup code will use word writes to zero bss */
   __l1_bss_start = .;
@@ -74,7 +78,7 @@ SECTIONS
     *(.dynsbss)
     *(.sbss .sbss.* .gnu.linkonce.sb.*)
     *(.scommon)
-  } > REGION_APP_KERNEL_DATA
+  } > REGION_APP_KERNEL_DATA :data
   . = ALIGN(4);
   __l1_bss_end = .;
 
@@ -92,29 +96,15 @@ SECTIONS
       pad the .data section.  */
    . = ALIGN(4);
    __ldm_bss_end = .;
-  } > REGION_APP_KERNEL_DATA
-  . = ALIGN(32 / 8);
-  . = SEGMENT_START("ldata-segment", .);
-  . = ALIGN(32 / 8);
-  _end = .; PROVIDE (end = .);
-  . = DATA_SEGMENT_END (.);
-
-
-  .stack :
-  {
-   . = ALIGN(16);
-   __stack_bottom = .;
-   . += __firmware_stack_size;
-   __stack_top = .;
-   __freertos_irq_stack_top = .;
-   . += 4;
-  } > REGION_LDM
+  } > REGION_APP_KERNEL_DATA :data
 
   l1_memory :
   {
     *(l1_memory)
     *(l1_memory_const) /* gcc complains about const and non-const data in the same segment. */
   } > ETH_L1
+
+  .riscv.attributes 0 : { *(.riscv.attributes) } :attributes
 
   /* Stabs debugging sections.  */
   .stab          0 : { *(.stab) }

--- a/tt_metal/hw/toolchain/sections.ld
+++ b/tt_metal/hw/toolchain/sections.ld
@@ -39,9 +39,19 @@ OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
 	      "elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
+
+PHDRS {
+  attributes 0x70000003;
+  text PT_LOAD;
+  data PT_LOAD;
+#if defined(TYPE_FIRMWARE)
+  stack PT_GNU_STACK;
+#endif
+}
+
 SECTIONS
 {
-  .text TEXT_START :
+  .text TEXT_START : ALIGN(4)
   {
     /* Because TEXT_START might not be the start of a region, we
        need to force this section to be emitted so that following sections
@@ -55,13 +65,13 @@ SECTIONS
     *(.text .stub .text.* .gnu.linkonce.t.*)
     /* .gnu.warning sections are handled specially by elf32.em.  */
     *(.gnu.warning)
-  } > REGION_CODE
+  } > REGION_CODE :text
   .init.fini :
   {
     /* We don't use .init/.fini (this isn't the '90s), make sure there aren't any.  */
     KEEP (*(.init .fini))
     ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections have contents");
-  } > REGION_CODE
+  } > REGION_CODE :text
 
   . = ALIGN(. + MEM_PAD, MEM_ALIGN);
 
@@ -75,7 +85,7 @@ SECTIONS
 #endif
 
   PROVIDE(__global_pointer$ = ORIGIN(REGION_DATA) + 0x7f0);
-  .data DATA_START :
+  .data DATA_START : ALIGN(4)
   {
      . = .; /* Force section emission.  */
      __ldm_data_start = .;
@@ -108,14 +118,14 @@ SECTIONS
     *(.got.plt) *(.igot.plt) *(.got) *(.igot)
     . = ALIGN(4);
     __ldm_data_end = .;
-  } > REGION_DATA
+  } > REGION_DATA :data
   .ctors.dtors :
   {
     /* We don't use .ctors/.dtors either (this still isn't the '90s), make sure there aren't any.  */
     KEEP (*(.ctors .ctors.* .dtors .dtors.*))
     ASSERT(SIZEOF(.ctors.dtors) == 0, ".ctors/.dtors sections have contents");
-  } > REGION_DATA
-  .bss ALIGN(4):
+  } > REGION_DATA :data
+  .bss : ALIGN(4)
   {
     __ldm_bss_start = .;
     *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*)
@@ -127,7 +137,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN(4);
     __ldm_bss_end = .;
-  } > REGION_DATA
+  } > REGION_DATA :data
 
 #ifdef TYPE_FIRMWARE
   . = ALIGN(MEM_ALIGN);
@@ -137,11 +147,12 @@ SECTIONS
 #ifdef TYPE_FIRMWARE
   .stack :
   {
-    __stack_bottom = .;
    . += FIRMWARE_STACK_SIZE;
     __stack_top = .;
-  } > REGION_STACK
+  } > REGION_STACK :stack
 #endif
+
+  .riscv.attributes 0 : { *(.riscv.attributes) } :attributes
 
   /* Stabs debugging sections.  */
   .stab          0 : { *(.stab) }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12979

### Problem description
continue moving the erisc linker scripts towards the common scripts.

### What's changed
1) Explicit PHDRS fragment in all 3 scripts,  I found the linker was making undesired decisions about what bytes are in segments.
2) Require text segment first, and optional stack segment last in the elf loader
3) Verify all allocatable sections reside in a loadable (or stack) segment
4) Cleanup the text segment of erisc-b0-kernel, matching erisc-b0-app-sections.

### Checklist
- [YES] Post commit CI passes
- [YES] Blackhole Post commit (if applicable)
- [NA] Model regression CI testing passes (if applicable)
- [NA] Device performance regression CI testing passes (if applicable)
- [YES] New/Existing tests provide coverage for changes
