### PR TITLE
core_coord and work_split changes/optimizations

### DIFF
--- a/best_practices.md
+++ b/best_practices.md
@@ -24,7 +24,7 @@ void write_buffer(queue_id cq_id, Tensor& dst, const std::vector<std::shared_ptr
 Consider using `tt::stl::Span` as input instead of `std::vector`. This allows `std::array` to be used as an argument as well.
 
 ### Explanation
-`tt::stl::Spann` is a lightweight view over a contiguous sequence of objects, such as arrays and vectors. It provides a safe and flexible way to handle array-like data structures without copying them.
+`tt::stl::Span` is a lightweight view over a contiguous sequence of objects, such as arrays and vectors. It provides a safe and flexible way to handle array-like data structures without copying them.
 
 ### Motivation
 - **Flexibility**: Enables functions to accept both `std::vector` and `std::array`.
@@ -234,7 +234,7 @@ Global classes can lead to issues with concurrency and resource management, espe
 - **Maintainability**: Avoids hidden dependencies and makes the code easier to understand and maintain.
 - **Predictability**: Improves the predictability of resource management and execution flow.
 
-## 12. Move Function  Implementations to `.cpp` Files
+## 12. Move Function Implementations to `.cpp` Files
 
 ### Practice
 Move function and method implementations from header files to `.cpp` files. Template heavy functions/methods implementations could be moved to the '_inl.hpp' file which should be included in the end of the header.

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -149,9 +149,9 @@ appropriate tile count when assigning args.
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_output_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
@@ -426,7 +426,7 @@ def test_sharded_nlp_create_qkv_heads_test(
     torch.manual_seed(1234)
     compute_grid_size = device.compute_with_storage_grid_size()
     num_cores = num_kv_heads
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     q_shape = [seq_len, 1, batch, num_cores, num_q_heads // num_cores * head_dim]
     kv_shape = [seq_len, 1, batch, num_cores, num_kv_heads // num_cores * head_dim]
     Q = torch.randn(q_shape)

--- a/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
+++ b/tech_reports/prog_examples/matmul_multi_core/matmul_multi_core.md
@@ -118,9 +118,9 @@ for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++){
     CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
     uint32_t num_output_tiles_per_core;
-    if (core_group_1.core_coord_in_core_ranges(core)) {
+    if (core_group_1.contains(core)) {
         num_output_tiles_per_core = num_output_tiles_per_core_group_1;
-    } else if (core_group_2.core_coord_in_core_ranges(core)) {
+    } else if (core_group_2.contains(core)) {
         num_output_tiles_per_core = num_output_tiles_per_core_group_2;
     } else {
         TT_ASSERT(false, "Core not in specified core ranges");

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_height_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_height_sharded.py
@@ -88,7 +88,7 @@ def run(
     # TODO: row_wise=False and ROW_MAJOR shard orientation gives bad PCC
     # TODO: COL_MAJOR shard orientation doesn't work for get_matmul_program_config
     input_a_memory_config.shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores_height, core_grid, row_wise=True)),
+        ttnn.num_cores_to_corerangeset(num_cores_height, core_grid, row_wise=True),
         (per_core_height, k_size),
         ttnn.ShardOrientation.ROW_MAJOR,
         False,

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
@@ -81,7 +81,7 @@ def run(
     # TODO: row_wise=False and ROW_MAJOR shard orientation gives bad PCC
     # TODO: COL_MAJOR shard orientation doesn't work for get_matmul_program_config
     input_a_memory_config.shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores_width, core_grid, row_wise=True)),
+        ttnn.num_cores_to_corerangeset(num_cores_width, core_grid, row_wise=True),
         (total_height, per_core_width),
         ttnn.ShardOrientation.ROW_MAJOR,
         False,

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -77,7 +77,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(28, core_grid, row_wise=True)),
+                    ttnn.num_cores_to_corerangeset(28, core_grid, row_wise=True),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -105,7 +105,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(35, core_grid, row_wise=True)),
+                    ttnn.num_cores_to_corerangeset(35, core_grid, row_wise=True),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -134,7 +134,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(28, core_grid, row_wise=True)),
+                    ttnn.num_cores_to_corerangeset(28, core_grid, row_wise=True),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -163,7 +163,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(30, core_grid, row_wise=True)),
+                    ttnn.num_cores_to_corerangeset(30, core_grid, row_wise=True),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
@@ -312,7 +312,7 @@ def run_sharded_nlp_create_qkv_heads_test(
     torch.manual_seed(1234)
     compute_grid_size = device.compute_with_storage_grid_size()
     num_cores = num_kv_heads
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     q_shape = [seq_len, 1, batch, num_cores, num_q_heads // num_cores * head_dim]
     kv_shape = [seq_len, 1, batch, num_cores, num_kv_heads // num_cores * head_dim]
     Q = torch.randn(q_shape)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
@@ -70,7 +70,7 @@ def test_rotary_embedding_prefill(W, Z, Y, X, cache_size, in_sharded, out_sharde
 
         if in_sharded:
             Ht = divup(num_blocks, num_cores)
-            shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [
@@ -143,7 +143,7 @@ def test_rotary_embedding_decode(
 
         if in_sharded:
             Ht = divup(num_blocks, num_cores)
-            shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [
@@ -216,7 +216,7 @@ def test_rotary_embedding_prefill_fp32(
 
         if in_sharded:
             Ht = divup(num_blocks, num_cores)
-            shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [
@@ -287,7 +287,7 @@ def test_rotary_embedding_decode_fp32(
 
         if in_sharded:
             Ht = divup(num_blocks, num_cores)
-            shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -113,11 +113,7 @@ class TtLlamaRotary(torch.nn.Module):
         cos = ttnn.to_layout(cos, ttnn.TILE_LAYOUT)
         sin = ttnn.to_layout(sin, ttnn.TILE_LAYOUT)
 
-        grid = (
-            ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(self.batch, self.core_grid, row_wise=True))
-            .bounding_box()
-            .grid_size()
-        )
+        grid = ttnn.num_cores_to_corerangeset(self.batch, self.core_grid, row_wise=True).bounding_box().grid_size()
         mem_config = ttnn.create_sharded_memory_config(
             shape=(1, self.batch, ttnn.TILE_SIZE, self.head_dim),
             core_grid=ttnn.CoreGrid(y=grid.y, x=grid.x),
@@ -230,11 +226,7 @@ def run_test_rotary_embedding_llama(
         # For decode, TTNN expects inputs to be [1, batch, nh, dhead]
         inp = [x.transpose(1, 2) for x in inp]
 
-        grid = (
-            ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(batch, tt_model.core_grid, row_wise=True))
-            .bounding_box()
-            .grid_size()
-        )
+        grid = ttnn.num_cores_to_corerangeset(batch, tt_model.core_grid, row_wise=True).bounding_box().grid_size()
         input_mem_config = ttnn.create_sharded_memory_config(
             shape=(1, batch, ttnn.TILE_SIZE, head_dim),
             core_grid=ttnn.CoreGrid(y=grid.y, x=grid.x),

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -206,7 +206,7 @@ def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
     input_shape = torch.Size([N, C, H, W])
 
     num_cores = min(N, compute_grid_size.x * compute_grid_size.y)
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
@@ -238,7 +238,7 @@ def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
     input_shape = torch.Size([N, C, H, W])
 
     num_cores = min(N, compute_grid_size.x * compute_grid_size.y)
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
@@ -271,7 +271,7 @@ def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
     input_shape = torch.Size([N, C, H, W])
 
     num_cores = min(N, compute_grid_size.x * compute_grid_size.y)
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -40,7 +40,7 @@ class TestUpdateCache:
             if in_sharded:
                 compute_grid_size = device.compute_with_storage_grid_size()
                 num_cores = min(seq_len // 32 * num_heads, 32)  # Always use max 32 cores for testing
-                shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+                shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
                 input_shard_spec = ttnn.ShardSpec(
                     shard_grid,
                     [
@@ -108,7 +108,7 @@ class TestUpdateCache:
         if in_sharded:
             compute_grid_size = device.compute_with_storage_grid_size()
             num_cores = min(max(num_users, 32) // 32 * num_heads, compute_grid_size.x * compute_grid_size.y)
-            shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [
@@ -175,7 +175,7 @@ class TestUpdateCacheFP32:
             if in_sharded:
                 compute_grid_size = device.compute_with_storage_grid_size()
                 num_cores = min(seq_len // 32 * num_heads, 32)  # Always use max 32 cores for testing
-                shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+                shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
                 input_shard_spec = ttnn.ShardSpec(
                     shard_grid,
                     [
@@ -241,7 +241,7 @@ class TestUpdateCacheFP32:
         if in_sharded:
             compute_grid_size = device.compute_with_storage_grid_size()
             num_cores = min(max(num_users, 32) // 32 * num_heads, compute_grid_size.x * compute_grid_size.y)
-            shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 shard_grid,
                 [

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -226,9 +226,9 @@ int main(int argc, char **argv) {
             for (uint32_t i = 0, input_offset = 0; i < num_cores; ++i) {
                 CoreCoord core = {i / num_cores_y, i % num_cores_y};
                 uint32_t num_tiles_per_core = 0;
-                if (core_group_1.core_coord_in_core_ranges(core)) {
+                if (core_group_1.contains(core)) {
                     num_tiles_per_core = num_tiles_per_core_group_1;
-                } else if (core_group_2.core_coord_in_core_ranges(core)) {
+                } else if (core_group_2.contains(core)) {
                     num_tiles_per_core = num_tiles_per_core_group_2;
                 } else {
                     TT_ASSERT(false, "Core not in specified core ranges");
@@ -411,9 +411,9 @@ bool assign_runtime_args_to_program(
     for (uint32_t i = 0, num_tiles_used = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");
@@ -451,9 +451,9 @@ bool validation(
         for (uint32_t i = 0, input_offset = 0; i < num_cores; ++i) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
             uint32_t num_tiles_per_core = 0;
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_tiles_per_core = num_tiles_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_tiles_per_core = num_tiles_per_core_group_2;
             } else {
                 TT_ASSERT(false, "Core not in specified core ranges");
@@ -483,9 +483,9 @@ bool validation(
         for (uint32_t i = 0, input_offset = 0; i < num_cores; ++i) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
             uint32_t num_tiles_per_core = 0;
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_tiles_per_core = num_tiles_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_tiles_per_core = num_tiles_per_core_group_2;
             } else {
                 TT_ASSERT(false, "Core not in specified core ranges");

--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -32,6 +32,8 @@ set(UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_iterator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_construct.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_contains.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_intersects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dram/direct.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/host_apis/test_tilize_untilize.cpp

--- a/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
@@ -33,4 +33,6 @@ class CoreCoordHarness : public ::testing::Test {
     CoreRange sc2 = CoreRange({0, 1}, {0, 1});
     CoreRange sc3 = CoreRange({0, 2}, {0, 2});
     CoreRange sc4 = CoreRange({1, 2}, {1, 2});
+    CoreRange sc5 = CoreRange({1, 0}, {1, 0});
+    CoreRange sc6 = CoreRange({0, 0}, {0, 0});
 };

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_contains.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_contains.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "core_coord_fixture.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/common/core_coord.hpp"
+
+namespace basic_tests::CoreRangeSet {
+
+TEST_F(CoreCoordHarness, TestCoreRangeSetContains) {
+    // Contains CoreCoord
+    EXPECT_TRUE(::CoreRangeSet(this->cr1).contains(this->cr5.start_coord));
+    EXPECT_TRUE(::CoreRangeSet(this->cr5).contains(this->cr1.end_coord));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->sc1, this->sc4}).contains(this->cr3.start_coord));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->cr17, this->cr16}).contains(this->sc2.start_coord));
+    EXPECT_TRUE(::CoreRangeSet(this->cr11).contains(this->cr12.end_coord));
+    // Contains CoreRange
+    EXPECT_TRUE(::CoreRangeSet(this->cr1).contains(this->sc1));
+    EXPECT_TRUE(::CoreRangeSet(this->cr8).contains(this->cr1));
+    EXPECT_TRUE(::CoreRangeSet(this->cr13).contains(this->cr16));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc5, this->sc6}).contains(this->cr1));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->cr17, this->cr16}).contains(this->cr1));
+    // Contains CoreRangeSet
+    EXPECT_TRUE(
+        ::CoreRangeSet(this->cr1).contains(::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc5, this->sc6})));
+    EXPECT_TRUE(::CoreRangeSet(this->cr5).contains(::CoreRangeSet()));
+    EXPECT_TRUE(::CoreRangeSet().contains(::CoreRangeSet()));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->sc6, cr5, sc2})
+                    .contains(::CoreRangeSet(std::vector{this->cr1, this->cr2, this->cr3})));
+    EXPECT_TRUE(::CoreRangeSet(this->cr12).contains(::CoreRangeSet(std::vector{this->sc6, this->cr11})));
+}
+
+TEST_F(CoreCoordHarness, TestCoreRangeSetNotContains) {
+    // Not Contains CoreCoord
+    EXPECT_FALSE(::CoreRangeSet(this->cr1).contains(this->cr2.start_coord));
+    EXPECT_FALSE(
+        ::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc3, this->sc4}).contains(this->cr17.start_coord));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->cr1, this->sc4}).contains(this->cr7.start_coord));
+    // No Contains CoreRange
+    EXPECT_FALSE(::CoreRangeSet(this->cr1).contains(this->sc3));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->sc1, this->sc5, this->sc6}).contains(this->cr1));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->cr7, this->cr1}).contains(this->cr16));
+    // Not Contains CoreRangeSet
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc5}).contains(::CoreRangeSet(this->cr1)));
+    EXPECT_FALSE(::CoreRangeSet().contains(::CoreRangeSet(this->cr5)));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->sc6, cr5})
+                     .contains(::CoreRangeSet(std::vector{this->cr1, this->cr2, this->cr3})));
+}
+
+}  // namespace basic_tests::CoreRangeSet

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_intersects.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_intersects.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "core_coord_fixture.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/common/core_coord.hpp"
+
+namespace basic_tests::CoreRangeSet {
+
+TEST_F(CoreCoordHarness, TestCoreRangeSetIntersects) {
+    // Intersects CoreCoord
+    EXPECT_TRUE(::CoreRangeSet(this->cr1).intersects(this->cr5.start_coord));
+    EXPECT_TRUE(::CoreRangeSet(this->cr5).intersects(this->cr1.end_coord));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->sc1, this->sc4}).intersects(this->cr3.start_coord));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->cr17, this->cr16}).intersects(this->sc4.start_coord));
+    EXPECT_TRUE(::CoreRangeSet(this->cr11).intersects(this->cr12.end_coord));
+    // Intersects CoreRange
+    EXPECT_TRUE(::CoreRangeSet(this->cr1).intersects(this->cr5));
+    EXPECT_TRUE(::CoreRangeSet(this->cr5).intersects(this->cr1));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->sc1, this->sc4}).intersects(this->cr3));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->cr17, this->cr16}).intersects(this->sc4));
+    EXPECT_TRUE(::CoreRangeSet(this->cr11).intersects(this->cr12));
+    // Intersects CoreRangeSet
+    EXPECT_TRUE(::CoreRangeSet(this->cr1).intersects(::CoreRangeSet(this->cr5)));
+    EXPECT_TRUE(::CoreRangeSet(this->cr5).intersects(::CoreRangeSet(this->cr1)));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->sc1, this->sc4}).intersects(::CoreRangeSet(this->cr3)));
+    EXPECT_TRUE(::CoreRangeSet(std::vector{this->cr17, this->cr16})
+                    .intersects(::CoreRangeSet(std::vector{this->sc2, this->sc4})));
+    EXPECT_TRUE(::CoreRangeSet(this->sc2).intersects(::CoreRangeSet(std::vector{this->cr7, this->cr1})));
+}
+
+TEST_F(CoreCoordHarness, TestCoreRangeSetNotIntersects) {
+    // Not Intersects CoreCoord
+    EXPECT_FALSE(::CoreRangeSet(this->cr1).intersects(this->cr2.start_coord));
+    EXPECT_FALSE(
+        ::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc3, this->sc4}).intersects(this->cr17.start_coord));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->cr1, this->sc4}).intersects(this->cr7.start_coord));
+    // Not Intersects CoreRange
+    EXPECT_FALSE(::CoreRangeSet(this->cr1).intersects(this->cr2));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc3, this->sc4}).intersects(this->cr17));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->cr1, this->sc4}).intersects(this->cr7));
+    // Not Intersects CoreRangeSet
+    EXPECT_FALSE(::CoreRangeSet(this->cr1).intersects(::CoreRangeSet(std::vector{this->cr2, this->cr3})));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->sc1, this->sc2, this->sc3, this->sc4})
+                     .intersects(::CoreRangeSet(std::vector{this->cr17, this->cr18})));
+    EXPECT_FALSE(::CoreRangeSet(std::vector{this->cr1, this->sc4}).intersects(::CoreRangeSet(this->cr7)));
+}
+
+}  // namespace basic_tests::CoreRangeSet

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
@@ -2,59 +2,60 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <set>
+#include <vector>
 
+#include "core_coord_fixture.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/common/core_coord.hpp"
-#include "core_coord_fixture.hpp"
-#include <set>
 
-namespace basic_tests::CoreRangeSet{
+namespace basic_tests::CoreRangeSet {
 
-TEST_F(CoreCoordHarness, TestCoreRangeSetMergeNoSolution)
-{
-    EXPECT_EQ(::CoreRangeSet(sc1).merge(std::set{sc3}).ranges(), std::set<::CoreRange>({sc1, sc3}));
-    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr2}).ranges(), std::set<::CoreRange>({cr1, cr2}));
-    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr1, cr2}).ranges(), std::set<::CoreRange>({cr1, cr2}));
-    EXPECT_EQ(
-        ::CoreRangeSet(cr1).merge(std::set{cr2}).merge(std::set{cr3}).ranges(), std::set<::CoreRange>({cr1, cr2, cr3}));
+TEST_F(CoreCoordHarness, TestCoreRangeSetMergeNoSolution) {
+    EXPECT_EQ(::CoreRangeSet(sc1).merge(std::set{sc3}), ::CoreRangeSet(std::set{sc1, sc3}));
+    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr2}), ::CoreRangeSet(std::set{cr1, cr2}));
+    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr1, cr2}), ::CoreRangeSet(std::set{cr1, cr2}));
+    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr2}).merge(std::set{cr3}), ::CoreRangeSet(std::set{cr1, cr2, cr3}));
 }
 
-TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreCoord)
-{
+TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreCoord) {
     ::CoreRangeSet empty_crs;
     EXPECT_EQ(empty_crs.merge(std::set{this->sc1}).ranges().size(), 1);
-    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{sc3, sc4}).ranges(), std::set<::CoreRange>({cr16}));
-    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{sc3}).merge(std::set{sc4}).ranges(), std::set<::CoreRange>({cr16}));
-    CoreRange rect ( {0,0}, {4,2});
+    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{sc3, sc4}), ::CoreRangeSet(std::set{cr16}));
+    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{sc3}).merge(std::set{sc4}), ::CoreRangeSet(std::set{cr16}));
+    CoreRange rect({0, 0}, {4, 2});
     std::set<CoreRange> rect_pts;
-    for (unsigned y = rect.start_coord.y; y <= rect.end_coord.y; y++){
-        for (unsigned x = rect.start_coord.x; x <= rect.end_coord.x; x++){
-            rect_pts.insert ( CoreRange( {x, y}, {x, y} ) );
+    for (unsigned y = rect.start_coord.y; y <= rect.end_coord.y; y++) {
+        for (unsigned x = rect.start_coord.x; x <= rect.end_coord.x; x++) {
+            rect_pts.insert(CoreRange({x, y}, {x, y}));
         }
     }
-    EXPECT_EQ ( empty_crs.merge(rect_pts).ranges(), std::set<::CoreRange>( {rect} ));
+    EXPECT_EQ(empty_crs.merge(rect_pts), ::CoreRangeSet(std::set{rect}));
 
     // upside-down "T"
-    rect_pts.insert ( { CoreRange ( { 2,0}, {3,5} )});
-    EXPECT_EQ ( empty_crs.merge(rect_pts).ranges(), std::set<::CoreRange>( {rect, CoreRange( {2,3}, {3,5} ) } ));
+    rect_pts.insert({CoreRange({2, 0}, {3, 5})});
+    EXPECT_EQ(empty_crs.merge(rect_pts), ::CoreRangeSet(std::set{rect, CoreRange({2, 3}, {3, 5})}));
 
     // "H", sub-optimal currently, should be reduced down to 3 CRs instead of 5
-    EXPECT_EQ ( empty_crs.merge( std::vector{ CoreRange { {0,0}, {1,5} }, CoreRange { {3,0}, {4,5}}, CoreRange { {0,2} , {4,3} }  } ).ranges(),
-                std::set<::CoreRange>( { CoreRange { {0,0}, {1,1} }, CoreRange { {0,2}, {4,3}}, CoreRange{ {0,4}, {1,5}},
-                                       CoreRange { {3,0}, {4,1} }, CoreRange{ {3,4}, {4,5} } } ));
+    EXPECT_EQ(
+        empty_crs.merge(std::vector{CoreRange{{0, 0}, {1, 5}}, CoreRange{{3, 0}, {4, 5}}, CoreRange{{0, 2}, {4, 3}}}),
+        ::CoreRangeSet(std::set{
+            CoreRange{{0, 0}, {1, 1}},
+            CoreRange{{0, 2}, {4, 3}},
+            CoreRange{{0, 4}, {1, 5}},
+            CoreRange{{3, 0}, {4, 1}},
+            CoreRange{{3, 4}, {4, 5}}}));
 }
 
-TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreRange)
-{
-    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr1}).ranges(), std::set<::CoreRange>({cr1}));
-    EXPECT_EQ(::CoreRangeSet(cr7).merge(std::set{cr6}).merge(std::set{cr4}).ranges(), std::set<::CoreRange>({cr8}));
+TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreRange) {
+    EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr1}), ::CoreRangeSet(std::set{cr1}));
+    EXPECT_EQ(::CoreRangeSet(cr7).merge(std::set{cr6}).merge(std::set{cr4}), ::CoreRangeSet(std::set{cr8}));
     EXPECT_EQ(
-        ::CoreRangeSet(cr8).merge(std::set{cr7}).merge(std::set{cr6}).merge(std::set{cr4}).ranges(),
-        std::set<::CoreRange>({cr8}));
-    EXPECT_EQ(::CoreRangeSet(std::vector{cr1, cr2, cr3}).merge(std::set{cr4}).ranges(), std::set<::CoreRange>({cr4}));
+        ::CoreRangeSet(cr8).merge(std::set{cr7}).merge(std::set{cr6}).merge(std::set{cr4}),
+        ::CoreRangeSet(std::set{cr8}));
+    EXPECT_EQ(::CoreRangeSet(std::vector{cr1, cr2, cr3}).merge(std::set{cr4}), ::CoreRangeSet(std::set{cr4}));
     EXPECT_EQ(
-        ::CoreRangeSet(std::vector{cr1, cr2}).merge(std::set{cr4}).merge(std::set{cr6}).ranges(),
-        std::set<::CoreRange>({cr6}));
+        ::CoreRangeSet(std::vector{cr1, cr2}).merge(std::set{cr4}).merge(std::set{cr6}), ::CoreRangeSet(std::set{cr6}));
 }
 
-}
+}  // namespace basic_tests::CoreRangeSet

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_contains.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_contains.cpp
@@ -2,24 +2,45 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <vector>
 
+#include "core_coord_fixture.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/common/core_coord.hpp"
-#include "core_coord_fixture.hpp"
 
-namespace basic_tests::CoreRange{
+namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordHarness, TestCoreRangeContains){
+TEST_F(CoreCoordHarness, TestCoreRangeContains) {
+    // Contains CoreCoord
+    EXPECT_TRUE(this->cr1.contains(this->sc1.start_coord));
+    EXPECT_TRUE(this->cr1.contains(this->cr1.start_coord));
+    EXPECT_TRUE(this->cr4.contains(this->cr2.start_coord));
+    // Contains CoreRange
     EXPECT_TRUE(this->cr1.contains(this->sc1));
     EXPECT_TRUE(this->cr1.contains(this->cr1));
     EXPECT_TRUE(this->cr4.contains(this->cr2));
+    // Contains CoreRangeSet
+    EXPECT_TRUE(this->cr1.contains(::CoreRangeSet(this->sc1)));
+    EXPECT_TRUE(this->cr1.contains(::CoreRangeSet(this->cr1)));
+    EXPECT_TRUE(this->cr4.contains(::CoreRangeSet(std::vector{this->cr1, this->cr2, this->cr3})));
 }
 
-TEST_F(CoreCoordHarness, TestCoreRangeNotContains){
-    EXPECT_FALSE( this->sc1.contains(this->cr1));
-    EXPECT_FALSE( this->sc1.contains(this->sc2));
-    EXPECT_FALSE( this->cr1.contains(this->cr2));
-    EXPECT_FALSE( this->cr7.contains(this->sc1));
+TEST_F(CoreCoordHarness, TestCoreRangeNotContains) {
+    // Not Contains CoreCoord
+    EXPECT_FALSE(this->sc1.contains(this->cr1.start_coord));
+    EXPECT_FALSE(this->sc1.contains(this->sc2.start_coord));
+    EXPECT_FALSE(this->cr1.contains(this->cr2.start_coord));
+    EXPECT_FALSE(this->cr7.contains(this->sc1.start_coord));
+    // Not Contains CoreRange
+    EXPECT_FALSE(this->sc1.contains(this->cr1));
+    EXPECT_FALSE(this->sc1.contains(this->sc2));
+    EXPECT_FALSE(this->cr1.contains(this->cr2));
+    EXPECT_FALSE(this->cr7.contains(this->sc1));
+    // Not Contains CoreRangeSet
+    EXPECT_FALSE(this->sc1.contains(::CoreRangeSet(this->cr1)));
+    EXPECT_FALSE(this->sc1.contains(::CoreRangeSet(this->sc2)));
+    EXPECT_FALSE(this->cr1.contains(::CoreRangeSet(std::vector{this->sc1, this->cr2})));
+    EXPECT_FALSE(this->cr10.contains(::CoreRangeSet(std::vector{this->sc3, this->sc4, this->sc1})));
 }
 
-}
+}  // namespace basic_tests::CoreRange

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_intersects.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_intersects.cpp
@@ -2,36 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
+#include "core_coord_fixture.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/common/core_coord.hpp"
-#include "core_coord_fixture.hpp"
 
-namespace basic_tests::CoreRange{
+namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordHarness, TestCoreRangeIntersects)
-{
+TEST_F(CoreCoordHarness, TestCoreRangeIntersects) {
+    EXPECT_TRUE(this->cr1.intersects(this->cr5));
+    EXPECT_EQ(this->cr1.intersection(this->cr5).value(), ::CoreRange({1, 0}, {1, 1}));
 
-    EXPECT_TRUE( this->cr1.intersects(this->cr5).has_value() );
-    EXPECT_EQ ( this->cr1.intersects(this->cr5).value(), ::CoreRange({1,0}, {1,1}));
+    EXPECT_TRUE(this->sc1.intersects(this->cr6));
+    EXPECT_EQ(this->sc1.intersection(this->cr6).value(), this->sc1);
 
-    EXPECT_TRUE( this->sc1.intersects(this->cr6).has_value());
-    EXPECT_EQ ( this->sc1.intersects(this->cr6).value(), this->sc1);
+    EXPECT_TRUE(this->cr4.intersects(this->cr5));
+    EXPECT_EQ(this->cr4.intersection(this->cr5).value(), ::CoreRange({1, 0}, {5, 4}));
 
-    EXPECT_TRUE( this->cr4.intersects(this->cr5).has_value());
-    EXPECT_EQ ( this->cr4.intersects(this->cr5).value(), ::CoreRange({1,0}, {5,4} ));
+    EXPECT_TRUE(this->cr1.intersects(this->cr6));
+    EXPECT_EQ(this->cr1.intersection(this->cr6).value(), this->cr1);
 
-    EXPECT_TRUE( this->cr1.intersects(this->cr6).has_value());
-    EXPECT_EQ ( this->cr1.intersects(this->cr6).value(), this->cr1 );
-
-    EXPECT_TRUE( this->cr7.intersects(this->cr8).has_value());
-    EXPECT_EQ ( this->cr7.intersects(this->cr8).value(), this->cr7 );
+    EXPECT_TRUE(this->cr7.intersects(this->cr8));
+    EXPECT_EQ(this->cr7.intersection(this->cr8).value(), this->cr7);
 }
 
-TEST_F(CoreCoordHarness, TestCoreRangeNotIntersects){
-    EXPECT_FALSE ( this->cr1.intersects(this->cr2));
-    EXPECT_FALSE ( this->sc1.intersects(this->cr2));
-    EXPECT_FALSE ( this->cr1.intersects(this->cr7));
+TEST_F(CoreCoordHarness, TestCoreRangeNotIntersects) {
+    EXPECT_FALSE(this->cr1.intersects(this->cr2));
+    EXPECT_FALSE(this->sc1.intersects(this->cr2));
+    EXPECT_FALSE(this->cr1.intersects(this->cr7));
 }
 
-}
+}  // namespace basic_tests::CoreRange

--- a/tests/ttnn/distributed/test_multidevice_TG.py
+++ b/tests/ttnn/distributed/test_multidevice_TG.py
@@ -737,7 +737,7 @@ class TestUpdateCache:
 
             compute_grid_size = mesh_device.compute_with_storage_grid_size()
             num_cores = min(seq_len // 32 * num_heads, 32)  # Always use max 32 cores for testing
-            mesh_shape = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+            mesh_shape = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
             input_shard_spec = ttnn.ShardSpec(
                 mesh_shape,
                 [
@@ -811,7 +811,7 @@ class TestUpdateCache:
         xt = x_new.permute(2, 1, 0, 3)
         compute_grid_size = mesh_device.compute_with_storage_grid_size()
         num_cores = min(max(num_users, 32) // 32 * num_heads, compute_grid_size.x * compute_grid_size.y)
-        mesh_shape = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+        mesh_shape = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
         input_shard_spec = ttnn.ShardSpec(
             mesh_shape,
             [

--- a/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
@@ -37,7 +37,7 @@ def run_test_update_cache_decode(
     # Input is sharded
     compute_grid_size = device.compute_with_storage_grid_size()
     num_cores = num_users
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
@@ -147,7 +147,7 @@ def test_update_cache_decode(
         # Input is sharded
         compute_grid_size = device.compute_with_storage_grid_size()
         num_cores = num_users
-        shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+        shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
@@ -230,7 +230,7 @@ def test_update_cache_decode_program_cache(
         # Input is sharded
         compute_grid_size = device.compute_with_storage_grid_size()
         num_cores = num_users
-        shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+        shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
@@ -272,7 +272,7 @@ def run_test_tensor_index_update_cache_decode(
     # Input is sharded
     compute_grid_size = device.compute_with_storage_grid_size()
     num_cores = num_users
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
@@ -410,7 +410,7 @@ def run_test_paged_update_cache_decode(
     # Input is sharded
     compute_grid_size = device.compute_with_storage_grid_size()
     num_cores = num_users
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         [
@@ -539,7 +539,7 @@ def test_paged_update_cache_decode_program_caching(
         # Input is sharded
         compute_grid_size = device.compute_with_storage_grid_size()
         num_cores = num_users
-        shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+        shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [

--- a/tests/ttnn/unit_tests/operations/test_ssm_prefix_scan.py
+++ b/tests/ttnn/unit_tests/operations/test_ssm_prefix_scan.py
@@ -35,7 +35,7 @@ def run_ssm_prefix_scan(L: int, E: int, N: int, num_cores: int, dtype, device):
     if num_availible_cores < num_cores:
         pytest.skip(f"Not enough cores availible (was {num_availible_cores} but need {num_cores})")
 
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     shard_spec = ttnn.ShardSpec(
         shard_grid,
         [L, E * N // num_cores],
@@ -119,7 +119,7 @@ def run_chunked_ssm_prefix_scan(L: int, E: int, N: int, chunk_size: int, num_cor
     if num_availible_cores < num_cores:
         pytest.skip(f"Not enough cores availible (was {num_availible_cores} but need {num_cores})")
 
-    shard_grid = ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
     shard_spec = ttnn.ShardSpec(
         shard_grid,
         [L, E * N // num_cores],

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(COMMON_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/metal_soc_descriptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_backend_api_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/work_split.cpp
 )
 
 add_library(common OBJECT ${COMMON_SRCS})

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -5,6 +5,7 @@
 #include "tt_metal/common/core_coord.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -47,7 +48,16 @@ CoreRange::CoreRange(const CoreCoord &start_coord, const CoreCoord &end_coord) {
     this->end_coord = end_coord;
 }
 
-std::optional<CoreRange> CoreRange::intersects(const CoreRange &other) const {
+bool CoreRange::intersects(const CoreRange &other) const {
+    bool first_core_left_of_second = this->end_coord.x < other.start_coord.x;
+    bool first_core_right_of_second = this->start_coord.x > other.end_coord.x;
+    bool first_core_above_second = this->end_coord.y < other.start_coord.y;
+    bool first_core_below_second = this->start_coord.y > other.end_coord.y;
+    return !(
+        first_core_left_of_second or first_core_right_of_second or first_core_above_second or first_core_below_second);
+}
+
+std::optional<CoreRange> CoreRange::intersection(const CoreRange &other) const {
     std::size_t x1 = std::max(this->start_coord.x, other.start_coord.x);
     std::size_t y1 = std::max(this->start_coord.y, other.start_coord.y);
     std::size_t x2 = std::min(this->end_coord.x, other.end_coord.x);
@@ -67,14 +77,23 @@ bool CoreRange::adjacent(const CoreRange &other) const {
     return ((x2 + 1 == x1 && y1 <= y2) || (y2 + 1 == y1 && x1 <= x2));
 }
 
+bool CoreRange::contains(const CoreCoord &other) const {
+    return (other.x >= this->start_coord.x) && (other.x <= this->end_coord.x) && (other.y >= this->start_coord.y) &&
+           (other.y <= this->end_coord.y);
+}
+
 bool CoreRange::contains(const CoreRange &other) const {
     return (other.start_coord.x >= this->start_coord.x) && (other.end_coord.x <= this->end_coord.x) &&
            (other.start_coord.y >= this->start_coord.y) && (other.end_coord.y <= this->end_coord.y);
 }
 
-bool CoreRange::contains(const CoreCoord &other) const {
-    return (other.x >= this->start_coord.x) && (other.x <= this->end_coord.x) && (other.y >= this->start_coord.y) &&
-           (other.y <= this->end_coord.y);
+bool CoreRange::contains(const CoreRangeSet &other) const {
+    for (const auto &cr : other.ranges()) {
+        if (!this->contains(cr)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Merge lined-up (in x or y dimension) intersecting/adjacent rectangles
@@ -143,7 +162,7 @@ auto fmt::formatter<CoreRange>::format(const CoreRange &core_range, format_conte
     return fmt::format_to(ctx.out(), "{}", ss.str());
 }
 
-CoreRangeSet::CoreRangeSet(const std::vector<CoreRange> &core_ranges) :
+CoreRangeSet::CoreRangeSet(tt::stl::Span<const CoreRange> core_ranges) :
     ranges_(core_ranges.begin(), core_ranges.end()) {
     ZoneScoped;
     this->validate_no_overlap();
@@ -172,9 +191,9 @@ CoreRangeSet &CoreRangeSet::operator=(const CoreRangeSet &other) {
     return *this;
 }
 
-CoreRangeSet::CoreRangeSet(CoreRangeSet &&other) { swap(*this, other); }
+CoreRangeSet::CoreRangeSet(CoreRangeSet &&other) noexcept { swap(*this, other); }
 
-CoreRangeSet &CoreRangeSet::operator=(CoreRangeSet &&other) {
+CoreRangeSet &CoreRangeSet::operator=(CoreRangeSet &&other) noexcept {
     swap(*this, other);
     return *this;
 }
@@ -252,19 +271,77 @@ CoreRangeSet CoreRangeSet::merge<CoreRangeSet>(const CoreRangeSet &other) const 
     return this->merge(other.ranges());
 }
 
-bool CoreRangeSet::core_coord_in_core_ranges(const CoreCoord &core_coord) const {
-    ZoneScoped;
-    for (const auto &cr : this->ranges_) {
-        if (cr.contains(core_coord))
+bool CoreRangeSet::intersects(const CoreCoord &other) const {
+    // For a CoreCoord, intersect and contains are equivalent
+    return this->contains(other);
+}
+
+bool CoreRangeSet::intersects(const CoreRange &other) const {
+    for (const auto &local_cr : this->ranges_) {
+        if (local_cr.intersects(other)) {
             return true;
+        }
     }
     return false;
 }
 
-bool CoreRangeSet::intersects(const CoreRange &cr) const {
-    for (const auto &local_cr : this->ranges_) {
-        if (local_cr.intersects(cr))
+bool CoreRangeSet::intersects(const CoreRangeSet &other) const {
+    for (const auto &cr : other.ranges()) {
+        if (this->intersects(cr)) {
             return true;
+        }
+    }
+    return false;
+}
+
+bool CoreRangeSet::contains(const CoreCoord &other) const {
+    for (const auto &cr : this->ranges_) {
+        if (cr.contains(other)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CoreRangeSet::contains(const CoreRange &other) const {
+    uint32_t num_remaining_cores = other.size();
+    if (num_remaining_cores == 0) {
+        return true;
+    } else if(this->num_cores() < num_remaining_cores) {
+        return false;
+    }
+    uint32_t num_intersect_cores = 0;
+    for (const auto &cr : this->ranges_) {
+        const auto& intersection = cr.intersection(other);
+        if (intersection.has_value()) {
+            num_remaining_cores -= intersection->size();
+            // Early exit
+            if (num_remaining_cores == 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool CoreRangeSet::contains(const CoreRangeSet &other) const {
+    uint32_t num_remaining_cores = other.num_cores();
+    if (num_remaining_cores == 0) {
+        return true;
+    } else if (this->num_cores() < num_remaining_cores) {
+        return false;
+    }
+    for (const auto &local_cr : this->ranges_) {
+        for (const auto& other_cr : other.ranges_) {
+            const auto& intersection = local_cr.intersection(other_cr);
+            if (intersection.has_value()) {
+                num_remaining_cores -= intersection->size();
+                // Early exit
+                if (num_remaining_cores == 0) {
+                    return true;
+                }
+            }
+        }
     }
     return false;
 }
@@ -311,15 +388,9 @@ void CoreRangeSet::validate_no_overlap() {
     }
     for (auto outer_it = this->ranges_.begin(); outer_it != this->ranges_.end() - 1; outer_it++) {
         for (auto inner_it = outer_it + 1; inner_it != this->ranges_.end(); inner_it++) {
-            CoreRange &first_core_range = *outer_it;
-            CoreRange &second_core_range = *inner_it;
-            bool first_core_left_of_second = first_core_range.end_coord.x < second_core_range.start_coord.x;
-            bool first_core_right_of_second = first_core_range.start_coord.x > second_core_range.end_coord.x;
-            bool first_core_above_second = first_core_range.end_coord.y < second_core_range.start_coord.y;
-            bool first_core_below_second = first_core_range.start_coord.y > second_core_range.end_coord.y;
-            auto no_overlap = first_core_left_of_second or first_core_right_of_second or first_core_above_second or
-                              first_core_below_second;
-            if (not no_overlap) {
+            const auto &first_core_range = *outer_it;
+            const auto &second_core_range = *inner_it;
+            if (first_core_range.intersects(second_core_range)) {
                 TT_THROW(
                     "Cannot create CoreRangeSet with specified core ranges because core ranges {} and {} overlap!",
                     first_core_range.str(),
@@ -354,11 +425,11 @@ std::vector<CoreCoord> grid_to_cores(uint32_t num_cores, uint32_t grid_size_x, u
         grid_size_y);
     if (row_wise) {
         for (uint32_t i = 0; i < num_cores; ++i) {
-            cores.push_back({i % grid_size_x, i / grid_size_x});
+            cores.emplace_back(i % grid_size_x, i / grid_size_x);
         }
     } else {
         for (uint32_t i = 0; i < num_cores; ++i) {
-            cores.push_back({i / grid_size_y, i % grid_size_y});
+            cores.emplace_back(i / grid_size_y, i % grid_size_y);
         }
     }
     return cores;
@@ -373,14 +444,14 @@ std::vector<CoreCoord> grid_to_cores(CoreCoord start, CoreCoord end, bool row_wi
     if (row_wise) {
         for (uint32_t j = start.y; j < (end.y + 1); j++) {
             for (uint32_t i = start.x; i < (end.x + 1); i++) {
-                cores.push_back({i, j});
+                cores.emplace_back(i, j);
             }
         }
 
     } else {
         for (uint32_t i = start.x; i < (end.x + 1); i++) {
             for (uint32_t j = start.y; j < (end.y + 1); j++) {
-                cores.push_back({i, j});
+                cores.emplace_back(i, j);
             }
         }
     }
@@ -404,25 +475,25 @@ std::vector<CoreCoord> grid_to_cores_with_noop(
 
     if (row_wise) {
         for (uint32_t i = 0; i < box_size_x * box_size_y; ++i) {
-            cores.push_back({i % box_size_x, i / box_size_x});
+            cores.emplace_back(i % box_size_x, i / box_size_x);
         }
     } else {
         for (uint32_t i = 0; i < box_size_x * box_size_y; ++i) {
-            cores.push_back({i / box_size_y, i % box_size_y});
+            cores.emplace_back(i / box_size_y, i % box_size_y);
         }
     }
 
     // Right rectangle noops
     for (uint32_t x = box_size_x; x < grid_size_x; ++x) {
         for (uint32_t y = 0; y < grid_size_y; ++y) {
-            cores.push_back({x, y});
+            cores.emplace_back(x, y);
         }
     }
 
     // Bottom rectangle noops
     for (uint32_t y = box_size_y; y < grid_size_y; ++y) {
         for (uint32_t x = 0; x < box_size_x; ++x) {
-            cores.push_back({x, y});
+            cores.emplace_back(x, y);
         }
     }
 
@@ -430,18 +501,18 @@ std::vector<CoreCoord> grid_to_cores_with_noop(
 }
 
 std::vector<CoreCoord> corerange_to_cores(const CoreRangeSet &crs, std::optional<uint32_t> max_cores, bool row_wise) {
-    uint32_t num_total_cores = 0;
     std::vector<CoreCoord> all_cores;
-    uint32_t offset = 0;
-
-    for (auto core_range : crs.ranges()) {
-        auto start_coord = core_range.start_coord;
-        auto end_coord = core_range.end_coord;
+    auto num_cores = crs.num_cores();
+    all_cores.reserve(max_cores.has_value() ? std::min(*max_cores, num_cores) : num_cores);
+    for (const auto &core_range : crs.ranges()) {
+        const auto &start_coord = core_range.start_coord;
+        const auto &end_coord = core_range.end_coord;
         auto cores = grid_to_cores(start_coord, end_coord, row_wise);
         if (max_cores.has_value()) {
-            if (all_cores.size() + cores.size() > max_cores.value()) {
-                uint32_t num_cores_to_add = max_cores.value() - all_cores.size();
+            if (all_cores.size() + cores.size() > *max_cores) {
+                uint32_t num_cores_to_add = *max_cores - all_cores.size();
                 all_cores.insert(all_cores.end(), cores.begin(), cores.begin() + num_cores_to_add);
+                break;
             } else {
                 all_cores.insert(all_cores.end(), cores.begin(), cores.end());
             }

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -14,8 +14,11 @@
 #include "third_party/json/json.hpp"
 #include "third_party/umd/device/tt_xy_pair.h"
 #include "tt_metal/tt_stl/reflection.hpp"
+#include "tt_metal/tt_stl/span.hpp"
 
 using CoreCoord = tt_xy_pair;
+
+struct CoreRangeSet;
 
 template <>
 struct fmt::formatter<CoreCoord> {
@@ -53,13 +56,17 @@ struct CoreRange {
     CoreRange(CoreRange &&other) = default;
     CoreRange &operator=(CoreRange &&other) = default;
 
-    std::optional<CoreRange> intersects(const CoreRange &other) const;
+    bool intersects(const CoreRange &other) const;
+
+    std::optional<CoreRange> intersection(const CoreRange &other) const;
 
     bool adjacent(const CoreRange &other) const;
 
+    bool contains(const CoreCoord &other) const;
+
     bool contains(const CoreRange &other) const;
 
-    bool contains(const CoreCoord &other) const;
+    bool contains(const CoreRangeSet &other) const;
 
     // Merge lined-up (in x or y dimension) intersecting/adjacent rectangles
     std::optional<CoreRange> merge(const CoreRange &cr) const;
@@ -113,7 +120,7 @@ struct fmt::formatter<CoreRange> {
 
 class CoreRangeSet {
    public:
-    CoreRangeSet(const std::vector<CoreRange> &core_ranges);
+    CoreRangeSet(tt::stl::Span<const CoreRange> core_ranges);
 
     CoreRangeSet(const std::set<CoreRange> &core_ranges);
 
@@ -127,9 +134,9 @@ class CoreRangeSet {
 
     CoreRangeSet &operator=(const CoreRangeSet &other);
 
-    CoreRangeSet(CoreRangeSet &&other);
+    CoreRangeSet(CoreRangeSet &&other) noexcept;
 
-    CoreRangeSet &operator=(CoreRangeSet &&other);
+    CoreRangeSet &operator=(CoreRangeSet &&other) noexcept;
 
     CoreRangeSet(std::vector<CoreRange> &&core_ranges);
 
@@ -138,9 +145,17 @@ class CoreRangeSet {
     template <typename T>
     CoreRangeSet merge(const T &other) const;
 
-    bool core_coord_in_core_ranges(const CoreCoord &core_coord) const;
+    bool intersects(const CoreCoord &other) const;
 
-    bool intersects(const CoreRange &cr) const;
+    bool intersects(const CoreRange &other) const;
+
+    bool intersects(const CoreRangeSet &other) const;
+
+    bool contains(const CoreCoord &other) const;
+
+    bool contains(const CoreRange &other) const;
+
+    bool contains(const CoreRangeSet &other) const;
 
     const std::vector<CoreRange> &ranges() const;
 

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Contains utility functions for partitioning work between multiple cores.
+//
+
+#include <cstdint>
+#include <tuple>
+#include <vector>
+
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+
+namespace tt {
+namespace tt_metal {
+
+uint32_t merge_num_sticks_to_read(uint32_t num_sticks_to_read, uint32_t stick_size_bytes, uint32_t max_read_size) {
+    uint32_t total_bytes = num_sticks_to_read * stick_size_bytes;
+    uint32_t new_num_sticks_to_read = num_sticks_to_read;
+    uint32_t new_stick_size_bytes = stick_size_bytes;
+
+    for (uint32_t current_size = stick_size_bytes; current_size <= max_read_size; current_size += stick_size_bytes) {
+        if (total_bytes % current_size == 0) {
+            new_stick_size_bytes = current_size;
+            new_num_sticks_to_read = total_bytes / current_size;
+        }
+    }
+    return new_num_sticks_to_read;
+}
+
+std::tuple<uint32_t, uint32_t> get_max_cores_divisible_by_tiles_per_core_tiles(
+    const uint32_t &num_tiles, const uint32_t &num_cores_max, bool request_even) {
+    uint32_t num_cores = 1;
+    for (int i = 2; i <= num_cores_max; i++) {
+        if ((num_tiles % i) == 0) {
+            num_cores = i;
+        }
+    }
+    if (request_even) {
+        num_cores = num_cores - num_cores % 2;
+    }
+    uint32_t per_core_tiles_dim = num_tiles / num_cores;
+    if (num_tiles % num_cores != 0)
+        per_core_tiles_dim++;
+    return {num_cores, per_core_tiles_dim};
+}
+
+int find_max_divisor(uint32_t val, uint32_t start_max_div) {
+    int result = 1;
+    for (int find_divisor = start_max_div; find_divisor >= 1; find_divisor--) {
+        if (find_divisor == 7 || find_divisor == 5)
+            continue;
+        if (val % find_divisor == 0) {
+            result = find_divisor;
+            break;
+        }
+    }
+    return result;
+}
+
+int find_max_block_size(uint32_t val, uint32_t max_block_size) {
+    int result = 1;
+    for (int find_divisor = max_block_size; find_divisor >= 1; find_divisor--) {
+        if (val % find_divisor == 0) {
+            result = find_divisor;
+            break;
+        }
+    }
+    return result;
+}
+
+CoreRangeSet num_cores_to_corerangeset(
+    const CoreCoord start_core, const uint32_t target_num_cores, const CoreCoord grid_size, const bool row_wise) {
+    uint32_t num_cores_x = grid_size.x;
+    uint32_t num_cores_y = grid_size.y;
+    uint32_t total_available_cores = 0;
+    TT_FATAL(start_core.x < num_cores_x && start_core.y < num_cores_y, "Start core must be within grid size");
+    if (row_wise) {
+        // Full Rows
+        total_available_cores += (num_cores_y - 1 - start_core.y) * num_cores_x;
+        // Partial Rows
+        total_available_cores += num_cores_x - start_core.x;
+    } else {
+        // Full Cols
+        total_available_cores += (num_cores_x - 1 - start_core.x) * num_cores_y;
+        // Partial Cols
+        total_available_cores += num_cores_y - start_core.y;
+    }
+    TT_FATAL(
+        target_num_cores <= total_available_cores,
+        "Target number of cores {} is greater than total number of available cores {}",
+        target_num_cores,
+        total_available_cores);
+
+    // 3 is the max number of ranges that will be generated when splitting a grid
+    std::vector<CoreRange> all_cores;
+    all_cores.reserve(3);
+    uint32_t leftover_size = target_num_cores;
+    CoreCoord s_core = start_core;
+    if (row_wise) {
+        // Partial row at start
+        if (s_core.x != 0 && leftover_size > num_cores_x - start_core.x) {
+            all_cores.emplace_back(s_core, CoreCoord(num_cores_x - 1, s_core.y));
+            s_core = {0, s_core.y + 1};
+            leftover_size -= all_cores.back().size();
+        }
+        // Full rows
+        if (leftover_size > num_cores_x) {
+            uint32_t num_full_rows = leftover_size / num_cores_x;
+            all_cores.emplace_back(s_core, CoreCoord(num_cores_x - 1, s_core.y + num_full_rows - 1));
+            leftover_size -= all_cores.back().size();
+            s_core = {0, s_core.y + num_full_rows};
+        }
+        // Partial row at end
+        if (leftover_size > 0) {
+            all_cores.emplace_back(s_core, CoreCoord(s_core.x + leftover_size - 1, s_core.y));
+        }
+    } else {
+        // Partial col at start
+        if (s_core.y != 0 && leftover_size > num_cores_y - start_core.y) {
+            all_cores.emplace_back(s_core, CoreCoord(s_core.x, num_cores_y - 1));
+            s_core = {s_core.x + 1, 0};
+            leftover_size -= all_cores.back().size();
+        }
+        // Full cols
+        if (leftover_size > num_cores_y) {
+            uint32_t num_full_cols = leftover_size / num_cores_y;
+            all_cores.emplace_back(s_core, CoreCoord(s_core.x + num_full_cols - 1, num_cores_y - 1));
+            leftover_size -= all_cores.back().size();
+            s_core = {s_core.x + num_full_cols, 0};
+        }
+        // Partial row at end
+        if (leftover_size > 0) {
+            all_cores.emplace_back(s_core, CoreCoord(s_core.x, s_core.y + leftover_size - 1));
+        }
+    }
+    return CoreRangeSet(std::move(all_cores));
+}
+
+CoreRangeSet num_cores_to_corerangeset(
+    const uint32_t target_num_cores, const CoreCoord grid_size, const bool row_wise) {
+    return num_cores_to_corerangeset({0, 0}, target_num_cores, grid_size, row_wise);
+}
+
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise) {
+    ZoneScoped;
+    uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y;
+    auto target_num_cores = std::min(units_to_divide, num_cores_x * num_cores_y);
+    CoreRangeSet all_cores = num_cores_to_corerangeset(target_num_cores, grid_size, row_wise);
+
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
+    uint32_t units_per_core_group_2 = 0;
+    // Evenly divided units to all target cores
+    if (units_to_divide % target_num_cores == 0) {
+        core_group_1 = all_cores;
+        // Uneven division of units across cores
+        // This case should only be hit when there are more units of work than a full grid of cores
+        // which is implicitly assumed in the following logic
+    } else {
+        // Group of cores that do more work
+        core_group_1 = num_cores_to_corerangeset(units_to_divide % target_num_cores, grid_size, row_wise);
+        const auto &last_block_group_1 = (*core_group_1.ranges().rbegin());
+        const auto &last_block_all_cores = (*all_cores.ranges().rbegin());
+        if (row_wise) {
+            // Case where only the last row is divided between core group 1 and 2
+            if (last_block_group_1.end_coord.y == last_block_all_cores.end_coord.y &&
+                last_block_group_1.end_coord.x != last_block_all_cores.end_coord.x) {
+                CoreRange leftover_block(
+                    CoreCoord(last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y),
+                    last_block_all_cores.end_coord);
+                core_group_2 = CoreRangeSet(leftover_block);
+            } else {
+                std::vector<CoreRange> core_group_2_set;
+                // Case where a middle row is divided between core group 1 and 2
+                if (last_block_group_1.end_coord.x != num_cores_x - 1) {
+                    core_group_2_set.emplace_back(
+                        CoreCoord(last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y),
+                        CoreCoord(num_cores_x - 1, last_block_group_1.end_coord.y));
+                }
+                // Remaining rows of cores that does less work
+                core_group_2_set.emplace_back(
+                    CoreCoord(0, last_block_group_1.end_coord.y + 1), last_block_all_cores.end_coord);
+                core_group_2 = CoreRangeSet(std::move(core_group_2_set));
+            }
+        } else {
+            // Case where only the last column is divided between core group 1 and 2
+            if (last_block_group_1.end_coord.x == last_block_all_cores.end_coord.x &&
+                last_block_group_1.end_coord.y != last_block_all_cores.end_coord.y) {
+                CoreRange leftover_block(
+                    CoreCoord(last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1),
+                    last_block_all_cores.end_coord);
+                core_group_2 = CoreRangeSet(leftover_block);
+            } else {
+                std::vector<CoreRange> core_group_2_set;
+                // Case where a middle column is divided between core group 1 and 2
+                if (last_block_group_1.end_coord.y != num_cores_y - 1) {
+                    core_group_2_set.emplace_back(
+                        CoreCoord(last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1),
+                        CoreCoord(last_block_group_1.end_coord.x, num_cores_y - 1));
+                }
+                // Remaining columns of cores that does less work
+                core_group_2_set.emplace_back(
+                    CoreCoord(last_block_group_1.end_coord.x + 1, 0), last_block_all_cores.end_coord);
+                core_group_2 = CoreRangeSet(std::move(core_group_2_set));
+            }
+        }
+        units_per_core_group_2 = units_per_core_group_1;
+        units_per_core_group_1++;
+    }
+
+    return std::make_tuple(
+        target_num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2);
+}
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/common/work_split.hpp
+++ b/tt_metal/common/work_split.hpp
@@ -8,229 +8,45 @@
 
 #pragma once
 
-#include "tt_metal/common/assert.hpp"
+#include <cstdint>
+#include <tuple>
+#include <vector>
+
 #include "tt_metal/common/core_coord.hpp"
-#include "tt_metal/common/math.hpp"
-#include "tt_metal/host_api.hpp"
 
 namespace tt {
 namespace tt_metal {
 
-inline uint32_t merge_num_sticks_to_read(uint32_t num_sticks_to_read, uint32_t stick_size_bytes, uint32_t max_read_size) {
-    uint32_t total_bytes = num_sticks_to_read * stick_size_bytes;
-    uint32_t new_num_sticks_to_read = num_sticks_to_read;
-    uint32_t new_stick_size_bytes = stick_size_bytes;
-
-    for (uint32_t current_size = stick_size_bytes; current_size <= max_read_size; current_size += stick_size_bytes) {
-        if (total_bytes % current_size == 0) {
-            new_stick_size_bytes = current_size;
-            new_num_sticks_to_read = total_bytes / current_size;
-        }
-    }
-    return new_num_sticks_to_read;
-}
+uint32_t merge_num_sticks_to_read(uint32_t num_sticks_to_read, uint32_t stick_size_bytes, uint32_t max_read_size);
 
 // Given a number of tiles and number of cores available
 // Set the largest number of cores less than the number of tiles
 // Returns the number of cores as well as the number of tiles per core
+std::tuple<uint32_t, uint32_t> get_max_cores_divisible_by_tiles_per_core_tiles(
+    const uint32_t &num_tiles, const uint32_t &num_cores_max, bool request_even = false);
 
-inline std::tuple<uint32_t, uint32_t> get_max_cores_divisible_by_tiles_per_core_tiles(
-    const uint32_t &num_tiles, const uint32_t &num_cores_max, bool request_even = false) {
-    uint32_t num_cores = 1;
-    for (int i = 2; i <= num_cores_max; i++) {
-        if ((num_tiles % i) == 0) {
-            num_cores = i;
-        }
-    }
-    if (request_even) {
-        num_cores = num_cores - num_cores % 2;
-    }
-    uint32_t per_core_tiles_dim = num_tiles / num_cores;
-    if (num_tiles % num_cores != 0)
-        per_core_tiles_dim++;
-    return {num_cores, per_core_tiles_dim};
-}
+// Finds the maximum divisor (excluding 5 or 7) of val starting at start_max_div and below
+int find_max_divisor(uint32_t val, uint32_t start_max_div);
 
-// Finds the maximum even divisor of val starting at start_max_div and below
-inline int find_max_divisor(uint32_t val, uint32_t start_max_div) {
-    int result = 1;
-    for (int find_divisor = start_max_div; find_divisor >= 1; find_divisor--) {
-        if (find_divisor == 7 || find_divisor == 5)
-            continue;
-        if (val % find_divisor == 0) {
-            result = find_divisor;
-            break;
-        }
-    }
-    return result;
-}
+int find_max_block_size(uint32_t val, uint32_t max_block_size = 8);
 
-inline int find_max_block_size(uint32_t val, uint32_t max_block_size = 8) {
-    int result = 1;
-    for (int find_divisor = max_block_size; find_divisor >= 1; find_divisor--) {
-        if (val % find_divisor == 0) {
-            result = find_divisor;
-            break;
-        }
-    }
-    return result;
-}
-
-inline std::set<CoreRange> num_cores_to_corerange_set(
+CoreRangeSet num_cores_to_corerangeset(
     const CoreCoord start_core,
     const uint32_t target_num_cores,
     const CoreCoord grid_size,
-    const bool row_wise = false) {
-    uint32_t num_cores_x = grid_size.x;
-    uint32_t num_cores_y = grid_size.y;
-    uint32_t total_available_cores = 0;
-    TT_FATAL(start_core.x < num_cores_x && start_core.y < num_cores_y, "Start core must be within grid size");
-    if (row_wise) {
-        // Full Rows
-        total_available_cores += (num_cores_y - 1 - start_core.y) * num_cores_x;
-        // Partial Rows
-        total_available_cores += num_cores_x - start_core.x;
-    } else {
-        // Full Cols
-        total_available_cores += (num_cores_x - 1 - start_core.x) * num_cores_y;
-        // Partial Cols
-        total_available_cores += num_cores_y - start_core.y;
-    }
-    TT_FATAL(
-        target_num_cores <= total_available_cores,
-        "Target number of cores {} is greater than total number of available cores {}",
-        target_num_cores,
-        total_available_cores);
-    std::set<CoreRange> all_cores_set;
-    uint32_t leftover_size = target_num_cores;
-    CoreCoord s_core = start_core;
-    if (row_wise) {
-        // Partial row at start
-        if (s_core.x != 0 && leftover_size > num_cores_x - start_core.x) {
-            CoreRange start_block(s_core, {num_cores_x - 1, s_core.y});
-            all_cores_set.insert(start_block);
-            s_core = {0, s_core.y + 1};
-            leftover_size -= start_block.size();
-        }
-        // Full rows
-        if (leftover_size > num_cores_x) {
-            uint32_t num_full_rows = leftover_size / num_cores_x;
-            CoreRange full_block(s_core, {num_cores_x - 1, s_core.y + num_full_rows - 1});
-            all_cores_set.insert(full_block);
-            leftover_size -= full_block.size();
-            s_core = {0, s_core.y + num_full_rows};
-        }
-        // Partial row at end
-        if (leftover_size > 0) {
-            CoreRange leftover_block(s_core, {s_core.x + leftover_size - 1, s_core.y});
-            all_cores_set.insert(leftover_block);
-        }
-    } else {
-        // Partial col at start
-        if (s_core.y != 0 && leftover_size > num_cores_y - start_core.y) {
-            CoreRange start_block(s_core, {s_core.x, num_cores_y - 1});
-            all_cores_set.insert(start_block);
-            s_core = {s_core.x + 1, 0};
-            leftover_size -= start_block.size();
-        }
-        // Full cols
-        if (leftover_size > num_cores_y) {
-            uint32_t num_full_cols = leftover_size / num_cores_y;
-            CoreRange full_block(s_core, {s_core.x + num_full_cols - 1, num_cores_y - 1});
-            all_cores_set.insert(full_block);
-            leftover_size -= full_block.size();
-            s_core = {s_core.x + num_full_cols, 0};
-        }
-        // Partial row at end
-        if (leftover_size > 0) {
-            CoreRange leftover_block(s_core, {s_core.x, s_core.y + leftover_size - 1});
-            all_cores_set.insert(leftover_block);
-        }
-    }
-    return all_cores_set;
-}
+    const bool row_wise = false);
 
 // TODO: Get rid of old function
-inline std::set<CoreRange> num_cores_to_corerange_set(
-    const uint32_t target_num_cores, const CoreCoord grid_size, const bool row_wise = false) {
-    return num_cores_to_corerange_set({0, 0}, target_num_cores, grid_size, row_wise);
-}
+CoreRangeSet num_cores_to_corerangeset(
+    const uint32_t target_num_cores, const CoreCoord grid_size, const bool row_wise = false);
 
 // This function takes in the core grid size, as well as the number of units of work to divide between the cores
 // This function returns the number of cores, the CoreRangeSet of all cores, and then the CoreRangeSet that does
 // the greater amount of work, and the CoreRangeSet that does less work if work cannot be evenly divided
 // If it can be evenly divided, the second CoreRangeSet is the same as the first, and the last is empty
 // The last 2 args are the units of work for the two core grids
-inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
-    const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise = false) {
-    ZoneScoped;
-    uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y;
-    auto target_num_cores = std::min(units_to_divide, num_cores_x * num_cores_y);
-    CoreRangeSet all_cores(num_cores_to_corerange_set(target_num_cores, grid_size, row_wise));
-
-    std::set<CoreRange> core_group_1_set;
-    std::set<CoreRange> core_group_2_set;
-    uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
-    uint32_t units_per_core_group_2 = 0;
-    // Evenly divided units to all target cores
-    if (units_to_divide % target_num_cores == 0) {
-        core_group_1_set = std::set<CoreRange>(all_cores.ranges().begin(), all_cores.ranges().end());
-        // Uneven division of units across cores
-        // This case should only be hit when there are more units of work than a full grid of cores
-        // which is implicitly assumed in the following logic
-    } else {
-        // Group of cores that do more work
-        core_group_1_set = num_cores_to_corerange_set(units_to_divide % target_num_cores, grid_size, row_wise);
-        auto last_block_group_1 = (*core_group_1_set.rbegin());
-        auto last_block_all_cores = (*all_cores.ranges().rbegin());
-        if (row_wise) {
-            // Case where only the last row is divided between core group 1 and 2
-            if (last_block_group_1.end_coord.y == last_block_all_cores.end_coord.y &&
-                last_block_group_1.end_coord.x != last_block_all_cores.end_coord.x) {
-                CoreRange leftover_block(
-                    {last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y}, last_block_all_cores.end_coord);
-                core_group_2_set.insert(leftover_block);
-            } else {
-                // Case where a middle row is divided between core group 1 and 2
-                if (last_block_group_1.end_coord.x != num_cores_x - 1) {
-                    CoreRange leftover_stick(
-                        {last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y},
-                        {num_cores_x - 1, last_block_group_1.end_coord.y});
-                    core_group_2_set.insert(leftover_stick);
-                }
-                // Remaining rows of cores that does less work
-                CoreRange leftover_block({0, last_block_group_1.end_coord.y + 1}, last_block_all_cores.end_coord);
-                core_group_2_set.insert(leftover_block);
-            }
-        } else {
-            // Case where only the last column is divided between core group 1 and 2
-            if (last_block_group_1.end_coord.x == last_block_all_cores.end_coord.x &&
-                last_block_group_1.end_coord.y != last_block_all_cores.end_coord.y) {
-                CoreRange leftover_block(
-                    {last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1}, last_block_all_cores.end_coord);
-                core_group_2_set.insert(leftover_block);
-            } else {
-                // Case where a middle column is divided between core group 1 and 2
-                if (last_block_group_1.end_coord.y != num_cores_y - 1) {
-                    CoreRange leftover_stick(
-                        {last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1},
-                        {last_block_group_1.end_coord.x, num_cores_y - 1});
-                    core_group_2_set.insert(leftover_stick);
-                }
-                // Remaining columns of cores that does less work
-                CoreRange leftover_block({last_block_group_1.end_coord.x + 1, 0}, last_block_all_cores.end_coord);
-                core_group_2_set.insert(leftover_block);
-            }
-        }
-        units_per_core_group_2 = units_per_core_group_1;
-        units_per_core_group_1++;
-    }
-    CoreRangeSet core_group_1(core_group_1_set);
-    CoreRangeSet core_group_2(core_group_2_set);
-
-    return std::make_tuple(
-        target_num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2);
-}
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise = false);
 
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -60,7 +60,7 @@ bool CircularBuffer::is_on_logical_corerange(const CoreRange &logical_cr) const 
 }
 
 bool CircularBuffer::is_on_logical_core(const CoreCoord &logical_core) const {
-    return this->core_ranges_.core_coord_in_core_ranges(logical_core);
+    return this->core_ranges_.contains(logical_core);
 }
 
 bool CircularBuffer::uses_buffer_index(uint32_t buffer_index) const {

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -47,7 +47,7 @@ Semaphore &Semaphore::operator=(Semaphore &&other) {
 }
 
 bool Semaphore::initialized_on_logical_core(const CoreCoord &logical_core) const {
-    return this->core_range_set_.core_coord_in_core_ranges(logical_core);
+    return this->core_range_set_.contains(logical_core);
 }
 
 uint32_t Semaphore::offset() const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -77,7 +77,7 @@ std::vector<CoreRange> Kernel::logical_coreranges() const {
 }
 
 bool Kernel::is_on_logical_core(const CoreCoord &logical_core) const {
-    return this->core_range_set_.core_coord_in_core_ranges(logical_core);
+    return this->core_range_set_.contains(logical_core);
 }
 
 CoreType Kernel::get_kernel_core_type() const {

--- a/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
@@ -207,9 +207,9 @@ void matmul_multi_core(std::vector<bfloat16>& a, std::vector<bfloat16>& b, std::
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_output_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -151,7 +151,7 @@ void matmul_multicore_reuse(std::vector<bfloat16>& a, std::vector<bfloat16>& b, 
     uint32_t num_blocks_x = Nt / per_core_N;
     uint32_t num_blocks_total =  num_blocks_y * num_blocks_x;
     TT_ASSERT(num_blocks_total <= num_cores_x * num_cores_y);
-    CoreRangeSet all_cores(tt::tt_metal::num_cores_to_corerange_set(num_blocks_x * num_blocks_y, compute_with_storage_grid_size, true));
+    CoreRangeSet all_cores(tt::tt_metal::num_cores_to_corerangeset(num_blocks_x * num_blocks_y, compute_with_storage_grid_size, true));
 
     //////////////////////////////////////////////////
     /*

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -339,8 +339,8 @@ void py_module(py::module& module) {
             py::arg("device") = nullptr});
 
     module.def(
-        "num_cores_to_corerange_set",
-        py::overload_cast<const uint32_t, const CoreCoord, const bool>(&tt::tt_metal::num_cores_to_corerange_set),
+        "num_cores_to_corerangeset",
+        py::overload_cast<const uint32_t, const CoreCoord, const bool>(&tt::tt_metal::num_cores_to_corerangeset),
         R"doc(Create a CoreRangeSet containing the specified number of cores)doc");
 
 }

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -105,9 +105,9 @@ BernoulliDeviceOperation::ProgramFactory::cached_program_t BernoulliDeviceOperat
     uint32_t tile_offset = 0;
     for (const auto& core : cores) {
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -98,7 +98,7 @@ ParallelConfig determine_parallel_config(
         if (num_cores_nhw < compute_grid_size.x && out_nhw_ntiles > compute_grid_size.x) {
             num_cores_nhw = find_closest_largest_divisor_with_num_padding(out_nhw_ntiles, compute_grid_size.x);
         }
-        grid = num_cores_to_corerange_set(num_cores_nhw, compute_grid_size, true);
+        grid = num_cores_to_corerangeset(num_cores_nhw, compute_grid_size, true);
     } else if (shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         uint32_t start_divisor =
                 block_shard_orientation == ShardOrientation::COL_MAJOR ? compute_grid_size.x : compute_grid_size.y;
@@ -111,7 +111,7 @@ ParallelConfig determine_parallel_config(
     } else if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         num_cores_nhw = 1;
         uint32_t num_cores_c = find_closest_common_largest_divisor(out_c_ntiles, std::ceil((float)input_channels / effective_tile_width), max_num_cores);
-        grid = num_cores_to_corerange_set(num_cores_c, compute_grid_size, true);
+        grid = num_cores_to_corerangeset(num_cores_c, compute_grid_size, true);
     } else {
         TT_THROW("Conv2d supports Height, Block or Width Sharded Layouts but got {}", shard_layout);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -172,7 +172,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
                 num_cores = total_height_tiles / this->parallelization_config.per_core_out_matrix_height_ntiles;
                 shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, output_shape[-1]};
             }
-            CoreRangeSet shard_grid = tt::tt_metal::num_cores_to_corerange_set(num_cores, this->parallelization_config.grid_size, true);
+            CoreRangeSet shard_grid = tt::tt_metal::num_cores_to_corerangeset(num_cores, this->parallelization_config.grid_size, true);
             auto shard_spec = ShardSpec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
             auto mem_config = this->memory_config;
             mem_config.shard_spec = shard_spec;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_multi_core_h.cpp
@@ -114,9 +114,9 @@ operation::ProgramWithCallbacks bcast_multi_core_h(const Tensor &a, const Tensor
 	for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_y * num_cores_x; i++){
 		CoreCoord core = {i / num_cores_y, i % num_cores_y};
 		uint32_t Ht_per_core;
-		if (core_group_1.core_coord_in_core_ranges(core)) {
+		if (core_group_1.contains(core)) {
 			Ht_per_core = Ht_per_core_group_1;
-		} else if (core_group_2.core_coord_in_core_ranges(core)) {
+		} else if (core_group_2.contains(core)) {
 			Ht_per_core = Ht_per_core_group_2;
 		} else {
 			constexpr std::array<uint32_t, 15> binary_reader_kernel_args{0};
@@ -238,9 +238,9 @@ operation::ProgramWithCallbacks bcast_multi_core_h(const Tensor &a, const Tensor
 			auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
 			auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
 
-			if (core_group_1.core_coord_in_core_ranges(core)) {
+			if (core_group_1.contains(core)) {
 				Ht_per_core = Ht_per_core_group_1;
-			} else if (core_group_2.core_coord_in_core_ranges(core)) {
+			} else if (core_group_2.contains(core)) {
 				Ht_per_core = Ht_per_core_group_2;
 			} else {
 				binary_reader_args[3] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -152,9 +152,9 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_y * num_cores_x; i++){
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tensor_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             constexpr std::array<uint32_t, 7> binary_reader_kernel_args{0};
@@ -285,9 +285,9 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
 			auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
 			auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
 
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_tensor_tiles_per_core = num_tiles_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_tensor_tiles_per_core = num_tiles_per_core_group_2;
             } else {
                 binary_reader_args[2] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
@@ -113,9 +113,9 @@ operation::ProgramWithCallbacks bcast_multi_core_w(const Tensor &a, const Tensor
 	for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_y * num_cores_x; i++){
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 		uint32_t Wt_per_core;
-		if (core_group_1.core_coord_in_core_ranges(core)) {
+		if (core_group_1.contains(core)) {
 			Wt_per_core = Wt_per_core_group_1;
-		} else if (core_group_2.core_coord_in_core_ranges(core)) {
+		} else if (core_group_2.contains(core)) {
 			Wt_per_core = Wt_per_core_group_2;
 		} else {
 			constexpr std::array<uint32_t, 16> binary_reader_kernel_args{0};
@@ -239,9 +239,9 @@ operation::ProgramWithCallbacks bcast_multi_core_w(const Tensor &a, const Tensor
 			auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
 			auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
 
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 Wt_per_core = Wt_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 Wt_per_core = Wt_per_core_group_2;
             } else {
                 binary_reader_args[3] = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -349,7 +349,7 @@ operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
         auto input_shard_spec = input_tensors[0].shard_spec().value();
         uint32_t curr_num_input_tensors;
         uint32_t curr_num_output_rows;
-        if (input_cores.core_coord_in_core_ranges(core)) {
+        if (input_cores.contains(core)) {
             curr_num_input_tensors = num_input_tensors;
             curr_num_output_rows = num_output_rows_per_core;
         } else {
@@ -392,7 +392,7 @@ operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
             for (auto core : cores) {
                 uint32_t curr_num_input_tensors;
                 uint32_t curr_num_output_rows;
-                if (input_cores.core_coord_in_core_ranges(core)) {
+                if (input_cores.contains(core)) {
                     curr_num_input_tensors = num_input_tensors;
                     curr_num_output_rows = num_output_rows_per_core;
                 } else {

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/device/expand_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/device/expand_rm_program_factory.cpp
@@ -147,9 +147,9 @@ ExpandOperation::ExpandRowMajorFactory::cached_program_t ExpandOperation::Expand
 
     uint32_t num_copies_this_core;
     for (auto core : cores) {
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_copies_this_core = num_copies_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_copies_this_core = num_copies_per_core_group_2;
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op_multi_core_program_factory.cpp
@@ -20,7 +20,7 @@ operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids,
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto set_of_core_ranges = tt::tt_metal::num_cores_to_corerange_set(num_cores_x*num_cores_y, compute_with_storage_grid_size);
+    auto set_of_core_ranges = tt::tt_metal::num_cores_to_corerangeset(num_cores_x*num_cores_y, compute_with_storage_grid_size);
     CoreRangeSet all_cores(set_of_core_ranges);
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -124,9 +124,9 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
     for (uint32_t i = 0, pages_handled_per_core = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_pages_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_pages_per_core = num_pages_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_pages_per_core = num_pages_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -909,9 +909,9 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
 
 
         uint32_t num_sticks_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_sticks_per_core = num_w_sticks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_sticks_per_core = num_w_sticks_per_core_group_2;
         } else {
             //no-op

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_program_factory.cpp
@@ -134,15 +134,15 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_new_sticks_per_core = 0, num_old_sticks_per_core = 0;
         if (split_work_by_old_sticks) {
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_old_sticks_per_core = num_w_sticks_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_old_sticks_per_core = num_w_sticks_per_core_group_2;
             }
         } else {
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_new_sticks_per_core = num_w_sticks_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_new_sticks_per_core = num_w_sticks_per_core_group_2;
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.cpp
@@ -58,7 +58,7 @@ ttnn::Tensor InterleavedToShardedOperation::invoke(
                         break;
                     default: TT_ASSERT(false, "Unsupported sharding scheme");
                 }
-                grid_set = tt::tt_metal::num_cores_to_corerange_set(num_cores, grid_size, row_wise);
+                grid_set = tt::tt_metal::num_cores_to_corerangeset(num_cores, grid_size, row_wise);
             } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
                 auto bbox = grid.bounding_box();
                 grid_size = CoreCoord{bbox.end_coord.x + 1, bbox.end_coord.y + 1};

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
@@ -48,7 +48,7 @@ ttnn::Tensor InterleavedToShardedPartialOperation::invoke(
                         break;
                     default: TT_ASSERT(false, "Unsupported sharding scheme");
                 }
-                grid_set = tt::tt_metal::num_cores_to_corerange_set(num_cores, grid_size, row_wise);
+                grid_set = tt::tt_metal::num_cores_to_corerangeset(num_cores, grid_size, row_wise);
             } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
                 TT_THROW("Unsupported type for grid. CoreRangeSet not supported. Switch to a different type.");
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -82,9 +82,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_sticks_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_sticks_per_core = num_sticks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_sticks_per_core = num_sticks_per_core_group_2;
         } else {
             // no-op

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -54,9 +54,9 @@ void override_runtime_args_mc_cn(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             //no-op
@@ -257,9 +257,9 @@ void override_runtime_args_mc_hc(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             //no-op
@@ -364,9 +364,9 @@ void override_runtime_args_mc_hc_rm(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_sticks_per_core;
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_sticks_per_core = num_w_sticks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_sticks_per_core = num_w_sticks_per_core_group_2;
         } else {
             //no-op
@@ -1151,9 +1151,9 @@ void override_runtime_args_wh(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             //noop
@@ -1285,9 +1285,9 @@ void override_runtime_args_wh_rm(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_hw_blocks_per_core;
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_hw_blocks_per_core = num_hw_blocks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_hw_blocks_per_core = num_hw_blocks_per_core_group_2;
         } else {
             //noop

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -86,7 +86,7 @@ std::vector<Tensor> Untilize::create_output_tensors(
             auto num_cores =
                 untilize_helpers::get_num_cores(input_tensor.device()->compute_with_storage_grid_size(), nblocks);
             auto shard_grid =
-                tt::tt_metal::num_cores_to_corerange_set(num_cores, input_tensor.device()->compute_with_storage_grid_size(), true);
+                tt::tt_metal::num_cores_to_corerangeset(num_cores, input_tensor.device()->compute_with_storage_grid_size(), true);
             uint32_t fused_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
             std::array<uint32_t, 2> shard_shape = {fused_height / num_cores, input_tensor.get_legacy_shape()[-1]};
             ShardSpec shard_spec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -184,7 +184,7 @@ operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
 
     for (uint32_t i = 0; i < cores.size(); i++) {
         CoreCoord core = cores[i];
-        if (!full_cores.core_coord_in_core_ranges(core)) {
+        if (!full_cores.contains(core)) {
             continue;
         }
         // reader runtime args
@@ -478,7 +478,7 @@ operation::ProgramWithCallbacks untilize_multi_core(
     auto cores = grid_to_cores(ncores_x * ncores_y, ncores_x, ncores_y, row_major);
     for (uint32_t i = 0; i < cores.size(); i++) {
         CoreCoord core = cores[i];
-        if (!full_cores.core_coord_in_core_ranges(core)) {
+        if (!full_cores.contains(core)) {
             continue;
         }
         // reader runtime args

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -177,9 +177,9 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);
         uint32_t num_tensor_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
@@ -333,9 +333,9 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
         auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
         auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             binary_reader_args[2] = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -143,9 +143,9 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
     for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);
         uint32_t Ht_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             Ht_per_core = Ht_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             Ht_per_core = Ht_per_core_group_2;
         } else {
             tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(15, 0));
@@ -279,9 +279,9 @@ void BinaryDeviceOperation ::BroadcastHeightMultiCore::override_runtime_argument
         auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
         auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             Ht_per_core = Ht_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             Ht_per_core = Ht_per_core_group_2;
         } else {
             binary_reader_args[3] = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
@@ -142,9 +142,9 @@ BinaryDeviceOperation::BroadcastWidthMultiCore::cached_program_t BinaryDeviceOpe
     for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);
         uint32_t Wt_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             Wt_per_core = Wt_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             Wt_per_core = Wt_per_core_group_2;
         } else {
             tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(16, 0));
@@ -279,9 +279,9 @@ void BinaryDeviceOperation::BroadcastWidthMultiCore::override_runtime_arguments(
         auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
         auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             Wt_per_core = Wt_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             Wt_per_core = Wt_per_core_group_2;
         } else {
             binary_reader_args[3] = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -127,9 +127,9 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -150,7 +150,7 @@ operation::ProgramWithCallbacks embedding_backward_multi_core(
     uint32_t offset = 0;
     for (auto core : cores) {
         reader_runtime_args[4] = offset;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             reader_runtime_args[5] = num_tiles_per_core_group_1;
         } else {
             reader_runtime_args[5] = num_tiles_per_core_group_2;

--- a/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
@@ -102,9 +102,9 @@ ExampleDeviceOperation::MultiCore::cached_program_t ExampleDeviceOperation::Mult
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
@@ -102,9 +102,9 @@ ExampleDeviceOperation::SingleCore::cached_program_t ExampleDeviceOperation::Sin
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
@@ -107,9 +107,9 @@ ExampleMultipleReturnDeviceOperation::SingleCore::cached_program_t ExampleMultip
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -164,9 +164,9 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(const Tensor &a, const Te
     for (uint32_t i = 0, num_blocks_written = 0; i < total_num_cores; i++){
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_output_blocks_per_core = num_output_blocks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_output_blocks_per_core = num_output_blocks_per_core_group_2;
         } else {
             tt::tt_metal::SetRuntimeArgs(program, reader_id, core, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
@@ -279,9 +279,9 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(const Tensor &a, const Te
         for (uint32_t i = 0, num_blocks_written = 0; i < total_num_cores; i++){
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_output_blocks_per_core = num_output_blocks_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_output_blocks_per_core = num_output_blocks_per_core_group_2;
             } else {
                 tt::tt_metal::SetRuntimeArgs(program, reader_id, core, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -75,7 +75,7 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
             const tt::tt_metal::LegacyShape output_shape = this->compute_output_shapes(input_tensors).at(0);
             const uint32_t num_cores = output_shape[1];
             CoreRangeSet all_cores =
-                num_cores_to_corerange_set(num_cores, this->compute_with_storage_grid_size, this->row_major);
+                num_cores_to_corerangeset(num_cores, this->compute_with_storage_grid_size, this->row_major);
 
             auto shard_shape = this->output_mem_config.shard_spec.value().shape;
             TT_FATAL(
@@ -146,7 +146,7 @@ std::vector<Tensor> GroupAttnMatmulDeviceOperation::create_output_tensors(const 
             const tt::tt_metal::LegacyShape output_shape = this->compute_output_shapes(input_tensors).at(0);
             const uint32_t num_cores = output_shape[1];
             CoreRangeSet all_cores =
-                num_cores_to_corerange_set(num_cores, this->compute_with_storage_grid_size, this->row_major);
+                num_cores_to_corerangeset(num_cores, this->compute_with_storage_grid_size, this->row_major);
 
             ShardOrientation shard_orientation =
                 this->row_major ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -91,7 +91,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
     // Only first 32 of cores mcast KV heads to match num_rows_in_one_tile in reader kernel, so these coordinates are static if we cache on compute_with_storage_grid_size
     // TODO: If this is not the case, then we should set reader_runtime_args to max possible size and update sender noc coordinates based on input
-    CoreCoord mcast_sender_grid = ((CoreRangeSet) num_cores_to_corerange_set(TILE_HEIGHT, compute_with_storage_grid_size, row_major)).bounding_box().grid_size();
+    CoreCoord mcast_sender_grid = ((CoreRangeSet) num_cores_to_corerangeset(TILE_HEIGHT, compute_with_storage_grid_size, row_major)).bounding_box().grid_size();
     std::vector<uint32_t> in1_mcast_sender_noc_x(mcast_sender_grid.x);
     std::vector<uint32_t> in1_mcast_sender_noc_y(mcast_sender_grid.y);
     for(uint32_t core_idx_x = 0; core_idx_x < mcast_sender_grid.x; ++core_idx_x) {
@@ -341,7 +341,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         // Mcast receiver args
         // NOTE: If Q_HEADS < 32, have all cores in mcast grid participate in semaphore syncing because we mcast KV_HEADS from/to the same CB
         // Otherwise, data corruption if sender is in mcast grid and it starts populating its mcast CB as other senders are sending
-        CoreRangeSet mcast_receiver_cores = num_cores_to_corerange_set(Q_HEADS, compute_with_storage_grid_size, row_major);
+        CoreRangeSet mcast_receiver_cores = num_cores_to_corerangeset(Q_HEADS, compute_with_storage_grid_size, row_major);
         CoreRange mcast_receiver_cores_bounding_box = mcast_receiver_cores.bounding_box();
         uint32_t mcast_num_dests = mcast_receiver_cores.num_cores(); // same as num_active_cores if Q_HEADS >= 32; also, always same as Q_HEADS
         uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -169,9 +169,9 @@ operation::ProgramWithCallbacks reduce_nc_factory(const ttnn::Tensor &input, con
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -61,7 +61,7 @@ std::vector<Tensor> NLPConcatHeadsDecodeDeviceOperation::create_output_tensors(c
     auto batch = output_shape[2];
 
     auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
-    auto shard_grid = num_cores_to_corerange_set(num_heads, core_grid, true);
+    auto shard_grid = num_cores_to_corerangeset(num_heads, core_grid, true);
     ShardSpec shard_spec{shard_grid, {batch, head_dim}};
     auto mem_config = tt::tt_metal::MemoryConfig{TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1};
     mem_config.shard_spec = shard_spec;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -105,11 +105,11 @@ NlpCreateHeadsDeviceOperation::tensor_return_value_t NlpCreateHeadsDeviceOperati
     }
     if (operation_attributes.output_mem_config.is_sharded()) {
         auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
-        auto q_shard_grid = num_cores_to_corerange_set(operation_attributes.num_q_heads, core_grid, true);
+        auto q_shard_grid = num_cores_to_corerangeset(operation_attributes.num_q_heads, core_grid, true);
         ShardSpec q_shard_spec{q_shard_grid, {TILE_HEIGHT, operation_attributes.head_dim}};
         auto q_mem_config = operation_attributes.output_mem_config;
         q_mem_config.shard_spec = q_shard_spec;
-        auto kv_shard_grid = num_cores_to_corerange_set(operation_attributes.num_kv_heads, core_grid, true);
+        auto kv_shard_grid = num_cores_to_corerangeset(operation_attributes.num_kv_heads, core_grid, true);
         ShardSpec kv_shard_spec{kv_shard_grid, {TILE_HEIGHT, operation_attributes.head_dim}};
         auto kv_mem_config = operation_attributes.output_mem_config;
         kv_mem_config.shard_spec = kv_shard_spec;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -198,9 +198,9 @@ NlpCreateHeadsDeviceOperation::Interleaved::cached_program_t NlpCreateHeadsDevic
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_blocks_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_blocks_per_core = num_blocks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_blocks_per_core = num_blocks_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -75,11 +75,11 @@ std::vector<Tensor> NLPCreateHeadsDecodeDeviceOperation::create_output_tensors(c
     auto num_q_heads_padded = ((this->num_q_heads - 1) / TILE_HEIGHT + 1) * TILE_HEIGHT;
     auto num_kv_heads_padded = ((this->num_q_heads - 1) / TILE_HEIGHT + 1) * TILE_HEIGHT;
     auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
-    auto q_shard_grid = num_cores_to_corerange_set(batch, core_grid, true);
+    auto q_shard_grid = num_cores_to_corerangeset(batch, core_grid, true);
     ShardSpec q_shard_spec{q_shard_grid, {num_q_heads_padded, this->head_dim}};
     auto q_mem_config = this->output_mem_config;
     q_mem_config.shard_spec = q_shard_spec;
-    auto kv_shard_grid = num_cores_to_corerange_set(batch, core_grid, true);
+    auto kv_shard_grid = num_cores_to_corerangeset(batch, core_grid, true);
     ShardSpec kv_shard_spec{kv_shard_grid, {num_kv_heads_padded, this->head_dim}};
     auto kv_mem_config = this->output_mem_config;
     kv_mem_config.shard_spec = kv_shard_spec;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
@@ -112,9 +112,9 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_falcon7b(const T
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_blocks_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_blocks_per_core = num_blocks_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_blocks_per_core = num_blocks_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -61,7 +61,7 @@ std::vector<Tensor> NlpKVCacheLoadSliceDeviceOperation::create_output_tensors(co
     auto fused_batch_heads = dim0 * dim1;
 
     auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
-    auto shard_grid = num_cores_to_corerange_set(fused_batch_heads, core_grid, true);
+    auto shard_grid = num_cores_to_corerangeset(fused_batch_heads, core_grid, true);
     ShardSpec shard_spec{shard_grid, {unpad_length, head_dim}};
     auto mem_config = tt::tt_metal::MemoryConfig{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1};
     mem_config.shard_spec = shard_spec;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -87,7 +87,7 @@ std::vector<Tensor> RotaryEmbedding::create_output_tensors(const std::vector<Ten
                 }
             }
             uint32_t Ht = div_up(num_blocks, num_cores);
-            shard_spec.grid = num_cores_to_corerange_set(num_cores, core_grid, true);
+            shard_spec.grid = num_cores_to_corerangeset(num_cores, core_grid, true);
             shard_spec.shape = {Ht * TILE_HEIGHT, input_tensor.get_legacy_shape()[-1]};
             shard_spec.orientation = ShardOrientation::ROW_MAJOR;
         }

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
@@ -71,9 +71,9 @@ FullOperation::ProgramFactory::cached_program_t FullOperation::ProgramFactory::c
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core))
+        if (core_group_1.contains(core))
             num_tiles_per_core = num_tiles_per_core_group_1;
-        else if (core_group_2.core_coord_in_core_ranges(core))
+        else if (core_group_2.contains(core))
             num_tiles_per_core = num_tiles_per_core_group_2;
         else
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/full_like/device/full_like_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/full_like/device/full_like_factory.cpp
@@ -80,9 +80,9 @@ FullLikeOperation::ProgramFactory::cached_program_t FullLikeOperation::ProgramFa
         const CoreCoord core(i / num_cores_y, i % num_cores_y);
 
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp
@@ -131,9 +131,9 @@ IndexFillOperation::MultiCore::cached_program_t IndexFillOperation::MultiCore::c
     for (uint32_t i = 0; i < cores.size(); i++) {
         const auto& core = cores[i];
         uint32_t num_rows_per_core = i < num_cores_group_1 ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_FATAL(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1373,7 +1373,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
                     uint32_t num_cores = num_blocks_x * num_blocks_y;
                     CoreRangeSet all_cores =
-                        num_cores_to_corerange_set(num_cores, program_config.compute_with_storage_grid_size, true);
+                        num_cores_to_corerangeset(num_cores, program_config.compute_with_storage_grid_size, true);
                     ShardSpec shard_spec = ShardSpec{
                         all_cores, {per_core_M * in0_tile_shape[0], per_core_N * in1_tile_shape[1]}, ShardOrientation::ROW_MAJOR};
                     auto mem_config = this->output_mem_config;
@@ -1460,7 +1460,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                         shard_orientation = input_tensor_b.shard_spec().value().orientation;
                     }
 
-                    CoreRangeSet all_cores = num_cores_to_corerange_set(
+                    CoreRangeSet all_cores = num_cores_to_corerangeset(
                         num_cores,
                         program_config.compute_with_storage_grid_size,
                         shard_orientation == ShardOrientation::ROW_MAJOR);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
@@ -149,9 +149,9 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_output_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -132,14 +132,14 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerange_set(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
 
     CoreRangeSet in0_mcast_sender_cores =
-        num_cores_to_corerange_set(in0_sender_num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset(in0_sender_num_cores, compute_with_storage_grid_size, row_major);
     CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
 
     CoreRangeSet all_cores_with_work =
-        num_cores_to_corerange_set(num_cores_with_work, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset(num_cores_with_work, compute_with_storage_grid_size, row_major);
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -161,7 +161,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             uint32_t core_idx_x = num_cores_with_work % num_cores_c;
             uint32_t core_idx_y = num_cores_with_work / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerange_set(
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerangeset(
                 start_core,
                 in0_mcast_cores_without_work_and_in_receiver_grid_num_cores,
                 compute_with_storage_grid_size,
@@ -174,7 +174,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
             uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
             CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerange_set(
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerangeset(
                 start_core,
                 in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
                 compute_with_storage_grid_size,
@@ -195,7 +195,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             auto receiver_start_core = start_core.x != (compute_with_storage_grid_size.x - 1)
                                            ? CoreCoord{start_core.x + 1, start_core.y}
                                            : CoreCoord{start_core.x, start_core.y + 1};
-            in0_mcast_receivers = num_cores_to_corerange_set(
+            in0_mcast_receivers = num_cores_to_corerangeset(
                 receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
         }
     }
@@ -982,7 +982,7 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
 
     constexpr bool row_major = true;
     CoreRangeSet all_cores =
-        num_cores_to_corerange_set(start_core, num_cores, compute_with_storage_grid_size, row_major);
+        num_cores_to_corerangeset(start_core, num_cores, compute_with_storage_grid_size, row_major);
     CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
     uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
@@ -993,7 +993,7 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
                                        ? CoreCoord{start_core.x + 1, start_core.y}
                                        : CoreCoord{start_core.x, start_core.y + 1};
         in1_mcast_receivers =
-            num_cores_to_corerange_set(receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
+            num_cores_to_corerangeset(receiver_start_core, num_cores - 1, compute_with_storage_grid_size, row_major);
     }
 
     // Mcast args

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -84,7 +84,7 @@ tt_metal::operation::ProgramWithCallbacks create_program(
     uint32_t num_blocks_y = M / per_core_M;
     uint32_t num_blocks_x = N / per_core_N;
 
-    CoreRangeSet all_cores(num_cores_to_corerange_set(
+    CoreRangeSet all_cores(num_cores_to_corerangeset(
         num_blocks_x * num_blocks_y, device->compute_with_storage_grid_size(), true));
 
     // Create circular buffers

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
@@ -194,9 +194,9 @@ MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::Program
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");
@@ -228,9 +228,9 @@ MorehAdamOperation::ProgramFactory::cached_program_t MorehAdamOperation::Program
             tile_offset};
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             tt::tt_metal::SetRuntimeArgs(program, compute_kernel_1_id, core, {step});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             tt::tt_metal::SetRuntimeArgs(program, compute_kernel_2_id, core, {step});
         } else {
             TT_THROW("Core not in specified core ranges.");
@@ -312,9 +312,9 @@ void MorehAdamOperation::ProgramFactory::override_runtime_arguments(
             }
         }
         {
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 tt::tt_metal::SetRuntimeArgs(program, compute_kernel_1_id, core, {operation_attributes.step});
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 tt::tt_metal::SetRuntimeArgs(program, compute_kernel_2_id, core, {operation_attributes.step});
             } else {
                 TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -178,9 +178,9 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");
@@ -216,9 +216,9 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
         // compute
         const std::vector<uint32_t> compute_runtime_args{step};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             tt_metal::SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             tt_metal::SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_THROW("Core not in specified core ranges.");
@@ -299,10 +299,10 @@ void MorehAdamWDeviceOperation::MultiCore::override_runtime_arguments(
         }
 
         {
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 auto& runtime_args = GetRuntimeArgs(program, compute_kernel_1_id, core);
                 runtime_args[0] = operation_attributes.step;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 auto& runtime_args = GetRuntimeArgs(program, compute_kernel_2_id, core);
                 runtime_args[0] = operation_attributes.step;
             } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
@@ -58,9 +58,9 @@ MorehArangeOperation::ProgramFactory::cached_program_t MorehArangeOperation::Pro
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core))
+        if (core_group_1.contains(core))
             num_tiles_per_core = num_tiles_per_core_group_1;
-        else if (core_group_2.core_coord_in_core_ranges(core))
+        else if (core_group_2.contains(core))
             num_tiles_per_core = num_tiles_per_core_group_2;
         else
             TT_FATAL(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_program_factory.cpp
@@ -137,9 +137,9 @@ MorehCumsumDeviceOperation::ProgramFactory::cached_program_t MorehCumsumDeviceOp
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");
@@ -175,9 +175,9 @@ MorehCumsumDeviceOperation::ProgramFactory::cached_program_t MorehCumsumDeviceOp
              static_cast<uint32_t>(dim),
              flip});
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_1_id, core, {num_cumsum_tiles, num_tiles_per_core});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             TT_ASSERT(compute_kernel_2_id.has_value());
             SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_cumsum_tiles, num_tiles_per_core});
         } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
@@ -251,9 +251,9 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_rows_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_factory.cpp
@@ -202,9 +202,9 @@ MorehGroupNormBackwardGammaBetaGradOperation::MorehGroupNormBackwardGammaBetaGra
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_channels_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_channels_per_core = num_channels_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_channels_per_core = num_channels_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
@@ -219,9 +219,9 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_rows_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
@@ -336,9 +336,9 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_rows_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_program_factory.cpp
@@ -234,9 +234,9 @@ MorehLayerNormBackwardGammaBetaGradOperation::ProgramFactory::create(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_cols_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
@@ -256,9 +256,9 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_rows_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_multi_core_program_factory.cpp
@@ -149,9 +149,9 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_cols_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges.");
@@ -175,7 +175,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
         SetRuntimeArgs(
             program, writer_kernel_id, core, {bias_grad.buffer()->address(), num_cols_per_core, tile_offset});
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(
                 program,
                 compute_kernel_1_id,
@@ -185,7 +185,7 @@ MorehBiasAddBackwardOperation::MultiCoreProgramFactory::create(
                  num_cols_per_core,  // Wt_per_core
                  static_cast<uint32_t>(do_mask_h),
                  static_cast<uint32_t>(do_mask_w && core_has_last_wt)});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             TT_ASSERT(compute_kernel_2_id.has_value());
             SetRuntimeArgs(
                 program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -430,13 +430,13 @@ MorehMatmulOperation::MultiCoreProgramFactory::cached_program_t MorehMatmulOpera
     for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_output_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_output_tiles_per_core_group_1;
             std::vector<uint32_t> compute_rt_args;
             compute_rt_args.push_back(num_tiles_written);
             compute_rt_args.insert(compute_rt_args.end(), output_stride.begin(), output_stride.end());
             tt::tt_metal::SetRuntimeArgs(program, compute_kernel_1_id, core, compute_rt_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             TT_FATAL(compute_kernel_2_id.has_value(), "Core not in specified core ranges");
             num_output_tiles_per_core = num_output_tiles_per_core_group_2;
             std::vector<uint32_t> compute_rt_args;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_h_program_factory.cpp
@@ -144,9 +144,9 @@ MorehMeanOperation::MorehMeanHFactory::cached_program_t MorehMeanOperation::More
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_nc_program_factory.cpp
@@ -133,10 +133,10 @@ MorehMeanOperation::MorehMeanNCFactory::cached_program_t MorehMeanOperation::Mor
         CoreCoord core = {i / core_h, i % core_h};
 
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
             SetRuntimeArgs(program, compute_kernel_ids[0], core, {num_reduce_input_tile, units_per_core});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
             SetRuntimeArgs(program, compute_kernel_ids[1], core, {num_reduce_input_tile, units_per_core});
         } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_w_program_factory.cpp
@@ -144,9 +144,9 @@ MorehMeanOperation::MorehMeanWFactory::cached_program_t MorehMeanOperation::More
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -186,9 +186,9 @@ MorehMeanBackwardOperation::MorehMeanBackwardFactory::create(
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_program_factory.cpp
@@ -139,9 +139,9 @@ MorehNllLossStep1DeviceOperation::Factory::cached_program_t MorehNllLossStep1Dev
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t num_units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_program_factory.cpp
@@ -140,9 +140,9 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -174,9 +174,9 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
         // compute
         const std::vector<uint32_t> compute_runtime_args{units_per_core};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
@@ -319,9 +319,9 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -355,9 +355,9 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
         // compute
         const std::vector<uint32_t> compute_runtime_args{units_per_core};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
@@ -508,9 +508,9 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -544,9 +544,9 @@ MorehNllLossStep2DeviceOperation::Factory::cached_program_t moreh_nll_loss_step2
         // compute
         const std::vector<uint32_t> compute_runtime_args{units_per_core};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_program_factory.cpp
@@ -136,9 +136,9 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -165,9 +165,9 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         // compute
         const std::vector<uint32_t> compute_runtime_args{units_per_core, tile_offset};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_FATAL(false, "Core not in specified core ranges.");
@@ -312,9 +312,9 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -342,9 +342,9 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         // compute
         const std::vector<uint32_t> compute_runtime_args{units_per_core, tile_offset};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_ASSERT(false, "Core not in specified core ranges.");
@@ -486,9 +486,9 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -516,9 +516,9 @@ MorehNllLossBackwardDeviceOperation::Factory::cached_program_t moreh_nll_loss_ba
         // compute
         const std::vector<uint32_t> compute_runtime_args{units_per_core, tile_offset};
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[0], core, compute_runtime_args);
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_ids[1], core, compute_runtime_args);
         } else {
             TT_ASSERT(false, "Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -102,9 +102,9 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -230,9 +230,9 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
@@ -357,9 +357,9 @@ MorehNllLossUnreducedBackwardDeviceOperation::Factory::cached_program_t moreh_nl
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h, i % core_h};
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_h.cpp
@@ -153,10 +153,10 @@ MorehNormOperation::ProgramFactoryH::cached_program_t MorehNormOperation::Progra
 
         uint32_t num_cols_per_core;
         KernelHandle compute_kernel_id;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_cols_per_core = num_units_per_core_group_1;
             compute_kernel_id = compute_kernels_id_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_cols_per_core = num_units_per_core_group_2;
             compute_kernel_id = compute_kernels_id_2;
         } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_other.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_other.cpp
@@ -159,10 +159,10 @@ MorehNormOperation::ProgramFactoryOther::cached_program_t MorehNormOperation::Pr
 
         uint32_t num_output_tiles_per_core;
         KernelHandle compute_kernel_id;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_output_tiles_per_core = num_units_per_core_group_1;
             compute_kernel_id = compute_kernels_id_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_output_tiles_per_core = num_units_per_core_group_2;
             compute_kernel_id = compute_kernels_id_2;
         } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_program_factory_w.cpp
@@ -153,10 +153,10 @@ MorehNormOperation::ProgramFactoryW::cached_program_t MorehNormOperation::Progra
 
         uint32_t num_units_per_core;
         KernelHandle compute_kernel_id;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_units_per_core = num_units_per_core_group_1;
             compute_kernel_id = compute_kernels_id_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_units_per_core = num_units_per_core_group_2;
             compute_kernel_id = compute_kernels_id_2;
         } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -224,10 +224,10 @@ MorehNormBackwardOperation::ProgramFactory::cached_program_t MorehNormBackwardOp
 
         KernelHandle compute_kernel_id;
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
             compute_kernel_id = compute_kernels_id_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
             compute_kernel_id = compute_kernels_id_2;
         } else {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_program_factory.cpp
@@ -182,9 +182,9 @@ MorehSgdOperation::ProgramFactory::cached_program_t MorehSgdOperation::ProgramFa
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_FATAL(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -120,9 +120,9 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -115,9 +115,9 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -116,9 +116,9 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -116,9 +116,9 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -115,9 +115,9 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -122,9 +122,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -120,9 +120,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -118,9 +118,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -120,9 +120,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -115,9 +115,9 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -152,9 +152,9 @@ MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::More
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_cols_per_core{0};
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
@@ -131,9 +131,9 @@ MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::Mor
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
@@ -157,9 +157,9 @@ MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::More
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_rows_per_core{0};
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -199,9 +199,9 @@ MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSu
     for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_cols_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_cols_per_core = num_cols_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
@@ -142,9 +142,9 @@ MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehS
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
@@ -194,9 +194,9 @@ MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSu
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
@@ -195,9 +195,9 @@ MorehSumBackwardOperation::ProgramFactory::cached_program_t MorehSumBackwardOper
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -326,9 +326,9 @@ operation::ProgramWithCallbacks layernorm_multi_core(
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
         uint32_t num_tile_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -642,7 +642,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             all_core_grid_size = grid_size;
             none_core_grid_size = grid_size;
         }
-        all_to_all_cores = num_cores_to_corerange_set(start_core, num_cores_all_to_all, all_core_grid_size, row_wise);
+        all_to_all_cores = num_cores_to_corerangeset(start_core, num_cores_all_to_all, all_core_grid_size, row_wise);
         if (row_wise) {
             if (use_mcast) {
                 CoreCoord all_start_core;
@@ -660,15 +660,14 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                         all_start_core = {end_core.x + 1, end_core.y};
                     }
                 }
-                all_to_all_workers_except_sender = num_cores_to_corerange_set(all_start_core, num_cores_all_to_all - 1, all_core_grid_size, row_wise);
+                all_to_all_workers_except_sender = num_cores_to_corerangeset(all_start_core, num_cores_all_to_all - 1, all_core_grid_size, row_wise);
             }
             if (num_none_all_to_all_workers > 0) {
                 if (use_two_stage_reduce) {
                     CoreCoord none_start_core = {all_core_grid_size.x, sender_cores.end_coord.y};
                     CoreCoord none_end_core = {num_cores_x - 1, num_cores_y - 1};
                     CoreRange none_core_range = CoreRange(none_start_core, none_end_core);
-                    std::set<CoreRange> none_core_set; none_core_set.insert(none_core_range);
-                    not_all_to_all_workers = CoreRangeSet(none_core_set);
+                    not_all_to_all_workers = CoreRangeSet(none_core_range);
                 } else {
                     CoreCoord none_start_core;
                     CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_coord;
@@ -677,7 +676,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                     } else {
                         none_start_core = {end_core.x + 1, end_core.y};
                     }
-                    not_all_to_all_workers = num_cores_to_corerange_set(none_start_core, num_none_all_to_all_workers, none_core_grid_size, row_wise);
+                    not_all_to_all_workers = num_cores_to_corerangeset(none_start_core, num_none_all_to_all_workers, none_core_grid_size, row_wise);
                 }
             }
         } else {
@@ -697,15 +696,14 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                         all_start_core = {end_core.x, end_core.y + 1};
                     }
                 }
-                all_to_all_workers_except_sender = num_cores_to_corerange_set(CoreCoord{start_core.x, start_core.y + 1}, num_cores_all_to_all - 1, all_core_grid_size, row_wise);
+                all_to_all_workers_except_sender = num_cores_to_corerangeset(CoreCoord{start_core.x, start_core.y + 1}, num_cores_all_to_all - 1, all_core_grid_size, row_wise);
             }
             if (num_none_all_to_all_workers > 0) {
                 if (use_two_stage_reduce) {
                     CoreCoord none_start_core = {sender_cores.end_coord.x, all_core_grid_size.y};
                     CoreCoord none_end_core = {num_cores_x - 1, num_cores_y - 1};
                     CoreRange none_core_range = CoreRange(none_start_core, none_end_core);
-                    std::set<CoreRange> none_core_set; none_core_set.insert(none_core_range);
-                    not_all_to_all_workers = CoreRangeSet(none_core_set);
+                    not_all_to_all_workers = CoreRangeSet(none_core_range);
                 } else {
                     CoreCoord none_start_core;
                     CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_coord;
@@ -714,7 +712,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                     } else {
                         none_start_core = {end_core.x, end_core.y + 1};
                     }
-                    not_all_to_all_workers = num_cores_to_corerange_set(none_start_core, num_none_all_to_all_workers, none_core_grid_size, row_wise);
+                    not_all_to_all_workers = num_cores_to_corerangeset(none_start_core, num_none_all_to_all_workers, none_core_grid_size, row_wise);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -366,9 +366,9 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
         uint32_t num_tile_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -231,9 +231,9 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
         CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
         uint32_t num_tile_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -246,9 +246,9 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
             continue;
         }
         uint32_t num_tile_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");
@@ -399,9 +399,9 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
                 continue;
             }
 
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_tile_rows_per_core = num_tile_rows_per_core_group_2;
             } else {
                 TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -218,9 +218,9 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
         for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
             const CoreCoord &core = cores[i];
             uint32_t num_cols_per_core = 0;
-            if (core_group_1.core_coord_in_core_ranges(core)) {
+            if (core_group_1.contains(core)) {
                 num_cols_per_core = num_cols_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            } else if (core_group_2.contains(core)) {
                 num_cols_per_core = num_cols_per_core_group_2;
             } else {
                 TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -134,9 +134,9 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
         const CoreCoord &core = cores[i];
         uint32_t num_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -129,9 +129,9 @@ operation::ProgramWithCallbacks prod_nc_format(const Tensor &input, const Tensor
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             num_tiles_per_core = num_cols_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges.");
@@ -158,9 +158,9 @@ operation::ProgramWithCallbacks prod_nc_format(const Tensor &input, const Tensor
             core,
             {output.buffer()->address(), num_tiles_per_core, tile_offset, static_cast<uint32_t>(ttnn::operations::is_dram(output))});
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_1_id, core, {num_reduce_input_tile, num_tiles_per_core});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             TT_ASSERT(compute_kernel_2_id.has_value());
             SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_reduce_input_tile, num_tiles_per_core});
         } else {

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -88,9 +88,9 @@ UniformDeviceOperation::ProgramFactory::cached_program_t UniformDeviceOperation:
     uint32_t tile_offset = 0;
     for (const auto& core : cores) {
         uint32_t units_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (core_group_1.contains(core)) {
             units_per_core = units_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (core_group_2.contains(core)) {
             units_per_core = units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -191,7 +191,7 @@ from ttnn.core import (
     dump_memory_config,
     load_memory_config,
     dump_stack_trace_on_segfault,
-    num_cores_to_corerange_set,
+    num_cores_to_corerangeset,
 )
 
 import ttnn.reflection

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -44,7 +44,7 @@ def is_sharded(tensor) -> bool:
 get_memory_config = ttnn._ttnn.core.get_memory_config
 
 
-def num_cores_to_corerange_set(
+def num_cores_to_corerangeset(
     target_num_cores: int,
     grid_size: ttnn.CoreCoord,
     row_wise: bool = False,
@@ -52,7 +52,7 @@ def num_cores_to_corerange_set(
     """
     Create a CoreRangeSet containing the specified number of cores
     """
-    return ttnn._ttnn.operations.core.num_cores_to_corerange_set(
+    return ttnn._ttnn.operations.core.num_cores_to_corerangeset(
         target_num_cores,
         grid_size,
         row_wise,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Future changes for sub devices (previously called sub core mesh) will have more interactions with CoreRangeSets. Requires some new contains/intersects apis, as well as optimizing some related functions. 

### What's changed
core_coord:
Add some new contains and intersects apis for core_coord types (needed for sub device changes)
Update CoreRangeSet constructor to use tt::stl::Span instead of vector
Rename core_coord_in_core_ranges to contains to match other apis

work_split:
Split work_split.hpp into separate impl and header file.
Update num_cores_to_corerange_set to return a CoreRangeSet instead of a set of CoreRanges. We were just using this to construct a CoreRangeSet with the return value in basically all use cases, no need to construct and return a set container. Rename the function to num_cores_to_corerangeset to better reflect the return type.
Optimize constructions of CoreRangeSets inside these functions to use vector instead of set.

Future todo is to probably switch the internal container of CoreRangeSet to small_vector, as well as in these functions that are constructing CoreRangeSets.

Most of the noise from this pr is from the function rename.

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/11623316358
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/11607238410/job/32320628389
Single card model perf: https://github.com/tenstorrent/tt-metal/actions/runs/11607225355
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/11607231729
T3K Perf: https://github.com/tenstorrent/tt-metal/actions/runs/11607228501
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
