### PR TITLE
#14830: Add support for groups in `ttnn.concat`

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -189,6 +189,99 @@ def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy
     assert_with_pcc(torch_output_tensor_2, output_2)
 
 
+def grouped_concat(activations, residuals, groups):
+    """
+    Concatenate activations and residuals with flexible interleaving based on groups.
+
+    Args:
+        activations (torch.Tensor): Activation tensor with shape [N, H, W, C].
+        residuals (torch.Tensor): Residual tensor with shape [N, H, W, C].
+        groups (int): Number of groups to split channels into.
+
+    Returns:
+        torch.Tensor: Concatenated tensor with interleaved groups.
+    """
+    assert (
+        activations.shape[:-1] == residuals.shape[:-1]
+    ), "Activations and residuals must have the same shape in all dims but -1"
+
+    N, H, W, activation_channels = activations.shape
+    assert activation_channels % groups == 0, "Channel count must be divisible by the number of groups"
+
+    N, H, W, residual_channels = residuals.shape
+    assert residual_channels % groups == 0, "Channel count must be divisible by the number of groups"
+
+    act_groups = activations.view(N, H, W, groups, activation_channels // groups)
+    res_groups = residuals.view(N, H, W, groups, residual_channels // groups)
+
+    # Interleave activations and residuals along the channel axis
+    interleaved = torch.cat([act_groups, res_groups], dim=-1)  # Shape: [N, H, W, groups, 2 * group_size]
+
+    # Reshape to combine groups and channels correctly
+    interleaved = interleaved.permute(0, 1, 2, 3, 4).reshape(N, H, W, residual_channels + activation_channels)
+
+    return interleaved
+
+
+@pytest.mark.parametrize("dim", [3])
+@pytest.mark.parametrize("groups", [1, 2, 4])
+@pytest.mark.parametrize(
+    "input_shapes, output_shape, core_grid",
+    (
+        (
+            ((1, 1, 1, 32), (1, 1, 1, 32)),
+            (1, 1, 1, 64),
+            ttnn.CoreGrid(x=1, y=1),
+        ),
+        (
+            ((1, 1, 1, 32), (1, 1, 1, 64)),
+            (1, 1, 1, 96),
+            ttnn.CoreGrid(x=1, y=1),
+        ),
+        (
+            ((1, 1, 1, 64), (1, 1, 1, 32)),
+            (1, 1, 1, 96),
+            ttnn.CoreGrid(x=1, y=1),
+        ),
+        (
+            ((1, 1, 1024, 64), (1, 1, 1024, 32)),
+            (1, 1, 1024, 96),
+            ttnn.CoreGrid(x=4, y=1),
+        ),
+        (
+            ((1, 1, 256, 64), (1, 1, 256, 128)),
+            (1, 1, 256, 192),
+            ttnn.CoreGrid(x=8, y=1),
+        ),
+    ),
+)
+def test_sharded_concat_with_groups(device, input_shapes, output_shape, dim, groups, core_grid):
+    torch_input_tensors = [torch.full(shapes, idx + 1, dtype=torch.bfloat16) for idx, shapes in enumerate(input_shapes)]
+
+    expected = grouped_concat(torch_input_tensors[0], torch_input_tensors[1], groups)
+
+    sharded_memory_configs = [
+        ttnn.create_sharded_memory_config(
+            x.shape, core_grid, ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.ROW_MAJOR
+        )
+        for x in torch_input_tensors
+    ]
+    ttnn_input_tensors = [
+        ttnn.from_torch(
+            x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=memory_config
+        )
+        for x, memory_config in zip(torch_input_tensors, sharded_memory_configs)
+    ]
+
+    output_memory_config = ttnn.create_sharded_memory_config(output_shape, core_grid, ttnn.ShardStrategy.HEIGHT)
+    z = ttnn.concat(
+        [ttnn_input_tensors[0], ttnn_input_tensors[1]], dim=dim, memory_config=output_memory_config, groups=groups
+    )
+
+    actual = ttnn.to_torch(z)
+    assert_with_pcc(expected, actual, 1.0)
+
+
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
 def test_concat_5d(device, dim):
     torch_input_tensor = torch.rand(1, 1, 1, 1, 2, dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -2,112 +2,108 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/common/constants.hpp"
-#include "ttnn/tensor/types.hpp"
-#include "ttnn/operations/core/core.hpp"
-
-#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp"
 
 #include <ranges>
 
+#include "ttnn/common/constants.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/tensor/types.hpp"
 
 namespace ttnn {
 namespace operations {
 namespace data_movement {
 
-    // Wrapper for TTDNN
-    ttnn::Tensor ConcatOperation::invoke(
-        uint8_t queue_id,
-        const std::vector<ttnn::Tensor>& input_tensors,
-        int dim,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<ttnn::Tensor> optional_output_tensor) {
-        TT_FATAL(input_tensors.size() > 0, "ttnn.concat: expected a non-empty list of Tensors!");
-        TT_FATAL(!optional_output_tensor.has_value(), "optional output tensor currently unsupported!");
-        const auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG); // should match input tensor memory config when unpopulated but causes CI errors for now
+// Wrapper for TTDNN
+ttnn::Tensor ConcatOperation::invoke(
+    uint8_t queue_id,
+    const std::vector<ttnn::Tensor>& input_tensors,
+    int dim,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    unsigned int groups) {
+    TT_FATAL(input_tensors.size() > 0, "ttnn.concat: expected a non-empty list of Tensors!");
+    TT_FATAL(!optional_output_tensor.has_value(), "optional output tensor currently unsupported!");
+    const auto mem_config =
+        memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);  // should match input tensor memory config when unpopulated
+                                                           // but causes CI errors for now
 
-        if (input_tensors.size() == 1) {
-            return ttnn::to_memory_config(input_tensors.at(0), mem_config, std::nullopt);
-        }
+    if (input_tensors.size() == 1) {
+        return ttnn::to_memory_config(input_tensors.at(0), mem_config, std::nullopt);
+    }
 
-        // TODO: Issue #8426: Add validation for ttnn.concat for sharded inputs
-        // const bool all_tensors_are_tile_layout_without_padding = std::all_of(input_tensors.begin(), input_tensors.end(),
-        // [dim](const ttnn::Tensor& input_tensor){
-        //    return input_tensor.get_layout() == ttnn::TILE_LAYOUT and not has_tile_padding(input_tensor, dim);
-        //});
-        // TT_FATAL(all_tensors_are_tile_layout_without_padding, "Not Implemented");
+    // TODO: Issue #8426: Add validation for ttnn.concat for sharded inputs
+    // const bool all_tensors_are_tile_layout_without_padding = std::all_of(input_tensors.begin(), input_tensors.end(),
+    // [dim](const ttnn::Tensor& input_tensor){
+    //    return input_tensor.get_layout() == ttnn::TILE_LAYOUT and not has_tile_padding(input_tensor, dim);
+    //});
+    // TT_FATAL(all_tensors_are_tile_layout_without_padding, "Not Implemented");
 
-        const ttnn::Tensor& first_tensor = input_tensors.front();
-        const int rank = first_tensor.get_shape().rank();
+    const ttnn::Tensor& first_tensor = input_tensors.front();
+    const int rank = first_tensor.get_shape().rank();
 
-        dim = first_tensor.get_legacy_shape().get_normalized_index(dim);
+    dim = first_tensor.get_legacy_shape().get_normalized_index(dim);
 
-        TT_FATAL(
-            dim >= 0 and dim < rank,
-            "ttnn: Dimension out of range: dim {} cannot be used for tensors of rank {}",
-            dim,
-            rank);
+    TT_FATAL(
+        dim >= 0 and dim < rank,
+        "ttnn: Dimension out of range: dim {} cannot be used for tensors of rank {}",
+        dim,
+        rank);
 
-        const bool shapes_match =
-            std::all_of(input_tensors.begin(), input_tensors.end(), [first_tensor, dim](const ttnn::Tensor& t) {
-                const auto& ft_shape = first_tensor.get_shape();
-                const auto& t_shape = t.get_shape();
+    const bool shapes_match =
+        std::all_of(input_tensors.begin(), input_tensors.end(), [first_tensor, dim](const ttnn::Tensor& t) {
+            const auto& ft_shape = first_tensor.get_shape();
+            const auto& t_shape = t.get_shape();
 
-                const bool ranks_match = ft_shape.rank() == t_shape.rank();
-                bool non_concat_dims_match = true;
-                for (int i = 0; i < ft_shape.rank(); i++) {
-                    non_concat_dims_match &= dim == i or t_shape[i] == ft_shape[i];
-                }
-                // bool non_concat_padded_dims_match = true;
-                // for(int i = 0; i < ft_shape.rank(); i++) {
-                //     non_concat_padded_dims_match &= dim == i or t_shape.with_tile_padding()[i] ==
-                //     ft_shape.with_tile_padding()[i];
-                // }
-                return ranks_match and non_concat_dims_match;  // and non_concat_padded_dims_match;
-            });
-
-        TT_FATAL(
-            shapes_match,
-            "All dimensions must be the same size except for the dimension along which the contenation is taking place.");
-
-        std::vector<ttnn::Tensor> itensor;
-        std::transform(
-            input_tensors.begin(),
-            input_tensors.end(),
-            std::back_inserter(itensor),
-            [rank](const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
-                auto output = (rank < 4) ? ttnn::unsqueeze_to_4D(input_tensor) : input_tensor;
-                return output;
-            });
-        // Convert dim after unsqueeze
-        dim = rank < 4 ? dim + 4 - rank : dim;
-        auto output_tensor = concat_impl(itensor, dim, mem_config);
-        while (output_tensor.get_shape().rank() > rank) {
-            const auto shape = output_tensor.get_shape();
-            const auto full_shape = output_tensor.get_shape().with_tile_padding();
-            SmallVector<uint32_t> shape_vec{};
-            SmallVector<uint32_t> full_shape_vec{};
-            // int i = 0;
-            // while(i < 3 and shape[i] == 1) i++;
-            for (int i = 1; i < shape.rank(); i++) {
-                shape_vec.push_back(shape[i]);
-                full_shape_vec.push_back(full_shape[i]);
+            const bool ranks_match = ft_shape.rank() == t_shape.rank();
+            bool non_concat_dims_match = true;
+            for (int i = 0; i < ft_shape.rank(); i++) {
+                non_concat_dims_match &= dim == i or t_shape[i] == ft_shape[i];
             }
-            output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(shape_vec, full_shape_vec));
+            return ranks_match and non_concat_dims_match;
+        });
+
+    TT_FATAL(
+        shapes_match,
+        "All dimensions must be the same size except for the dimension along which the contenation is taking place.");
+
+    std::vector<ttnn::Tensor> itensor;
+    std::transform(
+        input_tensors.begin(),
+        input_tensors.end(),
+        std::back_inserter(itensor),
+        [rank](const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
+            auto output = (rank < 4) ? ttnn::unsqueeze_to_4D(input_tensor) : input_tensor;
+            return output;
+        });
+    // Convert dim after unsqueeze
+    dim = rank < 4 ? dim + 4 - rank : dim;
+    auto output_tensor = concat_impl(itensor, dim, groups, mem_config);
+    while (output_tensor.get_shape().rank() > rank) {
+        const auto shape = output_tensor.get_shape();
+        const auto full_shape = output_tensor.get_shape().with_tile_padding();
+        SmallVector<uint32_t> shape_vec{};
+        SmallVector<uint32_t> full_shape_vec{};
+        for (int i = 1; i < shape.rank(); i++) {
+            shape_vec.push_back(shape[i]);
+            full_shape_vec.push_back(full_shape[i]);
         }
-
-        return output_tensor;
+        output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(shape_vec, full_shape_vec));
     }
 
-    ttnn::Tensor ConcatOperation::invoke (
-        const std::vector<ttnn::Tensor>& input_tensors,
-        int dim,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<ttnn::Tensor> optional_output_tensor) {
-        return invoke(DefaultQueueId, input_tensors, dim, memory_config, optional_output_tensor);
-    }
-};
+    return output_tensor;
+}
 
+ttnn::Tensor ConcatOperation::invoke(
+    const std::vector<ttnn::Tensor>& input_tensors,
+    int dim,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    unsigned int groups) {
+    return invoke(DefaultQueueId, input_tensors, dim, memory_config, optional_output_tensor, groups);
 }
-}
+
+}  // namespace data_movement
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
@@ -22,13 +22,15 @@ struct ConcatOperation {
         const std::vector<ttnn::Tensor>& input_tensors,
         int dim,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<ttnn::Tensor> optional_output_tensor=std::nullopt);
+        std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
+        unsigned int groups = 1);
 
     static ttnn::Tensor invoke(
         const std::vector<ttnn::Tensor>& input_tensors,
         int dim,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt);
+        std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
+        unsigned int groups = 1);
 };
 
 }  // namespace data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat_pybind.hpp
@@ -25,6 +25,7 @@ Keyword Args:
     memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
     queue_id (int, optional): command queue id. Defaults to `0`.
     output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+    groups (int, optional): When `groups` is set to a value greater than 1, the inputs are split into N `groups` partitions, and elements are interleaved from each group into the output tensor. Each group is processed independently, and elements from each group are concatenated in an alternating pattern based on the number of groups. This is useful for recombining grouped convolution outputs during residual concatenation. Defaults to `1`. Currently, groups > `1` is only supported for two height sharded input tensors.
 
 Returns:
     ttnn.Tensor: the output tensor.
@@ -52,14 +53,16 @@ Example:
                 const int dim,
                 std::optional<ttnn::Tensor> &optional_output_tensor,
                 std::optional<ttnn::MemoryConfig>& memory_config,
+                const int groups,
                 uint8_t queue_id) {
-                    return self(queue_id, tensors, dim, memory_config, optional_output_tensor);
+                    return self(queue_id, tensors, dim, memory_config, optional_output_tensor, groups);
                 },
                 py::arg("tensors"),
                 py::arg("dim") = 0,
                 py::kw_only(),
                 py::arg("output_tensor").noconvert() = std::nullopt,
                 py::arg("memory_config") = std::nullopt,
+                py::arg("groups") = 1,
                 py::arg("queue_id") = 0,
                 });
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -13,6 +13,7 @@ enum class ConcatOpParallelizationStrategy { MULTI_CORE, SHARDED_MULTI_CORE };
 
 struct ConcatDeviceOperation {
     uint32_t dim;
+    unsigned int groups;
     const MemoryConfig output_mem_config;
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -27,6 +28,7 @@ struct ConcatDeviceOperation {
 Tensor concat_impl(
     std::vector<Tensor> &input_tensors,
     const std::int64_t dim = 0,
+    unsigned int groups = 1,
     const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.hpp"
-#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
 
 #include <algorithm>
 #include <numeric>
 
-#include "tt_metal/common/work_split.hpp"
-#include "tt_metal/detail/util.hpp"
-#include "tt_metal/host_api.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 using namespace tt::constants;
 using namespace tt;
@@ -32,8 +30,14 @@ uint32_t find_greatest_common_page_size(std::vector<uint32_t> &stick_sizes, uint
 namespace ttnn::operations::data_movement::detail {
 
 operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
-    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output) {
+    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output, unsigned int groups) {
     TT_FATAL(dim == 3, "Sharded concat RM only supports dim=3");
+    TT_FATAL(groups == 1 || dim == 3, "Sharded concat RM only supports groups > 1 when dim=3");
+
+    TT_FATAL(
+        input_tensors.size() == 2 && input_tensors[0].get_legacy_shape()[-1] % groups == 0 &&
+            input_tensors[0].get_legacy_shape()[-1] % groups == 0,
+        "Input channels must both be evenly divisible by groups");
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
@@ -55,6 +59,7 @@ operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
 
     std::vector<uint32_t> cb_ids(num_input_tensors);
     uint32_t input_unit_size = input_tensors[0].shard_spec().value().shape[1] * input_tensors[0].element_size();
+
     // input CBs
     for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
         auto shard_spec = input_tensors[input_id].shard_spec().value();
@@ -93,53 +98,47 @@ operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
     auto input_1_stride = output_stick_size - input_1_stick_size;
     uint32_t num_output_rows_per_core = div_up(num_output_rows, all_cores.num_cores());
     auto num_pages_per_risc = div_up(num_output_rows_per_core, 2);
-    std::vector <uint32_t> compile_time_args_0 = {
-                                                    cb_dst_id,
-                                                    input_0_stick_size,
-                                                    input_1_stick_size,
-                                                    input_0_stride,
-                                                    input_1_stride,
-                                                    num_output_rows_per_core * num_input_tensors,
-                                                    0,
-                                                    num_pages_per_risc,
-                                                    0,
-                                                    0,
-                                                    0
-                                                };
+    std::vector<uint32_t> compile_time_args_0 = {
+        cb_dst_id,
+        input_0_stick_size,
+        input_1_stick_size,
+        input_0_stride,
+        input_1_stride,
+        num_output_rows_per_core * num_input_tensors,
+        0,
+        num_pages_per_risc,
+        0,
+        0,
+        0,
+        groups};
 
-    std::vector <uint32_t> compile_time_args_1 = {
-                                                    cb_dst_id,
-                                                    input_0_stick_size,
-                                                    input_1_stick_size,
-                                                    input_0_stride,
-                                                    input_1_stride,
-                                                    num_output_rows_per_core * num_input_tensors ,
-                                                    num_pages_per_risc,
-                                                    num_output_rows_per_core,
-                                                    num_pages_per_risc*output_stick_size,
-                                                    num_pages_per_risc*input_0_stick_size,
-                                                    num_pages_per_risc*input_1_stick_size,
-                                                };
-
-
-
-
+    std::vector<uint32_t> compile_time_args_1 = {
+        cb_dst_id,
+        input_0_stick_size,
+        input_1_stick_size,
+        input_0_stride,
+        input_1_stride,
+        num_output_rows_per_core * num_input_tensors,
+        num_pages_per_risc,
+        num_output_rows_per_core,
+        num_pages_per_risc * output_stick_size,
+        num_pages_per_risc * input_0_stick_size,
+        num_pages_per_risc * input_1_stick_size,
+        groups};
 
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+        "reader_height_sharded_width_concat_two_tensors.cpp",
         all_cores,
         tt_metal::ReaderDataMovementConfig(compile_time_args_0));
 
-
     tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+        "reader_height_sharded_width_concat_two_tensors.cpp",
         all_cores,
         tt_metal::WriterDataMovementConfig(compile_time_args_1));
-
-
-
 
     auto override_runtime_arguments_callback =
         [unary_reader_kernel_id, unary_writer_kernel_id, all_cores, num_input_tensors](
@@ -147,9 +146,7 @@ operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
             Program &program,
             const std::vector<Tensor> &input_tensors,
             const std::vector<std::optional<const Tensor>> &,
-            const std::vector<Tensor> &output_tensors) {
-                ;
-        };
+            const std::vector<Tensor> &output_tensors) { ; };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
@@ -420,17 +417,23 @@ operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
 }
 
 operation::ProgramWithCallbacks sharded_concat_multi_core(
-    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output) {
+    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output, unsigned int groups) {
     if (output.is_sharded()) {
         if (input_tensors.size() == 2) {
             // TODO(jerrysky3): Keep the unrolled two tensor concat tensor for now but it only supports height-sharded
             // width concat. Need to unroll s2s_rm_concat_multi_core if width-sharded height concat is needed for this
             // case.
-            return s2s_rm_concat_two_tensors_multi_core(input_tensors, dim, output);
+            return s2s_rm_concat_two_tensors_multi_core(input_tensors, dim, output, groups);
         } else {
+            TT_FATAL(
+                groups == 1,
+                "Sharded ttnn.concat with groups > 1 is only supported for 2 sharded input and sharded output tensors");
             return s2s_concat_multi_core(input_tensors, dim, output);
         }
     } else {
+        TT_FATAL(
+            groups == 1,
+            "Sharded ttnn.concat with groups > 1 is only supported for 2 sharded input and sharded output tensors");
         return s2i_rm_concat_multi_core(input_tensors, dim, output);
     }
 }
@@ -572,16 +575,18 @@ operation::ProgramWithCallbacks concat_multi_core(
     // Tilized reader
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
         program,
-        rm_layout
-            ? "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp"
-            : "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_interleaved_start_id.cpp",
+        rm_layout ? "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+                    "reader_concat_stick_layout_interleaved_start_id.cpp"
+                  : "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
+                    "reader_concat_interleaved_start_id.cpp",
         all_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, concat_defines));
 
     tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
         program,
-        rm_layout ? "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp"
-                  : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        rm_layout
+            ? "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp"
+            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
         all_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.hpp
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include "ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp"
 #include "tt_metal/common/work_split.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
-
-using namespace tt::constants;
-using namespace tt;
 
 namespace ttnn::operations::data_movement::detail {
 
@@ -25,16 +21,16 @@ struct CorePageRange {
     PageRange range;
 };
 
-operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks s2s_rm_concat_two_tensors_multi_core(
+    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output, unsigned int groups = 1);
+
+tt::tt_metal::operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
     const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output);
 
-operation::ProgramWithCallbacks s2i_rm_concat_multi_core(
-    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output);
+tt::tt_metal::operation::ProgramWithCallbacks sharded_concat_multi_core(
+    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output, unsigned int groups = 1);
 
-operation::ProgramWithCallbacks sharded_concat_multi_core(
-    const std::vector<Tensor> &input_tensors, uint32_t dim, Tensor &output);
-
-operation::ProgramWithCallbacks concat_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks concat_multi_core(
     const std::vector<Tensor> &input_tensors, const uint32_t dim, const Tensor &output);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_height_sharded_width_concat_two_tensors.cpp
@@ -1,3 +1,4 @@
+
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -5,48 +6,58 @@
 #include <stdint.h>
 
 void kernel_main() {
-	constexpr uint32_t output_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
 
-	constexpr uint32_t input_stick_size_0 = get_compile_time_arg_val(1);
-	constexpr uint32_t input_stick_size_1 = get_compile_time_arg_val(2);
-	constexpr uint32_t input_stride_0 = get_compile_time_arg_val(3);
-	constexpr uint32_t input_stride_1 = get_compile_time_arg_val(4);
+    constexpr uint32_t input_stick_size_0 = get_compile_time_arg_val(1);
+    constexpr uint32_t input_stick_size_1 = get_compile_time_arg_val(2);
+    constexpr uint32_t input_stride_0 = get_compile_time_arg_val(3);
+    constexpr uint32_t input_stride_1 = get_compile_time_arg_val(4);
 
-	const uint32_t num_output_pages = get_compile_time_arg_val(5);
-	const uint32_t page_start = get_compile_time_arg_val(6);
-	const uint32_t page_end = get_compile_time_arg_val(7);
-	const uint32_t output_stick_offset = get_compile_time_arg_val(8);
-	const uint32_t input_start_0 = get_compile_time_arg_val(9);
-	const uint32_t input_start_1 = get_compile_time_arg_val(10);
+    const uint32_t num_output_pages = get_compile_time_arg_val(5);
+    const uint32_t page_start = get_compile_time_arg_val(6);
+    const uint32_t page_end = get_compile_time_arg_val(7);
+    const uint32_t output_stick_offset = get_compile_time_arg_val(8);
+    const uint32_t input_start_0 = get_compile_time_arg_val(9);
+    const uint32_t input_start_1 = get_compile_time_arg_val(10);
 
-	const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    const uint32_t groups = get_compile_time_arg_val(11);
 
-	uint32_t l1_write_addr_0 = base_l1_write_addr + output_stick_offset;
-	const uint32_t l1_read_addr_0 = get_read_ptr(0) + input_start_0;
-	const uint64_t noc_addr_0 = get_noc_addr(l1_read_addr_0);
-	noc_async_read_one_packet_set_state(noc_addr_0, input_stick_size_0);
+    constexpr uint32_t group_stick_size_0 = input_stick_size_0 / groups;
+    constexpr uint32_t group_stick_size_1 = input_stick_size_1 / groups;
+    constexpr uint32_t group_stride_0 = input_stride_0 / groups;
+    constexpr uint32_t group_stride_1 = input_stride_1 / groups;
 
-	uint32_t read_offset_0 = l1_read_addr_0;
-	uint32_t l1_write_addr_inc_0 = input_stick_size_0 + input_stride_0;
-	for(uint32_t page_id_input = page_start; page_id_input < page_end; page_id_input++) {
-		noc_async_read_one_packet_with_state<true>(read_offset_0, l1_write_addr_0);
-		l1_write_addr_0 += (l1_write_addr_inc_0);
-		read_offset_0 += input_stick_size_0;
-	}
+    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
 
-	uint32_t l1_write_addr_1 = base_l1_write_addr + output_stick_offset + input_stick_size_0;
-	const uint32_t l1_read_addr_1 = get_read_ptr(1) + input_start_1;
-	const uint64_t noc_addr_1 = get_noc_addr(l1_read_addr_1);
-	noc_async_read_one_packet_set_state(noc_addr_1, input_stick_size_1);
+    uint32_t l1_write_addr_0 = base_l1_write_addr + output_stick_offset;
+    const uint32_t l1_read_addr_0 = get_read_ptr(0) + input_start_0;
+    const uint64_t noc_addr_0 = get_noc_addr(l1_read_addr_0);
+    noc_async_read_one_packet_set_state(noc_addr_0, group_stick_size_0);
 
-	uint32_t read_offset_1 = l1_read_addr_1;
-	uint32_t l1_write_addr_inc_1 = input_stick_size_1 + input_stride_1;
-	for(uint32_t page_id_input = page_start; page_id_input < page_end; page_id_input++) {
-		noc_async_read_one_packet_with_state<true>(read_offset_1, l1_write_addr_1);
-		l1_write_addr_1 += (l1_write_addr_inc_1);
-		read_offset_1 += input_stick_size_1;
-	}
+    uint32_t read_offset_0 = l1_read_addr_0;
+    uint32_t l1_write_addr_inc_0 = group_stick_size_0 + group_stride_0;
+    for (uint32_t page_id_input = page_start; page_id_input < page_end; page_id_input++) {
+        for (uint32_t i = 0; i < groups; i++) {
+            noc_async_read_one_packet_with_state<true>(read_offset_0, l1_write_addr_0);
+            l1_write_addr_0 += (l1_write_addr_inc_0);
+            read_offset_0 += group_stick_size_0;
+        }
+    }
 
-	noc_async_read_barrier();
+    uint32_t l1_write_addr_1 = base_l1_write_addr + output_stick_offset + group_stick_size_0;
+    const uint32_t l1_read_addr_1 = get_read_ptr(1) + input_start_1;
+    const uint64_t noc_addr_1 = get_noc_addr(l1_read_addr_1);
+    noc_async_read_one_packet_set_state(noc_addr_1, group_stick_size_1);
 
+    uint32_t read_offset_1 = l1_read_addr_1;
+    uint32_t l1_write_addr_inc_1 = group_stick_size_1 + group_stride_1;
+    for (uint32_t page_id_input = page_start; page_id_input < page_end; page_id_input++) {
+        for (uint32_t i = 0; i < groups; i++) {
+            noc_async_read_one_packet_with_state<true>(read_offset_1, l1_write_addr_1);
+            l1_write_addr_1 += (l1_write_addr_inc_1);
+            read_offset_1 += group_stick_size_1;
+        }
+    }
+
+    noc_async_read_barrier();
 }


### PR DESCRIPTION
### Ticket
#14830

### Problem description

In order to implement folding the batch dimension into channels so that we can leverage grouped convolutions in UNet Shallow, we need to handle the activation and residual concatenation by reshuffling the channels.


### What's changed
-  Add support for groups in `ttnn.concat`.  
   - When `groups` is set to a value greater than 1, the inputs are split  into N `groups` partitions, and elements are interleaved from each group into the output tensor.
   - Groups > 1 is only supported for two input tensors that are height sharded
   - Add unit tests for `groups > 1`.
-  The default behaviour of `ttnn.concat` is unchanged.


### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11723792959
- [x] New/Existing tests provide coverage for changes
