### PR TITLE
#14741: Add implementation and basic tests for global semaphores

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/ethernet/device_cluster_api.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ethernet/erisc_app_direct_send.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ethernet/ring_gather_kernels.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/global_semaphore/test_global_semaphores.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_stl/test_any_range.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_stl/slotmap.cpp
 )

--- a/tests/tt_metal/tt_metal/unit_tests/global_semaphore/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/global_semaphore/test_global_semaphores.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "device_fixture.hpp"
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/buffers/global_semaphore.hpp"
+
+TEST_F(DeviceFixture, InitializeGlobalSemaphores) {
+    CoreRangeSet cores(CoreRange({0, 0}, {1, 1}));
+
+    auto cores_vec = corerange_to_cores(cores);
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto device = devices_.at(id);
+        {
+            uint32_t initial_value = 1;
+            auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
+            auto address = global_semaphore->address();
+
+            for (const auto& core : cores_vec) {
+                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                    device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
+
+                EXPECT_EQ(sem_vals[0], initial_value);
+            }
+        }
+        {
+            uint32_t initial_value = 2;
+            auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
+            auto address = global_semaphore->address();
+
+            for (const auto& core : cores_vec) {
+                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                    device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
+                EXPECT_EQ(sem_vals[0], initial_value);
+            }
+        }
+    }
+}
+
+TEST_F(DeviceFixture, CreateMultipleGlobalSemaphoresOnSameCore) {
+    std::vector<CoreRangeSet> cores{CoreRange({0, 0}, {1, 1}), CoreRange({0, 0}, {2, 2}), CoreRange({3, 3}, {5, 6})};
+    std::vector<std::vector<CoreCoord>> cores_vecs;
+    cores_vecs.reserve(cores.size());
+    std::vector<uint32_t> initial_values{1, 2, 3};
+    for (const auto& crs : cores) {
+        cores_vecs.push_back(corerange_to_cores(crs));
+    }
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto device = devices_.at(id);
+        {
+            std::vector<std::unique_ptr<tt::tt_metal::GlobalSemaphore>> global_semaphores;
+            global_semaphores.reserve(cores.size());
+            std::vector<DeviceAddr> addresses;
+            addresses.reserve(cores.size());
+            for (size_t i = 0; i < cores.size(); i++) {
+                global_semaphores.push_back(tt::tt_metal::CreateGlobalSemaphore(device, cores[i], initial_values[i]));
+                addresses.push_back(global_semaphores[i]->address());
+            }
+            for (size_t i = 0; i < cores.size(); i++) {
+                const auto& address = addresses[i];
+                const auto& initial_value = initial_values[i];
+                const auto& cores_vec = cores_vecs[i];
+                for (const auto& core : cores_vec) {
+                    auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                        device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
+                    EXPECT_EQ(sem_vals[0], initial_value);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(DeviceFixture, ResetGlobalSemaphores) {
+    CoreRangeSet cores(CoreRange({0, 0}, {1, 1}));
+
+    auto cores_vec = corerange_to_cores(cores);
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto device = devices_.at(id);
+        {
+            uint32_t initial_value = 1;
+            std::vector<uint32_t> overwrite_value = {2};
+            auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
+            auto address = global_semaphore->address();
+
+            for (const auto& core : cores_vec) {
+                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                    device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
+                tt::llrt::write_hex_vec_to_core(
+                    device->id(), device->worker_core_from_logical_core(core), overwrite_value, address);
+                EXPECT_EQ(sem_vals[0], initial_value);
+            }
+            tt::Cluster::instance().l1_barrier(device->id());
+            for (const auto& core : cores_vec) {
+                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                    device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
+
+                EXPECT_EQ(sem_vals[0], overwrite_value[0]);
+            }
+            global_semaphore->reset_semaphore_value();
+            for (const auto& core : cores_vec) {
+                auto sem_vals = tt::llrt::read_hex_vec_from_core(
+                    device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
+                tt::llrt::write_hex_vec_to_core(
+                    device->id(), device->worker_core_from_logical_core(core), overwrite_value, address);
+                EXPECT_EQ(sem_vals[0], initial_value);
+            }
+        }
+    }
+}

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -53,8 +53,8 @@ struct CoreRange {
 
     CoreRange(const CoreRange &other) = default;
     CoreRange &operator=(const CoreRange &other) = default;
-    CoreRange(CoreRange &&other) = default;
-    CoreRange &operator=(CoreRange &&other) = default;
+    CoreRange(CoreRange &&other) noexcept = default;
+    CoreRange &operator=(CoreRange &&other) noexcept = default;
 
     bool intersects(const CoreRange &other) const;
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -39,6 +39,7 @@ class Trace;
 class CircularBuffer;
 class Event;
 class Buffer;
+class GlobalSemaphore;
 
 // ==================================================
 //                  HOST API: Device management
@@ -240,13 +241,45 @@ void UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, co
  * | program       | The program to which semaphore will be added to      | Program &                                                 |              | Yes      |
  * | core_spec     | Range of the Tensix co-ordinates using the semaphore | const std::variant<CoreRange,CoreRangeSet> &              |              | Yes      |
  * | initial_value | Initial value of the semaphore                       | uint32_t                                                  |              | Yes      |
- * | core_type     | Tensix or Ethernet core to create semaphore on.      | CoreType                                                  |              | Yes      |
+ * | core_type     | Tensix or Ethernet core to create semaphore on.      | CoreType                                                  |              | No       |
  */
 uint32_t CreateSemaphore(
     Program &program,
     const std::variant<CoreRange, CoreRangeSet> &core_spec,
     uint32_t initial_value,
     CoreType core_type = CoreType::WORKER);
+
+/**
+ * Initializes a global semaphore on all cores within the specified CoreRangeSet.
+ * This only supports tensix cores, and can only use L1 buffer types like BufferType::L1 and BufferType::L1_SMALL.
+ *
+ * Return value: std::unique_ptr<GlobalSemaphore>.
+ *
+ * | Argument      | Description                                          | Type                                                      | Valid Range  | Required |
+ * |---------------|------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
+ * | device        | The device to create the semaphore on                | Device *                                                  |              | Yes      |
+ * | cores         | Range of the Tensix co-ordinates using the semaphore | const CoreRangeSet &                                      |              | Yes      |
+ * | initial_value | Initial value of the semaphore                       | uint32_t                                                  |              | Yes      |
+ * | buffer_type   | Buffer type to store the semaphore                   | BufferType                                                | L1 types     | No       |
+ */
+std::unique_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+    Device *device, const CoreRangeSet &cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+
+/**
+ * Initializes a global semaphore on all cores within the specified CoreRangeSet.
+ * This only supports tensix cores, and can only use L1 buffer types like BufferType::L1 and BufferType::L1_SMALL.
+ *
+ * Return value: std::unique_ptr<GlobalSemaphore>.
+ *
+ * | Argument      | Description                                          | Type                                                      | Valid Range  | Required |
+ * |---------------|------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
+ * | device        | The device to create the semaphore on                | Device *                                                  |              | Yes      |
+ * | cores         | Range of the Tensix co-ordinates using the semaphore | CoreRangeSet &&                                           |              | Yes      |
+ * | initial_value | Initial value of the semaphore                       | uint32_t                                                  |              | Yes      |
+ * | buffer_type   | Buffer type to store the semaphore                   | BufferType                                                | L1 types     | No       |
+ */
+std::unique_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+    Device *device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
 /**
 *  Allocates an interleaved DRAM or L1 buffer on device

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -4,6 +4,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocator/algorithms/free_list.cpp

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/buffers/global_semaphore.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/buffers/buffer.hpp"
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/llrt/hal.hpp"
+
+namespace tt::tt_metal {
+
+GlobalSemaphore::GlobalSemaphore(
+    Device* device, const CoreRangeSet &cores, uint32_t initial_value, BufferType buffer_type) :
+    device_(device), cores_(cores), initial_value_(initial_value) {
+    this->setup_buffer(buffer_type);
+}
+
+GlobalSemaphore::GlobalSemaphore(Device* device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type) :
+    device_(device), cores_(std::move(cores)), initial_value_(initial_value) {
+    this->setup_buffer(buffer_type);
+}
+
+void GlobalSemaphore::setup_buffer(BufferType buffer_type) {
+    TT_FATAL(
+        buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
+        "Global semaphore can only be created for L1 buffer types");
+    TT_FATAL(this->device_ != nullptr, "Device cannot be null");
+    TT_FATAL(this->cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
+    const auto &device_grid_size = this->device_->compute_with_storage_grid_size();
+    uint32_t num_cores = this->cores_.num_cores();
+    auto shard_parameters =
+        ShardSpecBuffer(this->cores_, {1, 1}, ShardOrientation::ROW_MAJOR, false, {1, 1}, {num_cores, 1});
+
+    this->buffer_ = Buffer::create(
+        this->device_,
+        num_cores * sizeof(uint32_t),
+        sizeof(uint32_t),
+        buffer_type,
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        shard_parameters,
+        std::nullopt);
+
+    this->host_buffer_ = std::vector<uint32_t>(num_cores, this->initial_value_);
+    this->reset_semaphore_value();
+}
+
+std::unique_ptr<GlobalSemaphore> GlobalSemaphore::create(
+    Device* device, const CoreRangeSet &cores, uint32_t initial_value, BufferType buffer_type) {
+    return std::make_unique<GlobalSemaphore>(device, cores, initial_value, buffer_type);
+}
+std::unique_ptr<GlobalSemaphore> GlobalSemaphore::create(
+    Device* device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type) {
+    return std::make_unique<GlobalSemaphore>(device, std::move(cores), initial_value, buffer_type);
+}
+
+DeviceAddr GlobalSemaphore::address() const { return buffer_->address(); }
+
+void GlobalSemaphore::reset_semaphore_value() {
+    // Blocking write of semaphore value to buffer
+    if (this->device_->using_slow_dispatch()) {
+        detail::WriteToBuffer(*this->buffer_, this->host_buffer_);
+        tt::Cluster::instance().l1_barrier(this->device_->id());
+    } else {
+        EnqueueWriteBuffer(this->device_->command_queue(), this->buffer_, this->host_buffer_.data(), true);
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_semaphore.hpp
+++ b/tt_metal/impl/buffers/global_semaphore.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/llrt/hal.hpp"
+
+namespace tt::tt_metal {
+
+inline namespace v0 {
+
+class Buffer;
+class Device;
+
+class GlobalSemaphore {
+   public:
+    GlobalSemaphore(
+        Device *device, const CoreRangeSet &cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+
+    GlobalSemaphore(
+        Device *device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+
+    GlobalSemaphore(const GlobalSemaphore &) = default;
+    GlobalSemaphore &operator=(const GlobalSemaphore &) = default;
+
+    GlobalSemaphore(GlobalSemaphore &&) noexcept = default;
+    GlobalSemaphore &operator=(GlobalSemaphore &&) noexcept = default;
+
+    static std::unique_ptr<GlobalSemaphore> create(
+        Device *device, const CoreRangeSet &cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+
+    static std::unique_ptr<GlobalSemaphore> create(
+        Device *device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+
+    DeviceAddr address() const;
+
+    void reset_semaphore_value();
+
+   private:
+    void setup_buffer(BufferType buffer_type);
+
+    // GlobalSemaphore is implemented as a wrapper around a sharded buffer
+    // This can be updated in the future to be its own container with optimized dispatch functions
+    std::shared_ptr<Buffer> buffer_;
+    std::vector<uint32_t> host_buffer_;
+    Device *device_;
+    CoreRangeSet cores_;
+    uint32_t initial_value_ = 0;
+};
+
+}  // namespace v0
+
+}  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -23,6 +23,7 @@
 #include "tt_metal/impl/device/device_pool.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
+#include "tt_metal/impl/buffers/global_semaphore.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
 #include "tt_metal/graph/graph_tracking.hpp"
@@ -1124,6 +1125,16 @@ uint32_t CreateSemaphore(
             return semaphore_id.value();
         },
         core_spec);
+}
+
+std::unique_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+    Device *device, const CoreRangeSet &cores, uint32_t initial_value, BufferType buffer_type) {
+    return GlobalSemaphore::create(device, cores, initial_value, buffer_type);
+}
+
+std::unique_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+    Device *device, CoreRangeSet &&cores, uint32_t initial_value, BufferType buffer_type) {
+    return GlobalSemaphore::create(device, std::move(cores), initial_value, buffer_type);
 }
 
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14741

### Problem description
Global semaphores are used to provide a space in L1 across cores that can be used for syncing. These semaphores exist with lifetime similar to buffers, in that user creates them and their lifetime is not tied to programs, unlike regular semaphores.

### What's changed
Add implementation and basic unit tests for global semaphores.
Limitations:
- Only L1 type buffers supported
- Does not work for eth cores since this uses the allocator

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
