### PR TITLE
#14633: Fix using incorrect symbol

### DIFF
--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -170,11 +170,11 @@ struct dispatch_constants {
             if (dev_addr_type == CommandQueueDeviceAddrType::PREFETCH_Q_RD) {
                 device_cq_addr_sizes_[dev_addr_idx] = sizeof(uint32_t);
             } else if (dev_addr_type == CommandQueueDeviceAddrType::PREFETCH_Q_PCIE_RD) {
-                device_cq_addr_sizes_[dev_addr_idx] = L1_ALIGNMENT - sizeof(uint32_t);
+                device_cq_addr_sizes_[dev_addr_idx] = l1_alignment - sizeof(uint32_t);
             } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_MESSAGE) {
-                device_cq_addr_sizes_[dev_addr_idx] = 32; // Should this be 2x L1_ALIGNMENT?
+                device_cq_addr_sizes_[dev_addr_idx] = 32; // Should this be 2x l1_alignment?
             } else {
-                device_cq_addr_sizes_[dev_addr_idx] = L1_ALIGNMENT;
+                device_cq_addr_sizes_[dev_addr_idx] = l1_alignment;
             }
         }
 


### PR DESCRIPTION
### Ticket
Closes #14633 

### Problem description
L1_ALIGNMENT comes from ARCH_NAME specific include.
l1_alignment is local variable that comes from hal.
Should use the right symbol.

### What's changed
L1_ALIGNMENT -> l1_alignment

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
