### PR TITLE
#14379: Support pad_value for ttnn.from_torch

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -9,16 +9,12 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc, is_grayskull
-
 from tests.ttnn.unit_tests.operations.test_utils import (
-    get_compute_kernel_options,
-    compute_kernel_options,
     compute_kernel_ids,
+    compute_kernel_options,
+    create_ttnn_tilized_tensor,
+    get_compute_kernel_options,
 )
-
-
-def create_ttnn_tilized_tensor(torch_tensor, device, dtype):
-    return ttnn.from_torch(torch_tensor, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
 
 
 def get_tensors(

--- a/tests/ttnn/unit_tests/operations/test_moreh_mean.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_mean.py
@@ -8,19 +8,15 @@ from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose
-
 from tests.ttnn.unit_tests.operations.test_utils import (
-    get_compute_kernel_options,
-    compute_kernel_options,
-    compute_kernel_ids,
     TILE_HEIGHT,
     TILE_WIDTH,
     check_dim,
+    compute_kernel_ids,
+    compute_kernel_options,
+    create_ttnn_tilized_tensor,
+    get_compute_kernel_options,
 )
-
-
-def create_ttnn_tilized_tensor(torch_tensor, device, dtype):
-    return ttnn.from_torch(torch_tensor, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
 
 
 def run_moreh_mean(

--- a/tests/ttnn/unit_tests/operations/test_moreh_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_norm.py
@@ -4,22 +4,18 @@
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
 from models.utility_functions import comp_allclose, is_wormhole_b0
-from loguru import logger
-
 from tests.ttnn.unit_tests.operations.test_utils import (
-    get_compute_kernel_options,
-    compute_kernel_options,
-    compute_kernel_ids,
-    compute_output_shape,
     check_dim,
+    compute_kernel_ids,
+    compute_kernel_options,
+    compute_output_shape,
+    create_ttnn_tilized_tensor,
+    get_compute_kernel_options,
 )
-
-
-def create_ttnn_tilized_tensor(torch_tensor, device, dtype):
-    return ttnn.from_torch(torch_tensor, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
 
 
 def make_torch_tensors(input_shape, dim, keepdim=False, *, dtype=torch.float32):

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -2,12 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import ttnn
-import torch
-from models.utility_functions import is_wormhole_b0
 import copy
-import pytest
 
+import pytest
+import torch
+
+import ttnn
+from models.utility_functions import is_wormhole_b0
 
 TILE_HEIGHT = 32
 TILE_WIDTH = 32
@@ -197,3 +198,7 @@ def get_ttnn_torch_dtype(ttnn_dtype: ttnn.DataType) -> torch.dtype:
         ttnn.int32: torch.int32,
     }
     return dtype_map.get(ttnn_dtype, None)
+
+
+def create_ttnn_tilized_tensor(torch_tensor, device, dtype, pad_value=float("nan")):
+    return ttnn.from_torch(torch_tensor, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, pad_value=pad_value)


### PR DESCRIPTION
### Ticket
Link to Github Issue: #14379

### Problem description
The `ttnn.from_torch` function is very convenient for converting a PyTorch tensor into a `ttnn` tensor. However, it currently lacks support for specifying a `pad_value` when working with `TILE_LAYOUT` tensors. Adding this support would greatly enhance testing of `ttnn` operations.

Currently, `ttnn.from_torch` defaults to padding with `0` when `pad_value` is not specified, which may lead to misleading results in computations. Using `NaN` as a `pad_value` would provide a more "natural error assertion" by immediately indicating when padding cells are mistakenly included in kernel computations.

For example, padding with `NaN` would result in `NaN` in the computed output if padding cells are unintentionally accessed, clearly signaling an issue. In contrast, padding with `0` may yield seemingly "correct" results, such as in tile summation, thus concealing potential errors.


### What's changed
(1) core
Added `pad_value` parameter to `ttnn.from_torch`.
- If `pad_value` is not specified (i.e., `None`), `ttnn.from_torch` would retain its current behavior (and speed), padding `TILE_LAYOUT` tensors with `0`.
- If a `pad_value` is specified and the layout is `TILE_LAYOUT`, `ttnn.from_torch` would apply `tensor.pad_to_tile(pad_value)` to pad the tensor accordingly.

**Result:**
BFLOAT16:
```python
ttnn.Tensor([[[[ 0.06348,  0.66406,  ...,  0.73828, -0.05835],
               [-0.87891,  0.11816,  ...,  0.31641,  0.60938],
               ...,
               [     nan,      nan,  ...,      nan,      nan],
               [     nan,      nan,  ...,      nan,      nan]],
               ...
]], shape=Shape([5, 8, 78[96], 77[96]]), dtype=DataType::BFLOAT16, layout=Layout::TILE)
```

BFLOAT8_B:
```python
ttnn.Tensor([[[[ 0.06250,  0.66406,  ...,  0.74219, -0.05469],
               [-0.88281,  0.11719,  ...,  0.31250,  0.60938],
               ...,
               [     nan,      nan,  ...,      nan,      nan],
               [     nan,      nan,  ...,      nan,      nan]],
               ...
]], shape=Shape([5, 8, 78[96], 77[96]]), dtype=DataType::BFLOAT8_B, layout=Layout::TILE)
```

(2) test_utils
Move `create_ttnn_tilized_tensor` into test_utils for future use in TTNN unit test operations.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11757496501
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] Device performance regression CI testing passes (if applicable): N/A
- [X] New/Existing tests provide coverage for changes: N/A
