### PR TITLE
#14372: fix transpose hc RM pcc errors + add N-dimensional permute single core implementation

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -743,21 +743,23 @@ def test_transpose_4d_wh_tile(shape, device):
 @pytest.mark.parametrize(
     "config",
     [
-        [[1, 8, 4096, 40], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # bad pcc
-        [[1, 9, 8, 40], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # bad pcc
         [[64, 4, 49, 32], [-2, -1], ttnn.ROW_MAJOR_LAYOUT],  # Page size must be divisible by sizeof(uint32_t)
-        [[1, 1370, 1, 3, 1280], [0, -2], ttnn.ROW_MAJOR_LAYOUT],  # greater than 4D
+        [[1, 1370, 1, 3, 1280], [0, -2], ttnn.TILE_LAYOUT],  # untilize doesn't work with 4D
         [[12, 3], [0, 1], ttnn.ROW_MAJOR_LAYOUT],  # need tensor for this one
     ],
 )
-def test_transpose_failures(config, device):
+@pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
+def test_transpose_failures(config, memory_config, device):
     pytest.skip("Failures to fix after #13217 and #13005 are in - 5D, HC PCC issue and unaligned RM tensor")
     torch_input = torch.randn(config[0], dtype=torch.bfloat16)
     torch_output = torch_input.transpose(config[1][0], config[1][1])
 
-    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=config[2], device=device)
+    tt_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.DataType.BFLOAT16, layout=config[2], device=device, memory_config=memory_config
+    )
     tt_output = ttnn.transpose(tt_input, config[1][0], config[1][1])
     tt_output = ttnn.to_torch(tt_output)
+
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
@@ -769,24 +771,76 @@ def test_transpose_failures(config, device):
             [1, 16, 6, 64],
             [-1, -2],
             ttnn.ROW_MAJOR_LAYOUT,
-        ],  # (W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0 && (H * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH)
+        ],
         [
             [1, 16, 64, 6],
             [-1, -2],
             ttnn.ROW_MAJOR_LAYOUT,
-        ],  # (W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0 && (H * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH)
+        ],
         [
             [1, 16, 64, 6],
             [1, 2],
             ttnn.ROW_MAJOR_LAYOUT,
-        ],  # (W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0 for HC as well...
+        ],
+        [[1, 9, 8, 18], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # unaligned RM that fallsback to tiled
+        [[1, 9, 8, 14], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # unaligned RM that fallsback to tiled
+        [[1, 9, 8, 2], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # unaligned RM that fallsback to tiled
+        [[1, 2, 8, 2], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # unaligned RM that fallsback to tiled
+        [
+            [1, 8, 4096, 40],
+            [1, 2],
+            ttnn.ROW_MAJOR_LAYOUT,
+        ],  # RM that fallsback to tiled only when reading from DRAM (32B alignment requirement on DRAM, 16B on L1)
+        [[1, 9, 8, 40], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # RM that fallsback to tiled only when reading from DRAM
+        [[1, 8, 8, 8], [1, 2], ttnn.ROW_MAJOR_LAYOUT],  # RM that fallsback to tiled only when reading from DRAM
     ],
 )
-def test_transpose_unaligned(config, device):
+@pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
+def test_transpose_unaligned(config, memory_config, device):
     # this will convert to tiled for now
     torch_input = torch.randn(config[0], dtype=torch.bfloat16)
     torch_output = torch_input.transpose(config[1][0], config[1][1])
-    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=config[2], device=device)
+    tt_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.DataType.BFLOAT16, layout=config[2], device=device, memory_config=memory_config
+    )
     tt_output = ttnn.transpose(tt_input, config[1][0], config[1][1])
+    tt_output = ttnn.to_torch(tt_output)
+    assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(1, 2, 32, 100), (1, 35, 7, 7), (1, 1, 1, 1)],
+)
+def test_transpose_hc_padded_c(shape, device):
+    # this will convert to tiled for now
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = torch_input.transpose(1, 2)
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = ttnn.transpose(tt_input, 1, 2)
+    tt_output = ttnn.to_torch(tt_output)
+    assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[1, 197, 1, 3, 1024], [1, 197, 1, 3, 768], [1, 50, 1, 3, 1024], [1, 50, 1, 3, 768], [1, 1370, 1, 3, 1280]],
+)
+@pytest.mark.parametrize(
+    "dims",
+    [
+        (0, -2),
+    ],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [ttnn.ROW_MAJOR_LAYOUT],
+)
+def test_transpose_5d(shape, dims, layout, device):
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = torch_input.transpose(dims[0], dims[1])
+
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=layout, device=device)
+    tt_output = ttnn.transpose(tt_input, dims[0], dims[1])
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -49,7 +49,7 @@ void validate_buffer_size_and_page_size(
         size);
     TT_FATAL(
         page_size % sizeof(uint32_t) == 0,
-        "Page size must be divisible by sizeof(uint32_t) because buffers hold uint32_t values");
+        "Page size {} must be divisible by sizeof(uint32_t) because buffers hold uint32_t values", page_size);
 
     if (is_sharded(buffer_layout)) {
         TT_FATAL(

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -83,6 +83,8 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/pad/pad.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/permute.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/repeat.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr bool src0_is_dram          = (bool) get_compile_time_arg_val(0);
+    constexpr uint32_t N                 = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size         = get_compile_time_arg_val(2);
+    constexpr uint32_t num_rows          = get_compile_time_arg_val(3);
+
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+
+    const InterleavedAddrGen<src0_is_dram> s0 = {
+        .bank_base_address = src_addr,
+        .page_size = page_size
+    };
+
+    uint32_t curr_addr = src_addr;
+    for (uint32_t i = 0; i < num_rows; ++i) {
+        cb_reserve_back(tt::CB::c_in0, 1);
+        uint32_t src_buffer_l1_addr = get_write_ptr(tt::CB::c_in0);
+        noc_async_read_page(i, s0, src_buffer_l1_addr);
+        noc_async_read_barrier();
+        volatile tt_l1_ptr uint16_t* out_stick = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_buffer_l1_addr);
+        cb_push_back(tt::CB::c_in0, 1);
+    }
+
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+
+void kernel_main() {
+    constexpr bool dst_is_dram          = (bool) get_compile_time_arg_val(0);
+    constexpr uint32_t N                 = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size         = get_compile_time_arg_val(2);
+    constexpr uint32_t num_rows          = get_compile_time_arg_val(3);
+
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+
+    const InterleavedAddrGen<dst_is_dram> s0 = {
+        .bank_base_address = dst_addr,
+        .page_size = page_size
+    };
+
+    uint32_t input_shape[N], perm[N], dest_strides[N];
+    for (uint32_t i = 1; i <= N; i++) {
+        input_shape[i - 1] = get_arg_val<uint32_t>(i);
+        perm[i - 1] = get_arg_val<uint32_t>(i + N);
+        dest_strides[i - 1] = get_arg_val<uint32_t>(i + 2*N);
+    }
+
+    uint32_t src_buffer_l1_addr = get_write_ptr(tt::CB::c_in0);
+    uint32_t curr_addr = dst_addr;
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        // Compute multi-dimensional index for the source row
+        uint32_t src_multi_idx[N];
+        size_t remaining = row;
+        for(uint32_t i = 0; i < N - 1; ++i) {
+            size_t dim = N - 2 - i;  // Start from the second last dimension
+            src_multi_idx[dim] = remaining % input_shape[dim];
+            remaining /= input_shape[dim];
+        }
+        src_multi_idx[N - 1] = 0; // Row dimension index
+
+        // Apply permutation to get destination multi-dimensional index
+        uint32_t dest_multi_idx[N];
+        for(uint32_t i = 0; i < N; ++i) {
+            dest_multi_idx[i] = src_multi_idx[perm[i]];
+        }
+
+        // Convert destination multi-dimensional index to linear index
+        uint32_t dest_linear_idx = 0;
+        for(uint32_t i = 0; i < N - 1; ++i) {
+            dest_linear_idx += dest_multi_idx[i] * dest_strides[i];
+        }
+        cb_wait_front(tt::CB::c_in0, 1);
+        uint32_t l1_read_addr = get_read_ptr(tt::CB::c_in0);
+        uint64_t dst_noc_addr = get_noc_addr(dest_linear_idx, s0);
+        noc_async_write(l1_read_addr, dst_noc_addr, page_size);
+        noc_async_write_barrier();
+        cb_pop_front(tt::CB::c_in0, 1);
+    }
+
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ttnn/cpp/ttnn/tensor/types.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+
+namespace ttnn::operations::data_movement {
+
+PermuteDeviceOperation::program_factory_t PermuteDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return SingleCore{};
+}
+
+void PermuteDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+        TT_FATAL(attributes.dims.size() == tensor_args.input_tensor.get_logical_shape().rank(),
+                 "Permute dimensions must match input tensor rank");
+        TT_FATAL(attributes.dims.back() == tensor_args.input_tensor.get_logical_shape().rank() - 1,
+                 "Last dimension of permute must be the last dimension of the input tensor as page-breaking is not supported at the moment");
+        TT_FATAL(tensor_args.input_tensor.is_sharded() == false,
+                 "Permute operation does not support sharded input tensor");
+        TT_FATAL(tensor_args.input_tensor.get_layout() == Layout::ROW_MAJOR, "Permute operation only supports row-major layout");
+}
+
+void PermuteDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+
+PermuteDeviceOperation::shape_return_value_t PermuteDeviceOperation::compute_output_shapes(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    SmallVector<uint32_t> shape, padded_shape;
+    auto input_shape = tensor_args.input_tensor.get_logical_shape();
+    shape.reserve(input_shape.rank());
+    for (auto dim : attributes.dims) {
+        shape.push_back(input_shape[dim]);
+    }
+    return ttnn::SimpleShape(shape);
+}
+
+PermuteDeviceOperation::tensor_return_value_t PermuteDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_output_tensor.has_value()) {
+        return tensor_args.optional_output_tensor.value();
+    }
+    auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
+    const auto& input_tensor = tensor_args.input_tensor;
+    return create_device_tensor(
+        output_shape,
+        input_tensor.tensor_attributes->dtype,
+        input_tensor.tensor_attributes->layout,
+        input_tensor.device());
+}
+
+
+std::tuple<PermuteDeviceOperation::operation_attributes_t, PermuteDeviceOperation::tensor_args_t>
+PermuteDeviceOperation::invoke(const Tensor& input_tensor, const SmallVector<uint32_t>& dims,
+            const std::optional<MemoryConfig>& memory_config, std::optional<Tensor> optional_output_tensor) {
+    return {
+        operation_attributes_t{.dims=dims,
+        .output_mem_config=memory_config.value_or(input_tensor.memory_config())},
+        tensor_args_t{.input_tensor=input_tensor, .optional_output_tensor=optional_output_tensor}
+    };
+}
+
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/decorators.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+
+namespace ttnn::operations::data_movement {
+
+struct PermuteDeviceOperation {
+    struct operation_attributes_t {
+        const SmallVector<uint32_t> dims;
+        const MemoryConfig output_mem_config;
+    };
+     struct tensor_args_t {
+        const Tensor& input_tensor;
+        std::optional<Tensor> optional_output_tensor;
+    };
+
+    using shape_return_value_t = ttnn::SimpleShape; // waiting on TensorSpec here
+
+    using tensor_return_value_t = Tensor;
+
+    struct SingleCore {
+        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
+        struct shared_variables_t {
+            KernelHandle unary_reader_kernel_id;
+            KernelHandle unary_writer_kernel_id;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+    using program_factory_t = std::variant<SingleCore>;
+
+    // Mandatory methods
+
+    // Select the program factory based on the operation attributes and tensor args
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    // Validate the operation when it creates a program.
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    // Empty as there doesn't seem to be any complicated hashing requirement
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    // Compute the output shapes based on the operation attributes and tensor args
+    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+
+    // Create the output tensors based on the operation attributes and tensor args
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // API call to map user arguments to operation attributes and tensor args.
+    // This is the only method that is called by the user
+    // The user will be able to call the operation using `tensor_return_value_t output = ttnn::prim::example(input_tensor)` after the op is registered
+    // Keep in mind that the the overload with `queue_id` argument will be added automatically for primitive operations
+    // So, the user can also call this operation using `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor, const SmallVector<uint32_t>& dims,
+            const std::optional<MemoryConfig>& memory_config, std::optional<Tensor> optional_output_tensor) ;
+
+};
+}
+
+namespace ttnn::prim {
+    // Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
+constexpr auto permute = ttnn::register_operation<
+    "ttnn::prim::permute",
+    ttnn::operations::data_movement::PermuteDeviceOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_program_factory.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+
+namespace ttnn::operations::data_movement {
+
+namespace detail {
+    uint32_t num_pages(const ttnn::Tensor input_tensor) {
+        const auto& padded_shape = input_tensor.get_logical_shape();
+        return padded_shape.volume()/padded_shape[-1];
+    }
+
+    uint32_t page_size(const ttnn::Tensor input_tensor) {
+        const auto& padded_shape = input_tensor.get_logical_shape(); // in anticipation of RM padding
+        return padded_shape[-1] * input_tensor.element_size();
+    }
+
+    std::vector<uint32_t> get_row_strides(const ttnn::SimpleShape shape) {
+        std::vector<uint32_t> strides(shape.rank());
+        strides[shape.rank() - 1] = 1;
+        strides[shape.rank() - 2] = 1;
+        for (int i = shape.rank() - 3; i >= 0; i--) {
+            strides[i] = strides[i + 1] * shape[i + 1];
+        }
+        return strides;
+    }
+}
+
+PermuteDeviceOperation::SingleCore::cached_program_t PermuteDeviceOperation::SingleCore::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor.buffer();
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    uint32_t input_rm_page_size = detail::page_size(input_tensor);
+
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    uint32_t output_rm_page_size = detail::page_size(tensor_return_value);
+
+    uint32_t num_input_pages = detail::num_pages(input_tensor);
+
+    tt::tt_metal::Device* device = input_tensor.device();
+
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    uint32_t num_input_pages_to_read = 1;
+
+    CoreRange core({0, 0}, {0, 0});
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_rm_page_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, input_rm_page_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    uint32_t N = operation_attributes.dims.size();
+    uint32_t num_rows = input_tensor.volume() / input_tensor.get_logical_shape()[-1];
+
+
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, N, input_rm_page_size, num_rows};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm.cpp",
+        core,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)dst_is_dram, N, output_rm_page_size, num_rows};
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm.cpp",
+        core,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::vector<uint32_t> reader_runtime_args = {src_buffer->address()};
+
+
+    tt::tt_metal::SetRuntimeArgs(
+        program, unary_reader_kernel_id, core, reader_runtime_args);
+
+    auto input_shape_view = input_tensor.get_logical_shape().view();
+    auto output_strides = detail::get_row_strides(output_tensor.get_logical_shape()); // in anticipation of RM padding
+
+    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address()};
+    writer_runtime_args.insert(writer_runtime_args.end(), input_shape_view.begin(), input_shape_view.end());
+    writer_runtime_args.insert(writer_runtime_args.end(), operation_attributes.dims.begin(), operation_attributes.dims.end());
+    writer_runtime_args.insert(writer_runtime_args.end(), output_strides.begin(), output_strides.end());
+
+    tt::tt_metal::SetRuntimeArgs(
+        program, unary_writer_kernel_id, core, writer_runtime_args);
+
+    return {
+        std::move(program),
+        {.unary_reader_kernel_id = unary_reader_kernel_id, .unary_writer_kernel_id = unary_writer_kernel_id}};
+}
+
+void PermuteDeviceOperation::SingleCore::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor.buffer();
+
+    {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, CoreCoord{0, 0});
+        runtime_args[0] = src_buffer->address();
+    }
+
+    {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, CoreCoord{0, 0});
+        runtime_args[0] = dst_buffer->address();
+    }
+}
+
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -54,7 +54,7 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
     }
     if (this->dim == TransposeOpDim::HC) {
         if (row_major) {
-            TT_FATAL((W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0, "Error");
+            TT_FATAL((W * input_tensor.element_size()) % input_tensor.buffer()->alignment() == 0, "Error");
         } else {
             TT_FATAL(C % TILE_HEIGHT == 0, "Error");
         }


### PR DESCRIPTION
### Ticket
#14372 #14370 

### Problem description

## Transpose HC
There were some existing PCC issues for transpose HC for row major. One of the constraints is the limitation on FACE width that was used to mark limitations on the transpose WH. The constant was incorrectly reused in the device operation for the transpose hc kernel, which is actually an alignment issue. Certain shapes were working when inside L1 but not when inside DRAM.

## N-dimensional permute/transpose
There is no support for N-dimensional permute/transpose at the moment, which is required for PyTorch 2 models. In particular, 5D is needed.


### What's changed

## Transpose HC
Correct alignment constraint to use the requisite alignment based on whether or not the input is in DRAM or L1.

## N-dimensional permute/transpose
Add a kernel that generically supports N-dimensional permute except for the case where the inner dimension is moved. This kernel works for Row-major + Interleaved inputs. Unfortunately, since I'm being asked to do BH issues I've just made it single core for now.

Transpose coverage on pytorch2 traces goes up from 90% to 93% with this change.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11614629644
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
