### PR TITLE
#0: Remove references to ARCH::WORMHOLE

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -14,7 +14,6 @@ namespace {
 std::string get_string_lowercase(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::GRAYSKULL: return "grayskull"; break;
-        case tt::ARCH::WORMHOLE: return "wormhole"; break;
         case tt::ARCH::WORMHOLE_B0: return "wormhole_b0"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
         case tt::ARCH::Invalid: return "invalid"; break;
@@ -57,7 +56,7 @@ inline std::string get_umd_arch_name() {
             get_string_lowercase(detected_arch));
     }
 
-    return get_string_lowercase(arch); 
+    return get_string_lowercase(arch);
 
 }
 

--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -37,7 +37,6 @@ inline std::string get_core_descriptor_file(const tt::ARCH &arch, CoreType dispa
         switch (arch) {
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported"); // will be overwritten in tt_global_state constructor
             case tt::ARCH::GRAYSKULL: throw std::runtime_error("GRAYSKULL arch not supported for simulator");
-            case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported for simulator");
             case tt::ARCH::WORMHOLE_B0: return core_desc_dir + "wormhole_b0_versim_1x1_arch.yaml";
             case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
             default: throw std::runtime_error("Unsupported device arch");
@@ -46,7 +45,6 @@ inline std::string get_core_descriptor_file(const tt::ARCH &arch, CoreType dispa
         switch (arch) {
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported"); // will be overwritten in tt_global_state constructor
             case tt::ARCH::GRAYSKULL: return core_desc_dir + "grayskull_120_arch.yaml";
-            case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported");
             case tt::ARCH::WORMHOLE_B0: return core_desc_dir + (dispatch_core_type == CoreType::ETH ? "wormhole_b0_80_arch_eth_dispatch.yaml" : "wormhole_b0_80_arch.yaml");
             case tt::ARCH::BLACKHOLE: return core_desc_dir + (dispatch_core_type == CoreType::ETH ? "blackhole_140_arch_eth_dispatch.yaml" : "blackhole_140_arch.yaml");
             default: throw std::runtime_error("Unsupported device arch");

--- a/tt_metal/common/test_common.hpp
+++ b/tt_metal/common/test_common.hpp
@@ -36,7 +36,6 @@ inline std::string get_soc_description_file(const tt::ARCH &arch, tt::TargetDevi
         switch (arch) {
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported");
             case tt::ARCH::GRAYSKULL: throw std::runtime_error("GRAYSKULL arch not supported");
-            case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported");
             case tt::ARCH::WORMHOLE_B0: return tt_metal_home + "tt_metal/soc_descriptors/wormhole_b0_versim.yaml";
             case tt::ARCH::BLACKHOLE: return tt_metal_home + "tt_metal/soc_descriptors/blackhole_simulation_1x2_arch.yaml";
             default: throw std::runtime_error("Unsupported device arch");
@@ -45,7 +44,6 @@ inline std::string get_soc_description_file(const tt::ARCH &arch, tt::TargetDevi
         switch (arch) {
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported"); // will be overwritten in tt_global_state constructor
             case tt::ARCH::GRAYSKULL: return tt_metal_home + "tt_metal/soc_descriptors/grayskull_120_arch.yaml";
-            case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported");
             case tt::ARCH::WORMHOLE_B0: return tt_metal_home + "tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml";
             case tt::ARCH::BLACKHOLE: return tt_metal_home + "tt_metal/soc_descriptors/blackhole_140_arch.yaml";
             default: throw std::runtime_error("Unsupported device arch");

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -8,7 +8,6 @@
 std::string tt::get_string(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::GRAYSKULL: return "GRAYSKULL"; break;
-        case tt::ARCH::WORMHOLE: return "WORMHOLE"; break;
         case tt::ARCH::WORMHOLE_B0: return "WORMHOLE_B0"; break;
         case tt::ARCH::BLACKHOLE: return "BLACKHOLE"; break;
         case tt::ARCH::Invalid: return "Invalid"; break;
@@ -19,7 +18,6 @@ std::string tt::get_string(tt::ARCH arch) {
 std::string tt::get_string_lowercase(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::GRAYSKULL: return "grayskull"; break;
-        case tt::ARCH::WORMHOLE: return "wormhole"; break;
         case tt::ARCH::WORMHOLE_B0: return "wormhole_b0"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
         case tt::ARCH::Invalid: return "invalid"; break;
@@ -30,7 +28,6 @@ std::string tt::get_string_lowercase(tt::ARCH arch) {
 std::string tt::get_alias(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::GRAYSKULL: return "grayskull"; break;
-        case tt::ARCH::WORMHOLE: return "wormhole"; break;
         case tt::ARCH::WORMHOLE_B0: return "wormhole"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
         default: return "invalid"; break;
@@ -41,8 +38,6 @@ tt::ARCH tt::get_arch_from_string(const std::string &arch_str) {
     tt::ARCH arch;
     if ((arch_str == "grayskull") || (arch_str == "GRAYSKULL")) {
         arch = tt::ARCH::GRAYSKULL;
-    } else if ((arch_str == "wormhole") || (arch_str == "WORMHOLE")) {
-        arch = tt::ARCH::WORMHOLE;
     } else if ((arch_str == "wormhole_b0") || (arch_str == "WORMHOLE_B0")) {
         arch = tt::ARCH::WORMHOLE_B0;
     } else if ((arch_str == "blackhole") || (arch_str == "BLACKHOLE")) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -33,7 +33,6 @@ namespace tt::tt_metal {
 static std::string get_string_aliased_arch_lowercase(tt::ARCH arch) {
     switch (arch) {
         case tt::ARCH::GRAYSKULL: return "grayskull"; break;
-        case tt::ARCH::WORMHOLE: return "wormhole"; break;
         case tt::ARCH::WORMHOLE_B0: return "wormhole"; break;
         case tt::ARCH::BLACKHOLE: return "blackhole"; break;
         default: return "invalid"; break;

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -149,7 +149,6 @@ void configure_static_tlbs(tt::ARCH arch, chip_id_t mmio_device_id, const metal_
             dram_channel_0_x = tt::umd::grayskull::DRAM_CHANNEL_0_X;
             dram_channel_0_y = tt::umd::grayskull::DRAM_CHANNEL_0_Y;
             break;
-        case tt::ARCH::WORMHOLE:
         case tt::ARCH::WORMHOLE_B0:
             get_static_tlb_index = wormhole::get_static_tlb_index;
             dynamic_tlb_base_index = tt::umd::wormhole::DYNAMIC_TLB_BASE_INDEX;


### PR DESCRIPTION
### Ticket
NA

### Problem description
The wormhole arch is largely not supported as it doesn't really exist.
The definition of the enum was removed in latest UMD code.
https://github.com/tenstorrent/tt-umd/commit/76b185b312a1786f1525db1ee5ca2ddc61e7948f

### What's changed
rm -rf `ARCH::WORMHOLE`

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11594929307
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
