### PR TITLE
FD refactor + sub device support

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
@@ -1,5 +1,5 @@
 CreateBuffer
 =================
 
-.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const InterleavedBufferConfig & config);
-.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const ShardedBufferConfig & config);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const InterleavedBufferConfig &config, std::optional<DeviceAddr> address, std::optional<uint32_t> sub_device_id);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const ShardedBufferConfig &config, std::optional<DeviceAddr> address, std::optional<uint32_t> sub_device_id);

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/buffers/CreateBuffer.rst
@@ -1,5 +1,9 @@
 CreateBuffer
 =================
 
-.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const InterleavedBufferConfig &config, std::optional<DeviceAddr> address, std::optional<uint32_t> sub_device_id);
-.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const ShardedBufferConfig &config, std::optional<DeviceAddr> address, std::optional<uint32_t> sub_device_id);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const InterleavedBufferConfig &config);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const ShardedBufferConfig &config);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const InterleavedBufferConfig &config, DeviceAddr address);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const ShardedBufferConfig &config, DeviceAddr address);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const InterleavedBufferConfig &config, SubDeviceId sub_device_id);
+.. doxygenfunction:: tt::tt_metal::v0::CreateBuffer(const ShardedBufferConfig &config, SubDeviceId sub_device_id);

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/Finish.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/Finish.rst
@@ -3,4 +3,4 @@
 Finish
 ======
 
-.. doxygenfunction:: tt::tt_metal::v0::Finish(CommandQueue& cq)
+.. doxygenfunction:: tt::tt_metal::v0::Finish

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -167,11 +167,11 @@ def test_dispatch_cores():
     REF_COUNT_DICT = {
         "grayskull": {
             "Tensix CQ Dispatch": 16,
-            "Tensix CQ Prefetch": 24,
+            "Tensix CQ Prefetch": 25,
         },
         "wormhole_b0": {
             "Tensix CQ Dispatch": 16,
-            "Tensix CQ Prefetch": 24,
+            "Tensix CQ Prefetch": 25,
         },
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -14,6 +14,7 @@ constexpr uint32_t cb_start_addr = get_compile_time_arg_val(0);
 constexpr uint32_t cb_rd_ptr = get_compile_time_arg_val(0);
 constexpr uint32_t cb_size = get_compile_time_arg_val(1);
 constexpr uint32_t num_layers = get_compile_time_arg_val(2);
+constexpr bool global_sems = get_compile_time_arg_val(3);
 
 uint32_t rt_args_idx = 0;
 uint32_t vc;
@@ -64,8 +65,14 @@ FORCE_INLINE void setup_remote_receiver_cb_interface() {
 
     remote_cb_interface.fifo_start_addr = cb_start_addr;
 
-    remote_cb_interface.pages_acked = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_acked_semaphore_addr));
-    remote_cb_interface.pages_sent = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_sent_semaphore_addr));
+    // Global semaphores return an actual address instead of an index
+    if constexpr (global_sems) {
+        remote_cb_interface.pages_acked = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pages_acked_semaphore_addr);
+        remote_cb_interface.pages_sent = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pages_sent_semaphore_addr);
+    } else {
+        remote_cb_interface.pages_acked = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_acked_semaphore_addr));
+        remote_cb_interface.pages_sent = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_sent_semaphore_addr));
+    }
 
     remote_cb_interface.aligned_page_size = aligned_page_size;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
@@ -13,6 +13,7 @@ constexpr uint32_t cb_start_addr = get_compile_time_arg_val(0);
 constexpr uint32_t cb_rd_ptr = get_compile_time_arg_val(0);
 constexpr uint32_t cb_size = get_compile_time_arg_val(1);
 constexpr uint32_t num_layers = get_compile_time_arg_val(2);
+constexpr bool global_sems = get_compile_time_arg_val(3);
 
 uint32_t rt_args_idx = 0;
 uint32_t vc;
@@ -63,8 +64,13 @@ FORCE_INLINE void setup_remote_receiver_cb_interface() {
 
     remote_cb_interface.fifo_start_addr = cb_start_addr;
 
-    remote_cb_interface.pages_acked = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_acked_semaphore_addr));
-    remote_cb_interface.pages_sent = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_sent_semaphore_addr));
+    if constexpr (global_sems) {
+        remote_cb_interface.pages_acked = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pages_acked_semaphore_addr);
+        remote_cb_interface.pages_sent = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pages_sent_semaphore_addr);
+    } else {
+        remote_cb_interface.pages_acked = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_acked_semaphore_addr));
+        remote_cb_interface.pages_sent = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(pages_sent_semaphore_addr));
+    }
 
     remote_cb_interface.aligned_page_size = aligned_page_size;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/impl/dispatch/command_queue_interface.hpp"
+#include "tt_metal/impl/dispatch/memcpy.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_pgm_dispatch.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/sweep_pgm_dispatch.sh
@@ -182,7 +182,7 @@ build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 40
 echo "###" all procesors all cores 32 rta
 build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 256 -x $max_x -y $max_y -a 32 $trace_option
 build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 512 -x $max_x -y $max_y -a 32 $trace_option
-build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 1024 -x $max_x -y $max_y -a 32 $trace_optionv
+build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 1024 -x $max_x -y $max_y -a 32 $trace_option
 build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 2048 -x $max_x -y $max_y -a 32 $trace_option
 build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 4096 -x $max_x -y $max_y -a 32 $trace_option
 # build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch -w 5000 -s 8192 -x $max_x -y $max_y -a 32 $trace_option

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -477,7 +477,7 @@ int main(int argc, char **argv) {
              0,    // prefetch_downstream_buffer_pages
              num_compute_cores, // max_write_packed_cores
              0,
-             0,
+             dispatch_constants::DISPATCH_MESSAGE_ENTRIES,
              0,
              0,
              0,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -478,6 +478,7 @@ int main(int argc, char **argv) {
              num_compute_cores, // max_write_packed_cores
              0,
              dispatch_constants::DISPATCH_MESSAGE_ENTRIES,
+             dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES,
              0,
              0,
              0,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1920,7 +1920,7 @@ void configure_for_single_chip(Device *device,
          prefetch_downstream_buffer_pages,
          num_compute_cores, // max_write_packed_cores
          0,
-         0,
+         dispatch_constants::DISPATCH_MESSAGE_ENTRIES,
          0,
          0,
          0,
@@ -1940,6 +1940,7 @@ void configure_for_single_chip(Device *device,
         dispatch_compile_args[12] = dispatch_downstream_cb_sem;
         dispatch_compile_args[13] = dispatch_h_cb_sem;
         dispatch_compile_args[14] = dispatch_d_preamble_size;
+        dispatch_compile_args[21] = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
         CoreCoord phys_dispatch_d_downstream_core =
             packetized_path_en_g ? phys_dispatch_relay_mux_core : phys_dispatch_h_core;
         configure_kernel_variant<true, false>(program,
@@ -1960,6 +1961,7 @@ void configure_for_single_chip(Device *device,
         dispatch_compile_args[12] = dispatch_h_cb_sem;
         dispatch_compile_args[13] = dispatch_downstream_cb_sem;
         dispatch_compile_args[14] = 0; // preamble size
+        dispatch_compile_args[21] = 1; // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
         CoreCoord phys_dispatch_h_upstream_core =
             packetized_path_en_g ? phys_dispatch_relay_demux_core : phys_dispatch_core;
         configure_kernel_variant<false, true>(program,
@@ -2663,7 +2665,7 @@ void configure_for_multi_chip(Device *device,
          prefetch_downstream_buffer_pages,
          num_compute_cores,
          0,
-         0,
+         dispatch_constants::DISPATCH_MESSAGE_ENTRIES,
          0,
          0,
          0,
@@ -2683,6 +2685,7 @@ void configure_for_multi_chip(Device *device,
         dispatch_compile_args[12] = dispatch_downstream_cb_sem;
         dispatch_compile_args[13] = dispatch_h_cb_sem;
         dispatch_compile_args[14] = dispatch_d_preamble_size;
+        dispatch_compile_args[21] = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
         CoreCoord phys_dispatch_d_downstream_core =
             packetized_path_en_g ? phys_dispatch_relay_mux_core : phys_dispatch_h_core;
         configure_kernel_variant<true, false>(program_r,
@@ -2702,6 +2705,7 @@ void configure_for_multi_chip(Device *device,
         dispatch_compile_args[12] = dispatch_h_cb_sem;
         dispatch_compile_args[13] = dispatch_downstream_cb_sem;
         dispatch_compile_args[14] = 0; // preamble size
+        dispatch_compile_args[21] = 1; // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
         CoreCoord phys_dispatch_h_upstream_core =
             packetized_path_en_g ? phys_dispatch_relay_demux_core : phys_dispatch_core;
         configure_kernel_variant<false, true>(program,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1921,6 +1921,7 @@ void configure_for_single_chip(Device *device,
          num_compute_cores, // max_write_packed_cores
          0,
          dispatch_constants::DISPATCH_MESSAGE_ENTRIES,
+         dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES,
          0,
          0,
          0,
@@ -1941,6 +1942,7 @@ void configure_for_single_chip(Device *device,
         dispatch_compile_args[13] = dispatch_h_cb_sem;
         dispatch_compile_args[14] = dispatch_d_preamble_size;
         dispatch_compile_args[21] = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+        dispatch_compile_args[22] = dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         CoreCoord phys_dispatch_d_downstream_core =
             packetized_path_en_g ? phys_dispatch_relay_mux_core : phys_dispatch_h_core;
         configure_kernel_variant<true, false>(program,
@@ -1962,6 +1964,7 @@ void configure_for_single_chip(Device *device,
         dispatch_compile_args[13] = dispatch_downstream_cb_sem;
         dispatch_compile_args[14] = 0; // preamble size
         dispatch_compile_args[21] = 1; // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
+        dispatch_compile_args[22] = 1; // max_num_go_signal_noc_data_entries is used for array sizing, set to 1 even if array isn't used
         CoreCoord phys_dispatch_h_upstream_core =
             packetized_path_en_g ? phys_dispatch_relay_demux_core : phys_dispatch_core;
         configure_kernel_variant<false, true>(program,
@@ -2666,6 +2669,7 @@ void configure_for_multi_chip(Device *device,
          num_compute_cores,
          0,
          dispatch_constants::DISPATCH_MESSAGE_ENTRIES,
+         dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES,
          0,
          0,
          0,
@@ -2686,6 +2690,7 @@ void configure_for_multi_chip(Device *device,
         dispatch_compile_args[13] = dispatch_h_cb_sem;
         dispatch_compile_args[14] = dispatch_d_preamble_size;
         dispatch_compile_args[21] = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+        dispatch_compile_args[22] = dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         CoreCoord phys_dispatch_d_downstream_core =
             packetized_path_en_g ? phys_dispatch_relay_mux_core : phys_dispatch_h_core;
         configure_kernel_variant<true, false>(program_r,
@@ -2706,6 +2711,7 @@ void configure_for_multi_chip(Device *device,
         dispatch_compile_args[13] = dispatch_downstream_cb_sem;
         dispatch_compile_args[14] = 0; // preamble size
         dispatch_compile_args[21] = 1; // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
+        dispatch_compile_args[22] = 1; // max_num_go_signal_noc_data_entries is used for array sizing, set to 1 even if array isn't used
         CoreCoord phys_dispatch_h_upstream_core =
             packetized_path_en_g ? phys_dispatch_relay_demux_core : phys_dispatch_core;
         configure_kernel_variant<false, true>(program,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
         uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                                             NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                                             NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
         noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31, false);
 #endif
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -41,7 +41,7 @@ void MAIN {
 #endif
         uint64_t dispatch_addr =
             NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                        NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                        NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
         noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
     }
 #else

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UNIT_TESTS_FD_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/multichip/test_eth_ring_gather_EnqueueProgram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pipelining/basic_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/streams/test_autonomous_relay_streams.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/test_sub_device.cpp
 )
 
 add_executable(

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/incrementer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/incrementer.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t sem_addr = get_arg_val<uint32_t>(0);
+    uint32_t waiter_core_x = get_arg_val<uint32_t>(1);
+    uint32_t waiter_core_y = get_arg_val<uint32_t>(2);
+
+    uint64_t noc_remote_sem_addr = get_noc_addr(waiter_core_x, waiter_core_y, sem_addr);
+    noc_semaphore_inc(noc_remote_sem_addr, 1);
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/persistent_remote_waiter.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/persistent_remote_waiter.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t sem_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_inc = get_arg_val<uint32_t>(1);
+    uint32_t send_sync_core_x = get_arg_val<uint32_t>(2);
+    uint32_t send_sync_core_y = get_arg_val<uint32_t>(3);
+    uint32_t recv_sync_core_x = get_arg_val<uint32_t>(4);
+    uint32_t recv_sync_core_y = get_arg_val<uint32_t>(5);
+    uint32_t local_read_addr = get_arg_val<uint32_t>(6);
+
+    volatile tt_l1_ptr uint32_t *local_read_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_read_addr);
+
+    uint64_t noc_remote_send_sem_addr = get_noc_addr(send_sync_core_x, send_sync_core_y, sem_addr);
+    noc_semaphore_inc(noc_remote_send_sem_addr, 1);
+
+    uint64_t noc_remote_recv_sem_addr = get_noc_addr(recv_sync_core_x, recv_sync_core_y, sem_addr);
+    volatile tt_l1_ptr uint32_t* sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+    uint32_t num_read = 0;
+    do {
+        noc_async_read(noc_remote_recv_sem_addr, local_read_addr, 4);
+        noc_async_read_barrier();
+        invalidate_l1_cache();
+        num_read = *local_read_ptr;
+    } while (num_read != num_inc);
+
+    noc_semaphore_inc(noc_remote_recv_sem_addr, -num_inc);
+    noc_async_atomic_barrier();
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/persistent_waiter.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/persistent_waiter.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t sem_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_inc = get_arg_val<uint32_t>(1);
+    uint32_t sync_core_x = get_arg_val<uint32_t>(2);
+    uint32_t sync_core_y = get_arg_val<uint32_t>(3);
+
+    uint64_t noc_remote_sem_addr = get_noc_addr(sync_core_x, sync_core_y, sem_addr);
+    noc_semaphore_inc(noc_remote_sem_addr, 1);
+
+    uint64_t noc_local_sem_addr = get_noc_addr(sem_addr);
+    volatile tt_l1_ptr uint32_t* sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+    noc_semaphore_wait(sem, num_inc);
+    noc_semaphore_inc(noc_local_sem_addr, -num_inc);
+    noc_async_atomic_barrier();
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/syncer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/syncer.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t sem_addr = get_arg_val<uint32_t>(0);
+
+    volatile tt_l1_ptr uint32_t* sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+    noc_semaphore_wait(sem, 1);
+    uint64_t noc_local_sem_addr = get_noc_addr(sem_addr);
+    noc_semaphore_inc(noc_local_sem_addr, -1);
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/test_sub_device.cpp
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstddef>
+#include <cstdint>
+#include <array>
+#include <tuple>
+#include <vector>
+
+#include "command_queue_fixture.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/impl/buffers/global_semaphore.hpp"
+#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/event/event.hpp"
+#include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/command_queue_test_utils.hpp"
+
+using namespace tt::tt_metal;
+
+namespace basic_tests {
+
+std::tuple<Program, CoreCoord, std::unique_ptr<GlobalSemaphore>> create_single_sync_program(Device *device, SubDevice sub_device) {
+    auto syncer_coord = sub_device.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
+    auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
+    auto global_sem = CreateGlobalSemaphore(device, sub_device.cores(HalProgrammableCoreType::TENSIX), INVALID);
+
+    Program syncer_program = CreateProgram();
+    auto syncer_kernel = CreateKernel(
+        syncer_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/syncer.cpp",
+        syncer_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 1> syncer_rt_args = {global_sem->address()};
+    SetRuntimeArgs(syncer_program, syncer_kernel, syncer_core, syncer_rt_args);
+    return {std::move(syncer_program), std::move(syncer_coord), std::move(global_sem)};
+}
+
+std::tuple<Program, Program, Program, std::unique_ptr<GlobalSemaphore>> create_basic_sync_program(Device *device, const SubDevice& sub_device_1, const SubDevice& sub_device_2) {
+    auto waiter_coord = sub_device_2.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
+    auto waiter_core = CoreRangeSet(CoreRange(waiter_coord, waiter_coord));
+    auto waiter_core_physical = device->worker_core_from_logical_core(waiter_coord);
+    auto incrementer_cores = sub_device_1.cores(HalProgrammableCoreType::TENSIX);
+    auto syncer_coord = incrementer_cores.ranges().back().end_coord;
+    auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
+    auto syncer_core_physical = device->worker_core_from_logical_core(syncer_coord);
+    auto all_cores = waiter_core.merge(incrementer_cores).merge(syncer_core);
+    auto global_sem = CreateGlobalSemaphore(device, all_cores, INVALID);
+
+    Program waiter_program = CreateProgram();
+    auto waiter_kernel = CreateKernel(
+        waiter_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/persistent_waiter.cpp",
+        waiter_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 4> waiter_rt_args = {global_sem->address(), incrementer_cores.num_cores(), syncer_core_physical.x, syncer_core_physical.y};
+    SetRuntimeArgs(waiter_program, waiter_kernel, waiter_core, waiter_rt_args);
+
+    Program syncer_program = CreateProgram();
+    auto syncer_kernel = CreateKernel(
+        syncer_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/syncer.cpp",
+        syncer_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 1> syncer_rt_args = {global_sem->address()};
+    SetRuntimeArgs(syncer_program, syncer_kernel, syncer_core, syncer_rt_args);
+
+    Program incrementer_program = CreateProgram();
+    auto incrementer_kernel = CreateKernel(
+        incrementer_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/incrementer.cpp",
+        incrementer_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default});
+    std::array<uint32_t, 3> incrementer_rt_args = {global_sem->address(), waiter_core_physical.x, waiter_core_physical.y};
+    SetRuntimeArgs(incrementer_program, incrementer_kernel, incrementer_cores, incrementer_rt_args);
+    return {std::move(waiter_program), std::move(syncer_program), std::move(incrementer_program), std::move(global_sem)};
+}
+
+std::tuple<Program, Program, Program, std::unique_ptr<GlobalSemaphore>> create_basic_eth_sync_program(Device *device, const SubDevice& sub_device_1, const SubDevice& sub_device_2) {
+    auto waiter_coord = sub_device_2.cores(HalProgrammableCoreType::ACTIVE_ETH).ranges().at(0).start_coord;
+    auto waiter_core = CoreRangeSet(CoreRange(waiter_coord, waiter_coord));
+    auto waiter_core_physical = device->ethernet_core_from_logical_core(waiter_coord);
+    auto tensix_waiter_coord = sub_device_2.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
+    auto tensix_waiter_core = CoreRangeSet(CoreRange(tensix_waiter_coord, tensix_waiter_coord));
+    auto tensix_waiter_core_physical = device->worker_core_from_logical_core(tensix_waiter_coord);
+    auto incrementer_cores = sub_device_1.cores(HalProgrammableCoreType::TENSIX);
+    auto syncer_coord = incrementer_cores.ranges().back().end_coord;
+    auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
+    auto syncer_core_physical = device->worker_core_from_logical_core(syncer_coord);
+    auto all_cores = tensix_waiter_core.merge(incrementer_cores).merge(syncer_core);
+    auto global_sem = CreateGlobalSemaphore(device, all_cores, INVALID);
+
+    Program waiter_program = CreateProgram();
+    auto waiter_kernel = CreateKernel(
+        waiter_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/persistent_remote_waiter.cpp",
+        waiter_core,
+        tt_metal::EthernetConfig{
+            .noc = NOC::RISCV_0_default,
+            .processor = DataMovementProcessor::RISCV_0});
+    std::array<uint32_t, 7> waiter_rt_args = {global_sem->address(), incrementer_cores.num_cores(), syncer_core_physical.x, syncer_core_physical.y, tensix_waiter_core_physical.x, tensix_waiter_core_physical.y, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE};
+    SetRuntimeArgs(waiter_program, waiter_kernel, waiter_core, waiter_rt_args);
+
+    Program syncer_program = CreateProgram();
+    auto syncer_kernel = CreateKernel(
+        syncer_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/syncer.cpp",
+        syncer_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 1> syncer_rt_args = {global_sem->address()};
+    SetRuntimeArgs(syncer_program, syncer_kernel, syncer_core, syncer_rt_args);
+
+    Program incrementer_program = CreateProgram();
+    auto incrementer_kernel = CreateKernel(
+        incrementer_program,
+        "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/sub_device/kernels/incrementer.cpp",
+        incrementer_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default});
+    std::array<uint32_t, 3> incrementer_rt_args = {global_sem->address(), tensix_waiter_core_physical.x, tensix_waiter_core_physical.y};
+    SetRuntimeArgs(incrementer_program, incrementer_kernel, incrementer_cores, incrementer_rt_args);
+    return {std::move(waiter_program), std::move(syncer_program), std::move(incrementer_program), std::move(global_sem)};
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestSubDeviceAllocations) {
+    uint32_t local_l1_size = 3200;
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    CoreRangeSet sharded_cores_1 = CoreRange({0, 0}, {2, 2});
+    CoreRangeSet sharded_cores_2 = CoreRange({4, 4}, {4, 4});
+
+    auto sharded_cores_1_vec = corerange_to_cores(sharded_cores_1, std::nullopt, true);
+    auto sharded_cores_2_vec = corerange_to_cores(sharded_cores_2, std::nullopt, true);
+
+    ShardSpecBuffer shard_spec_buffer_1 = ShardSpecBuffer(sharded_cores_1, {1, 1}, ShardOrientation::ROW_MAJOR, false, {1, 1}, {sharded_cores_1.num_cores(), 1});
+    uint32_t page_size_1 = 32;
+    ShardedBufferConfig shard_config_1 = {nullptr, sharded_cores_1.num_cores() * page_size_1, page_size_1, BufferType::L1, TensorMemoryLayout::HEIGHT_SHARDED, shard_spec_buffer_1};
+    auto input_1 = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, shard_config_1.size / sizeof(uint32_t));
+
+    ShardSpecBuffer shard_spec_buffer_2 = ShardSpecBuffer(sharded_cores_2, {1, 1}, ShardOrientation::ROW_MAJOR, false, {1, 1}, {sharded_cores_2.num_cores(), 1});
+    uint32_t page_size_2 = 64;
+    ShardedBufferConfig shard_config_2 = {nullptr, sharded_cores_2.num_cores() * page_size_2, page_size_2, BufferType::L1, TensorMemoryLayout::HEIGHT_SHARDED, shard_spec_buffer_2};
+    auto input_2 = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, shard_config_2.size / sizeof(uint32_t));
+
+    uint32_t page_size_3 = 1024;
+    InterleavedBufferConfig interleaved_config = {nullptr, page_size_3, page_size_3, BufferType::L1, TensorMemoryLayout::INTERLEAVED};
+    auto input_3 = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, interleaved_config.size / sizeof(uint32_t));
+
+    for (Device *device : devices_) {
+        auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1}, local_l1_size);
+        auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
+        DeviceAddr l1_unreserved_base = device->get_base_allocator_addr(HalMemType::L1);
+        DeviceAddr max_addr = l1_unreserved_base + local_l1_size;
+
+        shard_config_1.device = device;
+        shard_config_2.device = device;
+        interleaved_config.device = device;
+
+        std::vector<CoreCoord> physical_cores_1;
+        physical_cores_1.reserve(sharded_cores_1_vec.size());
+        for (const auto& core : sharded_cores_1_vec) {
+            physical_cores_1.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        std::vector<CoreCoord> physical_cores_2;
+        physical_cores_2.reserve(sharded_cores_2_vec.size());
+        for (const auto& core : sharded_cores_2_vec) {
+            physical_cores_2.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        device->load_sub_device_manager(sub_device_manager_1);
+
+        auto buffer_1 = CreateBuffer(shard_config_1, SubDeviceId{0});
+        EXPECT_EQ(buffer_1->address(), max_addr - page_size_1);
+        EnqueueWriteBuffer(device->command_queue(), buffer_1, input_1, false);
+        std::vector<uint32_t> output_1;
+        EnqueueReadBuffer(device->command_queue(), buffer_1, output_1, true);
+        EXPECT_EQ(input_1, output_1);
+        auto input_1_it = input_1.begin();
+        for (const auto& physical_core : physical_cores_1) {
+            auto readback = tt::llrt::read_hex_vec_from_core(
+                device->id(), physical_core, buffer_1->address(), page_size_1);
+            EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
+            input_1_it += page_size_1 / sizeof(uint32_t);
+        }
+
+        auto buffer_2 = CreateBuffer(interleaved_config);
+
+        DeallocateBuffer(*buffer_1);
+        device->clear_loaded_sub_device_manager();
+        device->load_sub_device_manager(sub_device_manager_2);
+
+        auto buffer_3 = CreateBuffer(shard_config_2, SubDeviceId{1});
+        EXPECT_EQ(buffer_3->address(), max_addr - page_size_2);
+        EnqueueWriteBuffer(device->command_queue(), buffer_3, input_2, false);
+        std::vector<uint32_t> output_2;
+        EnqueueReadBuffer(device->command_queue(), buffer_3, output_2, true);
+        EXPECT_EQ(input_2, output_2);
+        auto input_2_it = input_2.begin();
+        for (const auto& physical_core : physical_cores_2) {
+            auto readback = tt::llrt::read_hex_vec_from_core(
+                device->id(), physical_core, buffer_3->address(), page_size_2);
+            EXPECT_TRUE(std::equal(input_2_it, input_2_it + page_size_2 / sizeof(uint32_t), readback.begin()));
+            input_2_it += page_size_2 / sizeof(uint32_t);
+        }
+
+        auto buffer_4 = CreateBuffer(shard_config_1,  SubDeviceId{0});
+        EXPECT_EQ(buffer_4->address(), max_addr - page_size_1);
+        EXPECT_THROW(CreateBuffer(interleaved_config, SubDeviceId{0}), std::exception);
+    }
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestSubDeviceSynchronization) {
+    uint32_t local_l1_size = 3200;
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    CoreRangeSet sharded_cores_1 = CoreRange({0, 0}, {2, 2});
+
+    auto sharded_cores_1_vec = corerange_to_cores(sharded_cores_1, std::nullopt, true);
+
+    ShardSpecBuffer shard_spec_buffer_1 = ShardSpecBuffer(sharded_cores_1, {1, 1}, ShardOrientation::ROW_MAJOR, false, {1, 1}, {sharded_cores_1.num_cores(), 1});
+    uint32_t page_size_1 = 32;
+    ShardedBufferConfig shard_config_1 = {nullptr, sharded_cores_1.num_cores() * page_size_1, page_size_1, BufferType::L1, TensorMemoryLayout::HEIGHT_SHARDED, shard_spec_buffer_1};
+    auto input_1 = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, shard_config_1.size / sizeof(uint32_t));
+
+    std::array sub_device_ids_to_block = {SubDeviceId{0}};
+    for (Device *device : devices_) {
+        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
+
+        shard_config_1.device = device;
+
+        std::vector<CoreCoord> physical_cores_1;
+        physical_cores_1.reserve(sharded_cores_1_vec.size());
+        for (const auto& core : sharded_cores_1_vec) {
+            physical_cores_1.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        device->load_sub_device_manager(sub_device_manager);
+
+        auto [program, syncer_core, global_semaphore] = create_single_sync_program(device, sub_device_2);
+        EnqueueProgram(device->command_queue(), program, false);
+
+        auto buffer_1 = CreateBuffer(shard_config_1, sub_device_ids_to_block[0]);
+
+        // Test blocking synchronize doesn't stall
+        Synchronize(device, 0, sub_device_ids_to_block);
+
+        // Test blocking write buffer doesn't stall
+        EnqueueWriteBuffer(device->command_queue(), buffer_1, input_1, true, sub_device_ids_to_block);
+
+        // Test record event won't cause a stall
+        auto event = std::make_shared<Event>();
+        EnqueueRecordEvent(device->command_queue(), event, sub_device_ids_to_block);
+        Synchronize(device, 0, sub_device_ids_to_block);
+
+        // Test blocking read buffer doesn't stall
+        std::vector<uint32_t> output_1;
+        EnqueueReadBuffer(device->command_queue(), buffer_1, output_1, true, sub_device_ids_to_block);
+        EXPECT_EQ(input_1, output_1);
+        auto input_1_it = input_1.begin();
+        for (const auto& physical_core : physical_cores_1) {
+            auto readback = tt::llrt::read_hex_vec_from_core(
+                device->id(), physical_core, buffer_1->address(), page_size_1);
+            EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
+            input_1_it += page_size_1 / sizeof(uint32_t);
+        }
+        auto sem_addr = global_semaphore->address();
+        auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
+        tt::llrt::write_hex_vec_to_core(device->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
+
+        // Full synchronization
+        Synchronize(device);
+    }
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestSubDeviceBasicPrograms) {
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    uint32_t num_iters = 5;
+    for (Device *device : devices_) {
+        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+        device->load_sub_device_manager(sub_device_manager);
+
+        auto [waiter_program, syncer_program, incrementer_program, global_sem] = create_basic_sync_program(device, sub_device_1, sub_device_2);
+
+        for (uint32_t i = 0; i < num_iters; i++) {
+            EnqueueProgram(device->command_queue(), waiter_program, false);
+            // Test blocking on one sub-device
+            EnqueueProgram(device->command_queue(), syncer_program, true);
+            EnqueueProgram(device->command_queue(), incrementer_program, false);
+        }
+        Synchronize(device);
+    }
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestSubDeviceBasicEthPrograms) {
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    uint32_t num_iters = 5;
+    for (Device *device : devices_) {
+        if (!does_device_have_active_eth_cores(device)) {
+            GTEST_SKIP() << "Skipping test because device " << device->id() << " does not have any active ethernet cores";
+        }
+        auto eth_core = *device->get_active_ethernet_cores(true).begin();
+        SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}), CoreRangeSet(CoreRange(eth_core, eth_core))});
+        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+        device->load_sub_device_manager(sub_device_manager);
+
+        auto [waiter_program, syncer_program, incrementer_program, global_sem] = create_basic_eth_sync_program(device, sub_device_1, sub_device_2);
+
+        for (uint32_t i = 0; i < num_iters; i++) {
+            EnqueueProgram(device->command_queue(), waiter_program, false);
+            // Test blocking on one sub-device
+            EnqueueProgram(device->command_queue(), syncer_program, true);
+            EnqueueProgram(device->command_queue(), incrementer_program, false);
+        }
+        Synchronize(device);
+    }
+}
+
+TEST_F(CommandQueueSingleCardTraceFixture, TestSubDeviceTraceBasicPrograms) {
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    uint32_t num_iters = 5;
+    for (Device *device : devices_) {
+        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+        device->load_sub_device_manager(sub_device_manager);
+
+        auto [waiter_program, syncer_program, incrementer_program, global_sem] = create_basic_sync_program(device, sub_device_1, sub_device_2);
+
+        // Compile the programs
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        // Test blocking on one sub-device
+        EnqueueProgram(device->command_queue(), syncer_program, true);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        Synchronize(device);
+
+        // Capture the trace
+        auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        EnqueueProgram(device->command_queue(), syncer_program, false);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        EndTraceCapture(device, device->command_queue().id(), tid_1);
+
+        auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
+        EnqueueProgram(device->command_queue(), syncer_program, false);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        EndTraceCapture(device, device->command_queue().id(), tid_2);
+
+        for (uint32_t i = 0; i < num_iters; i++) {
+            // Regular program execution
+            EnqueueProgram(device->command_queue(), waiter_program, false);
+            // Test blocking on one sub-device
+            EnqueueProgram(device->command_queue(), syncer_program, true);
+            EnqueueProgram(device->command_queue(), incrementer_program, false);
+
+            // Full trace execution
+            ReplayTrace(device, device->command_queue().id(), tid_1, false);
+
+            // Partial trace execution
+            EnqueueProgram(device->command_queue(), waiter_program, false);
+            ReplayTrace(device, device->command_queue().id(), tid_2, false);
+        }
+        Synchronize(device);
+    }
+}
+
+TEST_F(CommandQueueSingleCardTraceFixture, TestSubDeviceTraceBasicEthPrograms) {
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    uint32_t num_iters = 5;
+    for (Device *device : devices_) {
+        if (!does_device_have_active_eth_cores(device)) {
+            GTEST_SKIP() << "Skipping test because device " << device->id() << " does not have any active ethernet cores";
+        }
+        auto eth_core = *device->get_active_ethernet_cores(true).begin();
+        SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}), CoreRangeSet(CoreRange(eth_core, eth_core))});
+        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+        device->load_sub_device_manager(sub_device_manager);
+
+        auto [waiter_program, syncer_program, incrementer_program, global_sem] = create_basic_eth_sync_program(device, sub_device_1, sub_device_2);
+
+        // Compile the programs
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        // Test blocking on one sub-device
+        EnqueueProgram(device->command_queue(), syncer_program, true);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        Synchronize(device);
+
+        // Capture the trace
+        auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        EnqueueProgram(device->command_queue(), syncer_program, false);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        EndTraceCapture(device, device->command_queue().id(), tid_1);
+
+        auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
+        EnqueueProgram(device->command_queue(), syncer_program, false);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        EndTraceCapture(device, device->command_queue().id(), tid_2);
+
+        for (uint32_t i = 0; i < num_iters; i++) {
+            // Regular program execution
+            EnqueueProgram(device->command_queue(), waiter_program, false);
+            // Test blocking on one sub-device
+            EnqueueProgram(device->command_queue(), syncer_program, true);
+            EnqueueProgram(device->command_queue(), incrementer_program, false);
+
+            // Full trace execution
+            ReplayTrace(device, device->command_queue().id(), tid_1, false);
+
+            // Partial trace execution
+            EnqueueProgram(device->command_queue(), waiter_program, false);
+            ReplayTrace(device, device->command_queue().id(), tid_2, false);
+        }
+        Synchronize(device);
+    }
+}
+
+}  // namespace basic_tests

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -203,6 +203,8 @@ CoreRangeSet::CoreRangeSet(std::vector<CoreRange> &&core_ranges) : ranges_(std::
     this->validate_no_overlap();
 }
 
+bool CoreRangeSet::empty() const { return this->ranges_.empty(); }
+
 size_t CoreRangeSet::size() const { return ranges_.size(); }
 
 template <typename T>
@@ -292,6 +294,18 @@ bool CoreRangeSet::intersects(const CoreRangeSet &other) const {
         }
     }
     return false;
+}
+
+CoreRangeSet CoreRangeSet::intersection(const CoreRangeSet &other) const {
+    std::vector<CoreRange> intersection;
+    for (const auto& local_cr : this->ranges_) {
+        for (const auto& other_cr : other.ranges()) {
+            if (auto intersect = local_cr.intersection(other_cr); intersect.has_value()) {
+                intersection.push_back(*intersect);
+            }
+        }
+    }
+    return CoreRangeSet(std::move(intersection));
 }
 
 bool CoreRangeSet::contains(const CoreCoord &other) const {

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -140,6 +140,8 @@ class CoreRangeSet {
 
     CoreRangeSet(std::vector<CoreRange> &&core_ranges);
 
+    bool empty() const;
+
     size_t size() const;
 
     template <typename T>
@@ -150,6 +152,8 @@ class CoreRangeSet {
     bool intersects(const CoreRange &other) const;
 
     bool intersects(const CoreRangeSet &other) const;
+
+    CoreRangeSet intersection(const CoreRangeSet &other) const;
 
     bool contains(const CoreCoord &other) const;
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -485,72 +485,81 @@ RuntimeArgsData &GetCommonRuntimeArgs(const Program &program, KernelHandle kerne
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                                | Valid Range                            | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                      |                                        | Yes      |
- * | buffer       | The device buffer we are reading from                                  | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
- * | dst          | The vector where the results that are read will be stored              | vector<uint32_t> &                  |                                        | Yes      |
- * | blocking     | Whether or not this is a blocking operation                            | bool                                | Only blocking mode supported currently | Yes      |
+ * | Argument       | Description                                                                       | Type                                | Valid Range                            | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                        | Yes      |
+ * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
+ * | dst            | The vector where the results that are read will be stored                         | vector<uint32_t> &                  |                                        | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 void EnqueueReadBuffer(
     CommandQueue &cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<uint32_t> &dst,
-    bool blocking);
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 /**
  * Reads a buffer from the device
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                                | Valid Range                            | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                      |                                        | Yes      |
- * | buffer       | The device buffer we are reading from                                  | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
- * | dst          | The memory where the result will be stored                             | void*                               |                                        | Yes      |
- * | blocking     | Whether or not this is a blocking operation                            | bool                                | Only blocking mode supported currently | Yes      |
+ * | Argument       | Description                                                                       | Type                                | Valid Range                            | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                        | Yes      |
+ * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
+ * | dst            | The memory where the result will be stored                                        | void*                               |                                        | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                        | No       |
  */
 void EnqueueReadBuffer(
     CommandQueue &cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void *dst,
-    bool blocking);
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 /**
  * Writes a buffer to the device
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                                | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                      |                                    | Yes      |
- * | buffer       | The device buffer we are writing to                                    | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
- * | src          | The vector we are writing to the device                                | vector<uint32_t> &                  |                                    | Yes      |
- * | blocking     | Whether or not this is a blocking operation                            | bool                                |                                    | Yes      |
+ * | Argument       | Description                                                                       | Type                                | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
+ * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
+ * | src            | The vector we are writing to the device                                           | vector<uint32_t> &                  |                                    | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
+
  */
 void EnqueueWriteBuffer(
     CommandQueue &cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<uint32_t> &src,
-    bool blocking);
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 /**
  * Writes a buffer to the device
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                                | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                      |                                    | Yes      |
- * | buffer       | The device buffer we are writing to                                    | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
- * | src          | The memory we are writing to the device                                | HostDataType                        |                                    | Yes      |
- * | blocking     | Whether or not this is a blocking operation                            | bool                                |                                    | Yes      |
+ * | Argument       | Description                                                                       | Type                                | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
+ * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
+ * | src            | The memory we are writing to the device                                           | HostDataType                        |                                    | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 void EnqueueWriteBuffer(
     CommandQueue &cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
-    bool blocking);
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 /**
  * Writes a program to the device and launches it
@@ -570,11 +579,12 @@ void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking);
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
+ * | Argument       | Description                                                                       | Type                          | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t> |                                    | No       |
  */
-void Finish(CommandQueue &cq);
+void Finish(CommandQueue &cq, tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 /**
  * Begins capture on a trace, when the trace is in capture mode all programs pushed into the trace queue will have their execution delayed until the trace is instantiated and enqueued.
@@ -665,12 +675,13 @@ void DumpDeviceProfileResults(Device *device, const Program &program);
 /**
  * Enqueues a command to record an Event on the device for a given CQ, and updates the Event object for the user.
  * Return value: void
- * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
- * | event        | An event that will be populated by this function, and inserted in CQ   | std::shared_ptr<Event>        |                                    | Yes      |
+ * | Argument       | Description                                                                       | Type                          | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                |                                    | Yes      |
+ * | event          | An event that will be populated by this function, and inserted in CQ              | std::shared_ptr<Event>        |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t> |                                    | No       |
  */
-void EnqueueRecordEvent(CommandQueue &cq, const std::shared_ptr<Event> &event);
+void EnqueueRecordEvent(CommandQueue &cq, const std::shared_ptr<Event> &event, tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 /**
  * Enqueues a command on the device for a given CQ (non-blocking). The command on device will block and wait for completion of the specified event (which may be in another CQ).
@@ -708,12 +719,13 @@ bool EventQuery(const std::shared_ptr<Event> &event);
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | device       | The device to synchronize.                                             | Device *                      |                                    | Yes      |
- * | cq_id        | The specific command queue id to synchronize  .                        | uint8_t                       |                                    | No       |
+ * | Argument       | Description                                                                       | Type                          | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | device         | The device to synchronize.                                                        | Device *                      |                                    | Yes      |
+ * | cq_id          | The specific command queue id to synchronize  .                                   | uint8_t                       |                                    | No       |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t> |                                    | No       |
  */
-void Synchronize(Device *device, const std::optional<uint8_t> cq_id = std::nullopt);
+void Synchronize(Device *device, const std::optional<uint8_t> cq_id = std::nullopt, tt::stl::Span<const uint32_t> sub_device_ids = {});
 
 }  // namespace v0
 }  // namespace tt_metal

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -282,50 +282,31 @@ std::unique_ptr<GlobalSemaphore> CreateGlobalSemaphore(
     Device *device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
 /**
-*  Allocates an interleaved DRAM or L1 buffer on device
-*
-*  Return value: std::shared_ptr<Buffer>
-*
-*  | Argument        | Description                             | Type                     | Valid Range | Required |
-*  |-----------------|---------------------------------------- |--------------------------|-------------|----------|
-*  | config          | Config for the buffer                   | InterleavedBufferConfig  |             | Yes      |
-*/
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config);
-
-/**
 *  Creates a pre-allocated interleaved DRAM or L1 buffer on device
 *
 *  Return value: std::shared_ptr<Buffer>
 *
-*  | Argument        | Description                             | Type                     | Valid Range | Required |
-*  |-----------------|---------------------------------------- |--------------------------|-------------|----------|
-*  | config          | Config for the buffer                   | InterleavedBufferConfig  |             | Yes      |
-*  | address         | Device address of the buffer            | DeviceAddr               |             | Yes      |
-*/
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config, DeviceAddr address);
+*  | Argument        | Description                                                       | Type                      | Valid Range | Required |
+*  |-----------------|------------------------------------------------------------------ |---------------------------|-------------|----------|
+*  | config          | Config for the buffer                                             | InterleavedBufferConfig   |             | Yes      |
+*  | address         | Device address of the buffer. Default will calculate address      | std::optional<DeviceAddr> |             | No       |
+*  | sub_device_id   | The sub-device id to allocate on. Default is the global allocator | std::optional<uint32_t>   |             | No       |
 
-/**
-*  Allocates a sharded DRAM or L1 buffer on device
-*
-*  Return value: std::shared_ptr<Buffer>
-*
-*  | Argument        | Description                             | Type                     | Valid Range | Required |
-*  |-----------------|---------------------------------------- |--------------------------|-------------|----------|
-*  | config          | Config for the buffer                   | ShardedBufferConfig      |             | Yes      |
 */
-std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config);
+std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config, std::optional<DeviceAddr> address = std::nullopt, std::optional<uint32_t> sub_device_id = std::nullopt);
 
 /**
 *  Creates a pre-allocated sharded DRAM or L1 buffer on device
 *
 *  Return value: std::shared_ptr<Buffer>
 *
-*  | Argument        | Description                             | Type                     | Valid Range | Required |
-*  |-----------------|---------------------------------------- |--------------------------|-------------|----------|
-*  | config          | Config for the buffer                   | ShardedBufferConfig      |             | Yes      |
-*  | address         | Device address of the buffer            | DeviceAddr               |             | Yes      |
+*  | Argument        | Description                                                       | Type                      | Valid Range | Required |
+*  |-----------------|------------------------------------------------------------------ |---------------------------|-------------|----------|
+*  | config          | Config for the buffer                                             | ShardedBufferConfig       |             | Yes      |
+*  | address         | Device address of the buffer. Default will calculate address      | std::optional<DeviceAddr> |             | No       |
+*  | sub_device_id   | The sub-device id to allocate on. Default is the global allocator | std::optional<uint32_t>   |             | No       |
 */
-std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config, DeviceAddr address);
+std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config, std::optional<DeviceAddr> address = std::nullopt, std::optional<uint32_t> sub_device_id = std::nullopt);
 
 /**
 *  Deallocates buffer from device by marking its memory as free.

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -360,8 +360,14 @@ int main() {
 
     mailboxes->go_message.signal = RUN_MSG_DONE;
 
+    // Initialize the NoCs to a safe state
+    // This ensures if we send any noc txns without running a kernel setup are valid
+    // ex. Immediately after starting, we send a RUN_MSG_RESET_READ_PTR signal
     uint8_t noc_mode;
-    uint8_t prev_noc_mode = DM_INVALID_NOC;
+    noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
+    noc_local_state_init(noc_index);
+    uint8_t prev_noc_mode = DM_DEDICATED_NOC;
+
     while (1) {
         init_sync_registers();
         reset_ncrisc_with_iram();
@@ -379,7 +385,7 @@ int main() {
                 // For future proofing, the noc_index value is initialized to 0, to ensure an invalid NOC txn is not issued.
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                    NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                    NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
                 mailboxes->go_message.signal = RUN_MSG_DONE;
                 // Notify dispatcher that this has been done
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
@@ -465,7 +471,7 @@ int main() {
                 launch_msg_address->kernel_config.enables = 0;
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                        NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                        NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 // Only executed if watcher is enabled. Ensures that we don't report stale data due to invalid launch
                 // messages in the ring buffer. Must be executed before the atomic increment, as after that the launch

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -88,7 +88,7 @@ void __attribute__((noinline)) Application(void) {
                 launch_msg_address->kernel_config.enables = 0;
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                                NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                                NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 internal_::notify_dispatch_core_done(dispatch_addr);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
@@ -99,9 +99,9 @@ void __attribute__((noinline)) Application(void) {
         } else if (go_message_signal == RUN_MSG_RESET_READ_PTR) {
             // Reset the launch message buffer read ptr
             mailboxes->launch_msg_rd_ptr = 0;
-            int64_t dispatch_addr =
+            uint64_t dispatch_addr =
                 NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                            NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                            NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
             mailboxes->go_message.signal = RUN_MSG_DONE;
             internal_::notify_dispatch_core_done(dispatch_addr);
         } else {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -164,7 +164,7 @@ int main() {
                 launch_msg_address->kernel_config.enables = 0;
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
-                        NOC_Y(mailboxes->go_message.master_x), DISPATCH_MESSAGE_ADDR);
+                        NOC_Y(mailboxes->go_message.master_x), DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -112,7 +112,7 @@ struct kernel_config_msg_t {
 } __attribute__((packed));
 
 struct go_msg_t {
-    volatile uint8_t pad;
+    volatile uint8_t dispatch_message_offset;
     volatile uint8_t master_x;
     volatile uint8_t master_y;
     volatile uint8_t signal; // INIT, GO, DONE, RESET_RD_PTR

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(IMPL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_handle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp

--- a/tt_metal/impl/allocator/algorithms/free_list.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.cpp
@@ -21,6 +21,7 @@ FreeList::FreeList(DeviceAddr max_size_bytes, DeviceAddr offset_bytes, DeviceAdd
 }
 
 void FreeList::init() {
+    this->shrink_size_ = 0;
     auto block = boost::make_local_shared<Block>(0, this->max_size_bytes_);
     this->block_head_ = block;
     this->block_tail_ = block;

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -503,7 +503,6 @@ void clear(Allocator &allocator) {
     allocator.l1_manager.clear();
     allocator.l1_small_manager.clear();
     allocator.trace_buffer_manager.clear();
-    allocator.allocated_buffers.clear();
 }
 
 }  // namespace allocator

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -35,8 +35,8 @@ class BankManager {
    public:
     BankManager() {}
 
-    BankManager(const BufferType &buffer_type, const std::vector<int64_t> &bank_descriptors, DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr alloc_offset=0);
-    BankManager(const BufferType &buffer_type, const std::unordered_map<uint32_t, int64_t> &bank_id_to_descriptor, DeviceAddr size_bytes, DeviceAddr interleaved_address_limit, uint32_t alignment_bytes, DeviceAddr alloc_offset=0);
+    BankManager(const BufferType &buffer_type, const std::vector<int64_t> &bank_descriptors, DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr alloc_offset=0, bool disable_interleaved=false);
+    BankManager(const BufferType &buffer_type, const std::unordered_map<uint32_t, int64_t> &bank_id_to_descriptor, DeviceAddr size_bytes, DeviceAddr interleaved_address_limit, uint32_t alignment_bytes, DeviceAddr alloc_offset=0, bool disable_interleaved=false);
     BankManager&& operator=(BankManager&& that);
     ~BankManager();
     uint32_t num_banks() const;
@@ -45,7 +45,7 @@ class BankManager {
 
     int64_t bank_offset(uint32_t bank_id) const;
 
-    DeviceAddr allocate_buffer(DeviceAddr size, DeviceAddr page_size, bool bottom_up, CoreCoord compute_grid_size, std::optional<uint32_t> num_shards);
+    DeviceAddr allocate_buffer(DeviceAddr size, DeviceAddr page_size, bool bottom_up, const CoreRangeSet &compute_grid, std::optional<uint32_t> num_shards);
 
     void deallocate_buffer(DeviceAddr address);
     void deallocate_all();
@@ -109,6 +109,7 @@ std::optional<DeviceAddr> lowest_occupied_l1_address(const Allocator &allocator,
 DeviceAddr base_alloc(const AllocatorConfig & config, BankManager &bank_manager, DeviceAddr size, DeviceAddr page_size, bool bottom_up, std::optional<uint32_t> num_shards);
 
 void shrink_allocator_size(Allocator &allocator, const BufferType &buffer_type, DeviceAddr shrink_size, bool bottom_up=true);
+void reset_allocator_size(Allocator &allocator, const BufferType &buffer_type);
 
 DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, Buffer *buffer);
 

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -38,7 +38,7 @@ struct AllocatorConfig {
     uint32_t dram_unreserved_base = 0;
     //! worker specific configuration
     uint32_t l1_unreserved_base = 0;
-    CoreCoord worker_grid_size = {};
+    CoreRangeSet worker_grid = {};
     size_t worker_l1_size = 0;
     std::optional<uint32_t> storage_core_bank_size = 0;
     size_t l1_small_size = 0;
@@ -47,8 +47,9 @@ struct AllocatorConfig {
     std::unordered_map<int, int> worker_log_to_physical_routing_x = {};
     std::unordered_map<int, int> worker_log_to_physical_routing_y = {};
     BankMapping l1_bank_remap = {}; // for remapping which l1 bank points to which bank if we assume normal row-major assignment
-    CoreCoord compute_grid_size = {};
+    CoreRangeSet compute_grid = {};
     uint32_t alignment = 0;
+    bool disable_interleaved = false;
     void reset();
     ~AllocatorConfig() { reset(); }
 };

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -205,15 +205,16 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer& buffer) {
     return buffer_page_mapping;
 }
 
-void validate_sub_device_id(std::optional<uint32_t> sub_device_id, Device *device, BufferType buffer_type, const std::optional<ShardSpecBuffer>& shard_parameters) {
+void validate_sub_device_id(std::optional<SubDeviceId> sub_device_id, Device *device, BufferType buffer_type, const std::optional<ShardSpecBuffer>& shard_parameters) {
     // No need to validate if we're using the global allocator or not sharding
     if (!sub_device_id.has_value()) {
         return;
     }
     TT_FATAL(shard_parameters.has_value(), "Specifying sub-device for buffer requires buffer to be sharded");
     TT_FATAL(is_l1(buffer_type), "Specifying sub-device for buffer requires buffer to be L1");
-    // TODO: Validate that cores used match the sub-device
-    TT_FATAL(*sub_device_id == 0, "Invalid sub-device id");
+    const auto &sub_device_cores = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id.value());
+    const auto &shard_cores = shard_parameters->grid();
+    TT_FATAL(sub_device_cores.contains(shard_cores), "Shard cores specified {} do not match sub-device cores {}", shard_cores, sub_device_cores);
 }
 
 Buffer::Buffer(
@@ -224,7 +225,7 @@ Buffer::Buffer(
     const TensorMemoryLayout buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters,
     const std::optional<bool> bottom_up,
-    const std::optional<uint32_t> sub_device_id,
+    const std::optional<SubDeviceId> sub_device_id,
     const bool owns_data,
     Private) :
     device_(device),
@@ -237,9 +238,13 @@ Buffer::Buffer(
     sub_device_id_(sub_device_id),
     owns_data_(owns_data),
     buffer_page_mapping_(nullptr) {
-    TT_FATAL(this->device_ != nullptr && this->device_->allocator_ != nullptr, "Device and allocator need to not be null.");
+    TT_FATAL(this->device_ != nullptr, "Device needs to not be null.");
     if (this->sub_device_id_.has_value()) {
         validate_sub_device_id(this->sub_device_id_, this->device_, buffer_type, shard_parameters);
+        this->sub_device_manager_id_ = this->device_->get_active_sub_device_manager_id();
+        this->allocator_ = device->get_initialized_allocator(*this->sub_device_id_).get();
+    } else {
+        this->allocator_ = device->get_initialized_allocator().get();
     }
     if (size != 0) {
         validate_buffer_size_and_page_size(size, page_size, buffer_type, buffer_layout, shard_parameters);
@@ -254,7 +259,7 @@ std::shared_ptr<Buffer> Buffer::create(
     const TensorMemoryLayout buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters,
     const std::optional<bool> bottom_up,
-    const std::optional<uint32_t> sub_device_id) {
+    const std::optional<SubDeviceId> sub_device_id) {
     auto* bufferPtr = new Buffer(device, size, page_size, buffer_type, buffer_layout, shard_parameters, bottom_up, sub_device_id, true /* owns data */, Private());
     // Using a custom deleter to properly clean up the owned datas
     auto buffer = std::shared_ptr<Buffer>(bufferPtr, deleter);
@@ -295,7 +300,7 @@ std::shared_ptr<Buffer> Buffer::create(
     const TensorMemoryLayout buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters,
     const std::optional<bool> bottom_up,
-    const std::optional<uint32_t> sub_device_id) {
+    const std::optional<SubDeviceId> sub_device_id) {
     // Not using a custom deleter, because it doesn't own any data to cleanup
     auto buffer = std::make_shared<Buffer>(device, size, page_size, buffer_type, buffer_layout, shard_parameters, bottom_up, sub_device_id, false /* owns data */, Private());
     buffer->weak_self = buffer;
@@ -410,12 +415,12 @@ bool Buffer::is_trace() const {
 
 uint32_t Buffer::dram_channel_from_bank_id(uint32_t bank_id) const {
     TT_FATAL(this->is_dram(), "Expected DRAM buffer!");
-    return this->device_->dram_channel_from_bank_id(bank_id, this->sub_device_id_);
+    return allocator::dram_channel_from_bank_id(*this->allocator_, bank_id);
 }
 
 CoreCoord Buffer::logical_core_from_bank_id(uint32_t bank_id) const {
     TT_FATAL(this->is_l1(), "Expected L1 buffer!");
-    return this->device_->logical_core_from_bank_id(bank_id, this->sub_device_id_);
+    return allocator::logical_core_from_bank_id(*this->allocator_, bank_id);
 }
 
 CoreCoord Buffer::noc_coordinates(uint32_t bank_id) const {
@@ -440,7 +445,7 @@ CoreCoord Buffer::noc_coordinates(uint32_t bank_id) const {
 CoreCoord Buffer::noc_coordinates() const { return this->noc_coordinates(0); }
 
 DeviceAddr Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
-    auto num_banks = this->device_->num_banks(this->buffer_type_, this->sub_device_id_);
+    uint32_t num_banks = allocator::num_banks(*this->allocator_, this->buffer_type_);
     TT_FATAL(bank_id < num_banks, "Invalid Bank ID: {} exceeds total numbers of banks ({})!", bank_id, num_banks);
     int pages_offset_within_bank = (int)page_index / num_banks;
     auto offset = (round_up(this->page_size(), this->alignment()) * pages_offset_within_bank);
@@ -448,8 +453,9 @@ DeviceAddr Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
 }
 
 uint32_t Buffer::alignment() const {
-    return this->device_->get_allocator_alignment(this->sub_device_id_);
+    return this->allocator_->config.alignment;
 }
+
 DeviceAddr Buffer::aligned_page_size() const {
     return align(page_size(), this->alignment());
 }
@@ -484,7 +490,8 @@ std::optional<uint32_t> Buffer::num_cores() const {
 }
 
 DeviceAddr Buffer::translate_page_address(uint64_t offset, uint32_t bank_id) const {
-    DeviceAddr base_page_address = this->address() + this->device_->bank_offset(this->buffer_type_, bank_id, this->sub_device_id_);
+    allocator::bank_offset(*this->allocator_, this->buffer_type_, bank_id);
+    DeviceAddr base_page_address = this->address() + allocator::bank_offset(*this->allocator_, this->buffer_type_, bank_id);
     return base_page_address + offset;
 }
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -156,7 +156,8 @@ class Buffer final {
         BufferType buffer_type,
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt);
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<uint32_t> sub_device_id = std::nullopt);
     static std::shared_ptr<Buffer> create(
         Device *device,
         DeviceAddr address,
@@ -165,7 +166,8 @@ class Buffer final {
         BufferType buffer_type,
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt);
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<uint32_t> sub_device_id = std::nullopt);
 
     Buffer(const Buffer &other) = delete;
     Buffer &operator=(const Buffer &other) = delete;
@@ -223,6 +225,7 @@ class Buffer final {
 
     const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
 
+    std::optional<uint32_t> sub_device_id() const { return sub_device_id_; }
 
     Buffer(
         Device *device,
@@ -232,6 +235,7 @@ class Buffer final {
         TensorMemoryLayout buffer_layout,
         const std::optional<ShardSpecBuffer>& shard_parameter,
         std::optional<bool> bottom_up,
+        std::optional<uint32_t> sub_device_id,
         bool owns_data,
         Private);
 
@@ -256,6 +260,7 @@ class Buffer final {
     const BufferType buffer_type_;
     const TensorMemoryLayout buffer_layout_;
     const bool bottom_up_;
+    const std::optional<uint32_t> sub_device_id_;
     const bool owns_data_;
 
     std::atomic<AllocationStatus> allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1261,7 +1261,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                         uint32_t dev_completion_queue_rd_ptr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
                         settings.upstream_cores.push_back(demux_settings.worker_physical_core);
                         settings.downstream_cores.push_back(tt_cxy_pair(0, 0, 0));
-                        settings.compile_args.resize(30);
+                        settings.compile_args.resize(31);
                         auto& compile_args = settings.compile_args;
                         compile_args[0] = settings.cb_start_address;
                         compile_args[1] = settings.cb_log_page_size;
@@ -1285,14 +1285,15 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                         compile_args[19] = settings.num_compute_cores;
                         compile_args[20] = 0; // unused: dispatch_d only
                         compile_args[21] = 1; // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
-                        compile_args[22] = 0; // unused: dispatch_d only
+                        compile_args[22] = 1; // max_num_go_signal_noc_data_entries is used for array sizing, set to 1 even if array isn't used
                         compile_args[23] = 0; // unused: dispatch_d only
-                        compile_args[24] = 0;
-                        compile_args[25] = host_completion_queue_wr_ptr;
-                        compile_args[26] = dev_completion_queue_wr_ptr;
-                        compile_args[27] = dev_completion_queue_rd_ptr;
-                        compile_args[28] = false; // is_dram_variant
-                        compile_args[29] = true; // is_host_variant
+                        compile_args[24] = 0; // unused: dispatch_d only
+                        compile_args[25] = 0;
+                        compile_args[26] = host_completion_queue_wr_ptr;
+                        compile_args[27] = dev_completion_queue_wr_ptr;
+                        compile_args[28] = dev_completion_queue_rd_ptr;
+                        compile_args[29] = false; // is_dram_variant
+                        compile_args[30] = true; // is_host_variant
 
                         dispatch_idx++;
                     }
@@ -1315,7 +1316,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                             uint32_t dev_completion_queue_rd_ptr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
                             settings.upstream_cores.push_back(demux_settings.worker_physical_core);
                             settings.downstream_cores.push_back(tt_cxy_pair(0, 0, 0));
-                            settings.compile_args.resize(30);
+                            settings.compile_args.resize(31);
                             auto& compile_args = settings.compile_args;
                             compile_args[0] = settings.cb_start_address;
                             compile_args[1] = settings.cb_log_page_size;
@@ -1339,14 +1340,15 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                             compile_args[19] = settings.num_compute_cores;
                             compile_args[20] = 0; // unused: dispatch_d only
                             compile_args[21] = 1; // max_num_worker_sems is used for array sizing, set to 1 even if array isn't used
-                            compile_args[22] = 0; // unused: dispatch_d only
+                            compile_args[22] = 1; // max_num_go_signal_noc_data_entries is used for array sizing, set to 1 even if array isn't used
                             compile_args[23] = 0; // unused: dispatch_d only
-                            compile_args[24] = 0;
-                            compile_args[25] = host_completion_queue_wr_ptr;
-                            compile_args[26] = dev_completion_queue_wr_ptr;
-                            compile_args[27] = dev_completion_queue_rd_ptr;
-                            compile_args[28] = false; // is_dram_variant
-                            compile_args[29] = true; // is_host_variant
+                            compile_args[24] = 0; // unused: dispatch_d only
+                            compile_args[25] = 0;
+                            compile_args[26] = host_completion_queue_wr_ptr;
+                            compile_args[27] = dev_completion_queue_wr_ptr;
+                            compile_args[28] = dev_completion_queue_rd_ptr;
+                            compile_args[29] = false; // is_dram_variant
+                            compile_args[30] = true; // is_host_variant
                             dispatch_idx++;
                         }
                     }
@@ -1628,7 +1630,8 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 uint32_t mux_sem = mux_d_settings.consumer_semaphore_id;
                 uint32_t tensix_worker_go_signal_addr = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
                 uint32_t eth_worker_go_signal_addr = hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG);
-                uint32_t max_dispatch_message_entries = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+                constexpr uint32_t max_dispatch_message_entries = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+                constexpr uint32_t max_num_go_signal_noc_data_entries = dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
                 for (auto&[core, dispatch_d_settings] : device_worker_variants[DispatchWorkerType::DISPATCH_D]) {
                     auto prefetch_d_settings = std::get<1>(device_worker_variants[DispatchWorkerType::PREFETCH_D][dispatch_d_idx]); // 1 to 1 mapping bw prefetch_d and dispatch_d
                     auto dispatch_s_settings = std::get<1>(device_worker_variants[DispatchWorkerType::DISPATCH_S][dispatch_d_idx]); // 1 to 1 mapping bw dispatch_s and dispatch_d
@@ -1640,7 +1643,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     dispatch_d_settings.upstream_cores.push_back(prefetch_d_settings.worker_physical_core);
                     dispatch_d_settings.downstream_cores.push_back(mux_d_settings.worker_physical_core);
                     dispatch_d_settings.downstream_cores.push_back(dispatch_s_settings.worker_physical_core);
-                    dispatch_d_settings.compile_args.resize(30);
+                    dispatch_d_settings.compile_args.resize(32);
                     auto& compile_args = dispatch_d_settings.compile_args;
                     compile_args[0] = dispatch_d_settings.cb_start_address;
                     compile_args[1] = dispatch_d_settings.cb_log_page_size;
@@ -1664,14 +1667,15 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     compile_args[19] = dispatch_d_settings.num_compute_cores;
                     compile_args[20] = dispatch_s_sync_sem_base_addr;
                     compile_args[21] = max_dispatch_message_entries;
-                    compile_args[22] = tensix_worker_go_signal_addr;
-                    compile_args[23] = eth_worker_go_signal_addr;
-                    compile_args[24] = (dispatch_core_type == CoreType::ETH);
-                    compile_args[25] = host_completion_queue_wr_ptr;
-                    compile_args[26] = dev_completion_queue_wr_ptr;
-                    compile_args[27] = dev_completion_queue_rd_ptr;
-                    compile_args[28] = true; // is_dram_variant
-                    compile_args[29] = false; // is_host_variant
+                    compile_args[22] = max_num_go_signal_noc_data_entries;
+                    compile_args[23] = tensix_worker_go_signal_addr;
+                    compile_args[24] = eth_worker_go_signal_addr;
+                    compile_args[25] = (dispatch_core_type == CoreType::ETH);
+                    compile_args[26] = host_completion_queue_wr_ptr;
+                    compile_args[27] = dev_completion_queue_wr_ptr;
+                    compile_args[28] = dev_completion_queue_rd_ptr;
+                    compile_args[29] = true; // is_dram_variant
+                    compile_args[30] = false; // is_host_variant
                     dispatch_d_idx++; // move on to next dispatcher
                 }
                 break;
@@ -1690,8 +1694,9 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                         auto dispatch_core_type = dispatch_s_settings.dispatch_core_type;
                         uint32_t dispatch_message_base_addr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
                         uint32_t dispatch_s_sync_sem_base_addr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
-                        uint32_t max_dispatch_message_entries = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
-                        dispatch_s_settings.compile_args.resize(11);
+                        constexpr uint32_t max_dispatch_message_entries = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+                        constexpr uint32_t max_num_go_signal_noc_data_entries = dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
+                        dispatch_s_settings.compile_args.resize(12);
                         auto& compile_args = dispatch_s_settings.compile_args;
                         compile_args[0] = dispatch_s_settings.cb_start_address;
                         compile_args[1] = dispatch_s_settings.cb_log_page_size;
@@ -1704,6 +1709,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                         compile_args[8] = (dispatch_core_type == CoreType::ETH);
                         compile_args[9] = dispatch_message_base_addr;
                         compile_args[10] = max_dispatch_message_entries;
+                        compile_args[11] = max_num_go_signal_noc_data_entries;
                         dispatch_s_idx++;
                     }
                 }
@@ -2203,7 +2209,8 @@ void Device::compile_command_queue_programs() {
             uint32_t dev_completion_queue_wr_ptr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
             uint32_t dev_completion_queue_rd_ptr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
             uint32_t dispatch_message_addr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-            uint32_t max_dispatch_message_entries = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+            constexpr uint32_t max_dispatch_message_entries = dispatch_constants::DISPATCH_MESSAGE_ENTRIES;
+            constexpr uint32_t max_num_go_signal_noc_data_entries = dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
 
             const uint32_t prefetch_sync_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, 0, dispatch_core_type);
             const uint32_t prefetch_sem = tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(), dispatch_core_type);
@@ -2316,6 +2323,7 @@ void Device::compile_command_queue_programs() {
                 num_compute_cores, // max_write_packed_cores
                 dispatch_s_sync_sem_base_addr, // used to notify dispatch_s that its safe to send a go signal
                 max_dispatch_message_entries,
+                max_num_go_signal_noc_data_entries,
                 tensix_worker_go_signal_addr, // used by dispatch_d to mcast go signals when dispatch_s is not enabled
                 eth_worker_go_signal_addr, // used by dispatch_d to mcast go signals when dispatch_s is not enabled
                 dispatch_core_type == CoreType::ETH,
@@ -2354,6 +2362,7 @@ void Device::compile_command_queue_programs() {
                     dispatch_core_type == CoreType::ETH,
                     dispatch_message_addr,
                     max_dispatch_message_entries,
+                    max_num_go_signal_noc_data_entries,
                 };
                 configure_kernel_variant(
                     *command_queue_program_ptr,
@@ -2903,12 +2912,11 @@ void Device::init_command_queue_device() {
             }
         }
     }
-    // TODO: Move this inside the command queue
+
     for (auto& hw_cq : this->hw_command_queues_) {
-        hw_cq->set_num_worker_sems_on_dispatch(this->num_sub_devices());
+        hw_cq->set_num_worker_sems_on_dispatch(this->active_sub_device_manager_->num_sub_devices());
+        hw_cq->set_go_signal_noc_data_on_dispatch(this->active_sub_device_manager_->noc_mcast_unicast_data());
     }
-    // Added this for safety while debugging hangs with FD v1.3 tunnel to R, should experiment with removing it
-    // tt::Cluster::instance().l1_barrier(this->id());
 }
 
 void Device::initialize_synchronous_sw_cmd_queue() {
@@ -3161,18 +3169,16 @@ const std::unique_ptr<Allocator> &Device::get_initialized_allocator(SubDeviceId 
 }
 
 void Device::reset_sub_devices_state(const std::unique_ptr<detail::SubDeviceManager> &sub_device_manager) {
-    // Finish all running programs
-    Synchronize(this);
-
     auto num_sub_devices = sub_device_manager->num_sub_devices();
 
-    // Set new number of worker sems on dispatch_s
+    // TODO: This could be further optimized by combining all of these into a single prefetch entry
+    // Currently each one will be pushed into its own prefetch entry
     for (auto& hw_cq : this->hw_command_queues_) {
         // Only need to reset launch messages once, so reset on cq 0
         TT_FATAL(!hw_cq->manager.get_bypass_mode(), "Cannot reset worker state during trace capture");
         hw_cq->reset_worker_state(hw_cq->id == 0);
         hw_cq->set_num_worker_sems_on_dispatch(num_sub_devices);
-        // Reset the config buffer mgr (is this needed?)
+        hw_cq->set_go_signal_noc_data_on_dispatch(sub_device_manager->noc_mcast_unicast_data());
         hw_cq->reset_config_buffer_mgr(num_sub_devices);
     }
     // Reset the launch_message ring buffer state seen on host
@@ -3488,7 +3494,7 @@ void Device::begin_trace(const uint8_t cq_id, const uint32_t tid) {
     TT_FATAL(!this->hw_command_queues_[cq_id]->tid.has_value(), "CQ {} is already being used for tracing tid {}", (uint32_t)cq_id, tid);
     this->MarkAllocationsSafe();
     // Create an empty trace buffer here. This will get initialized in end_trace
-    TT_FATAL(this->active_sub_device_manager_->get_trace(tid) == nullptr, "Trace already exists for tid {} on device", tid);
+    TT_FATAL(this->active_sub_device_manager_->get_trace(tid) == nullptr, "Trace already exists for tid {} on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
     auto &trace_buffer = this->active_sub_device_manager_->create_trace(tid);
     this->hw_command_queues_[cq_id]->record_begin(tid, trace_buffer->desc);
 }
@@ -3498,7 +3504,7 @@ void Device::end_trace(const uint8_t cq_id, const uint32_t tid) {
     TracyTTMetalEndTrace(this->id(), tid);
     TT_FATAL(this->hw_command_queues_[cq_id]->tid == tid, "CQ {} is not being used for tracing tid {}", (uint32_t)cq_id, tid);
     auto trace_buffer = this->active_sub_device_manager_->get_trace(tid);
-    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device", tid);
+    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
     this->hw_command_queues_[cq_id]->record_end();
     Trace::initialize_buffer(this->command_queue(cq_id), trace_buffer);
     this->MarkAllocationsUnsafe();
@@ -3509,7 +3515,7 @@ void Device::replay_trace(const uint8_t cq_id, const uint32_t tid, const bool bl
     TracyTTMetalReplayTrace(this->id(), tid);
     constexpr bool check = false;
     const auto &trace_buffer = this->active_sub_device_manager_->get_trace(tid);
-    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device", tid);
+    TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
     if constexpr (check) {
         Trace::validate_instance(*trace_buffer);
     }
@@ -3577,37 +3583,22 @@ size_t Device::get_device_kernel_defines_hash() {
     return tt::utils::DefinesHash{}(this->device_kernel_defines_);
 }
 
-const vector_memcpy_aligned<uint32_t>& Device::noc_mcast_data(SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->noc_mcast_data(sub_device_id);
+uint8_t Device::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
+    return this->active_sub_device_manager_->num_noc_mcast_txns(sub_device_id);
 }
 
-const vector_memcpy_aligned<uint32_t>& Device::noc_unicast_data(SubDeviceId sub_device_id) const {
-    return this->active_sub_device_manager_->noc_unicast_data(sub_device_id);
+uint8_t Device::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
+    return this->active_sub_device_manager_->num_noc_unicast_txns(sub_device_id);
 }
 
-const vector_memcpy_aligned<uint32_t>& Device::noc_mcast_unicast_data(SubDeviceId sub_device_id, bool mcast_data, bool unicast_data) const {
-    // Needed for compatibility with tests that create programs with no kernels
-    static const vector_memcpy_aligned<uint32_t> empty = {};
-    if (mcast_data && unicast_data) {
-        return this->active_sub_device_manager_->noc_mcast_unicast_data(sub_device_id);
-    } else if (mcast_data) {
-        return this->active_sub_device_manager_->noc_mcast_data(sub_device_id);
+uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data, bool unicast_data) const {
+    if (mcast_data) {
+        return this->active_sub_device_manager_->noc_mcast_data_start_index(sub_device_id);
     } else if (unicast_data) {
-        return this->active_sub_device_manager_->noc_unicast_data(sub_device_id);
+        return this->active_sub_device_manager_->noc_unicast_data_start_index(sub_device_id);
     } else {
-        return empty;
+        return 0;
     }
-}
-
-uint32_t Device::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
-    return this->noc_mcast_data(sub_device_id).size() / 2;
-}
-uint32_t Device::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
-    return this->noc_unicast_data(sub_device_id).size();
-}
-
-uint32_t Device::num_noc_mcast_unicast_txns(SubDeviceId sub_device_id, bool mcast_data, bool unicast_data) const {
-    return (mcast_data ? this->num_noc_mcast_txns(sub_device_id) : 0) + (unicast_data ? this->num_noc_unicast_txns(sub_device_id) : 0);
 }
 
 LaunchMessageRingBufferState& Device::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
@@ -3631,35 +3622,32 @@ SubDeviceManagerId Device::get_default_sub_device_manager_id() const {
 }
 
 SubDeviceManagerId Device::create_sub_device_manager(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    TT_FATAL(!this->using_slow_dispatch(), "Using sub device managers is unsupported with slow dispatch");
     auto [sub_device_manager, _] = this->sub_device_managers_.insert_or_assign(this->get_next_sub_device_manager_id(), std::make_unique<detail::SubDeviceManager>(sub_devices, local_l1_size, this));
     return sub_device_manager->first;
 }
 
 void Device::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
+    TT_FATAL(!this->using_slow_dispatch(), "Using sub device managers is unsupported with slow dispatch");
     if (this->active_sub_device_manager_id_ == sub_device_manager_id) {
         return;
+    }
+    if (this->active_sub_device_manager_id_ != this->default_sub_device_manager_id_) {
+        TT_FATAL(!this->active_sub_device_manager_->has_allocations(), "Cannot switch sub device managers while sub devices still have local allocations");
     }
     auto sub_device_manager = this->sub_device_managers_.find(sub_device_manager_id);
     TT_FATAL(sub_device_manager != this->sub_device_managers_.end(), "Sub device manager does not exist");
     this->reset_sub_devices_state(sub_device_manager->second);
+    const auto& global_allocator = this->get_initialized_allocator();
+    allocator::reset_allocator_size(*global_allocator, BufferType::L1);
     // Shrink the global allocator size to make room for sub-device allocators
     auto local_l1_size = sub_device_manager->second->local_l1_size();
-    allocator::shrink_allocator_size(*this->get_initialized_allocator(), BufferType::L1, local_l1_size, true);
+    allocator::shrink_allocator_size(*global_allocator, BufferType::L1, local_l1_size, true);
     this->active_sub_device_manager_id_ = sub_device_manager_id;
     this->active_sub_device_manager_ = sub_device_manager->second.get();
 }
 
 void Device::clear_loaded_sub_device_manager() {
-    if (this->active_sub_device_manager_id_ == this->default_sub_device_manager_id_) {
-        return;
-    }
-    TT_FATAL(!this->active_sub_device_manager_->has_allocations(), "Cannot clear active sub device manager {} since it has allocations", this->active_sub_device_manager_id_);
-    auto &default_manager = this->sub_device_managers_.at(this->default_sub_device_manager_id_);
-    this->reset_sub_devices_state(default_manager);
-    allocator::reset_allocator_size(*this->get_initialized_allocator(), BufferType::L1);
-    this->active_sub_device_manager_id_ = this->default_sub_device_manager_id_;
-    this->active_sub_device_manager_ = default_manager.get();
+    this->load_sub_device_manager(this->default_sub_device_manager_id_);
 }
 
 void Device::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
@@ -3670,6 +3658,10 @@ void Device::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id)
     auto sub_device_manager = this->sub_device_managers_.find(sub_device_manager_id);
     TT_FATAL(sub_device_manager != this->sub_device_managers_.end(), "Sub device manager does not exist");
     this->sub_device_managers_.erase(sub_device_manager);
+}
+
+const std::vector<SubDeviceId> &Device::get_sub_device_ids() const {
+    return this->active_sub_device_manager_->get_sub_device_ids();
 }
 
 }  // namespace tt_metal

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -369,12 +369,9 @@ class Device {
     NOC dispatch_go_signal_noc() const;
     size_t get_device_kernel_defines_hash();
 
-    const vector_memcpy_aligned<uint32_t>& noc_mcast_data(SubDeviceId sub_device_id) const;
-    const vector_memcpy_aligned<uint32_t>& noc_unicast_data(SubDeviceId sub_device_id) const;
-    const vector_memcpy_aligned<uint32_t>& noc_mcast_unicast_data(SubDeviceId sub_device_id, bool mcast_data=true, bool unicast_data=true) const;
-    uint32_t num_noc_mcast_txns(SubDeviceId sub_device_id) const;
-    uint32_t num_noc_unicast_txns(SubDeviceId sub_device_id) const;
-    uint32_t num_noc_mcast_unicast_txns(SubDeviceId sub_device_id, bool mcast_data=true, bool unicast_data=true) const;
+    uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const;
+    uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const;
+    uint8_t noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data=true, bool unicast_data=true) const;
 
     LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id);
 
@@ -384,6 +381,7 @@ class Device {
     void load_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
     void clear_loaded_sub_device_manager();
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
+    const std::vector<SubDeviceId> &get_sub_device_ids() const;
    private:
     void initialize_default_sub_device_state(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap);
     SubDeviceManagerId get_next_sub_device_manager_id();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -45,9 +45,6 @@ using std::set;
 using std::shared_ptr;
 using std::unique_ptr;
 
-std::mutex finish_mutex;
-std::condition_variable finish_cv;
-
 namespace tt::tt_metal {
 
 namespace detail {
@@ -79,7 +76,7 @@ EnqueueReadBufferCommand::EnqueueReadBufferCommand(
     Buffer& buffer,
     void* dst,
     SystemMemoryManager& manager,
-    uint32_t expected_num_workers_completed,
+    tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
     uint32_t src_page_index,
     std::optional<uint32_t> pages_to_read) :
     command_queue_id(command_queue_id),
@@ -113,9 +110,10 @@ void EnqueueReadShardedBufferCommand::add_prefetch_relay(HugepageDeviceCommand& 
 }
 
 void EnqueueReadBufferCommand::process() {
+    uint32_t num_worker_counters = this->expected_num_workers_completed.size();
     // accounts for padding
     uint32_t cmd_sequence_sizeB =
-        CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
+        CQ_PREFETCH_CMD_BARE_MIN_SIZE * num_worker_counters +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
         CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_STALL
         CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH + CQ_DISPATCH_CMD_WRITE_LINEAR_HOST
         CQ_PREFETCH_CMD_BARE_MIN_SIZE;   // CQ_PREFETCH_CMD_RELAY_LINEAR or CQ_PREFETCH_CMD_RELAY_PAGED
@@ -124,10 +122,20 @@ void EnqueueReadBufferCommand::process() {
 
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
-    uint32_t dispatch_message_addr = dispatch_constants::get(
-        this->dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
+    uint32_t dispatch_message_base_addr = dispatch_constants::get(dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
+    uint32_t last_index = num_worker_counters - 1;
+    // We only need the write barrier + prefetch stall for the last wait cmd
+    for (uint32_t i = 0; i < last_index; ++i) {
+        auto [offset_index, workers_completed] = this->expected_num_workers_completed[i];
+        uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
+        command_sequence.add_dispatch_wait(
+            false, dispatch_message_addr, workers_completed);
+
+    }
+    auto [offset_index, workers_completed] = this->expected_num_workers_completed[last_index];
+    uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
     command_sequence.add_dispatch_wait_with_prefetch_stall(
-        true, dispatch_message_addr, this->expected_num_workers_completed);
+        true, dispatch_message_addr, workers_completed);
 
     uint32_t padded_page_size = this->buffer.aligned_page_size();
     bool flush_prefetch = false;
@@ -152,7 +160,7 @@ EnqueueWriteBufferCommand::EnqueueWriteBufferCommand(
     const void* src,
     SystemMemoryManager& manager,
     bool issue_wait,
-    uint32_t expected_num_workers_completed,
+    tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
     uint32_t bank_base_address,
     uint32_t padded_page_size,
     uint32_t dst_page_index,
@@ -276,6 +284,7 @@ void EnqueueWriteShardedBufferCommand::add_buffer_data(HugepageDeviceCommand& co
 }
 
 void EnqueueWriteBufferCommand::process() {
+    uint32_t num_worker_counters = this->expected_num_workers_completed.size();
     uint32_t data_size_bytes = this->pages_to_write * this->padded_page_size;
 
     uint32_t cmd_sequence_sizeB =
@@ -283,7 +292,7 @@ void EnqueueWriteBufferCommand::process() {
                                          // CQ_DISPATCH_CMD_WRITE_LINEAR)
         data_size_bytes;
     if (this->issue_wait) {
-        cmd_sequence_sizeB += CQ_PREFETCH_CMD_BARE_MIN_SIZE;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
+        cmd_sequence_sizeB += CQ_PREFETCH_CMD_BARE_MIN_SIZE * num_worker_counters;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
     }
 
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);
@@ -291,9 +300,13 @@ void EnqueueWriteBufferCommand::process() {
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     if (this->issue_wait) {
-        uint32_t dispatch_message_addr = dispatch_constants::get(
+        uint32_t dispatch_message_base_addr = dispatch_constants::get(
             this->dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-        command_sequence.add_dispatch_wait(false, dispatch_message_addr, this->expected_num_workers_completed);
+        for (uint32_t i = 0; i < num_worker_counters; ++i) {
+            auto [offset_index, workers_completed] = this->expected_num_workers_completed[i];
+            uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
+            command_sequence.add_dispatch_wait(false, dispatch_message_addr, workers_completed);
+        }
     }
 
     this->add_dispatch_write(command_sequence);
@@ -311,7 +324,7 @@ void EnqueueWriteBufferCommand::process() {
 }
 
 inline uint32_t get_packed_write_max_unicast_sub_cmds(Device* device) {
-    return device->num_worker_cores();
+    return device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y;
 }
 
 // EnqueueProgramCommand Section
@@ -326,21 +339,24 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     WorkerConfigBufferMgr& config_buffer_mgr,
     uint32_t expected_num_workers_completed,
     uint32_t multicast_cores_launch_message_wptr,
-    uint32_t unicast_cores_launch_message_wptr) :
+    uint32_t unicast_cores_launch_message_wptr,
+    uint32_t sub_device_id) :
     command_queue_id(command_queue_id),
     noc_index(noc_index),
     manager(manager),
     config_buffer_mgr(config_buffer_mgr),
     expected_num_workers_completed(expected_num_workers_completed),
     program(program),
-    dispatch_core(dispatch_core) {
+    dispatch_core(dispatch_core),
+    multicast_cores_launch_message_wptr(multicast_cores_launch_message_wptr),
+    unicast_cores_launch_message_wptr(unicast_cores_launch_message_wptr),
+    sub_device_id(sub_device_id) {
     this->device = device;
     this->dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
     this->packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
     this->dispatch_message_addr = dispatch_constants::get(
-        this->dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-    this->multicast_cores_launch_message_wptr = multicast_cores_launch_message_wptr;
-    this->unicast_cores_launch_message_wptr = unicast_cores_launch_message_wptr;
+        this->dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE) +
+        dispatch_constants::get(this->dispatch_core_type).get_dispatch_message_offset(this->sub_device_id);
 }
 
 void EnqueueProgramCommand::assemble_preamble_commands(
@@ -1085,7 +1101,13 @@ void EnqueueProgramCommand::assemble_device_commands(
     cmd_sequence_sizeB += (this->device->dispatch_s_enabled() || program_transfer_info.num_active_cores > 0) * CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 
     // either dispatch_s or dispatch_d will send the go signal (go_signal_mcast command)
-    cmd_sequence_sizeB += CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+    const auto& noc_mcast_unicast_data = device->noc_mcast_unicast_data(this->sub_device_id, multicast_go_signal_sub_cmds.size() > 0,  unicast_go_signal_sub_cmds.size() > 0);
+    const auto& num_noc_mcast_txns = multicast_go_signal_sub_cmds.size() > 0 ? device->num_noc_mcast_txns(this->sub_device_id) : 0;
+    const auto& num_noc_unicast_txns = unicast_go_signal_sub_cmds.size() > 0 ? device->num_noc_unicast_txns(this->sub_device_id) : 0;
+    cmd_sequence_sizeB += align(
+        sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) +
+        noc_mcast_unicast_data.size() * sizeof(uint32_t),
+        pcie_alignment);
 
     program_command_sequence.device_command_sequence = HostMemDeviceCommand(cmd_sequence_sizeB);
 
@@ -1208,9 +1230,7 @@ void EnqueueProgramCommand::assemble_device_commands(
     // Get the address for the slot this launch_message will be written to
     uint32_t multicast_launch_msg_addr = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::LAUNCH) + this->multicast_cores_launch_message_wptr * sizeof(launch_msg_t);
 
-    uint8_t go_signal_mcast_flag = 0x0;
     if (multicast_go_signal_sub_cmds.size() > 0) {
-        go_signal_mcast_flag |= (uint8_t)GoSignalMcastSettings::SEND_MCAST;
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [num_sub_cmds_in_cmd, multicast_go_signal_payload_sizeB] : multicast_go_signals_payload) {
             uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
@@ -1239,7 +1259,6 @@ void EnqueueProgramCommand::assemble_device_commands(
 
     if (unicast_go_signal_sub_cmds.size() > 0) {
         uint32_t unicast_launch_msg_addr = hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH) + this->unicast_cores_launch_message_wptr * sizeof(launch_msg_t);
-        go_signal_mcast_flag |= (uint8_t)GoSignalMcastSettings::SEND_UNICAST;
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [num_sub_cmds_in_cmd, unicast_go_signal_payload_sizeB] : unicast_go_signals_payload) {
             uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
@@ -1269,7 +1288,9 @@ void EnqueueProgramCommand::assemble_device_commands(
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     if (this->device->dispatch_s_enabled()) {
         // dispatch_d signals dispatch_s to send the go signal, use a barrier if there are cores active
-        device_command_sequence.add_notify_dispatch_s_go_signal_cmd(program_transfer_info.num_active_cores > 0);
+        uint16_t index_bitmask = 0;
+        index_bitmask |= 1 << this->sub_device_id;
+        device_command_sequence.add_notify_dispatch_s_go_signal_cmd(program_transfer_info.num_active_cores > 0, index_bitmask);
         dispatcher_for_go_signal = DispatcherSelect::DISPATCH_SLAVE;
     } else {
         // Wait Noc Write Barrier, wait for binaries/configs and launch_msg to be written to worker cores
@@ -1281,8 +1302,9 @@ void EnqueueProgramCommand::assemble_device_commands(
     run_program_go_signal.signal = RUN_MSG_GO;
     run_program_go_signal.master_x = (uint8_t)this->dispatch_core.x;
     run_program_go_signal.master_y = (uint8_t)this->dispatch_core.y;
+    run_program_go_signal.dispatch_message_offset = (uint8_t)dispatch_constants::get(this->dispatch_core_type).get_dispatch_message_offset(this->sub_device_id);
     uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
-    device_command_sequence.add_dispatch_go_signal_mcast(this->expected_num_workers_completed, go_signal_mcast_flag, *reinterpret_cast<uint32_t*>(&run_program_go_signal), this->dispatch_message_addr, dispatcher_for_go_signal);
+    device_command_sequence.add_dispatch_go_signal_mcast(this->expected_num_workers_completed, *reinterpret_cast<uint32_t*>(&run_program_go_signal), this->dispatch_message_addr, num_noc_mcast_txns, num_noc_unicast_txns, noc_mcast_unicast_data, dispatcher_for_go_signal);
     program_command_sequence.mcast_go_signal_cmd_ptr = &((CQDispatchCmd*) ((uint32_t*)device_command_sequence.data() + (write_offset_bytes + sizeof(CQPrefetchCmd)) / sizeof(uint32_t)))->mcast;
 }
 
@@ -1331,6 +1353,7 @@ void EnqueueProgramCommand::update_device_commands(
     run_program_go_signal.signal = RUN_MSG_GO;
     run_program_go_signal.master_x = (uint8_t)this->dispatch_core.x;
     run_program_go_signal.master_y = (uint8_t)this->dispatch_core.y;
+    run_program_go_signal.dispatch_message_offset = (uint8_t)dispatch_constants::get(this->dispatch_core_type).get_dispatch_message_offset(this->sub_device_id);
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->go_signal =  *reinterpret_cast<uint32_t*>(&run_program_go_signal);
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = this->expected_num_workers_completed;
 }
@@ -1357,8 +1380,7 @@ void EnqueueProgramCommand::write_program_command_sequence(
     uint32_t total_fetch_size_bytes =
         stall_fetch_size_bytes + preamble_fetch_size_bytes + runtime_args_fetch_size_bytes + program_fetch_size_bytes;
 
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device->id());
-    if (total_fetch_size_bytes <= dispatch_constants::get(dispatch_core_type).max_prefetch_command_size()) {
+    if (total_fetch_size_bytes <= dispatch_constants::get(this->dispatch_core_type).max_prefetch_command_size()) {
         this->manager.issue_queue_reserve(total_fetch_size_bytes, this->command_queue_id);
         uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
 
@@ -1510,10 +1532,10 @@ void EnqueueProgramCommand::process() {
     }
     uint32_t num_workers = 0;
     if (program.runs_on_noc_multicast_only_cores()) {
-        num_workers += device->num_worker_cores();
+        num_workers += device->num_worker_cores(HalProgrammableCoreType::TENSIX, this->sub_device_id);
     }
     if (program.runs_on_noc_unicast_only_cores()) {
-        num_workers += device->num_eth_worker_cores();
+        num_workers += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, this->sub_device_id);
     }
     this->config_buffer_mgr.alloc(this->expected_num_workers_completed + num_workers);
     std::vector<ConfigBufferEntry>& kernel_config_addrs_raw = reservation.second;
@@ -1579,7 +1601,7 @@ EnqueueRecordEventCommand::EnqueueRecordEventCommand(
     NOC noc_index,
     SystemMemoryManager& manager,
     uint32_t event_id,
-    uint32_t expected_num_workers_completed,
+    tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
     bool clear_count,
     bool write_barrier) :
     command_queue_id(command_queue_id),
@@ -1603,9 +1625,10 @@ void EnqueueRecordEventCommand::process() {
         align(sizeof(CQDispatchCmd) + num_hw_cqs * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment) +
         (align(dispatch_constants::EVENT_PADDED_SIZE, l1_alignment) * num_hw_cqs);
     uint32_t packed_write_sizeB = align(sizeof(CQPrefetchCmd) + packed_event_payload_sizeB, pcie_alignment);
+    uint32_t num_worker_counters = this->expected_num_workers_completed.size();
 
     uint32_t cmd_sequence_sizeB =
-        CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
+        CQ_PREFETCH_CMD_BARE_MIN_SIZE * num_worker_counters +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
         packed_write_sizeB +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PACKED + unicast subcmds + event
                               // payload
         align(
@@ -1617,11 +1640,22 @@ void EnqueueRecordEventCommand::process() {
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device->id());
-    uint32_t dispatch_message_addr = dispatch_constants::get(
+    uint32_t dispatch_message_base_addr = dispatch_constants::get(
         dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
 
+    uint32_t last_index = num_worker_counters - 1;
+    // We only need the write barrier for the last wait cmd
+    for (uint32_t i = 0; i < last_index; ++i) {
+        auto [offset_index, workers_completed] = this->expected_num_workers_completed[i];
+        uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
+        command_sequence.add_dispatch_wait(
+            false, dispatch_message_addr, workers_completed, this->clear_count);
+
+    }
+    auto [offset_index, workers_completed] = this->expected_num_workers_completed[last_index];
+    uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(offset_index);
     command_sequence.add_dispatch_wait(
-        this->write_barrier, dispatch_message_addr, this->expected_num_workers_completed, this->clear_count);
+            this->write_barrier, dispatch_message_addr, workers_completed, this->clear_count);
 
     CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device->id());
@@ -1708,75 +1742,96 @@ EnqueueTraceCommand::EnqueueTraceCommand(
     uint32_t command_queue_id,
     Device* device,
     SystemMemoryManager& manager,
-    std::shared_ptr<detail::TraceDescriptor>& desc,
+    std::shared_ptr<detail::TraceDescriptor>& descriptor,
     Buffer& buffer,
-    uint32_t& expected_num_workers_completed,
+    std::array<uint32_t, dispatch_constants::DISPATCH_MESSAGE_ENTRIES> & expected_num_workers_completed,
     NOC noc_index,
     CoreCoord dispatch_core) :
     command_queue_id(command_queue_id),
     buffer(buffer),
     device(device),
     manager(manager),
-    desc(desc),
+    descriptor(descriptor),
     expected_num_workers_completed(expected_num_workers_completed),
     clear_count(true),
     noc_index(noc_index),
     dispatch_core(dispatch_core) {}
 
 void EnqueueTraceCommand::process() {
+    uint32_t num_sub_devices = descriptor->descriptors.size();
+    uint32_t go_signals_cmd_size = 0;
+    uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
+    for (const auto& [index, desc] : descriptor->descriptors) {
+        uint32_t go_signal_cmd_size = sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd);
+        go_signal_cmd_size += desc.num_traced_programs_needing_go_signal_multicast ? device->num_noc_mcast_txns(index) * sizeof(uint32_t) : 0;
+        go_signal_cmd_size += desc.num_traced_programs_needing_go_signal_unicast ? device->num_noc_unicast_txns(index) * sizeof(uint32_t) : 0;
+        go_signals_cmd_size += align(go_signal_cmd_size, pcie_alignment);
+    }
     uint32_t cmd_sequence_sizeB =
         this->device->dispatch_s_enabled() * CQ_PREFETCH_CMD_BARE_MIN_SIZE + // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
-        CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // go signal cmd
-        CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // wait to ensure that reset go signal was processed (dispatch_d)
+        go_signals_cmd_size +  // go signal cmd
+        (CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // wait to ensure that reset go signal was processed (dispatch_d)
         // when dispatch_s and dispatch_d are running on 2 cores, workers update dispatch_s. dispatch_s is responsible for resetting worker count
         // and giving dispatch_d the latest worker state. This is encapsulated in the dispatch_s wait command (only to be sent when dispatch is distributed
         // on 2 cores)
-        (this->device->distributed_dispatcher()) * CQ_PREFETCH_CMD_BARE_MIN_SIZE +
+        (this->device->distributed_dispatcher()) * CQ_PREFETCH_CMD_BARE_MIN_SIZE) * num_sub_devices +
         CQ_PREFETCH_CMD_BARE_MIN_SIZE;  // CQ_PREFETCH_CMD_EXEC_BUF
 
-    uint8_t go_signal_mcast_flag = 0;
-    if (desc->num_traced_programs_needing_go_signal_multicast) {
-        go_signal_mcast_flag |= (uint8_t)GoSignalMcastSettings::SEND_MCAST;
-    }
-    if (desc->num_traced_programs_needing_go_signal_unicast) {
-        go_signal_mcast_flag |= (uint8_t)GoSignalMcastSettings::SEND_UNICAST;
-    }
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);
 
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     if (this->device->dispatch_s_enabled()) {
-        command_sequence.add_notify_dispatch_s_go_signal_cmd(false);
+        uint16_t index_bitmask = 0;
+        for (const auto &i : descriptor->sub_device_ids) {
+            index_bitmask |= 1 << i;
+        }
+        command_sequence.add_notify_dispatch_s_go_signal_cmd(false, index_bitmask);
         dispatcher_for_go_signal = DispatcherSelect::DISPATCH_SLAVE;
     }
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    uint32_t dispatch_message_base_addr = dispatch_constants::get(
+        dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
     go_msg_t reset_launch_message_read_ptr_go_signal;
     reset_launch_message_read_ptr_go_signal.signal = RUN_MSG_RESET_READ_PTR;
     reset_launch_message_read_ptr_go_signal.master_x = (uint8_t)this->dispatch_core.x;
     reset_launch_message_read_ptr_go_signal.master_y = (uint8_t)this->dispatch_core.y;
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
-    uint32_t dispatch_message_addr = dispatch_constants::get(
-        dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-    // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
-    command_sequence.add_dispatch_go_signal_mcast(this->expected_num_workers_completed, go_signal_mcast_flag, *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal), dispatch_message_addr, dispatcher_for_go_signal);
-    if (desc->num_traced_programs_needing_go_signal_multicast) {
-        this->expected_num_workers_completed += device->num_worker_cores();
-    }
-    if (desc->num_traced_programs_needing_go_signal_unicast) {
-        this->expected_num_workers_completed += device->num_eth_worker_cores();
+    for (const auto& [index, desc] : descriptor->descriptors) {
+        const auto& num_noc_mcast_txns = desc.num_traced_programs_needing_go_signal_multicast ? device->num_noc_mcast_txns(index) : 0;
+        const auto& num_noc_unicast_txns = desc.num_traced_programs_needing_go_signal_unicast ? device->num_noc_unicast_txns(index) : 0;
+        reset_launch_message_read_ptr_go_signal.dispatch_message_offset = (uint8_t)dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(index);
+        uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(index);
+        // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
+        command_sequence.add_dispatch_go_signal_mcast(
+            this->expected_num_workers_completed[index],
+            *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal),
+            dispatch_message_addr,
+            num_noc_mcast_txns,
+            num_noc_unicast_txns,
+            device->noc_mcast_unicast_data(index, desc.num_traced_programs_needing_go_signal_multicast, desc.num_traced_programs_needing_go_signal_unicast),
+            dispatcher_for_go_signal);
+        if (desc.num_traced_programs_needing_go_signal_multicast) {
+            this->expected_num_workers_completed[index] += device->num_worker_cores(HalProgrammableCoreType::TENSIX, index);
+        }
+        if (desc.num_traced_programs_needing_go_signal_unicast) {
+            this->expected_num_workers_completed[index] += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, index);
+        }
     }
     // Wait to ensure that all workers have reset their read_ptr. dispatch_d will stall until all workers have completed this step, before sending kernel config data to workers
     // or notifying dispatch_s that its safe to send the go_signal.
     // Clear the dispatch <--> worker semaphore, since trace starts at 0.
-    if (this->device->distributed_dispatcher()) {
+    for (const auto &index : descriptor->sub_device_ids) {
+        uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(index);
+        if (this->device->distributed_dispatcher()) {
+            command_sequence.add_dispatch_wait(
+                false, dispatch_message_addr, this->expected_num_workers_completed[index], this->clear_count, false, true, 1);
+        }
         command_sequence.add_dispatch_wait(
-            false, dispatch_message_addr, this->expected_num_workers_completed, this->clear_count, false, true, 1);
-    }
-    command_sequence.add_dispatch_wait(
-        false, dispatch_message_addr, this->expected_num_workers_completed, this->clear_count);
-
-    if (this->clear_count) {
-        this->expected_num_workers_completed = 0;
+            false, dispatch_message_addr, this->expected_num_workers_completed[index], this->clear_count);
+        if (this->clear_count) {
+            this->expected_num_workers_completed[index] = 0;
+        }
     }
 
     uint32_t page_size = buffer.page_size();
@@ -1870,29 +1925,103 @@ HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC noc_index) :
     this->completion_queue_thread = std::move(completion_queue_thread);
     // Set the affinity of the completion queue reader.
     set_device_thread_affinity(this->completion_queue_thread, device->completion_queue_reader_core);
-    this->expected_num_workers_completed = 0;
 
-    for (uint32_t index = 0; index < tt::tt_metal::hal.get_programmable_core_type_count(); index++) {
-        this->config_buffer_mgr.init_add_buffer(
-            tt::tt_metal::hal.get_dev_addr(
-                tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
-            tt::tt_metal::hal.get_dev_size(
-                tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG));
+    for (uint32_t i = 0; i < dispatch_constants::DISPATCH_MESSAGE_ENTRIES; i++) {
+        this->expected_num_workers_completed[i] = 0;
+        for (uint32_t index = 0; index < tt::tt_metal::hal.get_programmable_core_type_count(); index++) {
+            this->config_buffer_mgr[i].init_add_buffer(
+                tt::tt_metal::hal.get_dev_addr(
+                    tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
+                tt::tt_metal::hal.get_dev_size(
+                    tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG));
+        }
+        // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the previous
+        // launch message.
+        this->config_buffer_mgr[i].init_add_buffer(0, launch_msg_buffer_num_entries - 1);
     }
-    // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the previous
-    // launch message.
-    this->config_buffer_mgr.init_add_buffer(0, launch_msg_buffer_num_entries - 1);
 }
 
-void HWCommandQueue::set_unicast_only_cores_on_dispatch(const std::vector<uint32_t>& unicast_only_noc_encodings) {
-    uint32_t cmd_sequence_sizeB = align(CQ_PREFETCH_CMD_BARE_MIN_SIZE + unicast_only_noc_encodings.size() * sizeof(uint32_t), PCIE_ALIGNMENT);
+void HWCommandQueue::set_num_worker_sems_on_dispatch(uint32_t num_worker_sems) {
+    // Not needed for regular dispatch kernel
+    if (!this->device->dispatch_s_enabled()) {
+        return;
+    }
+    uint32_t cmd_sequence_sizeB = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
-    DispatcherSelect dispatcher_for_cmd = this->device->dispatch_s_enabled() ? DispatcherSelect::DISPATCH_SLAVE : DispatcherSelect::DISPATCH_MASTER;
-    command_sequence.add_dispatch_set_unicast_only_cores(unicast_only_noc_encodings, dispatcher_for_cmd);
+    command_sequence.add_dispatch_set_num_worker_sems(num_worker_sems, DispatcherSelect::DISPATCH_SLAVE);
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->id);
     this->manager.fetch_queue_reserve_back(this->id);
     this->manager.fetch_queue_write(cmd_sequence_sizeB, this->id);
+}
+
+void HWCommandQueue::reset_worker_state(bool reset_launch_msg_state) {
+    uint32_t num_sub_devices = device->num_sub_devices();
+    uint32_t go_signals_cmd_size = 0;
+    if (reset_launch_msg_state) {
+        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
+        for (uint32_t i = 0; i < num_sub_devices; ++i) {
+            uint32_t go_signal_cmd_size = sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd);
+            go_signal_cmd_size += device->num_noc_mcast_txns(i) * sizeof(uint32_t) + device->num_noc_unicast_txns(i) * sizeof(uint32_t);
+            go_signals_cmd_size += align(go_signal_cmd_size, pcie_alignment);
+        }
+    }
+    uint32_t cmd_sequence_sizeB =
+        reset_launch_msg_state * this->device->dispatch_s_enabled() * CQ_PREFETCH_CMD_BARE_MIN_SIZE + // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
+        go_signals_cmd_size +  // go signal cmd
+        (CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // wait to ensure that reset go signal was processed (dispatch_d)
+        // when dispatch_s and dispatch_d are running on 2 cores, workers update dispatch_s. dispatch_s is responsible for resetting worker count
+        // and giving dispatch_d the latest worker state. This is encapsulated in the dispatch_s wait command (only to be sent when dispatch is distributed
+        // on 2 cores)
+        this->device->distributed_dispatcher() * CQ_PREFETCH_CMD_BARE_MIN_SIZE) * num_sub_devices;
+    void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->id);
+    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    bool clear_count = true;
+    DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    uint32_t dispatch_message_base_addr = dispatch_constants::get(
+        dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
+    if (reset_launch_msg_state) {
+        if (device->dispatch_s_enabled()) {
+            uint16_t index_bitmask = 0;
+            for (uint32_t i = 0; i < num_sub_devices; ++i) {
+                index_bitmask |= 1 << i;
+            }
+            command_sequence.add_notify_dispatch_s_go_signal_cmd(false, index_bitmask);
+            dispatcher_for_go_signal = DispatcherSelect::DISPATCH_SLAVE;
+        }
+        go_msg_t reset_launch_message_read_ptr_go_signal;
+        reset_launch_message_read_ptr_go_signal.signal = RUN_MSG_RESET_READ_PTR;
+        reset_launch_message_read_ptr_go_signal.master_x = (uint8_t)this->physical_enqueue_program_dispatch_core.x;
+        reset_launch_message_read_ptr_go_signal.master_y = (uint8_t)this->physical_enqueue_program_dispatch_core.y;
+        for (uint32_t i = 0; i < num_sub_devices; ++i) {
+            reset_launch_message_read_ptr_go_signal.dispatch_message_offset = (uint8_t)dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(i);
+            uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(i);
+            // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
+            command_sequence.add_dispatch_go_signal_mcast(expected_num_workers_completed[i], *reinterpret_cast<uint32_t*>(&reset_launch_message_read_ptr_go_signal), dispatch_message_addr, device->num_noc_mcast_txns(i), device->num_noc_unicast_txns(i), device->noc_mcast_unicast_data(i), dispatcher_for_go_signal);
+            expected_num_workers_completed[i] += device->num_worker_cores(HalProgrammableCoreType::TENSIX, i);
+            expected_num_workers_completed[i] += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, i);
+        }
+    }
+    // Wait to ensure that all workers have reset their read_ptr. dispatch_d will stall until all workers have completed this step, before sending kernel config data to workers
+    // or notifying dispatch_s that its safe to send the go_signal.
+    // Clear the dispatch <--> worker semaphore, since trace starts at 0.
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(i);
+        if (device->distributed_dispatcher()) {
+            command_sequence.add_dispatch_wait(
+                false, dispatch_message_addr, expected_num_workers_completed[i], clear_count, false, true, 1);
+        }
+        command_sequence.add_dispatch_wait(
+            false, dispatch_message_addr, expected_num_workers_completed[i], clear_count);
+    }
+    this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->id);
+    this->manager.fetch_queue_reserve_back(this->id);
+    this->manager.fetch_queue_write(cmd_sequence_sizeB, this->id);
+
+    if (clear_count) {
+        std::fill(expected_num_workers_completed.begin(), expected_num_workers_completed.begin() + num_sub_devices, 0);
+    }
 }
 
 HWCommandQueue::~HWCommandQueue() {
@@ -1932,20 +2061,20 @@ void HWCommandQueue::set_exit_condition() {
 }
 
 template <typename T>
-void HWCommandQueue::enqueue_command(T& command, bool blocking) {
+void HWCommandQueue::enqueue_command(T& command, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids) {
     command.process();
     if (blocking) {
-        this->finish();
+        this->finish(sub_device_ids);
     }
 }
 
-void HWCommandQueue::enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking) {
-    this->enqueue_read_buffer(*buffer, dst, blocking);
+void HWCommandQueue::enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids) {
+    this->enqueue_read_buffer(*buffer, dst, blocking, sub_device_ids);
 }
 
 // Read buffer command is enqueued in the issue region and device writes requested buffer data into the completion
 // region
-void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking) {
+void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_read_buffer");
     TT_FATAL(!this->manager.get_bypass_mode(), "Enqueue Read Buffer cannot be used with tracing");
 
@@ -1957,6 +2086,8 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
     uint32_t pages_to_read = buffer.num_pages();
     uint32_t unpadded_dst_offset = 0;
     uint32_t src_page_index = 0;
+
+    auto expected_workers_completed = this->get_expected_workers_completed(sub_device_ids);
 
     if (is_sharded(buffer.buffer_layout())) {
         const bool width_split = buffer.shard_spec().shape_in_pages()[1] != buffer.shard_spec().tensor2d_shape[1];
@@ -2001,7 +2132,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
                     buffer,
                     dst,
                     this->manager,
-                    this->expected_num_workers_completed,
+                    expected_workers_completed,
                     cores[core_id],
                     bank_base_address,
                     src_page_index,
@@ -2019,12 +2150,12 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
                     buffer_page_mapping));
 
                 src_page_index += num_pages_to_read;
-                this->enqueue_command(command, false);
+                this->enqueue_command(command, false, sub_device_ids);
                 this->increment_num_entries_in_completion_q();
             }
         }
         if (blocking) {
-            this->finish();
+            this->finish(sub_device_ids);
         }
     } else {
         // this is a streaming command so we don't need to break down to multiple
@@ -2035,7 +2166,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
             buffer,
             dst,
             this->manager,
-            this->expected_num_workers_completed,
+            expected_workers_completed,
             src_page_index,
             pages_to_read);
 
@@ -2048,45 +2179,39 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
             unpadded_dst_offset,
             pages_to_read,
             src_page_index));
-        this->enqueue_command(command, blocking);
+        this->enqueue_command(command, blocking, sub_device_ids);
         this->increment_num_entries_in_completion_q();
     }
 }
 
 void HWCommandQueue::enqueue_write_buffer(
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking) {
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids) {
     // Top level API to accept different variants for buffer and src
     // For shared pointer variants, object lifetime is guaranteed at least till the end of this function
-    std::visit(
-        [this, &buffer, &blocking](auto&& data) {
-            using T = std::decay_t<decltype(data)>;
-            std::visit(
-                [this, &buffer, &blocking, &data](auto&& b) {
-                    using type_buf = std::decay_t<decltype(b)>;
-                    if constexpr (std::is_same_v<T, const void*>) {
-                        if constexpr (std::is_same_v<type_buf, std::shared_ptr<Buffer>>) {
-                            this->enqueue_write_buffer(*b, data, blocking);
-                        } else if constexpr (std::is_same_v<type_buf, std::reference_wrapper<Buffer>>) {
-                            this->enqueue_write_buffer(b.get(), data, blocking);
-                        }
-                    } else {
-                        if constexpr (std::is_same_v<type_buf, std::shared_ptr<Buffer>>) {
-                            this->enqueue_write_buffer(*b, data.get()->data(), blocking);
-                        } else if constexpr (std::is_same_v<type_buf, std::reference_wrapper<Buffer>>) {
-                            this->enqueue_write_buffer(b.get(), data.get()->data(), blocking);
-                        }
-                    }
-                },
-                buffer);
-        },
-        src);
+    auto data = std::visit([&](auto&& data) -> const void* {
+        using T = std::decay_t<decltype(data)>;
+        if constexpr (std::is_same_v<T, const void*>) {
+            return data;
+        } else {
+            return data->data();
+        }
+    }, src);
+    auto& b = std::visit([&](auto&& b) -> Buffer& {
+        using type_buf = std::decay_t<decltype(b)>;
+        if constexpr (std::is_same_v<type_buf, std::shared_ptr<Buffer>>) {
+            return *b;
+        } else {
+            return b.get();
+        }
+    }, buffer);
+    this->enqueue_write_buffer(b, data, blocking, sub_device_ids);
 }
 
 CoreType HWCommandQueue::get_dispatch_core_type() {
     return dispatch_core_manager::instance().get_dispatch_core_type(device->id());
 }
 
-void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking) {
+void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_write_buffer");
     TT_FATAL(!this->manager.get_bypass_mode(), "Enqueue Write Buffer cannot be used with tracing");
 
@@ -2099,6 +2224,8 @@ void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool 
         max_prefetch_command_size - (CQ_PREFETCH_CMD_BARE_MIN_SIZE * 2);  // * 2 to account for issue
 
     uint32_t dst_page_index = 0;
+
+    auto expected_workers_completed = this->get_expected_workers_completed(sub_device_ids);
 
     if (is_sharded(buffer.buffer_layout())) {
         const bool width_split = buffer.shard_spec().shape_in_pages()[1] != buffer.shard_spec().tensor2d_shape[1];
@@ -2167,7 +2294,7 @@ void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool 
                         src,
                         this->manager,
                         issue_wait,
-                        this->expected_num_workers_completed,
+                        expected_workers_completed,
                         address,
                         buffer_page_mapping,
                         cores[core_id],
@@ -2175,7 +2302,7 @@ void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool 
                         dst_page_index,
                         pages_to_write);
 
-                    this->enqueue_command(command, false);
+                    this->enqueue_command(command, false, sub_device_ids);
                     curr_page_idx_in_shard += pages_to_write;
                     num_pages -= pages_to_write;
                     dst_page_index += pages_to_write;
@@ -2258,13 +2385,13 @@ void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool 
                 src,
                 this->manager,
                 issue_wait,
-                this->expected_num_workers_completed,
+                expected_workers_completed,
                 bank_base_address,
                 page_size_to_write,
                 dst_page_index,
                 num_pages_to_write);
             this->enqueue_command(
-                command, false);  // don't block until the entire src data is enqueued in the issue queue
+                command, false, sub_device_ids);  // don't block until the entire src data is enqueued in the issue queue
 
             total_pages_to_write -= num_pages_to_write;
             dst_page_index += num_pages_to_write;
@@ -2272,18 +2399,21 @@ void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool 
     }
 
     if (blocking) {
-        this->finish();
+        this->finish(sub_device_ids);
     }
 }
 
 void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     ZoneScopedN("HWCommandQueue_enqueue_program");
+    std::vector<uint32_t> sub_device_ids = {program.determine_sub_device_ids(device)};
+    TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
     if (not program.is_finalized()) {
         program.finalize(device);
         TT_FATAL(!this->manager.get_bypass_mode(), "Tracing should only be used when programs have been cached");
         if (const auto &kernels_buffer = program.get_kernels_buffer()) {
+            // Only stall for used sub-devices
             this->enqueue_write_buffer(
-                *kernels_buffer, program.get_program_transfer_info().binary_data.data(), false);
+                *kernels_buffer, program.get_program_transfer_info().binary_data.data(), false, sub_device_ids);
         }
     }
 
@@ -2294,32 +2424,33 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         TT_FATAL(!this->manager.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
         if (const auto &buffer = program.get_kernels_buffer()) {
             std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
-            this->enqueue_read_buffer(*buffer, read_data.data(), true);
+            this->enqueue_read_buffer(*buffer, read_data.data(), true, sub_device_ids);
             TT_FATAL(
                 program.get_program_transfer_info().binary_data == read_data,
                 "Binary for program to be executed is corrupted. Another program likely corrupted this binary");
         }
     }
 #endif
+    auto sub_device_id = sub_device_ids[0];
 
     // Snapshot of expected workers from previous programs, used for dispatch_wait cmd generation.
-    uint32_t expected_workers_completed = this->manager.get_bypass_mode() ? this->trace_ctx->num_completion_worker_cores
-                                                                          : this->expected_num_workers_completed;
+    uint32_t expected_workers_completed = this->manager.get_bypass_mode() ? this->trace_ctx->descriptors[sub_device_id].num_completion_worker_cores
+                                                                          : this->expected_num_workers_completed[sub_device_id];
     if (this->manager.get_bypass_mode()) {
         if (program.runs_on_noc_multicast_only_cores()) {
-            this->trace_ctx->num_traced_programs_needing_go_signal_multicast++;
-            this->trace_ctx->num_completion_worker_cores += device->num_worker_cores();
+            this->trace_ctx->descriptors[sub_device_id].num_traced_programs_needing_go_signal_multicast++;
+            this->trace_ctx->descriptors[sub_device_id].num_completion_worker_cores += device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
         }
         if (program.runs_on_noc_unicast_only_cores()) {
-            this->trace_ctx->num_traced_programs_needing_go_signal_unicast++;
-            this->trace_ctx->num_completion_worker_cores += device->num_eth_worker_cores();
+            this->trace_ctx->descriptors[sub_device_id].num_traced_programs_needing_go_signal_unicast++;
+            this->trace_ctx->descriptors[sub_device_id].num_completion_worker_cores += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
         }
     } else {
         if (program.runs_on_noc_multicast_only_cores()) {
-            this->expected_num_workers_completed += device->num_worker_cores();
+            this->expected_num_workers_completed[sub_device_id] += device->num_worker_cores(HalProgrammableCoreType::TENSIX,sub_device_id);
         }
         if (program.runs_on_noc_unicast_only_cores()) {
-            this->expected_num_workers_completed += device->num_eth_worker_cores();
+            this->expected_num_workers_completed[sub_device_id] += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
         }
     }
 
@@ -2330,26 +2461,27 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         program,
         this->physical_enqueue_program_dispatch_core,
         this->manager,
-        this->config_buffer_mgr,
+        this->config_buffer_mgr[sub_device_id],
         expected_workers_completed,
         // The assembled program command will encode the location of the launch messages in the ring buffer
-        this->device->worker_launch_message_buffer_state.get_mcast_wptr(),
-        this->device->worker_launch_message_buffer_state.get_unicast_wptr());
+        this->device->worker_launch_message_buffer_state[sub_device_id].get_mcast_wptr(),
+        this->device->worker_launch_message_buffer_state[sub_device_id].get_unicast_wptr(),
+        sub_device_id);
     // Update wptrs for tensix and eth launch message in the device class
     if (program.runs_on_noc_multicast_only_cores()) {
-        this->device->worker_launch_message_buffer_state.inc_mcast_wptr(1);
+        this->device->worker_launch_message_buffer_state[sub_device_id].inc_mcast_wptr(1);
     }
     if (program.runs_on_noc_unicast_only_cores()) {
-        this->device->worker_launch_message_buffer_state.inc_unicast_wptr(1);
+        this->device->worker_launch_message_buffer_state[sub_device_id].inc_unicast_wptr(1);
     }
-    this->enqueue_command(command, blocking);
+    this->enqueue_command(command, blocking, sub_device_ids);
 
 #ifdef DEBUG
     if (tt::llrt::OptionsG.get_validate_kernel_binaries()) {
         TT_FATAL(!this->manager.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
         if (const auto& buffer = program.get_kernels_buffer()) {
             std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
-            this->enqueue_read_buffer(*buffer, read_data.data(), true);
+            this->enqueue_read_buffer(*buffer, read_data.data(), true, sub_device_ids);
             TT_FATAL(
                 program.get_program_transfer_info().binary_data == read_data,
                 "Binary for program that executed is corrupted. This program likely corrupted its own binary.");
@@ -2365,7 +2497,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         expected_workers_completed);
 }
 
-void HWCommandQueue::enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count) {
+void HWCommandQueue::enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count, tt::stl::Span<const uint32_t> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_enqueue_record_event");
 
     TT_FATAL(!this->manager.get_bypass_mode(), "Enqueue Record Event cannot be used with tracing");
@@ -2378,19 +2510,23 @@ void HWCommandQueue::enqueue_record_event(const std::shared_ptr<Event>& event, b
     event->device = this->device;
     event->ready = true;  // what does this mean???
 
+    auto expected_workers_completed = this->get_expected_workers_completed(sub_device_ids);
+
     auto command = EnqueueRecordEventCommand(
         this->id,
         this->device,
         this->noc_index,
         this->manager,
         event->event_id,
-        this->expected_num_workers_completed,
+        expected_workers_completed,
         clear_count,
         true);
-    this->enqueue_command(command, false);
+    this->enqueue_command(command, false, sub_device_ids);
 
     if (clear_count) {
-        this->expected_num_workers_completed = 0;
+        for (const auto&[id, _] : expected_workers_completed) {
+            this->expected_num_workers_completed[id] = 0;
+        }
     }
     this->issued_completion_q_reads.push(
         std::make_shared<detail::CompletionReaderVariant>(std::in_place_type<detail::ReadEventDescriptor>, event->event_id));
@@ -2401,7 +2537,7 @@ void HWCommandQueue::enqueue_wait_for_event(const std::shared_ptr<Event>& sync_e
     ZoneScopedN("HWCommandQueue_enqueue_wait_for_event");
 
     auto command = EnqueueWaitForEventCommand(this->id, this->device, this->manager, *sync_event, clear_count);
-    this->enqueue_command(command, false);
+    this->enqueue_command(command, false, {});
 
     if (clear_count) {
         this->manager.reset_event_id(this->id);
@@ -2415,29 +2551,28 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
     auto command = EnqueueTraceCommand(
         this->id, this->device, this->manager, trace_inst->desc, *trace_inst->buffer, this->expected_num_workers_completed, this->noc_index, this->physical_enqueue_program_dispatch_core);
 
-    this->enqueue_command(command, false);
+    this->enqueue_command(command, false, {});
 
-    // Increment the expected worker cores counter due to trace programs completion
-    this->expected_num_workers_completed += trace_inst->desc->num_completion_worker_cores;
-    // After trace runs, the rdptr on each worker will be incremented by the number of programs in the trace
-    // Update the wptr on host to match state. If the trace doesn't execute on a
-    // class of worker (unicast or multicast), it doesn't reset or modify the
-    // state for those workers.
-    if (trace_inst->desc->num_traced_programs_needing_go_signal_multicast) {
-        this->device->worker_launch_message_buffer_state.set_mcast_wptr(
-            trace_inst->desc->num_traced_programs_needing_go_signal_multicast);
+    for (const auto& [index, desc]: trace_inst->desc->descriptors) {
+         // Increment the expected worker cores counter due to trace programs completion
+        this->expected_num_workers_completed[index] += desc.num_completion_worker_cores;
+        // After trace runs, the rdptr on each worker will be incremented by the number of programs in the trace
+        // Update the wptr on host to match state. If the trace doesn't execute on a
+        // class of worker (unicast or multicast), it doesn't reset or modify the
+        // state for those workers.
+        if (desc.num_traced_programs_needing_go_signal_multicast) {
+            this->device->worker_launch_message_buffer_state[index].set_mcast_wptr(desc.num_traced_programs_needing_go_signal_multicast);
+        }
+        if (desc.num_traced_programs_needing_go_signal_unicast) {
+            this->device->worker_launch_message_buffer_state[index].set_unicast_wptr(desc.num_traced_programs_needing_go_signal_unicast);
+        }
+        // The config buffer manager is unaware of what memory is used inside the trace, so mark all memory as used so that
+        // it will force a stall and avoid stomping on in-use state.
+        // TODO(jbauman): Reuse old state from the trace.
+        this->config_buffer_mgr[index].mark_completely_full(this->expected_num_workers_completed[index]);
     }
-    if (trace_inst->desc->num_traced_programs_needing_go_signal_unicast) {
-        this->device->worker_launch_message_buffer_state.set_unicast_wptr(
-            trace_inst->desc->num_traced_programs_needing_go_signal_unicast);
-    }
-    // The config buffer manager is unaware of what memory is used inside the trace, so mark all memory as used so that
-    // it will force a stall and avoid stomping on in-use state.
-    // TODO(jbauman): Reuse old state from the trace.
-    this->config_buffer_mgr.mark_completely_full(this->expected_num_workers_completed);
-
     if (blocking) {
-        this->finish();
+        this->finish(trace_inst->desc->sub_device_ids);
     }
 }
 
@@ -2698,11 +2833,11 @@ void HWCommandQueue::read_completion_queue() {
     }
 }
 
-void HWCommandQueue::finish() {
+void HWCommandQueue::finish(tt::stl::Span<const uint32_t> sub_device_ids) {
     ZoneScopedN("HWCommandQueue_finish");
     tt::log_debug(tt::LogDispatch, "Finish for command queue {}", this->id);
     std::shared_ptr<Event> event = std::make_shared<Event>();
-    this->enqueue_record_event(event);
+    this->enqueue_record_event(event, false, sub_device_ids);
     if (tt::llrt::OptionsG.get_test_mode_enabled()) {
         while (this->num_entries_in_completion_q > this->num_completed_completion_q_reads) {
             if (DPrintServerHangDetected()) {
@@ -2729,55 +2864,84 @@ volatile bool HWCommandQueue::is_dprint_server_hung() { return dprint_server_han
 volatile bool HWCommandQueue::is_noc_hung() { return illegal_noc_txn_hang; }
 
 void HWCommandQueue::record_begin(const uint32_t tid, std::shared_ptr<detail::TraceDescriptor> ctx) {
+    uint32_t num_sub_devices = this->device->num_sub_devices();
     // Issue event as a barrier and a counter reset
     uint32_t cmd_sequence_sizeB = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
     if (this->device->distributed_dispatcher()) {
         // wait on dispatch_s before issuing counter reset
         cmd_sequence_sizeB += CQ_PREFETCH_CMD_BARE_MIN_SIZE;
     }
+    cmd_sequence_sizeB *= num_sub_devices;
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device->id());
-    uint32_t dispatch_message_addr = dispatch_constants::get(
+    uint32_t dispatch_message_base_addr = dispatch_constants::get(
         dispatch_core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_MESSAGE);
-    if (this->device->distributed_dispatcher()) {
-        // wait on dispatch_s before issuing counter reset
-        command_sequence.add_dispatch_wait(false, dispatch_message_addr, this->expected_num_workers_completed, true, false, true, 1);
+
+    // Currently Trace will track all sub_devices
+    // Potentially support tracking only used sub_devices in the future
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(i);
+        if (this->device->distributed_dispatcher()) {
+            // wait on dispatch_s before issuing counter reset
+            command_sequence.add_dispatch_wait(false, dispatch_message_addr, this->expected_num_workers_completed[i], true, false, true, 1);
+        }
+        // dispatch_d waits for latest non-zero counter from dispatch_s and then clears its local counter
+        command_sequence.add_dispatch_wait(false, dispatch_message_addr, this->expected_num_workers_completed[i], true);
     }
-    // dispatch_d waits for latest non-zero counter from dispatch_s and then clears its local counter
-    command_sequence.add_dispatch_wait(false, dispatch_message_addr, this->expected_num_workers_completed, true);
 
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->id);
     this->manager.fetch_queue_reserve_back(this->id);
     this->manager.fetch_queue_write(cmd_sequence_sizeB, this->id);
-    this->expected_num_workers_completed = 0;
+    std::fill(this->expected_num_workers_completed.begin(), this->expected_num_workers_completed.begin() + num_sub_devices, 0);
     // Record commands using bypass mode
     this->tid = tid;
     this->trace_ctx = ctx;
     // Record original value of launch msg wptr
-    this->multicast_cores_launch_message_wptr_reset = this->device->worker_launch_message_buffer_state.get_mcast_wptr();
-    this->unicast_cores_launch_message_wptr_reset = this->device->worker_launch_message_buffer_state.get_unicast_wptr();
-    // Set launch msg wptr to 0. Every time trace runs on device, it will ensure that the workers
-    // reset their rptr to be in sync with device.
-    this->device->worker_launch_message_buffer_state.reset();
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        this->multicast_cores_launch_message_wptr_reset[i] = this->device->worker_launch_message_buffer_state[i].get_mcast_wptr();
+        this->unicast_cores_launch_message_wptr_reset[i] = this->device->worker_launch_message_buffer_state[i].get_unicast_wptr();
+        // Set launch msg wptr to 0. Every time trace runs on device, it will ensure that the workers
+        // reset their rptr to be in sync with device.
+        this->device->worker_launch_message_buffer_state[i].reset();
+    }
     this->manager.set_bypass_mode(true, true);  // start
-    // Sync values in the trace need to match up with the counter starting at 0 again.
-    this->config_buffer_mgr.mark_completely_full(this->expected_num_workers_completed);
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        // Sync values in the trace need to match up with the counter starting at 0 again.
+        this->config_buffer_mgr[i].mark_completely_full(this->expected_num_workers_completed[i]);
+    }
 }
 
 void HWCommandQueue::record_end() {
-    this->tid = std::nullopt;
-    this->trace_ctx = nullptr;
+    auto &trace_data = this->trace_ctx->data;
+    trace_data = std::move(this->manager.get_bypass_data());
+    // Add command to terminate the trace buffer
+    DeviceCommand command_sequence(CQ_PREFETCH_CMD_BARE_MIN_SIZE);
+    command_sequence.add_prefetch_exec_buf_end();
+    for (int i = 0; i < command_sequence.size_bytes() / sizeof(uint32_t); i++) {
+        trace_data.push_back(((uint32_t*)command_sequence.data())[i]);
+    }
+    // Currently Trace will track all sub_devices
+    uint32_t num_sub_devices = this->device->num_sub_devices();
     // Reset the launch msg wptrs to their original value, so device can run programs after a trace
     // was captured. This is needed since trace capture modifies the wptr state on host, even though device
     // doesn't run any programs.
-    this->device->worker_launch_message_buffer_state.set_mcast_wptr(this->multicast_cores_launch_message_wptr_reset);
-    this->device->worker_launch_message_buffer_state.set_unicast_wptr(this->unicast_cores_launch_message_wptr_reset);
-    this->manager.set_bypass_mode(false, false);  // stop
-    // config_buffer_mgr reflects the state inside the trace, not on the current device, so reset it.
-    // TODO(jbauman): Use a temporary WorkingBufferSetMgr when recording a trace.
-    this->config_buffer_mgr.mark_completely_full(this->expected_num_workers_completed);
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        this->device->worker_launch_message_buffer_state[i].set_mcast_wptr(this->multicast_cores_launch_message_wptr_reset[i]);
+        this->device->worker_launch_message_buffer_state[i].set_unicast_wptr(this->unicast_cores_launch_message_wptr_reset[i]);
+    }
+    // Copy the desc keys into a separate vector. When enqueuing traces, we sometimes need to pass sub-device ids separately
+    this->trace_ctx->sub_device_ids.reserve(this->trace_ctx->descriptors.size());
+    for (const auto& [index, _]: this->trace_ctx->descriptors) {
+        this->trace_ctx->sub_device_ids.push_back(index);
+        // config_buffer_mgr reflects the state inside the trace, not on the current device, so reset it.
+        // TODO(jbauman): Use a temporary WorkingBufferSetMgr when recording a trace.
+        this->config_buffer_mgr[index].mark_completely_full(this->expected_num_workers_completed[index]);
+    }
+    this->tid = std::nullopt;
+    this->trace_ctx = nullptr;
+    this->manager.set_bypass_mode(false, true);  // stop
 }
 
 void HWCommandQueue::terminate() {
@@ -2785,8 +2949,45 @@ void HWCommandQueue::terminate() {
     TT_FATAL(!this->manager.get_bypass_mode(), "Terminate cannot be used with tracing");
     tt::log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id);
     auto command = EnqueueTerminateCommand(this->id, this->device, this->manager);
-    this->enqueue_command(command, false);
+    this->enqueue_command(command, false, {});
 }
+
+WorkerConfigBufferMgr& HWCommandQueue::get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr[index]; }
+
+void HWCommandQueue::reset_config_buffer_mgr(const uint32_t max_index) {
+    for (uint32_t i = 0; i < max_index; ++i) {
+        this->config_buffer_mgr[i] = WorkerConfigBufferMgr();
+        for (uint32_t index = 0; index < tt::tt_metal::hal.get_programmable_core_type_count(); index++) {
+            this->config_buffer_mgr[i].init_add_buffer(
+                tt::tt_metal::hal.get_dev_addr(
+                    tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
+                tt::tt_metal::hal.get_dev_size(
+                    tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG));
+        }
+        // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the previous
+        // launch message.
+        this->config_buffer_mgr[i].init_add_buffer(0, launch_msg_buffer_num_entries - 1);
+    }
+}
+
+std::vector<std::pair<uint32_t, uint32_t>> HWCommandQueue::get_expected_workers_completed(tt::stl::Span<const uint32_t> sub_device_ids) const {
+    std::vector<std::pair<uint32_t, uint32_t>> expected_workers_completed;
+    if (sub_device_ids.empty()) {
+        expected_workers_completed.reserve(this->device->num_sub_devices());
+        for (uint32_t i = 0; i < this->device->num_sub_devices(); ++i) {
+            expected_workers_completed.emplace_back(i, this->expected_num_workers_completed[i]);
+        }
+    } else {
+        expected_workers_completed.reserve(sub_device_ids.size());
+        for (uint32_t i = 0; i < sub_device_ids.size(); ++i) {
+            auto sub_device_id = sub_device_ids[i];
+            TT_FATAL(sub_device_id < this->device->num_sub_devices(), "Invalid sub_device_id: {}", sub_device_id);
+            expected_workers_completed.emplace_back(sub_device_id, this->expected_num_workers_completed[sub_device_id]);
+        }
+    }
+    return expected_workers_completed;
+}
+
 
 void EnqueueAddBufferToProgramImpl(
     const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
@@ -2861,7 +3062,8 @@ void EnqueueReadBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<uint32_t>& dst,
-    bool blocking) {
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids) {
     // TODO(agrebenisan): Move to deprecated
     ZoneScoped;
     tt_metal::detail::DispatchStateCheck(true);
@@ -2884,36 +3086,39 @@ void EnqueueReadBuffer(
         buffer);
 
     // TODO(agrebenisan): Move to deprecated
-    EnqueueReadBuffer(cq, buffer, dst.data(), blocking);
+    EnqueueReadBuffer(cq, buffer, dst.data(), blocking, sub_device_ids);
 }
 
 void EnqueueWriteBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<uint32_t>& src,
-    bool blocking) {
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids) {
     // TODO(agrebenisan): Move to deprecated
-    EnqueueWriteBuffer(cq, buffer, src.data(), blocking);
+    EnqueueWriteBuffer(cq, buffer, src.data(), blocking, sub_device_ids);
 }
 
 void EnqueueReadBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
-    bool blocking) {
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids) {
     detail::DispatchStateCheck(true);
     cq.run_command(CommandInterface{
-        .type = EnqueueCommandType::ENQUEUE_READ_BUFFER, .blocking = blocking, .buffer = buffer, .dst = dst});
+        .type = EnqueueCommandType::ENQUEUE_READ_BUFFER, .blocking = blocking, .buffer = buffer, .dst = dst, .sub_device_ids = sub_device_ids});
 }
 
 void EnqueueWriteBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
-    bool blocking) {
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids) {
     detail::DispatchStateCheck(true);
     cq.run_command(CommandInterface{
-        .type = EnqueueCommandType::ENQUEUE_WRITE_BUFFER, .blocking = blocking, .buffer = buffer, .src = src});
+        .type = EnqueueCommandType::ENQUEUE_WRITE_BUFFER, .blocking = blocking, .buffer = buffer, .src = src, .sub_device_ids = sub_device_ids});
 }
 
 void EnqueueProgram(
@@ -2923,12 +3128,13 @@ void EnqueueProgram(
         CommandInterface{.type = EnqueueCommandType::ENQUEUE_PROGRAM, .blocking = blocking, .program = &program});
 }
 
-void EnqueueRecordEvent(CommandQueue& cq, const std::shared_ptr<Event>& event) {
+void EnqueueRecordEvent(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const uint32_t> sub_device_ids) {
     detail::DispatchStateCheck(true);
     cq.run_command(CommandInterface{
         .type = EnqueueCommandType::ENQUEUE_RECORD_EVENT,
         .blocking = false,
         .event = event,
+        .sub_device_ids = sub_device_ids
     });
 }
 
@@ -2977,9 +3183,9 @@ bool EventQuery(const std::shared_ptr<Event>& event) {
     return event_completed;
 }
 
-void Finish(CommandQueue& cq) {
+void Finish(CommandQueue& cq, tt::stl::Span<const uint32_t> sub_device_ids) {
     detail::DispatchStateCheck(true);
-    cq.run_command(CommandInterface{.type = EnqueueCommandType::FINISH, .blocking = true});
+    cq.run_command(CommandInterface{.type = EnqueueCommandType::FINISH, .blocking = true, .sub_device_ids = sub_device_ids});
     TT_ASSERT(
         !(cq.device()->hw_command_queue(cq.id()).is_dprint_server_hung()),
         "Command Queue could not finish: device hang due to unanswered DPRINT WAIT.");
@@ -3002,13 +3208,14 @@ void EnqueueReadBufferImpl(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
-    bool blocking) {
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids) {
     std::visit(
-        [&cq, dst, blocking](auto&& b) {
+        [&](auto&& b) {
             using T = std::decay_t<decltype(b)>;
             if constexpr (
                 std::is_same_v<T, std::reference_wrapper<Buffer>> || std::is_same_v<T, std::shared_ptr<Buffer>>) {
-                cq.hw_command_queue().enqueue_read_buffer(b, dst, blocking);
+                cq.hw_command_queue().enqueue_read_buffer(b, dst, blocking, sub_device_ids);
             }
         },
         buffer);
@@ -3018,8 +3225,9 @@ void EnqueueWriteBufferImpl(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
-    bool blocking) {
-    cq.hw_command_queue().enqueue_write_buffer(buffer, src, blocking);
+    bool blocking,
+    tt::stl::Span<const uint32_t> sub_device_ids) {
+    cq.hw_command_queue().enqueue_write_buffer(buffer, src, blocking, sub_device_ids);
 }
 
 void EnqueueProgramImpl(
@@ -3037,8 +3245,8 @@ void EnqueueProgramImpl(
 
 }
 
-void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event) {
-    cq.hw_command_queue().enqueue_record_event(event);
+void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    cq.hw_command_queue().enqueue_record_event(event, false, sub_device_ids);
 }
 
 void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event) {
@@ -3054,7 +3262,7 @@ void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& eve
     cq.hw_command_queue().enqueue_wait_for_event(event);
 }
 
-void FinishImpl(CommandQueue& cq) { cq.hw_command_queue().finish(); }
+void FinishImpl(CommandQueue& cq, tt::stl::Span<const uint32_t> sub_device_ids) { cq.hw_command_queue().finish(sub_device_ids); }
 
 void EnqueueTraceImpl(CommandQueue& cq, uint32_t trace_id, bool blocking) {
     cq.hw_command_queue().enqueue_trace(trace_id, blocking);
@@ -3218,13 +3426,13 @@ void CommandQueue::run_command_impl(const CommandInterface& command) {
             TT_ASSERT(command.dst.has_value(), "Must provide a dst!");
             TT_ASSERT(command.buffer.has_value(), "Must provide a buffer!");
             TT_ASSERT(command.blocking.has_value(), "Must specify blocking value!");
-            EnqueueReadBufferImpl(*this, command.buffer.value(), command.dst.value(), command.blocking.value());
+            EnqueueReadBufferImpl(*this, command.buffer.value(), command.dst.value(), command.blocking.value(), command.sub_device_ids);
             break;
         case EnqueueCommandType::ENQUEUE_WRITE_BUFFER:
             TT_ASSERT(command.src.has_value(), "Must provide a src!");
             TT_ASSERT(command.buffer.has_value(), "Must provide a buffer!");
             TT_ASSERT(command.blocking.has_value(), "Must specify blocking value!");
-            EnqueueWriteBufferImpl(*this, command.buffer.value(), command.src.value(), command.blocking.value());
+            EnqueueWriteBufferImpl(*this, command.buffer.value(), command.src.value(), command.blocking.value(), command.sub_device_ids);
             break;
         case EnqueueCommandType::GET_BUF_ADDR:
             TT_ASSERT(command.dst.has_value(), "Must provide a dst address!");
@@ -3250,13 +3458,13 @@ void CommandQueue::run_command_impl(const CommandInterface& command) {
             break;
         case EnqueueCommandType::ENQUEUE_RECORD_EVENT:
             TT_ASSERT(command.event.has_value(), "Must provide an event!");
-            EnqueueRecordEventImpl(*this, command.event.value());
+            EnqueueRecordEventImpl(*this, command.event.value(), command.sub_device_ids);
             break;
         case EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT:
             TT_ASSERT(command.event.has_value(), "Must provide an event!");
             EnqueueWaitForEventImpl(*this, command.event.value());
             break;
-        case EnqueueCommandType::FINISH: FinishImpl(*this); break;
+        case EnqueueCommandType::FINISH: FinishImpl(*this, command.sub_device_ids); break;
         case EnqueueCommandType::FLUSH:
             // Used by CQ to push prior commands
             break;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -79,7 +79,8 @@ class EnqueueReadBufferCommand : public Command {
     Device* device;
     uint32_t command_queue_id;
     NOC noc_index;
-    tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed;
+    tt::stl::Span<const uint32_t> expected_num_workers_completed;
+    tt::stl::Span<const SubDeviceId> sub_device_ids;
     uint32_t src_page_index;
     uint32_t pages_to_read;
 
@@ -92,7 +93,8 @@ class EnqueueReadBufferCommand : public Command {
         Buffer& buffer,
         void* dst,
         SystemMemoryManager& manager,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         uint32_t src_page_index = 0,
         std::optional<uint32_t> pages_to_read = std::nullopt);
 
@@ -115,7 +117,8 @@ class EnqueueReadInterleavedBufferCommand : public EnqueueReadBufferCommand {
         Buffer& buffer,
         void* dst,
         SystemMemoryManager& manager,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         uint32_t src_page_index = 0,
         std::optional<uint32_t> pages_to_read = std::nullopt) :
         EnqueueReadBufferCommand(
@@ -126,6 +129,7 @@ class EnqueueReadInterleavedBufferCommand : public EnqueueReadBufferCommand {
             dst,
             manager,
             expected_num_workers_completed,
+            sub_device_ids,
             src_page_index,
             pages_to_read) {}
 };
@@ -144,7 +148,8 @@ class EnqueueReadShardedBufferCommand : public EnqueueReadBufferCommand {
         Buffer& buffer,
         void* dst,
         SystemMemoryManager& manager,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         const CoreCoord& core,
         uint32_t bank_base_address,
         uint32_t src_page_index = 0,
@@ -157,6 +162,7 @@ class EnqueueReadShardedBufferCommand : public EnqueueReadBufferCommand {
             dst,
             manager,
             expected_num_workers_completed,
+            sub_device_ids,
             src_page_index,
             pages_to_read),
         core(core),
@@ -179,7 +185,8 @@ class EnqueueWriteBufferCommand : public Command {
     NOC noc_index;
     const void* src;
     const Buffer& buffer;
-    tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed;
+    tt::stl::Span<const uint32_t> expected_num_workers_completed;
+    tt::stl::Span<const SubDeviceId> sub_device_ids;
     uint32_t bank_base_address;
     uint32_t padded_page_size;
     uint32_t dst_page_index;
@@ -195,7 +202,8 @@ class EnqueueWriteBufferCommand : public Command {
         const void* src,
         SystemMemoryManager& manager,
         bool issue_wait,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         uint32_t bank_base_address,
         uint32_t padded_page_size,
         uint32_t dst_page_index = 0,
@@ -222,7 +230,8 @@ class EnqueueWriteInterleavedBufferCommand : public EnqueueWriteBufferCommand {
         const void* src,
         SystemMemoryManager& manager,
         bool issue_wait,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         uint32_t bank_base_address,
         uint32_t padded_page_size,
         uint32_t dst_page_index = 0,
@@ -236,6 +245,7 @@ class EnqueueWriteInterleavedBufferCommand : public EnqueueWriteBufferCommand {
             manager,
             issue_wait,
             expected_num_workers_completed,
+            sub_device_ids,
             bank_base_address,
             padded_page_size,
             dst_page_index,
@@ -261,7 +271,8 @@ class EnqueueWriteShardedBufferCommand : public EnqueueWriteBufferCommand {
         const void* src,
         SystemMemoryManager& manager,
         bool issue_wait,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         uint32_t bank_base_address,
         const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping,
         const CoreCoord& core,
@@ -277,6 +288,7 @@ class EnqueueWriteShardedBufferCommand : public EnqueueWriteBufferCommand {
             manager,
             issue_wait,
             expected_num_workers_completed,
+            sub_device_ids,
             bank_base_address,
             padded_page_size,
             dst_page_index,
@@ -346,7 +358,8 @@ class EnqueueRecordEventCommand : public Command {
     NOC noc_index;
     SystemMemoryManager& manager;
     uint32_t event_id;
-    tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed;
+    tt::stl::Span<const uint32_t> expected_num_workers_completed;
+    tt::stl::Span<const SubDeviceId> sub_device_ids;
     bool clear_count;
     bool write_barrier;
 
@@ -357,7 +370,8 @@ class EnqueueRecordEventCommand : public Command {
         NOC noc_index,
         SystemMemoryManager& manager,
         uint32_t event_id,
-        tt::stl::Span<const std::pair<uint32_t, uint32_t>> expected_num_workers_completed,
+        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
         bool clear_count = false,
         bool write_barrier = true);
 
@@ -511,6 +525,7 @@ class HWCommandQueue {
     void record_begin(const uint32_t tid, std::shared_ptr<detail::TraceDescriptor> ctx);
     void record_end();
     void set_num_worker_sems_on_dispatch(uint32_t num_worker_sems);
+    void set_go_signal_noc_data_on_dispatch(const vector_memcpy_aligned<uint32_t>& go_signal_noc_data);
     void reset_worker_state(bool reset_launch_msg_state);
 
    private:
@@ -571,9 +586,8 @@ class HWCommandQueue {
     void increment_num_entries_in_completion_q();
     void set_exit_condition();
 
-    WorkerConfigBufferMgr& get_config_buffer_mgr(SubDeviceId sub_device_id);
+    WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index);
     void reset_config_buffer_mgr(const uint32_t num_entries);
-    std::vector<std::pair<uint32_t, uint32_t>> get_expected_workers_completed(tt::stl::Span<const SubDeviceId> sub_device_ids) const;
 
     friend void EnqueueTraceImpl(CommandQueue& cq, uint32_t trace_id, bool blocking);
     friend void EnqueueProgramImpl(

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -303,7 +303,7 @@ class EnqueueProgramCommand : public Command {
     uint32_t multicast_cores_launch_message_wptr = 0;
     uint32_t unicast_cores_launch_message_wptr = 0;
     // TODO: There will be multiple ids once programs support spanning multiple sub_devices
-    uint32_t sub_device_id = 0;
+    SubDeviceId sub_device_id = SubDeviceId{0};
 
    public:
     EnqueueProgramCommand(
@@ -317,7 +317,7 @@ class EnqueueProgramCommand : public Command {
         uint32_t expected_num_workers_completed,
         uint32_t multicast_cores_launch_message_wptr,
         uint32_t unicast_cores_launch_message_wptr,
-        uint32_t sub_device_id);
+        SubDeviceId sub_device_id);
 
     void assemble_preamble_commands(
         ProgramCommandSequence& program_command_sequence, const tt::stl::Span<ConfigBufferEntry> kernel_config_addrs);
@@ -555,25 +555,25 @@ class HWCommandQueue {
 
     // sub_device_ids only needs to be passed when blocking and there are specific sub_devices to wait on
     template <typename T>
-    void enqueue_command(T& command, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids);
+    void enqueue_command(T& command, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
 
-    void enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids);
-    void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids);
+    void enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
     void enqueue_write_buffer(
-        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids);
-    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking, tt::stl::Span<const uint32_t> sub_device_ids);
+        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
     void enqueue_program(Program& program, bool blocking);
-    void enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count = false, tt::stl::Span<const uint32_t> sub_device_ids = {});
+    void enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count = false, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void enqueue_wait_for_event(const std::shared_ptr<Event>& sync_event, bool clear_count = false);
     void enqueue_trace(const uint32_t trace_id, bool blocking);
-    void finish(tt::stl::Span<const uint32_t> sub_device_ids);
+    void finish(tt::stl::Span<const SubDeviceId> sub_device_ids);
     void terminate();
     void increment_num_entries_in_completion_q();
     void set_exit_condition();
 
-    WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index);
-    void reset_config_buffer_mgr(const uint32_t max_index);
-    std::vector<std::pair<uint32_t, uint32_t>> get_expected_workers_completed(tt::stl::Span<const uint32_t> sub_device_ids) const;
+    WorkerConfigBufferMgr& get_config_buffer_mgr(SubDeviceId sub_device_id);
+    void reset_config_buffer_mgr(const uint32_t num_entries);
+    std::vector<std::pair<uint32_t, uint32_t>> get_expected_workers_completed(tt::stl::Span<const SubDeviceId> sub_device_ids) const;
 
     friend void EnqueueTraceImpl(CommandQueue& cq, uint32_t trace_id, bool blocking);
     friend void EnqueueProgramImpl(
@@ -585,17 +585,17 @@ class HWCommandQueue {
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         void* dst,
         bool blocking,
-        tt::stl::Span<const uint32_t> sub_device_ids);
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
     friend void EnqueueWriteBufferImpl(
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
         bool blocking,
-        tt::stl::Span<const uint32_t> sub_device_ids);
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
     friend void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer);
     friend void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids);
     friend void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event);
-    friend void FinishImpl(CommandQueue& cq, tt::stl::Span<const uint32_t> sub_device_ids);
+    friend void FinishImpl(CommandQueue& cq, tt::stl::Span<const SubDeviceId> sub_device_ids);
     friend CommandQueue;
     friend Device;
     friend detail::Program_;
@@ -613,7 +613,7 @@ struct CommandInterface {
     std::optional<void*> dst;
     std::optional<std::shared_ptr<Event>> event;
     std::optional<uint32_t> trace_id;
-    tt::stl::Span<const uint32_t> sub_device_ids;
+    tt::stl::Span<const SubDeviceId> sub_device_ids;
 };
 
 inline namespace v0 {

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <climits>
 #include <magic_enum.hpp>
 #include <mutex>
 
@@ -67,8 +68,14 @@ struct dispatch_constants {
     using prefetch_q_entry_type = uint16_t;
 
     static constexpr uint8_t MAX_NUM_HW_CQS = 2;
+    // Currently arbitrary, can be adjusted as needed at the cost of more L1 memory
     static constexpr uint32_t DISPATCH_MESSAGE_ENTRIES = 16;
     static constexpr uint32_t DISPATCH_MESSAGES_MAX_OFFSET = std::numeric_limits<decltype(go_msg_t::dispatch_message_offset)>::max();
+    static_assert(dispatch_constants::DISPATCH_MESSAGE_ENTRIES <= sizeof(decltype(CQDispatchCmd::notify_dispatch_s_go_signal.index_bitmask)) * CHAR_BIT);
+    // Currently arbitrary, can be adjusted as needed at the cost of more static memory
+    static constexpr uint32_t DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES = 64;
+    static constexpr uint32_t GO_SIGNAL_BITS_PER_TXN_TYPE = 4;
+    static constexpr uint32_t GO_SIGNAL_MAX_TXNS_PER_TYPE = 1 << GO_SIGNAL_BITS_PER_TXN_TYPE - 1;
 
     static constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;
 

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -33,8 +33,9 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     // Max of 2 CQs. COMPLETION_Q*_LAST_EVENT_PTR track the last completed event in the respective CQs
     COMPLETION_Q0_LAST_EVENT = 4,
     COMPLETION_Q1_LAST_EVENT = 5,
-    DISPATCH_MESSAGE = 6,
-    UNRESERVED = 7
+    DISPATCH_S_SYNC_SEM = 6,
+    DISPATCH_MESSAGE = 7,
+    UNRESERVED = 8
 };
 
 enum class CommandQueueHostAddrType : uint8_t {
@@ -63,8 +64,12 @@ struct dispatch_constants {
         return *inst;
     }
 
+    using prefetch_q_entry_type = uint16_t;
+
     static constexpr uint8_t MAX_NUM_HW_CQS = 2;
-    typedef uint16_t prefetch_q_entry_type;
+    static constexpr uint32_t DISPATCH_MESSAGE_ENTRIES = 16;
+    static constexpr uint32_t DISPATCH_MESSAGES_MAX_OFFSET = std::numeric_limits<decltype(go_msg_t::dispatch_message_offset)>::max();
+
     static constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;
 
     static constexpr uint32_t LOG_TRANSFER_PAGE_SIZE = 12;
@@ -127,6 +132,12 @@ struct dispatch_constants {
         return tt::utils::underlying_type<CommandQueueHostAddrType>(host_addr) * tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
     }
 
+    uint32_t get_dispatch_message_offset(uint32_t index) const {
+        TT_ASSERT(index < DISPATCH_MESSAGE_ENTRIES);
+        uint32_t offset = index * hal.get_alignment(HalMemType::L1);
+        return offset;
+    }
+
    private:
     dispatch_constants(const CoreType &core_type, const uint32_t num_hw_cqs) {
         TT_ASSERT(core_type == CoreType::WORKER or core_type == CoreType::ETH);
@@ -159,6 +170,7 @@ struct dispatch_constants {
         TT_ASSERT(cmddat_q_size_ >= 2 * max_prefetch_command_size_);
         TT_ASSERT(scratch_db_size_ % 2 == 0);
         TT_ASSERT((dispatch_buffer_block_size & (dispatch_buffer_block_size - 1)) == 0);
+        TT_ASSERT(DISPATCH_MESSAGE_ENTRIES <= DISPATCH_MESSAGES_MAX_OFFSET / L1_ALIGNMENT + 1, "Number of dispatch message entries exceeds max representable offset");
 
         uint32_t pcie_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
         uint32_t l1_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1);
@@ -170,8 +182,10 @@ struct dispatch_constants {
                 device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
             } else if (dev_addr_type == CommandQueueDeviceAddrType::PREFETCH_Q_PCIE_RD) {
                 device_cq_addr_sizes_[dev_addr_idx] = l1_alignment - sizeof(uint32_t);
+            } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM) {
+                device_cq_addr_sizes_[dev_addr_idx] = DISPATCH_MESSAGE_ENTRIES * l1_alignment;
             } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_MESSAGE) {
-                device_cq_addr_sizes_[dev_addr_idx] = 32; // Should this be 2x l1_alignment?
+                device_cq_addr_sizes_[dev_addr_idx] = DISPATCH_MESSAGE_ENTRIES * l1_alignment;
             } else {
                 device_cq_addr_sizes_[dev_addr_idx] = l1_alignment;
             }
@@ -531,7 +545,7 @@ class SystemMemoryManager {
 
     bool get_bypass_mode() { return this->bypass_enable; }
 
-    std::vector<uint32_t> get_bypass_data() { return std::move(this->bypass_buffer); }
+    std::vector<uint32_t>& get_bypass_data() { return this->bypass_buffer; }
 
     uint32_t get_issue_queue_size(const uint8_t cq_id) const { return this->cq_interfaces[cq_id].issue_fifo_size << 4; }
 

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -49,7 +49,7 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_TERMINATE = 14,         // quit
     CQ_DISPATCH_CMD_SEND_GO_SIGNAL = 15,
     CQ_DISPATCH_NOTIFY_SLAVE_GO_SIGNAL = 16,
-    CQ_DISPATCH_SET_UNICAST_ONLY_CORES = 17,
+    CQ_DISPATCH_SET_NUM_WORKER_SEMS = 17,
     CQ_DISPATCH_CMD_MAX_COUNT,              // for checking legal IDs
 };
 
@@ -259,7 +259,8 @@ struct CQDispatchSetUnicastOnlyCoresCmd {
 
 struct CQDispatchGoSignalMcastCmd {
     uint32_t go_signal;
-    uint8_t mcast_flag; // mcast or unicast or both
+    uint8_t num_mcast_txns; // Cmd expects noc_mcast_coords and num_mcast_dests follow the cmd
+    uint8_t num_unicast_txns; // Cmd expects noc_unicast_coords to follow the mcast data
     uint32_t wait_count;
     uint32_t wait_addr;
 } __attribute__((packed));
@@ -267,9 +268,15 @@ struct CQDispatchGoSignalMcastCmd {
 struct CQDispatchNotifySlaveGoSignalCmd {
     // sends a counter update to dispatch_s when it sees this cmd
     uint8_t wait; // if true, issue a write barrier before sending signal to dispatch_s
-    uint16_t pad2;
+    uint16_t index_bitmask;
     uint32_t pad3;
 } __attribute__((packed));
+
+struct CQDispatchSetNumWorkerSemsCmd {
+    uint8_t pad1;
+    uint16_t pad2;
+    uint32_t num_worker_sems;
+} __attribute__ ((packed));
 
 struct CQDispatchCmd {
     CQDispatchBaseCmd base;
@@ -287,6 +294,7 @@ struct CQDispatchCmd {
         CQDispatchGoSignalMcastCmd mcast;
         CQDispatchSetUnicastOnlyCoresCmd set_unicast_only_cores;
         CQDispatchNotifySlaveGoSignalCmd notify_dispatch_s_go_signal;
+        CQDispatchSetNumWorkerSemsCmd set_num_worker_sems;
     } __attribute__((packed));
 };
 

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -50,6 +50,7 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_SEND_GO_SIGNAL = 15,
     CQ_DISPATCH_NOTIFY_SLAVE_GO_SIGNAL = 16,
     CQ_DISPATCH_SET_NUM_WORKER_SEMS = 17,
+    CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA = 18,
     CQ_DISPATCH_CMD_MAX_COUNT,              // for checking legal IDs
 };
 
@@ -259,8 +260,9 @@ struct CQDispatchSetUnicastOnlyCoresCmd {
 
 struct CQDispatchGoSignalMcastCmd {
     uint32_t go_signal;
-    uint8_t num_mcast_txns; // Cmd expects noc_mcast_coords and num_mcast_dests follow the cmd
-    uint8_t num_unicast_txns; // Cmd expects noc_unicast_coords to follow the mcast data
+    uint8_t num_mcast_txns;
+    uint8_t num_unicast_txns;
+    uint8_t noc_data_start_index;
     uint32_t wait_count;
     uint32_t wait_addr;
 } __attribute__((packed));
@@ -276,6 +278,12 @@ struct CQDispatchSetNumWorkerSemsCmd {
     uint8_t pad1;
     uint16_t pad2;
     uint32_t num_worker_sems;
+} __attribute__ ((packed));
+
+struct CQDispatchSetGoSignalNocDataCmd {
+    uint8_t pad1;
+    uint16_t pad2;
+    uint32_t num_words;
 } __attribute__ ((packed));
 
 struct CQDispatchCmd {
@@ -295,6 +303,7 @@ struct CQDispatchCmd {
         CQDispatchSetUnicastOnlyCoresCmd set_unicast_only_cores;
         CQDispatchNotifySlaveGoSignalCmd notify_dispatch_s_go_signal;
         CQDispatchSetNumWorkerSemsCmd set_num_worker_sems;
+        CQDispatchSetGoSignalNocDataCmd set_go_signal_noc_data;
     } __attribute__((packed));
 };
 

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -178,6 +178,10 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream 
                     val(cmd->debug.stride));
                 break;
             case CQ_DISPATCH_CMD_DELAY: cq_file << fmt::format(" (delay={})", val(cmd->delay.delay)); break;
+            case CQ_DISPATCH_SET_NUM_WORKER_SEMS:
+                cq_file << fmt::format(
+                    " (num_worker_sems={})", val(cmd->set_num_worker_sems.num_worker_sems));
+                break;
             // These commands don't have any additional data to dump.
             case CQ_DISPATCH_CMD_ILLEGAL: break;
             case CQ_DISPATCH_CMD_GO: break;
@@ -185,7 +189,6 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream 
             case CQ_DISPATCH_CMD_EXEC_BUF_END: break;
             case CQ_DISPATCH_CMD_SEND_GO_SIGNAL: break;
             case CQ_DISPATCH_NOTIFY_SLAVE_GO_SIGNAL: break;
-            case CQ_DISPATCH_SET_UNICAST_ONLY_CORES: break;
             case CQ_DISPATCH_CMD_TERMINATE: break;
             case CQ_DISPATCH_CMD_SET_WRITE_OFFSET: break;
             default: TT_THROW("Unrecognized dispatch command: {}", cmd_id); break;

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -182,6 +182,10 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream 
                 cq_file << fmt::format(
                     " (num_worker_sems={})", val(cmd->set_num_worker_sems.num_worker_sems));
                 break;
+            case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA:
+                cq_file << fmt::format(
+                    " (num_words={})", val(cmd->set_go_signal_noc_data.num_words));
+                break;
             // These commands don't have any additional data to dump.
             case CQ_DISPATCH_CMD_ILLEGAL: break;
             case CQ_DISPATCH_CMD_GO: break;

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -11,12 +11,11 @@
 #include "common/env_lib.hpp"
 #include "tt_metal/impl/dispatch/command_queue_interface.hpp"
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
+#include "tt_metal/impl/dispatch/memcpy.hpp"
 #include "tt_metal/tt_stl/aligned_allocator.hpp"
 #include "tt_metal/llrt/hal.hpp"
 
-template <typename T>
-using vector_memcpy_aligned = std::vector<T, tt::stl::aligned_allocator<T, MEMCPY_ALIGNMENT>>;
-
+namespace tt::tt_metal {
 template <bool hugepage_write = false>
 class DeviceCommand {
    public:
@@ -762,3 +761,5 @@ bool DeviceCommand<hugepage_write>::zero_init_enable = tt::parse_env<bool>("TT_M
 
 using HugepageDeviceCommand = DeviceCommand<true>;
 using HostMemDeviceCommand = DeviceCommand<false>;
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -70,7 +70,6 @@ struct dispatch_worker_build_settings_t{
     uint32_t cb_pages;
     uint32_t tunnel_stop;
     uint32_t num_compute_cores;
-    uint32_t compute_core_mcast_noc_coords;
     uint32_t vc_count;
 };
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -41,8 +41,8 @@ constexpr uint32_t prefetch_h_noc_xy = get_compile_time_arg_val(16);
 constexpr uint32_t prefetch_h_local_downstream_sem_addr = get_compile_time_arg_val(17);
 constexpr uint32_t prefetch_h_max_credits = get_compile_time_arg_val(18);
 constexpr uint32_t packed_write_max_unicast_sub_cmds = get_compile_time_arg_val(19); // Number of cores in compute grid
-constexpr uint32_t dispatch_s_sem_id = get_compile_time_arg_val(20);
-constexpr uint32_t worker_mcast_grid = get_compile_time_arg_val(21);
+constexpr uint32_t dispatch_s_sync_sem_base_addr = get_compile_time_arg_val(20);
+constexpr uint32_t max_num_worker_sems = get_compile_time_arg_val(21); // maximum number of worker semaphores
 constexpr uint32_t mcast_go_signal_addr = get_compile_time_arg_val(22);
 constexpr uint32_t unicast_go_signal_addr = get_compile_time_arg_val(23);
 constexpr uint32_t distributed_dispatcher = get_compile_time_arg_val(24);
@@ -110,9 +110,6 @@ typedef struct GoSignalState {
 static GoSignalState go_signal_state_ring_buf[4];
 static uint8_t go_signal_state_wr_ptr = 0;
 static uint8_t go_signal_state_rd_ptr = 0;
-// Used when dispatch_s is moved into main dispatcher and needs to unicast + multicast go signals
-static uint32_t unicast_only_cores[16];
-static int num_unicast_cores = -1; // Initialize to -1: Number of cores we need to unicast go signals to. Host will set this during init.
 
 FORCE_INLINE volatile uint32_t *get_cq_completion_read_ptr() {
     return reinterpret_cast<volatile uint32_t *>(dev_completion_q_rd_ptr);
@@ -822,30 +819,16 @@ void process_go_signal_mcast_cmd() {
     *aligned_go_signal_storage = cmd->mcast.go_signal;
 
     while (*worker_sem_addr < cmd->mcast.wait_count);
-    if (cmd->mcast.mcast_flag & GoSignalMcastSettings::SEND_MCAST) {
-        uint64_t dst = get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr);
-        // packed_write_max_unicast_sub_cmds is the total number of compute cores (num_mcast_dests for this txn)
-        noc_async_write_multicast_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t), packed_write_max_unicast_sub_cmds);
+    volatile uint32_t tt_l1_ptr *data_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr *>(cmd_ptr + sizeof(CQDispatchCmd));
+    for (uint32_t i = 0, num_mcasts = cmd->mcast.num_mcast_txns; i < num_mcasts; ++i) {
+        uint64_t dst = get_noc_addr_helper(*(data_ptr++), mcast_go_signal_addr);
+        noc_async_write_multicast_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t), *(data_ptr++));
     }
-    if (cmd->mcast.mcast_flag & GoSignalMcastSettings::SEND_UNICAST) {
-        for (int core_idx = 0; core_idx < num_unicast_cores; core_idx++) {
-            uint64_t dst = get_noc_addr_helper(unicast_only_cores[core_idx], unicast_go_signal_addr);
-            noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
-        }
+    for (uint32_t i = 0, num_unicasts = cmd->mcast.num_unicast_txns; i < num_unicasts; ++i) {
+        uint64_t dst = get_noc_addr_helper(*(data_ptr++), unicast_go_signal_addr);
+        noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
     }
-    cmd_ptr += sizeof(CQDispatchCmd);
-}
-
-FORCE_INLINE
-void process_set_unicast_only_cores() {
-    volatile CQDispatchCmd tt_l1_ptr *cmd = (volatile CQDispatchCmd tt_l1_ptr *)cmd_ptr;
-    num_unicast_cores = (int)(cmd->set_unicast_only_cores.num_unicast_only_cores);
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);;
-    for (int core_idx = 0; core_idx < num_unicast_cores; core_idx++) {
-        unicast_only_cores[core_idx] = *((uint32_t tt_l1_ptr*)data_ptr);
-        data_ptr += sizeof(uint32_t);
-    }
-    cmd_ptr += sizeof(CQDispatchCmd) + num_unicast_cores * sizeof(uint32_t);
+    cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
 }
 
 FORCE_INLINE
@@ -858,14 +841,22 @@ void process_notify_dispatch_s_go_signal_cmd() {
         DPRINT << " DISPATCH_S_NOTIFY BARRIER\n";
         noc_async_write_barrier();
     }
-    if constexpr (distributed_dispatcher) {
-        uint64_t dispatch_s_notify_addr = get_noc_addr_helper(dispatch_s_noc_xy, get_semaphore<fd_core_type>(dispatch_s_sem_id));
-        static uint32_t num_go_signals_safe_to_send = 1;
-        noc_inline_dw_write(dispatch_s_notify_addr, num_go_signals_safe_to_send);
-        num_go_signals_safe_to_send++;
-    } else {
-        tt_l1_ptr uint32_t* notify_ptr = (uint32_t tt_l1_ptr*)(get_semaphore<fd_core_type>(dispatch_s_sem_id));
-        *notify_ptr = (*notify_ptr) + 1;
+    uint16_t index_bitmask = cmd->notify_dispatch_s_go_signal.index_bitmask;
+
+    while(index_bitmask != 0) {
+        uint32_t set_index = __builtin_ctz(index_bitmask);
+        uint32_t dispatch_s_sync_sem_addr = dispatch_s_sync_sem_base_addr + set_index * L1_ALIGNMENT;
+        if constexpr (distributed_dispatcher) {
+            static uint32_t num_go_signals_safe_to_send[max_num_worker_sems] = {0};
+            uint64_t dispatch_s_notify_addr = get_noc_addr_helper(dispatch_s_noc_xy, dispatch_s_sync_sem_addr);
+            num_go_signals_safe_to_send[set_index]++;
+            noc_inline_dw_write(dispatch_s_notify_addr, num_go_signals_safe_to_send[set_index]);
+        } else {
+            tt_l1_ptr uint32_t* notify_ptr = (uint32_t tt_l1_ptr*)(dispatch_s_sync_sem_addr);
+            *notify_ptr = (*notify_ptr) + 1;
+        }
+        // Unset the bit
+        index_bitmask &= index_bitmask - 1;
     }
     cmd_ptr += sizeof(CQDispatchCmd);
 }
@@ -969,9 +960,10 @@ re_run_command:
             process_go_signal_mcast_cmd();
             break;
 
-        case CQ_DISPATCH_SET_UNICAST_ONLY_CORES:
-            DPRINT << "cmd_set_unicast_only_cores" << ENDL();
-            process_set_unicast_only_cores();
+        case CQ_DISPATCH_SET_NUM_WORKER_SEMS:
+            DPRINT << "cmd_set_num_worker_sems" << ENDL();
+            // This command is only used by dispatch_s
+            cmd_ptr += sizeof(CQDispatchCmd);
             break;
 
         case CQ_DISPATCH_CMD_SET_WRITE_OFFSET:

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -43,14 +43,15 @@ constexpr uint32_t prefetch_h_max_credits = get_compile_time_arg_val(18);
 constexpr uint32_t packed_write_max_unicast_sub_cmds = get_compile_time_arg_val(19); // Number of cores in compute grid
 constexpr uint32_t dispatch_s_sync_sem_base_addr = get_compile_time_arg_val(20);
 constexpr uint32_t max_num_worker_sems = get_compile_time_arg_val(21); // maximum number of worker semaphores
-constexpr uint32_t mcast_go_signal_addr = get_compile_time_arg_val(22);
-constexpr uint32_t unicast_go_signal_addr = get_compile_time_arg_val(23);
-constexpr uint32_t distributed_dispatcher = get_compile_time_arg_val(24);
-constexpr uint32_t host_completion_q_wr_ptr = get_compile_time_arg_val(25);
-constexpr uint32_t dev_completion_q_wr_ptr = get_compile_time_arg_val(26);
-constexpr uint32_t dev_completion_q_rd_ptr = get_compile_time_arg_val(27);
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(28);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(29);
+constexpr uint32_t max_num_go_signal_noc_data_entries = get_compile_time_arg_val(22); // maximum number of go signal data words
+constexpr uint32_t mcast_go_signal_addr = get_compile_time_arg_val(23);
+constexpr uint32_t unicast_go_signal_addr = get_compile_time_arg_val(24);
+constexpr uint32_t distributed_dispatcher = get_compile_time_arg_val(25);
+constexpr uint32_t host_completion_q_wr_ptr = get_compile_time_arg_val(26);
+constexpr uint32_t dev_completion_q_wr_ptr = get_compile_time_arg_val(27);
+constexpr uint32_t dev_completion_q_rd_ptr = get_compile_time_arg_val(28);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(29);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(30);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
@@ -110,6 +111,8 @@ typedef struct GoSignalState {
 static GoSignalState go_signal_state_ring_buf[4];
 static uint8_t go_signal_state_wr_ptr = 0;
 static uint8_t go_signal_state_rd_ptr = 0;
+
+static uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries] = {0};
 
 FORCE_INLINE volatile uint32_t *get_cq_completion_read_ptr() {
     return reinterpret_cast<volatile uint32_t *>(dev_completion_q_rd_ptr);
@@ -819,16 +822,18 @@ void process_go_signal_mcast_cmd() {
     *aligned_go_signal_storage = cmd->mcast.go_signal;
 
     while (*worker_sem_addr < cmd->mcast.wait_count);
-    volatile uint32_t tt_l1_ptr *data_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr *>(cmd_ptr + sizeof(CQDispatchCmd));
+    uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
+    // send go signal update here
     for (uint32_t i = 0, num_mcasts = cmd->mcast.num_mcast_txns; i < num_mcasts; ++i) {
-        uint64_t dst = get_noc_addr_helper(*(data_ptr++), mcast_go_signal_addr);
-        noc_async_write_multicast_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t), *(data_ptr++));
+        uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], mcast_go_signal_addr);
+        // packed_write_max_unicast_sub_cmds is the total number of compute cores (num_mcast_dests for this txn)
+        noc_async_write_multicast_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t), go_signal_noc_data[go_signal_noc_data_idx++]);
     }
     for (uint32_t i = 0, num_unicasts = cmd->mcast.num_unicast_txns; i < num_unicasts; ++i) {
-        uint64_t dst = get_noc_addr_helper(*(data_ptr++), unicast_go_signal_addr);
+        uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
         noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
     }
-    cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
+    cmd_ptr += sizeof(CQDispatchCmd);
 }
 
 FORCE_INLINE
@@ -859,6 +864,18 @@ void process_notify_dispatch_s_go_signal_cmd() {
         index_bitmask &= index_bitmask - 1;
     }
     cmd_ptr += sizeof(CQDispatchCmd);
+}
+
+FORCE_INLINE
+void set_go_signal_noc_data() {
+    volatile CQDispatchCmd tt_l1_ptr *cmd = (volatile CQDispatchCmd tt_l1_ptr *)cmd_ptr;
+    uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
+    ASSERT(num_words <= max_num_go_signal_noc_data_entries);
+    volatile tt_l1_ptr uint32_t *data_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(cmd_ptr + sizeof(CQDispatchCmd));
+    for (uint32_t i = 0; i < num_words; ++i) {
+        go_signal_noc_data[i] = *(data_ptr++);
+    }
+    cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
 }
 
 static inline bool process_cmd_d(uint32_t &cmd_ptr, uint32_t* l1_cache, uint32_t& block_noc_writes_to_clear, uint32_t block_next_start_addr[]) {
@@ -963,7 +980,12 @@ re_run_command:
         case CQ_DISPATCH_SET_NUM_WORKER_SEMS:
             DPRINT << "cmd_set_num_worker_sems" << ENDL();
             // This command is only used by dispatch_s
+            ASSERT(0);
             cmd_ptr += sizeof(CQDispatchCmd);
+            break;
+
+        case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA:
+            set_go_signal_noc_data();
             break;
 
         case CQ_DISPATCH_CMD_SET_WRITE_OFFSET:

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -9,7 +9,6 @@
 // - Handles the following commands:
 //  - CQ_DISPATCH_CMD_SEND_GO_SIGNAL: "multicast" go signal to all workers
 //  - CQ_DISPATCH_CMD_WAIT: Wait for workers to complete and reset wait count
-//  - CQ_DISPATCH_SET_UNICAST_ONLY_CORES: Track workers (ex: eth) that cannot be multicasted to
 //    and instead need a unicast for the go signal
 
 #include "debug/assert.h"
@@ -30,13 +29,12 @@ constexpr uint32_t cb_log_page_size = get_compile_time_arg_val(1);
 constexpr uint32_t cb_size = get_compile_time_arg_val(2);
 constexpr uint32_t my_dispatch_cb_sem_id = get_compile_time_arg_val(3);
 constexpr uint32_t upstream_dispatch_cb_sem_id = get_compile_time_arg_val(4);
-constexpr uint32_t dispatch_s_sync_sem_id = get_compile_time_arg_val(5);
-constexpr uint32_t worker_mcast_grid = get_compile_time_arg_val(6);
-constexpr uint32_t num_worker_cores_to_mcast = get_compile_time_arg_val(7);
-constexpr uint32_t mcast_go_signal_addr = get_compile_time_arg_val(8);
-constexpr uint32_t unicast_go_signal_addr = get_compile_time_arg_val(9);
-constexpr uint32_t distributed_dispatcher = get_compile_time_arg_val(10); // dispatch_s and dispatch_d running on different cores
-constexpr uint32_t worker_sem_addr = get_compile_time_arg_val(11); // workers update the semaphore at this location to signal completion
+constexpr uint32_t dispatch_s_sync_sem_base_addr = get_compile_time_arg_val(5);
+constexpr uint32_t mcast_go_signal_addr = get_compile_time_arg_val(6);
+constexpr uint32_t unicast_go_signal_addr = get_compile_time_arg_val(7);
+constexpr uint32_t distributed_dispatcher = get_compile_time_arg_val(8); // dispatch_s and dispatch_d running on different cores
+constexpr uint32_t worker_sem_base_addr = get_compile_time_arg_val(9); // workers update the semaphore at this location to signal completion
+constexpr uint32_t max_num_worker_sems = get_compile_time_arg_val(10); // maximum number of worker semaphores
 
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
 constexpr uint32_t dispatch_d_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
@@ -45,18 +43,16 @@ constexpr uint8_t my_noc_index = NOC_INDEX;
 
 constexpr uint32_t cb_page_size = 1 << cb_log_page_size;
 constexpr uint32_t cb_end = cb_base + cb_size;
-constexpr int max_num_unicast_cores = 16;
 static uint32_t num_pages_acquired = 0;
-static uint32_t num_mcasts_sent = 0;
+static uint32_t num_mcasts_sent[max_num_worker_sems] = {0};
 static uint32_t cmd_ptr;
-static uint32_t unicast_only_cores[max_num_unicast_cores]; // TODO: Allocate this on stack
-// Initialize to -1: Number of cores we need to unicast go signals to. Host will set this during init. Assert if not set
-static int num_unicast_cores = -1;
 
 // When dispatch_d and dispatch_s run on separate cores, dispatch_s gets the go signal update from workers.
 // dispatch_s is responsible for sending the latest worker completion count to dispatch_d.
 // To minimize the number of writes from dispatch_s to dispatch_d, locally track dispatch_d's copy.
-static uint32_t worker_count_update_for_dispatch_d = 0;
+static uint32_t worker_count_update_for_dispatch_d[max_num_worker_sems] = {0};
+
+static uint32_t num_worker_sems = 1;
 
 FORCE_INLINE
 void dispatch_s_wr_reg_cmd_buf_init() {
@@ -102,7 +98,8 @@ void dispatch_s_noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t noc_id,
 
 FORCE_INLINE
 void wait_for_workers(volatile CQDispatchCmd tt_l1_ptr *cmd) {
-    volatile tt_l1_ptr uint32_t* worker_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr);
+    uint8_t dispatch_message_offset = *((uint8_t *)&cmd->mcast.go_signal + offsetof(go_msg_t, dispatch_message_offset));
+    volatile tt_l1_ptr uint32_t* worker_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_base_addr + dispatch_message_offset);
     while (wrap_gt(cmd->mcast.wait_count, *worker_sem));
 }
 
@@ -110,12 +107,18 @@ template<bool flush_write = false>
 FORCE_INLINE
 void update_worker_completion_count_on_dispatch_d() {
     if constexpr(distributed_dispatcher) {
-        uint32_t num_workers_signalling_completion = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr);
-        if (num_workers_signalling_completion != worker_count_update_for_dispatch_d) {
-            worker_count_update_for_dispatch_d = num_workers_signalling_completion;
-            uint64_t dispatch_d_dst = get_noc_addr_helper(dispatch_d_noc_xy, worker_sem_addr);
-            dispatch_s_noc_inline_dw_write(dispatch_d_dst, num_workers_signalling_completion, my_noc_index);
-            if constexpr (flush_write) {
+        bool write = false;
+        for (uint32_t i = 0, worker_sem_addr = worker_sem_base_addr; i < num_worker_sems; ++i, worker_sem_addr += L1_ALIGNMENT) {
+            uint32_t num_workers_signalling_completion = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr);
+            if (num_workers_signalling_completion != worker_count_update_for_dispatch_d[i]) {
+                worker_count_update_for_dispatch_d[i] = num_workers_signalling_completion;
+                uint64_t dispatch_d_dst = get_noc_addr_helper(dispatch_d_noc_xy, worker_sem_addr);
+                dispatch_s_noc_inline_dw_write(dispatch_d_dst, num_workers_signalling_completion, my_noc_index);
+                write = true;
+            }
+        }
+        if constexpr (flush_write) {
+            if (write) {
                 noc_async_writes_flushed();
             }
         }
@@ -151,7 +154,18 @@ void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr *cmd = (volatile CQDispatchCmd tt_l1_ptr *)cmd_ptr;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
     volatile tt_l1_ptr uint32_t* sync_sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(dispatch_s_sync_sem_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dispatch_s_sync_sem_base_addr + (cmd->mcast.wait_addr - worker_sem_base_addr));
+
+    // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
+    uint32_t& mcasts_sent = num_mcasts_sent[(cmd->mcast.wait_addr - worker_sem_base_addr) / L1_ALIGNMENT];
+    while (wrap_ge(mcasts_sent, *sync_sem_addr)) {
+        // Update dispatch_d with the latest num_workers
+        update_worker_completion_count_on_dispatch_d();
+    }
+    mcasts_sent++; // Go signal sent -> update counter
+    // Wait until workers have completed before sending go signal
+    wait_for_workers(cmd);
+
     // The location of the go signal embedded in the command does not meet NOC alignment requirements.
     // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
     // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
@@ -159,51 +173,32 @@ void process_go_signal_mcast_cmd() {
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
     *aligned_go_signal_storage = cmd->mcast.go_signal;
 
-    // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
-    while (wrap_ge(num_mcasts_sent, *sync_sem_addr)) {
-        // Update dispatch_d with the latest num_workers
-        update_worker_completion_count_on_dispatch_d();
-    }
-    num_mcasts_sent++; // Go signal sent -> update counter
-    // Wait until workers have completed before sending go signal
-    wait_for_workers(cmd);
     // send go signal update here
-    if (cmd->mcast.mcast_flag & GoSignalMcastSettings::SEND_MCAST) {
-        uint64_t dst = get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr);
-        noc_async_write_multicast_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t), num_worker_cores_to_mcast);
+    volatile uint32_t tt_l1_ptr *data_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr *>(cmd_ptr + sizeof(CQDispatchCmd));
+    for (uint32_t i = 0, num_mcasts = cmd->mcast.num_mcast_txns; i < num_mcasts; ++i) {
+        uint64_t dst = get_noc_addr_helper(*(data_ptr++), mcast_go_signal_addr);
+        // packed_write_max_unicast_sub_cmds is the total number of compute cores (num_mcast_dests for this txn)
+        noc_async_write_multicast_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t), *(data_ptr++));
     }
-    if (cmd->mcast.mcast_flag & GoSignalMcastSettings::SEND_UNICAST) {
-        // If dispatch_s needs to unicast the go signal to specific cores, num_unicast_cores
-        // must be set using set_go_signal_unicast_only_cores
-        ASSERT(num_unicast_cores > 0);
-        for (int core_idx = 0; core_idx < num_unicast_cores; core_idx++) {
-            uint64_t dst = get_noc_addr_helper(unicast_only_cores[core_idx], unicast_go_signal_addr);
-            noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
-        }
+    for (uint32_t i = 0, num_unicasts = cmd->mcast.num_unicast_txns; i < num_unicasts; ++i) {
+        uint64_t dst = get_noc_addr_helper(*(data_ptr++), unicast_go_signal_addr);
+        noc_async_write_one_packet((uint32_t)(aligned_go_signal_storage), dst, sizeof(uint32_t));
     }
     update_worker_completion_count_on_dispatch_d();
-    cmd_ptr += sizeof(CQDispatchCmd);
-}
-
-FORCE_INLINE
-void set_go_signal_unicast_only_cores() {
-    volatile CQDispatchCmd tt_l1_ptr *cmd = (volatile CQDispatchCmd tt_l1_ptr *)cmd_ptr;
-    num_unicast_cores = (int)(cmd->set_unicast_only_cores.num_unicast_only_cores);
-    ASSERT(num_unicast_cores <= max_num_unicast_cores);
-    uint32_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
-    for (int core_idx = 0; core_idx < num_unicast_cores; core_idx++) {
-        unicast_only_cores[core_idx] = *((uint32_t tt_l1_ptr*)data_ptr);
-        data_ptr += sizeof(uint32_t);
-    }
-    cmd_ptr = data_ptr;
+    cmd_ptr = round_up_pow2((uint32_t)data_ptr, L1_ALIGNMENT);
 }
 
 FORCE_INLINE
 void process_dispatch_s_wait_cmd() {
+    static constexpr uint32_t worker_sem_max_addr = worker_sem_base_addr + (max_num_worker_sems - 1) * L1_ALIGNMENT;
+
     volatile CQDispatchCmd tt_l1_ptr *cmd = (volatile CQDispatchCmd tt_l1_ptr *)cmd_ptr;
     // Limited Usage of Wait CMD: dispatch_s should get a wait command only if it's not on the
     // same core as dispatch_d and is used to clear the worker count
-    ASSERT(cmd->wait.clear_count && (cmd->wait.addr == worker_sem_addr) && distributed_dispatcher);
+    ASSERT(cmd->wait.clear_count && distributed_dispatcher);
+    uint32_t worker_sem_addr = cmd->wait.addr;
+    ASSERT(worker_sem_addr >= worker_sem_base_addr && worker_sem_addr <= worker_sem_max_addr);
+    uint32_t index = (worker_sem_addr - worker_sem_base_addr) / L1_ALIGNMENT;
     volatile tt_l1_ptr uint32_t* worker_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr);
     // Wait for workers to complete
     while (wrap_gt(cmd->wait.count, *worker_sem));
@@ -211,7 +206,15 @@ void process_dispatch_s_wait_cmd() {
     // dispatch_d will clear it's own counter
     update_worker_completion_count_on_dispatch_d<true>();
     *worker_sem = 0;
-    worker_count_update_for_dispatch_d = 0; // Local worker count update for dispatch_d should reflect state of worker semaphore on dispatch_s
+    worker_count_update_for_dispatch_d[index] = 0; // Local worker count update for dispatch_d should reflect state of worker semaphore on dispatch_s
+    cmd_ptr += sizeof(CQDispatchCmd);
+}
+
+FORCE_INLINE
+void set_num_worker_sems() {
+    volatile CQDispatchCmd tt_l1_ptr *cmd = (volatile CQDispatchCmd tt_l1_ptr *)cmd_ptr;
+    num_worker_sems = cmd->set_num_worker_sems.num_worker_sems;
+    ASSERT(num_worker_sems <= max_num_worker_sems);
     cmd_ptr += sizeof(CQDispatchCmd);
 }
 
@@ -231,8 +234,8 @@ void kernel_main() {
             case CQ_DISPATCH_CMD_SEND_GO_SIGNAL:
                 process_go_signal_mcast_cmd();
                 break;
-            case CQ_DISPATCH_SET_UNICAST_ONLY_CORES:
-                set_go_signal_unicast_only_cores();
+            case CQ_DISPATCH_SET_NUM_WORKER_SEMS:
+                set_num_worker_sems();
                 break;
             case CQ_DISPATCH_CMD_WAIT:
                 process_dispatch_s_wait_cmd();

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -12,8 +12,8 @@
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
 #include "debug/dprint.h"
-
 #include "noc/noc_parameters.h" // PCIE_ALIGNMENT
+
 constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT; // for NOC PCIe alignemnt
 struct CQPrefetchHToPrefetchDHeader_s {
     uint32_t length;
@@ -24,7 +24,7 @@ typedef union {
 } CQPrefetchHToPrefetchDHeader;
 static_assert((sizeof(CQPrefetchHToPrefetchDHeader) & (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1)) == 0);
 
-typedef uint16_t prefetch_q_entry_type;
+using prefetch_q_entry_type = uint16_t;
 
 constexpr uint32_t downstream_cb_base = get_compile_time_arg_val(0);
 constexpr uint32_t downstream_cb_log_page_size = get_compile_time_arg_val(1);

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <emmintrin.h>
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/tt_stl/aligned_allocator.hpp"
+#include "tt_metal/third_party/umd/device/device_api_metal.h"
+
+namespace tt::tt_metal {
+
+static constexpr uint32_t MEMCPY_ALIGNMENT = sizeof(__m128i);
+
+template <typename T>
+using vector_memcpy_aligned = std::vector<T, tt::stl::aligned_allocator<T, MEMCPY_ALIGNMENT>>;
+
+// Ideally would work by cachelines, but the min size is less than that
+// TODO: Revisit this w/ regard to possibly eliminating min sizes and orphan writes at the end
+// TODO: ditto alignment isues
+template <bool debug_sync = false>
+static inline void memcpy_to_device(void *__restrict dst, const void *__restrict src, size_t n) {
+    TT_ASSERT((uintptr_t)dst % MEMCPY_ALIGNMENT == 0);
+    TT_ASSERT(n % sizeof(uint32_t) == 0);
+
+    static constexpr uint32_t inner_loop = 8;
+    static constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);
+
+    uint8_t *src8 = (uint8_t *)src;
+    uint8_t *dst8 = (uint8_t *)dst;
+
+    if (size_t num_lines = n / inner_blk_size) {
+        for (size_t i = 0; i < num_lines; ++i) {
+            for (size_t j = 0; j < inner_loop; ++j) {
+                __m256i blk = _mm256_loadu_si256((const __m256i *)src8);
+                _mm256_stream_si256((__m256i *)dst8, blk);
+                src8 += sizeof(__m256i);
+                dst8 += sizeof(__m256i);
+            }
+            n -= inner_blk_size;
+        }
+    }
+
+    if (n > 0) {
+        if (size_t num_lines = n / sizeof(__m256i)) {
+            for (size_t i = 0; i < num_lines; ++i) {
+                __m256i blk = _mm256_loadu_si256((const __m256i *)src8);
+                _mm256_stream_si256((__m256i *)dst8, blk);
+                src8 += sizeof(__m256i);
+                dst8 += sizeof(__m256i);
+            }
+            n -= num_lines * sizeof(__m256i);
+        }
+        if (size_t num_lines = n / sizeof(__m128i)) {
+            for (size_t i = 0; i < num_lines; ++i) {
+                __m128i blk = _mm_loadu_si128((const __m128i *)src8);
+                _mm_stream_si128((__m128i *)dst8, blk);
+                src8 += sizeof(__m128i);
+                dst8 += sizeof(__m128i);
+            }
+            n -= n / sizeof(__m128i) * sizeof(__m128i);
+        }
+        if (n > 0) {
+            for (size_t i = 0; i < n / sizeof(int32_t); ++i) {
+                _mm_stream_si32((int32_t *)dst8, *(int32_t *)src8);
+                src8 += sizeof(int32_t);
+                dst8 += sizeof(int32_t);
+            }
+        }
+    }
+    if constexpr (debug_sync) {
+        tt_driver_atomics::sfence();
+    }
+}
+
+} // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1310,6 +1310,10 @@ const std::vector<SubDeviceId> &detail::Program_::determine_sub_device_ids(const
         } else {
             std::unordered_set<SubDeviceId> used_sub_device_ids;
             auto find_sub_device_ids = [&] (HalProgrammableCoreType core_type) {
+                auto core_type_index = hal.get_programmable_core_type_index(core_type);
+                if (core_type_index == -1) {
+                    return;
+                }
                 const auto& program_kgs = this->get_kernel_groups(hal.get_programmable_core_type_index(core_type));
                 uint32_t num_intersections = 0;
                 uint32_t num_cores = 0;
@@ -1516,9 +1520,9 @@ uint32_t detail::Program_::get_sem_base_addr(Device *device, CoreCoord logical_c
     // TODO: This restriction can be lifted once we have support for programs spanning multiple sub-devices
     // Semaphores across sub-devices are expected to have the same address
     TT_FATAL(sub_device_ids.size() == 1, "get_sem_base_addr currently only supports programs spanning a single sub-device");
-    auto sub_device_id = sub_device_ids[0];
+    auto sub_device_index = sub_device_ids[0].to_index();
     uint32_t base_addr = device->using_fast_dispatch
-                             ? this->last_used_command_queue_for_testing->get_config_buffer_mgr(sub_device_id).get_last_slot_addr(
+                             ? this->last_used_command_queue_for_testing->get_config_buffer_mgr(sub_device_index).get_last_slot_addr(
                                    programmable_core_type)
                              : hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 
@@ -1538,9 +1542,9 @@ uint32_t detail::Program_::get_cb_base_addr(Device *device, CoreCoord logical_co
     // TODO: This restriction can be lifted once this function is changed to return a vector of addresses
     // Addresses are not the same across sub-devices
     TT_FATAL(sub_device_ids.size() == 1, "get_sem_base_addr currently only supports programs spanning a single sub-device");
-    auto sub_device_id = sub_device_ids[0];
+    auto sub_device_index = sub_device_ids[0].to_index();
     uint32_t base_addr = device->using_fast_dispatch
-                             ? this->last_used_command_queue_for_testing->get_config_buffer_mgr(sub_device_id).get_last_slot_addr(
+                             ? this->last_used_command_queue_for_testing->get_config_buffer_mgr(sub_device_index).get_last_slot_addr(
                                    programmable_core_type)
                              : hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -143,11 +143,13 @@ class Program {
     ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
 
     // debug/test
-    uint32_t get_sem_base_addr(Device *device, CoreCoord logical_core, CoreType core_type) const;
-    uint32_t get_cb_base_addr(Device *device, CoreCoord logical_core, CoreType core_type) const;
+    uint32_t get_sem_base_addr(Device *device, CoreCoord logical_core, CoreType core_type);
+    uint32_t get_cb_base_addr(Device *device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_sem_size(Device *device, CoreCoord logical_core, CoreType core_type) const;
     uint32_t get_cb_size(Device *device, CoreCoord logical_core, CoreType core_type) const;
     void set_last_used_command_queue_for_testing(HWCommandQueue *queue);
+
+    const std::vector<uint32_t> &determine_sub_device_ids(const Device *device);
 
    private:
     std::unique_ptr<detail::Program_> pimpl_;

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -149,7 +149,7 @@ class Program {
     uint32_t get_cb_size(Device *device, CoreCoord logical_core, CoreType core_type) const;
     void set_last_used_command_queue_for_testing(HWCommandQueue *queue);
 
-    const std::vector<uint32_t> &determine_sub_device_ids(const Device *device);
+    const std::vector<SubDeviceId> &determine_sub_device_ids(const Device *device);
 
    private:
     std::unique_ptr<detail::Program_> pimpl_;

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tt_metal/llrt/hal.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+namespace tt::tt_metal {
+
+SubDevice::SubDevice(const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores) : cores_(cores) {
+    this->validate();
+}
+
+SubDevice::SubDevice(tt::stl::Span<const CoreRangeSet> cores) {
+    TT_FATAL(cores.size() <= this->cores_.size(), "Too many core types for SubDevice");
+    std::copy(cores.begin(), cores.end(), this->cores_.begin());
+    this->validate();
+}
+
+SubDevice::SubDevice(std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cores) : cores_(std::move(cores)){
+    this->validate();
+}
+
+void SubDevice::validate() const {
+    auto num_core_types = hal.get_programmable_core_type_count();
+    for (uint32_t i = num_core_types; i < NumHalProgrammableCoreTypes; ++i) {
+        TT_FATAL(this->cores_[i].empty(), "CoreType {} is not allowed in SubDevice", static_cast<HalProgrammableCoreType>(i));
+    }
+    TT_FATAL(this->cores_[static_cast<uint32_t>(HalProgrammableCoreType::IDLE_ETH)].empty(), "CoreType IDLE_ETH is not allowed in SubDevice");
+}
+
+bool SubDevice::has_core_type(HalProgrammableCoreType core_type) const {
+    return !this->cores_[static_cast<uint32_t>(core_type)].empty();
+}
+
+uint32_t SubDevice::num_cores(HalProgrammableCoreType core_type) const {
+    return this->cores_[static_cast<uint32_t>(core_type)].num_cores();
+}
+
+const std::array<CoreRangeSet, NumHalProgrammableCoreTypes> &SubDevice::cores() const {
+    return this->cores_;
+}
+
+const CoreRangeSet &SubDevice::cores(HalProgrammableCoreType core_type) const {
+    return this->cores_[static_cast<uint32_t>(core_type)];
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device.hpp
+++ b/tt_metal/impl/sub_device/sub_device.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/llrt/hal.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+namespace tt::tt_metal {
+
+inline namespace v0 {
+
+class SubDevice {
+   public:
+    SubDevice(const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores);
+    SubDevice(tt::stl::Span<const CoreRangeSet> cores);
+    SubDevice(std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cores);
+
+    SubDevice(const SubDevice& sub_device) = default;
+    SubDevice& operator=(const SubDevice& sub_device) = default;
+
+    SubDevice(SubDevice&& sub_device) noexcept = default;
+    SubDevice& operator=(SubDevice&& sub_device) noexcept = default;
+
+    bool has_core_type(HalProgrammableCoreType core_type) const;
+    uint32_t num_cores(HalProgrammableCoreType core_type) const;
+    const std::array<CoreRangeSet, NumHalProgrammableCoreTypes>& cores() const;
+    const CoreRangeSet& cores(HalProgrammableCoreType core_type) const;
+
+   private:
+    void validate() const;
+
+    // These are logical coords from the original device grid
+    // There is no remapping of logical coords
+    std::array<CoreRangeSet, NumHalProgrammableCoreTypes> cores_;
+};
+
+}  // namespace v0
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/sub_device/sub_device_manager.hpp"
+
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/allocator/allocator.hpp"
+#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/dispatch/command_queue_interface.hpp"
+#include "tt_metal/impl/kernels/data_types.hpp"
+#include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
+#include "tt_metal/impl/trace/trace.hpp"
+#include "tt_metal/impl/trace/trace_buffer.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+namespace tt::tt_metal {
+
+namespace detail {
+
+SubDeviceManager::SubDeviceManager(
+    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, Device *device) :
+    sub_devices_(sub_devices.begin(), sub_devices.end()),
+    local_l1_size_(align(local_l1_size, hal.get_alignment(HalMemType::L1))),
+    device_(device) {
+    TT_ASSERT(device != nullptr, "Device must not be null");
+    this->validate_sub_devices();
+    this->populate_num_cores();
+    this->populate_sub_allocators();
+    this->populate_noc_data();
+    this->populate_worker_launch_message_buffer_state();
+}
+
+SubDeviceManager::SubDeviceManager(Device *device, std::unique_ptr<Allocator> &&global_allocator) : device_(device) {
+    TT_ASSERT(device != nullptr, "Device must not be null");
+    this->local_l1_size_ = 0;
+    const auto& compute_grid_size = this->device_->compute_with_storage_grid_size();
+    const auto& active_eth_cores = this->device_->get_active_ethernet_cores(true);
+    std::vector<CoreRange> active_eth_core_ranges;
+    active_eth_core_ranges.reserve(active_eth_cores.size());
+    for (const auto& core : active_eth_cores) {
+        active_eth_core_ranges.emplace_back(core, core);
+    }
+
+    this->sub_devices_ = {SubDevice(std::array{
+        CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1})),
+        CoreRangeSet(std::move(active_eth_core_ranges))})};
+    // No need to validate sub-devices since this constructs a sub-device of the entire grid
+    this->populate_num_cores();
+    this->sub_device_allocators_.push_back(std::move(global_allocator));
+    this->populate_noc_data();
+    this->populate_worker_launch_message_buffer_state();
+}
+
+SubDeviceManager::~SubDeviceManager() {
+    for (const auto &allocator : this->sub_device_allocators_) {
+        if (allocator) {
+            // Clear the bank managers, this makes subsequent buffer deallocations fast
+            allocator::clear(*allocator);
+            // Deallocate all buffers
+            // This is done to set buffer object status to Deallocated
+            const auto &allocated_buffers = allocator::get_allocated_buffers(*allocator);
+            for (auto buf = allocated_buffers.begin(); buf != allocated_buffers.end();) {
+                tt::tt_metal::DeallocateBuffer(*(*(buf++)));
+            }
+        }
+    }
+}
+
+uint8_t SubDeviceManager::num_sub_devices() const { return this->sub_devices_.size(); }
+
+const SubDevice& SubDeviceManager::sub_device(SubDeviceId sub_device_id) const {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    return sub_devices_[sub_device_index];
+}
+
+const vector_memcpy_aligned<uint32_t>& SubDeviceManager::noc_mcast_data(SubDeviceId sub_device_id) const {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    return noc_mcast_data_[sub_device_index];
+}
+
+const vector_memcpy_aligned<uint32_t>& SubDeviceManager::noc_unicast_data(SubDeviceId sub_device_id) const {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    return noc_unicast_data_[sub_device_index];
+}
+
+const vector_memcpy_aligned<uint32_t>& SubDeviceManager::noc_mcast_unicast_data(SubDeviceId sub_device_id) const {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    return noc_mcast_unicast_data_[sub_device_index];
+}
+
+const std::unique_ptr<Allocator> &SubDeviceManager::get_initialized_allocator(SubDeviceId sub_device_id) const {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    TT_FATAL(this->sub_device_allocators_[sub_device_index], "SubDevice allocator not initialized");
+    return this->sub_device_allocators_[sub_device_index];
+}
+
+std::unique_ptr<Allocator> &SubDeviceManager::sub_device_allocator(SubDeviceId sub_device_id) {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    return this->sub_device_allocators_[sub_device_index];
+}
+
+std::shared_ptr<TraceBuffer> &SubDeviceManager::create_trace(uint32_t tid) {
+    auto [trace, emplaced] = this->trace_buffer_pool_.emplace(tid, Trace::create_empty_trace_buffer());
+    TT_ASSERT(emplaced, "Trace buffer with tid {} already exists", tid);
+    return trace->second;
+}
+
+void SubDeviceManager::release_trace(uint32_t tid) {
+    this->trace_buffer_pool_.erase(tid);
+}
+
+std::shared_ptr<TraceBuffer> SubDeviceManager::get_trace(uint32_t tid) {
+    auto trace = this->trace_buffer_pool_.find(tid);
+    if (trace != this->trace_buffer_pool_.end()) {
+        return trace->second;
+    }
+    return nullptr;
+}
+
+void SubDeviceManager::reset_worker_launch_message_buffer_state() {
+    std::for_each(this->worker_launch_message_buffer_state_.begin(), this->worker_launch_message_buffer_state_.end(), std::mem_fn(&LaunchMessageRingBufferState::reset));
+}
+
+LaunchMessageRingBufferState& SubDeviceManager::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
+    auto sub_device_index = this->get_sub_device_index(sub_device_id);
+    return this->worker_launch_message_buffer_state_[sub_device_index];
+}
+
+bool SubDeviceManager::has_allocations() const {
+    for (const auto& allocator : this->sub_device_allocators_) {
+        if (allocator && allocator->allocated_buffers.size() > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+DeviceAddr SubDeviceManager::local_l1_size() const { return this->local_l1_size_; }
+
+uint8_t SubDeviceManager::get_sub_device_index(SubDeviceId sub_device_id) const {
+    auto sub_device_index = sub_device_id.to_index();
+    TT_FATAL(
+        sub_device_index < this->sub_devices_.size(),
+        "SubDevice index {} out of bounds {}",
+        sub_device_index,
+        this->sub_devices_.size());
+    return sub_device_index;
+}
+
+void SubDeviceManager::validate_sub_devices() const {
+    // Validate sub device cores fit inside the device grid
+    const auto& compute_grid_size = this->device_->compute_with_storage_grid_size();
+    CoreRange device_worker_cores = CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1});
+    const auto& device_eth_cores = this->device_->get_active_ethernet_cores(true);
+    for (const auto& sub_device : this->sub_devices_) {
+        const auto& worker_cores = sub_device.cores(HalProgrammableCoreType::TENSIX);
+        TT_FATAL(
+            device_worker_cores.contains(worker_cores),
+            "Tensix cores {} specified in sub device must be within device grid {}",
+            worker_cores,
+            device_worker_cores);
+        const auto& eth_cores = sub_device.cores(HalProgrammableCoreType::ACTIVE_ETH);
+        uint32_t num_eth_cores = 0;
+        for (const auto& dev_eth_core : device_eth_cores) {
+            if (eth_cores.contains(dev_eth_core)) {
+                num_eth_cores++;
+            }
+        }
+        TT_FATAL(
+            num_eth_cores == eth_cores.num_cores(),
+            "Ethernet cores {} specified in sub device must be within device grid",
+            eth_cores);
+    }
+    if (this->sub_devices_.size() < 2) {
+        return;
+    }
+    // Validate no overlap of sub devices
+    for (uint32_t i = 0; i < this->sub_devices_.size(); ++i) {
+        for (uint32_t j = i + 1; j < this->sub_devices_.size(); ++j) {
+            for (uint32_t k = 0; k < NumHalProgrammableCoreTypes; ++k) {
+                TT_FATAL(
+                    !(this->sub_devices_[i].cores()[k].intersects(this->sub_devices_[j].cores()[k])),
+                    "SubDevices specified for SubDeviceManager intersect");
+            }
+        }
+    }
+}
+
+void SubDeviceManager::populate_num_cores() {
+    for (const auto& sub_device : this->sub_devices_) {
+        for (uint32_t i = 0; i < NumHalProgrammableCoreTypes; ++i) {
+            this->num_cores_[i] += sub_device.num_cores(static_cast<HalProgrammableCoreType>(i));
+        }
+    }
+}
+
+void SubDeviceManager::populate_sub_allocators() {
+    this->sub_device_allocators_.resize(this->num_sub_devices());
+    if (this->local_l1_size_ == 0) {
+        return;
+    }
+    const auto& global_allocator_config = this->device_->get_initialized_allocator()->config;
+    // Construct allocator config from soc_desc
+    // Take max alignment to satisfy NoC rd/wr constraints
+    // Tensix/Eth -> PCIe/DRAM src and dst addrs must be L1_ALIGNMENT aligned
+    // PCIe/DRAM -> Tensix/Eth src and dst addrs must be DRAM_ALIGNMENT aligned
+    // Tensix/Eth <-> Tensix/Eth src and dst addrs must be L1_ALIGNMENT aligned
+    for (uint32_t i = 0; i < this->num_sub_devices(); ++i) {
+        const auto& compute_cores = this->sub_devices_[i].cores(HalProgrammableCoreType::TENSIX);
+        if (compute_cores.empty()) {
+            continue;
+        }
+        AllocatorConfig config(
+            {.num_dram_channels = global_allocator_config.num_dram_channels,
+             .dram_bank_size = 0,
+             .dram_bank_offsets = global_allocator_config.dram_bank_offsets,
+             .dram_unreserved_base = global_allocator_config.dram_unreserved_base,
+             .l1_unreserved_base = global_allocator_config.l1_unreserved_base,
+             .worker_grid = compute_cores,
+             .worker_l1_size = global_allocator_config.l1_unreserved_base + this->local_l1_size_,
+             .storage_core_bank_size = std::nullopt,
+             .l1_small_size = 0,
+             .trace_region_size = 0,
+             .core_type_from_noc_coord_table = {},  // Populated later
+             .worker_log_to_physical_routing_x = global_allocator_config.worker_log_to_physical_routing_x,
+             .worker_log_to_physical_routing_y = global_allocator_config.worker_log_to_physical_routing_y,
+             .l1_bank_remap = {},
+             .compute_grid = compute_cores,
+             .alignment = global_allocator_config.alignment,
+             .disable_interleaved = true});
+        TT_FATAL(
+            config.l1_small_size < (config.storage_core_bank_size.has_value()
+                                        ? config.storage_core_bank_size.value()
+                                        : config.worker_l1_size - config.l1_unreserved_base),
+            "Reserved size must be less than bank size");
+        TT_FATAL(
+            config.l1_small_size % config.alignment == 0,
+            "Reserved size must be aligned to allocator alignment {}",
+            config.alignment);
+
+        // sub_devices only have compute cores for allocation
+        for (const CoreCoord& core : corerange_to_cores(compute_cores)) {
+            const auto noc_coord = this->device_->worker_core_from_logical_core(core);
+            config.core_type_from_noc_coord_table.insert({noc_coord, AllocCoreType::ComputeAndStore});
+        }
+
+        // L1_BANKING scheme creates 1 bank per DRAM core and splits up L1 such that there are power 2 num L1 banks
+        // This is the only allocator scheme supported because kernel APIs assume num L1 banks are power of 2
+        TT_ASSERT(this->device_->allocator_scheme_ == MemoryAllocator::L1_BANKING);
+        this->sub_device_allocators_[i] = std::make_unique<L1BankingAllocator>(config);
+    }
+}
+
+void SubDeviceManager::populate_noc_data() {
+    uint32_t num_sub_devices = this->num_sub_devices();
+    this->noc_mcast_data_.resize(num_sub_devices);
+    this->noc_unicast_data_.resize(num_sub_devices);
+    this->noc_mcast_unicast_data_.resize(num_sub_devices);
+
+    NOC noc_index = this->device_->dispatch_go_signal_noc();
+
+    for (uint32_t i = 0; i < num_sub_devices; ++i) {
+        const auto& tensix_cores = this->sub_devices_[i].cores(HalProgrammableCoreType::TENSIX);
+        const auto& eth_cores = this->sub_devices_[i].cores(HalProgrammableCoreType::ACTIVE_ETH);
+
+        uint32_t idx = 0;
+        auto& noc_mcast_data = this->noc_mcast_data_[i];
+        noc_mcast_data.resize(tensix_cores.size() * 2);
+        for (const auto& core_range : tensix_cores.ranges()) {
+            auto physical_start =
+                this->device_->physical_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
+            auto physical_end = this->device_->physical_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
+            auto physical_core_range = CoreRange(physical_start, physical_end);
+            noc_mcast_data[idx++] = this->device_->get_noc_multicast_encoding(noc_index, physical_core_range);
+            noc_mcast_data[idx++] = core_range.size();
+        }
+
+        idx = 0;
+        auto& noc_unicast_data = this->noc_unicast_data_[i];
+        for (const auto& core_range : eth_cores.ranges()) {
+            noc_unicast_data.resize(noc_unicast_data.size() + core_range.size());
+            for (const auto& core : core_range) {
+                auto physical_core = this->device_->physical_core_from_logical_core(core, CoreType::ETH);
+                noc_unicast_data[idx++] = this->device_->get_noc_unicast_encoding(noc_index, physical_core);
+            }
+        }
+        auto& noc_mcast_unicast_data = this->noc_mcast_unicast_data_[i];
+        noc_mcast_unicast_data.resize(noc_mcast_data.size() + noc_unicast_data.size());
+        std::copy(noc_mcast_data.begin(), noc_mcast_data.end(), noc_mcast_unicast_data.begin());
+        std::copy(
+            noc_unicast_data.begin(), noc_unicast_data.end(), noc_mcast_unicast_data.begin() + noc_mcast_data.size());
+    }
+}
+
+void SubDeviceManager::populate_worker_launch_message_buffer_state() {
+    this->worker_launch_message_buffer_state_.resize(this->num_sub_devices());
+    this->reset_worker_launch_message_buffer_state();
+}
+
+}  // namespace detail
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "tt_metal/impl/allocator/allocator.hpp"
+#include "tt_metal/impl/dispatch/memcpy.hpp"
+#include "tt_metal/impl/kernels/data_types.hpp"
+#include "tt_metal/impl/sub_device/sub_device.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
+#include "tt_metal/tt_stl/span.hpp"
+
+namespace tt::tt_metal {
+
+class LaunchMessageRingBufferState;
+class TraceBuffer;
+
+inline namespace v0 {
+class Device;
+}  // namespace v0
+
+namespace detail {
+class SubDeviceManager {
+   public:
+    static constexpr uint32_t MAX_NUM_SUB_DEVICES = 16;
+    static_assert(MAX_NUM_SUB_DEVICES <= std::numeric_limits<SubDeviceId::Id>::max(), "MAX_NUM_SUB_DEVICES must be less than or equal to the max value of SubDeviceId::Id");
+    // Constructor used for the default/global device
+    SubDeviceManager(Device *device, std::unique_ptr<Allocator> &&global_allocator);
+    // Constructor used for regular sub-devices
+    SubDeviceManager(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, Device *device);
+
+    SubDeviceManager(const SubDeviceManager &other) = delete;
+    SubDeviceManager &operator=(const SubDeviceManager &other) = delete;
+
+    SubDeviceManager(SubDeviceManager &&other) noexcept = default;
+    SubDeviceManager &operator=(SubDeviceManager &&other) noexcept = default;
+
+    ~SubDeviceManager();
+
+    const SubDevice &sub_device(SubDeviceId sub_device_id) const;
+    const vector_memcpy_aligned<uint32_t> &noc_mcast_data(SubDeviceId sub_device_id) const;
+    const vector_memcpy_aligned<uint32_t> &noc_unicast_data(SubDeviceId sub_device_id) const;
+    const vector_memcpy_aligned<uint32_t> &noc_mcast_unicast_data(SubDeviceId sub_device_id) const;
+
+    const std::unique_ptr<Allocator> &get_initialized_allocator(SubDeviceId sub_device_id) const;
+
+    std::unique_ptr<Allocator> &sub_device_allocator(SubDeviceId sub_device_id);
+
+    std::shared_ptr<TraceBuffer> &create_trace(uint32_t tid);
+    void release_trace(uint32_t tid);
+    std::shared_ptr<TraceBuffer> get_trace(uint32_t tid);
+
+    void reset_worker_launch_message_buffer_state();
+    LaunchMessageRingBufferState &get_worker_launch_message_buffer_state(SubDeviceId sub_device_id);
+
+    uint8_t num_sub_devices() const;
+    bool has_allocations() const;
+    DeviceAddr local_l1_size() const;
+
+   private:
+    void validate_sub_devices() const;
+    uint8_t get_sub_device_index(SubDeviceId sub_device_id) const;
+    void populate_num_cores();
+    void populate_sub_allocators();
+    void populate_noc_data();
+    void populate_worker_launch_message_buffer_state();
+
+    // TODO: We have a max number of sub-devices, so we can use a fixed size array
+    std::vector<SubDevice> sub_devices_;
+    Device *device_;
+
+    DeviceAddr local_l1_size_;
+    std::vector<std::unique_ptr<Allocator>> sub_device_allocators_;
+
+    std::array<uint32_t, NumHalProgrammableCoreTypes> num_cores_{};
+    std::vector<vector_memcpy_aligned<uint32_t>> noc_mcast_data_;
+    std::vector<vector_memcpy_aligned<uint32_t>> noc_unicast_data_;
+    // Concatenation of noc_mcast_data_ and noc_unicast_data_
+    // Useful for optimized copying of all coords when constructing FD commands
+    std::vector<vector_memcpy_aligned<uint32_t>> noc_mcast_unicast_data_;
+
+    std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
+
+    std::vector<LaunchMessageRingBufferState> worker_launch_message_buffer_state_;
+};
+
+}  // namespace detail
+
+}  // namespace tt_metal

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -43,13 +43,16 @@ class SubDeviceManager {
 
     ~SubDeviceManager();
 
+    const std::vector<SubDeviceId> &get_sub_device_ids() const;
     const SubDevice &sub_device(SubDeviceId sub_device_id) const;
-    const vector_memcpy_aligned<uint32_t> &noc_mcast_data(SubDeviceId sub_device_id) const;
-    const vector_memcpy_aligned<uint32_t> &noc_unicast_data(SubDeviceId sub_device_id) const;
-    const vector_memcpy_aligned<uint32_t> &noc_mcast_unicast_data(SubDeviceId sub_device_id) const;
+
+    const vector_memcpy_aligned<uint32_t> &noc_mcast_unicast_data() const;
+    uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const;
+    uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const;
+    uint8_t noc_mcast_data_start_index(SubDeviceId sub_device_id) const;
+    uint8_t noc_unicast_data_start_index(SubDeviceId sub_device_id) const;
 
     const std::unique_ptr<Allocator> &get_initialized_allocator(SubDeviceId sub_device_id) const;
-
     std::unique_ptr<Allocator> &sub_device_allocator(SubDeviceId sub_device_id);
 
     std::shared_ptr<TraceBuffer> &create_trace(uint32_t tid);
@@ -66,6 +69,7 @@ class SubDeviceManager {
    private:
     void validate_sub_devices() const;
     uint8_t get_sub_device_index(SubDeviceId sub_device_id) const;
+    void populate_sub_device_ids();
     void populate_num_cores();
     void populate_sub_allocators();
     void populate_noc_data();
@@ -73,17 +77,20 @@ class SubDeviceManager {
 
     // TODO: We have a max number of sub-devices, so we can use a fixed size array
     std::vector<SubDevice> sub_devices_;
+    std::vector<SubDeviceId> sub_device_ids_;
     Device *device_;
 
     DeviceAddr local_l1_size_;
     std::vector<std::unique_ptr<Allocator>> sub_device_allocators_;
 
     std::array<uint32_t, NumHalProgrammableCoreTypes> num_cores_{};
-    std::vector<vector_memcpy_aligned<uint32_t>> noc_mcast_data_;
-    std::vector<vector_memcpy_aligned<uint32_t>> noc_unicast_data_;
-    // Concatenation of noc_mcast_data_ and noc_unicast_data_
-    // Useful for optimized copying of all coords when constructing FD commands
-    std::vector<vector_memcpy_aligned<uint32_t>> noc_mcast_unicast_data_;
+
+    // mcast txn data followed by unicast txn data
+    vector_memcpy_aligned<uint32_t> noc_mcast_unicast_data_;
+    std::vector<uint8_t> num_noc_mcast_txns_;
+    std::vector<uint8_t> num_noc_unicast_txns_;
+    std::vector<uint8_t> noc_mcast_data_start_index_;
+    std::vector<uint8_t> noc_unicast_data_start_index_;
 
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
 

--- a/tt_metal/impl/sub_device/sub_device_types.hpp
+++ b/tt_metal/impl/sub_device/sub_device_types.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+#include <tuple>
 #include <type_traits>
 
 namespace tt::tt_metal {
@@ -85,7 +87,6 @@ struct SubDeviceManagerId {
 
 
 namespace std {
-
 template <>
 struct hash<tt::tt_metal::SubDeviceId> {
     std::size_t operator()(tt::tt_metal::SubDeviceId const &o) const {

--- a/tt_metal/impl/sub_device/sub_device_types.hpp
+++ b/tt_metal/impl/sub_device/sub_device_types.hpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace tt::tt_metal {
+
+struct SubDeviceId {
+    using Id = uint8_t;
+    Id id;
+
+    Id to_index() const { return id; }
+
+    SubDeviceId& operator++() {
+        id++;
+        return *this;
+    }
+
+    SubDeviceId operator++(int) {
+        auto ret = *this;
+        this->operator++();
+        return ret;
+    }
+
+    SubDeviceId& operator+=(Id n) {
+        id += n;
+        return *this;
+    }
+
+    bool operator==(const SubDeviceId &other) const {
+        return id == other.id;
+    }
+
+    bool operator!=(const SubDeviceId &other) const {
+        return id != other.id;
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple("id");
+    constexpr auto attribute_values() const {
+        return std::forward_as_tuple(this->id);
+    }
+};
+
+struct SubDeviceManagerId {
+    using Id = uint64_t;
+    Id id;
+
+    Id to_index() const { return id; }
+
+    SubDeviceManagerId& operator++() {
+        id++;
+        return *this;
+    }
+
+    SubDeviceManagerId operator++(int) {
+        auto ret = *this;
+        this->operator++();
+        return ret;
+    }
+
+    SubDeviceManagerId& operator+=(Id n) {
+        id += n;
+        return *this;
+    }
+
+    bool operator==(const SubDeviceManagerId &other) const {
+        return id == other.id;
+    }
+
+    bool operator!=(const SubDeviceManagerId &other) const {
+        return id != other.id;
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple("id");
+    constexpr auto attribute_values() const {
+        return std::forward_as_tuple(this->id);
+    }
+};
+
+}  // namespace tt::tt_metal
+
+
+namespace std {
+
+template <>
+struct hash<tt::tt_metal::SubDeviceId> {
+    std::size_t operator()(tt::tt_metal::SubDeviceId const &o) const {
+        return std::hash<decltype(tt::tt_metal::SubDeviceId::id)>{}(o.to_index());
+    }
+};
+
+template <>
+struct hash<tt::tt_metal::SubDeviceManagerId> {
+    std::size_t operator()(tt::tt_metal::SubDeviceManagerId const &o) const {
+        return std::hash<decltype(tt::tt_metal::SubDeviceManagerId::id)>{}(o.to_index());
+    }
+};
+
+}  // namespace std

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -81,9 +81,10 @@ void Trace::initialize_buffer(CommandQueue& cq, std::shared_ptr<TraceBuffer> tra
         trace_data.resize(trace_data.size() + numel_padding, 0 /*padding value*/);
     }
     cq.device()->trace_buffers_size += padded_size;
+    auto trace_region_size = cq.device()->get_initialized_allocator()->config.trace_region_size;
     TT_FATAL(
-        cq.device()->trace_buffers_size <= cq.device()->allocator_->config.trace_region_size,
-        "Creating trace buffers of size {}B on device {}, but only {}B is allocated for trace region.",  cq.device()->trace_buffers_size, cq.device()->id(),  cq.device()->allocator_->config.trace_region_size);
+        cq.device()->trace_buffers_size <= trace_region_size,
+        "Creating trace buffers of size {}B on device {}, but only {}B is allocated for trace region.",  cq.device()->trace_buffers_size, cq.device()->id(),  trace_region_size);
     // Commit trace to device DRAM
     trace_buffer->buffer = Buffer::create(
                             cq.device(), padded_size, page_size, BufferType::TRACE, TensorMemoryLayout::INTERLEAVED);

--- a/tt_metal/impl/trace/trace_buffer.hpp
+++ b/tt_metal/impl/trace/trace_buffer.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <unordered_map>
 #include <utility>
 #include <variant>
 
@@ -16,9 +17,16 @@ namespace tt::tt_metal {
 
 namespace detail {
 struct TraceDescriptor {
-    uint32_t num_completion_worker_cores = 0;
-    uint32_t num_traced_programs_needing_go_signal_multicast = 0;
-    uint32_t num_traced_programs_needing_go_signal_unicast = 0;
+    struct Descriptor {
+        uint32_t num_completion_worker_cores = 0;
+        uint32_t num_traced_programs_needing_go_signal_multicast = 0;
+        uint32_t num_traced_programs_needing_go_signal_unicast = 0;
+    };
+    // Mapping of sub_device_id to descriptor
+    std::unordered_map<uint32_t, Descriptor> descriptors;
+    // Store the keys of the map in a vector after descriptor has finished being populated
+    // This is an optimization since we sometimes need to only pass the keys in a container
+    std::vector<uint32_t> sub_device_ids;
     std::vector<uint32_t> data;
 };
 }  // namespace detail

--- a/tt_metal/impl/trace/trace_buffer.hpp
+++ b/tt_metal/impl/trace/trace_buffer.hpp
@@ -12,6 +12,7 @@
 #include <variant>
 
 #include "tt_metal/impl/buffers/buffer.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
 
 namespace tt::tt_metal {
 
@@ -23,10 +24,10 @@ struct TraceDescriptor {
         uint32_t num_traced_programs_needing_go_signal_unicast = 0;
     };
     // Mapping of sub_device_id to descriptor
-    std::unordered_map<uint32_t, Descriptor> descriptors;
+    std::unordered_map<SubDeviceId, Descriptor> descriptors;
     // Store the keys of the map in a vector after descriptor has finished being populated
     // This is an optimization since we sometimes need to only pass the keys in a container
-    std::vector<uint32_t> sub_device_ids;
+    std::vector<SubDeviceId> sub_device_ids;
     std::vector<uint32_t> data;
 };
 }  // namespace detail

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -31,6 +31,8 @@ enum class HalProgrammableCoreType {
     COUNT      = 3
 };
 
+static constexpr uint32_t NumHalProgrammableCoreTypes = static_cast<uint32_t>(HalProgrammableCoreType::COUNT);
+
 enum class HalProcessorClassType : uint8_t {
     DM      = 0,
     // Setting this to 2 because we currently treat brisc and ncrisc as two unique processor classes on Tensix

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1279,13 +1279,13 @@ void ReplayTrace(Device *device, const uint8_t cq_id, const uint32_t tid, const 
 
 void ReleaseTrace(Device *device, const uint32_t tid) { device->release_trace(tid); }
 
-void Synchronize(Device *device, const std::optional<uint8_t> cq_id) {
+void Synchronize(Device *device, const std::optional<uint8_t> cq_id, tt::stl::Span<const uint32_t> sub_device_ids) {
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
         if (cq_id.has_value()) {
-            Finish(device->command_queue(cq_id.value()));
+            Finish(device->command_queue(cq_id.value()), sub_device_ids);
         } else {
             for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); ++cq_id) {
-                Finish(device->command_queue(cq_id));
+                Finish(device->command_queue(cq_id), sub_device_ids);
             }
         }
     }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -24,6 +24,7 @@
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
 #include "tt_metal/impl/buffers/global_semaphore.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
 #include "tt_metal/graph/graph_tracking.hpp"
@@ -837,9 +838,15 @@ DeviceAddr AllocateBuffer(Buffer *buffer) {
         GraphTracker::instance().track_allocate(buffer);
         return 0;
     }
-    // TODO: Validate correct sub-device manager id
-    auto& allocator = buffer->device()->get_initialized_allocator(buffer->sub_device_id());
+    if (buffer->sub_device_manager_id().has_value()) {
+        TT_FATAL(*(buffer->sub_device_manager_id()) == buffer->device()->get_active_sub_device_manager_id(),
+            "Sub-device manager id mismatch. Buffer sub-device manager id: {}, Device active sub-device manager id: {}",
+            *buffer->sub_device_manager_id(),
+            buffer->device()->get_active_sub_device_manager_id());
+    }
+    auto allocator = buffer->allocator();
     DeviceAddr allocated_addr;
+
     if (is_sharded(buffer->buffer_layout())) {
         allocated_addr = allocator::allocate_buffer(
             *allocator,
@@ -876,8 +883,13 @@ void DeallocateBuffer(Buffer *buffer) {
         TracyFreeN(reinterpret_cast<void const *>(buffer->address()), get_buffer_location_name(buffer->buffer_type(), buffer->device()->id()));
     }
 #endif
-    // TODO: Validate correct sub-device manager id
-    auto& allocator = buffer->device()->get_initialized_allocator(buffer->sub_device_id());
+    if (buffer->sub_device_manager_id().has_value()) {
+        TT_FATAL(*(buffer->sub_device_manager_id()) == buffer->device()->get_active_sub_device_manager_id(),
+            "Sub-device manager id mismatch. Buffer sub-device manager id: {}, Device active sub-device manager id: {}",
+            *buffer->sub_device_manager_id(),
+            buffer->device()->get_active_sub_device_manager_id());
+    }
+    auto allocator = buffer->allocator();
     allocator::deallocate_buffer(*allocator, buffer);
 }
 
@@ -1140,38 +1152,72 @@ std::unique_ptr<GlobalSemaphore> CreateGlobalSemaphore(
     return GlobalSemaphore::create(device, std::move(cores), initial_value, buffer_type);
 }
 
-std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config, std::optional<DeviceAddr> address, std::optional<uint32_t> sub_device_id) {
-    if (address.has_value()) {
-        return Buffer::create(
-            config.device, *address, config.size, config.page_size, config.buffer_type, config.buffer_layout, std::nullopt, std::nullopt, sub_device_id);
-    } else {
-        return Buffer::create(
-            config.device, config.size, config.page_size, config.buffer_type, config.buffer_layout, std::nullopt, std::nullopt, sub_device_id);
-    }
+std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config) {
+    return Buffer::create(
+        config.device,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt);
 }
-std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config, std::optional<DeviceAddr> address, std::optional<uint32_t> sub_device_id) {
-    if (address.has_value()) {
-        return Buffer::create(
-            config.device,
-            *address,
-            config.size,
-            config.page_size,
-            config.buffer_type,
-            config.buffer_layout,
-            config.shard_parameters,
-            std::nullopt,
-            sub_device_id);
-    } else {
-        return Buffer::create(
-            config.device,
-            config.size,
-            config.page_size,
-            config.buffer_type,
-            config.buffer_layout,
-            config.shard_parameters,
-            std::nullopt,
-            sub_device_id);
-    }
+std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config, DeviceAddr address) {
+    return Buffer::create(
+        config.device,
+        address,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        std::nullopt,
+        std::nullopt);
+}
+std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config, SubDeviceId sub_device_id) {
+    return Buffer::create(
+        config.device,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        std::nullopt,
+        std::nullopt,
+        sub_device_id);
+}
+std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config) {
+    return Buffer::create(
+        config.device,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        config.shard_parameters,
+        std::nullopt,
+        std::nullopt);
+}
+std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config, DeviceAddr address) {
+    return Buffer::create(
+        config.device,
+        address,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        config.shard_parameters,
+        std::nullopt,
+        std::nullopt);
+}
+std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config, SubDeviceId sub_device_id) {
+    return Buffer::create(
+        config.device,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        config.shard_parameters,
+        std::nullopt,
+        sub_device_id);
 }
 
 void DeallocateBuffer(Buffer &buffer) { buffer.deallocate(); }
@@ -1283,7 +1329,7 @@ void ReplayTrace(Device *device, const uint8_t cq_id, const uint32_t tid, const 
 
 void ReleaseTrace(Device *device, const uint32_t tid) { device->release_trace(tid); }
 
-void Synchronize(Device *device, const std::optional<uint8_t> cq_id, tt::stl::Span<const uint32_t> sub_device_ids) {
+void Synchronize(Device *device, const std::optional<uint8_t> cq_id, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
         if (cq_id.has_value()) {
             Finish(device->command_queue(cq_id.value()), sub_device_ids);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13655

### Problem description
Various aspects of FD/runtime need to be updated to support multiple sub devices.
SubDevice: Container of the various cores we want to group together from a device
SubDeviceManager: Container of the state/objects that represent a configuration of the device that is split into SubDevices.

### What's changed
Support multiple dispatch entries for worker->dispatch sync

Update dispatch d/s to have a semaphore per dispatch entry to enable syncing on specific worker counts

Update LaunchMessageRingBufferState and WorkerConfigBufferMgr to be tracked per sub_device

Update various FD commands to support syncing on multiple sub devices:
- ERB, EWB, ERE, Synchronize/finish takes in a list of sub devices for blocking/issuing waits on. Will wait on all sub-devices if none are provided
- Trace will track only specific sub devices used
- EP currently only supports one sub-device

Update allocator to support taking in a CoreRangeSet for banks, instead of assuming a rectangular grid

Add support for splitting a device into multiple SubDevices, as well and maintaining different SubDeviceManager configurations, owned by device

Add basic tests to validate sub-device support

I will be continuing to add/updates tests in the near future, but would like to get this merged since this touches a lot of files/state to avoid dealing with conflicts.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11823639393
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
