### PR TITLE
#0: Bump the timeout

### DIFF
--- a/.github/workflows/tgg-unit-tests-impl.yaml
+++ b/.github/workflows/tgg-unit-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run unit regression tests
-        timeout-minutes: 45
+        timeout-minutes: 60
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME


### PR DESCRIPTION
### Ticket
None

### Problem description
Successful runs already brush up against this limit: https://github.com/tenstorrent/tt-metal/actions/runs/11587903090/job/32260805419
And some runs trip over it: https://github.com/tenstorrent/tt-metal/actions/runs/11595963824/job/32286007664

### What's changed
Bumped the timeout limit

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
