### PR TITLE
[ON HOLD] #14375: Optimize usage of unordered_map in tt::Cluster

### DIFF
--- a/tt_metal/llrt/index_map.hpp
+++ b/tt_metal/llrt/index_map.hpp
@@ -17,48 +17,51 @@ namespace tt {
 template <typename T>
 class IndexMap {
 public:
-    class Iterator {
+    class Iterator final {
     public:
-        Iterator(const std::vector<std::optional<T>>& data, size_t idx): data_(data), idx_(idx) {
-            for (;idx_ < data_.size() && !data_[idx_].has_value(); idx_++);
+        Iterator(const std::vector<std::optional<T>>* data, size_t idx) noexcept: data_(data), idx_(idx) {
+            for (;idx_ < data_->size() && !(*data_)[idx_].has_value(); idx_++) {}
         }
-        Iterator(const Iterator&) = default;
-        Iterator& operator=(const Iterator&) = default;
-        bool operator==(const Iterator& other) const {
+        ~Iterator() = default;
+        Iterator(const Iterator&) noexcept = default;
+        Iterator& operator=(const Iterator&) noexcept = default;
+        Iterator(Iterator&&) noexcept = default;
+        Iterator& operator=(Iterator&&) noexcept = default;
+        [[nodiscard]] bool operator==(const Iterator& other) const noexcept {
             return idx_ == other.idx_;
         }
-        bool operator!=(const Iterator& other) const {
+        [[nodiscard]] bool operator!=(const Iterator& other) const noexcept {
             return idx_ != other.idx_;
         }
 
-        Iterator& operator++() {
+        Iterator& operator++() noexcept {
             idx_++;
-            for (;idx_ < data_.size() && !data_[idx_].has_value(); idx_++);
+            for (;idx_ < data_->size() && !(*data_)[idx_].has_value(); idx_++) {}
             return *this;
         }
 
-        std::pair<size_t, const T&> operator*() const {
-            return {idx_, data_[idx_].value()};
+        [[nodiscard]] std::pair<size_t, const T&> operator*() const noexcept {
+            return {idx_, (*data_)[idx_].value()};
         }
     private:
-        const std::vector<std::optional<T>>& data_;
+        const std::vector<std::optional<T>>* data_;
         size_t idx_ = 0;
     };
 
     IndexMap() = default;
 
-    void clear() {
+    void clear() noexcept {
         data_.clear();
         size_ = 0;
     }
 
-    T& at(size_t idx) {
+    [[nodiscard]] T& at(size_t idx) {
         return data_.at(idx).value();
     }
-    const T& at(size_t idx) const {
+    [[nodiscard]] const T& at(size_t idx) const {
         return data_.at(idx).value();
     }
-    bool contains(size_t idx) const {
+    [[nodiscard]] bool contains(size_t idx) const noexcept {
         if (idx >= data_.size()) {
             return false;
         }
@@ -86,28 +89,28 @@ public:
         return false;
     }
 
-    Iterator find(size_t idx) const {
+    [[nodiscard]] Iterator find(size_t idx) const noexcept {
         if (idx >= data_.size()) {
             return end();
         }
         if (!data_[idx].has_value()) {
             return end();
         }
-        return Iterator(data_, idx);
+        return Iterator(&data_, idx);
     }
 
-    size_t size() const {
+    [[nodiscard]] size_t size() const noexcept {
         return size_;
     }
-    bool empty() const {
+    [[nodiscard]] bool empty() const noexcept {
         return size_ == 0;
     }
 
-    Iterator begin() const {
-        return Iterator(data_, 0);
+    [[nodiscard]] Iterator begin() const noexcept {
+        return Iterator(&data_, 0);
     }
-    Iterator end() const {
-        return Iterator(data_, data_.size());
+    [[nodiscard]] Iterator end() const noexcept {
+        return Iterator(&data_, data_.size());
     }
 
 private:

--- a/tt_metal/llrt/index_map.hpp
+++ b/tt_metal/llrt/index_map.hpp
@@ -9,6 +9,11 @@
 
 namespace tt {
 
+/**
+ * IndexMap is a container, which mimics std::map with an assumption that all keys are indexes.
+ * Provides vector-like performance, consumes the size proportional to the maximum used index.
+ * Implemented as an auto-resizing vector of optionals.
+ */
 template <typename T>
 class IndexMap {
 public:

--- a/tt_metal/llrt/index_map.hpp
+++ b/tt_metal/llrt/index_map.hpp
@@ -53,6 +53,12 @@ public:
     const T& at(size_t idx) const {
         return data_.at(idx).value();
     }
+    bool contains(size_t idx) const {
+        if (idx >= data_.size()) {
+            return false;
+        }
+        return data_[idx].has_value();
+    }
     T& operator[](size_t idx) {
         if (idx >= data_.size()) {
             data_.resize(idx + 1);

--- a/tt_metal/llrt/index_map.hpp
+++ b/tt_metal/llrt/index_map.hpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+#include <optional>
+
+namespace tt {
+
+template <typename T>
+class IndexMap {
+public:
+    class Iterator {
+    public:
+        Iterator(const std::vector<std::optional<T>>& data, size_t idx): data_(data), idx_(idx) {
+            for (;idx_ < data_.size() && !data_[idx_].has_value(); idx_++);
+        }
+        Iterator(const Iterator&) = default;
+        Iterator& operator=(const Iterator&) = default;
+        bool operator==(const Iterator& other) const {
+            return idx_ == other.idx_;
+        }
+        bool operator!=(const Iterator& other) const {
+            return idx_ != other.idx_;
+        }
+
+        Iterator& operator++() {
+            idx_++;
+            for (;idx_ < data_.size() && !data_[idx_].has_value(); idx_++);
+            return *this;
+        }
+
+        std::pair<size_t, const T&> operator*() const {
+            return {idx_, data_[idx_].value()};
+        }
+    private:
+        const std::vector<std::optional<T>>& data_;
+        size_t idx_ = 0;
+    };
+
+    IndexMap() = default;
+
+    void clear() {
+        data_.clear();
+        size_ = 0;
+    }
+
+    T& at(size_t idx) {
+        return data_.at(idx).value();
+    }
+    const T& at(size_t idx) const {
+        return data_.at(idx).value();
+    }
+    T& operator[](size_t idx) {
+        if (idx >= data_.size()) {
+            data_.resize(idx + 1);
+        }
+        if (!data_[idx].has_value()) {
+            data_[idx] = T();
+            size_++;
+        }
+        return *data_[idx];
+    }
+    bool insert(size_t idx, T value) {
+        if(idx >= data_.size()) {
+            data_.resize(idx + 1);
+        }
+        if (!data_[idx].has_value()) {
+            data_[idx] = std::move(value);
+            size_++;
+            return true;
+        }
+        return false;
+    }
+
+    Iterator find(size_t idx) const {
+        if (idx >= data_.size()) {
+            return end();
+        }
+        if (!data_[idx].has_value()) {
+            return end();
+        }
+        return Iterator(data_, idx);
+    }
+
+    size_t size() const {
+        return size_;
+    }
+    bool empty() const {
+        return size_ == 0;
+    }
+
+    Iterator begin() const {
+        return Iterator(data_, 0);
+    }
+    Iterator end() const {
+        return Iterator(data_, data_.size());
+    }
+
+private:
+    std::vector<std::optional<T>> data_;
+    size_t size_ = 0;
+};
+
+}

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -272,7 +272,7 @@ void Cluster::get_metal_desc_from_tt_desc(
     const std::unordered_map<chip_id_t, uint32_t> &per_chip_id_harvesting_masks) {
     for (const auto it : input) {
         chip_id_t id = it.first;
-        this->sdesc_per_chip_.emplace(id, metal_SocDescriptor(it.second, per_chip_id_harvesting_masks.at(id)));
+        this->sdesc_per_chip_.insert(id, metal_SocDescriptor(it.second, per_chip_id_harvesting_masks.at(id)));
     }
 }
 
@@ -639,7 +639,7 @@ void Cluster::set_tunnels_from_mmio_device() {
         TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(mmio_chip_id));
 
         if (all_eth_connections.find(mmio_chip_id) == all_eth_connections.end()) {
-            this->tunnels_from_mmio_device.insert({mmio_chip_id, {}});
+            this->tunnels_from_mmio_device.insert(mmio_chip_id, {});
             continue;
         }
 
@@ -647,7 +647,7 @@ void Cluster::set_tunnels_from_mmio_device() {
         device_ids.erase(mmio_chip_id);
 
         if (device_ids.size() == 0) {
-            this->tunnels_from_mmio_device.insert({mmio_chip_id, {}});
+            this->tunnels_from_mmio_device.insert(mmio_chip_id, {});
             continue;
         }
 
@@ -716,7 +716,7 @@ void Cluster::set_tunnels_from_mmio_device() {
             }
             dev_vec.insert(dev_vec.begin(), mmio_chip_id);
         }
-        this->tunnels_from_mmio_device.insert({mmio_chip_id, tunnels_from_mmio});
+        this->tunnels_from_mmio_device.insert(mmio_chip_id, tunnels_from_mmio);
     }
 }
 
@@ -724,7 +724,7 @@ void Cluster::set_tunnels_from_mmio_device() {
 void Cluster::initialize_ethernet_sockets() {
     for (const auto &chip_id : this->cluster_desc_->get_all_chips()) {
         if (this->ethernet_sockets_.find(chip_id) == this->ethernet_sockets_.end()) {
-            this->ethernet_sockets_.insert({chip_id, {}});
+            this->ethernet_sockets_.insert(chip_id, {});
         }
         for (const auto &[connected_chip_id, eth_cores] :
              this->get_ethernet_cores_grouped_by_connected_chips(chip_id)) {
@@ -733,7 +733,7 @@ void Cluster::initialize_ethernet_sockets() {
                 this->ethernet_sockets_.at(chip_id).insert({connected_chip_id, {}});
             }
             if (this->ethernet_sockets_.find(connected_chip_id) == this->ethernet_sockets_.end()) {
-                this->ethernet_sockets_.insert({connected_chip_id, {}});
+                this->ethernet_sockets_.insert(connected_chip_id, {});
             }
             if (this->ethernet_sockets_.at(connected_chip_id).find(chip_id) ==
                 this->ethernet_sockets_.at(connected_chip_id).end()) {
@@ -760,7 +760,7 @@ void Cluster::reserve_ethernet_cores_for_tunneling() {
     for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
         for (const auto &chip_id : devices) {
             if (this->device_eth_routing_info_.find(chip_id) == this->device_eth_routing_info_.end()) {
-                this->device_eth_routing_info_.insert({chip_id, {}});
+                this->device_eth_routing_info_.insert(chip_id, {});
             }
         }
         std::map<std::tuple<chip_id_t, chip_id_t>, bool> reserved_chip_connections = {};

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -15,6 +15,7 @@
 #include "third_party/umd/device/device_api_metal.h"
 #include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
+#include "index_map.hpp"
 
 // clang-format off
 #include "noc/noc_parameters.h"
@@ -264,7 +265,7 @@ class Cluster {
 
     // There is one device driver per PCIe card. This map points id of the MMIO device points to the associated device
     // driver
-    std::unordered_map<chip_id_t, std::unique_ptr<tt_device>> mmio_device_id_to_driver_;
+    tt::IndexMap<std::unique_ptr<tt_device>> mmio_device_id_to_driver_;
 
     // Need to hold reference to cluster descriptor to detect total number of devices available in cluster
     // UMD static APIs `detect_available_device_ids` and `detect_number_of_chips` only returns number of MMIO mapped
@@ -272,20 +273,20 @@ class Cluster {
     std::string cluster_desc_path_;
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc_;
     // There is an entry for every device that can be targeted (MMIO and remote)
-    std::unordered_map<chip_id_t, metal_SocDescriptor> sdesc_per_chip_;
+    tt::IndexMap<metal_SocDescriptor> sdesc_per_chip_;
 
     // Collections of devices that are grouped based on the associated MMIO device. MMIO device is included in the
     // grouping
-    std::unordered_map<chip_id_t, std::set<chip_id_t>> devices_grouped_by_assoc_mmio_device_;
+    tt::IndexMap<std::set<chip_id_t>> devices_grouped_by_assoc_mmio_device_;
     // Save mapping of device id to associated MMIO device id for fast lookup
-    std::unordered_map<chip_id_t, chip_id_t> device_to_mmio_device_;
+    tt::IndexMap<chip_id_t> device_to_mmio_device_;
 
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     bool is_tg_cluster_;
 
     // Tunnels setup in cluster
-    std::map<chip_id_t, std::vector<std::vector<chip_id_t>>> tunnels_from_mmio_device = {};
+    tt::IndexMap<std::vector<std::vector<chip_id_t>>> tunnels_from_mmio_device = {};
 
     // Currently, each device is mapped to its own channel in host memory to enable fast dispatch
     // Channels are unique within a group of devices all controlled by a particular MMIO device
@@ -296,10 +297,10 @@ class Cluster {
     //          2 -> 1
     //          1 -> 0
     //          3 -> 1
-    std::unordered_map<chip_id_t, uint16_t> device_to_host_mem_channel_;
+    tt::IndexMap<uint16_t> device_to_host_mem_channel_;
 
     // Mapping of each devices' ethernet routing mode
-    std::unordered_map<chip_id_t, std::unordered_map<CoreCoord, EthRouterMode>> device_eth_routing_info_;
+    tt::IndexMap<std::unordered_map<CoreCoord, EthRouterMode>> device_eth_routing_info_;
 
     tt_device_l1_address_params l1_address_params = {
         (uint32_t)MEM_NCRISC_FIRMWARE_BASE,
@@ -338,7 +339,7 @@ class Cluster {
         RESPONSE_ROUTING_CMD_QUEUE_BASE,
         CMD_BUF_PTR_MASK};
 
-    std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::vector<CoreCoord>>> ethernet_sockets_;
+    tt::IndexMap<std::unordered_map<chip_id_t, std::vector<CoreCoord>>> ethernet_sockets_;
 };
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -211,7 +211,7 @@ class Cluster {
     // Returns collection of devices that are controlled by the specified MMIO device inclusive of the MMIO device
     const std::set<chip_id_t> &get_devices_controlled_by_mmio_device(chip_id_t mmio_device_id) const {
         TT_ASSERT(
-            this->devices_grouped_by_assoc_mmio_device_.count(mmio_device_id),
+            this->devices_grouped_by_assoc_mmio_device_.contains(mmio_device_id),
             "Expected device {} to be an MMIO device!",
             mmio_device_id);
         return this->devices_grouped_by_assoc_mmio_device_.at(mmio_device_id);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14375

### Problem description
Cluster::get_driver consumes a lot of resources according to the profiler. Primarily there are two reasons: it's being called too often, and it uses an std::unordered_map where an std::vector would work

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11601152068/job/32308191457)
- [x] [T3K model perf CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11601156713) (the same failure as on [main](https://github.com/tenstorrent/tt-metal/actions/runs/11592862881))
- [x] New/Existing tests provide coverage for changes
