### PR TITLE
Add device specific defines to kernel build command and hash

### DIFF
--- a/tt_metal/common/utils.cpp
+++ b/tt_metal/common/utils.cpp
@@ -56,6 +56,13 @@ namespace utils
         return outpath;
     }
 
+    size_t DefinesHash::operator()(const std::map<std::string, std::string> &c_defines) const {
+        size_t hash_value = 0;
+        for (auto it = c_defines.begin(); it != c_defines.end(); ++it)
+            hash_combine(hash_value, std::hash<std::string>{}(it->first + it->second));
+        return hash_value;
+    }
+
 }   // namespace utils
 
 }   // namespace tt

--- a/tt_metal/common/utils.hpp
+++ b/tt_metal/common/utils.hpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <map>
 
 using std::string;
 
@@ -26,6 +27,11 @@ namespace utils
         std::hash<T> hasher;
         seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
     }
+
+    struct DefinesHash {
+        DefinesHash() {}
+        size_t operator()(const std::map<std::string, std::string> &c_defines) const;
+    };
 
     inline std::vector<std::string> strsplit(std::string input, char delimiter) {
         std::vector<std::string> result = {};

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -273,24 +273,27 @@ void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size
 
 void Device::initialize_device_kernel_defines()
 {
+    // Clear previously stored defines, in case we are running with different configuration this time.
+    // This is needed to handle the case where the number of L1 banks on GS can be changed in each run.
+    this->device_kernel_defines_.clear();
     const size_t num_dram_banks = this->num_banks(BufferType::DRAM);
     const size_t num_l1_banks = this->num_banks(BufferType::L1);
 
     bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
     bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);
 
-    this->device_kernel_defines.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
-    this->device_kernel_defines.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
+    this->device_kernel_defines_.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
+    this->device_kernel_defines_.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
 
     if (is_dram_pow2) {
-        this->device_kernel_defines.emplace("LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(static_cast<size_t>(log2(num_dram_banks))));
+        this->device_kernel_defines_.emplace("LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(static_cast<size_t>(log2(num_dram_banks))));
     } else {
-        this->device_kernel_defines.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
+        this->device_kernel_defines_.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
     }
     if (is_l1_pow2) {
-        this->device_kernel_defines.emplace("LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(static_cast<size_t>(log2(num_l1_banks))));
+        this->device_kernel_defines_.emplace("LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(static_cast<size_t>(log2(num_l1_banks))));
     } else {
-        this->device_kernel_defines.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
+        this->device_kernel_defines_.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
     }
 }
 
@@ -298,7 +301,7 @@ void Device::initialize_build() {
     ZoneScoped;
 
     this->initialize_device_kernel_defines();
-    this->build_env_.init(this->build_key(), this->arch(), device_kernel_defines);
+    this->build_env_.init(this->build_key(), this->arch(), this->device_kernel_defines_);
 
     CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->id());
     uint32_t dispatch_message_addr =
@@ -3430,7 +3433,7 @@ void Device::generate_device_headers(const std::string &path) const
 }
 
 size_t Device::get_device_kernel_defines_hash() {
-    return tt::utils::DefinesHash{}(this->device_kernel_defines);
+    return tt::utils::DefinesHash{}(this->device_kernel_defines_);
 }
 
 }  // namespace tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3405,6 +3405,39 @@ void Device::generate_device_headers(const std::string &path) const
     );
 }
 
+size_t Device::get_device_defines_hash() {
+    std::map<std::string, std::string> device_defines;
+
+    const size_t num_dram_banks = this->num_banks(BufferType::DRAM);
+    const size_t num_l1_banks = this->num_banks(BufferType::L1);
+
+    bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
+    bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);
+
+    device_defines.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
+    device_defines.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
+
+    if (is_dram_pow2) {
+        device_defines.emplace("LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(log2(num_dram_banks)));
+    } else {
+        device_defines.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
+    }
+    if (is_l1_pow2) {
+        device_defines.emplace("LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(log2(num_l1_banks)));
+    } else {
+        device_defines.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
+    }
+    return DeviceDefinesHash{}(device_defines);
+}
+
+size_t DeviceDefinesHash::operator()(const std::map<std::string, std::string> &c_defines) const {
+    size_t hash_value = 0;
+    for (auto it = c_defines.begin(); it != c_defines.end(); ++it)
+        tt::utils::hash_combine(hash_value, std::hash<std::string>{}(it->first + it->second));
+    return hash_value;
+}
+
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -279,18 +279,18 @@ void Device::initialize_device_kernel_defines()
     bool is_dram_pow2 = ceil(log2(num_dram_banks)) == log2(num_dram_banks);
     bool is_l1_pow2 = ceil(log2(num_l1_banks)) == log2(num_l1_banks);
 
-    device_kernel_defines.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
-    device_kernel_defines.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
+    this->device_kernel_defines.emplace("NUM_DRAM_BANKS", std::to_string(num_dram_banks));
+    this->device_kernel_defines.emplace("NUM_L1_BANKS", std::to_string(num_l1_banks));
 
     if (is_dram_pow2) {
-        device_kernel_defines.emplace("LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(static_cast<size_t>(log2(num_dram_banks))));
+        this->device_kernel_defines.emplace("LOG_BASE_2_OF_NUM_DRAM_BANKS", std::to_string(static_cast<size_t>(log2(num_dram_banks))));
     } else {
-        device_kernel_defines.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
+        this->device_kernel_defines.emplace("IS_NOT_POW2_NUM_DRAM_BANKS", "1");
     }
     if (is_l1_pow2) {
-        device_kernel_defines.emplace("LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(static_cast<size_t>(log2(num_l1_banks))));
+        this->device_kernel_defines.emplace("LOG_BASE_2_OF_NUM_L1_BANKS", std::to_string(static_cast<size_t>(log2(num_l1_banks))));
     } else {
-        device_kernel_defines.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
+        this->device_kernel_defines.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
     }
 }
 
@@ -3430,16 +3430,8 @@ void Device::generate_device_headers(const std::string &path) const
 }
 
 size_t Device::get_device_kernel_defines_hash() {
-    return DeviceKernelDefinesHash{}(device_kernel_defines);
+    return tt::utils::DefinesHash{}(this->device_kernel_defines);
 }
-
-size_t DeviceKernelDefinesHash::operator()(const std::map<std::string, std::string> &c_defines) const {
-    size_t hash_value = 0;
-    for (auto it = c_defines.begin(); it != c_defines.end(); ++it)
-        tt::utils::hash_combine(hash_value, std::hash<std::string>{}(it->first + it->second));
-    return hash_value;
-}
-
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -61,8 +61,8 @@ static constexpr float  INF_BH = INF_WHB0;
 
 inline namespace v0 {
 
-struct DeviceDefinesHash {
-    DeviceDefinesHash() {}
+struct DeviceKernelDefinesHash {
+    DeviceKernelDefinesHash() {}
 
     size_t operator()(const std::map<std::string, std::string> &c_defines) const;
 };
@@ -242,6 +242,7 @@ class Device {
     void initialize_cluster();
     void initialize_allocator(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {});
     void initialize_build();
+    void initialize_device_kernel_defines();
     void build_firmware();
     void initialize_firmware(const HalProgrammableCoreType &core_type, CoreCoord phys_core, launch_msg_t *launch_msg, go_msg_t* go_msg);
     void reset_cores();
@@ -348,12 +349,13 @@ class Device {
     std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const CoreRangeContainer& ranges, const CoreType core_type);
     bool dispatch_s_enabled() const;
     bool distributed_dispatcher() const;
-    size_t get_device_defines_hash();
+    size_t get_device_kernel_defines_hash();
 
    private:
     void MarkAllocationsUnsafe();
     void MarkAllocationsSafe();
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
+    std::map<std::string, std::string> device_kernel_defines;
 };
 
 }  // namespace v0

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -61,12 +61,6 @@ static constexpr float  INF_BH = INF_WHB0;
 
 inline namespace v0 {
 
-struct DeviceKernelDefinesHash {
-    DeviceKernelDefinesHash() {}
-
-    size_t operator()(const std::map<std::string, std::string> &c_defines) const;
-};
-
 // A physical PCIexpress Tenstorrent device
 class Device {
    public:

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -349,7 +349,7 @@ class Device {
     void MarkAllocationsUnsafe();
     void MarkAllocationsSafe();
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
-    std::map<std::string, std::string> device_kernel_defines;
+    std::map<std::string, std::string> device_kernel_defines_;
 };
 
 }  // namespace v0

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -61,6 +61,12 @@ static constexpr float  INF_BH = INF_WHB0;
 
 inline namespace v0 {
 
+struct DeviceDefinesHash {
+    DeviceDefinesHash() {}
+
+    size_t operator()(const std::map<std::string, std::string> &c_defines) const;
+};
+
 // A physical PCIexpress Tenstorrent device
 class Device {
    public:
@@ -342,6 +348,7 @@ class Device {
     std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const CoreRangeContainer& ranges, const CoreType core_type);
     bool dispatch_s_enabled() const;
     bool distributed_dispatcher() const;
+    size_t get_device_defines_hash();
 
    private:
     void MarkAllocationsUnsafe();

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -175,7 +175,7 @@ std::string Kernel::compute_hash() const {
         "{}_{}_{}_{}",
         std::hash<std::string>{}(this->kernel_src_.source_),
         fmt::join(this->compile_time_args_, "_"),
-        KernelDefinesHash{}(this->defines_),
+        tt::utils::DefinesHash{}(this->defines_),
         this->config_hash());
 }
 
@@ -476,13 +476,6 @@ std::ostream &operator<<(std::ostream &os, const DataMovementProcessor &processo
         default: TT_THROW("Unknown data movement processor");
     }
     return os;
-}
-
-size_t KernelDefinesHash::operator()(const std::map<std::string, std::string> &c_defines) const {
-    size_t hash_value = 0;
-    for (auto it = c_defines.begin(); it != c_defines.end(); ++it)
-        tt::utils::hash_combine(hash_value, std::hash<std::string>{}(it->first + it->second));
-    return hash_value;
 }
 
 }  // namespace tt_metal

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -243,12 +243,6 @@ class ComputeKernel : public Kernel {
 
 std::ostream& operator<<(std::ostream& os, const DataMovementProcessor& processor);
 
-struct KernelDefinesHash {
-    KernelDefinesHash() {}
-
-    size_t operator()(const std::map<std::string, std::string> &c_defines) const;
-};
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -70,7 +70,7 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel> kernel, JitBuildOptions &
     {
         unique_lock<mutex> lock;
         f << kernel->name() << " :: " << build_key << "::" << std::hash<tt_hlk_desc>{}(build_options.hlk_desc)
-          << " :: " << kernel->compute_hash() << " :: " << compile_hash_str << " " << compile_hash << std::endl
+          << " :: " << kernel->compute_hash() << " :: " << device_kernel_defines_hash << " :: " << compile_hash_str << " " << compile_hash << std::endl
           << std::flush;
     }
 #endif

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -44,7 +44,7 @@ void GenerateBinaries(Device *device, JitBuildOptions &build_options, std::share
 #include <fstream>
 #endif
 
-size_t KernelCompileHash(const std::shared_ptr<Kernel> kernel, JitBuildOptions &build_options, uint32_t build_key, size_t device_defines_hash) {
+size_t KernelCompileHash(const std::shared_ptr<Kernel> kernel, JitBuildOptions &build_options, uint32_t build_key, size_t device_kernel_defines_hash) {
     // Account for device id in hash because generated headers are dependent on harvesting config, which can differ per
     // device This can be removed with https://github.com/tenstorrent/tt-metal/issues/3381
 
@@ -55,7 +55,7 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel> kernel, JitBuildOptions &
         build_key,
         std::to_string(std::hash<tt_hlk_desc>{}(build_options.hlk_desc)),
         kernel->compute_hash(),
-        device_defines_hash,
+        device_kernel_defines_hash,
         tt::llrt::OptionsG.get_watcher_enabled());
 
     for (int i = 0; i < llrt::RunTimeDebugFeatureCount; i++) {
@@ -1378,7 +1378,7 @@ void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
                     this->set_cb_data_fmt(device, kernel->logical_coreranges(), build_options);
                     this->set_cb_tile_dims(device, kernel->logical_coreranges(), build_options);
 
-                    auto kernel_hash = KernelCompileHash(kernel, build_options, device->build_key(), device->get_device_defines_hash());
+                    auto kernel_hash = KernelCompileHash(kernel, build_options, device->build_key(), device->get_device_kernel_defines_hash());
                     std::string kernel_path_suffix = kernel->name() + "/" + std::to_string(kernel_hash) + "/";
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -41,7 +41,7 @@ static std::string get_string_aliased_arch_lowercase(tt::ARCH arch) {
 
 JitBuildEnv::JitBuildEnv() {}
 
-void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch) {
+void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string> &device_kernel_defines) {
     // Paths
     this->root_ = llrt::OptionsG.get_root_dir();
     this->out_root_ = this->root_ + "built/";
@@ -83,6 +83,9 @@ void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch) {
         case ARCH::WORMHOLE_B0: this->defines_ = "-DARCH_WORMHOLE "; break;
         case ARCH::BLACKHOLE: this->defines_ = "-DARCH_BLACKHOLE "; break;
         default: break;
+    }
+    for (auto it = device_kernel_defines.begin(); it != device_kernel_defines.end(); ++it) {
+        this->defines_ += "-D" + it->first + "=" + it->second + " ";
     }
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
 

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -46,7 +46,7 @@ class JitBuildEnv {
 
   public:
     JitBuildEnv();
-    void init(uint32_t build_key, tt::ARCH arch);
+    void init(uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string> &device_kernel_defines);
 
     tt::ARCH get_arch() const { return arch_; }
     const string& get_root_path() const { return root_; }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -549,8 +549,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     std::vector<int32_t>& l1_bank_offset_map,
     uint32_t allocator_alignment) {
     stringstream ss;
-    bool is_dram_pow2 = ceil(log2(dram_bank_map.size())) == log2(dram_bank_map.size());
-    bool is_l1_pow2 = ceil(log2(l1_bank_map.size())) == log2(l1_bank_map.size());
 
     ss << "// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc." << endl;
     ss << "//" << endl;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -569,21 +569,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "#include <noc/noc_parameters.h>" << endl;
     ss << endl;
 
-    ss << "#define NUM_DRAM_BANKS " << dram_bank_map.size() << endl;
-    ss << "#define NUM_L1_BANKS " << l1_bank_map.size() << endl;
-
-    if (is_dram_pow2) {
-        ss << "#define LOG_BASE_2_OF_NUM_DRAM_BANKS " << log2(dram_bank_map.size()) << endl;
-    } else {
-        ss << "#define IS_NOT_POW2_NUM_DRAM_BANKS 1" << endl;
-    }
-    if (is_l1_pow2) {
-        ss << "#define LOG_BASE_2_OF_NUM_L1_BANKS " << log2(l1_bank_map.size()) << endl;
-    } else {
-        ss << "#define IS_NOT_POW2_NUM_L1_BANKS 1" << endl;
-    }
-    ss << endl;
-
     ss << "static_assert(NUM_NOCS == 2);" << endl;
     ss << endl;
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13869)

### Problem description
Kernel build is dependent on header files generated from the device.

### What's changed
Removed NUM_DRAM_BANKS, NUM_L1_BANKS, LOG_BASE_2_OF_NUM_DRAM_BANKS, LOG_BASE_2_OF_NUM_L1_BANKS, IS_NOT_POW2_NUM_DRAM_BANKS and IS_NOT_POW2_NUM_L1_BANKS from genfiles.cpp and added them to the kernel build command.
Also added above defines to kernel build hash.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11725245883
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
