### PR TITLE
Enable weka on models post commit workflow

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -55,6 +55,12 @@ jobs:
       - cloud-virtual-machine
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - uses: ./.github/actions/retry-command
+        with:
+          timeout-seconds: 100
+          max-retries: 10
+          backoff-seconds: 60
+          command: ./.github/scripts/cloud_utils/mount_weka.sh
       - uses: actions/download-artifact@v4
         with:
           name: eager-dist-${{ matrix.os }}-${{ inputs.arch }}


### PR DESCRIPTION

### Problem description
There are references to `/mnt/MLPerf` in models post-commit workflow. We've held the position (so far) that no job post-commit will rely on weka as it has been very unreliable in the past.

### What's changed
Let's relax this restriction for the models post-commit sub-pipeline. FAFO

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
