### PR TITLE
#0: Permit merges and --fixup

### DIFF
--- a/infra/git_hooks/verify_commit_message.py
+++ b/infra/git_hooks/verify_commit_message.py
@@ -10,7 +10,8 @@ Commit msg must be in the format:
 """
 FORMAT_MSG = "#<GH ISSUE NUMBER> or MET-<JIRA ISSUE NUMBER>: <non-empty message>"
 VALID_PREFIXES = "|".join(["#", "MET-"])
-MATCHING_REGEX = f"^({VALID_PREFIXES})(\d+\:\ .)"
+STANDARD_PREFIXES = "|".join(["Merge remote-tracking branch ", "fixup! "])
+MATCHING_REGEX = f"^(({VALID_PREFIXES})(\d+\:\ .)|({STANDARD_PREFIXES}))"
 
 
 def print_commit_msg(commit_msg_whole):


### PR DESCRIPTION
### Ticket
None

### Problem description
Local dev is hampered by not being able to `git merge` or `git commit --fixup` without also building `--no-verify` into muscle memory (which is not a good muscle memory to develop).

### What's changed
Permit automatic commit messages for merge and fixup commits.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
