### PR TITLE
#14510: Disable reduce scalar until investigated

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
@@ -456,8 +456,8 @@ TEST_F(DeviceFixture, ComputeReduceW) {
         }
     }
 }
-
-TEST_F(DeviceFixture, ComputeReduceHW) {
+// Disabled due to GH issue #14510
+TEST_F(DeviceFixture, DISABLED_ComputeReduceHW) {
     std::vector<uint32_t> shape = {1, 2, 7*TILE_HEIGHT, 5*TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
     for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {


### PR DESCRIPTION
### Ticket
#14510 

### Problem description
Reduce with scalar hangs on GS.

### What's changed
Disable the test until investigated.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
