### PR TITLE
Disable mistral7b demo and add warning to README

### DIFF
--- a/models/demos/wormhole/mistral7b/README.md
+++ b/models/demos/wormhole/mistral7b/README.md
@@ -4,6 +4,12 @@ Demo showcasing Mistral-7B running on Wormhole, using ttnn.
 
 ## How to Run
 
+⚠️ **WARNING: DO NOT RUN THIS DEMO FOR NOW** ⚠️
+
+This demo is currently disabled as it has been linked to hardware failures that can permanently damage cards. Please do not attempt to run it until further notice.
+
+[The issue](https://github.com/tenstorrent/cloud/issues/3323) appears to be connected to blown FETs (Field Effect Transistors) that can disable cards. We are investigating the root cause and will update this notice once the demo is confirmed to be safe to run.
+
 ### Download the weights
 
 Download the weights tarfile directly from Mistral-AI:

--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -330,8 +330,7 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
     ],
 )
 def test_mistral7B_demo(device, use_program_cache, input_prompts, instruct_weights, is_ci_env, num_batches):
-    if is_ci_env:
-        pytest.skip("Issue #14440: May kill WH cards")
+    pytest.skip("https://github.com/tenstorrent/cloud/issues/3323: May kill WH cards (internal issue 14440)")
 
     if (is_ci_env and instruct_weights == False) or (is_ci_env and not (num_batches == 1 or num_batches == 3)):
         pytest.skip(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/cloud/issues/3323)

### Problem description
CI has reported WH cards dying whilst running the mistral7b demo and have requested we disable it with a warning to users the issue has been root caused.

### What's changed
Disable mistral demo test for everyone not just CI and add a README warning.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11590181447)
- [ ] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/11590186450)
