### PR TITLE
#14225: Limit log max to 50m to further help with disk space dying for some reason it's still saving to JSON.…

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -78,6 +78,7 @@ runs:
           -v ${{ github.workspace }}:${{ github.workspace }}
           --net=host
           --log-driver none
+          --log-opt max-size=50m
           ${{ inputs.docker_opts }}
           -e LOGURU_LEVEL=${{ env.LOGURU_LEVEL }}
           -e PYTHONPATH=${{ github.workspace }}

--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -77,7 +77,7 @@ runs:
           -v /etc/bashrc:/etc/bashrc:ro
           -v ${{ github.workspace }}:${{ github.workspace }}
           --net=host
-          --log-driver none
+          --log-driver local
           --log-opt max-size=50m
           ${{ inputs.docker_opts }}
           -e LOGURU_LEVEL=${{ env.LOGURU_LEVEL }}


### PR DESCRIPTION
… 

### Ticket

#14225 

### Problem description

We still JSON logs saving to disk. Add log max size to enable rotation.

### What's changed

Should limit log file size on disk.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
