### PR TITLE
#14518: Skip unsupported repeat case for BH

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_transpose.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole
+from models.utility_functions import skip_for_grayskull
 
 shape_wh = [
     [[1, 1, 32, 32]],  # Single core
@@ -17,7 +17,6 @@ shape_wh = [
 ]
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("input_shapes", shape_wh)
 def test_run_transpose_wh_test(input_shapes, device, function_level_defaults):
     datagen_func = [
@@ -100,7 +99,6 @@ def test_run_transpose_nh_test(input_shapes, device, function_level_defaults):
     run_single_pytorch_test("transpose", input_shapes, datagen_func, comparison_func, device, test_args)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -123,7 +121,6 @@ def test_run_transpose_nw_test(input_shapes, device, function_level_defaults):
     run_single_pytorch_test("transpose", input_shapes, datagen_func, comparison_func, device, test_args)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_min_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_min_max.py
@@ -6,10 +6,8 @@ import torch
 import pytest
 from functools import partial
 import ttnn
-from models.utility_functions import skip_for_blackhole
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "shape_dim",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax_sharded.py
@@ -20,7 +20,6 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_ze
 from models.utility_functions import is_grayskull, skip_for_blackhole
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "in0_mem_config",
@@ -94,7 +93,6 @@ def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
     assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "causal_mask",
@@ -289,7 +287,6 @@ def test_scale_mask_softmax_rm(device, in_dtype, in0_mem_config, causal_mask):
     assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "shard_orient",

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -50,7 +50,9 @@ ttnn::Tensor RepeatOperation::invoke(
                 if (input_tensor.get_layout() == Layout::ROW_MAJOR && dim == input_rank - 1) {
                     TT_FATAL(
                         (padded_input_shape[dim] * input_tensor.element_size()) % input_tensor.buffer()->alignment() == 0,
-                        "Current repeat implementation requires aligned last dim when repeating on last dim");
+                        "Current repeat implementation requires last dim ({}) to be aligned to {} repeating on last dim",
+                        (padded_input_shape[dim] * input_tensor.element_size()),
+                        input_tensor.buffer()->alignment());
                 }
                 auto outputs = operation::run_without_autoformat(RepeatDeviceOperation{dim, repeat_dims[dim], memory_config}, {output});
                 TT_FATAL(outputs.size() == 1, "ttnn.repeat: expected 1 output tensor from run_without_autoformat, but got {}", outputs.size());


### PR DESCRIPTION
### Ticket
#14518 

### Problem description
Part of #12349  push

### What's changed
Skipping unsupported case for repeat op. Per discussions with @ntarafdar we will skip over tests that hit op asserts but leave the issue open so it can be addressed as a separate generality uplift 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11677492297)
- [ ] Blackhole Post commit (if applicable)
