### PR TITLE
Fix a non-c-typedef-for-linkage error

### DIFF
--- a/tt_metal/hw/inc/blackhole/tensix_types.h
+++ b/tt_metal/hw/inc/blackhole/tensix_types.h
@@ -57,7 +57,7 @@ typedef struct {
     uint32_t reserved_3 : 32;
 } packer_config_t;  // 16B
 
-typedef struct {
+struct fifo_ctl_t {
     uint32_t rd_ptr;
     uint32_t wr_ptr;
     uint32_t rsvd0;
@@ -67,7 +67,7 @@ typedef struct {
         return fmt::format("Fifo Control: rd_ptr(0x{:08x}) wr_ptr(0x{:08x})", rd_ptr, wr_ptr);
     }
 #endif
-} fifo_ctl_t;
+};
 
 typedef struct {
     uint32_t val[4];


### PR DESCRIPTION
Allowing compilation to pass on Blackhole.

### Ticket
[Forge Issue](https://github.com/tenstorrent/tt-forge-fe/issues/614)

### Problem description
Compilation failed in forge:
```
/localdev/gfeng/fg/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/blackhole/tensix_types.h:60:15: error: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]
   60 | typedef struct {
      |               ^
      |                fifo_ctl_t
/localdev/gfeng/fg/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/blackhole/tensix_types.h:66:5: note: type is not C-compatible due to this member declaration
   66 |     operator std::string() const {
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   67 |         return fmt::format("Fifo Control: rd_ptr(0x{:08x}) wr_ptr(0x{:08x})", rd_ptr, wr_ptr);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |     }
      |     ~
/localdev/gfeng/fg/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/blackhole/tensix_types.h:70:3: note: type is given name 'fifo_ctl_t' for linkage purposes by this typedef declaration
   70 | } fifo_ctl_t;
      |   ^
1 error generated.
```

### What's changed
The same change has been made to wormhole:
https://github.com/tenstorrent/tt-metal/blob/81033ff9be4092d3e844865dab83caaaa1f5d160/tt_metal/hw/inc/wormhole/wormhole_b0_defines/tensix_types.h#L60

### Checklist
- [ ] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
