### PR TITLE
#0: Sub sweep test

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/binary/add/add_all_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/add/add_all_pytorch2.py
@@ -14,20 +14,16 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "nov5_5": {
         "input_shape": [
-            {"self": [0, 1], "other": [0, 1]},
-            {"self": [0], "other": [0]},
+            {"self": [0, 1], "other": [0, 1]},  # 0 is not a valid shape
+            {"self": [0], "other": [0]},  # 0 is not a valid shape
             {"self": [1, 1, 1024], "other": [1, 1, 1024]},
             {"self": [1, 1, 16, 32], "other": [1, 1, 16, 32]},
             {"self": [1, 1, 3072], "other": [1, 1, 3072]},
@@ -403,7 +399,7 @@ parameters = {
             {"self": [8732, 1], "other": [8732, 1]},
             {"self": [8732, 2], "other": [8732, 2]},
             {"self": [8732], "other": [8732]},
-            {"self": [], "other": []},
+            {"self": [], "other": []},  # without empty tensor
             {"self": [920, 1, 256], "other": [256]},
             {"self": [920, 1, 256], "other": [920, 1, 256]},
             {"self": [1, 1, 1, 42], "other": -6.0},
@@ -504,7 +500,7 @@ parameters = {
             {"self": [7], "other": 0.0},
             {"self": [800], "other": 0.5},
             {"self": [80], "other": 0.5},
-            {"self": [], "other": 1},
+            {"self": [], "other": 1},  # without empty tensor
         ],
         # {"self": [s0 + 1, s0 + 1], "other": 16},
         # {"self": [s0 + 1, s0 + 1], "other": 0},
@@ -527,10 +523,30 @@ parameters = {
         "input_b_dtype": [ttnn.bfloat16],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
+        # "input_a_memory_config": [ttnn.L1_MEMORY_CONFIG,],
+        # "input_b_memory_config": [ttnn.L1_MEMORY_CONFIG,],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid. len(test_vector["input_shape"]["other"]) >= 4
+# def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+#     if isinstance(test_vector["input_shape"]["other"], list) and len(test_vector["input_shape"]["self"]) >= 4:
+#         is_less_than_3d = len(test_vector["input_shape"]["other"]) < 3
+#         c_index = test_vector["input_shape"]["self"][-3]
+#         if is_less_than_3d or (
+#             len(test_vector["input_shape"]["other"]) >= 3 and test_vector["input_shape"]["other"][-3] < c_index
+#         ):
+#             print("checking channel bcast")
+#             print("input ", test_vector["input_shape"]["self"])
+#             print("other ", test_vector["input_shape"]["other"])
+#             return True, "channel dim bcast not supported"
+
+#     return False, None
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -548,19 +564,23 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
-        torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-        )(input_shape["other"])
+        if len(input_shape["other"]):
+            torch_input_tensor_b = gen_func_with_cast_tt(
+                partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+            )(input_shape["other"])
+        else:
+            print("input shape", input_shape)
+            torch_input_tensor_b = torch.tensor(0, dtype=torch.bfloat16)
+            print("torch_input_tensor_b shape", torch_input_tensor_b)
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
         # torch_input_tensor_b = input_shape["other"]
 
     golden_function = ttnn.get_golden_function(ttnn.add)
@@ -587,7 +607,13 @@ def run(
 
     start_time = start_measuring_time()
     result = ttnn.add(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(result)
+
+    # handles 1 D input_a and scalar or empty [] input_b
+    if len(input_shape["self"]) == 1 and (not isinstance(input_shape["other"], list) or not input_shape["other"]):
+        output_tensor = ttnn.to_torch(result, original_shape=input_shape["self"])
+    else:
+        output_tensor = ttnn.to_torch(result)
+
     e2e_perf = stop_measuring_time(start_time)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.9999), e2e_perf]
+    return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/div/div_tensor_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/div/div_tensor_pytorch2.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -14,14 +13,9 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
-
 
 parameters = {
-    "nightly": {
+    "nightly_14": {
         "input_specs": [
             {"shape": [0, 1], "other": 1.0},
             {"shape": [1, 1, 16384, 256], "other": 5.656854249492381},
@@ -143,8 +137,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     input_shape = input_specs["shape"]
     if len(input_shape) == 0:
@@ -186,7 +179,14 @@ def run(
     start_time = start_measuring_time()
 
     output_tensor = ttnn.divide(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+
+    # handles 1 D input_a and scalar or empty [] input_b
+    if len(input_specs["shape"]) == 1 and (
+        not isinstance(input_specs["other"], list) or not input_specs["other"] or len(input_specs["other"]) == 1
+    ):
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_specs["shape"])
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
 
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/eltwise/binary/eq/eq_scalar_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/eq/eq_scalar_pytorch2.py
@@ -25,7 +25,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_1": {
         "input_shape": [
             [1, 1, 256],
             [1, 16],
@@ -83,7 +83,11 @@ def run(
 
     start_time = start_measuring_time()
     output_tensor = ttnn.eq(input_tensor_a, scalar, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/floor_divide/floor_divide_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/floor_divide/floor_divide_pytorch2.py
@@ -25,7 +25,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_1": {
         "input_shape": [
             [128],
         ],
@@ -91,7 +91,11 @@ def run(
 
     start_time = start_measuring_time()
     output_tensor = ttnn.floor_div(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/gt/gt_scalar_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/gt/gt_scalar_pytorch2.py
@@ -25,11 +25,11 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_1": {
         "input_shape": [
             [10, 10],
             [15, 15],
-            [],
+            [],  # how should this be tested ?
         ],
         "scalar": [0, 0],
         "input_a_dtype": [ttnn.bfloat16],
@@ -74,7 +74,11 @@ def run(
 
     start_time = start_measuring_time()
     output_tensor = ttnn.gt(input_tensor_a, scalar, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/multiply/mul_tensor_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/multiply/mul_tensor_pytorch2.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -14,19 +13,15 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "nov5_5": {
         "input_shape": [
-            {"self": [0], "other": 0.5},
+            {"self": [0], "other": 0.5},  # is [0] a valid shape ?
             {"self": [1, 1, 1, 10], "other": -3.4028234663852886e38},
             {"self": [1, 1, 1, 12], "other": -3.4028234663852886e38},
             {"self": [1, 1, 1, 14], "other": -3.4028234663852886e38},
@@ -191,8 +186,8 @@ parameters = {
             {"self": [8732, 2], "other": 0.5},
             {"self": [8732], "other": 0.5},
             # vec other
-            {"self": [0, 1], "other": [0, 1]},
-            {"self": [0], "other": []},
+            {"self": [0, 1], "other": [0, 1]},  # invalid shape
+            {"self": [0], "other": []},  # invalid shape [0]
             {"self": [1, 1, 1, 17], "other": [1, 1, 1, 17]},
             {"self": [1, 1, 1, 1], "other": [1, 1, 1, 1]},
             {"self": [1, 1, 1, 2], "other": [1, 1, 1, 2]},
@@ -401,15 +396,52 @@ parameters = {
             {"self": [], "other": [1, 24, 768]},
             {"self": [], "other": [3234, 1]},
             {"self": [], "other": [8732, 1]},
+            # untested
+            # |  25 | Tensor<[1, 1, 1, s0 + 1]> self = ?,<br>Tensor other = -3.3895313892515355e+38
+            # |  26 | Tensor<[1, 1, 1, s0 + 1]> self = ?,<br>Tensor<[1, 1, 1, s0 + 1]> other = ?
+            # | 281 | Tensor<[1, s0*s1, 2560]> self = ?,<br>Tensor<[1, s0*s1, 2560]> other = ?
+            # | 282 | Tensor<[1, s0*s1, 5120]> self = ?,<br>Tensor<[1, s0*s1, 5120]> other = ?
+            # | 283 | Tensor<[1, s1*s2, 1280]> self = ?,<br>Tensor<[1, s1*s2, 1280]> other = ?
+            # | 284 | Tensor<[1, s1*s2, 2560]> self = ?,<br>Tensor<[1, s1*s2, 2560]> other = ?
+            # | 285 | Tensor<[1, s1*s2, 5120]> self = ?,<br>Tensor<[1, s1*s2, 5120]> other = ?
+            # | 286 | Tensor<[1, s10 + 1]> self = ?,<br>Tensor<[1, s10 + 1]> other = ?
+            # | 320 | Tensor<[2*s0]> self = ?,<br>Tensor<0.500000000000000> other = ?
+            # | 321 | Tensor<[2*s1]> self = ?,<br>Tensor<0.500000000000000> other = ?
+            # | 322 | Tensor<[2*s2]> self = ?,<br>Tensor<0.500000000000000> other = ?
+            # | 391 | Tensor<[s0 + 1, s0 + 1]> self = ?,<br>Tensor other = 16
         ],
         "input_a_dtype": [ttnn.bfloat16],
         "input_b_dtype": [ttnn.bfloat16],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        # "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        # "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "input_a_memory_config": [ttnn.L1_MEMORY_CONFIG],
+        "input_b_memory_config": [ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid. len(test_vector["input_shape"]["other"]) >= 4
+# def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+#     if len(test_vector["input_shape"]["self"]) == 0 or (
+#         isinstance(test_vector["input_shape"]["other"], list) and len(test_vector["input_shape"]["other"]) == 0
+#     ):
+#         return True, "empty shape not supported"
+# if isinstance(test_vector["input_shape"]["other"], list) and len(test_vector["input_shape"]["self"]) >= 4:
+#     is_less_than_3d = len(test_vector["input_shape"]["other"]) < 3
+#     c_index = test_vector["input_shape"]["self"][-3]
+#     if is_less_than_3d or (
+#         len(test_vector["input_shape"]["other"]) >= 3 and test_vector["input_shape"]["other"][-3] < c_index
+#     ):
+#         print("checking channel bcast")
+#         print("input ", test_vector["input_shape"]["self"])
+#         print("other ", test_vector["input_shape"]["other"])
+#         return True, "channel dim bcast not supported"
+
+# return False, None
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -427,19 +459,21 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype
     )(input_shape["self"])
 
     if isinstance(input_shape["other"], list):
-        torch_input_tensor_b = gen_func_with_cast_tt(
-            partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-        )(input_shape["other"])
+        if len(input_shape["other"]):
+            torch_input_tensor_b = gen_func_with_cast_tt(
+                partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_b_dtype
+            )(input_shape["other"])
+        else:
+            torch_input_tensor_b = torch.tensor(0, dtype=torch.bfloat16)
     else:
-        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.float32)
+        torch_input_tensor_b = torch.tensor(input_shape["other"], dtype=torch.bfloat16)
         # torch_input_tensor_b = input_shape["other"]
 
     golden_function = ttnn.get_golden_function(ttnn.mul)
@@ -466,7 +500,11 @@ def run(
 
     start_time = start_measuring_time()
     result = ttnn.mul(input_tensor_a, input_tensor_b)
-    output_tensor = ttnn.to_torch(result)
+    # handles 1 D input_a and scalar or empty [] input_b
+    if len(input_shape["self"]) == 1 and (not isinstance(input_shape["other"], list) or not input_shape["other"]):
+        output_tensor = ttnn.to_torch(result, original_shape=input_shape["self"])
+    else:
+        output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_scalar_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_scalar_pytorch2.py
@@ -25,7 +25,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_1": {
         "input_shape": [
             [1],
         ],
@@ -72,7 +72,11 @@ def run(
 
     start_time = start_measuring_time()
     output_tensor = ttnn.remainder(input_tensor_a, scalar, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_tensor_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_tensor_pytorch2.py
@@ -17,8 +17,8 @@ from models.utility_functions import torch_random
 parameters = {
     "subtract_test": {
         "input_specs": [
-            {"shape": [0, 1], "other": [0, 1]},
-            {"shape": [0], "other": [0]},
+            # {"shape": [0, 1], "other": [0, 1]},
+            # {"shape": [0], "other": [0]},
             {"shape": [1, 1, 1, 42], "other": -3.0},
             {"shape": [1, 1, 1, 42], "other": -3.75},
             {"shape": [1, 1, 1, 42], "other": 0.5},

--- a/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_tensor_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_tensor_pytorch2.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -14,13 +13,9 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
-TIMEOUT = 30
-
-random.seed(0)
-
 
 parameters = {
-    "nightly": {
+    "nightly_17": {
         "input_specs": [
             {"shape": [0, 1], "other": [0, 1]},
             {"shape": [0], "other": [0]},
@@ -127,8 +122,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     input_shape = input_specs["shape"]
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -143,8 +137,8 @@ def run(
             partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
         )(other)
 
-    golden_function = ttnn.get_golden_function(ttnn.sub)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_other_tensor)
+    # golden_function = ttnn.get_golden_function(ttnn.sub)
+    torch_output_tensor = torch.sub(torch_input_tensor_a, torch_other_tensor)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -161,12 +155,18 @@ def run(
         device=device,
         memory_config=input_b_memory_config,
     )
-
     start_time = start_measuring_time()
 
     output_tensor = ttnn.subtract(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+
+    # handles 1 D input_a and scalar or empty [] input_b
+    if len(input_specs["shape"]) == 1 and (
+        not isinstance(input_specs["other"], list) or not input_specs["other"] or len(input_specs["other"]) == 1
+    ):
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_specs["shape"])
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
 
     e2e_perf = stop_measuring_time(start_time)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.99), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_tensor_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/subtract/subtract_tensor_pytorch2.py
@@ -15,7 +15,7 @@ from models.utility_functions import torch_random
 
 
 parameters = {
-    "nightly_17": {
+    "subtract_test": {
         "input_specs": [
             {"shape": [0, 1], "other": [0, 1]},
             {"shape": [0], "other": [0]},

--- a/tests/sweep_framework/sweeps/eltwise/unary/ceil/ceil_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/ceil/ceil_pytorch2.py
@@ -24,7 +24,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_1": {
         "input_shape": [[1066], [120], [128], [160], [240], [300], [30], [320], [40], [480], [60], [640], [800], [80]],
         "input_a_dtype": [ttnn.bfloat16],
         "input_a_layout": [ttnn.TILE_LAYOUT],
@@ -74,8 +74,12 @@ def run(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.ceil(input_tensor_a, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(result)
+    output_tensor = ttnn.ceil(input_tensor_a, memory_config=output_memory_config)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/exp/exp_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/exp/exp_pytorch2.py
@@ -24,9 +24,9 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_1": {
         "input_shape": [
-            [0, 1],
+            [0, 1],  # this is an invalid shape
             [12, 1, 1],
             [16, 1, 1],
             [160],
@@ -38,7 +38,7 @@ parameters = {
             [6, 1, 1],
             [8, 1, 1],
             [8732, 1],
-            [],
+            [],  # no support for [ ] shape
         ],
         "input_a_dtype": [ttnn.bfloat16],
         "input_a_layout": [ttnn.TILE_LAYOUT],
@@ -81,7 +81,11 @@ def run(
 
     start_time = start_measuring_time()
     result = ttnn.exp(input_tensor_a, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(result)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(result, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/hardtanh/hardtanh_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/hardtanh/hardtanh_pytorch2.py
@@ -15,7 +15,7 @@ from models.utility_functions import torch_random
 
 
 parameters = {
-    "nightly": {
+    "nov5_3": {
         "input_specs": [
             {"shape": [1, 1024, 7, 7], "min_val": 0.0, "max_val": 6.0},
             {"shape": [1, 1152, 7, 7], "min_val": 0.0, "max_val": 6.0},
@@ -158,7 +158,7 @@ def run(
 
     golden_function = ttnn.get_golden_function(ttnn.hardtanh)
     torch_output_tensor = golden_function(torch_input_tensor_a, min_val=min_val, max_val=max_val)
-
+    
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_dtype,

--- a/tests/sweep_framework/sweeps/eltwise/unary/rsub/rsub_pytorch2.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/rsub/rsub_pytorch2.py
@@ -25,7 +25,7 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "pass_2_bf16": {
         "input_shape": [
             [1, 1, 1, 10],
             [1, 1, 1, 12],
@@ -78,7 +78,7 @@ parameters = {
             [800, 1],
             [80],
         ],
-        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat16],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -121,7 +121,11 @@ def run(
 
     start_time = start_measuring_time()
     output_tensor = ttnn.rsub(input_tensor_a, value=factor, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
+    # to handle 1D inputs giving 2D outputs
+    if len(input_shape) == 1:
+        output_tensor = ttnn.to_torch(output_tensor, original_shape=input_shape)
+    else:
+        output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -93,6 +93,11 @@ def run(test_module, input_queue, output_queue):
                 output_queue.put([status, message, e2e_perf, perf_result])
             else:
                 output_queue.put([status, message, e2e_perf, None])
+            if not status:
+                print("-----------------------")
+                print("current parameter ", test_vector)
+                print("STATUS", status)
+                print("message", message)
     except Empty as e:
         try:
             # Run teardown in mesh_device_fixture

--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -94,10 +94,14 @@ def run(test_module, input_queue, output_queue):
             else:
                 output_queue.put([status, message, e2e_perf, None])
             if not status:
-                print("-----------------------")
-                print("current parameter ", test_vector)
-                print("STATUS", status)
-                print("message", message)
+                try:
+                    float(message)
+                    print("message", message)
+                except (TypeError, ValueError):
+                    print("-----------------------")
+                    print("current parameter ", test_vector)
+                    print("STATUS", status)
+                    print("message", message)
     except Empty as e:
         try:
             # Run teardown in mesh_device_fixture

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
@@ -88,3 +88,20 @@ def test_sub_4D(device, n, c, h, w):
     output = ttnn.to_torch(output)
 
     assert_with_pcc(torch_output_tensor, output, 0.9999)
+
+
+@pytest.mark.parametrize("shapes", [[[1, 10], [10, 1]], [[10, 1], [1, 10]]])
+def test_sub_pcc_fail(device, shapes):
+    print(shapes)
+    torch_input_tensor_a = torch.ones(shapes[0], dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.ones(shapes[1], dtype=torch.bfloat16)
+    torch_output_tensor = torch.sub(torch_input_tensor_a, torch_input_tensor_b)
+    print("torch_output_tensor", torch_output_tensor)
+    print("torch_output_tensor", torch_output_tensor.shape)
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output = ttnn.sub(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+    print("ttnn", output)
+
+    assert_with_pcc(torch_output_tensor, output, 0.999)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -194,7 +194,12 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     const std::optional<Tensor> &optional_output_tensor,
     std::optional<unary::FusedActivations> activations,
     std::optional<unary::UnaryWithParam> input_tensor_a_activation) {
-    return ttnn::prim::binary(
+
+    if(binary_op_type == BinaryOpType::DIV_FAST && scalar != 0){
+        return ttnn::div_sfpu(queue_id, input_tensor_a, scalar, memory_config, optional_output_tensor);
+    }
+    else {
+        return ttnn::prim::binary(
         queue_id,
         input_tensor_a,
         scalar,
@@ -204,6 +209,7 @@ Tensor BinaryOperation<binary_op_type>::invoke(
         optional_output_tensor,
         activations,
         input_tensor_a_activation);
+    }
 }
 
 // TODO: this case should use BinaryWithScalarProgramConfig and there should be a custom kernel to run this

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -158,12 +158,13 @@ def from_torch(
     device: Optional[ttnn.Device] = None,
     memory_config: Optional[ttnn.MemoryConfig] = None,
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
-) -> ttnn.Tensor:
+) -> Union[ttnn.Tensor, float, int]:
     """
     Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. For bfloat8_b or bfloat4_b format, the function itself is called twice,
     first call runs in bfloat16 format, and calls to_layout to convert from row_major layout to tile layout (for padding purpose in case input
     is not tile padded). Second call runs in desired format and does not call to_layout for bfloat8_b or bfloat4_b as we now convert
     to tile layout during tensor creation (ttnn.Tensor).
+    Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. A 0-dimensional torch Tensor is converted to a scalar value.
 
     Args:
         tensor (torch.Tensor): the input tensor.
@@ -187,6 +188,8 @@ def from_torch(
     """
 
     shape_with_padding = None
+    if tensor.dim() == 0:
+        return tensor.item()
     if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
         if len(tensor.shape) < 2:
             raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires at least 2 dimensions!")
@@ -256,6 +259,7 @@ def to_torch(
     torch_rank: Optional[int] = None,
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
     device: Optional[ttnn.Device] = None,
+    original_shape: Optional[list] = None,
     cq_id: Optional[int] = 0,
 ) -> "torch.Tensor":
     """
@@ -302,6 +306,11 @@ def to_torch(
     tensor = tensor.to_torch()
     slices = [slice(None, x) for x in shape_without_tile_padding]
     tensor = tensor[slices]
+
+    # to handle 1D inputs giving 2D outputs
+    if original_shape is not None and len(original_shape) == 1:
+        if tensor.shape[0] == 1:
+            tensor = torch.squeeze(tensor, 0)
 
     if torch_rank is not None:
         while len(tensor.shape) > torch_rank:


### PR DESCRIPTION
From PR: https://github.com/tenstorrent/tt-metal/pull/14280
Issues faced : 

- `round_up: multiple must not be 0`
  - Shapes : 
    - {"shape": [0, 1], "other": [0, 1]}
    - {"shape": [0], "other": [0]},
<img width="955" alt="Screenshot 2024-11-05 at 3 50 49 PM" src="https://github.com/user-attachments/assets/4ad48378-273f-4107-906d-5893a73799c1">

- PCC Drop due to broadcasting
