### PR TITLE
#12743: Enable clang-tidy bot to run one check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,3 @@
 Checks: >
-  bugprone-*,
-  performance-*,
-  modernize-*,
-  readability-*,
-  cppcoreguidelines-*,
-  -modernize-use-trailing-return-type
-
-CheckOptions:
-  - key: readability-identifier-length.IgnoredVariableNames
-    value: 'x|y|z|i|j|k|t|it|ix|itr|a|b'
+  -*,
+  google-build-using-namespace

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -95,8 +95,7 @@ jobs:
       pull-requests: write
       # OPTIONAL: auto-closing conversations requires the `contents` permission
       contents: write
-    # if: github.event_name == 'pull_request'  # Only run this job on pull request events
-    if : false
+    if: github.event_name == 'pull_request'  # Only run this job on pull request events
     steps:
     - uses: actions/checkout@v4
       with:
@@ -123,10 +122,10 @@ jobs:
     - name: Analyze
       run: |
         git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j4
-      timeout-minutes: 10
+      timeout-minutes: 5
       continue-on-error: true
     - name: Run clang-tidy-pr-comments action
-      uses: platisd/clang-tidy-pr-comments@837ad8077b1f554dab31a8a43e8bb12c89d2f144
+      uses: platisd/clang-tidy-pr-comments@1b7395ce6f5a4186acabbba24cdd1e846f001aa8
       with:
         # The GitHub token (or a personal access token)
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -27,6 +27,10 @@
 class CoreRange;
 class CoreRangeSet;
 
+using namespace std;
+
+using namespace tt::tt_metal;
+
 namespace tt {
 
 namespace tt_metal {

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -27,10 +27,6 @@
 class CoreRange;
 class CoreRangeSet;
 
-using namespace std;
-
-using namespace tt::tt_metal;
-
 namespace tt {
 
 namespace tt_metal {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12743

### Problem description
We have had problems in this repo with people introducing `using namespace tt;` `using namespace tt::metal;` in header files. Enabling this clang-tidy check via bot, will at least warn people about what they are doing.

### What's changed
Use latest version of clang-tidy pr review git action.
Simplify .clang-tidy to run only one check
Enable clang-tidy again in static checks.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
