### PR TITLE
Support unidirection for matmul op signaler

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -28,6 +28,11 @@ enum class FusedOpSignalerMode {
     MULTI
 };
 
+enum Direction {
+    CW,
+    CCW
+};
+
 struct AllGatherFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
     std::vector<CoreCoord> fused_op_receiver_cores_noc = {};
@@ -75,7 +80,6 @@ struct MatmulFusedOpSignaler {
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
     /* All Gather specs */
-    uint32_t num_transfers = 0;
     uint32_t ring_size = 0;
     uint32_t start_ring_index = 0;
     uint32_t tensor_slice_shape_width = 0;
@@ -89,7 +93,6 @@ struct MatmulFusedOpSignaler {
     bool initialized_fused_op = false;
 
     void init_all_gather(
-        uint32_t num_transfers,
         uint32_t ring_size,
         uint32_t start_ring_index,
         uint32_t tensor_slice_shape_width,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -249,7 +249,6 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
     // Create a matmul signal info object that gets populated by the matmul kernel
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler> matmul_fused_op_signaler = ttnn::experimental::ccl::MatmulFusedOpSignaler();
     matmul_fused_op_signaler->init_all_gather(
-        num_transfers,
         ring_size,
         ring_index,
         tensor_slicer.num_cols,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -58,7 +58,6 @@ void kernel_main() {
         fused_op_receiver = MatmulOpReceiver(
             true, /* wait_for_op_signal */
             rt_args_idx,
-            num_blocks,
             in0_block_w /* tiles_per_block (in the same dimension as tensor slice) */
         );
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -118,7 +118,6 @@ void kernel_main() {
         fused_op_receiver = MatmulOpReceiver(
             sender_id < num_remote_senders, /* wait_for_op_signal */
             rt_args_idx,
-            num_blocks,
             in0_block_w /* tiles_per_block (in the same dimension as tensor slice) */
         );
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -108,8 +108,7 @@ void kernel_main() {
         fused_op_receiver = MatmulOpReceiver(
             false, /* wait_for_op_signal */
             rt_args_idx,
-            num_blocks,
-            in1_block_h /* tiles_per_block (in the same dimension */
+            in1_block_h /* tiles_per_block (in the same dimension as tensor slice) */
         );
     }
 


### PR DESCRIPTION
### Ticket
- #14536

### What's Changed
Added support for unidirectional all gather in fused all gather/matmul. Also cleaned up part of the interface for `MatmulOpReceiver`.

### Checklist
- [ ] Post commit CI passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/11619527150))
- [ ] Model regression CI testing passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/11619531601))
