### PR TITLE
#14351: enable single core fused op tests on BH

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_single_core_fused_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_single_core_fused_ops.py
@@ -12,13 +12,11 @@ from tt_lib.utils import (
     is_close,
 )
 
-from models.utility_functions import comp_pcc, pad_by_zero, skip_for_blackhole
+from models.utility_functions import comp_pcc, pad_by_zero
 
 shapes = [[1, 1, 32, 32], [1, 1, 32, 128], [1, 2, 128, 128]]
 
 
-# still have to skip b/c of very low PCC in WH B0
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("shape", shapes)
 def test_softmax(shape, device):
     torch.manual_seed(1234)
@@ -35,7 +33,6 @@ def test_softmax(shape, device):
     assert passing
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("shape", shapes)
 def test_layernorm(shape, device):
     torch.manual_seed(1234)


### PR DESCRIPTION
### Ticket
Link to Github Issues https://github.com/tenstorrent/tt-metal/issues/14351 https://github.com/tenstorrent/tt-metal/issues/14355

### Problem description
- single core fused op tests were skipped on BH because of earlier issues

### What's changed
- the issues have been resolved therefore the tests can be enabled

### Checklist
- [ ] Post commit CI passes N/A
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11692213332
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
