### PR TITLE
Add transposed tile layout and fix tiny tiles with Bfloat format

### DIFF
--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
@@ -101,11 +101,8 @@ def run_bert_large_matmul_test(
     )
 
     if bias_mem_config is not None:
-        bias_t = (
-            ttnn.Tensor(BIAS, bias_dtype)
-            .pad(bias_pad_shape, [0, 0, 0, 0], 0)
-            .to(ttnn.TILE_LAYOUT)
-            .to(device, bias_mem_config)
+        bias_t = ttnn.from_torch(
+            BIAS, dtype=bias_dtype, layout=ttnn.TILE_LAYOUT, memory_config=bias_mem_config, device=device
         )
     else:
         bias_t = None

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads_sharded.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads_sharded.py
@@ -70,13 +70,10 @@ def test_split_query_key_value_and_split_heads_with_program_cache(device, dtype,
 
     tt_q = ttnn.sharded_to_interleaved(q, out_mem_config)
     tt_q = tt_q.cpu().to_torch().float()
-    tt_q = untilize(tt_q)
     tt_k = ttnn.sharded_to_interleaved(k, out_mem_config)
     tt_k = tt_k.cpu().to_torch().float()
-    tt_k = untilize(tt_k)
     tt_v = ttnn.sharded_to_interleaved(v, out_mem_config)
     tt_v = tt_v.cpu().to_torch().float()
-    tt_v = untilize(tt_v)
 
     fused_qkv_heads = torch.split(in0, input_shape[-1] // grid_size[1], dim=-1)
     ref_q_list = []

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_softmax_sharded.py
@@ -130,10 +130,7 @@ def test_softmax(device, in_dtype, causal_mask, grid_size, seq_len, scale_mask):
     else:
         tt_output_sharded = ttnn.softmax_in_place(in1_t_shard, program_config=program_config)
 
-    tt_output = ttnn.sharded_to_interleaved(tt_output_sharded, in0_mem_config)
-    tt_output_tensor = tt_output.cpu().to_torch().float()
-    tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
-    tt_output_tensor = untilize(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_sharded)
 
     if causal_mask == False:
         attention_mask = attention_mask.reshape(batch, 1, 1, seq_len)

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -82,8 +82,8 @@ def test_tiny_tiles(device, n, c, h, w, tile_h, tile_w):
 
 
 @run_for_wormhole_b0()
-@pytest.mark.parametrize("b", [8])
-@pytest.mark.parametrize("h", [4])
+@pytest.mark.parametrize("b", [2])
+@pytest.mark.parametrize("h", [3])
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [256])
 @pytest.mark.parametrize("n", [256])
@@ -190,7 +190,7 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
 
 
 @run_for_wormhole_b0()
-@pytest.mark.parametrize("k", [8192])
+@pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1280])
 @pytest.mark.parametrize("has_bias", [False, True])
 @pytest.mark.parametrize("grid_size", [(8, 1)])
@@ -328,15 +328,15 @@ def test_matmul_in1_dram_sharded_tiny_tile(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.parametrize("m", [1536])
+@pytest.mark.parametrize("m", [768])
 @pytest.mark.parametrize("k", [1024])
-@pytest.mark.parametrize("n", [3072])
+@pytest.mark.parametrize("n", [768])
 @pytest.mark.parametrize("has_bias", [False, True])
 @pytest.mark.parametrize("grid_size", [(8, 4)])
 @pytest.mark.parametrize("tile_h", [16, 32])
 @pytest.mark.parametrize("tile_w", [16, 32])
-@pytest.mark.parametrize("in0_sharded", [True, False])
-@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("in0_sharded", [True])
+@pytest.mark.parametrize("out_sharded", [True])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("transpose_tile", [True, False])
 def test_matmul_2d_tiny_tile(
@@ -457,15 +457,15 @@ def test_matmul_2d_tiny_tile(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.parametrize("m", [256])
+@pytest.mark.parametrize("m", [128])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1024])
 @pytest.mark.parametrize("has_bias", [False, True])
 @pytest.mark.parametrize("grid_size", [(8, 4)])
 @pytest.mark.parametrize("tile_h", [16, 32])
 @pytest.mark.parametrize("tile_w", [16, 32])
-@pytest.mark.parametrize("in0_sharded", [True, False])
-@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("in0_sharded", [True])
+@pytest.mark.parametrize("out_sharded", [True])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("transpose_tile", [True, False])
 def test_matmul_1d_tiny_tile(

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -31,202 +31,34 @@ def find_max_subblock(out_block_h, out_block_w):
 
 
 # @pytest.mark.parametrize("n", [2])
-# @pytest.mark.parametrize("c", [3])
-# @pytest.mark.parametrize("h", [96])
-# @pytest.mark.parametrize("w", [128])
-# @pytest.mark.parametrize("tile_h", [16, 32])
-# @pytest.mark.parametrize("tile_w", [16, 32])
-@pytest.mark.parametrize("n", [1])
-@pytest.mark.parametrize("c", [1])
-@pytest.mark.parametrize("h", [16])
-@pytest.mark.parametrize("w", [16])
-@pytest.mark.parametrize("tile_h", [16])
-@pytest.mark.parametrize("tile_w", [16])
-def test_tiny_tiles_transposed_tile(device, n, c, h, w, tile_h, tile_w):
-    torch.manual_seed(0)
-    torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
-
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor,
-        tile=ttnn.Tile((tile_h, tile_w), transpose_tile=True),
-        layout=ttnn.TILE_LAYOUT,
-        dtype=ttnn.bfloat8_b,
-        device=device,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-    )
-    output_tensor = ttnn.to_torch(input_tensor)
-
-    flattened_tensor = output_tensor.flatten()
-    tile_hw = tile_h * tile_w
-    face_h = 16
-    face_w = 16
-    face_hw = face_h * face_w
-    num_tiles_x = w // tile_w
-    num_tiles_y = n * c * h // tile_h
-    num_faces_y = tile_h // face_h
-    num_faces_x = tile_w // face_w
-    result = []
-
-    if tile_h == 16 and tile_w == 32:
-        for tile_y in range(num_tiles_y):
-            tile_start = tile_y * w * tile_h
-            for col in range(face_w):
-                start = tile_start + col
-                for tile_x in range(num_tiles_x):
-                    start_tile_x = start + tile_x * tile_w
-                    for face_x in range(num_faces_x):
-                        offset = start_tile_x + face_x * face_w
-                        for row in range(face_h):
-                            result.append(flattened_tensor[offset + row * w])
-        transposed_output_tensor = torch.tensor(result)
-        transposed_output_tensor = transposed_output_tensor.view(n, c, h, w)
-    elif tile_h == 32 and tile_w == 16:
-        for tile_y in range(num_tiles_y):
-            tile_start = tile_y * w * tile_h
-            for face_y in range(num_faces_y):
-                start = tile_start + face_y * face_h * w
-                for col in range(face_w):
-                    start_col = start + col
-                    for tile_x in range(num_tiles_x):
-                        offset = start_col + tile_x * tile_w
-                        for row in range(face_h):
-                            result.append(flattened_tensor[offset + row * w])
-        transposed_output_tensor = torch.tensor(result)
-        transposed_output_tensor = transposed_output_tensor.view(n, c, h, w)
-    else:
-        output_tensor = output_tensor.view(n, c, h // tile_h, tile_h, w // tile_w, tile_w)
-        output_tensor = output_tensor.permute(0, 1, 2, 4, 3, 5).transpose(-1, -2)
-        output_tensor = output_tensor.permute(0, 1, 2, 4, 3, 5)
-        transposed_output_tensor = output_tensor.contiguous().view(n, c, h, w)
-
-    assert_with_pcc(torch_input_tensor, transposed_output_tensor, 1)
-
-
-@run_for_wormhole_b0()
-@pytest.mark.parametrize("b", [1])
-@pytest.mark.parametrize("h", [1])
-@pytest.mark.parametrize("m", [32])
-@pytest.mark.parametrize("k", [32])
-@pytest.mark.parametrize("n", [32])
-@pytest.mark.parametrize("tile_h", [16, 32])
-@pytest.mark.parametrize("tile_w", [16, 32])
-@pytest.mark.parametrize("in0_sharded", [True])
-@pytest.mark.parametrize("in1_sharded", [True])
-@pytest.mark.parametrize("out_sharded", [True])
-@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("transpose_tile", [False])
-def test_matmul_reuse_config_sharded_tiny_tile_transpose(
-    device, b, h, m, k, n, tile_h, tile_w, in0_sharded, in1_sharded, out_sharded, in1_dtype, transpose_tile
-):
-    torch.manual_seed(0)
-
-    grid_size = (b, h)
-
-    in0 = torch.randn((b, h, m, k), dtype=torch.bfloat16)
-    in1 = torch.randn((b, h, k, n), dtype=torch.bfloat16)
-
-    if in0_sharded:
-        in0_memory_config = ttnn.create_sharded_memory_config(
-            (b, h, m, k),
-            core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
-    else:
-        in0_memory_config = ttnn.L1_MEMORY_CONFIG
-    print(in0_memory_config)
-    in0_t = ttnn.from_torch(
-        in0,
-        tile=ttnn.Tile((tile_h, 32)),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=in0_memory_config,
-    )
-
-    if in1_sharded:
-        in1_memory_config = ttnn.create_sharded_memory_config(
-            (b, h, k, n),
-            core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
-    else:
-        in1_memory_config = ttnn.L1_MEMORY_CONFIG
-    print(in1_memory_config)
-    in1_t = ttnn.from_torch(
-        in1,
-        tile=ttnn.Tile((32, tile_w), transpose_tile=transpose_tile),
-        dtype=in1_dtype,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=in1_memory_config,
-    )
-
-    out_block_h = m // tile_h
-    out_block_w = n // tile_w
-    out_subblock_h, out_subblock_w, _ = find_max_subblock(out_block_h, out_block_w)
-
-    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
-        compute_with_storage_grid_size=grid_size,
-        in0_block_w=k // 32,
-        out_subblock_h=out_subblock_h,
-        out_subblock_w=out_subblock_w,
-        per_core_M=out_block_h,
-        per_core_N=out_block_w,
-    )
-    if out_sharded:
-        out_mem_config = ttnn.MemoryConfig(
-            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            buffer_type=ttnn.BufferType.L1,
-        )
-    else:
-        out_mem_config = ttnn.L1_MEMORY_CONFIG
-    output_tile = ttnn.Tile([tile_h, tile_w])
-    output_t = ttnn.matmul(
-        in0_t,
-        in1_t,
-        program_config=program_config,
-        memory_config=out_mem_config,
-    )
-
-    print(output_tile)
-
-    output_tensor = ttnn.to_torch(output_t)
-    pt_out = in0 @ in1
-    if in1_dtype == ttnn.bfloat4_b:
-        expected_pcc = 0.993
-    else:
-        expected_pcc = 0.999
-
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
-    _, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
-    print(pcc_message)
-
-
-# @pytest.mark.parametrize("n", [2])
 # @pytest.mark.parametrize("c", [5])
 # @pytest.mark.parametrize("h", [384])
 # @pytest.mark.parametrize("w", [768])
 # @pytest.mark.parametrize("tile_h", [4, 8, 16, 32])
 # @pytest.mark.parametrize("tile_w", [16, 32])
 # @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
-
-
+# @pytest.mark.parametrize("transpose_tile", [True, False])
 @pytest.mark.parametrize("n", [1])
 @pytest.mark.parametrize("c", [1])
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])
-@pytest.mark.parametrize("tile_h", [16])
-@pytest.mark.parametrize("tile_w", [16])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype):
+@pytest.mark.parametrize("tile_h", [32])
+@pytest.mark.parametrize("tile_w", [32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("transpose_tile", [True])
+def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype, transpose_tile):
+    if tile_h < 16 and transpose_tile:
+        pytest.skip("transpose tile does not support tile height less than 16")
     # minimum tile_h = 4 for fbloat, as exponents are packed into uint32 (4 exponents minmum)
     torch.manual_seed(0)
-    torch_input_tensor = torch.randn((n, c, h, w), dtype=torch.bfloat16)
+    # torch_input_tensor = torch.randn((n, c, h, w), dtype=torch.bfloat16)
+    total_elements = n * c * h * w
+    increment_tensor = torch.arange(1, total_elements + 1, dtype=torch.bfloat16) % 500
+    torch_input_tensor = increment_tensor.view(n, c, w, h)
+    torch_input_tensor = torch_input_tensor.permute(0, 1, 3, 2)
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
-        tile=ttnn.Tile((tile_h, tile_w), transpose_tile=True),
+        tile=ttnn.Tile((tile_h, tile_w), transpose_tile=transpose_tile),
         layout=ttnn.TILE_LAYOUT,
         dtype=dtype,
         device=device,
@@ -238,6 +70,16 @@ def test_tiny_tiles_bfloat(device, n, c, h, w, tile_h, tile_w, dtype):
     elif dtype == ttnn.bfloat4_b:
         expected_pcc = 0.989
     assert_with_pcc(torch_input_tensor, output_tensor, expected_pcc)
+    pcc_passed, pcc_message = comp_pcc(torch_input_tensor, output_tensor, expected_pcc)
+    print(pcc_message)
+    torch.set_printoptions(
+        threshold=100000,  # Maximum elements to display
+        edgeitems=2,  # Number of elements to show at the edges (if truncated)
+        precision=1,  # Decimal precision for floating-point values
+        linewidth=1000,  # Width of each line for printing
+    )
+    print(torch_input_tensor)
+    print(output_tensor)
 
 
 @pytest.mark.parametrize("n", [1])

--- a/tt_metal/common/bfloat4.hpp
+++ b/tt_metal/common/bfloat4.hpp
@@ -14,11 +14,12 @@
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "blockfloat_common.hpp"
 
+
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor
 struct bfloat4_b {};
 
-inline std::vector<uint32_t> pack_fp32_vec_as_bfp4_tiles(const std::vector<float> &fp32_vec, bool row_major_input, bool is_exp_a) {
-    return pack_fp32_vec_as_bfp_tiles<tt::DataFormat::Bfp4_b>(fp32_vec, row_major_input, is_exp_a);
+inline std::vector<uint32_t> pack_fp32_vec_as_bfp4_tiles(const std::vector<float> &fp32_vec, bool row_major_input, bool is_exp_a, const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {
+    return pack_fp32_vec_as_bfp_tiles<tt::DataFormat::Bfp4_b>(fp32_vec, row_major_input, is_exp_a, tile);
 }
 
 constexpr int log2(int n) {
@@ -27,7 +28,7 @@ constexpr int log2(int n) {
     return log;
 }
 
-inline std::vector<float> unpack_bfp4_tiles_into_float_vec(const std::vector<uint32_t> &bfp_tiles, bool row_major_output, bool is_exp_a) {
+inline std::vector<float> unpack_bfp4_tiles_into_float_vec(const std::vector<uint32_t> &bfp_tiles, bool row_major_output, bool is_exp_a, const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {
     ZoneScoped;
 
     constexpr int num_elements_in_dword = 8;

--- a/tt_metal/common/bfloat4.hpp
+++ b/tt_metal/common/bfloat4.hpp
@@ -94,7 +94,8 @@ inline std::vector<float> unpack_bfp4_tiles_into_float_vec(const std::vector<uin
                         int exponent_index = (data_index >> data_dwords_per_exp_dword_log2) + (num_bfp_dwords_in_tile * tile_index);
                         exp_word = bfp_tiles.at(exponent_index); // Extract the uint32_t value that stores the shared exponent for this set of data. Each 32 bit word is shared amongst 64 datums
 
-                        sub_word_index = (tile_and_data_index >> data_dwords_per_exp_log2) & 0x3; // Extract the byte in which the shared exponent is stored. Each byte is shared amongst 16 datums.
+                        int num_exponent_words_skip = tile_index * num_exp_words;
+                        sub_word_index = ((tile_and_data_index - num_exponent_words_skip) >> data_dwords_per_exp_log2) & 0x3; // Extract the byte in which the shared exponent is stored. Each byte is shared amongst 16 datums.
                         __m256i exp_vector0 = _mm256_set1_epi32(get_byte(exp_word, sub_word_index)); // Replicate exp scalar in a vector
                         __m256i exp_vector1 = exp_vector0;
 

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -231,7 +231,8 @@ inline std::vector<float> unpack_bfp8_tiles_into_float_vec(const std::vector<uin
                         int exponent_index = (data_index >> 4) + (num_bfp8_in_tile * tile_index);
                         exp_word = bfp8_tiles.at(exponent_index); // Extract the uint32_t value that stores the shared exponent for this set of data. Each 32 bit word is shared amongst 64 datums
 
-                        sub_word_index = (tile_and_data_index >> 2) & 0x3; // Extract the byte in which the shared exponent is stored. Each byte is shared amongst 16 datums.
+                        int num_exponent_words_skip = tile_index * num_exp_words;
+                        sub_word_index = ((tile_and_data_index - num_exponent_words_skip) >> 2) & 0x3; // Extract the byte in which the shared exponent is stored. Each byte is shared amongst 16 datums.
                         __m256i exp_vector = _mm256_set1_epi32(get_byte(exp_word, sub_word_index)); // Replicate exp scalar in a vector
                         // Take 2 uint32_t values. These are 8 BFP8 values
                         __m128i first = _mm_set1_epi32(bfp8_tiles.at(num_exp_words + tile_and_data_index)); // Replicate first uint32_t 4 times (one for each BFP8 value)

--- a/tt_metal/common/blockfloat_common.hpp
+++ b/tt_metal/common/blockfloat_common.hpp
@@ -12,7 +12,7 @@
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
-
+#include "tt_metal/impl/tile/tile.hpp"
 
 inline uint8_t get_max_exp(const std::vector<uint32_t> &vec, bool is_exp_a) {
     TT_ASSERT(vec.size() == 16);
@@ -272,7 +272,7 @@ inline uint32_t create_packed_bfp_packed_as_u32(const std::vector<uint32_t> &u32
 }
 
 template <tt::DataFormat BfpFormat>
-inline std::vector<uint32_t> pack_fp32_vec_as_bfp_tiles(const std::vector<float> &fp32_vec, bool row_major_input, bool is_exp_a) {
+inline std::vector<uint32_t> pack_fp32_vec_as_bfp_tiles(const std::vector<float> &fp32_vec, bool row_major_input, bool is_exp_a, const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {
     ZoneScoped;
 
     TT_ASSERT(

--- a/tt_metal/impl/tile/tile.hpp
+++ b/tt_metal/impl/tile/tile.hpp
@@ -47,10 +47,6 @@ struct Tile {
     Tile(std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH}, bool transpose_tile = false) :
         tile_shape(tile_shape) {
 
-        // if (transpose_tile) {
-        //     std::swap(this->tile_shape[0], this->tile_shape[1]);
-        // }
-
         auto it = std::find_if(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(),
                             [this](const auto& pair) {
                                 if (pair[0] == this->tile_shape) {

--- a/tt_metal/impl/tile/tile.hpp
+++ b/tt_metal/impl/tile/tile.hpp
@@ -123,32 +123,6 @@ struct Tile {
         }
     }
 
-    const uint32_t get_tile_volume(const DataFormat& format) const {
-        switch (format) {
-            case DataFormat::Bfp2:
-            case DataFormat::Bfp2_b:
-            case DataFormat::Bfp4:
-            case DataFormat::Bfp4_b:
-            case DataFormat::Bfp8:
-            case DataFormat::Bfp8_b: return tile_hw + (face_shape[0] * num_faces);
-            case DataFormat::Float16:
-            case DataFormat::Float16_b:
-            case DataFormat::Float32: return tile_hw;
-            case DataFormat::Tf32: throw std::invalid_argument("TF32 unsupported atm");
-            case DataFormat::Int8:
-            case DataFormat::Lf8:
-            case DataFormat::UInt8:
-            case DataFormat::UInt16:
-            case DataFormat::UInt32:
-            case DataFormat::RawUInt8:
-            case DataFormat::RawUInt16:
-            case DataFormat::Int32:
-            case DataFormat::RawUInt32: return tile_hw;
-            case DataFormat::Invalid: throw std::invalid_argument("Invalid data format");
-            default: throw std::invalid_argument("Unknown format");
-        }
-    }
-
     // operators
     bool operator==(const Tile& other) const {
         return tile_shape == other.tile_shape && face_shape == other.face_shape;

--- a/tt_metal/impl/tile/tile.hpp
+++ b/tt_metal/impl/tile/tile.hpp
@@ -47,9 +47,9 @@ struct Tile {
     Tile(std::array<uint32_t, 2> tile_shape = {constants::TILE_HEIGHT, constants::TILE_WIDTH}, bool transpose_tile = false) :
         tile_shape(tile_shape) {
 
-        if (transpose_tile) {
-            std::swap(this->tile_shape[0], this->tile_shape[1]);
-        }
+        // if (transpose_tile) {
+        //     std::swap(this->tile_shape[0], this->tile_shape[1]);
+        // }
 
         auto it = std::find_if(TILE_FACE_HW_CHOICES.begin(), TILE_FACE_HW_CHOICES.end(),
                             [this](const auto& pair) {

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -480,7 +480,7 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
     auto distributed_tensor_config = get_distributed_tensor_config(strategy);
     auto storage = MultiDeviceHostStorage{distributed_tensor_config, std::move(host_owned_buffers), host_owned_shapes};
 
-    auto output = Tensor(std::move(storage), tt_shards.at(0).get_legacy_shape(), tt_shards.at(0).get_dtype(), Layout::ROW_MAJOR, tt_shards.at(0).get_tile());
+    auto output = Tensor(std::move(storage), tt_shards.at(0).get_legacy_shape(), tt_shards.at(0).get_dtype(), tt_shards.at(0).get_layout(), tt_shards.at(0).get_tile());
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -547,14 +547,32 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
             TT_ASSERT(std::holds_alternative<OwnedBuffer>(buffer), "Unexpected type {}", tt::stl::get_active_type_name_in_variant(buffer));
             auto uint32_data = std::get<owned_buffer::Buffer<std::uint32_t>>(std::get<OwnedBuffer>(buffer)).get();
             auto float_unpacked_data = unpack_bfp8_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-            buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto float_tensor = Tensor(
+                                    OwnedStorage{input_float_buffer},
+                                    tt_tensor.get_shape(),
+                                    DataType::FLOAT32,
+                                    tt_tensor.get_layout(),
+                                    tt_tensor.get_tile())
+                                    .to(Layout::ROW_MAJOR);
+            auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
+            buffer = owned_buffer::create<float>(std::move(output_float_data));
             tt_dtype = DataType::FLOAT32;
         }
         if (tt_dtype == DataType::BFLOAT4_B) {
             TT_ASSERT(std::holds_alternative<OwnedBuffer>(buffer), "Unexpected type {}", tt::stl::get_active_type_name_in_variant(buffer));
             auto uint32_data = std::get<owned_buffer::Buffer<std::uint32_t>>(std::get<OwnedBuffer>(buffer)).get();
             auto float_unpacked_data = unpack_bfp4_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-            buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto float_tensor = Tensor(
+                                    OwnedStorage{input_float_buffer},
+                                    tt_tensor.get_shape(),
+                                    DataType::FLOAT32,
+                                    tt_tensor.get_layout(),
+                                    tt_tensor.get_tile())
+                                    .to(Layout::ROW_MAJOR);
+            auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
+            buffer = owned_buffer::create<float>(std::move(output_float_data));
             tt_dtype = DataType::FLOAT32;
         }
 
@@ -623,7 +641,16 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
             auto uint32_data = std::get<owned_buffer::Buffer<std::uint32_t>>(std::get<OwnedBuffer>(buffer)).get();
             auto float_unpacked_data =
                 unpack_bfp8_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-            buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto float_tensor = Tensor(
+                                    OwnedStorage{input_float_buffer},
+                                    tt_tensor.get_shape(),
+                                    DataType::FLOAT32,
+                                    tt_tensor.get_layout(),
+                                    tt_tensor.get_tile())
+                                    .to(Layout::ROW_MAJOR);
+            auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
+            buffer = owned_buffer::create<float>(std::move(output_float_data));
             tt_dtype = DataType::FLOAT32;
         }
         if (tt_dtype == DataType::BFLOAT4_B) {
@@ -631,7 +658,16 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
             auto uint32_data = std::get<owned_buffer::Buffer<std::uint32_t>>(std::get<OwnedBuffer>(buffer)).get();
             auto float_unpacked_data =
                 unpack_bfp4_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-            buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
+            auto float_tensor = Tensor(
+                                    OwnedStorage{input_float_buffer},
+                                    tt_tensor.get_shape(),
+                                    DataType::FLOAT32,
+                                    tt_tensor.get_layout(),
+                                    tt_tensor.get_tile())
+                                    .to(Layout::ROW_MAJOR);
+            auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
+            buffer = owned_buffer::create<float>(std::move(output_float_data));
             tt_dtype = DataType::FLOAT32;
         }
 

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -221,20 +221,46 @@ Tensor convert_torch_tensor_to_tt_tensor(
         case DataType::BFLOAT8_B: {
             auto data_ptr = reinterpret_cast<float *>(torch_data_ptr);
             auto data = std::vector<float>(data_ptr, data_ptr + num_elements);
-            auto uint32_vector = pack_fp32_vec_as_bfp8_tiles(data, /*row_major_input=*/false, /*is_exp_a=*/false, optional_tile);
-            auto buffer = owned_buffer::create<uint32_t>(std::move(uint32_vector));
-            auto storage = OwnedStorage{std::move(buffer)};
-            // TODO(arakhmati): should it be Layout::TILE?
-            return Tensor(std::move(storage), shape, data_type, Layout::ROW_MAJOR, optional_tile);
+            auto buffer = owned_buffer::create<float>(std::move(data));
+            auto tensor = Tensor(
+                            OwnedStorage{buffer},
+                            shape,
+                            DataType::FLOAT32,
+                            Layout::ROW_MAJOR,
+                            optional_tile)
+                            .to(Layout::TILE);
+            auto output_float_data = owned_buffer::get_as<float>(tensor).get();
+            auto output_packed_data = pack_fp32_vec_as_bfp8_tiles(
+                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tensor.get_tile());
+            auto output_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
+            return Tensor(
+                    std::move(OwnedStorage{std::move(output_buffer)}),
+                    shape,
+                    data_type,
+                    Layout::TILE,
+                    tensor.get_tile());
         }
         case DataType::BFLOAT4_B: {
             auto data_ptr = reinterpret_cast<float *>(torch_data_ptr);
             auto data = std::vector<float>(data_ptr, data_ptr + num_elements);
-            auto uint32_vector = pack_fp32_vec_as_bfp4_tiles(data, /*row_major_input=*/false, /*is_exp_a=*/false, optional_tile);
-            auto buffer = owned_buffer::create<uint32_t>(std::move(uint32_vector));
-            auto storage = OwnedStorage{std::move(buffer)};
-            // TODO(arakhmati): should it be Layout::TILE?
-            return Tensor(std::move(storage), shape, data_type, Layout::ROW_MAJOR, optional_tile);
+            auto buffer = owned_buffer::create<float>(std::move(data));
+            auto tensor = Tensor(
+                            OwnedStorage{buffer},
+                            shape,
+                            DataType::FLOAT32,
+                            Layout::ROW_MAJOR,
+                            optional_tile)
+                            .to(Layout::TILE);
+            auto output_float_data = owned_buffer::get_as<float>(tensor).get();
+            auto output_packed_data = pack_fp32_vec_as_bfp4_tiles(
+                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tensor.get_tile());
+            auto output_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
+            return Tensor(
+                    std::move(OwnedStorage{std::move(output_buffer)}),
+                    shape,
+                    data_type,
+                    Layout::TILE,
+                    tensor.get_tile());
         }
         default: {
             TT_THROW("Unsupported DataType: {}", data_type);

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -221,34 +221,46 @@ Tensor convert_torch_tensor_to_tt_tensor(
         case DataType::BFLOAT8_B: {
             auto data_ptr = reinterpret_cast<float *>(torch_data_ptr);
             auto data = std::vector<float>(data_ptr, data_ptr + num_elements);
-            auto tile = optional_tile.value_or(tt::tt_metal::Tile());
             auto buffer = owned_buffer::create<float>(std::move(data));
-            auto output_float_data = tt::tt_metal::tensor_impl::convert_layout_row_major_to_tile(tt::tt_metal::SimpleShape(shape), tile, buffer);
+            auto tensor = Tensor(
+                            OwnedStorage{buffer},
+                            shape,
+                            DataType::FLOAT32,
+                            Layout::ROW_MAJOR,
+                            optional_tile)
+                            .to(Layout::TILE);
+            auto output_float_data = owned_buffer::get_as<float>(tensor).get();
             auto output_packed_data = pack_fp32_vec_as_bfp8_tiles(
-                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tensor.get_tile());
             auto output_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
             return Tensor(
                     std::move(OwnedStorage{std::move(output_buffer)}),
                     shape,
                     data_type,
                     Layout::TILE,
-                    tile);
+                    tensor.get_tile());
         }
         case DataType::BFLOAT4_B: {
             auto data_ptr = reinterpret_cast<float *>(torch_data_ptr);
             auto data = std::vector<float>(data_ptr, data_ptr + num_elements);
-            auto tile = optional_tile.value_or(tt::tt_metal::Tile());
             auto buffer = owned_buffer::create<float>(std::move(data));
-            auto output_float_data = tt::tt_metal::tensor_impl::convert_layout_row_major_to_tile(tt::tt_metal::SimpleShape(shape), tile, buffer);
+            auto tensor = Tensor(
+                            OwnedStorage{buffer},
+                            shape,
+                            DataType::FLOAT32,
+                            Layout::ROW_MAJOR,
+                            optional_tile)
+                            .to(Layout::TILE);
+            auto output_float_data = owned_buffer::get_as<float>(tensor).get();
             auto output_packed_data = pack_fp32_vec_as_bfp4_tiles(
-                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tensor.get_tile());
             auto output_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
             return Tensor(
                     std::move(OwnedStorage{std::move(output_buffer)}),
                     shape,
                     data_type,
                     Layout::TILE,
-                    tile);
+                    tensor.get_tile());
         }
         default: {
             TT_THROW("Unsupported DataType: {}", data_type);
@@ -384,34 +396,46 @@ Tensor convert_numpy_tensor_to_tt_tensor(
         case DataType::BFLOAT8_B: {
             auto data_ptr = reinterpret_cast<float *>(np_data_ptr);
             auto data = std::vector<float>(data_ptr, data_ptr + num_elements);
-            auto tile = optional_tile.value_or(tt::tt_metal::Tile());
             auto buffer = owned_buffer::create<float>(std::move(data));
-            auto output_float_data = tt::tt_metal::tensor_impl::convert_layout_row_major_to_tile(tt::tt_metal::SimpleShape(shape), tile, buffer);
+            auto tensor = Tensor(
+                            OwnedStorage{buffer},
+                            shape,
+                            DataType::FLOAT32,
+                            Layout::ROW_MAJOR,
+                            optional_tile)
+                            .to(Layout::TILE);
+            auto output_float_data = owned_buffer::get_as<float>(tensor).get();
             auto output_packed_data = pack_fp32_vec_as_bfp8_tiles(
-                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tensor.get_tile());
             auto output_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
             return Tensor(
                     std::move(OwnedStorage{std::move(output_buffer)}),
                     shape,
                     data_type,
                     Layout::TILE,
-                    tile);
+                    tensor.get_tile());
         }
         case DataType::BFLOAT4_B: {
             auto data_ptr = reinterpret_cast<float *>(np_data_ptr);
             auto data = std::vector<float>(data_ptr, data_ptr + num_elements);
-            auto tile = optional_tile.value_or(tt::tt_metal::Tile());
             auto buffer = owned_buffer::create<float>(std::move(data));
-            auto output_float_data = tt::tt_metal::tensor_impl::convert_layout_row_major_to_tile(tt::tt_metal::SimpleShape(shape), tile, buffer);
+            auto tensor = Tensor(
+                            OwnedStorage{buffer},
+                            shape,
+                            DataType::FLOAT32,
+                            Layout::ROW_MAJOR,
+                            optional_tile)
+                            .to(Layout::TILE);
+            auto output_float_data = owned_buffer::get_as<float>(tensor).get();
             auto output_packed_data = pack_fp32_vec_as_bfp4_tiles(
-                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+                output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tensor.get_tile());
             auto output_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
             return Tensor(
                     std::move(OwnedStorage{std::move(output_buffer)}),
                     shape,
                     data_type,
                     Layout::TILE,
-                    tile);
+                    tensor.get_tile());
         }
         default: {
             TT_THROW("Unsupported DataType: {}", data_type);
@@ -524,7 +548,14 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
             auto uint32_data = std::get<owned_buffer::Buffer<std::uint32_t>>(std::get<OwnedBuffer>(buffer)).get();
             auto float_unpacked_data = unpack_bfp8_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
             auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
-            auto output_float_data = tt::tt_metal::tensor_impl::convert_layout_tile_to_row_major(tt_tensor.get_padded_shape(), tile, input_float_buffer);
+            auto float_tensor = Tensor(
+                                    OwnedStorage{input_float_buffer},
+                                    tt_tensor.get_shape(),
+                                    DataType::FLOAT32,
+                                    tt_tensor.get_layout(),
+                                    tt_tensor.get_tile())
+                                    .to(Layout::ROW_MAJOR);
+            auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
             buffer = owned_buffer::create<float>(std::move(output_float_data));
             tt_dtype = DataType::FLOAT32;
         }
@@ -533,7 +564,14 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
             auto uint32_data = std::get<owned_buffer::Buffer<std::uint32_t>>(std::get<OwnedBuffer>(buffer)).get();
             auto float_unpacked_data = unpack_bfp4_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
             auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
-            auto output_float_data = tt::tt_metal::tensor_impl::convert_layout_tile_to_row_major(tt_tensor.get_padded_shape(), tile, input_float_buffer);
+            auto float_tensor = Tensor(
+                                    OwnedStorage{input_float_buffer},
+                                    tt_tensor.get_shape(),
+                                    DataType::FLOAT32,
+                                    tt_tensor.get_layout(),
+                                    tt_tensor.get_tile())
+                                    .to(Layout::ROW_MAJOR);
+            auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
             buffer = owned_buffer::create<float>(std::move(output_float_data));
             tt_dtype = DataType::FLOAT32;
         }

--- a/ttnn/cpp/pybind11/tensor.cpp
+++ b/ttnn/cpp/pybind11/tensor.cpp
@@ -134,17 +134,22 @@ void tensor_mem_config_module(py::module& m_tensor) {
     py::implicitly_convertible<std::tuple<std::size_t, std::size_t>, CoreCoord>();
 
     auto py_tile = static_cast<py::class_<Tile>>(m_tensor.attr("Tile"));
-    py_tile.def(py::init<const std::array<uint32_t, 2>&>())
-        .def(py::init<>([](const std::array<uint32_t, 2>& tile) {
-            return Tile{tile};
+    py_tile
+        .def(py::init<const std::array<uint32_t, 2>&, bool>(),
+            py::arg("tile_shape"), py::arg("transpose_tile") = false)
+        .def(py::init<>([](const std::array<uint32_t, 2>& tile_shape, bool transpose_tile = false) {
+            return Tile{tile_shape, transpose_tile};
         }))
         .def("__repr__", [](const Tile& self) {
             return fmt::format("Tile with shape: [{}, {}]", self.get_tile_shape()[0], self.get_tile_shape()[1]);
         })
         .def_readonly("tile_shape", &Tile::tile_shape)
         .def_readonly("face_shape", &Tile::face_shape)
-        .def_readonly("num_faces", &Tile::num_faces);
-    py::implicitly_convertible<std::array<uint32_t, 2>, Tile>();
+        .def_readonly("num_faces", &Tile::num_faces)
+        .def_readonly("partial_face", &Tile::partial_face)
+        .def_readonly("narrow_tile", &Tile::narrow_tile)
+        .def_readonly("transpose_within_face", &Tile::transpose_within_face)
+        .def_readonly("transpose_of_faces", &Tile::transpose_of_faces);
 
     auto py_shape = static_cast<py::class_<tt::tt_metal::LegacyShape>>(m_tensor.attr("Shape"));
     py_shape.def(py::init<std::array<uint32_t, 4>>())

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -28,8 +28,8 @@ namespace ttnn {
 
 namespace core {
 
-inline std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value) {
-    return (value + (ttnn::TILE_SIZE - 1)) / ttnn::TILE_SIZE * ttnn::TILE_SIZE;
+inline std::uint32_t pad_to_multiple_of_tile_size(std::uint32_t value, std::uint32_t tile_size) {
+    return (value + (tile_size - 1)) / tile_size * tile_size;
 }
 
 inline bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& storage_type) {

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -110,9 +110,10 @@ Tensor to_layout_impl(
 
     auto padded_output_shape = output_shape;
     for (auto index = output_shape.size() - 2; index < output_shape.size(); ++index) {
-        padded_output_shape[index] = (index == output_shape.size() - 2) ?
-            ttnn::pad_to_multiple_of_tile_size(padded_output_shape[index], tile.get_tile_shape()[0]) :
-            ttnn::pad_to_multiple_of_tile_size(padded_output_shape[index], tile.get_tile_shape()[1]);
+        padded_output_shape[index] =
+            ttnn::pad_to_multiple_of_tile_size(
+                padded_output_shape[index],
+                (index == output_shape.size() - 2) ? tile.get_tile_shape()[0] : tile.get_tile_shape()[1]);
     }
 
     auto output_memory_config =
@@ -160,11 +161,11 @@ Tensor to_layout_impl(
             SmallVector<uint32_t> padded_output_shape;
 
             for (int index = 0; index < tensor.get_shape().rank(); ++index) {
-                padded_output_shape.push_back(
-                    (index == tensor.get_shape().rank() - 2) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[0]) :
-                    (index == tensor.get_shape().rank() - 1) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[1]) :
-                    tensor.get_shape()[index]
-                );
+                uint32_t second_last_rank = tensor.get_shape().rank() - 2; // h dim
+                uint32_t padded_value = index < second_last_rank ?
+                                            tensor.get_shape()[index] : ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index],
+                                            index == second_last_rank ? tile.get_tile_shape()[0] : tile.get_tile_shape()[1]);
+                padded_output_shape.push_back(padded_value);
             }
             if (tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 // ttnn::tilize_with_val_padding doesn't support height sharded tensors
@@ -211,11 +212,11 @@ Tensor to_layout_impl(
             SmallVector<uint32_t> padded_output_shape;
             SmallVector<uint32_t> padded_input_start;
             for (int index = 0; index < tensor.get_shape().rank(); ++index) {
-                padded_output_shape.push_back(
-                    (index == tensor.get_shape().rank() - 2) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[0]) :
-                    (index == tensor.get_shape().rank() - 1) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[1]) :
-                    tensor.get_shape()[index]
-                );
+                uint32_t second_last_rank = tensor.get_shape().rank() - 2; // h dim
+                uint32_t padded_value = index < second_last_rank ?
+                        tensor.get_shape()[index] : ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index],
+                        index == second_last_rank ? tile.get_tile_shape()[0] : tile.get_tile_shape()[1]);
+                padded_output_shape.push_back(padded_value);
                 padded_input_start.push_back(0);
             }
             tensor = tensor.pad(padded_output_shape, ttnn::SimpleShape(std::move(padded_input_start)), 0);

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -110,11 +110,9 @@ Tensor to_layout_impl(
 
     auto padded_output_shape = output_shape;
     for (auto index = output_shape.size() - 2; index < output_shape.size(); ++index) {
-        if (index == output_shape.size() - 2) { // h
-            padded_output_shape[index] = ttnn::pad_to_multiple_of_tile_size(padded_output_shape[index], tile.get_tile_shape()[0]);
-        } else { // w
-            padded_output_shape[index] = ttnn::pad_to_multiple_of_tile_size(padded_output_shape[index], tile.get_tile_shape()[1]);
-        }
+        padded_output_shape[index] = (index == output_shape.size() - 2) ?
+            ttnn::pad_to_multiple_of_tile_size(padded_output_shape[index], tile.get_tile_shape()[0]) :
+            ttnn::pad_to_multiple_of_tile_size(padded_output_shape[index], tile.get_tile_shape()[1]);
     }
 
     auto output_memory_config =
@@ -162,13 +160,11 @@ Tensor to_layout_impl(
             SmallVector<uint32_t> padded_output_shape;
 
             for (int index = 0; index < tensor.get_shape().rank(); ++index) {
-                if (index == tensor.get_shape().rank() - 2) { // h dim
-                    padded_output_shape.push_back(ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[0]));
-                } else if (index == tensor.get_shape().rank() - 1) { // w dim
-                    padded_output_shape.push_back(ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[1]));
-                } else {
-                    padded_output_shape.push_back(tensor.get_shape()[index]);
-                }
+                padded_output_shape.push_back(
+                    (index == tensor.get_shape().rank() - 2) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[0]) :
+                    (index == tensor.get_shape().rank() - 1) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[1]) :
+                    tensor.get_shape()[index]
+                );
             }
             if (tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 // ttnn::tilize_with_val_padding doesn't support height sharded tensors
@@ -215,13 +211,11 @@ Tensor to_layout_impl(
             SmallVector<uint32_t> padded_output_shape;
             SmallVector<uint32_t> padded_input_start;
             for (int index = 0; index < tensor.get_shape().rank(); ++index) {
-                if (index == tensor.get_shape().rank() - 2) { // h dim
-                    padded_output_shape.push_back(ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[0]));
-                } else if (index == tensor.get_shape().rank() - 1) { // w dim
-                    padded_output_shape.push_back(ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[1]));
-                } else {
-                    padded_output_shape.push_back(tensor.get_shape()[index]);
-                }
+                padded_output_shape.push_back(
+                    (index == tensor.get_shape().rank() - 2) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[0]) :
+                    (index == tensor.get_shape().rank() - 1) ? ttnn::pad_to_multiple_of_tile_size(tensor.get_shape()[index], tile.get_tile_shape()[1]) :
+                    tensor.get_shape()[index]
+                );
                 padded_input_start.push_back(0);
             }
             tensor = tensor.pad(padded_output_shape, ttnn::SimpleShape(std::move(padded_input_start)), 0);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -28,6 +28,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
     uint32_t in0_cb_id,
     uint32_t in1_cb_id,
     uint32_t mm_partials_cb_id,
+    bool in1_transpose_tile,
     uint32_t out_subblock_num_tiles,
     uint32_t out_subblock_w,
     uint32_t out_subblock_h,
@@ -43,7 +44,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
     cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
     // Reconfigure srcA back
     mm_block_init_short_with_dt(
-        in0_cb_id, in1_cb_id, mm_partials_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
 }
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
@@ -175,6 +176,7 @@ void MAIN {
                             in0_cb_id,
                             in1_cb_id,
                             mm_partials_cb_id,
+                            in1_transpose_tile,
                             out_subblock_num_tiles,
                             out_subblock_w,
                             out_subblock_h,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -16,6 +16,7 @@
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 
 
+
 // Please update
 // tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
 // when making any changes to this file.

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -127,9 +127,15 @@ void MAIN {
     SFPU_OP_INIT_ACTIVATION
 #endif
 
+#ifdef IN1_TRANSPOSE_TILE
+    constexpr uint32_t in1_transpose_tile = true;
+#else
+    constexpr uint32_t in1_transpose_tile = false;
+#endif
+
     constexpr bool spill = num_blocks > 1;
 
-    mm_block_init(in0_cb_id, in1_cb_id, mm_partials_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+    mm_block_init(in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
     for (uint32_t b = 0; b < batch; b++) {
         bool enable_reload = false;
         uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
@@ -190,7 +196,7 @@ void MAIN {
                             in0_index,
                             in1_index,
                             dst_index,
-                            false,
+                            in1_transpose_tile,
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -296,9 +296,9 @@ MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
     uint32_t per_core_M, per_core_N;
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
     if (mcast_in0) {
         per_core_M = M / in0_tile_shape[0];
         per_core_N = div_up(div_up(N, grid_size.x * grid_size.y), in1_tile_shape[1]);
@@ -343,9 +343,9 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
 
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
 
     // Parameters for large matmul with reuse
     uint32_t B = batch_size_a;
@@ -586,9 +586,9 @@ MatmulProgramConfig get_matmul_program_config(
 
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
 
     // MCAST matmuls only support input_b in INTERLEAVED
     if (matmul) {
@@ -834,7 +834,8 @@ tt::tt_metal::Tile get_output_tile(const MemoryConfig& output_mem_config, const 
     auto in1_tile_shape = in1_tile.get_tile_shape();
     if (output_tile.has_value()) {
         uint32_t in0_tile_h = in0_tile_shape[0];
-        uint32_t in1_tile_w = in1_tile.get_transpose_of_faces() ? in1_tile_shape[0] : in1_tile_shape[1];
+        uint32_t in1_tile_w = in1_tile_shape[1];
+        // uint32_t in1_tile_w = in1_tile.get_transpose_of_faces() ? in1_tile_shape[0] : in1_tile_shape[1];
         const auto& out_tile_shape = output_tile->get_tile_shape();
         TT_FATAL(out_tile_shape[1] > 0, "the override output tile width needs to be greater than zero");
         TT_FATAL(out_tile_shape[1] % in1_tile_w == 0, "the override output tile width be multiple of in1 tile width");
@@ -998,9 +999,9 @@ void Matmul::validate(
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
 
-    if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
 
     if (input_tensor_a.device()->arch() == tt::ARCH::GRAYSKULL) {
         TT_FATAL(
@@ -1369,9 +1370,9 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
     const auto& input_tensor_b = input_tensors.at(1);
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
     auto output_tile = this->output_tile.value();
     auto tile_width_ratio = output_tile.get_tile_shape()[1] / in1_tile_shape[1];
     auto output_layout = this->untilize_out ? Layout::ROW_MAJOR : Layout::TILE;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -296,9 +296,6 @@ MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
     uint32_t per_core_M, per_core_N;
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
     if (mcast_in0) {
         per_core_M = M / in0_tile_shape[0];
         per_core_N = div_up(div_up(N, grid_size.x * grid_size.y), in1_tile_shape[1]);
@@ -343,9 +340,6 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
 
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
 
     // Parameters for large matmul with reuse
     uint32_t B = batch_size_a;
@@ -586,9 +580,6 @@ MatmulProgramConfig get_matmul_program_config(
 
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
 
     // MCAST matmuls only support input_b in INTERLEAVED
     if (matmul) {
@@ -999,10 +990,6 @@ void Matmul::validate(
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
 
-    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
-
     if (input_tensor_a.device()->arch() == tt::ARCH::GRAYSKULL) {
         TT_FATAL(
             (input_tensor_a.get_tile().get_tile_shape()[1] == TILE_WIDTH && input_tensor_a.get_tile().get_tile_shape()[0] == TILE_HEIGHT),
@@ -1370,9 +1357,6 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
     const auto& input_tensor_b = input_tensors.at(1);
     auto in0_tile_shape = input_tensor_a.get_tile().get_tile_shape();
     auto in1_tile_shape = input_tensor_b.get_tile().get_tile_shape();
-    // if (input_tensor_b.get_tile().get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
     auto output_tile = this->output_tile.value();
     auto tile_width_ratio = output_tile.get_tile_shape()[1] / in1_tile_shape[1];
     auto output_layout = this->untilize_out ? Layout::ROW_MAJOR : Layout::TILE;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -826,7 +826,6 @@ tt::tt_metal::Tile get_output_tile(const MemoryConfig& output_mem_config, const 
     if (output_tile.has_value()) {
         uint32_t in0_tile_h = in0_tile_shape[0];
         uint32_t in1_tile_w = in1_tile_shape[1];
-        // uint32_t in1_tile_w = in1_tile.get_transpose_of_faces() ? in1_tile_shape[0] : in1_tile_shape[1];
         const auto& out_tile_shape = output_tile->get_tile_shape();
         TT_FATAL(out_tile_shape[1] > 0, "the override output tile width needs to be greater than zero");
         TT_FATAL(out_tile_shape[1] % in1_tile_w == 0, "the override output tile width be multiple of in1 tile width");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -60,6 +60,10 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     bool output_is_sharded,
     bool untilize_out,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> &fused_op_signaler) {
+
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
     bool fuse_op = fused_op_signaler.has_value();
 
     uint32_t num_blocks = K / in0_block_w;
@@ -357,6 +361,9 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     }
     if (fp32_dest_acc_en) {
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
@@ -908,6 +915,10 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     bool in0_is_sharded,
     bool output_is_sharded,
     bool untilize_out) {
+
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
     tt_metal::Program program{};
 
     bool fuse_op = false;
@@ -1145,6 +1156,9 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     }
     if (fp32_dest_acc_en) {
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -56,6 +56,10 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     tt::DataFormat output_data_format,
     bool untilize_out,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> &fused_op_signaler) {
+
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
     bool fuse_op = fused_op_signaler.has_value();
 
     TensorMemoryLayout in0_memory_layout = in0_buffer->buffer_layout();
@@ -474,6 +478,9 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     }
     if (fp32_dest_acc_en) {
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), cores.size(), mm_kernel_defines);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -456,6 +456,9 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
     log_debug("M: {}, K: {}, N: {}", M, K, N);
     log_debug("per_core_M: {}, per_core_N_storage: {}", per_core_M, per_core_N_storage);
 
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
     tt_metal::Program program{};
 
     // get the dram readers
@@ -737,6 +740,9 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         mm_kernel_in1_sender_writer_defines["SKIP_WRITE_BACK"] = "1";
     }
     mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
 
     auto mm_kernel_in0_sender_id = tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -63,8 +63,14 @@ operation::ProgramWithCallbacks create_program(
 
     auto in0_tile = in0.get_tile();
     auto in1_tile = in1.get_tile();
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+    auto in1_tile_shape = in1_tile.get_tile_shape();
+    if (in1_tile.get_transpose_of_faces()) {
+        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    }
     // cannot use the output tensor tile directly as that might be changed by user override
-    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile.get_tile_shape()[1]});
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile_shape[1]});
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
     uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
@@ -218,6 +224,9 @@ operation::ProgramWithCallbacks create_program(
     }
     if (fp32_dest_acc_en) {
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
@@ -490,6 +499,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
     const auto& bshape = b.get_legacy_shape();
     auto in0_tile_shape = a.get_tile().get_tile_shape();
     auto in1_tile_shape = b.get_tile().get_tile_shape();
+    if (b.get_tile().get_transpose_of_faces()) {
+        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    }
 
     TT_FATAL(
         (bcast_batch == false) or (ashape[0] == 1) or (ashape.rank() == 2),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -66,9 +66,9 @@ operation::ProgramWithCallbacks create_program(
     // currently only support transpose of the full tile
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
     auto in1_tile_shape = in1_tile.get_tile_shape();
-    if (in1_tile.get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (in1_tile.get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
     // cannot use the output tensor tile directly as that might be changed by user override
     auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile_shape[1]});
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
@@ -499,9 +499,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
     const auto& bshape = b.get_legacy_shape();
     auto in0_tile_shape = a.get_tile().get_tile_shape();
     auto in1_tile_shape = b.get_tile().get_tile_shape();
-    if (b.get_tile().get_transpose_of_faces()) {
-        std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    }
+    // if (b.get_tile().get_transpose_of_faces()) {
+    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
+    // }
 
     TT_FATAL(
         (bcast_batch == false) or (ashape[0] == 1) or (ashape.rank() == 2),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -66,9 +66,6 @@ operation::ProgramWithCallbacks create_program(
     // currently only support transpose of the full tile
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
     auto in1_tile_shape = in1_tile.get_tile_shape();
-    // if (in1_tile.get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
     // cannot use the output tensor tile directly as that might be changed by user override
     auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile_shape[1]});
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
@@ -499,9 +496,6 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
     const auto& bshape = b.get_legacy_shape();
     auto in0_tile_shape = a.get_tile().get_tile_shape();
     auto in1_tile_shape = b.get_tile().get_tile_shape();
-    // if (b.get_tile().get_transpose_of_faces()) {
-    //     std::swap(in1_tile_shape[0], in1_tile_shape[1]);
-    // }
 
     TT_FATAL(
         (bcast_batch == false) or (ashape[0] == 1) or (ashape.rank() == 2),

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -732,20 +732,7 @@ DeviceBuffer to_device_buffer(
             using StorageType = std::decay_t<decltype(storage)>;
             if constexpr (std::is_same_v<StorageType, OwnedStorage> or std::is_same_v<StorageType, BorrowedStorage>) {
                 auto data_to_write = host_buffer::get_as<T>(storage.buffer);
-                auto buffer_size = compute_buffer_size(shape, data_type, tile);
-                TT_ASSERT(
-                    buffer_size == data_to_write.size(),
-                        "Tensor buffer size and number of data elements does not match: {} != {}",
-                        buffer_size,
-                        data_to_write.size());
-                if (layout == Layout::TILE) {
-                    auto tile_shape = tile.value_or(Tile{{constants::TILE_HEIGHT, constants::TILE_WIDTH}}).get_tile_shape();
-                    TT_ASSERT(
-                        (shape[-2] % tile_shape[0] == 0 && shape[-1] % tile_shape[1] == 0),
-                        "Tensor shape incompatible for specified layout");
-                }
-                return initialize_data_on_device<T>(
-                    data_to_write, device, shape, data_type, layout, memory_config, shard_spec, tile);
+                return initialize_data_on_device<T>(data_to_write, device, shape, tensor_layout, queue);
             } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
                 TT_THROW("Device storage doesn't support to_device_buffer");
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -181,12 +181,14 @@ void validate_on_device_dtype_and_layout(Device* device, const ttnn::SimpleShape
 
 Tensor pad_bfloat8_b(
     const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
+
+    const auto& tile = tensor.get_tile();
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and pad
     auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
     auto input_float_data =
-        unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+        unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
     auto float_tensor =
         Tensor(OwnedStorage{input_float_buffer}, tensor.get_legacy_shape(), DataType::FLOAT32, tensor.get_layout(), tensor.get_tile())
@@ -195,7 +197,7 @@ Tensor pad_bfloat8_b(
     // Convert back to BFLOAT8_B
     auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
     auto output_packed_data =
-        pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+        pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
     return Tensor(
         std::move(OwnedStorage{std::move(output_uint32_buffer)}),
@@ -206,12 +208,13 @@ Tensor pad_bfloat8_b(
 }
 
 Tensor unpad_bfloat8_b(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
+    const auto& tile = tensor.get_tile();
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and unpad
     auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
     auto input_float_data =
-        unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+        unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
     auto float_tensor =
         Tensor(OwnedStorage{input_float_buffer}, tensor.get_legacy_shape(), DataType::FLOAT32, tensor.get_layout(), tensor.get_tile())
@@ -220,7 +223,7 @@ Tensor unpad_bfloat8_b(const Tensor& tensor, const ttnn::SimpleShape& output_ten
     // Convert back to BFLOAT8_B
     auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
     auto output_packed_data =
-        pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+        pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
     return Tensor(
         std::move(OwnedStorage{std::move(output_uint32_buffer)}),
@@ -232,12 +235,13 @@ Tensor unpad_bfloat8_b(const Tensor& tensor, const ttnn::SimpleShape& output_ten
 
 Tensor pad_bfloat4_b(
     const Tensor& tensor, const tt::tt_metal::LegacyShape& output_tensor_shape, const ttnn::SimpleShape& input_tensor_start, float pad_value) {
+    const auto& tile = tensor.get_tile();
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and pad
     auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
     auto input_float_data =
-        unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+        unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
     auto float_tensor =
         Tensor(OwnedStorage{input_float_buffer}, tensor.get_legacy_shape(), DataType::FLOAT32, tensor.get_layout(), tensor.get_tile())
@@ -246,7 +250,7 @@ Tensor pad_bfloat4_b(
     // Convert back to BFLOAT4_B
     auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
     auto output_packed_data =
-        pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+        pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
     return Tensor(
         std::move(OwnedStorage{std::move(output_uint32_buffer)}),
@@ -257,12 +261,13 @@ Tensor pad_bfloat4_b(
 }
 
 Tensor unpad_bfloat4_b(const Tensor& tensor, const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) {
+    const auto& tile = tensor.get_tile();
     // TODO(arakhmati): do not convert to FLOAT32
 
     // Convert to FLOAT32 tensor and unpad
     auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
     auto input_float_data =
-        unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+        unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
     auto float_tensor =
         Tensor(OwnedStorage{input_float_buffer}, tensor.get_legacy_shape(), DataType::FLOAT32, tensor.get_layout(), tensor.get_tile())
@@ -271,7 +276,7 @@ Tensor unpad_bfloat4_b(const Tensor& tensor, const ttnn::SimpleShape& output_ten
     // Convert back to BFLOAT4_B
     auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
     auto output_packed_data =
-        pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+        pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
     return Tensor(
         std::move(OwnedStorage{std::move(output_uint32_buffer)}),
@@ -454,6 +459,7 @@ std::string to_string(const BufferType& buffer, const tt::tt_metal::LegacyShape&
 
 template <typename T>
 std::string to_string(const Tensor& tensor, std::optional<DataType> original_dtype) {
+    const auto& tile = tensor.get_tile();
     const auto shape = tensor.get_legacy_shape();
     const auto dtype = original_dtype.value_or(tensor.get_dtype());
     const auto layout = tensor.get_layout();
@@ -479,7 +485,7 @@ std::string to_string(const Tensor& tensor, std::optional<DataType> original_dty
                     // Convert to FLOAT32 tensor before printing
                     auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
                     auto input_float_data = unpack_bfp8_tiles_into_float_vec(
-                        input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+                        input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
                     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
                     auto float_tensor = Tensor(
                         OwnedStorage{input_float_buffer},
@@ -494,7 +500,7 @@ std::string to_string(const Tensor& tensor, std::optional<DataType> original_dty
                     // Convert to FLOAT32 tensor before printing
                     auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
                     auto input_float_data = unpack_bfp4_tiles_into_float_vec(
-                        input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+                        input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
                     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
                     auto float_tensor = Tensor(
                         OwnedStorage{input_float_buffer},
@@ -726,7 +732,20 @@ DeviceBuffer to_device_buffer(
             using StorageType = std::decay_t<decltype(storage)>;
             if constexpr (std::is_same_v<StorageType, OwnedStorage> or std::is_same_v<StorageType, BorrowedStorage>) {
                 auto data_to_write = host_buffer::get_as<T>(storage.buffer);
-                return initialize_data_on_device<T>(data_to_write, device, shape, tensor_layout, queue);
+                auto buffer_size = compute_buffer_size(shape, data_type, tile);
+                TT_ASSERT(
+                    buffer_size == data_to_write.size(),
+                        "Tensor buffer size and number of data elements does not match: {} != {}",
+                        buffer_size,
+                        data_to_write.size());
+                if (layout == Layout::TILE) {
+                    auto tile_shape = tile.value_or(Tile{{constants::TILE_HEIGHT, constants::TILE_WIDTH}}).get_tile_shape();
+                    TT_ASSERT(
+                        (shape[-2] % tile_shape[0] == 0 && shape[-1] % tile_shape[1] == 0),
+                        "Tensor shape incompatible for specified layout");
+                }
+                return initialize_data_on_device<T>(
+                    data_to_write, device, shape, data_type, layout, memory_config, shard_spec, tile);
             } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
                 TT_THROW("Device storage doesn't support to_device_buffer");
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {
@@ -951,9 +970,10 @@ Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout) {
                 std::vector<OwnedBuffer> output_buffers;
                 for (int i = 0; i < storage.num_buffers(); i++) {
                     // Convert to FLOAT32 tensor and change layout
+                    const auto& tile = tensor.get_tile();
                     auto input_packed_data = owned_buffer::get_as<uint32_t>(storage.get_buffer(i)).get();
                     auto input_float_data = unpack_bfloat_tiles_into_float_vec(
-                        T{}, input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+                        T{}, input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
                     auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
                     auto float_tensor = Tensor(
                                             OwnedStorage{input_float_buffer},
@@ -966,7 +986,7 @@ Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout) {
                     // Convert back to BFLOAT8_B
                     auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
                     auto output_packed_data = pack_fp32_vec_as_bfloat_tiles(
-                        T{}, output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+                        T{}, output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
                     auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
                     output_buffers.push_back(output_uint32_buffer);
                 }
@@ -979,9 +999,10 @@ Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout) {
 
             } else {
                 // Convert to FLOAT32 tensor and change layout
+                const auto& tile = tensor.get_tile();
                 auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
                 auto input_float_data = unpack_bfloat_tiles_into_float_vec(
-                    T{}, input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false);
+                    T{}, input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
                 auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
                 auto float_tensor = Tensor(
                                         OwnedStorage{input_float_buffer},
@@ -994,7 +1015,7 @@ Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout) {
                 // Convert back to BFLOAT
                 auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
                 auto output_packed_data = pack_fp32_vec_as_bfloat_tiles(
-                    T{}, output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+                    T{}, output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
                 auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
                 return Tensor(
                     std::move(OwnedStorage{std::move(output_uint32_buffer)}),

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -832,7 +832,7 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
         return tensor;
     }
 
-    auto shape = tensor.get_padded_shape();
+    auto shape = tensor.get_legacy_shape();
     auto source_layout = tensor.get_layout();
     auto tile = tensor.tile();
     auto convert = [tile, &shape, source_layout, target_layout](const auto& input_data) -> std::vector<T> {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -53,7 +53,7 @@ void validate_sharded_buffer_allocation(
     DataType data_type,
     const ShardSpecBuffer& shard_params,
     const MemoryConfig& memory_config,
-    const std::optional<Tile>& tile) {
+    const Tile& tile) {
     const auto& shard_spec = memory_config.shard_spec.value();
     const auto& shard_shape = shard_spec.shape;
 
@@ -114,7 +114,7 @@ void validate_sharded_buffer_allocation(
         TT_THROW("Unsupported sharding scheme");
     }
     if (layout == Layout::TILE) {
-        auto tile_shape = tile.value_or(Tile{{constants::TILE_HEIGHT, constants::TILE_WIDTH}}).get_tile_shape();
+        auto tile_shape = tile.get_tile_shape();
         TT_FATAL(
             (shard_shape[0] % tile_shape[0] == 0 && shard_shape[1] % tile_shape[1] == 0),
             "Shard shape {} must be tile {} sized!", shard_shape, tile_shape);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -832,7 +832,7 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
         return tensor;
     }
 
-    auto shape = tensor.get_legacy_shape();
+    auto shape = tensor.get_padded_shape();
     auto source_layout = tensor.get_layout();
     auto tile = tensor.tile();
     auto convert = [tile, &shape, source_layout, target_layout](const auto& input_data) -> std::vector<T> {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -220,8 +220,10 @@ template <typename T, template <typename> typename BufferType>
 inline std::vector<T> convert_layout_tile_to_row_major(const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     auto tile_shape = ttnn::SmallVector<uint32_t>{ tile.get_tile_shape()[0], tile.get_tile_shape()[1] };
     auto face_shape = ttnn::SmallVector<uint32_t>{ tile.get_face_shape()[0], tile.get_face_shape()[1] };
+    auto transpose_within_face = tile.get_transpose_within_face();
+    auto transpose_of_faces = tile.get_transpose_of_faces();
     return convert_layout(
-        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::TILED_NFACES, tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tile_shape, face_shape);
+        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::TILED_NFACES, tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 }
 
 // ======================================================================================

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -210,8 +210,10 @@ inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::Legac
 
     auto tile_shape = ttnn::SmallVector<uint32_t>{ tile.get_tile_shape()[0], tile.get_tile_shape()[1] };
     auto face_shape = ttnn::SmallVector<uint32_t>{ tile.get_face_shape()[0], tile.get_face_shape()[1] };
+    auto transpose_within_face = tile.get_transpose_within_face();
+    auto transpose_of_faces = tile.get_transpose_of_faces();
     return convert_layout(
-        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tests::utils::TensorLayoutType::TILED_NFACES, tile_shape, face_shape);
+        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tests::utils::TensorLayoutType::TILED_NFACES, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 }
 
 template <typename T, template <typename> typename BufferType>

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -236,7 +236,7 @@ void validate_sharded_buffer_allocation(
     DataType data_type,
     const ShardSpecBuffer& shard_params,
     const MemoryConfig& memory_config,
-    const std::optional<Tile>& tile = std::nullopt);
+    const Tile& tile);
 // -----------------------------------------------------------------------------------------------------------------------------------------------
 // ===============================================================================================================================================
 //                                                              High Level APIs

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -203,7 +203,7 @@ static ttnn::SmallVector<uint32_t> to_4D_shape(const tt::tt_metal::LegacyShape& 
 }  // namespace detail
 
 template <typename T, template <typename> typename BufferType>
-inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
+inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::SimpleShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     TT_FATAL(
         (shape[-2] % tile.get_tile_shape()[0] == 0 && shape[-1] % tile.get_tile_shape()[1] == 0),
         "Unsupported shape for tensor conversion from row-major to tile layout. The tensor shape height and width must be a multiple of tile height ({}) and width ({}), but the provided shape is {}", tile.get_tile_shape()[0], tile.get_tile_shape()[1], shape);
@@ -213,17 +213,17 @@ inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::Legac
     auto transpose_within_face = tile.get_transpose_within_face();
     auto transpose_of_faces = tile.get_transpose_of_faces();
     return convert_layout(
-        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tests::utils::TensorLayoutType::TILED_NFACES, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
+        data_to_convert, shape.view(), tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tests::utils::TensorLayoutType::TILED_NFACES, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 }
 
 template <typename T, template <typename> typename BufferType>
-inline std::vector<T> convert_layout_tile_to_row_major(const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
+inline std::vector<T> convert_layout_tile_to_row_major(const tt::tt_metal::SimpleShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     auto tile_shape = ttnn::SmallVector<uint32_t>{ tile.get_tile_shape()[0], tile.get_tile_shape()[1] };
     auto face_shape = ttnn::SmallVector<uint32_t>{ tile.get_face_shape()[0], tile.get_face_shape()[1] };
     auto transpose_within_face = tile.get_transpose_within_face();
     auto transpose_of_faces = tile.get_transpose_of_faces();
     return convert_layout(
-        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::TILED_NFACES, tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
+        data_to_convert, shape.view(), tests::utils::TensorLayoutType::TILED_NFACES, tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 }
 
 // ======================================================================================

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -203,7 +203,7 @@ static ttnn::SmallVector<uint32_t> to_4D_shape(const tt::tt_metal::LegacyShape& 
 }  // namespace detail
 
 template <typename T, template <typename> typename BufferType>
-inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::SimpleShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
+inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     TT_FATAL(
         (shape[-2] % tile.get_tile_shape()[0] == 0 && shape[-1] % tile.get_tile_shape()[1] == 0),
         "Unsupported shape for tensor conversion from row-major to tile layout. The tensor shape height and width must be a multiple of tile height ({}) and width ({}), but the provided shape is {}", tile.get_tile_shape()[0], tile.get_tile_shape()[1], shape);
@@ -213,17 +213,17 @@ inline std::vector<T> convert_layout_row_major_to_tile(const tt::tt_metal::Simpl
     auto transpose_within_face = tile.get_transpose_within_face();
     auto transpose_of_faces = tile.get_transpose_of_faces();
     return convert_layout(
-        data_to_convert, shape.view(), tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tests::utils::TensorLayoutType::TILED_NFACES, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
+        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tests::utils::TensorLayoutType::TILED_NFACES, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 }
 
 template <typename T, template <typename> typename BufferType>
-inline std::vector<T> convert_layout_tile_to_row_major(const tt::tt_metal::SimpleShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
+inline std::vector<T> convert_layout_tile_to_row_major(const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     auto tile_shape = ttnn::SmallVector<uint32_t>{ tile.get_tile_shape()[0], tile.get_tile_shape()[1] };
     auto face_shape = ttnn::SmallVector<uint32_t>{ tile.get_face_shape()[0], tile.get_face_shape()[1] };
     auto transpose_within_face = tile.get_transpose_within_face();
     auto transpose_of_faces = tile.get_transpose_of_faces();
     return convert_layout(
-        data_to_convert, shape.view(), tests::utils::TensorLayoutType::TILED_NFACES, tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
+        data_to_convert, tt::stl::Span(shape.begin(), shape.end()), tests::utils::TensorLayoutType::TILED_NFACES, tests::utils::TensorLayoutType::LIN_ROW_MAJOR, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 }
 
 // ======================================================================================

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -337,6 +337,7 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::reshape", input_tensor, new_shape);
     const auto& new_padded_shape = new_shape.padded_shape();
+    const auto& tile = input_tensor.get_tile();
     TT_ASSERT(
         input_tensor.volume() == new_padded_shape.volume(),
         "{} != {}",
@@ -344,7 +345,7 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
         new_padded_shape.volume());
     if (input_tensor.get_layout() == Layout::TILE) {
         TT_ASSERT(
-            new_padded_shape[-2] % constants::TILE_HEIGHT == 0 && new_padded_shape[-1] % constants::TILE_WIDTH == 0 &&
+            new_padded_shape[-2] % tile.get_tile_shape()[0] == 0 && new_padded_shape[-1] % tile.get_tile_shape()[1] == 0 &&
             "Expected a multiple of 32 for H, W (or -1 evaluating to such) in Tensor::reshape()!");
     }
     auto output = std::visit(
@@ -356,7 +357,7 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                 for (int i = 0; i < updated_storage.shapes.size(); i++) {
                     updated_storage.shapes[i] = new_shape;
                 }
-                return Tensor(updated_storage, new_shape, tensor.get_dtype(), tensor.get_layout());
+                return Tensor(updated_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
             }
             if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
                 MultiDeviceStorage updated_storage = std::get<T>(tensor.get_storage());
@@ -366,7 +367,7 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                     new_shapes.insert({device_id, new_shape});
                 }
                 updated_storage.shapes = new_shapes;
-                return Tensor(updated_storage, new_shape, tensor.get_dtype(), tensor.get_layout());
+                return Tensor(updated_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
             }
             if constexpr (std::is_same_v<T, DeviceStorage>) {
                 if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
@@ -375,7 +376,7 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                         DeviceBuffer device_buffer = device_storage.get_buffer();
                         device_buffer->set_page_size(new_shape[-1] * tensor.element_size());
                         device_storage.insert_buffer(device_buffer);
-                        return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout());
+                        return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
                     } else {
                         DeviceStorage device_storage = std::get<T>(tensor.get_storage());
                         DeviceBuffer device_buffer = device_storage.get_buffer();
@@ -397,13 +398,13 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                         device_buffer->set_shard_spec(shard_spec_buffer);
                         device_storage.insert_buffer(device_buffer);
 
-                        return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout());
+                        return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
                     }
                 } else {
-                    return Tensor(tensor.get_storage(), new_shape, tensor.get_dtype(), tensor.get_layout());
+                    return Tensor(tensor.get_storage(), new_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
                 }
             } else {
-                return Tensor(tensor.get_storage(), new_shape, tensor.get_dtype(), tensor.get_layout());
+                return Tensor(tensor.get_storage(), new_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
             }
         },
         input_tensor.get_storage());

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -76,16 +76,16 @@ static std::size_t compute_buffer_size(const ttnn::SimpleShape& shape, DataType 
     const size_t volume = shape.volume();
     auto tile_hw = tile.has_value() ? tile->get_tile_hw() : constants::TILE_HW;
     if (data_type == DataType::BFLOAT8_B) {
-        auto tile_volume = tile.has_value() ? tile->get_tile_volume(DataFormat::Bfp8_b) : constants::BFLOAT8_B_TILE_HW;
+        auto tile_size_bytes= tile.has_value() ? tile->get_tile_size(DataFormat::Bfp8_b) : constants::BFLOAT8_B_TILE_HW;
         TT_ASSERT(volume % tile_hw == 0);
-        const auto bfloat8_b_volume = volume / tile_hw * tile_volume;
+        const auto bfloat8_b_volume = volume / tile_hw * tile_size_bytes;
         TT_ASSERT(volume % sizeof(std::uint32_t) == 0);
         return bfloat8_b_volume / sizeof(std::uint32_t);
     }
     if (data_type == DataType::BFLOAT4_B) {
-        auto tile_volume = tile.has_value() ? tile->get_tile_volume(DataFormat::Bfp4_b) : constants::BFLOAT4_B_TILE_HW;
+        auto tile_size_bytes = tile.has_value() ? tile->get_tile_size(DataFormat::Bfp4_b) : constants::BFLOAT4_B_TILE_HW;
         TT_ASSERT(volume % tile_hw == 0);
-        const auto bfloat4_b_volume = volume / tile_hw * tile_volume;
+        const auto bfloat4_b_volume = volume / tile_hw * tile_size_bytes;
         TT_ASSERT(volume % sizeof(std::uint32_t) == 0);
         return bfloat4_b_volume / sizeof(std::uint32_t);
     }

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -72,18 +72,18 @@ static int compute_flat_indices(tt::stl::Span<const int> indices, tt::stl::Span<
     return flat_index;
 };
 
-static std::size_t compute_buffer_size(const ttnn::SimpleShape& shape, DataType data_type, const std::optional<Tile>& tile = std::nullopt) {
+static std::size_t compute_buffer_size(const ttnn::SimpleShape& shape, DataType data_type, const Tile& tile) {
     const size_t volume = shape.volume();
-    auto tile_hw = tile.has_value() ? tile->get_tile_hw() : constants::TILE_HW;
+    auto tile_hw = tile.get_tile_hw();
     if (data_type == DataType::BFLOAT8_B) {
-        auto tile_size_bytes= tile.has_value() ? tile->get_tile_size(DataFormat::Bfp8_b) : constants::BFLOAT8_B_TILE_HW;
+        auto tile_size_bytes = tile.get_tile_size(DataFormat::Bfp8_b);
         TT_ASSERT(volume % tile_hw == 0);
         const auto bfloat8_b_volume = volume / tile_hw * tile_size_bytes;
         TT_ASSERT(volume % sizeof(std::uint32_t) == 0);
         return bfloat8_b_volume / sizeof(std::uint32_t);
     }
     if (data_type == DataType::BFLOAT4_B) {
-        auto tile_size_bytes = tile.has_value() ? tile->get_tile_size(DataFormat::Bfp4_b) : constants::BFLOAT4_B_TILE_HW;
+        auto tile_size_bytes = tile.get_tile_size(DataFormat::Bfp4_b);
         TT_ASSERT(volume % tile_hw == 0);
         const auto bfloat4_b_volume = volume / tile_hw * tile_size_bytes;
         TT_ASSERT(volume % sizeof(std::uint32_t) == 0);

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -184,22 +184,21 @@ def from_torch(
     """
 
     shape_with_padding = None
-    # if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
-    #     if len(tensor.shape) < 2:
-    #         raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires at least 2 dimensions!")
-    #     if layout != ttnn.TILE_LAYOUT:
-    #         raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
-    #     # Tilize tensor
-    #     tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile)
-    #     shape_with_padding = tensor.shape
-    #     tensor = tensor.reshape(tensor.shape.with_tile_padding())
-    #     tensor = ttnn.to_torch(tensor)
+    if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
+        if len(tensor.shape) < 2:
+            raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires at least 2 dimensions!")
+        if layout != ttnn.TILE_LAYOUT:
+            raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
+        # Tilize tensor
+        tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile)
+        shape_with_padding = tensor.shape
+        tensor = tensor.reshape(tensor.shape.with_tile_padding())
+        tensor = ttnn.to_torch(tensor)
 
     if memory_config is not None:
         if device is None:
             raise RuntimeError("device must be specified when memory_config is specified")
 
-    print("create tensor")
     if mesh_mapper:
         shards = mesh_mapper.map(tensor)
         tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config())
@@ -209,8 +208,7 @@ def from_torch(
         else:
             tensor = ttnn.Tensor(tensor, dtype)
 
-    print("change alyout")
-    if layout is not None:
+    if layout is not None and not (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b):
         tensor = ttnn.to_layout(tensor, layout, device=device)
 
     if device is not None:

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -184,21 +184,22 @@ def from_torch(
     """
 
     shape_with_padding = None
-    if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
-        if len(tensor.shape) < 2:
-            raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires at least 2 dimensions!")
-        if layout != ttnn.TILE_LAYOUT:
-            raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
-        # Tilize tensor
-        tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile)
-        shape_with_padding = tensor.shape
-        tensor = tensor.reshape(tensor.shape.with_tile_padding())
-        tensor = ttnn.to_torch(tensor)
+    # if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
+    #     if len(tensor.shape) < 2:
+    #         raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires at least 2 dimensions!")
+    #     if layout != ttnn.TILE_LAYOUT:
+    #         raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
+    #     # Tilize tensor
+    #     tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile)
+    #     shape_with_padding = tensor.shape
+    #     tensor = tensor.reshape(tensor.shape.with_tile_padding())
+    #     tensor = ttnn.to_torch(tensor)
 
     if memory_config is not None:
         if device is None:
             raise RuntimeError("device must be specified when memory_config is specified")
 
+    print("create tensor")
     if mesh_mapper:
         shards = mesh_mapper.map(tensor)
         tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config())
@@ -208,6 +209,7 @@ def from_torch(
         else:
             tensor = ttnn.Tensor(tensor, dtype)
 
+    print("change alyout")
     if layout is not None:
         tensor = ttnn.to_layout(tensor, layout, device=device)
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -278,13 +278,17 @@ def to_torch(
     if ttnn.is_tensor_storage_on_device(tensor):
         tensor = ttnn.from_device(tensor, cq_id=cq_id)
 
-    if tensor.layout != ttnn.ROW_MAJOR_LAYOUT:
+    if (tensor.layout != ttnn.ROW_MAJOR_LAYOUT) and not (
+        tensor.dtype == ttnn.bfloat8_b or tensor.dtype == ttnn.bfloat4_b
+    ):
         tensor = tensor.to(ttnn.ROW_MAJOR_LAYOUT, device)
 
     shape_without_tile_padding = tuple(tensor.shape)
     if tensor.storage_type() == ttnn.DEVICE_STORAGE_TYPE:
         raise RuntimeError("ttnn.Tensor cannot be on device when converting to torch.Tensor!")
-    if tensor.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+    if (tensor.layout != ttnn.ROW_MAJOR_LAYOUT) and not (
+        tensor.dtype == ttnn.bfloat8_b or tensor.dtype == ttnn.bfloat4_b
+    ):
         raise RuntimeError("ttnn.Tensor has to be in ROW_MAJOR Layout to be converted to torch.Tensor")
     if mesh_composer:
         return mesh_composer.compose(tensor)

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -201,7 +201,10 @@ def from_torch(
 
     if mesh_mapper:
         shards = mesh_mapper.map(tensor)
-        tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config())
+        if tile is not None:
+            tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config(), tile)
+        else:
+            tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config())
     else:
         if tile is not None:
             tensor = ttnn.Tensor(tensor, dtype, {}, tile)

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -190,7 +190,7 @@ def from_torch(
         if layout != ttnn.TILE_LAYOUT:
             raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
         # Tilize tensor
-        tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT)
+        tensor = ttnn.from_torch(tensor, layout=ttnn.TILE_LAYOUT, tile=tile)
         shape_with_padding = tensor.shape
         tensor = tensor.reshape(tensor.shape.with_tile_padding())
         tensor = ttnn.to_torch(tensor)

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -160,10 +160,10 @@ def from_torch(
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
 ) -> ttnn.Tensor:
     """
-    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. For bfloat8_b or bfloat4_b format, call from_torch twice, first call
-    runs in bfloat16 format, and calls to_layout to convert from row_major layout to tile layout (for padding purpose in case input
+    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. For bfloat8_b or bfloat4_b format, the function itself is called twice,
+    first call runs in bfloat16 format, and calls to_layout to convert from row_major layout to tile layout (for padding purpose in case input
     is not tile padded). Second call runs in desired format and does not call to_layout for bfloat8_b or bfloat4_b as we now convert
-    to tile layout during tensor creation.
+    to tile layout during tensor creation (ttnn.Tensor).
 
     Args:
         tensor (torch.Tensor): the input tensor.
@@ -260,7 +260,7 @@ def to_torch(
 ) -> "torch.Tensor":
     """
     Converts the `ttnn.Tensor` tensor into a `torch.Tensor`. It does not call to_layout for bfloat8_b or bfloat4_b as we now convert
-    to tile layout during when calling to_torch.
+    to tile layout during tensor.to_torch().
 
     Args:
         tensor (ttnn.Tensor): the input tensor.

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -160,7 +160,7 @@ def from_torch(
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
 ) -> ttnn.Tensor:
     """
-    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. for bfloat8_b or bfloat4_b format, call from_torch twice, first call
+    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. For bfloat8_b or bfloat4_b format, call from_torch twice, first call
     runs in bfloat16 format, and calls to_layout to convert from row_major layout to tile layout (for padding purpose in case input
     is not tile padded). Second call runs in desired format and does not call to_layout for bfloat8_b or bfloat4_b as we now convert
     to tile layout during tensor creation.
@@ -259,7 +259,8 @@ def to_torch(
     cq_id: Optional[int] = 0,
 ) -> "torch.Tensor":
     """
-    Converts the `ttnn.Tensor` tensor into a `torch.Tensor`.
+    Converts the `ttnn.Tensor` tensor into a `torch.Tensor`. It does not call to_layout for bfloat8_b or bfloat4_b as we now convert
+    to tile layout during when calling to_torch.
 
     Args:
         tensor (ttnn.Tensor): the input tensor.

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -160,7 +160,10 @@ def from_torch(
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
 ) -> ttnn.Tensor:
     """
-    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`.
+    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. for bfloat8_b or bfloat4_b format, call from_torch twice, first call
+    runs in bfloat16 format, and calls to_layout to convert from row_major layout to tile layout (for padding purpose in case input
+    is not tile padded). Second call runs in desired format and does not call to_layout for bfloat8_b or bfloat4_b as we now convert
+    to tile layout during tensor creation.
 
     Args:
         tensor (torch.Tensor): the input tensor.


### PR DESCRIPTION
### Problem description
Need a new transpoed tile layout for better accuracy when performing matmul, as a shared exponent will be shared across face rows, not face cols.

Tiny tile was not properly tested with Bfloat format, fixed several things with hardcoded tile dims.

previously, we do pack to bfloat during tensor creation in row major, this is not correct and lose precision.
Changed to do pack to bfloat after convert to tile layout.
changed from_torch, for bfloat we don't do to_layout anymore, and do to_layout during tensor creation.
changed to_torch, for bfloat we don't do to_layout anymore, and do to_layout during tensor.to_torch.

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/11631222952/job/32392107561
- [x] Blackhole Post commit https://github.com/tenstorrent/tt-metal/actions/runs/11633272619
- [x] Model regression  https://github.com/tenstorrent/tt-metal/actions/runs/11632261921
- [x] Device performance regression  https://github.com/tenstorrent/tt-metal/actions/runs/11632256943
- [x] nightly https://github.com/tenstorrent/tt-metal/actions/runs/11632273937
- [x] t3k nightly https://github.com/tenstorrent/tt-metal/actions/runs/11632267554
- [x] t3k frequent https://github.com/tenstorrent/tt-metal/actions/runs/11634045853
- [x] t3k demo https://github.com/tenstorrent/tt-metal/actions/runs/11633242170
- [x] tg demo https://github.com/tenstorrent/tt-metal/actions/runs/11633256094
- [x] tgg model  https://github.com/tenstorrent/tt-metal/actions/runs/11633698427
