### PR TITLE
#0: Fixes for TensorLayout fromLegacyPaddedShape

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -76,8 +76,6 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         CreateTensorParams{.shape=ttnn::SimpleShape({1, 1, 32, 32})},
         CreateTensorParams{.shape=ttnn::SimpleShape({2, 1, 32, 32})},
-        CreateTensorParams{.shape=ttnn::SimpleShape({64, 1, 256, 1})},
-        CreateTensorParams{.shape=ttnn::SimpleShape({1, 1, 21120, 16})},
         CreateTensorParams{.shape=ttnn::SimpleShape({0, 0, 0, 0})},
         CreateTensorParams{.shape=ttnn::SimpleShape({0, 1, 32, 32})},
         CreateTensorParams{.shape=ttnn::SimpleShape({0})}
@@ -108,6 +106,9 @@ INSTANTIATE_TEST_SUITE_P(
         EmptyTensorParams{.shape=ttnn::Shape({1, 1, 21120, 16})},
         EmptyTensorParams{.shape=ttnn::Shape({0, 0, 0, 0})},
         EmptyTensorParams{.shape=ttnn::Shape({0, 1, 32, 32})},
-        EmptyTensorParams{.shape=ttnn::Shape({0})}
+        EmptyTensorParams{.shape=ttnn::Shape({0})},
+        EmptyTensorParams{.shape=ttnn::Shape({1, 1, 1, 1})},
+        EmptyTensorParams{.shape=ttnn::Shape({1})},
+        EmptyTensorParams{.shape=ttnn::Shape({})}
     )
 );

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -36,7 +36,7 @@ void run_create_tensor_test(tt::tt_metal::Device* device, ttnn::SimpleShape inpu
 
     tt::tt_metal::TensorLayout tensor_layout(dtype, PageConfig(Layout::TILE), mem_cfg);
     ASSERT_EQ(input_buf_size_datums * datum_size_bytes, tensor_layout.compute_packed_buffer_size_bytes(input_shape));
-    auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device( device, input_shape, tensor_layout);
+    auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, input_shape, tensor_layout);
 
     auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
 
@@ -56,6 +56,11 @@ void run_create_tensor_test(tt::tt_metal::Device* device, ttnn::SimpleShape inpu
 struct CreateTensorParams {
     ttnn::SimpleShape shape;
 };
+
+struct EmptyTensorParams {
+    ttnn::Shape shape;
+};
+
 }
 
 class CreateTensorTest : public ttnn::TTNNFixtureWithDevice, public ::testing::WithParamInterface<CreateTensorParams> {};
@@ -71,8 +76,38 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         CreateTensorParams{.shape=ttnn::SimpleShape({1, 1, 32, 32})},
         CreateTensorParams{.shape=ttnn::SimpleShape({2, 1, 32, 32})},
+        CreateTensorParams{.shape=ttnn::SimpleShape({64, 1, 256, 1})},
+        CreateTensorParams{.shape=ttnn::SimpleShape({1, 1, 21120, 16})},
         CreateTensorParams{.shape=ttnn::SimpleShape({0, 0, 0, 0})},
         CreateTensorParams{.shape=ttnn::SimpleShape({0, 1, 32, 32})},
         CreateTensorParams{.shape=ttnn::SimpleShape({0})}
+    )
+);
+
+class EmptyTensorTest : public ttnn::TTNNFixtureWithDevice, public ::testing::WithParamInterface<EmptyTensorParams> {};
+
+TEST_P(EmptyTensorTest, Tile) {
+    EmptyTensorParams params = GetParam();
+    auto tensor = tt::tt_metal::create_device_tensor(params.shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, device_, ttnn::DRAM_MEMORY_CONFIG);
+    EXPECT_EQ(tensor.get_logical_shape(), params.shape.logical_shape());
+}
+
+TEST_P(EmptyTensorTest, RowMajor) {
+    EmptyTensorParams params = GetParam();
+    auto tensor = tt::tt_metal::create_device_tensor(params.shape, DataType::BFLOAT16, ttnn::ROW_MAJOR_LAYOUT, device_, ttnn::DRAM_MEMORY_CONFIG);
+    EXPECT_EQ(tensor.get_logical_shape(), params.shape.logical_shape());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EmptyTensorTestWithShape,
+    EmptyTensorTest,
+    ::testing::Values(
+        EmptyTensorParams{.shape=ttnn::Shape({1, 1, 32, 32})},
+        EmptyTensorParams{.shape=ttnn::Shape({2, 1, 32, 32})},
+        EmptyTensorParams{.shape=ttnn::Shape({64, 1, 256, 1})},
+        EmptyTensorParams{.shape=ttnn::Shape({1, 1, 21120, 16})},
+        EmptyTensorParams{.shape=ttnn::Shape({0, 0, 0, 0})},
+        EmptyTensorParams{.shape=ttnn::Shape({0, 1, 32, 32})},
+        EmptyTensorParams{.shape=ttnn::Shape({0})}
     )
 );

--- a/ttnn/cpp/ttnn/tensor/layout/page_config.hpp
+++ b/ttnn/cpp/ttnn/tensor/layout/page_config.hpp
@@ -23,7 +23,7 @@ public:
     Alignment create_default_alignment(DataType dtype) const;
     void validate_alignment(const Alignment& alignment, DataType dtype) const;
 
-    Size get_page_shape(const Size& physical_size, const MemoryConfig& memory_config) const;
+    Size get_page_shape(const Size& physical_size, DataType dtype, const MemoryConfig& memory_config) const;
     size_t get_page_size_bytes(const Size& page_size, DataType dtype) const;
 };
 
@@ -34,7 +34,7 @@ public:
     Alignment create_default_alignment(DataType dtype) const;
     void validate_alignment(const Alignment& alignment, DataType dtype) const;
 
-    Size get_page_shape(const Size& physical_size, const MemoryConfig& memory_config) const;
+    Size get_page_shape(const Size& physical_size, DataType dtype, const MemoryConfig& memory_config) const;
     size_t get_page_size_bytes(const Size& page_size, DataType dtype) const;
 
     const Tile& get_tile() const;
@@ -54,7 +54,7 @@ public:
     Alignment create_default_alignment(DataType dtype) const;
     void validate_alignment(const Alignment& alignment, DataType dtype) const;
 
-    Size get_page_shape(const Size& physical_size, const MemoryConfig& memory_config) const;
+    Size get_page_shape(const Size& physical_size, DataType dtype, const MemoryConfig& memory_config) const;
     size_t get_page_size_bytes(const Size& page_size, DataType dtype) const;
 
     std::optional<Tile> get_tile() const;

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
@@ -16,7 +16,12 @@ size_t round_up(size_t value, size_t multiple) {
     return ((value + multiple - 1) / multiple) * multiple;
 };
 
-Alignment legacyPaddedShapeToAlignment(const ttnn::SimpleShape& legacy_padded_shape) {
+Alignment legacyShapeToAlignment(const ttnn::Shape& shape) {
+    auto legacy_padded_shape = shape.padded_shape();
+    if (shape.logical_shape() == legacy_padded_shape) {
+        return Alignment{};
+    }
+
     const auto rank = legacy_padded_shape.rank();
     ttnn::SmallVector<uint32_t> values(rank);
 
@@ -30,7 +35,7 @@ Alignment legacyPaddedShapeToAlignment(const ttnn::SimpleShape& legacy_padded_sh
         values[i] = legacy_padded_shape[i] * values[i + 1];
     }
 
-    Alignment result(values);
+    Alignment result(std::move(values));
     return result;
 }
 
@@ -51,8 +56,8 @@ TensorLayout::TensorLayout(DataType dtype, const PageConfig& page_config, const 
     validate_alignment();
 }
 
-TensorLayout TensorLayout::fromLegacyPaddedShape(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const ttnn::SimpleShape& legacy_padded_shape) {
-    return TensorLayout(dtype, page_config, memory_config, CMAKE_UNIQUE_NAMESPACE::legacyPaddedShapeToAlignment(legacy_padded_shape));
+TensorLayout TensorLayout::fromLegacyPaddedShape(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const ttnn::Shape& legacy_shape) {
+    return TensorLayout(dtype, page_config, memory_config, CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(legacy_shape));
 }
 
 void TensorLayout::initialize_alignment() {
@@ -79,10 +84,10 @@ std::optional<ShardSpecBuffer> TensorLayout::compute_shard_spec_buffer(const ttn
     const Size physical_size = compute_physical_shape(shape);
     const Size page_shape = compute_page_shape(physical_size);
 
-    TT_FATAL(physical_size.width() % page_shape.width() == 0, "Physical width {} must be multiple of page width {}", physical_size.width(), page_shape.width());
-    TT_FATAL(physical_size.height() % page_shape.height() == 0, "Physical height {} must be multiple of page height {}", physical_size.height(), page_shape.height());
-    const auto width_in_pages = physical_size.width() / page_shape.width();
-    const auto height_in_pages = physical_size.height() / page_shape.height();
+    TT_FATAL(page_shape.width() == 0 ? physical_size.width() == 0 : physical_size.width() % page_shape.width() == 0, "Physical width {} must be multiple of page width {}", physical_size.width(), page_shape.width());
+    TT_FATAL(page_shape.height() == 0 ? physical_size.height() == 0 : physical_size.height() % page_shape.height() == 0, "Physical height {} must be multiple of page height {}", physical_size.height(), page_shape.height());
+    const auto width_in_pages = page_shape.width() == 0 ? 0 : physical_size.width() / page_shape.width();
+    const auto height_in_pages = page_shape.height() == 0 ? 0 : physical_size.height() / page_shape.height();
     const std::array<uint32_t, 2> tensor2d_shape {height_in_pages, width_in_pages};
 
     ShardSpecBuffer shard_spec_buffer(shard_spec, std::array<uint32_t, 2>(page_shape), tensor2d_shape);
@@ -92,14 +97,14 @@ std::optional<ShardSpecBuffer> TensorLayout::compute_shard_spec_buffer(const ttn
 size_t TensorLayout::compute_packed_buffer_size_bytes(const ttnn::SimpleShape& shape) const {
     const Size physical_size = compute_physical_shape(shape);
     const Size page_shape = compute_page_shape(physical_size);
-    const auto width_remainder = physical_size.width() % page_shape.width();
-    const auto height_remainder = physical_size.height() % page_shape.height();
+    const auto width_remainder = page_shape.width() == 0 ? 0 : physical_size.width() % page_shape.width();
+    const auto height_remainder = page_shape.height() == 0 ? 0 : physical_size.height() % page_shape.height();
     TT_FATAL(width_remainder == 0 && height_remainder == 0, "Physical size {} must be multiple of page size {}", physical_size, page_shape);
 
     const size_t physical_area = physical_size.height() * physical_size.width();
     const size_t page_area = page_shape.height() * page_shape.width();
 
-    const size_t page_count = physical_area / page_area;
+    const size_t page_count = page_area == 0 ? 0 : physical_area / page_area;
     const size_t page_size_bytes = compute_page_size_bytes(page_shape);
 
     return page_count * page_size_bytes;

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
@@ -26,7 +26,7 @@ public:
 
     // static method makes it easy to find and remove all of its usages in the codebase - thats why it is not a constructor
     [[deprecated("Use of Legacy Padded Shape is deprecated")]]
-    static TensorLayout fromLegacyPaddedShape(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const ttnn::SimpleShape& legacy_padded_shape);
+    static TensorLayout fromLegacyPaddedShape(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const ttnn::Shape& legacy_shape);
 
     Layout get_layout() const { return page_config_.is_row_major() ? Layout::ROW_MAJOR : Layout::TILE; }
     PageConfig get_page_config() const { return page_config_; }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -678,7 +678,7 @@ Tensor create_device_tensor(const ttnn::SimpleShape& shape, DataType data_type, 
 
 Tensor create_device_tensor(
     const ttnn::Shape& shape, DataType data_type, Layout layout, Device* device, const MemoryConfig& memory_config, const std::optional<Tile>& tile) {
-    return create_device_tensor(shape.logical_shape(), TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout, tile), memory_config, shape.padded_shape()), device);
+    return create_device_tensor(shape.logical_shape(), TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout, tile), memory_config, shape), device);
 }
 
 namespace detail {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -755,16 +755,16 @@ Tensor to_device(const Tensor& tensor, Device* target_device, const MemoryConfig
     TT_FATAL(target_device != nullptr, "Need target device in order to move tensor to device!");
     TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
+    auto legacy_shape = tensor.get_shape();
     auto shape = tensor.get_logical_shape();
-    auto padded_shape = tensor.get_padded_shape();
     auto data_type = tensor.get_dtype();
     auto layout = tensor.get_layout();
     auto tile = tensor.get_tile();
-    TensorLayout tensor_layout = TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout, tile), memory_config, padded_shape);
+    TensorLayout tensor_layout = TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout, tile), memory_config, legacy_shape);
 
     auto device_buffer = tensor_impl::to_device_buffer<T>(tensor.get_storage(), target_device, shape, tensor_layout, queue);
 
-    return Tensor(DeviceStorage{device_buffer}, tensor.get_shape(), data_type, layout, tile);
+    return Tensor(DeviceStorage{device_buffer}, legacy_shape, data_type, layout, tile);
 }
 
 template Tensor to_device<bfloat16>(

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -755,16 +755,16 @@ Tensor to_device(const Tensor& tensor, Device* target_device, const MemoryConfig
     TT_FATAL(target_device != nullptr, "Need target device in order to move tensor to device!");
     TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
-    auto legacy_shape = tensor.get_shape();
-    auto shape = tensor.get_logical_shape();
+    auto shape = tensor.get_shape();
+    auto logical_shape = tensor.get_logical_shape();
     auto data_type = tensor.get_dtype();
     auto layout = tensor.get_layout();
     auto tile = tensor.get_tile();
-    TensorLayout tensor_layout = TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout, tile), memory_config, legacy_shape);
+    TensorLayout tensor_layout = TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout, tile), memory_config, shape);
 
-    auto device_buffer = tensor_impl::to_device_buffer<T>(tensor.get_storage(), target_device, shape, tensor_layout, queue);
+    auto device_buffer = tensor_impl::to_device_buffer<T>(tensor.get_storage(), target_device, logical_shape, tensor_layout, queue);
 
-    return Tensor(DeviceStorage{device_buffer}, legacy_shape, data_type, layout, tile);
+    return Tensor(DeviceStorage{device_buffer}, shape, data_type, layout, tile);
 }
 
 template Tensor to_device<bfloat16>(


### PR DESCRIPTION
### Ticket

### Problem description
Tensor creation failed for some shape due to incorrect derivation of alignment from legacy padded shape

### What's changed
Use default alignment if logical shape and padded shape are the same
Better handling for 0-volume tensors in TensorLayout
Added tests for creating tensors with different shapes

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11621126032)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
