### PR TITLE
Fold batches into channels and use grouped convolutions in UNet Shallow

### DIFF
--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-UNET_FULL_MODEL_PCC = 0.9916
+UNET_FULL_MODEL_PCC = 0.99995
 
 
 def is_n300_with_eth_dispatch_cores(mesh_device) -> bool:
@@ -33,6 +33,7 @@ def verify_with_pcc(torch_tensor, ttnn_tensor, pcc):
         )
 
 
+# TODO: This is the same as the function below, we should consolidate them
 def check_pcc_conv(torch_tensor, ttnn_tensor, pcc=0.999, mesh_composer=None):
     B, C, H, W = torch_tensor.shape
     ttnn_tensor = (

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -14,12 +14,12 @@ from models.experimental.functional_unet.tt import unet_shallow_ttnn
 from models.experimental.functional_unet.tests.common import check_pcc_conv, UNET_FULL_MODEL_PCC
 
 
-@pytest.mark.parametrize("batch", [2])
-@pytest.mark.parametrize("groups", [1])
+@pytest.mark.parametrize("batch", [1])
+@pytest.mark.parametrize("groups", [2])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
-    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -21,8 +21,8 @@ from models.experimental.functional_unet.tests.common import (
 )
 
 
-@pytest.mark.parametrize("batch", [2])
-@pytest.mark.parametrize("groups", [1])
+@pytest.mark.parametrize("batch", [1])
+@pytest.mark.parametrize("groups", [2])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, reset_seeds):
     if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
@@ -32,7 +32,7 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
@@ -42,7 +42,7 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     logger.info(f"Using {num_devices} devices for this test")
 
     torch_input, ttnn_input = create_unet_input_tensors(
-        mesh_device, num_devices * batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        num_devices * batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(

--- a/models/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/models/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -15,16 +15,16 @@ from models.experimental.functional_unet.tt import unet_shallow_torch
 from models.experimental.functional_unet.tt import unet_shallow_ttnn
 
 
-@pytest.mark.parametrize("batch, groups", [(2, 1)])
+@pytest.mark.parametrize("batch, groups", [(1, 2)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_output_layer(batch, groups, device, reset_seeds):
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=False, input_channels=16)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=False, input_channels=16)
     torch_output = model.output_layer(torch_input)
 
     ttnn_input = ttnn.to_device(ttnn_input, device=device)
@@ -35,4 +35,4 @@ def test_unet_output_layer(batch, groups, device, reset_seeds):
     ttnn_output = ttnn.to_torch(ttnn_output)
     assert list(ttnn_output.shape) == [1, 1, B * H * W, C], "Expected output layer to be [1, 1, BHW, C]"
     ttnn_output = ttnn_output.reshape(B, H, W, C).permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output, ttnn_output, 0.99995)
+    assert_with_pcc(torch_output, ttnn_output, 0.9995)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -34,15 +34,17 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((2, 1, 766.0),),
+    ((1, 2, 975.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
+    total_batch = groups * batch
+
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
     post_processed_results = run_device_perf(
-        command, subdir="unet_shallow", num_iterations=1, cols=cols, batch_size=batch
+        command, subdir="unet_shallow", num_iterations=1, cols=cols, batch_size=total_batch
     )
     expected_perf_cols = {inference_time_key: expected_device_perf_fps}
     expected_results = check_device_perf(
@@ -50,7 +52,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
     )
     prep_device_perf_report(
         model_name=f"unet-shallow_batch-{batch}_groups-{groups}",
-        batch_size=batch,
+        batch_size=total_batch,
         post_processed_results=post_processed_results,
         expected_results=expected_results,
         comments="",
@@ -62,7 +64,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
-    ((2, 1, 16, 25.0, 39.0),),
+    ((1, 2, 16, 25.0, 39.0),),
 )
 def test_unet_perf_e2e(
     batch: int,
@@ -76,10 +78,10 @@ def test_unet_perf_e2e(
 ):
     profiler.clear()
 
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
 
     profiler.start(f"initialize_ref_model")
-    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     profiler.end(f"initialize_ref_model")
 
     profiler.start(f"initialize_model")
@@ -137,7 +139,7 @@ def test_unet_perf_e2e(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
-    ((2, 1, 16, 25.0, 61.0),),
+    ((1, 2, 16, 25.0, 61.0),),
 )
 def test_unet_data_parallel_perf_e2e(
     batch: int,
@@ -159,7 +161,7 @@ def test_unet_data_parallel_perf_e2e(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
 
     profiler.start(f"initialize_ref_model")
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
@@ -173,7 +175,7 @@ def test_unet_data_parallel_perf_e2e(
     num_devices = len(mesh_device.get_device_ids())
     total_batch = num_devices * batch
     torch_input, ttnn_input = create_unet_input_tensors(
-        mesh_device, total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -31,7 +31,7 @@ from models.utility_functions import skip_for_grayskull, divup
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 68864, "trace_region_size": 444416}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations",
-    ((2, 1, 32),),
+    ((1, 2, 32),),
 )
 def test_unet_trace(
     batch: int,
@@ -41,9 +41,9 @@ def test_unet_trace(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
 
-    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
@@ -117,7 +117,7 @@ def test_unet_trace(
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
-    ((2, 1, 32),),
+    ((1, 2, 32),),
 )
 def test_unet_trace_2cq(
     batch: int,
@@ -127,9 +127,9 @@ def test_unet_trace_2cq(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
 
-    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
@@ -235,7 +235,7 @@ def buffer_address(tensor):
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
-    ((2, 1, 32),),
+    ((1, 2, 32),),
 )
 def test_unet_trace_2cq_multi_device(
     batch: int, groups: int, iterations: int, mesh_device, use_program_cache, reset_seeds, enable_async_mode
@@ -247,7 +247,7 @@ def test_unet_trace_2cq_multi_device(
     weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
@@ -258,7 +258,7 @@ def test_unet_trace_2cq_multi_device(
 
     total_batch = num_devices * batch
     torch_input, ttnn_input = create_unet_input_tensors(
-        mesh_device, total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
@@ -358,7 +358,7 @@ def test_unet_trace_2cq_multi_device(
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
-    ((2, 1, 32),),
+    ((1, 2, 32),),
 )
 def test_unet_trace_2cq_same_io(
     batch: int,
@@ -368,9 +368,9 @@ def test_unet_trace_2cq_same_io(
     use_program_cache,
     reset_seeds,
 ):
-    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(batch, groups, pad_input=True)
 
-    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
     torch_output_tensor = model(torch_input)
 
     parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -11,7 +11,7 @@ from models.experimental.functional_unet.tt import unet_shallow_torch
 
 
 def create_unet_input_tensors(
-    device, batch, groups, pad_input=True, input_channels=4, input_height=1056, input_width=160, mesh_mapper=None
+    batch: int, groups: int, pad_input=True, input_channels=4, input_height=1056, input_width=160, mesh_mapper=None
 ):
     torch_input_tensor = torch.randn(batch, input_channels * groups, input_height, input_width)
     ttnn_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
@@ -38,104 +38,108 @@ def create_unet_input_tensors(
     return torch_input_tensor, ttnn_input_tensor
 
 
-def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: torch.Tensor, groups: int, device):
-    assert groups == 1, "Only groups=1 is supported for now"
-
+def create_unet_model_parameters(
+    model: unet_shallow_torch.UNet, input_tensor: torch.Tensor, groups: int, device: ttnn.Device
+):
     parameters = infer_ttnn_module_args(model=model, run_model=lambda model: model(input_tensor), device=None)
     assert parameters is not None
     for key in parameters.keys():
         parameters[key].module = getattr(model, key)
 
-    parameters.p1["parallel_config_override"] = {
-        "grid_size": (8, 8),
-        "num_cores_nhw": 64,
-    }
-    parameters.p2["parallel_config_override"] = {
-        "grid_size": (8, 8),
-        "num_cores_nhw": 60,
-    }
-    parameters.p3["parallel_config_override"] = {
-        "grid_size": (8, 8),
-        "num_cores_nhw": 60,
-    }
-    parameters.p4["parallel_config_override"] = {
-        "grid_size": (8, 7),
-        "num_cores_nhw": 55,
-    }
-
     parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c1["use_split_reader"] = True
     parameters.c1["use_activation_double_buffer"] = True
     parameters.c1["input_channels_alignment"] = 16
-
     parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.c1_2["use_split_reader"] = True
     parameters.c1_2["use_activation_double_buffer"] = True
+    parameters.c1_2["input_channels_alignment"] = 16
 
     parameters.c2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c2["use_split_reader"] = True
     parameters.c2["use_activation_double_buffer"] = True
-
+    parameters.c2["input_channels_alignment"] = 16
     parameters.c2_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c2_2["use_activation_double_buffer"] = True
     parameters.c2_2["use_split_reader"] = True
     parameters.c2_2["use_activation_double_buffer"] = True
+    parameters.c2_2["input_channels_alignment"] = 16
 
     parameters.c3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c3["use_split_reader"] = True
     parameters.c3["use_activation_double_buffer"] = True
+    parameters.c3["input_channels_alignment"] = 16
     parameters.c3_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c3_2["use_split_reader"] = True
     parameters.c3_2["use_activation_double_buffer"] = True
+    parameters.c3_2["input_channels_alignment"] = 16
 
     parameters.c4["conv_blocking_and_parallelization_config_override"] = None
     parameters.c4["use_activation_double_buffer"] = True
+    parameters.c4["input_channels_alignment"] = 16
     parameters.c4_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c4_2["use_activation_double_buffer"] = True
+    parameters.c4_2["input_channels_alignment"] = 16
 
     parameters.bnc["conv_blocking_and_parallelization_config_override"] = None
     parameters.bnc["use_activation_double_buffer"] = True
+    parameters.bnc["input_channels_alignment"] = 16
     parameters.bnc_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.bnc_2["use_activation_double_buffer"] = True
+    parameters.bnc_2["input_channels_alignment"] = 16
 
     parameters.c5["conv_blocking_and_parallelization_config_override"] = None
-    parameters.c5["use_activation_double_buffer"] = True
+    parameters.c5["use_activation_double_buffer"] = False
+    parameters.c5["input_channels_alignment"] = 16
     parameters.c5_2["conv_blocking_and_parallelization_config_override"] = None
-    parameters.c5_2["use_activation_double_buffer"] = True
+    parameters.c5_2["use_activation_double_buffer"] = False
+    parameters.c5_2["input_channels_alignment"] = 16
     parameters.c5_3["conv_blocking_and_parallelization_config_override"] = None
-    parameters.c5_3["use_activation_double_buffer"] = True
+    parameters.c5_3["use_activation_double_buffer"] = False
+    parameters.c5_3["input_channels_alignment"] = 16
 
     parameters.c6["conv_blocking_and_parallelization_config_override"] = None
     parameters.c6["use_split_reader"] = True
     parameters.c6["use_activation_double_buffer"] = True
+    parameters.c6["input_channels_alignment"] = 16
     parameters.c6_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c6_2["use_split_reader"] = True
     parameters.c6_2["use_activation_double_buffer"] = True
+    parameters.c6_2["input_channels_alignment"] = 16
     parameters.c6_3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c6_3["use_split_reader"] = True
     parameters.c6_3["use_activation_double_buffer"] = True
+    parameters.c6_3["input_channels_alignment"] = 16
 
-    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c7["use_activation_double_buffer"] = True
     parameters.c7["use_split_reader"] = True
     parameters.c7["input_channels_alignment"] = 16
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
     parameters.c7_2["use_activation_double_buffer"] = True
+    parameters.c7_2["input_channels_alignment"] = 16
     parameters.c7_3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_3["use_split_reader"] = True
     parameters.c7_3["use_activation_double_buffer"] = True
+    parameters.c7_3["input_channels_alignment"] = 16
 
-    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
-    parameters.c8["use_split_reader"] = True
+    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8["use_activation_double_buffer"] = True
-    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.c8["use_split_reader"] = True
+    parameters.c8["input_channels_alignment"] = 16
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True
-    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.c8_2["input_channels_alignment"] = 16
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8_3["use_activation_double_buffer"] = True
     parameters.c8_3["use_split_reader"] = True
+    parameters.c8_3["input_channels_alignment"] = 16
 
-    parameters.output_layer["conv_blocking_and_parallelization_config_override"] = None
+    parameters.output_layer["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.output_layer["use_activation_double_buffer"] = True
+    parameters.output_layer["use_split_reader"] = True
+    parameters.output_layer["input_channels_alignment"] = 16
 
     return parameters

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -50,83 +50,31 @@ def get_core_grid_from_num_cores(num_cores: int, grid_rows: int = 8, grid_cols: 
     return ttnn.CoreRangeSet({*ranges})
 
 
-def unet_concat(inputs: List, dim=-1):
+def concatenate(inputs: List, dim=-1, groups=2):
     assert len(inputs) > 0
     assert dim < 0
-    all_sharded = all(tensor.is_sharded() for tensor in inputs)
-    if all_sharded:
-        max_idx, memory_config = max(
-            ((i, t.memory_config()) for i, t in enumerate(inputs)), key=lambda m: m[1].shard_spec.num_cores()
-        )
-        for i in range(0, len(inputs)):
-            if i == max_idx:
-                continue
-            t = inputs[i]
-            t_mem_config = t.memory_config()
-            t_shard_shape = t_mem_config.shard_spec.shape
-            output_shard_shape = memory_config.shard_spec.shape
-            output_shard_shape[dim] += t_shard_shape[dim]
-            memory_config.shard_spec.shape = output_shard_shape
+    assert all(tensor.is_sharded() for tensor in inputs), "All inputs to `ttnn.concat` must be sharded"
+    max_idx, output_memory_config = max(
+        ((i, t.memory_config()) for i, t in enumerate(inputs)), key=lambda m: m[1].shard_spec.num_cores()
+    )
+    for i in range(0, len(inputs)):
+        if i == max_idx:
+            continue
+        tensor = inputs[i]
+        memory_config = tensor.memory_config()
+        shard_shape = memory_config.shard_spec.shape
+        output_shard_shape = output_memory_config.shard_spec.shape
+        output_shard_shape[dim] += shard_shape[dim]
+        output_memory_config.shard_spec.shape = output_shard_shape
 
-            reshard_shape = output_shard_shape
-            reshard_shape[dim] = t_shard_shape[dim]
-            if reshard_shape != t_shard_shape:
-                t_mem_config.shard_spec.shape = reshard_shape
-                t_mem_config.shard_spec.grid = memory_config.shard_spec.grid
-                t_mem_config.shard_spec.orientation = memory_config.shard_spec.orientation
-                inputs[i] = ttnn.reshard(t, t_mem_config)
-    else:
-        memory_config = ttnn.DRAM_MEMORY_CONFIG
-        for i in range(0, len(inputs)):
-            if inputs[i].is_sharded():
-                inputs[i] = ttnn.to_memory_config(inputs[i], memory_config)
-    return ttnn.concat(inputs, dim=dim, memory_config=memory_config)
-
-
-class UNetPointwiseConv2D:
-    def __init__(
-        self,
-        conv,
-        device=None,
-        activation_dtype=ttnn.bfloat16,
-        mesh_mapper=None,
-    ):
-        self.device = device
-        self.in_channels = conv.in_channels
-        self.mesh_mapper = mesh_mapper
-        self.activation_dtype = activation_dtype
-
-        weight, bias = conv.module.weight, conv.module.bias
-
-        assert conv.kernel_size == (1, 1)
-        assert conv.stride == (1, 1)
-        assert conv.padding == (0, 0)
-
-        weight = weight.reshape(1, 1, self.in_channels, 1)
-        bias = torch.reshape(bias, (1, 1, 1, -1))
-
-        # Do this in two steps because tensors are padded differently in multi-device vs. single device
-        self.weight = ttnn.from_torch(weight, device=None, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper)
-        self.bias = ttnn.from_torch(bias, device=None, dtype=ttnn.bfloat16, mesh_mapper=mesh_mapper)
-        self.weight = ttnn.to_layout(self.weight, ttnn.TILE_LAYOUT).to(device)
-        self.bias = ttnn.to_layout(self.bias, ttnn.TILE_LAYOUT).to(device)
-
-    def __call__(self, x):
-        x = ttnn.linear(
-            x,
-            self.weight,
-            memory_config=x.memory_config(),
-            bias=self.bias,
-            dtype=self.activation_dtype,
-            core_grid=ttnn.CoreGrid(y=8, x=8),
-            compute_kernel_config=ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi2,
-                math_approx_mode=True,
-                fp32_dest_acc_en=False,
-                packer_l1_acc=False,
-            ),
-        )
-        return x
+        reshard_shape = output_shard_shape
+        reshard_shape[dim] = shard_shape[dim]
+        if reshard_shape != shard_shape:
+            memory_config.shard_spec.shape = reshard_shape
+            memory_config.shard_spec.grid = output_memory_config.shard_spec.grid
+            memory_config.shard_spec.orientation = output_memory_config.shard_spec.orientation
+            inputs[i] = ttnn.reshard(tensor, memory_config)
+    return ttnn.concat(inputs, dim=dim, memory_config=output_memory_config, groups=groups)
 
 
 class UNetConv2D:
@@ -139,6 +87,7 @@ class UNetConv2D:
         activation="relu",
         activation_dtype=ttnn.bfloat8_b,
         weights_dtype=ttnn.bfloat8_b,
+        output_layout=ttnn.TILE_LAYOUT,
         mesh_mapper=None,
     ):
         self.device = device
@@ -175,7 +124,7 @@ class UNetConv2D:
             enable_split_reader=conv.use_split_reader if "use_split_reader" in conv else False,
             enable_subblock_padding=False,
             activation=activation,
-            output_layout=ttnn.TILE_LAYOUT,
+            output_layout=output_layout,
             input_channels_alignment=conv.input_channels_alignment if "input_channels_alignment" in conv else 32,
         )
         config_override = conv.conv_blocking_and_parallelization_config_override
@@ -187,7 +136,6 @@ class UNetConv2D:
         else:
             weight, bias = conv.module.weight, conv.module.bias
 
-        weight = weight
         bias = torch.reshape(bias, (1, 1, 1, -1))
 
         self.weight = ttnn.from_torch(weight, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
@@ -209,6 +157,7 @@ class UNetConv2D:
             padding=self.padding,
             conv_config=self.conv_config,
             conv_op_cache=self.cache,
+            groups=2,
         )
         return x
 
@@ -259,7 +208,7 @@ class UNetDownblock:
 
         self.should_reshard = should_reshard
         if self.should_reshard:
-            parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
+            self.parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
                 shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                 batch_size=self.conv1.batch_size,
                 input_channels=self.conv1.in_channels,
@@ -279,15 +228,15 @@ class UNetDownblock:
                         nearest_32(self.conv1.in_channels),
                     ]
                 ),
-                parallel_config=parallel_config,
-                tile_size=32 if conv1.dtype == ttnn.bfloat8_b else 1,
+                parallel_config=self.parallel_config,
+                tile_size=32,
             )
 
     def __call__(self, x):
         assert list(x.shape) == [
             1,
             1,
-            nearest_32(self.conv1.input_height * self.conv1.input_width * self.conv1.batch_size),
+            self.conv1.input_height * self.conv1.input_width * self.conv1.batch_size,
             x.shape[-1],  # Channels can be padded
         ], f"Expected downblock input to flattened into [1, 1, BHW, C] but was {list(x.shape)}"
         if self.should_reshard:
@@ -295,6 +244,7 @@ class UNetDownblock:
                 x,
                 memory_config=self.sharded_memory_config,
             )
+
         x = self.conv1(x)
         x = self.conv2(x)
         residual = x
@@ -313,7 +263,7 @@ class UNetUpblock:
 
         self.should_reshard = should_reshard
         if self.should_reshard:
-            parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
+            self.parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
                 shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
                 batch_size=self.conv1.batch_size,
                 input_channels=self.conv1.in_channels,
@@ -330,11 +280,11 @@ class UNetUpblock:
                         1,
                         1,
                         self.conv1.input_width * self.conv1.input_height * self.conv1.batch_size,
-                        self.conv1.in_channels,
+                        nearest_32(self.conv1.in_channels),
                     ]
                 ),
-                parallel_config=parallel_config,
-                tile_size=32 if conv1.dtype == ttnn.bfloat8_b else 1,
+                parallel_config=self.parallel_config,
+                tile_size=32,
             )
 
     def upsample(self, x):
@@ -371,7 +321,14 @@ class UNetUpblock:
 
         x = self.upsample(x)
 
-        y = unet_concat([x, residual], dim=-1)
+        if not residual.is_sharded():
+            core_grid = get_core_grid_from_num_cores(x.memory_config().shard_spec.num_cores())
+            memory_config = ttnn.create_sharded_memory_config_(
+                residual.shape, core_grid, ttnn.ShardStrategy.HEIGHT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+            )
+            residual = ttnn.to_memory_config(residual, memory_config)
+
+        y = concatenate([x, residual], dim=-1)
         ttnn.deallocate(x)
         ttnn.deallocate(residual)
 
@@ -462,7 +419,7 @@ class UNet:
                 ]
             ),
             parallel_config=bnc_parallel_config,
-            tile_size=(32 if self.bnc.conv_config.dtype == ttnn.bfloat8_b else 1),
+            tile_size=32,
         )
 
         self.upblock1 = UNetUpblock(
@@ -514,23 +471,34 @@ class UNet:
             mesh_mapper=mesh_mapper,
         )
 
-        self.output_layer = UNetPointwiseConv2D(
-            parameters.output_layer,
-            device=device,
-            mesh_mapper=mesh_mapper,
+        self.output_layer = UNetConv2D(
+            parameters.output_layer, device=device, cache=self.conv_cache, activation="", mesh_mapper=mesh_mapper
         )
 
-        self.input_sharded_memory_config = ttnn.create_sharded_memory_config(
-            [
-                1,
-                1,
-                self.downblock1.conv1.batch_size
-                * self.downblock1.conv1.input_height
-                * self.downblock1.conv1.input_width,
-                nearest_16(self.downblock1.conv1.in_channels),
-            ],
-            ttnn.CoreGrid(x=8, y=8),
-            ttnn.ShardStrategy.HEIGHT,
+        self.parallel_config = ttnn._ttnn.operations.conv.determine_parallel_config(
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            batch_size=self.downblock1.conv1.batch_size,
+            input_channels=self.downblock1.conv1.in_channels,
+            output_height=self.downblock1.conv2.input_height,
+            output_width=self.downblock1.conv2.input_width,
+            output_channels=self.downblock1.conv1.out_channels,
+            compute_grid_size=device.compute_with_storage_grid_size(),
+            block_shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            is_out_tiled=True,
+        )
+        self.input_sharded_memory_config = ttnn._ttnn.operations.conv.create_sharded_memory_config_from_parallel_config(
+            tensor_shape=ttnn.Shape(
+                [
+                    1,
+                    1,
+                    self.downblock1.conv1.batch_size
+                    * self.downblock1.conv1.input_height
+                    * self.downblock1.conv1.input_width,
+                    nearest_16(self.downblock1.conv1.in_channels),
+                ]
+            ),
+            parallel_config=self.parallel_config,
+            tile_size=32,
         )
 
     def bottleneck(self, x):


### PR DESCRIPTION
### Summary

- Improve UNet performance by folding batches into channels and use grouped convolutions in UNet Shallow.
- Residual concatenation handled with `ttnn.concat` by passing `groups` parameter (available since 4fc773ab18affaabe1bf6d66552acd4e73d636aa).
- This change depends on: https://github.com/tenstorrent/tt-metal/pull/14914.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11941429555
- [x] Model regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/11941446766
- [x] Device performance regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/11941436895
