### PR TITLE
#14773: Set default to true when getting active ethernet cores

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
@@ -18,11 +18,11 @@ static void RunTest(WatcherFixture *fixture, Device *device, riscv_id_t riscv_ty
     // Depending on riscv type, choose one core to run the test on (since the test hangs the board).
     CoreCoord logical_core, phys_core;
     if (riscv_type == DebugErisc) {
-        if (device->get_active_ethernet_cores().empty()) {
+        if (device->get_active_ethernet_cores(true).empty()) {
             log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
             GTEST_SKIP();
         }
-        logical_core = *(device->get_active_ethernet_cores().begin());
+        logical_core = *(device->get_active_ethernet_cores(true).begin());
         phys_core = device->ethernet_core_from_logical_core(logical_core);
     } else if (riscv_type == DebugIErisc) {
         if (device->get_inactive_ethernet_cores().empty()) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
@@ -27,11 +27,11 @@ static void RunTest(WatcherFixture *fixture, Device *device, riscv_id_t riscv_ty
     // Depending on riscv type, choose one core to run the test on.
     CoreCoord logical_core, phys_core;
     if (riscv_type == DebugErisc) {
-        if (device->get_active_ethernet_cores().empty()) {
+        if (device->get_active_ethernet_cores(true).empty()) {
             log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
             GTEST_SKIP();
         }
-        logical_core = *(device->get_active_ethernet_cores().begin());
+        logical_core = *(device->get_active_ethernet_cores(true).begin());
         phys_core = device->ethernet_core_from_logical_core(logical_core);
     } else if (riscv_type == DebugIErisc) {
         if (device->get_inactive_ethernet_cores().empty()) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12914)
https://github.com/tenstorrent/tt-metal/issues/14773

### Problem description
T3K VMs were failing on some watcher tests in t3k unit tests.


### What's changed
With help from @mo-tenstorrent @tt-dma. These changes allow for T3K VMs to pass t3k unit tests due to failing to enumerate correctly which core to use.

Merging this test in allows for T3K VMs to be added into CI and alleviate heavy t3k functional test load

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11695346421
- [ ] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11695417179
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [ ] t3k unit https://github.com/tenstorrent/tt-metal/actions/runs/11695348568
- [ ] t3k freq https://github.com/tenstorrent/tt-metal/actions/runs/11695347560

Custom Dispatch on previously failing t3k tests
https://github.com/tenstorrent/tt-metal/actions/runs/11694254577/job/32567562536
https://github.com/tenstorrent/tt-metal/actions/runs/11694265540/job/32567581892
https://github.com/tenstorrent/tt-metal/actions/runs/11694273627/job/32567674280