### PR TITLE
#14363: Optimize Shape::operator[]

### DIFF
--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -417,6 +417,10 @@ uint64_t SimpleShape::volume() const {
 
 namespace ttnn::types {
 
-uint32_t Shape::operator[](std::int64_t index) const { return this->value.without_padding()[index]; }
+uint32_t Shape::operator[](std::int64_t index) const {
+    const auto dimension = value[index];
+    auto [front_pad, back_pad] = value.padding().pad_dimensions_[index];
+    return dimension - (front_pad + back_pad);
+}
 
 }  // namespace ttnn::types

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -419,7 +419,7 @@ namespace ttnn::types {
 
 uint32_t Shape::operator[](std::int64_t index) const {
     const auto dimension = value[index];
-    auto [front_pad, back_pad] = value.padding().pad_dimensions_[index];
+    auto [front_pad, back_pad] = value.padding()[index];
     return dimension - (front_pad + back_pad);
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14363

### Problem description
Shape::operator[] calculates the whole LegacyShape::without_padding to get a single element out of it

### What's changed
Calculate only the needed value within Shape::operator[]

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11568060340/)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
