### PR TITLE
UMD bump: Remove usage of create-ethernet-map

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -127,38 +127,6 @@ void Cluster::detect_arch_and_target() {
         this->target_type_);
 }
 
-std::filesystem::path get_cluster_desc_yaml() {
-    namespace fs = std::filesystem;
-
-    // TODO: The interface into create-ethernet-map should be through an API rather a
-    // subprocess call to the binary
-    const fs::path tt_metal_dir = fs::path(tt::llrt::OptionsG.get_root_dir()) / "tt_metal";
-    const fs::path umd_path = fs::path(tt::llrt::OptionsG.get_root_dir()) / ".umd";
-    fs::create_directory(umd_path);
-    const fs::path cluster_desc_path = umd_path / "cluster_desc.yaml";
-    if (!fs::exists(cluster_desc_path)) {
-        auto val = system(("touch " + cluster_desc_path.string()).c_str());
-        if (val != 0)
-            throw std::runtime_error("YAML Cluster folder and file before create-ethernet-map failed!");
-    }
-
-    // Generates the cluster descriptor in the CWD
-
-#if defined(__x86_64__) || defined(__i386__)
-    const fs::path eth_fpath = tt_metal_dir / "third_party/umd/device/bin/silicon/x86/create-ethernet-map";
-#elif defined(__aarch64__) || defined(_M_ARM64)
-    const fs::path eth_fpath = tt_metal_dir / "third_party/umd/device/bin/silicon/aarch64/create-ethernet-map";
-#else
-#error "Unsupported host architecture"
-#endif
-    std::string cmd = eth_fpath.string() + " " + cluster_desc_path.string();
-    int val = system(cmd.c_str());
-    if (val != 0)
-        throw std::runtime_error("Cluster Generation with create-ethernet-map Failed!");
-
-    return fs::absolute(cluster_desc_path);
-}
-
 bool Cluster::is_galaxy_cluster() const {
     return this->is_tg_cluster_;
 }
@@ -169,10 +137,10 @@ BoardType Cluster::get_board_type(chip_id_t chip_id) const {
 
 void Cluster::generate_cluster_descriptor() {
     this->cluster_desc_path_ = (this->target_type_ == TargetDevice::Silicon and this->arch_ == tt::ARCH::WORMHOLE_B0)
-                                   ? get_cluster_desc_yaml().string()
+                                   ? tt_ClusterDescriptor::get_cluster_descriptor_file_path().string()
                                    : "";
 
-    // create-eth-map not available for Blackhole bring up
+    // Cluster descriptor yaml not available for Blackhole bring up
     if (this->arch_ == tt::ARCH::GRAYSKULL or this->arch_ == tt::ARCH::BLACKHOLE or this->target_type_ == TargetDevice::Simulator) {
         // Cannot use tt_SiliconDevice::detect_available_device_ids because that returns physical device IDs
         std::vector<chip_id_t> physical_mmio_device_ids;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -137,7 +137,7 @@ BoardType Cluster::get_board_type(chip_id_t chip_id) const {
 
 void Cluster::generate_cluster_descriptor() {
     this->cluster_desc_path_ = (this->target_type_ == TargetDevice::Silicon and this->arch_ == tt::ARCH::WORMHOLE_B0)
-                                   ? tt_ClusterDescriptor::get_cluster_descriptor_file_path().string()
+                                   ? tt_ClusterDescriptor::get_cluster_descriptor_file_path()
                                    : "";
 
     // Cluster descriptor yaml not available for Blackhole bring up

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -33,6 +33,7 @@
 #include "third_party/umd/device/tt_soc_descriptor.h"
 #include "third_party/umd/device/tt_xy_pair.h"
 #include "third_party/umd/device/xy_pair.h"
+#include "third_party/umd/device/hugepage.h"
 
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
@@ -180,7 +181,7 @@ void Cluster::generate_cluster_descriptor() {
         }
     }
 
-    uint32_t total_num_hugepages = get_num_hugepages();
+    uint32_t total_num_hugepages = tt::umd::get_num_hugepages();
     if (this->is_tg_cluster_) {
         // TODO: don't think this check is correct, we want to have total num hugepages == num chips even for Galaxy
         TT_FATAL(


### PR DESCRIPTION
### Ticket
Related to #13948 

### What's changed
Related UMD PR: https://github.com/tenstorrent/tt-umd/pull/245

Remove usage of create-ethernet-map. This is now a static lib in UMD, and UMD now offers an interface to get cluster yaml. In following PRs even this will be removed, and won't be visible to clients at all.

The change points to a non-main branch for purposes of having approval before completing UMD PR, but this PR will be switched to point to UMD main before checked in.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11700690832
- [x] Blackhole Post commit (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/11700703747
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
