### PR TITLE
#14508: Add bfloat8_b tests for moreh_adam, moreh_matmul[_backward] and moreh_sum[_backward]

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -16,18 +16,23 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 
 
-def create_tt_tensor(tensor: torch.Tensor, device):
-    return ttnn.from_torch(tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+def create_tt_tensor(tensor: torch.Tensor, dtype, layout, device):
+    return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device)
 
 
 def get_tensors(
-    input_shape, other_shape, output_shape, require_input_grad, require_other_grad, is_1d, device, use_randint=True
+    input_shape,
+    other_shape,
+    output_shape,
+    require_input_grad,
+    require_other_grad,
+    is_1d,
+    device,
+    use_randint=True,
+    npu_dtype=ttnn.bfloat16,
+    cpu_dtype=torch.bfloat16,
+    npu_layout=ttnn.TILE_LAYOUT,
 ):
-    npu_dtype = ttnn.bfloat16
-    cpu_dtype = torch.bfloat16
-    npu_layout = ttnn.TILE_LAYOUT
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-
     # create tensors for forward
     if use_randint:
         input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype)
@@ -38,9 +43,9 @@ def get_tensors(
         other = torch.rand(other_shape, dtype=cpu_dtype)
         output = torch.rand(output_shape, dtype=cpu_dtype)
 
-    tt_input = create_tt_tensor(input, device)
-    tt_other = create_tt_tensor(other, device)
-    tt_output = create_tt_tensor(output, device)
+    tt_input = create_tt_tensor(input, npu_dtype, npu_layout, device)
+    tt_other = create_tt_tensor(other, npu_dtype, npu_layout, device)
+    tt_output = create_tt_tensor(output, npu_dtype, npu_layout, device)
 
     torch_input = input.reshape(-1) if is_1d else input
     torch_other = other.reshape(-1) if is_1d else other
@@ -53,7 +58,8 @@ def get_tensors(
             if use_randint
             else torch.rand(output_shape, dtype=cpu_dtype)
         )
-        tt_output_grad = ttnn.Tensor(output_grad, npu_dtype).pad_to_tile(float(-1)).to(npu_layout).to(device)
+        tt_output_grad = create_tt_tensor(output_grad, npu_dtype, npu_layout, device)
+
         torch_output_grad = output_grad[0][0][0][0] if is_1d else output_grad
 
         if require_input_grad:
@@ -62,15 +68,7 @@ def get_tensors(
 
         if require_other_grad:
             other_grad = torch.full(other_shape, float("nan"), dtype=cpu_dtype)
-            tt_other_grad = (
-                ttnn.Tensor(
-                    other_grad,
-                    npu_dtype,
-                )
-                .pad_to_tile(float("nan"))
-                .to(npu_layout)
-                .to(device)
-            )
+            tt_other_grad = create_tt_tensor(other_grad, npu_dtype, npu_layout, device)
 
     return (
         tt_input,
@@ -95,19 +93,38 @@ def get_bias_tensors(bias_shape, require_bias_grad, device, use_int=True):
         if use_int
         else torch.rand(bias_shape, dtype=cpu_dtype) * 10 - 5
     )
-    tt_bias = ttnn.Tensor(bias, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_bias = create_tt_tensor(bias, npu_dtype, npu_layout, device)
     tt_bias_grad = None
     if require_bias_grad:
         bias_grad = torch.full(bias_shape, float("nan"), dtype=cpu_dtype)
-        tt_bias_grad = ttnn.Tensor(bias_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        tt_bias_grad = create_tt_tensor(bias_grad, npu_dtype, npu_layout, device)
     return tt_bias, bias, tt_bias_grad
 
 
-def moreh_matmul(params, has_output, compute_kernel_config, device):
+def moreh_matmul(
+    params,
+    has_output,
+    compute_kernel_config,
+    device,
+    use_randint=True,
+    npu_dtype=ttnn.bfloat16,
+    cpu_dtype=torch.bfloat16,
+    npu_layout=ttnn.TILE_LAYOUT,
+):
     torch.manual_seed(3072)
     input_shape, other_shape, output_shape, transpose_input, transpose_other = params
     tt_input, tt_other, tt_output, _, _, _, torch_input, torch_other, _ = get_tensors(
-        input_shape, other_shape, output_shape, False, False, False, device
+        input_shape,
+        other_shape,
+        output_shape,
+        False,
+        False,
+        False,
+        device,
+        use_randint=use_randint,
+        npu_dtype=npu_dtype,
+        cpu_dtype=cpu_dtype,
+        npu_layout=npu_layout,
     )
     if not has_output:
         tt_output = None
@@ -125,18 +142,89 @@ def moreh_matmul(params, has_output, compute_kernel_config, device):
         output=tt_output,
         compute_kernel_config=compute_kernel_config,
     )
-    tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
+    tt_output_cpu = ttnn.to_torch(tt_output)
 
     # torch matmul
     torch_out = torch.matmul(torch_input, torch_other)
 
     # test for equivalance
     rtol = atol = 0.1
-    passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+    passing, output_pcc = comp_allclose_and_pcc(
+        torch_out, tt_output_cpu, pcc=0.999 if use_randint else 0.99, rtol=rtol, atol=atol
+    )
     logger.debug(f"Out passing={passing}")
     logger.debug(f"Output pcc={output_pcc}")
 
     return passing
+
+
+def moreh_matmul_backward(params, requires_grad, device, dtype=ttnn.bfloat16, use_randint=True):
+    input_shape, other_shape, output_shape = params
+    require_input_grad, require_other_grad = requires_grad
+
+    # get tensors
+    (
+        tt_input,
+        tt_other,
+        _,
+        tt_output_grad,
+        tt_input_grad,
+        tt_other_grad,
+        torch_input,
+        torch_other,
+        torch_output_grad,
+    ) = get_tensors(
+        input_shape,
+        other_shape,
+        output_shape,
+        require_input_grad,
+        require_other_grad,
+        False,
+        device,
+        use_randint=use_randint,
+        npu_dtype=dtype,
+    )
+
+    # torch matmul
+    torch_out = torch.matmul(
+        torch_input.requires_grad_(require_input_grad), torch_other.requires_grad_(require_other_grad)
+    )
+    torch_out.backward(torch_output_grad)
+
+    # tt matmul backward
+    tt_input_grad, tt_other_grad = ttnn.operations.moreh.matmul_backward(
+        tt_output_grad,
+        tt_input,
+        tt_other,
+        are_required_outputs=(require_input_grad, require_other_grad),
+        input_a_grad=tt_input_grad,
+        input_b_grad=tt_other_grad,
+    )
+
+    # test for equivalance
+    rtol = atol = 0.1
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    if require_input_grad:
+        ttcpu_input_grad = ttnn.to_torch(tt_input_grad)
+        passing, output_pcc = comp_allclose_and_pcc(
+            torch_input.grad, ttcpu_input_grad, pcc=0.999 if use_randint else 0.99, rtol=rtol, atol=atol
+        )
+        logger.debug(f"input_grad passing={passing}")
+        logger.debug(f"input_grad pcc={output_pcc}")
+        assert passing
+    else:
+        assert tt_input_grad is None
+
+    if require_other_grad:
+        ttcpu_other_grad = ttnn.to_torch(tt_other_grad)
+        passing, output_pcc = comp_allclose_and_pcc(
+            torch_other.grad, ttcpu_other_grad, pcc=0.999 if use_randint else 0.99, rtol=rtol, atol=atol
+        )
+        logger.debug(f"other_grad passing={passing}")
+        logger.debug(f"other_grad pcc={output_pcc}")
+        assert passing
+    else:
+        assert tt_other_grad is None
 
 
 @pytest.mark.parametrize(
@@ -167,10 +255,14 @@ def moreh_matmul(params, has_output, compute_kernel_config, device):
         ),  # batched matmul
     ),
 )
+@pytest.mark.parametrize("use_randint", [True, False])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-def test_moreh_matmul(params, compute_kernel_options, device):
+def test_moreh_matmul(params, dtype, use_randint, compute_kernel_options, device):
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-    passing = moreh_matmul(params, True, compute_kernel_config, device)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
+    passing = moreh_matmul(params, True, compute_kernel_config, device, use_randint=use_randint, npu_dtype=dtype)
     assert passing
 
 
@@ -190,8 +282,14 @@ def test_moreh_matmul(params, compute_kernel_options, device):
         ),  # batched matmul
     ),
 )
-def test_moreh_matmul_wo_output(params, device):
-    passing = moreh_matmul(params, False, None, device)
+@pytest.mark.parametrize("use_randint", [True, False])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_matmul_wo_output(params, use_randint, dtype, compute_kernel_options, device):
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
+    passing = moreh_matmul(params, False, compute_kernel_config, device, use_randint, dtype)
     assert passing
 
 
@@ -263,8 +361,8 @@ def test_moreh_matmul_fp32_dest_acc(params, device):
         compute_kernel_config=compute_kernel_config_bf16_dest_acc,
     )
 
-    tt_output_cpu_fp32 = tt_output_fp32.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
-    tt_output_cpu_bf16 = tt_output_fp16.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
+    tt_output_cpu_fp32 = ttnn.to_torch(tt_output_fp32)
+    tt_output_cpu_bf16 = ttnn.to_torch(tt_output_fp16)
 
     # torch matmul (float)
     torch_out = torch.matmul(torch_input.float(), torch_other.float())
@@ -294,43 +392,6 @@ def test_moreh_matmul_fp32_dest_acc(params, device):
 
 
 @pytest.mark.parametrize(
-    "input_shape",
-    (
-        [1, 1, 1, 10],  # test not mutiple of 32 case
-        [1, 1, 1, 32],  # test single tile
-        [1, 1, 1, 352],  # test multiple tiles
-        [1, 1, 1, 323],  # test multiple tiles, not a multiple of 32
-    ),
-)
-def test_moreh_matmul_1d(input_shape, device):
-    torch.manual_seed(3072)
-    # get tensors
-    output_shape = [1, 1, 1, 1]
-    tt_input, tt_other, _, _, _, _, torch_input, torch_other, _ = get_tensors(
-        input_shape, input_shape, output_shape, False, False, True, device
-    )
-
-    # tt matmul
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_out = (
-        ttnn.operations.moreh.matmul(tt_input, tt_other).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
-    )
-
-    # torch matmul
-    torch_input = torch.reshape(torch_input, (torch_input.shape[-1],))
-    torch_other = torch.reshape(torch_other, (torch_other.shape[-1],))
-    torch_out = torch.matmul(torch_input, torch_other)
-
-    # test for equivalance
-    rtol = atol = 0.1
-    passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out[0][0][0][0], pcc=0.999, rtol=rtol, atol=atol)
-    logger.debug(f"Out passing={passing}")
-    logger.debug(f"Output pcc={output_pcc}")
-
-    assert passing
-
-
-@pytest.mark.parametrize(
     "params",
     (
         # input, other, output shape
@@ -348,135 +409,12 @@ def test_moreh_matmul_1d(input_shape, device):
         (True, True),
     ),
 )
-def test_moreh_matmul_backward(params, requires_grad, device):
+@pytest.mark.parametrize("dtype", (ttnn.bfloat8_b, ttnn.bfloat16), ids=["bfloat8_b", "bfloat16"])
+def test_moreh_matmul_backward(params, requires_grad, dtype, device):
     torch.manual_seed(3072)
-    input_shape, other_shape, output_shape = params
-    require_input_grad, require_other_grad = requires_grad
-
-    # get tensors
-    (
-        tt_input,
-        tt_other,
-        _,
-        tt_output_grad,
-        tt_input_grad,
-        tt_other_grad,
-        torch_input,
-        torch_other,
-        torch_output_grad,
-    ) = get_tensors(input_shape, other_shape, output_shape, require_input_grad, require_other_grad, False, device)
-
-    # torch matmul
-    torch_out = torch.matmul(
-        torch_input.requires_grad_(require_input_grad), torch_other.requires_grad_(require_other_grad)
-    )
-    torch_out.backward(torch_output_grad)
-
-    # tt matmul backward
-    tt_input_grad, tt_other_grad = ttnn.operations.moreh.matmul_backward(
-        tt_output_grad,
-        tt_input,
-        tt_other,
-        are_required_outputs=(require_input_grad, require_other_grad),
-        input_a_grad=tt_input_grad,
-        input_b_grad=tt_other_grad,
-    )
-
-    # test for equivalance
-    rtol = atol = 0.1
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    if require_input_grad:
-        ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
-        passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.debug(f"input_grad passing={passing}")
-        logger.debug(f"input_grad pcc={output_pcc}")
-        assert passing
-    else:
-        assert tt_input_grad is None
-
-    if require_other_grad:
-        ttcpu_other_grad = tt_other_grad.cpu().to(cpu_layout).unpad_from_tile(other_shape).to_torch()
-        passing, output_pcc = comp_allclose_and_pcc(torch_other.grad, ttcpu_other_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.debug(f"other_grad passing={passing}")
-        logger.debug(f"other_grad pcc={output_pcc}")
-        assert passing
-    else:
-        assert tt_other_grad is None
-
-
-@pytest.mark.parametrize(
-    "input_shape",
-    (
-        [1, 1, 1, 10],  # test not mutiple of 32 case
-        [1, 1, 1, 32],  # test single tile
-        [1, 1, 1, 352],  # test multiple tiles
-        [1, 1, 1, 323],  # test multiple tiles, not a multiple of 32
-    ),
-)
-@pytest.mark.parametrize(
-    "requires_grad",
-    (
-        (True, False),
-        (False, True),
-        (True, True),
-    ),
-)
-def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
-    torch.manual_seed(3072)
-    require_input_grad, require_other_grad = requires_grad
-    output_shape = [1, 1, 1, 1]
-    # get tensors
-    (
-        tt_input,
-        tt_other,
-        _,
-        tt_output_grad,
-        tt_input_grad,
-        tt_other_grad,
-        torch_input,
-        torch_other,
-        torch_output_grad,
-    ) = get_tensors(input_shape, input_shape, output_shape, require_input_grad, require_other_grad, True, device)
-
-    # torch matmul
-    torch_out = torch.matmul(
-        torch_input.requires_grad_(require_input_grad), torch_other.requires_grad_(require_other_grad)
-    )
-    torch_out.backward(torch_output_grad)
-
-    # tt matmul backward
-    for _ in range(2):
-        ttnn.operations.moreh.matmul_backward(
-            tt_output_grad,
-            tt_input,
-            tt_other,
-            are_required_outputs=(require_input_grad, require_other_grad),
-            input_a_grad=tt_input_grad,
-            input_b_grad=tt_other_grad,
-        )
-
-    # test for equivalance
-    rtol = atol = 0.1
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    if require_input_grad:
-        ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
-
-        passing, output_pcc = comp_allclose_and_pcc(
-            torch_input.grad, ttcpu_input_grad.reshape(-1), pcc=0.999, rtol=rtol, atol=atol
-        )
-        logger.debug(f"input_grad passing={passing}")
-        logger.debug(f"input_grad pcc={output_pcc}")
-        assert passing
-
-    if require_other_grad:
-        ttcpu_other_grad = tt_other_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
-
-        passing, output_pcc = comp_allclose_and_pcc(
-            torch_other.grad, ttcpu_other_grad.reshape(-1), pcc=0.999, rtol=rtol, atol=atol
-        )
-        logger.debug(f"other_grad passing={passing}")
-        logger.debug(f"other_grad pcc={output_pcc}")
-        assert passing
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
+    moreh_matmul_backward(params, requires_grad, device, dtype=dtype)
 
 
 @skip_for_grayskull("GS does not support fp32")
@@ -516,9 +454,10 @@ def test_moreh_matmul_with_bias_add_fp32_dest_acc(params, device):
         bias=tt_bias,
         compute_kernel_config=compute_kernel_config_bf16_dest_acc,
     )
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu_fp32 = tt_output_fp32.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
-    tt_output_cpu_bf16 = tt_output_fp16.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
+
+    tt_output_cpu_fp32 = ttnn.to_torch(tt_output_fp32)
+    tt_output_cpu_bf16 = ttnn.to_torch(tt_output_fp16)
+
     # torch matmul (float)
     torch_out = torch.matmul(torch_input.float(), torch_other.float()) + torch_bias
     # test for equivalance


### PR DESCRIPTION
### Ticket
Closes #14508 

### Problem description
Adds boilerplate/outline bfloat8_b tests for these operations. These tests are currently all pytest.skip() due to the kernel being unable to support them, but may be used later for verification if we modify these ops.

### What's changed
bfloat8_b tests has been added to:
- test_moreh_adam
- test_moreh_matmul
- test_moreh_sum

and their respective backward variants

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
