### PR TITLE
Change tt_SiliconDevice to tt::umd::Cluster

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -43,7 +43,7 @@ inline std::string get_umd_arch_name() {
         return get_env_arch_name();
     }
 
-    std::vector<chip_id_t> physical_mmio_device_ids = tt_SiliconDevice::detect_available_device_ids();
+    std::vector<chip_id_t> physical_mmio_device_ids = tt::umd::Cluster::detect_available_device_ids();
     tt::ARCH arch = detect_arch(physical_mmio_device_ids.at(0));
     for (int dev_index = 1; dev_index < physical_mmio_device_ids.size(); dev_index++) {
         chip_id_t device_id = physical_mmio_device_ids.at(dev_index);

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 #include "tt_metal/common/assert.hpp"
-#include "tt_metal/third_party/umd/device/tt_device.h"
+#include "tt_metal/third_party/umd/device/cluster.h"
 #include "yaml-cpp/yaml.h"
 
 CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_channel(int dram_chan) const {

--- a/tt_metal/hw/inc/blackhole/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/blackhole/noc/noc_parameters.h
@@ -350,7 +350,7 @@
 
 #define NOC_XY_ENCODING(x, y) ((((uint32_t)(y)) << (NOC_ADDR_NODE_ID_BITS)) | (((uint32_t)(x))))
 
-// Base address pulled from tt_SiliconDevice::get_pcie_base_addr_from_device
+// Base address pulled from tt::umd::Cluster::get_pcie_base_addr_from_device
 #define NOC_XY_PCIE_ENCODING(x, y, noc_index)                                        \
    ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET))) |  \
    ((noc_index ? (x == PCIE_NOC1_X and y == PCIE_NOC1_Y) : (x == PCIE_NOC_X and y == PCIE_NOC_Y)) * 0x1000000000000000) \

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -29,7 +29,7 @@
 #include "third_party/umd/device/tt_arch_types.h"
 #include "third_party/umd/device/tt_cluster_descriptor.h"
 #include "third_party/umd/device/tt_cluster_descriptor_types.h"
-#include "third_party/umd/device/tt_device.h"
+#include "third_party/umd/device/cluster.h"
 #include "third_party/umd/device/tt_soc_descriptor.h"
 #include "third_party/umd/device/tt_xy_pair.h"
 #include "third_party/umd/device/xy_pair.h"
@@ -90,7 +90,7 @@ void Cluster::detect_arch_and_target() {
         this->arch_ = tt::get_arch_from_string(arch_env);
     }else {
         this->target_type_ = TargetDevice::Silicon;
-        std::vector<chip_id_t> physical_mmio_device_ids = tt_SiliconDevice::detect_available_device_ids();
+        std::vector<chip_id_t> physical_mmio_device_ids = tt::umd::Cluster::detect_available_device_ids();
         this->arch_ = detect_arch(physical_mmio_device_ids.at(0));
         for (int dev_index = 1; dev_index < physical_mmio_device_ids.size(); dev_index++) {
             chip_id_t device_id = physical_mmio_device_ids.at(dev_index);
@@ -143,7 +143,7 @@ void Cluster::generate_cluster_descriptor() {
 
     // Cluster descriptor yaml not available for Blackhole bring up
     if (this->target_type_ == TargetDevice::Simulator) {
-        // Cannot use tt_SiliconDevice::detect_available_device_ids because that returns physical device IDs
+        // Cannot use tt::umd::Cluster::detect_available_device_ids because that returns physical device IDs
         std::vector<chip_id_t> physical_mmio_device_ids;
         std::set<chip_id_t> logical_mmio_device_ids;
         physical_mmio_device_ids = tt_SimulationDevice::detect_available_device_ids();
@@ -215,7 +215,7 @@ void Cluster::assert_risc_reset() {
 
 void Cluster::assign_mem_channels_to_devices(
     chip_id_t mmio_device_id, const std::set<chip_id_t> &controlled_device_ids) {
-    // g_MAX_HOST_MEM_CHANNELS (4) is defined in tt_SiliconDevice and denotes the max number of host memory channels per
+    // g_MAX_HOST_MEM_CHANNELS (4) is defined in tt::umd::Cluster and denotes the max number of host memory channels per
     // MMIO device Metal currently assigns 1 channel per device. See https://github.com/tenstorrent/tt-metal/issues/4087
     // One WH gateway should have 8 remote deivces in its control group.
     TT_ASSERT(controlled_device_ids.size() <= 9, "Unable to assign each device to its own host memory channel!");
@@ -253,7 +253,7 @@ void Cluster::open_driver(const bool &skip_driver_allocs) {
         // This will remove harvested rows from the soc descriptor
         const bool perform_harvesting = true;
         const bool clean_system_resources = true;
-        device_driver = std::make_unique<tt_SiliconDevice>(
+        device_driver = std::make_unique<tt::umd::Cluster>(
             sdesc_path,
             this->cluster_desc_path_,
             all_chips_set,

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -93,7 +93,7 @@ class Cluster {
         std::vector<uint32_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair &target) const {
-        tt_SiliconDevice *device = dynamic_cast<tt_SiliconDevice *>(driver_.get());
+        tt::umd::Cluster *device = dynamic_cast<tt::umd::Cluster *>(driver_.get());
         const metal_SocDescriptor &soc_desc = this->get_soc_desc(target.chip);
         tt_cxy_pair virtual_chip_coord = soc_desc.convert_to_umd_coordinates(target);
         return device->get_tlb_data_from_target(virtual_chip_coord);
@@ -102,14 +102,14 @@ class Cluster {
     std::function<void(uint32_t, uint32_t, const uint8_t *)> get_fast_pcie_static_tlb_write_callable(
         int chip_id) const {
         chip_id_t mmio_device_id = device_to_mmio_device_.at(chip_id);
-        tt_SiliconDevice *device = dynamic_cast<tt_SiliconDevice *>(driver_.get());
+        tt::umd::Cluster *device = dynamic_cast<tt::umd::Cluster *>(driver_.get());
         return device->get_fast_pcie_static_tlb_write_callable(mmio_device_id);
     }
 
     // Returns a writer object which holds a pointer to a static tlb
     // Allows for fast writes when targeting same device core by only doing the lookup once and avoiding repeated stack traversals
     tt::Writer get_static_tlb_writer(tt_cxy_pair target) const {
-        tt_SiliconDevice *device = dynamic_cast<tt_SiliconDevice *>(driver_.get());
+        tt::umd::Cluster *device = dynamic_cast<tt::umd::Cluster *>(driver_.get());
         const metal_SocDescriptor &soc_desc = this->get_soc_desc(target.chip);
         tt_cxy_pair virtual_target = soc_desc.convert_to_umd_coordinates(target);
         return device->get_static_tlb_writer(virtual_target);
@@ -117,7 +117,7 @@ class Cluster {
 
     std::uint32_t get_numa_node_for_device(uint32_t device_id) const {
         uint32_t mmio_device_id = this->get_associated_mmio_device(device_id);
-        tt_SiliconDevice *device = dynamic_cast<tt_SiliconDevice *>(driver_.get());
+        tt::umd::Cluster *device = dynamic_cast<tt::umd::Cluster *>(driver_.get());
         return driver_->get_numa_node_for_pcie_device(mmio_device_id);
     }
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -616,7 +616,7 @@ set(TTNN_PRECOMPILED_HEADERS
     ${PROJECT_SOURCE_DIR}/ttnn/cpp/ttnn/operation.hpp
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/device/device_api_metal.h
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/device/tt_device.h
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/device/cluster.h
     <functional>
     <map>
     <memory>


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/13948

### What's changed
Related UMD PR: https://github.com/tenstorrent/tt-umd/pull/265
Changed naming
tt_device.h -> cluster.h
tt_SiliconDriver -> tt::umd::Cluster

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11846636922
- [x] Blackhole Post commit (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/11839014934
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
