### PR TITLE
#12743: Fix namespace tt::tt_metal usage in tt_metal

### DIFF
--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -22,7 +22,7 @@ struct CoreDescriptorComparator {
 #define CoreDescriptorSet std::set<CoreDescriptor, CoreDescriptorComparator>
 
 // Helper function to get CoreDescriptors for all debug-relevant cores on device.
-static CoreDescriptorSet GetAllCores(Device *device) {
+static CoreDescriptorSet GetAllCores(tt::tt_metal::Device *device) {
     CoreDescriptorSet all_cores;
     // The set of all printable cores is Tensix + Eth cores
     CoreCoord logical_grid_size = device->logical_grid_size();
@@ -43,10 +43,10 @@ static CoreDescriptorSet GetAllCores(Device *device) {
 
 // Helper function to get CoreDescriptors for all cores that are used for dispatch. Should be a subset of
 // GetAllCores().
-static CoreDescriptorSet GetDispatchCores(Device* device) {
+static CoreDescriptorSet GetDispatchCores(tt::tt_metal::Device* device) {
     CoreDescriptorSet dispatch_cores;
     unsigned num_cqs = device->num_hw_cqs();
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    CoreType dispatch_core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(device->id());
     tt::log_warning("Dispatch Core Type = {}", dispatch_core_type);
     for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_type)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});
@@ -54,9 +54,9 @@ static CoreDescriptorSet GetDispatchCores(Device* device) {
     return dispatch_cores;
 }
 
-inline uint64_t GetDprintBufAddr(Device *device, const CoreCoord &phys_core, int risc_id) {
+inline uint64_t GetDprintBufAddr(tt::tt_metal::Device *device, const CoreCoord &phys_core, int risc_id) {
 
-    dprint_buf_msg_t *buf = device->get_dev_addr<dprint_buf_msg_t *>(phys_core, HalL1MemAddrType::DPRINT);
+    dprint_buf_msg_t *buf = device->get_dev_addr<dprint_buf_msg_t *>(phys_core, tt::tt_metal::HalL1MemAddrType::DPRINT);
     return reinterpret_cast<uint64_t>(buf->data[risc_id]);
 }
 

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -14,6 +14,8 @@
 #include "hostdevcommon/dprint_common.h"
 #include "tt_metal/impl/device/device.hpp"
 
+using namespace tt::tt_metal;
+
 // 32 buckets to match the number of bits in uint32_t lengths on device
 #define NOC_DATA_SIZE sizeof(uint32_t) * 8
 using noc_data_t = std::array<uint64_t, NOC_DATA_SIZE>;

--- a/tt_metal/impl/debug/noc_logging.hpp
+++ b/tt_metal/impl/debug/noc_logging.hpp
@@ -7,6 +7,6 @@
 #include "tt_metal/impl/device/device.hpp"
 
 namespace tt {
-void ClearNocData(Device *device);
-void DumpNocData(std::vector<Device *> devices);
+void ClearNocData(tt_metal::Device *device);
+void DumpNocData(std::vector<tt_metal::Device *> devices);
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -15,6 +15,8 @@
 
 #include "watcher_device_reader.hpp"
 
+using namespace tt::tt_metal;
+
 using std::string;
 namespace { // Helper functions
 

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -24,7 +24,7 @@ typedef struct {
 class WatcherDeviceReader {
     public:
      WatcherDeviceReader(
-         FILE *f, Device *device, std::vector<std::string> &kernel_names, void (*set_watcher_exception_message)(const std::string &));
+         FILE *f, tt_metal::Device *device, std::vector<std::string> &kernel_names, void (*set_watcher_exception_message)(const std::string &));
      ~WatcherDeviceReader();
      void Dump(FILE *file = nullptr);
 
@@ -48,7 +48,7 @@ class WatcherDeviceReader {
     std::string GetKernelName(CoreDescriptor &core, const launch_msg_t *launch_msg, uint32_t type);
 
     FILE *f;
-    Device *device;
+    tt_metal::Device *device;
     std::vector<std::string> &kernel_names;
     void (* set_watcher_exception_message)(const std::string &);
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -23,6 +23,8 @@
 #include "debug/ring_buffer.h"
 #include "watcher_device_reader.hpp"
 
+using namespace tt::tt_metal;
+
 namespace tt {
 namespace watcher {
 

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -8,9 +8,9 @@
 
 namespace tt {
 
-void watcher_init(Device *device);
-void watcher_attach(Device *device);
-void watcher_detach(Device *dev);
+void watcher_init(tt_metal::Device *device);
+void watcher_attach(tt_metal::Device *device);
+void watcher_detach(tt_metal::Device *dev);
 
 void watcher_sanitize_host_noc_read(const metal_SocDescriptor &soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord core, uint64_t addr, uint32_t len);

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/device/device_handle.hpp"
 
+using namespace tt::tt_metal;
+
 namespace tt {
 
 namespace device_cpu_allocator {

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -21,7 +21,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices);
 using Device = tt_metal::Device;
 class DevicePool {
     friend Device;
-    friend v1::DeviceHandle;
+    friend tt_metal::v1::DeviceHandle;
     friend void tt_metal::detail::CloseDevices(std::map<chip_id_t, Device *> devices);
 
    public:
@@ -40,16 +40,16 @@ class DevicePool {
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
         size_t trace_region_size,
-        DispatchCoreType dispatch_core_type,
+        tt_metal::DispatchCoreType dispatch_core_type,
         const std::vector<uint32_t> &l1_bank_remap = {}) noexcept;
 
-    v1::DeviceHandle get_active_device(chip_id_t device_id) const;
-    std::vector<v1::DeviceHandle> get_all_active_devices() const;
+    tt_metal::v1::DeviceHandle get_active_device(chip_id_t device_id) const;
+    std::vector<tt_metal::v1::DeviceHandle> get_all_active_devices() const;
     bool close_device(chip_id_t device_id);
     void close_devices(const std::vector<Device *> &devices);
     bool is_device_active(chip_id_t id) const;
-    void register_worker_thread_for_device(v1::DeviceHandle device, std::thread::id worker_thread_id);
-    void unregister_worker_thread_for_device(v1::DeviceHandle device);
+    void register_worker_thread_for_device(tt_metal::v1::DeviceHandle device, std::thread::id worker_thread_id);
+    void unregister_worker_thread_for_device(tt_metal::v1::DeviceHandle device);
     const std::unordered_set<std::thread::id>& get_worker_thread_ids() const;
    private:
     ~DevicePool();
@@ -81,12 +81,12 @@ class DevicePool {
     void init_firmware_on_active_devices() const;
     void init_profiler_devices() const;
     void activate_device(chip_id_t id);
-    void initialize_device(v1::DeviceHandle dev) const;
+    void initialize_device(tt_metal::v1::DeviceHandle dev) const;
     void add_devices_to_pool(std::vector<chip_id_t> device_ids);
     static DevicePool *_inst;
 
     // TODO remove with v0
-    v1::DeviceHandle get_handle(Device* device) const;
+    tt_metal::v1::DeviceHandle get_handle(Device* device) const;
 };
 
 }  // namespace tt

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -33,6 +33,8 @@
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
 
+using namespace tt::tt_metal;
+
 using std::map;
 using std::pair;
 using std::set;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -697,5 +697,5 @@ void EnqueueAddBufferToProgram(
 
 }  // namespace tt::tt_metal
 
-std::ostream& operator<<(std::ostream& os, EnqueueCommandType const& type);
-std::ostream& operator<<(std::ostream& os, CommandQueue::CommandQueueMode const& type);
+std::ostream& operator<<(std::ostream& os, tt::tt_metal::EnqueueCommandType const& type);
+std::ostream& operator<<(std::ostream& os, tt::tt_metal::CommandQueue::CommandQueueMode const& type);

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -125,7 +125,7 @@ struct dispatch_constants {
     }
 
     uint32_t get_host_command_queue_addr(const CommandQueueHostAddrType &host_addr) const {
-        return tt::utils::underlying_type<CommandQueueHostAddrType>(host_addr) * hal.get_alignment(HalMemType::HOST);
+        return tt::utils::underlying_type<CommandQueueHostAddrType>(host_addr) * tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
     }
 
    private:
@@ -146,7 +146,7 @@ struct dispatch_constants {
             dispatch_buffer_block_size = 512 * 1024;
             prefetch_d_buffer_size_ = 256 * 1024;
             dispatch_s_buffer_size_ = 32 * 1024; // dispatch_s only sends Go Signals -> CB can be small
-            base_device_command_queue_addr = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+            base_device_command_queue_addr = tt::tt_metal::hal.get_dev_addr(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
         } else {
             prefetch_q_entries_ = 128;
             max_prefetch_command_size_ = 32 * 1024;
@@ -155,14 +155,14 @@ struct dispatch_constants {
             dispatch_buffer_block_size = 128 * 1024;
             prefetch_d_buffer_size_ = 128 * 1024;
             dispatch_s_buffer_size_ = 32 * 1024; // dispatch_s only sends Go Signals -> CB can be small
-            base_device_command_queue_addr = hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
+            base_device_command_queue_addr = tt::tt_metal::hal.get_dev_addr(tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
         }
         TT_ASSERT(cmddat_q_size_ >= 2 * max_prefetch_command_size_);
         TT_ASSERT(scratch_db_size_ % 2 == 0);
         TT_ASSERT((dispatch_buffer_block_size & (dispatch_buffer_block_size - 1)) == 0);
 
-        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
-        uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+        uint32_t pcie_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
+        uint32_t l1_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1);
         uint8_t num_dev_cq_addrs = magic_enum::enum_count<CommandQueueDeviceAddrType>();
         std::vector<uint32_t> device_cq_addr_sizes_(num_dev_cq_addrs, 0);
         for (auto dev_addr_idx = 0; dev_addr_idx < num_dev_cq_addrs; dev_addr_idx++) {
@@ -248,7 +248,7 @@ inline uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t c
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
     uint32_t channel_offset = (channel >> 2) * MAX_DEV_CHANNEL_SIZE;
-    CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
+    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
     uint32_t issue_q_rd_ptr = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
     tt::Cluster::instance().read_sysmem(
         &recv,
@@ -267,7 +267,7 @@ inline uint32_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t c
     uint32_t recv;
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
-    CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
+    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
     uint32_t issue_q_wr_ptr = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
     tt::Cluster::instance().read_sysmem(&recv, sizeof(uint32_t), issue_q_wr_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
     if (not addr_16B) {
@@ -282,7 +282,7 @@ inline uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint3
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
     uint32_t channel_offset = (channel >> 2) * MAX_DEV_CHANNEL_SIZE;
-    CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
+    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
     uint32_t completion_q_wr_ptr = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
     tt::Cluster::instance().read_sysmem(
         &recv,
@@ -301,7 +301,7 @@ inline uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint3
     uint32_t recv;
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
-    CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
+    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(chip_id);
     uint32_t completion_q_rd_ptr = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
     tt::Cluster::instance().read_sysmem(&recv, sizeof(uint32_t), completion_q_rd_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
     if (not addr_16B) {
@@ -449,7 +449,7 @@ class SystemMemoryManager {
     std::vector<uint32_t> bypass_buffer;
     uint32_t bypass_buffer_write_offset;
 
-    WorkerConfigBufferMgr config_buffer_mgr;
+    tt::tt_metal::WorkerConfigBufferMgr config_buffer_mgr;
 
    public:
     SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
@@ -487,20 +487,20 @@ class SystemMemoryManager {
         }
         this->channel_offset = MAX_HUGEPAGE_SIZE * get_umd_channel(channel) + (channel >> 2) * MAX_DEV_CHANNEL_SIZE;
 
-        CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(device_id);
+        CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(device_id);
         uint32_t completion_q_rd_ptr = dispatch_constants::get(core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
         uint32_t prefetch_q_base = dispatch_constants::get(core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
         uint32_t cq_start = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             tt_cxy_pair prefetcher_core =
-                dispatch_core_manager::instance().prefetcher_core(device_id, channel, cq_id);
+                tt::tt_metal::dispatch_core_manager::instance().prefetcher_core(device_id, channel, cq_id);
             tt_cxy_pair prefetcher_physical_core =
                 tt_cxy_pair(prefetcher_core.chip, tt::get_physical_core_coordinate(prefetcher_core, core_type));
             this->prefetcher_cores[cq_id] = prefetcher_physical_core;
             this->prefetch_q_writers.emplace_back(tt::Cluster::instance().get_static_tlb_writer(prefetcher_physical_core));
 
             tt_cxy_pair completion_queue_writer_core =
-                dispatch_core_manager::instance().completion_queue_writer_core(device_id, channel, cq_id);
+                tt::tt_metal::dispatch_core_manager::instance().completion_queue_writer_core(device_id, channel, cq_id);
             const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data =
                 tt::Cluster::instance()
                     .get_tlb_data(tt_cxy_pair(
@@ -531,10 +531,10 @@ class SystemMemoryManager {
         std::vector<std::mutex> temp_mutexes(num_hw_cqs);
         cq_to_event_locks.swap(temp_mutexes);
 
-        for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        for (uint32_t index = 0; index < tt::tt_metal::hal.get_programmable_core_type_count(); index++) {
             this->config_buffer_mgr.init_add_core(
-                hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG),
-                hal.get_dev_size(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG));
+                tt::tt_metal::hal.get_dev_addr(tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
+                tt::tt_metal::hal.get_dev_size(tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG));
         }
     }
 
@@ -649,7 +649,7 @@ class SystemMemoryManager {
         uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
 
         const uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
-        if (issue_q_write_ptr + align(cmd_size_B, hal.get_alignment(HalMemType::HOST)) > command_issue_limit) {
+        if (issue_q_write_ptr + align(cmd_size_B, tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST)) > command_issue_limit) {
             this->wrap_issue_queue_wr_ptr(cq_id);
             issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
         }
@@ -696,10 +696,10 @@ class SystemMemoryManager {
         }
 
         // All data needs to be 32B aligned
-        uint32_t push_size_16B = align(push_size_B, hal.get_alignment(HalMemType::HOST)) >> 4;
+        uint32_t push_size_16B = align(push_size_B, tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST)) >> 4;
 
         SystemMemoryCQInterface &cq_interface = this->cq_interfaces[cq_id];
-        CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device_id);
+        CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(this->device_id);
         uint32_t issue_q_wr_ptr = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
 
         if (cq_interface.issue_fifo_wr_ptr + push_size_16B >= cq_interface.issue_fifo_limit) {
@@ -747,7 +747,7 @@ class SystemMemoryManager {
         // Also store this data in hugepages in case we hang and can't get it from the device.
         chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_id);
         uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_id);
-        CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device_id);
+        CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(this->device_id);
         uint32_t completion_q_rd_ptr = dispatch_constants::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
         tt::Cluster::instance().write_sysmem(
             &read_ptr_and_toggle,
@@ -791,7 +791,7 @@ class SystemMemoryManager {
         if (this->bypass_enable)
             return;
 
-        CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(device_id);
+        CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(device_id);
         const uint32_t prefetch_q_rd_ptr = dispatch_constants::get(core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
 
         // Helper to wait for fetch queue space, if needed
@@ -819,7 +819,7 @@ class SystemMemoryManager {
 
     void fetch_queue_write(uint32_t command_size_B, const uint8_t cq_id, bool stall_prefetcher = false) {
         CoreType dispatch_core_type =
-            dispatch_core_manager::instance().get_dispatch_core_type(this->device_id);
+            tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(this->device_id);
         uint32_t max_command_size_B = dispatch_constants::get(dispatch_core_type, num_hw_cqs).max_prefetch_command_size();
         TT_ASSERT(
             command_size_B <= max_command_size_B,
@@ -845,7 +845,7 @@ class SystemMemoryManager {
         this->prefetch_q_dev_ptrs[cq_id] += sizeof(dispatch_constants::prefetch_q_entry_type);
     }
 
-    WorkerConfigBufferMgr& get_config_buffer_mgr() { return config_buffer_mgr; }
+    tt::tt_metal::WorkerConfigBufferMgr& get_config_buffer_mgr() { return config_buffer_mgr; }
 
 };
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -10,6 +10,7 @@
 #include <magic_enum.hpp>
 
 using namespace tt;
+using namespace tt::tt_metal;
 
 namespace {
 

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -25,13 +25,13 @@ typedef enum e_data_collector_t {
  *      transaction_size - size in bytes of this transaction.
  *      riscv - riscv core that this transaction is used for, only relevant for DISPATCH_DATA_BINARY transactions.
  */
-void RecordDispatchData(Program &program, data_collector_t type, uint32_t transaction_size, RISCV riscv = RISCV::MAX);
+void RecordDispatchData(tt_metal::Program &program, data_collector_t type, uint32_t transaction_size, RISCV riscv = RISCV::MAX);
 
 // Record the KernelGroups present in this program (per core type). Should only be called per program created, not
 // program enqueued.
-void RecordKernelGroups(Program &program, CoreType core_type, std::vector<KernelGroup> &kernel_groups);
+void RecordKernelGroups(tt_metal::Program &program, CoreType core_type, std::vector<tt_metal::KernelGroup> &kernel_groups);
 
 // Update stats with an enqueue of given program.
-void RecordProgramRun(Program &program);
+void RecordProgramRun(tt_metal::Program &program);
 
 } // end namespace tt

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -751,8 +751,8 @@ class DeviceCommand {
     uint32_t cmd_sequence_sizeB = 0;
     void *cmd_region = nullptr;
     uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
-    uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+    uint32_t pcie_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
+    uint32_t l1_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1);
 
     vector_memcpy_aligned<uint32_t> cmd_region_vector;
 };

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -9,6 +9,7 @@
 #include "impl/dispatch/debug_tools.hpp"
 
 using namespace tt;
+using namespace tt::tt_metal;
 using std::cout, std::endl;
 using std::string;
 using std::vector;


### PR DESCRIPTION
### Ticket
#12743 

### Problem description
Egregious namespace pollution caused by `using namespace tt::tt_metal;` in command_queue_interface.hpp
Removing it causes compile errors everywhere.
To take a step towards cleaning it up, I have corrected usage inside of tt_metal.
This is not a breaking change, because the polluting "using" declaration is still there.
Still to be fixed: tt_metal tests, ttnn.

### What's changed
Add tt::tt_metal qualifier in header files.
Add using namespace tt::tt_metal; in cpp files.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11569824480
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
