### PR TITLE
#12549: Fix BH unaligned read issue for tiled interleaved transpose HC

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_transpose.py
@@ -34,7 +34,6 @@ def test_run_transpose_wh_test(input_shapes, device, function_level_defaults):
     run_single_pytorch_test("transpose", input_shapes, datagen_func, comparison_func, device, test_args)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -63,7 +62,6 @@ shape_cn = [
 ]
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("input_shapes", shape_cn)
 def test_run_transpose_cn_test(input_shapes, device, function_level_defaults):
     datagen_func = [
@@ -80,7 +78,6 @@ def test_run_transpose_cn_test(input_shapes, device, function_level_defaults):
     run_single_pytorch_test("transpose", input_shapes, datagen_func, comparison_func, device, test_args)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -55,13 +55,12 @@ def transpose(
         assert device.num_program_cache_entries() == expected_program_cache_size
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),
     ids=["bfloat16", "float"],
 )
-def test_transpose_hc(dtype, device):
+def test_transpose_hc_unit(dtype, device):
     if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull")
 
@@ -95,7 +94,6 @@ def test_transpose_wh_bfp4(device):
     transpose(input_shape, device, dim0=-2, dim1=-1, input_dtype=ttnn.bfloat4_b)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),
@@ -487,7 +485,6 @@ def test_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w, use_progr
     assert device.num_program_cache_entries() == 3
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("n", [16])
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
@@ -527,7 +524,6 @@ def run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache)
     assert_with_pcc(torch_output_tensor, activation_pyt_padded_out, 0.9999)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("n", [20])
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
@@ -610,7 +606,6 @@ def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, u
     assert device.num_program_cache_entries() == 3
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "shape, swap_dims",
     [
@@ -631,7 +626,6 @@ def test_transpose_bfloat8_b(device, shape, swap_dims):
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),
@@ -650,7 +644,6 @@ def test_transpose_hc(dtype, shape, device):
     transpose(shape, device, dim0=1, dim1=-2, input_dtype=dtype)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),
@@ -679,7 +672,6 @@ def test_transpose_2D(dtype, shape, layout, device):
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),
@@ -763,7 +755,6 @@ def test_transpose_failures(config, memory_config, device):
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "config",
     [

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -54,7 +54,8 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
     }
     if (this->dim == TransposeOpDim::HC) {
         if (row_major) {
-            TT_FATAL((W * input_tensor.element_size()) % input_tensor.buffer()->alignment() == 0, "Error");
+            auto BUFFER_ALIGNMENT = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? DRAM_ALIGNMENT : L1_ALIGNMENT;
+            TT_FATAL((W * input_tensor.element_size()) % BUFFER_ALIGNMENT == 0, "Buffer is not aligned for this implementation row_size_bytes {} buffer_alignment {}", W * input_tensor.element_size(), BUFFER_ALIGNMENT);
         } else {
             TT_FATAL(C % TILE_HEIGHT == 0, "Error");
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -486,6 +486,12 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t src0_cb_index = 0;
+    // check if we need to allocate a scratch buffer
+    // The kernel reads several 16 element face lines (32B for BFLOAT16) from different input tiles to form a single output tile, one output tile at a time
+    // Each face line is 32 bytes, so if our minimum read alignment is greater than that (64B for Blackhole) then we will have reads from unaligned face-lines into differently aligned destination face-lines
+    // TODO: noc_async_write only require 16B alignment for both DRAM and L1 for Blackhole, so instead of reading in face-lines from C tiles to form a single tile, we can load a single tile and then write out its face-lines to C tiles
+    uint32_t alignment = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? DRAM_ALIGNMENT : L1_ALIGNMENT;
+    bool misaligned = alignment > sub_tile_line_bytes;
     if (row_major) {
         auto num_sticks = num_tiles_per_core_group_1 > num_tiles_per_core_group_2 ? num_tiles_per_core_group_1 : num_tiles_per_core_group_2;
         auto stick_size = W * a.element_size();
@@ -497,6 +503,14 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
         tt::tt_metal::CircularBufferConfig cb_src0_config = tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
             .set_page_size(src0_cb_index, single_tile_size);
         auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
+
+        // need some scratch memory here - if we need data from a misaligned address then we need to read from the nearest aligned address and then copy the data to the correct location
+        if (misaligned) {
+            uint32_t src1_cb_index = 1;
+            tt::tt_metal::CircularBufferConfig cb_src1_config = tt::tt_metal::CircularBufferConfig(alignment, {{src1_cb_index, cb_data_format}})
+            .set_page_size(src1_cb_index, alignment);
+            auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, total_cores, cb_src1_config);
+        }
     }
 
     tt::tt_metal::Buffer *src0_buffer = a.buffer();
@@ -522,6 +536,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
     } else {
         reader_compile_time_args.push_back((std::uint32_t) sub_tile_line_bytes);
         reader_compile_time_args.push_back((std::uint32_t) (cb_data_format == tt::DataFormat::Float32));
+        reader_compile_time_args.push_back((std::uint32_t) alignment);
     }
     bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> writer_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -57,7 +57,8 @@ inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const Me
     bool tiled_only = false;
     bool pad_n = false;
     constexpr uint32_t FACE_WIDTH = tt::constants::FACE_WIDTH; // this is a highly restrictive constraint on the RM transpose_wh kernel, and with all the other bugs/limitations we should rewrite it
-    auto BUFFER_ALIGNMENT = a.buffer()->alignment(); // Need stick width to be read alignment (currently 32 for DRAM and 16 for L1)
+    // use device->get_allocator_alignment when the it reflects the alignment of the buffer and doesn't just default to DRAM
+    auto BUFFER_ALIGNMENT = a.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? DRAM_ALIGNMENT : L1_ALIGNMENT;
     uint32_t W = a.get_padded_shape()[-1];
     uint32_t H = a.get_padded_shape()[-2];
     switch (transpose_dim) {


### PR DESCRIPTION
- Replace buffer.alignment() calls with buffer type check as buffer.alignment() always returns DRAM alignment even though it's in L1
- Reenable some disabled test
- Fix resnet asserting out on transpose with the buffer.alignment() removal

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
