### PR TITLE
#0: integrated sharded reduce scatter in TG Model

### DIFF
--- a/models/demos/tg/llama3_70b/tt/llama_common.py
+++ b/models/demos/tg/llama3_70b/tt/llama_common.py
@@ -87,6 +87,32 @@ def tt_sharded_all_reduce(input_tensor, mesh_device, cluster_axis, dim=0, num_li
     return reduced_tensors
 
 
+def tt_composite_sharded_all_reduce(
+    input_tensor, mesh_device, cluster_axis, dim=3, num_links=2, reduce_scatter_mem_cfg=None
+):
+    input_mem_cfg = input_tensor.memory_config()
+    reduce_scattered_tensor = ttnn.reduce_scatter(
+        input_tensor,
+        scatter_dim=dim,
+        math_op=ttnn.ReduceType.Sum,
+        num_links=num_links,
+        cluster_axis=cluster_axis,
+        mesh_device=mesh_device,
+        memory_config=reduce_scatter_mem_cfg,
+        topology=ttnn.Topology.Linear,
+    )
+    reduced_tensor = ttnn.all_gather(
+        reduce_scattered_tensor,
+        dim,
+        num_links=num_links,
+        cluster_axis=cluster_axis,
+        mesh_device=mesh_device,
+        memory_config=input_mem_cfg,
+        topology=ttnn.Topology.Linear,
+    )
+    return reduced_tensor
+
+
 def tt_sharded_all_gather(input_tensor, mesh_device, cluster_axis, dim, num_links=2, memory_config=None):
     # Ensure the input tensor is in the correct memory configuration
 

--- a/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
@@ -11,7 +11,6 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
     ShardTensor2dMesh,
 )
 from models.demos.tg.llama3_70b.tt.llama_common import (
-    tt_all_gather,
     tt_sharded_distributed_rmsnorm,
     tt_distributed_rmsnorm,
 )
@@ -162,7 +161,6 @@ class TtLlamaDecoder_galaxy:
         )
 
         attn_outs = self.attention(attn_norm_out, rot_mats, start_pos, attn_masks, mode="decode")
-        attn_outs = ttnn.to_memory_config(attn_outs, memory_config=self.decoder_config["ATTN_ACT_MEMCFG"])
 
         output = ttnn.add(
             xs,

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -21,7 +21,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 )
 from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,
-    tt_all_gather,
+    tt_composite_sharded_all_reduce,
     tt_sharded_distributed_rmsnorm,
     tt_distributed_rmsnorm,
 )
@@ -334,13 +334,12 @@ class TtLlamaModel_galaxy:
         )
         norm_out.deallocate(True)
 
-        lm_head_out = tt_all_reduce(
+        lm_head_out = tt_composite_sharded_all_reduce(
             lm_head_out,
             mesh_device=self.mesh_device,
             cluster_axis=1,
-            dim=0,
             num_links=2,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            reduce_scatter_mem_cfg=self.core_model_config["LM_HEAD_OUT_REDUCE_SCATTER_MEMCFG"],
         )
 
         return lm_head_out

--- a/models/demos/tg/llama3_70b/tt/model_config.py
+++ b/models/demos/tg/llama3_70b/tt/model_config.py
@@ -369,7 +369,7 @@ def set_mlp_config(model_config, cluster_shape):
         use_height_and_width_as_shard_shape=True,
     )
     decode_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = ttnn.create_sharded_memory_config(
-        shape=(M, N // 28 // cluster_shape[0]),
+        shape=(M, N // 28 // cluster_shape[0]),  # shard_grid_cores = 28
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))}),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,


### PR DESCRIPTION
### Problem description
Remove fast_reduce_nc op and use composite sharded line_reduce_scatter + line_all_gather
Perf improvements:
1. Total device Ops reduced from 56-> 50
2. 1 layer Decode perf improved by 80µs
3.  LM Head perf improved by 120µs
4. E2e perf remains the same as previous 1.6 t/s/u

### What's changed
1. Added _composite_sharded_all_reduce_ function in llama common
2. Added reduce scatter mem_cfgs in model_configs
3. Replaced old hacky sharded_all_reduce with full sharded composite fucntion in MLP, Attention and Full Model
4. Fixed Demo acccuracy by increasing the precision of dense_out.
### Checklist
- [x] TG Frequent [all relevant tests passed, pipeline has resnet50 failures] https://github.com/tenstorrent/tt-metal/actions/runs/1159343034
- [x] TG Nightly https://github.com/tenstorrent/tt-metal/actions/runs/11593421527
