### PR TITLE
#14623: Remove dead ARCH_NAME specific code

### DIFF
--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "tt_metal/common/assert.hpp"
-#include "dev_mem_map.h"
 #include "tt_metal/third_party/umd/device/tt_device.h"
 #include "yaml-cpp/yaml.h"
 

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -372,7 +372,6 @@ void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
 // virtual coordinates because UMD APIs expect virtual coordinates.
 metal_SocDescriptor::metal_SocDescriptor(const tt_SocDescriptor& other, uint32_t harvesting_mask) :
     tt_SocDescriptor(other) {
-    this->trisc_sizes = {MEM_TRISC0_FIRMWARE_SIZE, MEM_TRISC1_FIRMWARE_SIZE, MEM_TRISC2_FIRMWARE_SIZE};  // TODO: Read trisc size from yaml
     this->generate_physical_descriptors_from_virtual(harvesting_mask);
     this->load_dram_metadata_from_device_descriptor();
     this->generate_logical_eth_coords_mapping();


### PR DESCRIPTION
### Ticket
Closes #14623 

### Problem description
We are initializing a dead class member with ARCH_NAME specific parameters.

### What's changed
Eliminate initialization of dead class member.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11711858750
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
