### PR TITLE
#14815: Add new mode to graph capture with tracks memory allocations

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -2,25 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "gtest/gtest.h"
-#include "tt_metal/common/logger.hpp"
-#include "tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp"
-#include "ttnn/device.hpp"
-#include "ttnn/operations/eltwise/binary/binary.hpp"
-#include "ttnn/operations/core/core.hpp"
-#include "ttnn/operations/creation.hpp"
-#include "ttnn_test_fixtures.hpp"
-
-#include "ttnn/tensor/types.hpp"
-
-#include "ttnn/graph/graph_processor.hpp"
-#include "ttnn/graph/graph_trace_utils.hpp"
-#include "ttnn/graph/graph_operation_queries.hpp"
-
-#include "ttnn/tensor/types.hpp"
-
 #include <cstdint>
 #include <string>
+
+#include "gtest/gtest.h"
+#include "tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp"
+#include "tt_metal/common/logger.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/graph/graph_operation_queries.hpp"
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn_test_fixtures.hpp"
 
 namespace ttnn {
 namespace operations {
@@ -30,7 +26,8 @@ namespace test {
 struct AddOpGraphTestParam {
     ttnn::Shape a_Shape;
     ttnn::Shape b_Shape;
-    ttnn::MemoryConfig memory_config; //DRAM_MEMORY_CONFIG, L1_MEMORY_CONFIG, L1_BLOCK_SHARDED_MEMORY_CONFIG, L1_HEIGHT_SHARDED_MEMORY_CONFIG, L1_WIDTH_SHARDED_MEMORY_CONFIG
+    ttnn::MemoryConfig memory_config;  // DRAM_MEMORY_CONFIG, L1_MEMORY_CONFIG, L1_BLOCK_SHARDED_MEMORY_CONFIG,
+                                       // L1_HEIGHT_SHARDED_MEMORY_CONFIG, L1_WIDTH_SHARDED_MEMORY_CONFIG
     std::vector<std::string> expected_calltrace;
     uint32_t expected_peak_L1_memory_usage = 0;
     uint32_t expected_intermediate_tensors_count = 0;
@@ -39,9 +36,13 @@ struct AddOpGraphTestParam {
     std::vector<graph::TensorInfo> expected_output_info;
 };
 
-class AddOpGraphTestFixture : public TTNNFixtureWithDevice,
-                              public testing::WithParamInterface<std::tuple<AddOpGraphTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
+class AddOpGraphTestFixture
+    : public TTNNFixtureWithDevice,
+      public testing::WithParamInterface<std::tuple<AddOpGraphTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
 
+class CompilerTraceAddOpGraphTestFixture
+    : public TTNNFixtureWithDevice,
+      public testing::WithParamInterface<std::tuple<AddOpGraphTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
 
 TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
     auto param_combination = GetParam();
@@ -49,8 +50,10 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
     auto run_mode = std::get<1>(param_combination);
 
     {
-        const auto input_tensor_a = ttnn::zeros(params.a_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, this->getDevice(), params.memory_config);
-        const auto input_tensor_b = ttnn::zeros(params.b_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, this->getDevice(), params.memory_config);
+        const auto input_tensor_a =
+            ttnn::zeros(params.a_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, this->getDevice(), params.memory_config);
+        const auto input_tensor_b =
+            ttnn::zeros(params.b_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, this->getDevice(), params.memory_config);
 
         auto call = [&] {
             const auto output_tensor = ttnn::add(input_tensor_a, input_tensor_b);
@@ -67,7 +70,8 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
             EXPECT_EQ(graph::extract_peak_L1_memory_usage(json_trace), params.expected_peak_L1_memory_usage);
             EXPECT_EQ(graph::extract_output_tensors(json_trace).size(), 1);
 
-            auto [intermediate_tensors_count, output_tensors_count] = graph::count_intermediate_and_output_tensors(json_trace);
+            auto [intermediate_tensors_count, output_tensors_count] =
+                graph::count_intermediate_and_output_tensors(json_trace);
             EXPECT_EQ(intermediate_tensors_count, params.expected_intermediate_tensors_count);
             EXPECT_EQ(output_tensors_count, 1);
         }
@@ -90,15 +94,17 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
 
             EXPECT_EQ(peak_L1_memory_usage, params.expected_peak_L1_memory_usage);
 
-
-            if(output_info.size() != params.expected_output_info.size()) {
-                auto print = [](const auto& infos){
+            if (output_info.size() != params.expected_output_info.size()) {
+                auto print = [](const auto& infos) {
                     for (const auto& info : infos) {
                         tt::log_info("{}", info);
                     }
                 };
 
-                tt::log_info("Output info size mismatch. Expected {} but got {}", params.expected_output_info.size(), output_info.size());
+                tt::log_info(
+                    "Output info size mismatch. Expected {} but got {}",
+                    params.expected_output_info.size(),
+                    output_info.size());
 
                 tt::log_info("Expected output info:");
                 print(params.expected_output_info);
@@ -116,8 +122,8 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    AddOpGraphTests, // Prefix for the instantiated test suite
-    AddOpGraphTestFixture, // Test suite name
+    AddOpGraphTests,        // Prefix for the instantiated test suite
+    AddOpGraphTestFixture,  // Test suite name
     ::testing::Combine(
         ::testing::Values(
             // AddOpGraphTestParam instances for different test cases
@@ -125,7 +131,8 @@ INSTANTIATE_TEST_SUITE_P(
                 .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
                 .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
-                .expected_calltrace = { "ttnn::add", "ttnn::prim::binary", "BinaryDeviceOperation", "tt::tt_metal::create_device_tensor" },
+                .expected_calltrace =
+                    {"ttnn::add", "ttnn::prim::binary", "BinaryDeviceOperation", "tt::tt_metal::create_device_tensor"},
                 .expected_peak_L1_memory_usage = 30720,
                 .expected_intermediate_tensors_count = 0,
                 .expected_l1_output_per_core = 2048,
@@ -141,7 +148,15 @@ INSTANTIATE_TEST_SUITE_P(
                 .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{4, 3, 32, 32}),
                 .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
-                .expected_calltrace = { "ttnn::add", "ttnn::repeat", "ttnn::prim::old_infra_device_operation", "RepeatDeviceOperation", "tt::tt_metal::create_device_tensor", "ttnn::prim::binary", "BinaryDeviceOperation", "tt::tt_metal::create_device_tensor"},
+                .expected_calltrace =
+                    {"ttnn::add",
+                     "ttnn::repeat",
+                     "ttnn::prim::old_infra_device_operation",
+                     "RepeatDeviceOperation",
+                     "tt::tt_metal::create_device_tensor",
+                     "ttnn::prim::binary",
+                     "BinaryDeviceOperation",
+                     "tt::tt_metal::create_device_tensor"},
                 .expected_peak_L1_memory_usage = 92160,
                 .expected_intermediate_tensors_count = 0,
                 .expected_l1_output_per_core = 2048,
@@ -153,12 +168,64 @@ INSTANTIATE_TEST_SUITE_P(
                         .type = tt::tt_metal::BufferType::L1
                     }
                 },
-            }
-        ),
-        ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH, tt::tt_metal::IGraphProcessor::RunMode::NORMAL)
-    )
-);
+            }),
+        ::testing::Values(
+            tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH, tt::tt_metal::IGraphProcessor::RunMode::NORMAL)));
 
+TEST_P(CompilerTraceAddOpGraphTestFixture, AddGraphTrace) {
+    auto param_combination = GetParam();
+    auto params = std::get<0>(param_combination);
+    auto run_mode = std::get<1>(param_combination);
+
+    {
+        const auto input_tensor_a =
+            ttnn::zeros(params.a_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, this->getDevice(), params.memory_config);
+        const auto input_tensor_b =
+            ttnn::zeros(params.b_Shape, DataType::BFLOAT16, ttnn::TILE_LAYOUT, this->getDevice(), params.memory_config);
+
+        auto call = [&] {
+            std::vector<tt::tt_metal::Tensor> res;
+            for (int i = 0; i < 500; i++) {
+                res.push_back(ttnn::add(
+                    input_tensor_a,
+                    input_tensor_b,
+                    std::make_optional(DataType::BFLOAT16),
+                    std::make_optional(ttnn::L1_MEMORY_CONFIG)));
+            }
+
+            return res;
+        };
+
+        EXPECT_THROW(
+            {
+                ttnn::graph::GraphProcessor::begin_graph_capture(
+                    tt::tt_metal::IGraphProcessor::RunMode::COMPILER_TRACE);
+                { auto output = call(); }
+                auto json_trace = ttnn::graph::GraphProcessor::end_graph_capture();
+            },
+            std::exception);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CompilerTraceAddOpGraphTests,        // Prefix for the instantiated test suite
+    CompilerTraceAddOpGraphTestFixture,  // Test suite name
+    ::testing::Combine(
+        ::testing::Values(
+            // AddOpGraphTestParam instances for different test cases
+            AddOpGraphTestParam{
+                .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{100, 120, 32, 32}),
+                .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{100, 120, 32, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+                .expected_calltrace =
+                    {"ttnn::add", "ttnn::prim::binary", "BinaryDeviceOperation", "tt::tt_metal::create_device_tensor"},
+                .expected_peak_L1_memory_usage = 30720,
+                .expected_intermediate_tensors_count = 0,
+                .expected_output_info = {graph::TensorInfo{
+                    .shape = ttnn::Shape(tt::tt_metal::Array4D{1000, 3, 32, 32}),
+                    .size = 6144,
+                    .type = tt::tt_metal::BufferType::L1}}}),
+        ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::COMPILER_TRACE)));
 
 }  // namespace test
 }  // namespace binary

--- a/tt_metal/graph/graph_tracking.hpp
+++ b/tt_metal/graph/graph_tracking.hpp
@@ -23,7 +23,8 @@ inline namespace v0 {
     public:
         enum class RunMode {
             NORMAL, // running everything as is
-            NO_DISPATCH // don't do memory allocations and program runs.
+            NO_DISPATCH, // don't do memory allocations and program runs.
+            COMPILER_TRACE, // do memory allocations but don't dispatch programs.
         };
 
         IGraphProcessor() = default;

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -437,7 +437,9 @@ void GraphProcessor::begin_capture(RunMode mode) {
     if (!tt::tt_metal::GraphTracker::instance().get_hook()) {
         hook = std::make_shared<ProcessorHooks>();
         tt::tt_metal::GraphTracker::instance().add_hook(hook);
-        hook->set_block(mode == RunMode::NO_DISPATCH);
+
+        hook->set_block(mode != RunMode::NORMAL);
+        hook->set_track_memory_alloc(mode != RunMode::NO_DISPATCH);
     }
     current_op_id.push(0);
 }
@@ -485,11 +487,11 @@ nlohmann::json GraphProcessor::end_graph_capture() {
 }
 
 bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer) {
-    return do_block;
+    return !track_memory_alloc;
 }
 
 bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) {
-    return do_block;
+    return !track_memory_alloc;
 }
 
 bool ProcessorHooks::hook_program(tt::tt_metal::Program*) {
@@ -501,5 +503,12 @@ void ProcessorHooks::set_block(bool block) {
 }
 bool ProcessorHooks::get_block() const {
     return do_block;
+}
+
+void ProcessorHooks::set_track_memory_alloc(bool track_memory_alloc) {
+    this->track_memory_alloc = track_memory_alloc;
+}
+bool ProcessorHooks::get_track_memory_alloc() const {
+    return track_memory_alloc;
 }
 }

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -19,6 +19,7 @@ namespace ttnn::graph {
     class ProcessorHooks : public tt::tt_metal::IGraphHooks {
     private:
         bool do_block = false;
+        bool track_memory_alloc = false;
 
     public:
         ProcessorHooks() = default;
@@ -32,7 +33,11 @@ namespace ttnn::graph {
 
         void set_block(bool block);
 
+        void set_track_memory_alloc(bool track_memory_alloc);
+
         bool get_block() const;
+
+        bool get_track_memory_alloc() const;
     };
     class GraphProcessor : public tt::tt_metal::IGraphProcessor{
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14815

### Problem description
GraphCapture doesn't throw an error for L1 overflow in NO_DISPATCH mode. This mode is required for the generality in the Force compiler, so that compiler can recompile/slice the graph without duplication of memory tracking logic.

### What's changed
Added new mode, COMPILER_TRACE, to graph capture which tracks memory allocations but doesn't dispatch program runs. Exception will be thrown if a given graph causes L1 memory overflow. Added UTs which test this case.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
