### PR TITLE
#14825: Adding fix for float32

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_float32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_float32.py
@@ -1,0 +1,62 @@
+import pytest
+
+import torch
+
+import ttnn
+from models.utility_functions import is_grayskull
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+from loguru import logger
+
+
+# https://github.com/tenstorrent/tt-metal/issues/14862
+def test_unary_float32(device):
+    torch.manual_seed(0)
+
+    torch.set_printoptions(precision=10)
+
+    torch_input_tensor = torch.tensor([[0.00001]], dtype=torch.float32)
+    torch_output_tensor = -torch_input_tensor
+
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    import os
+
+    print(f"Debugging PID: {os.getpid()}")
+    ttnn_output_tensor = ttnn.neg(ttnn_input_tensor)
+
+    print(torch_input_tensor, ttnn.to_torch(ttnn_input_tensor))
+    print(torch_output_tensor, ttnn.to_torch(ttnn_output_tensor))
+
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    assert True == torch.allclose(torch_output_tensor, output_tensor, atol=1e-8, rtol=1e-5, equal_nan=False)
+
+
+# https://github.com/tenstorrent/tt-metal/issues/14825
+def test_binary_float32(device):
+    torch.manual_seed(0)
+
+    torch.set_printoptions(precision=10)
+
+    torch_input_tensor_a = torch.tensor([[1]], dtype=torch.float32)
+    torch_input_tensor_b = torch.tensor([[0.00030171126]], dtype=torch.float32)
+    torch_output_tensor = torch_input_tensor_a - torch_input_tensor_b
+    ttnn_input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    ttnn_input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    expected_ttnn_output_tensor = ttnn.from_torch(
+        torch_output_tensor, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    import os
+
+    print(f"Debugging PID: {os.getpid()}")
+    actual_ttnn_output_tensor = ttnn.subtract(ttnn_input_tensor_a, ttnn_input_tensor_b)
+    actual_ttnn_output_tensor = ttnn.to_torch(actual_ttnn_output_tensor)
+    print(torch_output_tensor, ttnn.to_torch(expected_ttnn_output_tensor), actual_ttnn_output_tensor)
+
+    assert True == torch.allclose(torch_output_tensor, actual_ttnn_output_tensor, atol=1e-6, rtol=1e-5, equal_nan=False)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -315,6 +315,11 @@ BinaryDeviceOperation::invoke(
             output_dtype.value() == optional_output_tensor.value().get_dtype(),
             "If both output dtype and output tensor provided dtype should match");
     }
+    DataType dtype = output_dtype.has_value() ? output_dtype.value() :
+    optional_output_tensor.has_value() ? optional_output_tensor.value().dtype() : input_tensor_a_arg.dtype();
+    bool fp32_dest_acc_en = dtype == DataType::UINT32 or
+                        dtype == DataType::INT32 or
+                        dtype == DataType::FLOAT32;
 
     return {
         operation_attributes_t{
@@ -324,7 +329,8 @@ BinaryDeviceOperation::invoke(
             std::nullopt,
             memory_config.value_or(input_tensor_a_arg.memory_config()),
             output_dtype.value_or(input_tensor_a_arg.get_dtype()),
-            std::nullopt},
+            std::nullopt,
+            fp32_dest_acc_en},
         tensor_args_t{input_tensor_a_arg, input_tensor_b_arg, optional_output_tensor}};
 }
 
@@ -344,6 +350,12 @@ BinaryDeviceOperation::invoke(
             "If both output dtype and output tensor provided dtype should match");
     }
 
+    DataType dtype = output_dtype.has_value() ? output_dtype.value() :
+    optional_output_tensor.has_value() ? optional_output_tensor.value().dtype() : input_tensor_a_arg.dtype();
+    bool fp32_dest_acc_en = dtype == DataType::UINT32 or
+                        dtype == DataType::INT32 or
+                        dtype == DataType::FLOAT32;
+
     return {
         operation_attributes_t{
             binary_op_type,
@@ -352,7 +364,8 @@ BinaryDeviceOperation::invoke(
             scalar,
             memory_config.value_or(input_tensor_a_arg.memory_config()),
             output_dtype.value_or(input_tensor_a_arg.get_dtype()),
-            std::nullopt},
+            std::nullopt,
+            fp32_dest_acc_en},
         tensor_args_t{input_tensor_a_arg, std::nullopt, optional_output_tensor}};
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -35,6 +35,9 @@ struct BinaryDeviceOperation {
         const MemoryConfig memory_config;
         const DataType dtype;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        const bool fp32_dest_acc_en = false;
+
+
 
         tt::stl::hash::hash_t to_hash() const {
             // hash has to exclude the scalar value

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -172,7 +172,7 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp",
         all_device_cores,
-        tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_compute_defines});
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en, .compile_args = {}, .defines = bcast_compute_defines});
 
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -138,7 +138,7 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp",
         all_device_cores,
-        tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_defines});
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en, .compile_args = {}, .defines = bcast_defines});
 
     for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -166,7 +166,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreShardedOptimized::create(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp",
         all_cores,
-        tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_defines});
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en, .compile_args = {}, .defines = bcast_defines});
 
     uint32_t ncores_y = ncores / ncores_x;
     TT_FATAL((NC * H / TILE_HEIGHT) % bN == 0, "N*C*H of input0 must be devisible by batch size of input1");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
@@ -144,7 +144,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreSharded::create(
         program,
         "ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp",
         all_cores,
-        tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_defines}
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en, .compile_args = {}, .defines = bcast_defines}
     );
 
     uint32_t ncores_y = ncores / ncores_x;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
@@ -137,7 +137,7 @@ BinaryDeviceOperation::BroadcastWidthMultiCore::cached_program_t BinaryDeviceOpe
         program,
         "ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp",
         all_device_cores,
-        tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_defines});
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en, .compile_args = {}, .defines = bcast_defines});
 
     for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -431,14 +431,11 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
         all_device_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
 
-    bool fp32_dest_acc_en = dst_cb_data_format == tt::DataFormat::UInt32 ||
-                            dst_cb_data_format == tt::DataFormat::Int32 ||
-                            dst_cb_data_format == tt::DataFormat::Float32;
     auto eltwise_binary_kernel_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp",
         all_device_cores,
-        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .defines = eltwise_defines});
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en, .defines = eltwise_defines});
 
     set_eltwise_binary_runtime_args<true>(
         program,


### PR DESCRIPTION
### Ticket
#14825 

### Problem description
We are not properly sending the precision flag to the ComputeKernelConfig

### What's changed
Updated code for binary op to pass this precision flag in the operation_attributes_t.  

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
