### PR TITLE
#13794: Relax auto-shard rules for block sharding

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -315,8 +315,6 @@ static TensorMemoryLayout select_shard_spec(
     uint32_t weights_width,
     uint32_t input_width,
     ShardOrientation shard_orientation,
-    const std::array<uint32_t, 2>& kernel_size,
-    const std::array<uint32_t, 2>& stride,
     const CoreCoord& compute_grid_size) {
     auto get_core_count_for_sharding = [&](TensorMemoryLayout shard_layout) {
         return determine_parallel_config(
@@ -331,11 +329,6 @@ static TensorMemoryLayout select_shard_spec(
             .grid.num_cores();
     };
 
-    // Block sharding supports very few kernel dims.
-    const bool is_block_sharding_valid =
-        (kernel_size[0] == 3 && kernel_size[1] == 3 && (stride[0] == 1 || stride[0] == 2)) ||
-        (kernel_size[0] == 1 && kernel_size[1] == 1 && stride[0] == 2);
-
     // 1d convs support only height sharding
     const bool is_conv1d = weights_width == 1 && input_width == 1;
 
@@ -343,8 +336,7 @@ static TensorMemoryLayout select_shard_spec(
     // matmul doesn't support width sharding
     const uint32_t cc_width =
         !is_mm_conv && !is_conv1d ? get_core_count_for_sharding(TensorMemoryLayout::WIDTH_SHARDED) : 0;
-    const uint32_t cc_block =
-        (is_block_sharding_valid || is_mm_conv) && !is_conv1d ? get_core_count_for_sharding(TensorMemoryLayout::BLOCK_SHARDED) : 0;
+    const uint32_t cc_block = !is_conv1d ? get_core_count_for_sharding(TensorMemoryLayout::BLOCK_SHARDED) : 0;
 
     uint32_t max_cc = cc_block;
     TensorMemoryLayout shard_layout = TensorMemoryLayout::BLOCK_SHARDED;
@@ -763,8 +755,6 @@ static void adjust_conv_op_config_for_auto_shard(
     uint32_t output_width,
     uint32_t weights_width,
     uint32_t input_width,
-    const std::array<uint32_t, 2>& kernel_size,
-    const std::array<uint32_t, 2>& stride,
     const CoreCoord& compute_grid_size,
     Conv2dConfig& conv_config) {
     ShardOrientation shard_orientation =
@@ -779,8 +769,6 @@ static void adjust_conv_op_config_for_auto_shard(
         weights_width,
         input_width,
         shard_orientation,
-        kernel_size,
-        stride,
         compute_grid_size);
 
     if (conv_config.act_block_h_override == 0 && conv_config.shard_layout != TensorMemoryLayout::WIDTH_SHARDED) {
@@ -833,8 +821,6 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             output_width,
             weight_tensor.get_shape()[3],
             input_width,
-            kernel_size,
-            stride,
             device->compute_with_storage_grid_size(),
             conv_config);
     }


### PR DESCRIPTION
#d28568c5 added support for arbitrary kernel dims for block sharded conv2d.
This commit relaxes rules for auto-shard codepath, so that auto-shard heuristic can pick block-sharding for any kernel dims.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
