### PR TITLE
sanitize_shape refactoring

### DIFF
--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -41,6 +41,7 @@ def sanitize_shape(shape, method, **kwargs):
             min_sum_heads_size = 32 * (3 * num_heads)
         else:
             min_sum_heads_size = 32 * (num_heads + 2 * num_kv_heads)
+            hidden_size = 4672
 
         if hidden_size % min_sum_heads_size != 0:
             if hidden_size < min_sum_heads_size:

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -20,19 +20,6 @@ def sanitize_shape_rm(input_shape):
     return input_shape
 
 
-# at the moment, topk only works on last dim
-# last dim must be a multiple of 64 and a pow of 2
-def santize_topk_shape(input_shape):
-    num_dims = len(input_shape)
-    last_dim = input_shape[num_dims - 1]
-    if not (last_dim & (last_dim - 1) == 0) and last_dim != 0:
-        last_dim = 2 ** math.ceil(math.log2(last_dim))
-        last_dim = last_dim + last_dim % 64
-
-    input_shape[num_dims - 1] = last_dim
-    return input_shape
-
-
 def sanitize_shape(shape, method, **kwargs):
     if method == "topk":
         print(shape)

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -22,7 +22,6 @@ def sanitize_shape_rm(input_shape):
 
 def sanitize_shape(shape, method, **kwargs):
     if method == "topk":
-        print(shape)
         num_dims = len(shape)
         last_dim = shape[num_dims - 1]
         if not (last_dim & (last_dim - 1) == 0) and last_dim != 0:
@@ -30,7 +29,6 @@ def sanitize_shape(shape, method, **kwargs):
             if last_dim < 64:
                 last_dim = 64
         shape[num_dims - 1] = last_dim
-        print(shape)
 
     if method == "split_query_key_value_and_split_heads":
         assert len(shape) == 3

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -11,12 +11,60 @@ import ttnn
 import math
 import itertools
 from typing import Optional, List
+import copy
 
 
 def sanitize_shape_rm(input_shape):
     if input_shape[-1] % 2 != 0:
         input_shape[-1] = input_shape[-1] + input_shape[-1] % 2
     return input_shape
+
+
+# at the moment, topk only works on last dim
+# last dim must be a multiple of 64 and a pow of 2
+def santize_topk_shape(input_shape):
+    num_dims = len(input_shape)
+    last_dim = input_shape[num_dims - 1]
+    if not (last_dim & (last_dim - 1) == 0) and last_dim != 0:
+        last_dim = 2 ** math.ceil(math.log2(last_dim))
+        last_dim = last_dim + last_dim % 64
+
+    input_shape[num_dims - 1] = last_dim
+    return input_shape
+
+
+def sanitize_shape(shape, method, **kwargs):
+    if method == "topk":
+        print(shape)
+        num_dims = len(shape)
+        last_dim = shape[num_dims - 1]
+        if not (last_dim & (last_dim - 1) == 0) and last_dim != 0:
+            last_dim = 2 ** math.ceil(math.log2(last_dim))
+            if last_dim < 64:
+                last_dim = 64
+        shape[num_dims - 1] = last_dim
+        print(shape)
+
+    if method == "split_query_key_value_and_split_heads":
+        assert len(shape) == 3
+
+        hidden_size = shape[2]
+        num_heads = kwargs.pop("num_heads")
+        num_kv_heads = kwargs.pop("num_kv_heads")
+
+        if num_kv_heads is None:
+            min_sum_heads_size = 32 * (3 * num_heads)
+        else:
+            min_sum_heads_size = 32 * (num_heads + 2 * num_kv_heads)
+
+        if hidden_size % min_sum_heads_size != 0:
+            if hidden_size < min_sum_heads_size:
+                hidden_size = min_sum_heads_size
+            else:
+                hidden_size = (hidden_size // min_sum_heads_size) * min_sum_heads_size
+            shape[2] = hidden_size
+
+    return shape
 
 
 def tensor_to_dtype(x, dtype):
@@ -144,49 +192,36 @@ def gen_with_zeroes(size, probabilityzeroes=0.5, low=-100, high=100, dtype=torch
     return mask
 
 
-# at the moment, topk only works on last dim
-# last dim must be a multiple of 64 and a pow of 2
-def santize_topk_shape(input_shape):
-    num_dims = len(input_shape)
-    last_dim = input_shape[num_dims - 1]
-    if not (last_dim & (last_dim - 1) == 0) and last_dim != 0:
-        last_dim = 2 ** math.ceil(math.log2(last_dim))
-        last_dim = last_dim + last_dim % 64
-
-    input_shape[num_dims - 1] = last_dim
-
-    return input_shape
-
-
 def gen_rand_integers(low, high, num_samples):
     for i in range(num_samples):
         yield random.randint(low, high)
 
 
 def gen_split_qkv_heads_spec(
-    batch_size_list: List[int],
-    sequence_size_list: List[int],
-    num_heads_list: List[int],
+    input_shape_list: List[int],
     transpose_key_list: List[bool],
+    num_heads_list: List[int],
     num_kv_heads_list: List[int] = [None],
     kv_input_tensor_list: List[bool] = [False],
     use_invalid_hidden_size=False,
 ):
-    for batch_size, sequence_size, num_heads, num_kv_heads, kv_input_tensor, transpose_key in itertools.product(
-        batch_size_list, sequence_size_list, num_heads_list, num_kv_heads_list, kv_input_tensor_list, transpose_key_list
+    for input_shape, num_heads, num_kv_heads, kv_input_tensor, transpose_key in itertools.product(
+        input_shape_list, num_heads_list, num_kv_heads_list, kv_input_tensor_list, transpose_key_list
     ):
-        if num_kv_heads is None:
-            num_kv_heads = num_heads
+        input_shape_ = input_shape.copy()
+
         if use_invalid_hidden_size is False:
-            head_size = 32 * random.randint(1, 3)
-            hidden_size = head_size * (num_heads + num_kv_heads * 2)
-        else:
-            hidden_size = random.randint(num_heads + num_kv_heads * 2, 2048)
+            input_shape_ = sanitize_shape(
+                input_shape_,
+                "split_query_key_value_and_split_heads",
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+            )
 
         yield {
-            "batch_size": batch_size,
-            "sequence_size": sequence_size,
-            "hidden_size": hidden_size,
+            "batch_size": input_shape_[0],
+            "sequence_size": input_shape_[1],
+            "hidden_size": input_shape_[2],
             "num_heads": num_heads,
             "num_kv_heads": num_kv_heads,
             "kv_input_tensor": kv_input_tensor,

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -16,7 +16,7 @@ import copy
 
 def sanitize_shape_rm(input_shape):
     if input_shape[-1] % 2 != 0:
-        input_shape[-1] = input_shape[-1] + input_shape[-1] % 2
+        input_shape[-1] = input_shape[-1] + 1
     return input_shape
 
 

--- a/tests/sweep_framework/sweep_utils/utils.py
+++ b/tests/sweep_framework/sweep_utils/utils.py
@@ -48,7 +48,8 @@ def sanitize_shape(shape, method, **kwargs):
                 hidden_size = min_sum_heads_size
             else:
                 hidden_size = (hidden_size // min_sum_heads_size) * min_sum_heads_size
-            shape[2] = hidden_size
+
+        shape[2] = hidden_size
 
     return shape
 

--- a/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
+++ b/tests/sweep_framework/sweeps/reduction/argmax/argmax.py
@@ -26,9 +26,9 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 1, 1], [2, 6, 128, 128], [1, 1, 1, 1], 128)
-        + gen_shapes([1, 1, 1], [6, 128, 128], [1, 1, 1], 128)
-        + gen_shapes([1, 1], [128, 128], [1, 1], 128),
+        "input_shape": gen_shapes([1, 1, 1, 1], [2, 6, 128, 128], [1, 1, 1, 1], 32)
+        + gen_shapes([1, 1, 1], [6, 128, 128], [1, 1, 1], 32)
+        + gen_shapes([1, 1], [128, 128], [1, 1], 32),
         "dim": [0, 1, 2, 3, None],
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -124,3 +124,20 @@ def run(
     )
 
     return [(passing, output_str), e2e_perf]
+
+
+from tests.sweep_framework.framework.permutations import *
+
+for suite in parameters.keys():
+    device_id = 0
+    device = ttnn.open_device(device_id=device_id)
+    suite_vectors = list(permutations(parameters[suite]))
+    print(len(suite_vectors))
+    for vector in suite_vectors:
+        if invalidate_vector(vector)[0]:
+            continue
+        passed, _ = run(**vector, device=device)
+        if passed[0] != True:
+            print(passed)
+
+    ttnn.close_device(device)

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -8,7 +8,7 @@ from functools import partial
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes, santize_topk_shape
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_topk_simmilarity
@@ -89,7 +89,7 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    input_shape = santize_topk_shape(input_shape)
+    input_shape = sanitize_shape(input_shape, "topk")
 
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype

--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -124,20 +124,3 @@ def run(
     )
 
     return [(passing, output_str), e2e_perf]
-
-
-from tests.sweep_framework.framework.permutations import *
-
-for suite in parameters.keys():
-    device_id = 0
-    device = ttnn.open_device(device_id=device_id)
-    suite_vectors = list(permutations(parameters[suite]))
-    print(len(suite_vectors))
-    for vector in suite_vectors:
-        if invalidate_vector(vector)[0]:
-            continue
-        passed, _ = run(**vector, device=device)
-        if passed[0] != True:
-            print(passed)
-
-    ttnn.close_device(device)

--- a/tests/sweep_framework/sweeps/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.py
+++ b/tests/sweep_framework/sweeps/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.py
@@ -61,15 +61,10 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
             // (test_vector["input_spec"]["num_heads"] + test_vector["input_spec"]["num_kv_heads"] * 2)
         ) % 32 != 0:
             return True, "Head size must be a multiple of 32"
-        if (
-            test_vector["input_spec"]["hidden_size"] != 4672
-            or test_vector["input_spec"]["num_kv_heads"] != 1
-            or test_vector["input_spec"]["num_heads"] != 71
-        ):
-            return (
-                True,
-                "When using num_kv_heads, hidden_size must be 4672, num_kv_heads must be 1 and num_heads must be 71",
-            )
+        if test_vector["input_spec"]["hidden_size"] != 4672:
+            return True, "When using num_kv_heads, hidden_size must be 4672"
+        if not (test_vector["input_spec"]["num_kv_heads"] == 1 and test_vector["input_spec"]["num_kv_heads"] == 71):
+            return True, "When using num_kv_heads, num_kv_heads must be 1, and num_heads must be 71"
         if test_vector["input_spec"]["transpose_key"] is True:
             return True, "Can't transpose key when using separate kv heads"
     else:


### PR DESCRIPTION
### Problem description
Refactoring all sweeps who use input_shape mutilation (except for row_major sanitize).

### What's changed
1. Added sanitize_shape function in sweep_framework/utils.py
2. Removed sanitize_topk_shape function in sweep_framework/utils.py
3. Refactored split_query_key_value_and_split_heads, split_query_key_value_and_split_heads_kv_input accordingly and included golden functions
4. Refactored topk accordingly
5. Also reduced number of argmax sweep parameters