### PR TITLE
#0: Enable UnpackTilize Unit Test for BH

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_untilize_tilize.cpp
@@ -312,7 +312,7 @@ TEST_F(DeviceFixture, ComputeUnpackTilize) {
     for(auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {true, false}) {
             // FP32 dest acc not possible for GS and unpack_tilize hangs on BH -> tt-metal/#13640
-            if ((fp32_dest_acc_en == true) && (this->arch_ != tt::ARCH::WORMHOLE_B0)) continue;
+            if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
             for (bool dst_full_sync_en : {true, false}) {
                 unit_tests::compute::tilize::TestConfig test_config = {
                     .dst_full_sync_en = dst_full_sync_en,
@@ -354,7 +354,7 @@ TEST_F(DeviceFixture, ComputeUnpackTilizeShortInit) {
     for(auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {true, false}) {
             // FP32 dest acc not possible for GS and unpack_tilize hangs on BH -> tt-metal/#13640
-            if ((fp32_dest_acc_en == true) && (this->arch_ != tt::ARCH::WORMHOLE_B0)) continue;
+            if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
             for (bool dst_full_sync_en : {true, false}) {
             unit_tests::compute::tilize::TestConfig test_config = {
                 .short_init = true,

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_untilize_tilize.cpp
@@ -311,7 +311,7 @@ TEST_F(DeviceFixture, ComputeUnpackTilize) {
     vector<vector<uint32_t> > num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
     for(auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {true, false}) {
-            // FP32 dest acc not possible for GS and unpack_tilize hangs on BH -> tt-metal/#13640
+            // FP32 dest acc not possible for GS
             if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
             for (bool dst_full_sync_en : {true, false}) {
                 unit_tests::compute::tilize::TestConfig test_config = {
@@ -353,7 +353,7 @@ TEST_F(DeviceFixture, ComputeUnpackTilizeShortInit) {
     vector<vector<uint32_t> > num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
     for(auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {true, false}) {
-            // FP32 dest acc not possible for GS and unpack_tilize hangs on BH -> tt-metal/#13640
+            // FP32 dest acc not possible for GS
             if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;
             for (bool dst_full_sync_en : {true, false}) {
             unit_tests::compute::tilize::TestConfig test_config = {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Unpack Tilize API Unit tests were skipped for BH although the fix was made in LLK submodule.

### What's changed
Enabled the test for BH.

### Checklist
- [x] Post commit CI passes - [#19210](https://github.com/tenstorrent/tt-metal/actions/runs/11631141760)
- [x] Blackhole Post commit (if applicable - [#1430](https://github.com/tenstorrent/tt-metal/actions/runs/11632829877)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
