### PR TITLE
#0: Revert "#12815: update mish op (#14270)"

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -321,7 +321,8 @@ def test_unary_composite_log1p_ttnn(input_shapes, device):
     ),
 )
 def test_unary_composite_mish_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -20, 100, device)
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
     output_tensor = ttnn.mish(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn.mish)
     golden_tensor = golden_function(in_data1)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -315,19 +315,26 @@ Tensor _log1p(const Tensor& x, const std::optional<MemoryConfig>& output_mem_con
     return result_log1p;
 }
 
-// log[exp[x] + 1] => softplus[x]
 // mish[x] = x*tanh[softplus[x]]
-Tensor ExecuteMish::invoke(const Tensor& x, const std::optional<MemoryConfig>& output_mem_config) {
-    using ttnn::operations::unary::UnaryWithParam;
-    using ttnn::operations::unary::UnaryOpType;
-    std::vector<UnaryWithParam> ops_chain = {
-    UnaryWithParam{UnaryOpType::EXP, 1.0f},
-    UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-    UnaryWithParam{UnaryOpType::LOG},
-    UnaryWithParam{UnaryOpType::TANH} };
-    Tensor result = ttnn::unary_chain(x, ops_chain, output_mem_config);
-    Tensor mish_x = ttnn::multiply(x, result, std::nullopt, output_mem_config);
-    return mish_x;
+// use transformation y = x*tanh[softplus[x]] by broadcast
+// Ref: https://krutikabapat.github.io/Swish-Vs-Mish-Latest-Activation-Functions/
+Tensor _mish(const Tensor& x, const std::optional<MemoryConfig>& output_mem_config) {
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({x}))};
+    operation::launch_op(
+        [output_mem_config](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            const auto& x = input_tensors.at(0);
+            Tensor sp_x = ttnn::softplus(x, 1.0f, 20.0f, output_mem_config);
+            Tensor tanh_x = ttnn::tanh(sp_x, output_mem_config);
+            sp_x.deallocate();
+            Tensor mish_x = ttnn::multiply(x, tanh_x, std::nullopt, output_mem_config);
+            return {mish_x};
+        },
+        {x},
+        output_tensors);
+    return output_tensors.at(0);
 }
 
 // multivariate log-gamma function

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -25,6 +25,7 @@ enum class UnaryCompositeOpType {
     DIGAMMA,
     LGAMMA,
     LOG1P,
+    MISH,
     MULTIGAMMALN,
     SINH,
     SOFTSIGN,
@@ -65,6 +66,7 @@ Tensor _cosh(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _digamma(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _lgamma(const Tensor&,  const std::optional<MemoryConfig>&);
 Tensor _log1p(const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _mish(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _multigammaln(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _sinh(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _softsign(const Tensor&, const std::optional<MemoryConfig>&);
@@ -187,6 +189,13 @@ template <>
 struct OpHandler<UnaryCompositeOpType::LOG1P> {
     static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
         return _log1p(t1, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<UnaryCompositeOpType::MISH> {
+    static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
+        return _mish(t1, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -153,12 +153,6 @@ struct ExecuteRdiv {
         std::optional<Tensor> optional_output_tensor = std::nullopt);
 };
 
-struct ExecuteMish {
-    static Tensor invoke(
-        const Tensor& input_tensor,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
-};
-
 }  // namespace unary
 }  // namespace operations
 
@@ -246,7 +240,7 @@ constexpr auto log1p = ttnn::register_operation_with_auto_launch_op<
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOG1P>>();
 constexpr auto mish = ttnn::register_operation_with_auto_launch_op<
     "ttnn::mish",
-    operations::unary::ExecuteMish>();
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MISH>>();
 constexpr auto multigammaln = ttnn::register_operation_with_auto_launch_op<
     "ttnn::multigammaln",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MULTIGAMMALN>>();


### PR DESCRIPTION
This reverts commit dec1dc2c6da1d547535bedb11d41f6373c66a69f.

to fix nightly fast dispatch

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
