### PR TITLE
Added absolute path for view trace for CI

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/view/view_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/view/view_pytorch2.py
@@ -64,7 +64,7 @@ def parse_md_file_simple_no_regex(file_path):
 
 parameters = {
     "nightly": {
-        "view_specs": parse_md_file_simple_no_regex("sweeps/data_movement/view/view_trace.md"),
+        "view_specs": parse_md_file_simple_no_regex("tests/sweep_framework/sweeps/data_movement/view/view_trace.md"),
         "dtype": [ttnn.bfloat16],
         "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
     }


### PR DESCRIPTION
### Ticket
[Failing Sweep Run](https://github.com/tenstorrent/tt-metal/actions/runs/11601627561/job/32305245681)
### Problem description
Sweep CI needs absolute path since it runs from tt-metal dir

### What's changed
gave absolute path for view_trace.md

### Checklist
- [ ] Passing generate sweeps: https://github.com/tenstorrent/tt-metal/actions/runs/11618012766/job/32354560046