### PR TITLE
Update timeout limit of C++ tests to 60 minutes

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 60
   workflow_dispatch:
     inputs:
       arch:
@@ -33,7 +33,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 45
+        default: 60
 
 jobs:
   models:


### PR DESCRIPTION

### Problem description
N300 C++ tests take more than 45 minutes now

### What's changed
Bump limit to 60 minutes

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
