### PR TITLE
#14361: Implement program API

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -75,3 +75,9 @@ CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.
 ############################################################################################################################
 
 CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.0.1)
+
+############################################################################################################################
+# range-v3 : https://github.com/ericniebler/range-v3
+############################################################################################################################
+
+CPMAddPackage(NAME range-v3 GITHUB_REPOSITORY ericniebler/range-v3 GIT_TAG 0.12.0)

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(
         ${UMD_HOME}
         ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
+        include
 )
 target_compile_options(tt_metal PUBLIC -Wno-int-to-pointer-cast)
 add_dependencies(tt_metal hw_toolchain)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -27,7 +27,12 @@ set(IMPL_SRC
 add_library(impl OBJECT ${IMPL_SRC})
 add_library(Metalium::Metal::Impl ALIAS impl)
 
-target_link_libraries(impl PRIVATE Boost::smart_ptr)
+target_link_libraries(
+    impl
+    PRIVATE
+        Boost::smart_ptr
+        range-v3::range-v3
+)
 target_link_libraries(impl PUBLIC common)
 
 target_include_directories(
@@ -35,6 +40,7 @@ target_include_directories(
     PUBLIC
         ${PROJECT_SOURCE_DIR}/tt_metal
         ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal/include
 )
 
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast)

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -42,6 +42,8 @@ namespace detail{
     std::shared_ptr<Kernel> GetKernel(const Program &program, KernelHandle kernel_id);
     std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CBHandle id);
     void AddConfigBuffer(Program &program, std::shared_ptr<Buffer> config_buffer);
+
+    class Internal_;
 }
 
 typedef std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX> kernel_id_array_t;
@@ -169,6 +171,7 @@ class Program {
 
     friend HWCommandQueue;
     friend EnqueueProgramCommand;
+    friend detail::Internal_;
 
     const ProgramTransferInfo &get_program_transfer_info() const noexcept;
     const std::shared_ptr<Buffer> &get_kernels_buffer() const noexcept;

--- a/tt_metal/include/tt_metal/internal/types.hpp
+++ b/tt_metal/include/tt_metal/internal/types.hpp
@@ -4,14 +4,10 @@
 
 #pragma once
 
-#include "tt_metal/api/types.hpp"
+#include "tt_metal/types.hpp"
 
-namespace tt::tt_metal{
-
+namespace tt::tt_metal {
 namespace v1 {
 
 }
-
-
-
-}
+}  // namespace tt::tt_metal

--- a/tt_metal/include/tt_metal/program.hpp
+++ b/tt_metal/include/tt_metal/program.hpp
@@ -9,6 +9,7 @@
 
 #include "tt_metal/impl/kernels/kernel_types.hpp"
 #include "tt_metal/impl/buffers/circular_buffer_types.hpp"
+#include "tt_metal/tt_stl/any_range.hpp"
 
 //==================================================
 //                  PROGRAM MANAGEMENT
@@ -17,12 +18,16 @@
 namespace tt::tt_metal{
 namespace v1 {
 
+MAKE_ANY_RANGE(SizedCircularBufferRange, stl::AnySizedInputRange<CircularBufferHandle, stl::default_any_range_capacity, 24>);
+
+MAKE_ANY_RANGE(CircularBufferRange, stl::AnyInputRange<CircularBufferHandle, 96, 32>);
+
 /**
  * @brief Creates a Program object, which bundles kernels, circular buffers, and semaphores for execution on the device.
  *
  * @return Program handle to the created program.
  */
-Program CreateProgram();
+ProgramHandle CreateProgram();
 
 
 /**
@@ -35,7 +40,7 @@ Program CreateProgram();
  * @return KernelHandle representing the kernel ID.
  */
 KernelHandle CreateKernel(
-    Program program,
+    ProgramHandle &program,
     std::string_view file_name,
     const CoreRangeSet &core_spec,
     const DataMovementConfig &config);
@@ -50,7 +55,7 @@ KernelHandle CreateKernel(
  * @return KernelHandle representing the kernel ID.
  */
 KernelHandle CreateKernel(
-    Program program,
+    ProgramHandle &program,
     std::string_view file_name,
     const CoreRangeSet &core_spec,
     const ComputeConfig &config);
@@ -65,7 +70,7 @@ KernelHandle CreateKernel(
  * @return KernelHandle representing the kernel ID.
  */
 KernelHandle CreateKernel(
-    Program program,
+    ProgramHandle &program,
     std::string_view file_name,
     const CoreRangeSet &core_spec,
     const EthernetConfig &config);
@@ -81,9 +86,9 @@ KernelHandle CreateKernel(
  * @return Semaphore address as a uint32_t.
  */
 uint32_t CreateSemaphore(
-    Program program,
+    ProgramHandle &program,
     const CoreRangeSet &core_spec,
-    uint32_t initial_value,
+    std::uint32_t initial_value,
     CoreType core_type = CoreType::WORKER);
 
 
@@ -95,8 +100,8 @@ uint32_t CreateSemaphore(
  * @param config Configuration for the circular buffer.
  * @return CBHandle representing the Circular Buffer ID.
  */
-CBHandle CreateCircularBuffer(
-    Program program,
+CircularBufferHandle CreateCircularBuffer(
+    ProgramHandle &program,
     const CoreRangeSet &core_spec,
     const CircularBufferConfig &config);
 
@@ -107,24 +112,24 @@ CBHandle CreateCircularBuffer(
  * @param cb_handle Handle of the circular buffer.
  * @return Reference to the CircularBufferConfig.
  */
-const CircularBufferConfig &GetCircularBufferConfig(Program program, CBHandle cb_handle);
+const CircularBufferConfig &GetCircularBufferConfig(ProgramHandle &program, CircularBufferHandle cb_handle);
 
 /**
  * @brief Retrieves the circular buffers associated with the program.
  *
  * @param program The program to query.
- * @return Reference to a vector of shared pointers to CircularBuffer objects.
+ * @return A sized input range of CircularBufferHandle.
  */
-const std::vector<CircularBuffer> &GetCircularBuffers(Program program);
+SizedCircularBufferRange GetCircularBuffers(ProgramHandle &program);
 
 /**
  * @brief Retrieves the circular buffers associated with the program on a specific core range.
  *
  * @param program The program to query.
  * @param cr The core range to consider.
- * @return Vector of shared pointers to CircularBuffer objects on the core range.
+ * @return An input range of CircularBufferHandle on the given core range.
  */
-std::vector<CircularBuffer> GetCircularBuffersOnCoreRange(Program program, const CoreRange &cr);
+CircularBufferRange GetCircularBuffersOnCoreRange(ProgramHandle &program, CoreRange cr);
 
 
 //==================================================
@@ -138,7 +143,7 @@ std::vector<CircularBuffer> GetCircularBuffersOnCoreRange(Program program, const
  * @param cb_handle Handle of the circular buffer.
  * @param total_size New total size of the circular buffer in bytes.
  */
-void UpdateCircularBufferTotalSize(Program program, CBHandle cb_handle, uint32_t total_size);
+void UpdateCircularBufferTotalSize(ProgramHandle &program, CircularBufferHandle cb_handle, std::uint32_t total_size);
 
 /**
  * @brief Updates the address of a dynamic circular buffer.
@@ -147,15 +152,7 @@ void UpdateCircularBufferTotalSize(Program program, CBHandle cb_handle, uint32_t
  * @param cb_handle Handle of the circular buffer.
  * @param buffer Dynamically allocated L1 buffer that shares address space with the circular buffer.
  */
-void UpdateDynamicCircularBufferAddress(Program program, CBHandle cb_handle, const Buffer buffer);
-
-
-/**
- * @brief Captures dependencies for multi-device execution in the program.
- *
- * @param program The program to modify.
- */
-void CaptureMultiDeviceDependencies(Program program);
+void UpdateDynamicCircularBufferAddress(ProgramHandle &program, CircularBufferHandle cb_handle, BufferHandle buffer);
 
 
 } // namespace v1

--- a/tt_metal/include/tt_metal/types.hpp
+++ b/tt_metal/include/tt_metal/types.hpp
@@ -6,22 +6,52 @@
 
 #include "device/tt_cluster_descriptor_types.h"
 #include "hostdevcommon/common_values.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/device/device_handle.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 
-namespace tt::tt_metal{
-
+namespace tt::tt_metal {
 namespace v1 {
 
-// Opaque classes
-class Program;
-class Device;
+using ProgramHandle = v0::Program;
+class DeviceHandle;
 class CommandQueue;
 class Trace;
 
-// Ideally these would be opaque but this work requires
-// completion of the prototype of the runtime args.
-class CircularBuffer;
-class Buffer;
+class KernelHandle {
+   public:
+    explicit constexpr KernelHandle(tt_metal::KernelHandle kernel_id) noexcept : kernel_id{kernel_id} {}
+
+    explicit constexpr operator tt_metal::KernelHandle() const noexcept { return kernel_id; }
+
+   private:
+    tt_metal::KernelHandle kernel_id;
+};
+
+class CircularBufferHandle {
+   public:
+    explicit constexpr CircularBufferHandle(v0::CBHandle cb_id) noexcept : cb_id{cb_id} {}
+
+    explicit constexpr operator v0::CBHandle() const noexcept { return cb_id; }
+
+   private:
+    v0::CBHandle cb_id;
+};
+
+class BufferHandle {
+   public:
+    explicit BufferHandle(const std::shared_ptr<v0::Buffer> &buffer_ptr) noexcept : buffer_ptr{buffer_ptr} {}
+    explicit BufferHandle(std::shared_ptr<v0::Buffer> &&buffer_ptr) noexcept :
+        buffer_ptr{static_cast<std::shared_ptr<v0::Buffer> &&>(buffer_ptr)} {}
+
+    explicit operator const std::shared_ptr<v0::Buffer> &() const noexcept { return buffer_ptr; }
+
+    v0::Buffer &operator*() const noexcept { return *buffer_ptr.get(); }
+    v0::Buffer *operator->() const noexcept { return buffer_ptr.get(); }
+
+   private:
+    std::shared_ptr<v0::Buffer> buffer_ptr;
+};
 
 // Not likely going to be opaque, but pending review of
 // completion of the prototype of the runtime args.
@@ -29,8 +59,5 @@ class Event;
 class RuntimeArgs;
 class RuntimeArgsData;
 
-}
-
-
-
-}
+}  // namespace v1
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#14361

### Problem description
Metal 1.0 API declares interfaces but does not yet provide implementation.

### What's changed
This implements the Metal 1.0 API functions related to the creation and usage of Programs, in a manner compatible with v0 until it is deprecated and removed.

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11690229303, https://github.com/tenstorrent/tt-metal/actions/runs/11728607423)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
