### PR TITLE
#0: Allow Users to provide extra tag for T3K choose your own pipeline

### DIFF
--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -13,9 +13,9 @@ on:
           - CI
         default: "Release"
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
       build-with-tracy:
         required: false
         type: boolean

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -12,6 +12,10 @@ on:
           - RelWithDebInfo
           - CI
         default: "Release"
+      extra-tag:
+        required: false
+        type: string
+        default: ""
       build-with-tracy:
         required: false
         type: boolean
@@ -54,29 +58,41 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
     if: ${{ inputs.t3000-unit }}
   t3000-demo-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
     if: ${{ inputs.t3000-demo }}
   t3000-frequent-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
     if: ${{ inputs.t3000-frequent }}
   t3000-nightly-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
     if: ${{ inputs.t3000-nightly }}
   t3000-model-perf-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
     if: ${{ inputs.t3000-model-perf }}
   t3000-profiler-tests:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
     if: ${{ inputs.t3000-profiler }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -28,7 +28,12 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
+    runs-on:
+      - arch-wormhole_b0
+      - config-t3000
+      - in-service
+      - pipeline-functional
+      - ${{ inputs.extra-tag }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] T3000 demo tests impl"
 
 on:
   workflow_call:
+    inputs:
+      extra-tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   t3000-demo-tests:
@@ -23,7 +28,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
 
 jobs:
   t3000-demo-tests:
@@ -31,8 +31,7 @@ jobs:
     runs-on:
       - arch-wormhole_b0
       - config-t3000
-      - in-service
-      - pipeline-functional
+      - pipeline-perf
       - ${{ inputs.extra-tag }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -28,7 +28,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
+    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
 
 jobs:
   t3000-frequent-tests:

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
+    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/ensure-active-weka-mount

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] T3000 frequent tests impl"
 
 on:
   workflow_call:
+    inputs:
+      extra-tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   t3000-frequent-tests:
@@ -27,7 +32,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/ensure-active-weka-mount

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -32,7 +32,11 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
+    runs-on:
+      - arch-wormhole_b0
+      - config-t3000
+      - pipeline-functional
+      - ${{ inputs.extra-tag }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/ensure-active-weka-mount

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -30,7 +30,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf", ${{ inputs.extra-tag }}]
+    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
 
 jobs:
 
@@ -30,7 +30,11 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
+    runs-on:
+      - arch-wormhole_b0
+      - config-t3000
+      - pipeline-perf
+      - ${{ inputs.extra-tag }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] T3000 model perf tests impl"
 
 on:
   workflow_call:
+    inputs:
+      extra-tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
 
@@ -25,7 +30,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf", ${{ inputs.extra-tag }}]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
 
 jobs:
   t3000-nightly-tests:
@@ -23,7 +23,11 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
+    runs-on:
+      - arch-wormhole_b0
+      - config-t3000
+      - pipeline-functional
+      - ${{ inputs.extra-tag }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] T3000 nightly tests impl"
 
 on:
   workflow_call:
+    inputs:
+      extra-tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   t3000-nightly-tests:
@@ -18,7 +23,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -23,7 +23,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
+    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -17,7 +17,11 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
+            runs-on:
+              - arch-wormhole_b0
+              - config-t3000
+              - pipeline-perf
+              - ${{ inputs.extra-tag }}
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] T3000 profiler tests impl"
 
 on:
   workflow_call:
+    inputs:
+      extra-tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   t3000-profiler-tests:
@@ -12,7 +17,7 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf", ${{ inputs.extra-tag }}],
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
 
 jobs:
   t3000-profiler-tests:

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -17,11 +17,7 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on:
-              - arch-wormhole_b0
-              - config-t3000
-              - pipeline-perf
-              - ${{ inputs.extra-tag }}
+            runs-on: ["arch-wormhole_b0", "config-t3000", "pipeline-perf", "${{ inputs.extra-tag }}"],
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -17,7 +17,7 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf", ${{ inputs.extra-tag }}],
+            runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extra-tag:
-        required: false
+        required: true
         type: string
-        default: ""
+        default: "in-service"
 
 jobs:
   t3000-unit-tests:
@@ -33,7 +33,11 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
+    runs-on:
+      - arch-wormhole_b0
+      - config-t3000
+      - pipeline-functional
+      - ${{ inputs.extra-tag }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -33,7 +33,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
+    runs-on: ${{ toJson([ "arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional" ] + (inputs.extra-tag != '' && inputs.extra-tag != null ? [inputs.extra-tag] : [])) }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] T3000 unit tests impl"
 
 on:
   workflow_call:
+    inputs:
+      extra-tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   t3000-unit-tests:
@@ -28,7 +33,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional", ${{ inputs.extra-tag }}]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build


### PR DESCRIPTION
### Ticket
NA

### Problem description
Choose your own pipeline workflow dispatch does not allow users to target specific runners.

### What's changed
Allow an optional extra tag to be supplied during workflow dispatch.
Currently only applied to T3K workflows.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
