### PR TITLE
#13655: Add limited ability to shrink allocator size from the bottom

### DIFF
--- a/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
+++ b/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
@@ -58,11 +58,16 @@ class Algorithm {
 
     virtual void dump_blocks(std::ofstream &out) const = 0;
 
+    virtual void shrink_size(DeviceAddr shrink_size, bool bottom_up=true) = 0;
+
+    virtual void reset_size() = 0;
+
    protected:
     DeviceAddr max_size_bytes_;
     DeviceAddr offset_bytes_;
     DeviceAddr min_allocation_size_;
     DeviceAddr alignment_;
+    DeviceAddr shrink_size_ = 0;
     std::optional<DeviceAddr> lowest_occupied_address_;
 };
 

--- a/tt_metal/impl/allocator/algorithms/free_list.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.hpp
@@ -35,6 +35,10 @@ class FreeList : public Algorithm {
 
     void dump_blocks(std::ofstream &out) const;
 
+    void shrink_size(DeviceAddr shrink_size, bool bottom_up=true);
+
+    void reset_size();
+
    private:
     struct Block {
         Block(DeviceAddr address, DeviceAddr size) : address(address), size(size) {}

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -58,6 +58,9 @@ class BankManager {
 
     void dump_blocks(std::ofstream &out) const;
 
+    void shrink_size(DeviceAddr shrink_size, bool bottom_up=true);
+    void reset_size();
+
    private:
     void deallocate_buffer_(DeviceAddr address);
 
@@ -104,6 +107,8 @@ void dump_memory_blocks(const Allocator &allocator, const BufferType &buffer_typ
 std::optional<DeviceAddr> lowest_occupied_l1_address(const Allocator &allocator, uint32_t bank_id);
 
 DeviceAddr base_alloc(const AllocatorConfig & config, BankManager &bank_manager, DeviceAddr size, DeviceAddr page_size, bool bottom_up, std::optional<uint32_t> num_shards);
+
+void shrink_allocator_size(Allocator &allocator, const BufferType &buffer_type, DeviceAddr shrink_size, bool bottom_up=true);
 
 DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, Buffer *buffer);
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.hpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.hpp
@@ -23,7 +23,7 @@ uint64_t alloc_at_addr_in_compute_and_storage(const AllocatorConfig &config, Ban
 }   // namespace allocator
 
 
-// Currently only designed for Grayskull.
+// For Grayskull:
 // There are 108 (9x12) compute and storage cores where each core has one 1 MB bank with top 512 KB (non-exclusively) dedicated to L1 buffer storage.
 // Circular buffers can grow into L1 buffer storage space but L1 buffers cannot grow past 512 KB.
 // There are an additional 10 storage cores where each core has two banks of 512 KB dedicated solely to L1 buffer storage.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13655

### Problem description
For sub devices, we will slice off a chunk of memory from the global allocator. This memory will then be used by allocators local to a sub device in order to allow allocating buffers on one sub device without affecting memory on another sub device

### What's changed
Add a function that can shrink an allocator's memory from the bottom, as well as a function to reset an allocator back to its original size.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11632947736
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
