### PR TITLE
Afuller/clang tidy ignore not built files

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -158,12 +158,33 @@ jobs:
     - name: Prepare compile_commands.json
       run: |
         ARCH_NAME=grayskull cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF
+    - name: 'Install jq'
+      uses: dcarbone/install-jq-action@v2
     - name: Create results directory
       run: |
         mkdir clang-tidy-result
     - name: Analyze
+      shell: bash
       run: |
-        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-17.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j4
+        set -euo pipefail
+
+        # Find all touched files present in compile_commands.json
+        # This is not as simple as filtering non-code files, as some code (eg: Kernels) are C++ code that
+        # is not built at this level, and thus clang-tidy will be unable to process them.
+        PREFIX=$(pwd)
+        jq --arg prefix "$PREFIX/" -r '.[].file | sub("^" + $prefix; "")' build/compile_commands.json > relative_files_in_build.txt
+        git diff --name-only "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")..." > changed_files.txt
+        grep -F -f relative_files_in_build.txt changed_files.txt > common_files.txt || true
+
+        # Exit if there are no modified files known to CMake
+        [[ -s common_files.txt ]] || {
+          echo "No files to analyze"
+          exit 0
+        }
+
+        # Analyze the relevant diffs of the relevant files
+        git diff "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" -- $(cat common_files.txt) > filtered_changes.diff
+        clang-tidy-diff-17.py -p1 -path build  -export-fixes clang-tidy-result/fixes.yml -j$(nproc) < filtered_changes.diff
       timeout-minutes: 5
       continue-on-error: true
     - name: Run clang-tidy-pr-comments action


### PR DESCRIPTION
### Ticket
None

### Problem description
Clang-tidy was trying (and failing) to analyze non-compiled code (JIT-compiled kernels).

### What's changed
Filter out the list of candidates to analyze based on compile_commands.json to give clang-tidy a fighting chance.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
