### PR TITLE
#11895: Dispatch async to ringbuffer

### DIFF
--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -87,10 +87,11 @@ void __attribute__((noinline)) Application(void) {
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
                                 NOC_Y(mailboxes->go_message.master_y), DISPATCH_MESSAGE_ADDR);
+                CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 internal_::notify_dispatch_core_done(dispatch_addr);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
-                // Only executed if watcher is enabled. Ensures that we don't report stale data due to invalid launch messages in the ring buffer
-                CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
+                // Only executed if watcher is enabled. Ensures that we don't report stale data due to invalid launch
+                // messages in the ring buffer
             }
 
         } else if (go_message_signal == RUN_MSG_RESET_READ_PTR) {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -171,9 +171,9 @@ int main() {
                     NOC_XY_ADDR(NOC_X(mailboxes->go_message.master_x),
                         NOC_Y(mailboxes->go_message.master_x), DISPATCH_MESSAGE_ADDR);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
+                CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
                 noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
-                CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
             }
 
 #ifndef ARCH_BLACKHOLE

--- a/tt_metal/hw/inc/debug/watcher_common.h
+++ b/tt_metal/hw/inc/debug/watcher_common.h
@@ -37,8 +37,9 @@ inline uint32_t debug_get_which_riscv()
 
 void clear_previous_launch_message_entry_for_watcher() {
     uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
-    // Once the read pointer has been incremented, clear the watcher info 2 entries before to ensure that we don't report stale data
-    uint32_t prev_rd_ptr = (launch_msg_rd_ptr - 2 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
+    // Before the read pointer has been incremented, clear the watcher info 1 entries before to ensure that we don't
+    // report stale data
+    uint32_t prev_rd_ptr = (launch_msg_rd_ptr - 1 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
     launch_msg_t tt_l1_ptr *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[prev_rd_ptr]);
     // Clear kernel ids and NOC ID used by stale program entry, since these are queried by watcher
     for (int idx = 0; idx < DISPATCH_CLASS_MAX; idx++) {
@@ -47,7 +48,6 @@ void clear_previous_launch_message_entry_for_watcher() {
     launch_msg->kernel_config.brisc_noc_id = 0;
 }
 #define CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER() clear_previous_launch_message_entry_for_watcher()
-
 #else // !WATCHER_ENABLED
 
 #define CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER()

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -3,17 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <magic_enum.hpp>
 #include <mutex>
 
 #include "tt_metal/common/base.hpp"
 #include "tt_metal/common/math.hpp"
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
-#include "tt_metal/impl/dispatch/worker_config_buffer.hpp"
-#include "tt_metal/llrt/llrt.hpp"
 #include "tt_metal/llrt/hal.hpp"
-
-#include <magic_enum.hpp>
+#include "tt_metal/llrt/llrt.hpp"
 
 using namespace tt::tt_metal;
 
@@ -449,17 +447,13 @@ class SystemMemoryManager {
     std::vector<uint32_t> bypass_buffer;
     uint32_t bypass_buffer_write_offset;
 
-    tt::tt_metal::WorkerConfigBufferMgr config_buffer_mgr;
-
    public:
     SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
         device_id(device_id),
         num_hw_cqs(num_hw_cqs),
         fast_write_callable(tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device_id)),
         bypass_enable(false),
-        bypass_buffer_write_offset(0),
-        config_buffer_mgr() {
-
+        bypass_buffer_write_offset(0) {
         this->completion_byte_addrs.resize(num_hw_cqs);
         this->prefetcher_cores.resize(num_hw_cqs);
         this->prefetch_q_writers.reserve(num_hw_cqs);
@@ -530,12 +524,6 @@ class SystemMemoryManager {
         }
         std::vector<std::mutex> temp_mutexes(num_hw_cqs);
         cq_to_event_locks.swap(temp_mutexes);
-
-        for (uint32_t index = 0; index < tt::tt_metal::hal.get_programmable_core_type_count(); index++) {
-            this->config_buffer_mgr.init_add_core(
-                tt::tt_metal::hal.get_dev_addr(tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
-                tt::tt_metal::hal.get_dev_size(tt::tt_metal::hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG));
-        }
     }
 
     uint32_t get_next_event(const uint8_t cq_id) {
@@ -844,9 +832,6 @@ class SystemMemoryManager {
         this->prefetch_q_writers[cq_id].write(this->prefetch_q_dev_ptrs[cq_id], command_size_16B);
         this->prefetch_q_dev_ptrs[cq_id] += sizeof(dispatch_constants::prefetch_q_entry_type);
     }
-
-    tt::tt_metal::WorkerConfigBufferMgr& get_config_buffer_mgr() { return config_buffer_mgr; }
-
 };
 
 struct LaunchMessageRingBufferState {

--- a/tt_metal/impl/dispatch/worker_config_buffer.hpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.hpp
@@ -37,7 +37,7 @@ class WorkerConfigBufferMgr {
   public:
     WorkerConfigBufferMgr();
 
-    void init_add_core(uint32_t base_addr, uint32_t size);
+    void init_add_buffer(uint32_t base_addr, uint32_t size);
     const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> reserve(const std::vector<uint32_t>& sizes);
     void free(uint32_t free_up_to_sync_count);
     void alloc(uint32_t when_freeable_sync_count);

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -147,6 +147,7 @@ class Program {
     uint32_t get_cb_base_addr(Device *device, CoreCoord logical_core, CoreType core_type) const;
     uint32_t get_sem_size(Device *device, CoreCoord logical_core, CoreType core_type) const;
     uint32_t get_cb_size(Device *device, CoreCoord logical_core, CoreType core_type) const;
+    void set_last_used_command_queue_for_testing(HWCommandQueue *queue);
 
    private:
     std::unique_ptr<detail::Program_> pimpl_;
@@ -168,6 +169,7 @@ class Program {
 
     bool runs_on_noc_unicast_only_cores();
     bool runs_on_noc_multicast_only_cores();
+    bool kernel_binary_always_stored_in_ringbuffer();
 
     friend HWCommandQueue;
     friend EnqueueProgramCommand;


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11795)

### Problem description
Currently the previous program needs to be finished before the dispatcher is allowed to copy the next one into a ringbuffer.

### What's changed

Don't wait for previous programs to finish before copying new ones into the
ringbuffer. This allows more parts of dispatch to work in parallel with
programs.

Ethernet kernels aren't placed in the ringbuffer, so any programs including
ethernet kernels dispatch the same as previously.

Also move the WorkerConfigBufferMgr from the SystemMemoryManager to the
HWCommandQueue, since it relies on sync counts that are dispatcher-specific.
Between command-queues we need to wait for the commands to completely drain,
since we have no way to wait for a specific command in a different command
queue to finish.


### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
