### PR TITLE
#0: fix broken tt-mlir build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,16 @@ if(ENABLE_LIBCXX)
     #    $<$<LINK_LANG_AND_ID:CXX,Clang>:-lc++>
     #    $<$<LINK_LANG_AND_ID:CXX,Clang>:-lc++abi>
     #)
+else()
+    # required when linking with libstdc++ with clang and gcc
+    add_compile_options(-fsized-deallocation)
 endif()
 
 # Using below until we can move to CMake >= 3.18 for LINK_LANG_AND_ID
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND ENABLE_LIBCXX)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++ -lc++abi")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++ -lc++abi")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ENABLE_LIBCXX)
-    add_compile_options(-fsized-deallocation)
 endif()
-
-add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fsized-deallocation>)
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND ENABLE_LIBCXX)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++ -lc++abi")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++ -lc++abi")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ENABLE_LIBCXX)
+    add_compile_options(-fsized-deallocation)
 endif()
 
 add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fsized-deallocation>)


### PR DESCRIPTION
Fix broken tt-mlir build, fsized-deallocation is required for a path when compiler is clang but libcxx is disabled