### PR TITLE
#0: Remove DPRINT check on tile idx going out of CB page

### DIFF
--- a/tt_metal/hw/inc/debug/dprint_tile.h
+++ b/tt_metal/hw/inc/debug/dprint_tile.h
@@ -210,11 +210,6 @@ struct TileSlice : TileSliceHostDev<MAX_BYTES> {
         this->cb_ptr += tile_idx * tile_info.tile_size;
 
         // Check for unprintable data, and return error as necessary
-        if ((tile_idx + 1) * tile_info.tile_size > CB_PAGE_SIZE(this->cb_id)) {
-            this->cb_ptr = CB_PAGE_SIZE(this->cb_id); // Save the page size we weren't expecting so host can read.
-            this->return_code = DPrintErrorBadTileIdx;
-            return;
-        }
         if (this->cb_ptr < L1_UNRESERVED_BASE || this->cb_ptr >= MEM_L1_SIZE) {
             this->return_code = DPrintErrorBadPointer;
             return; // bad tile pointer, return

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -201,12 +201,6 @@ static void PrintTileSlice(ostream& stream, uint8_t* ptr, int hart_id) {
     switch (ts->return_code) {
         case DPrintOK:
             break; // Continue to print the tile slice
-        case DPrintErrorBadTileIdx:
-            {
-            uint32_t page_size = ts->cb_ptr;
-            stream << fmt::format("Tried printing {}: unexpected tile size ({})\n", cb, page_size);
-            return;
-            }
         case DPrintErrorBadPointer:
             {
             uint32_t ptr = ts->cb_ptr;


### PR DESCRIPTION
Developers prefer to not have to advance the pointer to print tiles, and instead use tile idx to go past the CB page to print data.

CI running: https://github.com/tenstorrent/tt-metal/actions/runs/11712522478