### PR TITLE
Bump timeout limit of SD unit tests to 35 minutes

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 25
+        default: 35
   workflow_dispatch:
     inputs:
       arch:
@@ -33,7 +33,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 25
+        default: 35
 jobs:
   unit-tests-slow-dispatch:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }}


### PR DESCRIPTION

### Problem description
The new 8vCPU runners are noticeably slower than the 14vCPU ones. To run this test suite successfully on a 8vCPU runner needs more than 25 minutes. For example, see:

 https://github.com/tenstorrent/tt-metal/actions/runs/11605868684/job/32317010098

### What's changed
Bump timeout limit to 35 minutes.

Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
