### PR TITLE
#14466: cleanup unary composite

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -11,10 +11,6 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-def torch_mac(input, tensor1, tensor2):
-    return torch.add(torch.mul(input, tensor1), tensor2)
-
-
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_mac_all_tensors(device, h, w):
@@ -23,7 +19,9 @@ def test_mac_all_tensors(device, h, w):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor2 = torch.rand((h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch_mac(torch_input_tensor, torch_input_tensor1, torch_input_tensor2)
+
+    golden_fn = ttnn.get_golden_function(ttnn.mac)
+    torch_output_tensor = golden_fn(torch_input_tensor, torch_input_tensor1, torch_input_tensor2)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor = ttnn.to_device(input_tensor, device)
@@ -49,9 +47,9 @@ def test_mac_tensor_with_2_scalaras(device, h, w, scalar1, scalar2):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor1 = scalar1
     torch_input_tensor2 = scalar2
-    torch_output_tensor = torch.unsqueeze(
-        torch.unsqueeze(torch_mac(torch_input_tensor, torch_input_tensor1, torch_input_tensor2), 0), 0
-    )
+
+    golden_fn = ttnn.get_golden_function(ttnn.mac)
+    torch_output_tensor = golden_fn(torch_input_tensor, torch_input_tensor1, torch_input_tensor2)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor = ttnn.to_device(input_tensor, device)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -106,13 +106,9 @@ Tensor _mac(const Tensor& a, const Tensor& b, const Tensor& c, const std::option
     return ttnn::add(ttnn::multiply(a, b), c);
 }
 
+// y = a * b + c
 Tensor _mac_overload(const Tensor& a, float b, float c, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor t_b = ttnn::operations::creation::create_scalar(b, a.get_dtype(), Layout::TILE, a.device());
-    Tensor t_c = ttnn::operations::creation::create_scalar(c, a.get_dtype(), Layout::TILE, a.device());
-    Tensor return_tensor = _mac(a, t_b, t_c, output_mem_config);
-    t_b.deallocate();
-    t_c.deallocate();
-    return return_tensor;
+    return ttnn::add(ttnn::multiply(a, b, std::nullopt, output_mem_config), c, std::nullopt, output_mem_config);
 }
 
 } // namespace ttnn::operations::ternary


### PR DESCRIPTION
### Ticket
Link to Github Issue #14466

### Problem description
Use binary tensor-scalar support in composite ops instead of creation ops

### What's changed
wherever binary tensor-scalar support is possible, removed usage of creation ops

**on main**
**op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)**
ttnn.cosh,800,0.178,0.184,0.71,0.061
ttnn.hardsigmoid,800,0.185,0.212,0.561,0.056
ttnn.lgamma,120,1.279,1.403,5.029,0.493
ttnn.sinh,800,0.179,0.191,0.71,0.062

vs 
**on branch**
ttnn.cosh,800,0.137,0.144,0.576,0.051
ttnn.hardsigmoid,800,0.091,0.097,0.29,0.031
ttnn.lgamma,120,1.208,1.225,4.953,0.464
ttnn.sinh,800,0.136,0.141,0.576,0.05

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11741081069
https://github.com/tenstorrent/tt-metal/actions/runs/11766921873
- [x] Nightly FD https://github.com/tenstorrent/tt-metal/actions/runs/11741696706
https://github.com/tenstorrent/tt-metal/actions/runs/11766922914
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
