### PR TITLE
#0: [llama70b] Separate device read from decode_forward_trace

### DIFF
--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -262,7 +262,7 @@ def run_decode(
     if trace_mode:
         logger.info("Capturing trace")
         trace_id, tt_inp_emb, rot_mat, cache_idxs_tt, tt_logits, _ = model.capture_trace(
-            tokens[:, prev_pos:min_prompt_len], prev_pos
+            tokens[:, prev_pos : prev_pos + 1], prev_pos
         )
 
     for cur_pos in range(min_prompt_len, total_len):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- For a vLLM optimization, it is required to execute `TtLlamaModelForGeneration::decode_forward_trace` without reading back from device immediately after.

### What's changed
- Add `read_from_device` option (enabled by default) to TtLlamaModelForGeneration::decode_forward_trace and move read to `read_forward_trace` so the two can be done separately in vLLM
- Fix bug in llama70b demo when capturing trace while prefill_decode is enabled

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
