### PR TITLE
#14620: Remove unnecessary ARCH_NAME specific includes from llrt.hpp

### DIFF
--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -4,14 +4,14 @@
 
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <condition_variable>
 #include <functional>
-#include <mutex>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <unistd.h>
 #include <unordered_map>

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -2,19 +2,38 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <memory>
+#include <thread>
 #include <unistd.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
 
 #include "llrt.hpp"
+#include "llrt/rtoptions.hpp"
 #include "hal.hpp"
-#include "hostdevcommon/common_values.hpp"
 
 #include "jit_build/settings.hpp"
 
-#include "fmt/ranges.h"
+#include <fmt/base.h>
+#include <fmt/ranges.h>
 
-#include <unordered_set>
-#include <mutex>
-#include "dev_msgs.h"
+// FIXME: ARCH_NAME specific
+#include "dev_msgs.h" // RUN_MSG_DONE
+#include "eth_l1_address_map.h" // address_map
+
 
 namespace tt {
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -3,22 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
 #include <algorithm>
-#include <filesystem>
-#include <functional>
-#include <iostream>
-#include <random>
-#include <tuple>
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 // clang-format off
 #include "llrt/tt_cluster.hpp"
-#include "tensix.h"
-#include "tt_metal/third_party/umd/device/device_api_metal.h"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
-#include "llrt_common/tiles.hpp"
 #include "llrt/tt_memory.h"
-#include "jit_build/build.hpp"
-#include "dev_msgs.h"
 // clang-format on
 
 namespace tt {

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -8,6 +8,9 @@
 
 #define DATUMS_PER_ROW 16
 
+// FIXME: ARCH_NAME specific include
+#include "tensix_types.h" // DEST_REGISTER_FULL_SIZE
+
 namespace ttnn {
 
 DeviceComputeKernelConfig init_device_compute_kernel_config(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -7,6 +7,9 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 
+// FIXME: ARCH_NAME specific include
+#include "tensix_types.h" // L1_SIZE
+
 using namespace tt::constants;
 using namespace tt;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -7,6 +7,9 @@
 
 #include "tt_metal/host_api.hpp"
 
+// FIXME: ARCH_NAME specific include
+#include "tensix_types.h" // L1_SIZE
+
 namespace ttnn::operations::experimental::transformer {
 
 void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -5,6 +5,9 @@
 #include "topk_op.hpp"
 #include "topk_program_factory.hpp"
 
+// FIXME: ARCH_NAME specific include
+#include "tensix_types.h" // L1_SIZE
+
 namespace topk_utils {
 
 static inline bool verify_available_cores(uint16_t width, uint16_t min_dim, uint16_t max_dim, CoreCoord grid, uint16_t k, const uint32_t value_tile_size, const uint32_t index_tile_size) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -8,6 +8,9 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_log.h"
 
+// FIXME: ARCH_NAME specific include
+#include "tensix_types.h" // L1_SIZE
+
 namespace ttnn::operations::reduction::detail {
 
 operation::ProgramWithCallbacks topk_single_core_interleaved(const Tensor &input_tensor, const uint16_t k, const int8_t dim, Tensor &value_tensor, Tensor &index_tensor) {


### PR DESCRIPTION
### Ticket
Closes #14620

### Problem description
Cannot include tensix.h or dev_msgs.h outside of hal, or you become ARCH_NAME bound at compile time.
While this PR fixes the problem in the llrt.hpp scope, it lays plain that work is to be done in llrt.cpp and ttnn.
See newly filed issue: #14622 

### What's changed
Remove ARCH_NAME specific and unnecessary includes from llrt.hpp

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11640985152
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
