### PR TITLE
Avora/decode rope integration

### DIFF
--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -261,7 +261,7 @@ def run_decode(
     # capture trace
     if trace_mode:
         logger.info("Capturing trace")
-        trace_id, tt_inp_emb, rot_mat, cache_idxs_tt, tt_logits, _ = model.capture_trace(
+        trace_id, tt_inp_emb, rope_setup, rot_idxs_tt, cache_idxs_tt, tt_logits, _ = model.capture_trace(
             tokens[:, prev_pos : prev_pos + 1], prev_pos
         )
 
@@ -270,7 +270,7 @@ def run_decode(
         input_tokens = tokens[:, prev_pos:cur_pos]
         if trace_mode and input_tokens.shape[1] == 1:
             logits = model.decode_forward_trace(
-                input_tokens, prev_pos, trace_id, tt_inp_emb, rot_mat, cache_idxs_tt, tt_logits
+                input_tokens, prev_pos, trace_id, tt_inp_emb, rope_setup, rot_idxs_tt, cache_idxs_tt, tt_logits
             )
         else:
             logits = model.forward(input_tokens, prev_pos)

--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -261,7 +261,7 @@ def run_decode(
     # capture trace
     if trace_mode:
         logger.info("Capturing trace")
-        trace_id, tt_inp_emb, rope_setup, rot_idxs_tt, cache_idxs_tt, tt_logits, _ = model.capture_trace(
+        trace_id, tt_inp_emb, rot_idxs_tt, cache_idxs_tt, tt_logits, _ = model.capture_trace(
             tokens[:, prev_pos : prev_pos + 1], prev_pos
         )
 
@@ -270,7 +270,7 @@ def run_decode(
         input_tokens = tokens[:, prev_pos:cur_pos]
         if trace_mode and input_tokens.shape[1] == 1:
             logits = model.decode_forward_trace(
-                input_tokens, prev_pos, trace_id, tt_inp_emb, rope_setup, rot_idxs_tt, cache_idxs_tt, tt_logits
+                input_tokens, prev_pos, trace_id, tt_inp_emb, rot_idxs_tt, cache_idxs_tt, tt_logits
             )
         else:
             logits = model.forward(input_tokens, prev_pos)

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -224,13 +224,17 @@ class TtLlamaAttention_optimized:
             raise ValueError(f"Unknown llm_mode: {mode}")
 
     def decode_forward(self, xs, rot_mats, start_pos: int, cache_idxs, page_table=None, kv_cache=None):
-        query_layer, key_layer, value_layer = self.attn_qkv(xs, rot_mats, cache_idxs)
+        query_layer, key_layer, value_layer = self.attn_qkv(xs, rot_mats)
         attn_outputs = self.attn_mqa(
             query_layer, key_layer, value_layer, start_pos, cache_idxs, page_table=page_table, kv_cache=kv_cache
         )
         return self.attn_selfout(attn_outputs)
 
-    def attn_qkv(self, xs, rot_mats, cache_idxs):
+    def attn_qkv(
+        self,
+        xs,
+        rot_mats,
+    ):
         # Fused QKV
         fused_query_key_value = ttnn.matmul(
             xs,

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -209,7 +209,14 @@ class TtLlamaAttention_optimized:
     ):
         # Decode should have input tensor of shape (seqlen=1, 1, batch, hidden_size)
         if mode == "decode":
-            return self.decode_forward(xs, rot_mats, start_pos, cache_idxs, page_table=page_table, kv_cache=kv_cache)
+            return self.decode_forward(
+                xs,
+                rot_mats,
+                start_pos,
+                cache_idxs,
+                page_table=page_table,
+                kv_cache=kv_cache,
+            )
         # Prefill should have input tensor of shape (1, batch=1, seqlen, hidden_size)
         elif mode == "prefill":
             return self.prefill_forward(xs, rot_mats, user_id, page_table=page_table, kv_cache=kv_cache)
@@ -217,17 +224,13 @@ class TtLlamaAttention_optimized:
             raise ValueError(f"Unknown llm_mode: {mode}")
 
     def decode_forward(self, xs, rot_mats, start_pos: int, cache_idxs, page_table=None, kv_cache=None):
-        query_layer, key_layer, value_layer = self.attn_qkv(xs, rot_mats)
+        query_layer, key_layer, value_layer = self.attn_qkv(xs, rot_mats, cache_idxs)
         attn_outputs = self.attn_mqa(
             query_layer, key_layer, value_layer, start_pos, cache_idxs, page_table=page_table, kv_cache=kv_cache
         )
         return self.attn_selfout(attn_outputs)
 
-    def attn_qkv(
-        self,
-        xs,
-        rot_mats,
-    ):
+    def attn_qkv(self, xs, rot_mats, cache_idxs):
         # Fused QKV
         fused_query_key_value = ttnn.matmul(
             xs,
@@ -259,26 +262,19 @@ class TtLlamaAttention_optimized:
 
         fused_query_key_value.deallocate(True)
 
-        # ROTARY EMBEDDINGS
-        # Q Rotary Embeddings
-        query_layer = ttnn.matmul(
-            query_layer,
-            rot_mats,
-            program_config=self.model_config["ROT_MAT_MM_PROGCFG"],
-            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
-            compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
-            # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
+        # Q ROTARY EMBEDDINGS
+        query_layer_ret = ttnn.experimental.rotary_embedding_llama(
+            query_layer, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
         )
+        query_layer.deallocate(True)
 
-        key_layer = ttnn.matmul(
-            key_layer,
-            rot_mats,
-            program_config=self.model_config["ROT_MAT_MM_PROGCFG"],
-            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
-            compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
+        # K Rotary Embeddings
+        key_layer_ret = ttnn.experimental.rotary_embedding_llama(
+            key_layer, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
         )
+        key_layer.deallocate(True)
 
-        return query_layer, key_layer, value_layer
+        return query_layer_ret, key_layer_ret, value_layer
 
     def attn_mqa(self, query_layer, key_layer, value_layer, start_pos: int, cache_idxs, page_table=None, kv_cache=None):
         # K CACHE UPDATE
@@ -416,14 +412,14 @@ class TtLlamaAttention_optimized:
         # Q Rotary Embeddings
         # query_layer: ttnn.Shape([1, 8, seq_len, 128]) -> [bsz, n_local_heads, seq_len, head_dim]
         query_layer_ret = ttnn.experimental.rotary_embedding_llama(
-            query_layer, rot_mats[0], rot_mats[1], self.transformation_mats
+            query_layer, rot_mats[0], rot_mats[1], self.transformation_mats["prefill"]
         )
         query_layer.deallocate(True)
 
         # K Rotary Embeddings
         # key_layer: ttnn.Shape([1, 1, seq_len, 128]) -> [bsz, n_local_kv_heads, seq_len, head_dim]
         key_layer_ret = ttnn.experimental.rotary_embedding_llama(
-            key_layer, rot_mats[0], rot_mats[1], self.transformation_mats
+            key_layer, rot_mats[0], rot_mats[1], self.transformation_mats["prefill"]
         )
         key_layer.deallocate(True)
 

--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -172,7 +172,7 @@ class TtLlamaModelForGeneration:
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
         logger.info("Done Capturing Decode Trace")
 
-        return trace_id, tt_inp, self.tt_model.rope_setup_decode, rot_idxs_tt, cache_idxs_tt, tt_logits, tt_page_table
+        return trace_id, tt_inp, rot_idxs_tt, cache_idxs_tt, tt_logits, tt_page_table
 
     def delete_trace(self, trace_id):
         ttnn.release_trace(self.mesh_device, trace_id)
@@ -183,7 +183,6 @@ class TtLlamaModelForGeneration:
         start_pos: int,
         trace_id,
         tt_inp,
-        rope_setup_decode,
         rot_idxs_tt,
         cache_idxs_tt,
         tt_logits,

--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -158,7 +158,7 @@ class TtLlamaModelForGeneration:
         # Run TT model
         tt_inp_emb = self.tt_model.tt_embd(tt_inp)
         tt_inp_emb = ttnn.interleaved_to_sharded(tt_inp_emb, self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"])
-        rot_mat = self.tt_model.rope_setup_decode.get_rot_mats(rot_idxs_tt, rot_idxs_tt.device)
+        rot_mat = self.tt_model.rope_setup_decode.get_rot_mats(rot_idxs_tt)
         tt_logits = self.tt_model(
             tt_inp_emb,
             rot_mat,

--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -130,14 +130,14 @@ class TtLlamaModelForGeneration:
             cache_idxs_tt,
             tt_page_table,
             tt_inp,
-            rot_mat_rm,
+            rot_idxs_tt,
         ) = self.tt_model.prepare_device_inputs(
             tokens,
             start_pos,
             mode="decode",
             page_table=page_table,
             return_tokens=True,
-            return_rot_mat_rm=True,
+            return_rot_idxs=True,
         )
 
         # Compile model
@@ -150,6 +150,7 @@ class TtLlamaModelForGeneration:
             kv_cache=kv_cache,
             mode="decode",
         )
+        logger.info("Done Compiling Model")
 
         # Capture trace
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
@@ -157,8 +158,7 @@ class TtLlamaModelForGeneration:
         # Run TT model
         tt_inp_emb = self.tt_model.tt_embd(tt_inp)
         tt_inp_emb = ttnn.interleaved_to_sharded(tt_inp_emb, self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"])
-        rot_mat = ttnn.to_layout(rot_mat_rm, ttnn.TILE_LAYOUT)
-        rot_mat = ttnn.interleaved_to_sharded(rot_mat, self.model_config["ROT_MAT_MM_IN1_MEMCFG"])
+        rot_mat = self.tt_model.rope_setup_decode.get_rot_mats(rot_idxs_tt, rot_idxs_tt.device)
         tt_logits = self.tt_model(
             tt_inp_emb,
             rot_mat,
@@ -172,7 +172,7 @@ class TtLlamaModelForGeneration:
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
         logger.info("Done Capturing Decode Trace")
 
-        return trace_id, tt_inp, rot_mat_rm, cache_idxs_tt, tt_logits, tt_page_table
+        return trace_id, tt_inp, self.tt_model.rope_setup_decode, rot_idxs_tt, cache_idxs_tt, tt_logits, tt_page_table
 
     def delete_trace(self, trace_id):
         ttnn.release_trace(self.mesh_device, trace_id)
@@ -183,7 +183,8 @@ class TtLlamaModelForGeneration:
         start_pos: int,
         trace_id,
         tt_inp,
-        rot_mat,
+        rope_setup_decode,
+        rot_idxs_tt,
         cache_idxs_tt,
         tt_logits,
         page_table=None,
@@ -196,12 +197,13 @@ class TtLlamaModelForGeneration:
         (
             updated_tt_inp,
             start_pos,
-            updated_rot_mat,
+            _,
+            updated_rot_idxs_tt,
             updated_cache_idxs_tt,
             updated_tt_page_table,
         ) = self.tt_model.prepare_inputs(tokens, start_pos, mode="decode", page_table=page_table)
         ttnn.copy_host_to_device_tensor(updated_tt_inp, tt_inp)
-        ttnn.copy_host_to_device_tensor(updated_rot_mat, rot_mat)
+        ttnn.copy_host_to_device_tensor(updated_rot_idxs_tt, rot_idxs_tt)
         ttnn.copy_host_to_device_tensor(updated_cache_idxs_tt, cache_idxs_tt)
         if page_table is not None:
             ttnn.copy_host_to_device_tensor(updated_tt_page_table, tt_page_table)

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -284,7 +284,10 @@ class TtLlamaModel_optimized:
             )
 
             rot_mats = None  # Created in prepare_device_inputs
-            rot_idxs_tt = self.rope_setup_decode.get_rot_idxs(cache_idxs)
+            rot_cache_idxs = torch.maximum(
+                cache_idxs, torch.tensor(0, dtype=torch.int64)
+            )  # Ensure position indices are non-negative
+            rot_idxs_tt = self.rope_setup_decode.get_rot_idxs(rot_cache_idxs)
 
             if isinstance(page_table, torch.Tensor):
                 # Support vLLM tensor page_table input

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -320,7 +320,7 @@ class TtLlamaModel_optimized:
             tt_inp_emb = ttnn.interleaved_to_sharded(tt_inp_emb, self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"])
             cache_idxs_tt = ttnn.to_device(cache_idxs_tt, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
             rot_mat, rot_idxs_tt = self.rope_setup_decode.get_rot_mats(
-                rot_idxs_tt, self.mesh_device, return_rot_idxs=True
+                rot_idxs_tt, return_rot_idxs=True
             )  # Sends rot_idxs to device internally
             if tt_page_table is not None:
                 tt_page_table = ttnn.to_device(tt_page_table, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -71,7 +71,9 @@ class TtLlamaModel_optimized:
         transformation_mats_prefill = ttnn.to_device(transformation_mats_prefill, mesh_device)
 
         # Transformation matrix for rotary embeddings (decode)
-        self.rope_setup_decode = TtLlamaRotarySetup(self.mesh_device, self.head_dim, self.max_seq_len, self.rope_theta)
+        self.rope_setup_decode = TtLlamaRotarySetup(
+            self.mesh_device, self.head_dim, self.max_seq_len, self.rope_theta, self.use_scaled_rope
+        )
         transformation_mats_decode = self.rope_setup_decode.get_trans_mats()
 
         transformation_mats = {"prefill": transformation_mats_prefill, "decode": transformation_mats_decode}

--- a/models/demos/t3000/llama2_70b/tt/llama_rope.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_rope.py
@@ -1,0 +1,141 @@
+import torch
+import ttnn
+from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
+from models.common.lightweightmodule import LightweightModule
+from models.demos.t3000.llama2_70b.tt.llama_common import precompute_freqs
+from loguru import logger
+
+
+def get_rot_transformation_mat(dhead):
+    rot_emb_matrix = torch.zeros(1, 1, dhead, dhead)
+    rot_emb_matrix[..., torch.arange(0, dhead, 2), torch.arange(1, dhead, 2)] = 1
+    rot_emb_matrix[..., torch.arange(1, dhead, 2), torch.arange(0, dhead, 2)] = -1
+    return rot_emb_matrix
+
+
+def compute_gather_cos_sin(dhead, end, theta, position_ids):
+    cos, sin = precompute_freqs(dhead, end, theta)
+    position_id_expanded = position_ids.unsqueeze(1).expand(-1, cos.shape[-1])
+    cos = cos.gather(0, position_id_expanded)
+    sin = sin.gather(0, position_id_expanded)
+    cos = torch.stack([cos, cos], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
+    sin = torch.stack([sin, sin], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
+    return cos, sin
+
+
+class TtLlamaRotarySetup(LightweightModule):
+    def __init__(
+        self,
+        device,
+        head_dim: int,
+        max_seq_len: int,
+        rope_theta: float,
+        datatype=ttnn.bfloat16,
+    ):
+        super().__init__()
+
+        self.head_dim = head_dim
+        self.device = device
+
+        self.core_grid = device.compute_with_storage_grid_size()
+        num_cores = self.core_grid.x * self.core_grid.y
+
+        # Generate the cos/sin matrices needed for ttnn.embedding op
+        cos_matrix, sin_matrix = compute_gather_cos_sin(
+            dhead=head_dim, end=max_seq_len * 2, theta=rope_theta, position_ids=torch.arange(max_seq_len)
+        )
+
+        self.cos_matrix = ttnn.from_torch(
+            cos_matrix.repeat(1, 1, 1, ttnn.TILE_SIZE),
+            device=device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=datatype,
+            mesh_mapper=ReplicateTensorToMesh(device),
+        )
+        self.sin_matrix = ttnn.from_torch(
+            sin_matrix.repeat(1, 1, 1, ttnn.TILE_SIZE),
+            device=device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=datatype,
+            mesh_mapper=ReplicateTensorToMesh(device),
+        )
+
+        # Generate the transformation matrix
+        trans_mat = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(
+            1, 1, num_cores, 1
+        )  # Repeat across all cores on device
+        trans_mat_mem_config = ttnn.create_sharded_memory_config(
+            shape=(1, 1, ttnn.TILE_SIZE * num_cores, ttnn.TILE_SIZE),
+            core_grid=ttnn.CoreGrid(y=self.core_grid.y, x=self.core_grid.x),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        self.transformation_mat = ttnn.from_torch(
+            trans_mat,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=datatype,
+            memory_config=trans_mat_mem_config,
+            mesh_mapper=ReplicateTensorToMesh(device),
+        )
+
+    def get_trans_mats(self):
+        assert self.transformation_mat is not None, "Transformation matrix not initialized"
+        return self.transformation_mat
+
+    def get_rot_idxs(self, position_idxs):
+        assert isinstance(position_idxs, torch.Tensor), "Position ids must be a torch tensor"
+
+        batch = position_idxs.shape[0]
+        position_idxs = position_idxs.unsqueeze(0)
+        assert position_idxs.shape == (1, batch), "position idxs must be a [1, batch] tensor"
+        assert torch.min(position_idxs) >= 0, "position idxs must be non-negative"
+
+        rot_idxs = ttnn.as_tensor(
+            position_idxs,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ReplicateTensorToMesh(self.device),
+        )
+
+        return rot_idxs
+
+    def get_rot_mats(self, position_idxs, device=None, return_rot_idxs=False):
+        device = self.device if device is None else device
+
+        # If position_idxs is a torch tensor, get the TTNN version of it
+        if isinstance(position_idxs, torch.Tensor):
+            rot_idxs = self.get_rot_idxs(position_idxs)
+        else:
+            rot_idxs = position_idxs
+            # assert len(rot_idxs.shape) == 2 and rot_idxs.shape[0] == 1, "rot_idxs must be a [1, batch] tensor"
+
+        # Send the idxs to device
+        if rot_idxs.device != device:
+            rot_idxs = ttnn.to_device(rot_idxs, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        batch = rot_idxs.shape[1]
+
+        cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)  # [1, batch, head_dim]
+        sin = ttnn.embedding(rot_idxs, self.sin_matrix, layout=ttnn.TILE_LAYOUT)  # [1, batch, head_dim]
+
+        cos = ttnn.reshape(cos, (1, batch, ttnn.TILE_SIZE, self.head_dim))  # [1, batch, 1[32], self.head_dim]
+        sin = ttnn.reshape(sin, (1, batch, ttnn.TILE_SIZE, self.head_dim))  # [1, batch, 1[32], self.head_dim]
+
+        grid = (
+            ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(batch, self.core_grid, row_wise=True))
+            .bounding_box()
+            .grid_size()
+        )
+        mem_config = ttnn.create_sharded_memory_config(
+            shape=(1, batch, ttnn.TILE_SIZE, self.head_dim),
+            core_grid=ttnn.CoreGrid(y=grid.y, x=grid.x),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+
+        cos = ttnn.interleaved_to_sharded(cos, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.head_dim]
+        sin = ttnn.interleaved_to_sharded(sin, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.head_dim]
+
+        if return_rot_idxs:
+            return [cos, sin], rot_idxs
+        return [cos, sin]

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -12,8 +12,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
 from models.utility_functions import skip_for_grayskull, skip_for_blackhole
-
 from models.demos.t3000.llama2_70b.tt.llama_common import precompute_freqs, freqs_to_rotation_matrix, gather_rotary_emb
+from models.demos.t3000.llama2_70b.tt.llama_rope import TtLlamaRotarySetup
 
 MAX_SEQ_LEN = 128 * 1024
 
@@ -30,66 +30,19 @@ class TtLlamaRotary(torch.nn.Module):
     def __init__(
         self,
         device,
-        batch,
         head_dim: int,
         mode: str,
         datatype=ttnn.bfloat16,
     ):
         super().__init__()
 
-        self.batch = batch
         self.head_dim = head_dim
         self.device = device
         self.mode = mode
 
-        self.cos_matrix = ttnn.from_torch(
-            cos_matrix.squeeze(0).squeeze(0), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=datatype
-        )
-        self.sin_matrix = ttnn.from_torch(
-            sin_matrix.squeeze(0).squeeze(0), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=datatype
-        )
-
-        # Generate the transformation matrix
-        trans_mat = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(
-            1, 1, num_cores, 1
-        )  # Repeat across all cores on device
-        trans_mat_mem_config = ttnn.create_sharded_memory_config(
-            shape=(1, 1, ttnn.TILE_SIZE * num_cores, ttnn.TILE_SIZE),
-            core_grid=ttnn.CoreGrid(y=self.core_grid.y, x=self.core_grid.x),
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
         self.transformation_mat = ttnn.from_torch(
-            trans_mat, device=device, layout=ttnn.TILE_LAYOUT, dtype=datatype, memory_config=trans_mat_mem_config
+            get_rot_transformation_mat(dhead=ttnn.TILE_SIZE), device=device, layout=ttnn.TILE_LAYOUT, dtype=datatype
         )
-
-        if mode == "decode":
-            # Generate the cos/sin matrices needed for ttnn.embedding op
-            cos_matrix, sin_matrix = compute_gather_cos_sin(
-                dhead=head_dim, end=MAX_SEQ_LEN * 2, position_ids=torch.arange(MAX_SEQ_LEN)
-            )
-
-            self.cos_matrix = ttnn.from_torch(cos_matrix, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=datatype)
-            self.sin_matrix = ttnn.from_torch(sin_matrix, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=datatype)
-
-            # Generate the transformation matrix
-            trans_mat = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(
-                1, 1, num_cores, 1
-            )  # Repeat across all cores on device
-            trans_mat_mem_config = ttnn.create_sharded_memory_config(
-                shape=(1, 1, ttnn.TILE_SIZE * num_cores, ttnn.TILE_SIZE),
-                core_grid=ttnn.CoreGrid(y=self.core_grid.y, x=self.core_grid.x),
-                strategy=ttnn.ShardStrategy.HEIGHT,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            )
-            self.transformation_mat = ttnn.from_torch(
-                trans_mat, device=device, layout=ttnn.TILE_LAYOUT, dtype=datatype, memory_config=trans_mat_mem_config
-            )
-
-        else:
-            self.transformation_mat = ttnn.from_torch(
-                get_rot_transformation_mat(dhead=ttnn.TILE_SIZE), device=device, layout=ttnn.TILE_LAYOUT, dtype=datatype
-            )
 
     def apply_rotary(self, x, cos, sin):
         # n_head = 8 for Q
@@ -113,33 +66,6 @@ class TtLlamaRotary(torch.nn.Module):
         )
 
         return rotary_output
-
-    def prepare_decode_cos_sin(self, position_ids):
-        assert isinstance(position_ids, torch.Tensor), "Position ids must be a torch tensor"
-
-        position_ids = position_ids.unsqueeze(0)  # [1, batch]
-        position_ids = ttnn.from_torch(
-            position_ids, device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.uint32
-        )
-
-        cos = ttnn.embedding(position_ids, self.cos_matrix, layout=ttnn.TILE_LAYOUT)  # [batch, head_dim, head_dim]
-        sin = ttnn.embedding(position_ids, self.sin_matrix, layout=ttnn.TILE_LAYOUT)  # [batch, head_dim, head_dim]
-
-        cos = ttnn.permute(cos, [1, 0, 2])
-        sin = ttnn.permute(sin, [1, 0, 2])
-
-        grid = ttnn.num_cores_to_corerangeset(self.batch, self.core_grid, row_wise=True).bounding_box().grid_size()
-        mem_config = ttnn.create_sharded_memory_config(
-            shape=(1, self.batch, ttnn.TILE_SIZE, self.head_dim),
-            core_grid=ttnn.CoreGrid(y=grid.y, x=grid.x),
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        )
-
-        cos = ttnn.interleaved_to_sharded(cos, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.head_dim]
-        sin = ttnn.interleaved_to_sharded(sin, mem_config)  # [1, 1 (= batch / shard_num_cores), 1[32], self.head_dim]
-
-        return cos, sin
 
     def forward(self, xq, xk, cos, sin):
         xq = self.apply_rotary(xq, cos, sin)
@@ -197,27 +123,30 @@ def run_test_rotary_embedding_llama(
     torch.manual_seed(0)
     mode = "decode" if seq_len == 1 else "prefill"
 
+    if mode == "decode":
+        max_seq_len = MAX_SEQ_LEN
+
     inp = [
         (torch.rand(batch, n_heads, seq_len, head_dim) * 2) - 1,
         (torch.rand(batch, n_kv_heads, seq_len, head_dim) * 2) - 1,
     ]
 
-    if mode == "decode":  # For decode, torch expects [1, n_heads, batch, head_dim]
+    # To test with different position ids, assume that batch
+    # dimension is the seq len dimension when passing inputs to torch
+    if mode == "decode":
         inp = [x.permute(2, 1, 0, 3) for x in inp]
+        # inp: [seq_len, n_heads, batch, head_dim]
 
     freqs_cis = precompute_freqs_cis(
         # Note that self.params.max_seq_len is multiplied by 2 because the token limit for the Llama 2 generation of models is 4096.
         # Adding this multiplier instead of using 4096 directly allows for dynamism of token lengths while training or fine-tuning.
         head_dim,
-        MAX_SEQ_LEN * 2 if mode == "decode" else max_seq_len * 2,  # In decode, precompute for all positions
+        max_seq_len * 2,  # In decode, precompute for all positions
     )  # torch.Size([8192, 64])
 
     start_pos = 0  # Must pick non-zero start pos to get non-zero freqs_cis
 
-    if mode == "decode":  # In decode, each user has a different position
-        position_ids = torch.arange(batch)  # TODO: Update to check other indices as well
-    else:
-        position_ids = slice(start_pos, start_pos + seq_len)
+    position_ids = torch.arange(batch) if mode == "decode" else slice(start_pos, start_pos + seq_len)
 
     freqs_cis = freqs_cis[position_ids]
 
@@ -233,15 +162,18 @@ def run_test_rotary_embedding_llama(
     pytorch_out = (torch_xq, torch_xk)
 
     # TT hardware / Modified PyTorch execution -------------------------------------------------------------
-    tt_model = TtLlamaRotary(device, batch, head_dim, mode, datatype)
+    tt_model = TtLlamaRotary(device, head_dim, mode, datatype)
 
     if mode == "decode":
-        cos, sin = tt_model.prepare_decode_cos_sin(position_ids)
+        rope_setup_decode = TtLlamaRotarySetup(device, head_dim, max_seq_len)
+        cos, sin = rope_setup_decode.get_rot_mats(position_ids)
+        tt_model.transformation_mat = rope_setup_decode.transformation_mat
 
         # For decode, TTNN expects inputs to be [1, batch, nh, dhead]
         inp = [x.transpose(1, 2) for x in inp]
+        # inp: [seq_len, batch, n_heads, head_dim]
 
-        grid = ttnn.num_cores_to_corerangeset(batch, tt_model.core_grid, row_wise=True).bounding_box().grid_size()
+        grid = ttnn.num_cores_to_corerangeset(batch, rope_setup_decode.core_grid, row_wise=True).bounding_box().grid_size()
         input_mem_config = ttnn.create_sharded_memory_config(
             shape=(1, batch, ttnn.TILE_SIZE, head_dim),
             core_grid=ttnn.CoreGrid(y=grid.y, x=grid.x),
@@ -267,8 +199,9 @@ def run_test_rotary_embedding_llama(
     tt_out = tt_model(*tt_inp)
     tt_out = [ttnn.to_torch(tt_out_tensor) for tt_out_tensor in tt_out]
 
-    if mode == "decode":  # Swap back the n_head and batch dimensions to compare with torch output
+    if mode == "decode":
         tt_out = [x.transpose(1, 2) for x in tt_out]
+        # tt_out: [seq_len, n_heads, batch, head_dim]
 
     # check outputs ----------------------------------------------------------------------
     assert len(pytorch_out) == len(tt_out), "Lengths of pytorch and tt outputs do not match!"
@@ -368,6 +301,9 @@ def test_rotary_embedding_llama(
     if seq_len == 1 and (n_heads > ttnn.TILE_SIZE or n_kv_heads > ttnn.TILE_SIZE):
         pytest.skip("n_heads or n_kv_heads cannot be greater than ttnn.TILE_SIZE for decode mode")
 
+    if seq_len == 1 and (batch % ttnn.TILE_SIZE != 0):
+        pytest.skip(f"Batch size should be multiple of {ttnn.TILE_SIZE=} in decode mode.")
+
     max_seq_len = max(4096, seq_len)
 
     run_test_rotary_embedding_llama(device, batch, seq_len, pcc, n_heads, n_kv_heads, head_dim, max_seq_len, datatype)
@@ -432,6 +368,9 @@ def test_rotary_embedding_llama_with_program_cache(
     if compute_grid_size.x < 8 or compute_grid_size.y < 8:
         pytest.skip(f"Requires grid size of at least {(8, 8)} to run")
 
+    if seq_len == 1 and (batch % ttnn.TILE_SIZE != 0):
+        pytest.skip(f"Batch size should be multiple of {ttnn.TILE_SIZE=} in decode mode.")
+
     max_seq_len = max(4096, seq_len)
 
     mode = "decode" if seq_len == 1 else "prefill"
@@ -458,6 +397,6 @@ def test_rotary_embedding_llama_with_program_cache(
         cache_tensors.append(test_tensor)
 
     if mode == "decode":
-        assert device.num_program_cache_entries() == 6  # 2 * Rope + embedding + permute +
+        assert device.num_program_cache_entries() == 6  # 2 * Rope + embedding + unsqueeze_to_4D + transpose + ?
     else:
         assert device.num_program_cache_entries() == 2  # 2 * Rope

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -173,7 +173,9 @@ def run_test_rotary_embedding_llama(
         inp = [x.transpose(1, 2) for x in inp]
         # inp: [seq_len, batch, n_heads, head_dim]
 
-        grid = ttnn.num_cores_to_corerangeset(batch, rope_setup_decode.core_grid, row_wise=True).bounding_box().grid_size()
+        grid = (
+            ttnn.num_cores_to_corerangeset(batch, rope_setup_decode.core_grid, row_wise=True).bounding_box().grid_size()
+        )
         input_mem_config = ttnn.create_sharded_memory_config(
             shape=(1, batch, ttnn.TILE_SIZE, head_dim),
             core_grid=ttnn.CoreGrid(y=grid.y, x=grid.x),


### PR DESCRIPTION
### Ticket
- #14107 

### Problem description
Currently, the llama2/3/vllm codebase does not use the `ttnn.experimental.rotary_embedding_llama` op in decode mode.

### What's changed
This PR changes all modules and tests that are relevant including:
- model, demo, attention unit tests and modules
- llama_generation, demo

Also, a new module is added to `llama_rope`, to help set up tensors for decode mode rope.

Note: The current integration only supports batch sizes that are a multiple of 32.

### Checklist
- [x] Post commit CI passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/11695355582))
- [ ] Model regression CI testing passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/11691004791))
