### PR TITLE
#14457: Fix CreateSemaphore documentation related to return value

### DIFF
--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -231,9 +231,9 @@ void UpdateCircularBufferPageSize(Program &program, CBHandle cb_handle, uint8_t 
 void UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, const Buffer &buffer);
 
 /**
- * Initializes semaphore on all cores within core range (inclusive). Each core can have up to four 32B semaphores.
+ * Initializes semaphore on all cores within core range (inclusive). Each core can have up to eight 4B semaphores aligned to L1_ALIGNMENT.
  *
- * Return value: Semaphore address (uint32_t)
+ * Return value: Semaphore id (uint32_t). This can be used inside a kernel to extract the address using get_semaphore
  *
  * | Argument      | Description                                          | Type                                                      | Valid Range  | Required |
  * |---------------|------------------------------------------------------|-----------------------------------------------------------|--------------|----------|


### PR DESCRIPTION
as well as number and size of semaphores

### Ticket
https://github.com/tenstorrent/tt-metal/issues/14457

### Problem description
Incorrect semaphore documentation

### What's changed
Fix the description for return type, and number and size of semaphores

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
