### PR TITLE
#14610: Split routing_info_t out of dev_msgs.h

### DIFF
--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -15,6 +15,7 @@
 #include "dev_mem_map.h"
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
+#include "routing_info.h"
 
 // TODO: move these to processor specific files
 #if defined(COMPILE_FOR_ERISC)
@@ -333,24 +334,9 @@ static_assert( sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 #endif
 #endif
 
-struct eth_word_t {
-    volatile uint32_t bytes_sent;
-    volatile uint32_t dst_cmd_valid;
-    uint32_t reserved_0;
-    uint32_t reserved_1;
-};
-
 enum class SyncCBConfigRegion : uint8_t {
     DB_TENSIX = 0,
     TENSIX = 1,
     ROUTER_ISSUE = 2,
     ROUTER_COMPLETION = 3,
-};
-
-struct routing_info_t {
-    volatile uint32_t routing_enabled;
-    volatile uint32_t src_sent_valid_cmd;
-    volatile uint32_t dst_acked_valid_cmd;
-    volatile uint32_t unused_arg0;
-    eth_word_t fd_buffer_msgs[2];
 };

--- a/tt_metal/hw/inc/routing_info.h
+++ b/tt_metal/hw/inc/routing_info.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+struct eth_word_t {
+    volatile uint32_t bytes_sent;
+    volatile uint32_t dst_cmd_valid;
+    uint32_t reserved_0;
+    uint32_t reserved_1;
+};
+
+struct routing_info_t {
+    volatile uint32_t routing_enabled;
+    volatile uint32_t src_sent_valid_cmd;
+    volatile uint32_t dst_acked_valid_cmd;
+    volatile uint32_t unused_arg0;
+    eth_word_t fd_buffer_msgs[2];
+};

--- a/tt_metal/hw/inc/routing_info.h
+++ b/tt_metal/hw/inc/routing_info.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 struct eth_word_t {
     volatile uint32_t bytes_sent;
     volatile uint32_t dst_cmd_valid;


### PR DESCRIPTION
### Ticket
#14610 

### Problem description
dev_msgs.h aggregates many things, some are ARCH_NAME specific some are not
When dev_msgs.h is included in any TU that TU now needs to know the ARCH at compile time.
By splitting this header file, TUs that need `routing_info_t` can just include what they need, and not become dependent on ARCH_NAME. This will be useful for `tt_cluster.cpp`.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11637684746
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
