### PR TITLE
Better op report column names

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -40,10 +40,21 @@ run_tracing_async_mode_T3000_test(){
         else
             echo "Verifying test results"
             runDate=$(ls $PROFILER_OUTPUT_DIR/)
+            echo $runDate
             LINE_COUNT=4100 # Smoke test to see at least 4100 ops are reported
             res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
             echo $res
         fi
+
+        #Testing device only report on the same artifacts
+        rm -rf $PROFILER_OUTPUT_DIR/
+        ./tt_metal/tools/profiler/process_ops_logs.py --device-only --date
+        echo "Verifying device-only results"
+        runDate=$(ls $PROFILER_OUTPUT_DIR/)
+        echo $runDate
+        LINE_COUNT=3600 # Smoke test to see at least 4100 ops are reported
+        res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
+        echo $res
     fi
 }
 


### PR DESCRIPTION
### Ticket
#9956 

### Problem description
Trace id and Trace Runtime ID are confusing names

### What's changed
Trace ID-> Metal Trace ID
Trace Runtime ID - > Metal Trace Replay Session ID

Also a bug fix for device only perf report

### Checklist
- [x] [Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11692284700) 
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/11688872046)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/11692279490)
