### PR TITLE
Add block aligned CB sync for matmul use case

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -97,6 +97,32 @@ FORCE_INLINE void setup_remote_cb_page_size(uint32_t page_size, uint32_t remote_
     }
 }
 
+FORCE_INLINE void setup_remote_cb_page_size_block_aligned(uint32_t page_size, uint32_t block_size, uint32_t remote_noc_x, uint32_t remote_noc_y, uint8_t noc = noc_index) {
+    uint32_t num_blocks = remote_cb_interface.fifo_size / block_size;
+    uint32_t cb_size_block_aligned = num_blocks * block_size;
+
+    remote_cb_interface.fifo_limit_page_aligned = cb_size_block_aligned + remote_cb_interface.fifo_start_addr;
+    remote_cb_interface.fifo_page_size = page_size;
+    remote_cb_interface.fifo_aligned_num_pages = num_blocks * block_size / remote_cb_interface.aligned_page_size;
+
+    uint32_t curr_fifo_rd_ptr = remote_cb_interface.fifo_rd_ptr;
+    bool fifo_rd_ptr_exceed_fifo_limit = curr_fifo_rd_ptr > remote_cb_interface.fifo_limit_page_aligned;
+    uint32_t num_blocks_till_fifo_limit = (remote_cb_interface.fifo_limit_page_aligned - curr_fifo_rd_ptr) / block_size;
+
+    if (fifo_rd_ptr_exceed_fifo_limit) {
+        remote_cb_interface.fifo_rd_ptr = remote_cb_interface.fifo_start_addr;
+    } else {
+        uint32_t next_fifo_rd_ptr = remote_cb_interface.fifo_limit_page_aligned - num_blocks_till_fifo_limit * block_size;
+        uint32_t pages_acked = (next_fifo_rd_ptr - remote_cb_interface.fifo_rd_ptr) / remote_cb_interface.aligned_page_size;
+        remote_cb_interface.fifo_rd_ptr = next_fifo_rd_ptr;
+
+        // increment the aligned pages acked because we skipped to next aligned page location
+        *remote_cb_interface.pages_acked += pages_acked;
+        uint64_t remote_ack_ptr_addr = get_noc_addr(remote_noc_x, remote_noc_y, (uint32_t)remote_cb_interface.pages_acked, noc);
+        noc_semaphore_inc(remote_ack_ptr_addr, pages_acked, noc);
+    }
+}
+
 FORCE_INLINE void remote_cb_wait_front(uint32_t num_pages) {
     uint32_t len_bytes = num_pages * remote_cb_interface.fifo_page_size;
     uint32_t num_pages_wait = len_bytes / remote_cb_interface.aligned_page_size;
@@ -152,7 +178,8 @@ void kernel_main() {
         uint32_t curr_num_blocks = num_blocks[l];
         uint32_t curr_block_num_tiles = block_num_tiles[l];
 
-        setup_remote_cb_page_size(curr_page_size, noc_x, noc_y);
+        uint32_t curr_block_size = curr_block_num_tiles * curr_page_size;
+        setup_remote_cb_page_size_block_aligned(curr_page_size, curr_block_size, noc_x, noc_y);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
             remote_cb_wait_front(curr_block_num_tiles);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/writer_l1.cpp
@@ -111,6 +111,35 @@ FORCE_INLINE void setup_remote_cb_page_size(uint32_t page_size, uint32_t* remote
     }
 }
 
+FORCE_INLINE void setup_remote_cb_page_size_block_aligned(uint32_t page_size, uint32_t block_size, uint32_t* remote_noc_x, uint32_t* remote_noc_y, uint8_t noc = noc_index) {
+    uint32_t num_blocks = remote_cb_interface.fifo_size / block_size;
+    uint32_t cb_size_block_aligned = num_blocks * block_size;
+
+    remote_cb_interface.fifo_limit_page_aligned = cb_size_block_aligned + remote_cb_interface.fifo_start_addr;
+    remote_cb_interface.fifo_page_size = page_size;
+    remote_cb_interface.fifo_aligned_num_pages = num_blocks * block_size / remote_cb_interface.aligned_page_size;
+
+    uint32_t curr_fifo_wr_ptr = remote_cb_interface.fifo_wr_ptr;
+    bool fifo_wr_ptr_exceed_fifo_limit = curr_fifo_wr_ptr > remote_cb_interface.fifo_limit_page_aligned;
+    uint32_t num_blocks_till_fifo_limit = (remote_cb_interface.fifo_limit_page_aligned - curr_fifo_wr_ptr) / block_size;
+
+    if (fifo_wr_ptr_exceed_fifo_limit) {
+        remote_cb_interface.fifo_wr_ptr = remote_cb_interface.fifo_start_addr;
+    } else {
+        uint32_t next_fifo_wr_ptr = remote_cb_interface.fifo_limit_page_aligned - num_blocks_till_fifo_limit * block_size;
+        uint32_t pages_sent = (next_fifo_wr_ptr - remote_cb_interface.fifo_wr_ptr) / remote_cb_interface.aligned_page_size;
+        remote_cb_interface.fifo_wr_ptr = next_fifo_wr_ptr;
+
+        // increment the aligned pages sent because we skipped to next aligned page location
+        for (uint32_t i=0; i < remote_cb_interface.num_receivers; ++i) {
+            uint32_t remote_noc_xy = uint32_t(NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, remote_noc_x[i]), DYNAMIC_NOC_Y(noc, remote_noc_y[i])));
+            *remote_cb_interface.pages_sent[i] += pages_sent;
+            uint64_t remote_ack_ptr_addr = get_noc_addr_helper(remote_noc_xy, (uint32_t)remote_cb_interface.pages_sent[i]);
+            noc_semaphore_inc(remote_ack_ptr_addr, pages_sent, noc);
+        }
+    }
+}
+
 FORCE_INLINE void remote_cb_reserve_back(uint32_t num_pages) {
     uint32_t len_bytes = num_pages * remote_cb_interface.fifo_page_size;
     uint32_t num_pages_wait = len_bytes / remote_cb_interface.aligned_page_size;
@@ -312,7 +341,8 @@ void kernel_main() {
         uint32_t curr_num_tile_rows = num_tile_rows[l];
         uint32_t curr_receiver_block_num_tiles = curr_block_num_tiles / num_receivers;
 
-        setup_remote_cb_page_size(curr_page_size, noc_x, noc_y, noc);
+        uint32_t curr_block_size = curr_receiver_block_num_tiles * curr_page_size;
+        setup_remote_cb_page_size_block_aligned(curr_page_size, curr_block_size, noc_x, noc_y, noc);
 
         for (uint32_t block = 0; block < curr_num_blocks; ++block) {
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -476,15 +476,12 @@ bool validation_mixed_df(
             page_size = 1088;
         }
         layer_transfer_size = page_size * kt * nt / num_receivers;
-        // num_pages = fifo_size / page_size;
-        // fifo_size_page_aligned = page_size * num_pages;
 
         uint32_t block_size = block_num_tiles * 32*32*2; // fp16
         uint32_t num_blocks = fifo_size / block_size;
         uint32_t cb_size_block_aligned = num_blocks * block_size;
 
         bool fifo_wr_ptr_exceed_fifo_limit = fifo_wr_ptr > cb_size_block_aligned;
-        // uint32_t num_pages_till_fifo_limit = (cb_size_block_aligned - fifo_wr_ptr) / page_size;
         uint32_t num_blocks_till_fifo_limit = (cb_size_block_aligned - fifo_wr_ptr) / block_size;
         // start pointer addr of current layer
         fifo_wr_ptr = fifo_wr_ptr_exceed_fifo_limit ? 0 : cb_size_block_aligned - num_blocks_till_fifo_limit * block_size;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -477,7 +477,7 @@ bool validation_mixed_df(
         }
         layer_transfer_size = page_size * kt * nt / num_receivers;
 
-        uint32_t block_size = block_num_tiles * 32*32*2; // fp16
+        uint32_t block_size = block_num_tiles * tt::constants::TILE_HW * datum_size(tt::DataFormat::Float16_b); // fp16
         uint32_t num_blocks = fifo_size / block_size;
         uint32_t cb_size_block_aligned = num_blocks * block_size;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -461,6 +461,10 @@ bool validation_mixed_df(
     // compare with the result tilized with tilized
     auto values_fp16 = tt::test_utils::tilize(input_tensor_fp16.get_values(), kt*32, nt*32);
 
+    uint32_t block_h = kt / num_blocks;
+    uint32_t block_w = nt;
+    uint32_t block_num_tiles = block_h * block_w;
+
     auto num_datums_per_cb = kt * nt * 32 * 32 / num_blocks * cb_num_blocks / num_receivers;
     int start_index = 0;
     int fifo_size = kt*32 / num_blocks * cb_num_blocks * nt*32 * 2 / num_receivers;
@@ -472,17 +476,22 @@ bool validation_mixed_df(
             page_size = 1088;
         }
         layer_transfer_size = page_size * kt * nt / num_receivers;
-        num_pages = fifo_size / page_size;
-        fifo_size_page_aligned = page_size * num_pages;
+        // num_pages = fifo_size / page_size;
+        // fifo_size_page_aligned = page_size * num_pages;
 
-        bool fifo_wr_ptr_exceed_fifo_limit = fifo_wr_ptr > fifo_size_page_aligned;
-        uint32_t num_pages_till_fifo_limit = (fifo_size_page_aligned - fifo_wr_ptr) / page_size;
+        uint32_t block_size = block_num_tiles * 32*32*2; // fp16
+        uint32_t num_blocks = fifo_size / block_size;
+        uint32_t cb_size_block_aligned = num_blocks * block_size;
+
+        bool fifo_wr_ptr_exceed_fifo_limit = fifo_wr_ptr > cb_size_block_aligned;
+        // uint32_t num_pages_till_fifo_limit = (cb_size_block_aligned - fifo_wr_ptr) / page_size;
+        uint32_t num_blocks_till_fifo_limit = (cb_size_block_aligned - fifo_wr_ptr) / block_size;
         // start pointer addr of current layer
-        fifo_wr_ptr = fifo_wr_ptr_exceed_fifo_limit ? 0 : fifo_size_page_aligned - num_pages_till_fifo_limit * page_size;
+        fifo_wr_ptr = fifo_wr_ptr_exceed_fifo_limit ? 0 : cb_size_block_aligned - num_blocks_till_fifo_limit * block_size;
         // start index to read, fifo_wr_ptr / 2 because fp16 format
-        start_index = fifo_wr_ptr == fifo_size_page_aligned ? 0 : fifo_wr_ptr / 2;
+        start_index = fifo_wr_ptr == cb_size_block_aligned ? 0 : fifo_wr_ptr / 2;
         // end pointer addr of current layer
-        fifo_wr_ptr = (fifo_wr_ptr + layer_transfer_size) % fifo_size_page_aligned;
+        fifo_wr_ptr = (fifo_wr_ptr + layer_transfer_size) % cb_size_block_aligned;
     }
 
     std::vector<std::vector<float> > values_fp16_split(num_receivers, std::vector<float>(values_fp16.size() / num_receivers));


### PR DESCRIPTION
add block aligned CB sync for matmul, since we need to make sure each block is contiguous, so that matmul_block wont break.


### Checklist
- [ ] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/11686744777
- [ ] ubenchmark https://github.com/tenstorrent/tt-metal/actions/runs/11686748632
