### PR TITLE
[skip ci] #0: Update all-static-checks.yaml

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -157,7 +157,7 @@ jobs:
         sudo ln -s $(which clang-tidy-17) /usr/local/bin/clang-tidy
     - name: Prepare compile_commands.json
       run: |
-        ARCH_NAME=grayskull cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+        ARCH_NAME=grayskull cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF
     - name: Create results directory
       run: |
         mkdir clang-tidy-result


### PR DESCRIPTION
Ensure that compile_commands.json has necessary information for tests.

### Ticket
NA

### Problem description
`clang-tidy` bot was spitting out a bunch of diagnostic errors.

### What's changed
Enable tests during cmake configure in the clang-tidy check.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
