### PR TITLE
#14581: Remove deprecated UMD API host_addr_params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,6 @@ if("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
             tt_metal/hw/inc/wormhole
             ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
             ${UMD_HOME}/device/wormhole
-            ${UMD_HOME}/src/firmware/riscv/wormhole
     )
 else()
     target_include_directories(
@@ -271,7 +270,6 @@ else()
         INTERFACE
             ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}
             ${UMD_HOME}/device/$ENV{ARCH_NAME}
-            ${UMD_HOME}/src/firmware/riscv/$ENV{ARCH_NAME}
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ if("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
             tt_metal/hw/inc/wormhole
             ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
             ${UMD_HOME}/device/wormhole
+            ${UMD_HOME}/src/firmware/riscv/wormhole
     )
 else()
     target_include_directories(
@@ -270,6 +271,7 @@ else()
         INTERFACE
             ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}
             ${UMD_HOME}/device/$ENV{ARCH_NAME}
+            ${UMD_HOME}/src/firmware/riscv/$ENV{ARCH_NAME}
     )
 endif()
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -302,7 +302,6 @@ void Cluster::open_driver(const bool &skip_driver_allocs) {
                 device_driver->configure_active_ethernet_cores_for_mmio_device(mmio_device_id, {});
             }
         }
-        device_driver->set_driver_host_address_params(host_address_params);
         device_driver->set_driver_eth_interface_params(eth_interface_params);
 
         // Adding this check is a workaround for current UMD bug that only uses this getter to populate private metadata

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -11,7 +11,6 @@
 #include "common/metal_soc_descriptor.h"
 #include "common/test_common.hpp"
 #include "common/tt_backend_api_types.hpp"
-#include "host_mem_address_map.h"
 #include "third_party/umd/device/device_api_metal.h"
 #include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
@@ -297,9 +296,6 @@ class Cluster {
         (uint32_t)eth_l1_mem::address_map::ERISC_BARRIER_BASE,
         (uint32_t)eth_l1_mem::address_map::FW_VERSION_ADDR,
     };
-
-    tt_driver_host_address_params host_address_params = {
-        host_mem::address_map::ETH_ROUTING_BLOCK_SIZE, host_mem::address_map::ETH_ROUTING_BUFFERS_START};
 
     tt_driver_eth_interface_params eth_interface_params = {
         NOC_ADDR_LOCAL_BITS,


### PR DESCRIPTION
### Ticket
Closes #14581 
#596 

### Problem description
Circular interaction with UMD has been fixed. No need to do this. UMD will self initialize these parameters based on detected ARCH.

### What's changed
Removed usage of deprecated API

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11695072302
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
