### PR TITLE
Enable Program Cache for Two Concat Tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -77,7 +77,6 @@ def test_concat(device, height, width, dim, async_mode):
             ttnn.ShardStrategy.HEIGHT,
             ttnn.ROW_MAJOR_LAYOUT,
             True,
-            marks=pytest.mark.xfail(reason="two tensors concat kernel doesn't work with program cache (#13466)"),
         ),
         (
             [((1, 1, 16, 16), (8, 16)), ((1, 1, 16, 16), (8, 16)), ((1, 1, 16, 16), (8, 16))],


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13466)

### Problem description
Program cache use was not implemented in callback for two rm concat tensors

### What's changed
Added implementation for concat program cache, re-enabled disabled test for this

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11716248800)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
