### PR TITLE
#14301: Add profiler wheel to release assets, despite not being tested

### DIFF
--- a/.github/actions/install-metal-dev-deps/dependencies.json
+++ b/.github/actions/install-metal-dev-deps/dependencies.json
@@ -9,7 +9,7 @@
   ],
   "ubuntu-22.04": [
     "git",
-    "git-lfs",    
+    "git-lfs",
     "pandoc",
     "pkg-config",
     "ninja-build",

--- a/.github/actions/install-metal-dev-deps/dependencies.json
+++ b/.github/actions/install-metal-dev-deps/dependencies.json
@@ -5,7 +5,9 @@
     "git-lfs",
     "pandoc",
     "pkg-config",
-    "ninja-build"
+    "ninja-build",
+    "libtbb-dev",
+    "libcapstone-dev"
   ],
   "ubuntu-22.04": [
     "git",
@@ -13,6 +15,8 @@
     "pandoc",
     "pkg-config",
     "ninja-build",
-    "g++-12"
+    "g++-12",
+    "libtbb-dev",
+    "libcapstone-dev"
   ]
 }

--- a/.github/workflows/_build-wheels-impl.yaml
+++ b/.github/workflows/_build-wheels-impl.yaml
@@ -13,6 +13,10 @@ on:
         required: True
         default: True
         type: boolean
+      profiler-build:
+        required: True
+        default: False
+        type: boolean
 
 jobs:
   build-wheel:
@@ -47,15 +51,19 @@ jobs:
         if: ${{ inputs.from-precompiled }}
         with:
           arch: ${{ inputs.arch }}
+          is_profiler: ${{ inputs.profiler-build }}
       - name: Set precompiled dir for precompile builds
         if: ${{ inputs.from-precompiled }}
         # TT_FROM_PRECOMPILED_DIR env variable allows us to not re-run the full C++ build and instead
         # rely on the artifact that was already compiled. We point it to where the repo is.
         run: echo "TT_FROM_PRECOMPILED_DIR=${{ github.workspace }}" >> $GITHUB_ENV
+      - name: Set profiler build if requested
+        if: ${{ inputs.profiler-build }}
+        run: echo "TT_IS_PROFILER_BUILD=True" >> $GITHUB_ENV
       - name: Build Python package distribution
         run: python -m build
       - name: Upload distribution as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: eager-dist-${{ inputs.os }}-${{ inputs.arch }}
+          name: eager-dist-${{ inputs.os }}-${{ inputs.arch }}${{ '-profiler' && inputs.profiler-build || '' }}
           path: dist/

--- a/.github/workflows/_test-wheels-impl.yaml
+++ b/.github/workflows/_test-wheels-impl.yaml
@@ -7,6 +7,10 @@ on:
         description: "Use precompiled assets for wheel build"
         default: True
         type: boolean
+      profiler-build:
+        description: "Build with the profiler tools and libraries"
+        default: False
+        type: boolean
 
 # Since pre-compiled assets are only built on ubuntu-20.04, we force tests
 # to only be run on ubuntu-20.04.
@@ -37,7 +41,7 @@ jobs:
           os: ${{ matrix.os }}
       - uses: actions/download-artifact@v4
         with:
-          name: eager-dist-${{ matrix.os }}-${{ matrix.runner-hw-info.arch }}
+          name: eager-dist-${{ matrix.os }}-${{ matrix.runner-hw-info.arch }}${{ '-profiler' && inputs.profiler-build || '' }}
       - name: Set up end-to-end tests environment
         run: ./tests/scripts/set_up_end_to_end_tests_env.sh
       - name: Activate env and run release tests - host

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -29,18 +29,23 @@ jobs:
     uses: ./.github/workflows/all-static-checks.yaml
     secrets: inherit
   build-wheels:
-    needs: build-artifact
+    needs:
+      - build-artifact
+      - build-artifact-profiler
     strategy:
       matrix:
         # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
         # The full 22.04 flow can be tested without precompiled
         os: [ubuntu-20.04]
         arch: [grayskull, wormhole_b0]
+        profiler-build: [False]
     uses: ./.github/workflows/_build-wheels-impl.yaml
     with:
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       from-precompiled: true
+      # Issue #14301: Test only regular build for now, as nothing uses profiler wheel yet
+      profiler-build: ${{ matrix.profiler-build }}
     secrets: inherit
   test-wheels:
     needs: build-wheels

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -7,10 +7,6 @@ on:
         description: "Use precompiled assets for wheel build"
         default: True
         type: boolean
-      profiler-build:
-        description: "Build with the profiler tools and libraries"
-        default: True
-        type: boolean
   schedule:
     - cron: "0 0 * * *"
 
@@ -18,12 +14,10 @@ jobs:
   build-artifact:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
     uses: ./.github/workflows/build-artifact.yaml
-    secrets: inherit
-  build-artifact-profiler:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
-    uses: ./.github/workflows/build-artifact.yaml
+    strategy:
+      profiler-build: [False, True]
     with:
-      tracy: true
+      tracy: ${{ matrix.profiler-build }}
   build-wheels:
     needs: build-artifact
     if: ${{ always() }}
@@ -33,16 +27,20 @@ jobs:
         # The full 22.04 flow can be tested without precompiled
         os: ${{ fromJson((github.event_name == 'schedule' || inputs.from-precompiled) && '["ubuntu-20.04"]' || '["ubuntu-20.04", "ubuntu-22.04"]') }}
         arch: [grayskull, wormhole_b0]
+        profiler-build: [False, True]
     uses: ./.github/workflows/_build-wheels-impl.yaml
     with:
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       from-precompiled: ${{ inputs.from-precompiled }}
-      profiler-build: ${{ inputs.profiler-build }}
+      profiler-build: ${{ matrix.profiler-build }}
   test-wheels:
     needs: build-wheels
     if: ${{ always() }}
+    strategy:
+      matrix:
+        profiler-build: [False, True]
     uses: ./.github/workflows/_test-wheels-impl.yaml
     with:
       from-precompiled: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
-      profiler-build: ${{ github.event_name == 'workflow_dispatch' && inputs.profiler-build }}
+      profiler-build: ${{ github.event_name == 'workflow_dispatch' && matrix.profiler-build }}

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -15,6 +15,11 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
+  build-artifact-profiler:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      tracy: true
   build-wheels:
     needs: build-artifact
     if: ${{ always() }}

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -15,7 +15,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
     uses: ./.github/workflows/build-artifact.yaml
     strategy:
-      profiler-build: [False, True]
+      matrix:
+        profiler-build: [False, True]
     with:
       tracy: ${{ matrix.profiler-build }}
   build-wheels:

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -45,3 +45,4 @@ jobs:
     uses: ./.github/workflows/_test-wheels-impl.yaml
     with:
       from-precompiled: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
+      profiler-build: ${{ github.event_name == 'workflow_dispatch' && inputs.profiler-build }}

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -7,6 +7,10 @@ on:
         description: "Use precompiled assets for wheel build"
         default: True
         type: boolean
+      profiler-build:
+        description: "Build with the profiler tools and libraries"
+        default: True
+        type: boolean
   schedule:
     - cron: "0 0 * * *"
 
@@ -34,6 +38,7 @@ jobs:
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       from-precompiled: ${{ inputs.from-precompiled }}
+      profiler-build: ${{ inputs.profiler-build }}
   test-wheels:
     needs: build-wheels
     if: ${{ always() }}

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,13 @@ def get_from_precompiled_dir():
     return Path(precompiled_dir) if precompiled_dir else None
 
 
+def get_is_profiler_build():
+    """
+    Retrieve option from user to buuild using profiler build + tracy.
+    """
+    return os.environ.get("TT_IS_PROFILER_BUILD", None) == "True"
+
+
 @dataclass(frozen=True)
 class MetalliumBuildConfig:
     arch_name = get_arch_name()
@@ -131,6 +138,9 @@ class CMakeBuild(build_ext):
             # We indirectly set a wheel build for our CMake build by using BUILD_SHARED_LIBS. This does the following things:
             # - Bundles (most) of our libraries into a static library to deal with a potential singleton bug error with tt_cluster (to fix)
             build_script_args = ["--build-static-libs", "--release"]
+
+            if get_is_profiler_build():
+                build_script_args.append("--enable-profiler")
 
             subprocess.check_call(["./build_metal.sh", *build_script_args], cwd=source_dir, env=build_env)
 


### PR DESCRIPTION
### Ticket

#14301

### Problem description

Add additional profiler option for wheel build.

### What's changed

Add option into build and use `TT_IS_PROFILER_BUILD` to control wheel build from scratch.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
