### PR TITLE
Update build command used by bisect script

### DIFF
--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -56,7 +56,7 @@ while [[ "$found" = "false" ]]; do
    build_code=0
    echo "at commit `git rev-parse HEAD`"
    echo "building Metal"
-   . build_metal.sh; build_code+=$?
+   ./build_metal.sh --build-tests; build_code+=$?
 
    if [[ $build_code -ne 0 ]]; then
       echo "Build failed"


### PR DESCRIPTION
### Problem description
Git bisect script not working due to invocation of `build_metal.sh`

### What's changed
Fix it

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
