### PR TITLE
Adds option to save detailed tensors as host agnostic

### DIFF
--- a/ttnn/cpp/ttnn/config.hpp
+++ b/ttnn/cpp/ttnn/config.hpp
@@ -30,6 +30,7 @@ struct Config {
         bool enable_graph_report = false;
         bool enable_detailed_buffer_report = false;
         bool enable_detailed_tensor_report = false;
+        bool enable_detailed_tensor_report_pytorch_converted = false;
         bool enable_comparison_mode = false;
         float comparison_mode_pcc = 0.9999;
         std::filesystem::path root_report_path = "generated/ttnn/reports";
@@ -86,6 +87,18 @@ struct Config {
                         tt::LogAlways,
                         "Logging cannot be enabled in fast runtime mode. Please disable fast runtime mode if you want "
                         "to enable logging.");
+                }
+            }
+        }
+
+        if (
+            name == "enable_detailed_tensor_report_pytorch_converted") {
+            if (not this->attributes.enable_detailed_tensor_report) {
+                if (this->attributes.enable_logging) {
+                    tt::log_warning(
+                        tt::LogAlways,
+                        "Running without detailed tensor report. Please enable detailed tensor report mode if you want "
+                        "to enable saving all tensors as pytorch.");
                 }
             }
         }

--- a/ttnn/cpp/ttnn/config.hpp
+++ b/ttnn/cpp/ttnn/config.hpp
@@ -97,8 +97,8 @@ struct Config {
                 if (this->attributes.enable_logging) {
                     tt::log_warning(
                         tt::LogAlways,
-                        "Running without detailed tensor report. Please enable detailed tensor report mode if you want "
-                        "to enable saving all tensors as pytorch.");
+                        "Running without detailed tensor report. Enable detailed tensor report to enable saving all "
+                        " tensors as PyTorch (.pt) files to enable reading on non-host machines.");
                 }
             }
         }

--- a/ttnn/ttnn/database.py
+++ b/ttnn/ttnn/database.py
@@ -502,6 +502,8 @@ def save_tensor_as_ttnn(tensor, tensor_file_name, detach_saved_tensors):
 
 def save_tensor_as_torch(tensor, tensor_file_name, detach_saved_tensors):
     """Save a torch tensor to file, detaching if necessary."""
+    import torch
+
     if detach_saved_tensors:
         tensor = tensor.detach().cpu()
     torch.save(tensor, tensor_file_name)


### PR DESCRIPTION
# Detach and Cast Tensors to CPU for Non-Host Device Readability

### ~~Ticket~~
~~Link to Github Issue~~

### Problem description

This pull request introduces logic that allows tensors to be detached from the computation graph and cast to the CPU before further processing, based on a configurable flag. The main purpose of this change is to improve the ability to read and handle tensors on non-host devices (e.g., reading tensors originally on a GPU from a CPU-based environment). 

#### Reasoning:

- Detaching Tensors: Using .detach() allows tensors to be separated from the computation graph, preventing unnecessary gradient tracking and reducing memory usage. This is useful when tensors need to be utilized for logging, serialization, or analysis without affecting the computational state.
- Casting to CPU: Applying .cpu() transfers tensors to the CPU, which allows them to be read and processed on devices without access to the original device (such as a GPU). This step ensures that data can be read in environments restricted to CPU processing.

#### Impact:

- Allows tensors to be read, processed, and serialized on non-host devices when the config flag is enabled.
- Facilitates workflows where data from GPU operations needs to be accessed in CPU-only contexts for logging, analysis, or other CPU-bound tasks.
- If the config flag is not enabled, the existing functionality remains unchanged, ensuring that current workflows and operations are not impacted.

These changes provide greater flexibility in tensor handling, enabling cross-device use cases while maintaining existing behavior for environments where the configuration is not applied.

### What's changed
- Adds conditional logic within `database.py` to check for the configuration flag and cast to detached torch tensor if flag is enabled.
- Adds logging output if configuration flag is enabled but detailed tensor reporting is not enabled.
- New configuration name (placeholder, still looking for a good name to describe this configuration): `enable_detailed_tensor_report_pytorch_converted`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
