### PR TITLE
#14453: Fix `moreh_getitem` assert bug

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
@@ -242,8 +242,6 @@ void MorehGetItemOperation::MorehGetItemRmFactory::override_runtime_arguments(
     auto index_dims = cached_program.shared_variables.index_dims;
     auto input_dim_offset = cached_program.shared_variables.input_dim_offset;
 
-    TT_ASSERT(tensor_return_value.buffer()->size() == 1);
-
     auto src_buffer = tensor_args.input.buffer();
     auto dst_buffer = tensor_return_value.buffer();
     auto index_tensors = tensor_args.index_tensors;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
@@ -555,8 +555,6 @@ void MorehGetItemOperation::MorehGetItemTilizedFactory::override_runtime_argumen
     auto index_dims = cached_program.shared_variables.index_dims;
     auto input_dim_offset = cached_program.shared_variables.input_dim_offset;
 
-    TT_ASSERT(tensor_return_value.buffer()->size() == 1);
-
     auto src_buffer = tensor_args.input.buffer();
     auto dst_buffer = tensor_return_value.buffer();
     auto index_tensors = tensor_args.index_tensors;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14453)

### Problem description
 tests/ttnn/unit_tests/operations/test_moreh_getitem.py::test_getitem_RAW_MAJOR_callback[index_size=4-int32-shape_index_dim=[[10, 70], 0]] test is failing.

### What's changed
I’ve removed the incorrect assert.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
