### PR TITLE
#13774: Fix subalpha_bw op (#14341)

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/binary_backward/subalpha_bw/subalpha_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_backward/subalpha_bw/subalpha_bw.py
@@ -25,7 +25,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "xfail": {
+    "nightly": {
         "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 4)
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 4)
         + gen_shapes([1, 1], [256, 256], [1, 1], 4),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -123,6 +123,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardSubAlpha::invoke(
     }
     if (are_required_outputs.at(1)) {
         ttnn::neg(queue_id, grad, output_mem_config, other_grad);
+        ttnn::multiply(queue_id, other_grad.value(), alpha, std::nullopt, output_mem_config, other_grad);
         result[1] = other_grad;
     }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Unit test for SFPU LLK doesn't test the whole domain of the SFPU functions, data format is hardcoded to bfloat16 and input block and the number of tiles are limited. This PR resolves those issues.

### What's changed
The SFPU unit test (test_sfpu_compute.cpp) now sweeps over:
- the whole domain of the SFPU functions
- fp_32_dest_accum_en flag
- different input block shapes
- different number of tiles
- different data formats (currently Float32, Float16_b, Bfp8_b and Bfp4_b for input, and Float32/Float16_b for output)

### Checklist
- [x] Post commit CI passes -  [#18781](https://github.com/tenstorrent/tt-metal/actions/runs/11550334013)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

