### PR TITLE
#14464: Re-enable split_reader on gs resnet

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -571,7 +571,7 @@ class resnet50:
             transpose_shards=self.transpose_shards,
             packer_l1_accum_enabled=True if whb0_and_b16 else False,
             enable_act_double_buffer=True if whb0_and_b16 else False,
-            enable_split_reader=True if whb0_and_b16 else False,
+            enable_split_reader=True if whb0_and_b16 or not is_wormhole_b0() else False,
             enable_subblock_padding=False,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             reshard_if_not_optimal=False,


### PR DESCRIPTION
After commit #0194005 Resnet50 device perf
regressed to 6600.
Commit above decoupled two conv2d features
shallow_conv and split_reader.
Previously if shallow conv was enabled,
split_reader would be enabled under the hood even
if it's not requested.
Resnet50 on wh was configured to use split_reader, but on gs it was configured not to use split_reader and this lead to perf regression.

This change configures split_reader on gs explicitly to restore the perf.
