### PR TITLE
#0: Fix for running kernels out of idle erisc cores on WH

### DIFF
--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -175,6 +175,12 @@ int main() {
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
             }
+
+#ifndef ARCH_BLACKHOLE
+            while (1) {
+                RISC_POST_HEARTBEAT(heartbeat);
+            }
+#endif
         }
     }
 


### PR DESCRIPTION
### Ticket
No issue

### Problem description
Recent changes to enable second risc on BH eth caused hangs in running core out of idle erisc cores out of WH. This was caused by removing heartbeat posting.

### What's changed
Add back erroneously removed heartbeat posting


### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11668461244)
- [x] [Single device perf](https://github.com/tenstorrent/tt-metal/actions/runs/11668472935)
