### PR TITLE
#14636: Update device_command.hpp

### DIFF
--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -270,7 +270,7 @@ class DeviceCommand {
         } else {
             initialize_mcast_cmd(mcast_cmd_dst);
         }
-        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
     void add_notify_dispatch_s_go_signal_cmd(uint8_t wait) {
@@ -289,7 +289,7 @@ class DeviceCommand {
         } else {
             initialize_sem_update_cmd(dispatch_s_sem_update_dst);
         }
-        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
     template <bool inline_data = false>
@@ -394,7 +394,7 @@ class DeviceCommand {
             initialize_set_unicast_only_cores_cmd(set_unicast_only_cores_cmd_dst);
         }
         uint32_t data_sizeB = noc_encodings.size() * sizeof(uint32_t);
-        uint32_t increment_sizeB = align(data_sizeB, PCIE_ALIGNMENT);
+        uint32_t increment_sizeB = align(data_sizeB, this->pcie_alignment);
         this->add_data(noc_encodings.data(), data_sizeB, increment_sizeB);
     }
 


### PR DESCRIPTION
### Ticket
Closes #14636 

### Problem description
`PCIE_ALIGNMENT` is a constant that comes from noc_parameters.h
This file is `ARCH_NAME` specific.
The constant is already available to be queried at runtime by hal.

### What's changed
Use this->pcie_alignment

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11678277691
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
