### PR TITLE
#0: Update dprint_server.cpp

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -17,13 +17,11 @@
 
 #include "dprint_server.hpp"
 #include "debug_helpers.hpp"
-#include "llrt/tt_cluster.hpp"
 #include "llrt/rtoptions.hpp"
 #include "common/bfloat8.hpp"
 
 #include "hostdevcommon/dprint_common.h"
 #include "tt_metal/impl/device/device.hpp"
-#include "tensix_types.h"
 
 using std::uint32_t;
 using std::int32_t;


### PR DESCRIPTION
### Ticket
#596 

### Problem description
`tensix_types.h` is ARCH_NAME specific. We can't be directly including these files (outside of hal) if we want to build architecture agnostic.

### What's changed
Remove two unused includes per iwyu tool.
One of them was ARCH_NAME specific.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11659231452
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
