### PR TITLE
#14407: Add channel bcast support for non-4D tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -10,6 +10,29 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+@pytest.mark.parametrize(
+    "shapes", [[[63, 1, 4], [1, 9, 4]], [[13600, 1, 4], [1, 9, 4]], [[1, 16, 6, 64, 64], [1, 16, 1, 64, 64]]]
+)
+def test_non_4D_channel_bcast(device, shapes):
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988
+
+
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("size", [64])
 def test_add_1D_tensor_and_scalar(device, scalar, size):

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -114,9 +114,12 @@ auto preprocess_inputs(const Tensor &input_tensor_a_arg, const Tensor &input_ten
             second = ttnn::repeat(second, repeats);
         }
         // repeats second if it is smaller
-        if (first_shape.rank() == 4 and second_shape.rank() == 4 and first_shape[1] > second_shape[1]) {
-            TT_FATAL(second_shape[1] == 1, "Dimension trying to broadcast is not equal to 1");
-            Shape repeats(std::array<uint32_t, 4>{1, first_shape[1], 1, 1});
+        if (first_shape.rank() >= 3 and second_shape.rank() >= 3 and first_shape[-3] > second_shape[-3]) {
+            TT_FATAL(second_shape[-3] == 1, "Dimension trying to broadcast is not equal to 1");
+            int rank_a = first_shape.rank();
+            std::vector<uint32_t> repeat_dim(rank_a, 1);
+            repeat_dim[rank_a - 3] = first_shape[rank_a - 3];
+            Shape repeats(repeat_dim);
             second = ttnn::repeat(second, repeats);
         }
     };


### PR DESCRIPTION
### Ticket
Link to Github Issue #14407

### Problem description
Currently, eltwise binary ops provide channel bcast support using ttnn.repeat for 4D tensors i.e tensors of rank==4.
We need to be able to support 3D, 5D,..etc tensors as well

### What's changed
Added channel beast support for tensors with rank >=3

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11565403065
https://github.com/tenstorrent/tt-metal/actions/runs/11569644027
- [ ] Nightly FD https://github.com/tenstorrent/tt-metal/actions/runs/11565471113
https://github.com/tenstorrent/tt-metal/actions/runs/11569640358
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
