### PR TITLE
Remove dependency of Kernel on Device.

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/ping_legal_l1s.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/ping_legal_l1s.cpp
@@ -13,12 +13,8 @@ void kernel_main() {
 
     for (uint32_t id = 0; id < NUM_L1_BANKS; id += 1) {
         uint32_t bank_id;
-#ifdef IS_NOT_POW2_NUM_L1_BANKS
         bank_id = umodsi3_const_divisor<NUM_L1_BANKS>(id);
-#else
-        bank_id = id & (NUM_L1_BANKS - 1);
-#endif
-        uint32_t l1_address = base_l1_address + bank_to_l1_offset[bank_id];  
+        uint32_t l1_address = base_l1_address + bank_to_l1_offset[bank_id];
         uint32_t noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         uint64_t noc_addr = get_noc_addr_helper(noc_xy, l1_address);
 

--- a/tt_metal/hw/inc/blackhole/core_config.h
+++ b/tt_metal/hw/inc/blackhole/core_config.h
@@ -47,3 +47,7 @@ constexpr uint8_t MaxProcessorsPerCoreType = 5;
 constexpr uint8_t NumTensixDispatchClasses = 3;
 constexpr uint8_t NumEthDispatchClasses = 1;
 constexpr uint8_t NumDramDispatchClasses = 1;
+constexpr uint8_t noc_size_x = 17;
+constexpr uint8_t noc_size_y = 12;
+#define ALLOCATOR_ALIGNMENT 32
+#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT 5

--- a/tt_metal/hw/inc/blackhole/core_config.h
+++ b/tt_metal/hw/inc/blackhole/core_config.h
@@ -49,5 +49,5 @@ constexpr uint8_t NumEthDispatchClasses = 1;
 constexpr uint8_t NumDramDispatchClasses = 1;
 constexpr uint8_t noc_size_x = 17;
 constexpr uint8_t noc_size_y = 12;
-#define ALLOCATOR_ALIGNMENT 32
-#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT 5
+#define ALLOCATOR_ALIGNMENT 64
+#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT 6

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -110,17 +110,9 @@ template <bool DRAM>
 FORCE_INLINE
 uint32_t get_bank_index(uint32_t id, uint32_t bank_offset_index) {
     if constexpr (DRAM) {   // DRAM
-#ifdef IS_NOT_POW2_NUM_DRAM_BANKS
         return id - bank_offset_index * NUM_DRAM_BANKS;
-#else
-        return id & (NUM_DRAM_BANKS - 1);
-#endif
     } else {                // L1
-#ifdef IS_NOT_POW2_NUM_L1_BANKS
         return id - bank_offset_index * NUM_L1_BANKS;
-#else
-        return id & (NUM_L1_BANKS - 1);
-#endif
     }
 }
 

--- a/tt_metal/hw/inc/grayskull/core_config.h
+++ b/tt_metal/hw/inc/grayskull/core_config.h
@@ -32,3 +32,7 @@ enum class TensixProcessorTypes : uint8_t {
 
 constexpr uint8_t MaxProcessorsPerCoreType = 5;
 constexpr uint8_t NumTensixDispatchClasses = 3;
+constexpr uint8_t noc_size_x = 13;
+constexpr uint8_t noc_size_y = 12;
+#define ALLOCATOR_ALIGNMENT 32
+#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT 5

--- a/tt_metal/hw/inc/wormhole/core_config.h
+++ b/tt_metal/hw/inc/wormhole/core_config.h
@@ -40,3 +40,7 @@ enum class EthProcessorTypes : uint8_t {
 constexpr uint8_t MaxProcessorsPerCoreType = 5;
 constexpr uint8_t NumTensixDispatchClasses = 3;
 constexpr uint8_t NumEthDispatchClasses = 1;
+constexpr uint8_t noc_size_x = 10;
+constexpr uint8_t noc_size_y = 12;
+#define ALLOCATOR_ALIGNMENT 32
+#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT 5

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -570,8 +570,8 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "#include <noc/noc_parameters.h>" << endl;
     ss << endl;
 
-    ss << "#define ALLOCATOR_ALIGNMENT " << allocator_alignment << endl;
-    ss << "#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT " << std::bit_width(allocator_alignment) - 1 << endl;
+    //ss << "#define ALLOCATOR_ALIGNMENT " << allocator_alignment << endl;
+    //ss << "#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT " << std::bit_width(allocator_alignment) - 1 << endl;
     ss << "#define NUM_DRAM_BANKS " << dram_bank_map.size() << endl;
     ss << "#define NUM_L1_BANKS " << l1_bank_map.size() << endl;
 
@@ -585,10 +585,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     } else {
         ss << "#define IS_NOT_POW2_NUM_L1_BANKS 1" << endl;
     }
-    ss << endl;
-
-    ss << "constexpr uint8_t noc_size_x = " << grid_size.x << ";" << endl;
-    ss << "constexpr uint8_t noc_size_y = " << grid_size.y << ";" << endl;
     ss << endl;
 
     ss << "static_assert(NUM_NOCS == 2);" << endl;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -570,8 +570,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "#include <noc/noc_parameters.h>" << endl;
     ss << endl;
 
-    //ss << "#define ALLOCATOR_ALIGNMENT " << allocator_alignment << endl;
-    //ss << "#define LOG_BASE_2_OF_ALLOCATOR_ALIGNMENT " << std::bit_width(allocator_alignment) - 1 << endl;
     ss << "#define NUM_DRAM_BANKS " << dram_bank_map.size() << endl;
     ss << "#define NUM_L1_BANKS " << l1_bank_map.size() << endl;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13869

### Problem description
Move certain definition out of JIT build, to kernel specific files header files. 
Remove usage of certain macros in Kernel which are defined in JIT build.

### What's changed
Moved few global variable definition to kernel specific core_config.h
Removed usage of IS_NOT_POW2_NUM_DRAM_BANKS and IS_NOT_POW2_NUM_L1_BANKS in get_bank_index. Did not do the same for get_bank_offset_index as it resulted in grayskull post commit test failure.

### Checklist
- [ x] Post commit CI passes. (https://github.com/tenstorrent/tt-metal/actions/runs/11623398386)
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
