### PR TITLE
#14501: Stall enqueue_program after enqueue_trace

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UNIT_TESTS_FD_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/command_queue/test_events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/command_queue/test_HostAsyncCQ.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/command_queue/test_worker_config_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/sfpu/sfpu_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multichip/test_device_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multichip/test_eth_EnqueueProgram.cpp

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_worker_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_worker_config_buffer.cpp
@@ -22,7 +22,7 @@ TEST(WorkingConfigBuffer, MarkCompletelyFull) {
 
     mgr.mark_completely_full(5);
 
-    // Allocation would succed, except buffer is marked completely full.
+    // Allocation would suceed, except buffer is marked completely full.
     auto new_reservation = mgr.reserve({12, 0});
     EXPECT_TRUE(new_reservation.first.need_sync);
     EXPECT_EQ(new_reservation.first.sync_count, 5u);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_worker_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_worker_config_buffer.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "tt_metal/impl/dispatch/worker_config_buffer.hpp"
+
+using std::vector;
+using namespace tt::tt_metal;
+
+namespace working_config_buffer_tests {
+
+TEST(WorkingConfigBuffer, MarkCompletelyFull) {
+    WorkerConfigBufferMgr mgr;
+    mgr.init_add_core(1024, 1024);
+    mgr.init_add_core(2, 1024);
+
+    auto reservation = mgr.reserve({12, 12});
+    mgr.alloc(1);
+
+    mgr.mark_completely_full(5);
+
+    // Allocation would succed, except buffer is marked completely full.
+    auto new_reservation = mgr.reserve({12, 0});
+    EXPECT_TRUE(new_reservation.first.need_sync);
+    EXPECT_EQ(new_reservation.first.sync_count, 5u);
+    EXPECT_EQ(new_reservation.second[0].size, 12u);
+    EXPECT_EQ(new_reservation.second[1].size, 0u);
+    mgr.free(5);
+
+    mgr.alloc(1);
+
+    auto next_reservation = mgr.reserve({12, 12});
+
+    EXPECT_FALSE(next_reservation.first.need_sync);
+}
+}  // namespace working_config_buffer_tests

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2373,6 +2373,10 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
     // Update the wptr on host to match state
     this->device->worker_launch_message_buffer_state.set_mcast_wptr(trace_inst->desc->num_traced_programs_needing_go_signal_multicast);
     this->device->worker_launch_message_buffer_state.set_unicast_wptr(trace_inst->desc->num_traced_programs_needing_go_signal_unicast);
+    // The config buffer manager is unaware of what memory is used inside the trace, so mark all memory as used so that
+    // it will force a stall and avoid stomping on in-use state.
+    // TODO(jbauman): Reuse old state from the trace.
+    this->manager.get_config_buffer_mgr().mark_completely_full(this->expected_num_workers_completed);
 
     if (blocking) {
         this->finish();

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -297,7 +297,6 @@ class EnqueueProgramCommand : public Command {
     uint32_t unicast_cores_launch_message_wptr = 0;
 
    public:
-
     EnqueueProgramCommand(
         uint32_t command_queue_id,
         Device* device,

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -162,6 +162,27 @@ uint32_t WorkerConfigBufferMgr::get_last_slot_addr(HalProgrammableCoreType progr
     return this->reservation_[index].addr;
 }
 
+void WorkerConfigBufferMgr::mark_completely_full(uint32_t sync) {
+    size_t num_core_types = this->reservation_.size();
+    for (uint32_t idx = 0; idx < num_core_types; idx++) {
+        constexpr uint32_t kNewFreeIndex = 0;
+        constexpr uint32_t kNewAllocIndex = 1;
+        this->alloc_index_[idx] = kNewAllocIndex;
+        this->free_index_[idx] = kNewFreeIndex;
+
+        auto& free_entry = this->entries_[kNewFreeIndex][idx];
+        free_entry.addr = this->base_addrs_[idx];
+        free_entry.size = this->end_addrs_[idx] - this->base_addrs_[idx];
+        free_entry.sync_count = sync;
+
+        auto& alloc_entry = this->entries_[kNewAllocIndex][idx];
+        // This address will immediately cause a wrap and failure to allocate.
+        alloc_entry.addr = this->end_addrs_[idx];
+        alloc_entry.size = 0;
+        alloc_entry.sync_count = 0xbabababa;  // debug
+    }
+}
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/dispatch/worker_config_buffer.hpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.hpp
@@ -41,6 +41,7 @@ class WorkerConfigBufferMgr {
     const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> reserve(const std::vector<uint32_t>& sizes);
     void free(uint32_t free_up_to_sync_count);
     void alloc(uint32_t when_freeable_sync_count);
+    void mark_completely_full(uint32_t sync);
 
     // Test/Debug
     uint32_t get_last_slot_addr(HalProgrammableCoreType programmable_core_type) const;


### PR DESCRIPTION
enqueue_program normally writes out the RTA to the ringbuffer before it stalls waiting for the previous program to finish. If a kernel is running due to enqueue_trace, the config buffer manager is unaware of the memory that's in use by the kernel, so the RTA may overwrite the kernel binary or other L1 memory that's in use.

enqueue_program should ensure that a stall happens before the RTA is written out if there was an enqueue_trace that was recently called.

### Ticket
#14501 

### Problem description
Failures on pytest tests/nightly/single_card/functional_unet/experimental/functional_unet/tests/test_unet_trace.py::test_unet_trace_2cq_same_io[2-1-32-device_params0] with the ring-buffer change (and potentially failures otherwise even without that change).

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
