### PR TITLE
#14880: Ternary composite op clean up

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -37,7 +37,7 @@ Tensor _addcdiv(
     Tensor t_factor = ttnn::multiply(t_div, value, std::nullopt, output_mem_config);
     t_div.deallocate();
     Tensor result = ttnn::add(input_a, t_factor, std::nullopt, output_mem_config);
-    Tensor t_inf = ttnn::full_like(input_a, std::numeric_limits<float>::infinity());
+    float t_inf = std::numeric_limits<float>::infinity();
     Tensor t_nan = ttnn::full_like(input_a, std::nanf(""));
     return ttnn::where(
         ttnn::eqz(input_c, output_mem_config),
@@ -45,7 +45,7 @@ Tensor _addcdiv(
                      : ttnn::where(
                            ttnn::eqz(input_b, output_mem_config),
                            t_nan,
-                           ttnn::multiply(t_inf, ttnn::sign(input_b, output_mem_config), std::nullopt, output_mem_config)),
+                           ttnn::multiply(ttnn::sign(input_b, output_mem_config), t_inf, std::nullopt, output_mem_config)),
         result,
         output_mem_config);
 }


### PR DESCRIPTION
### Ticket
#14466 

### Problem description
Remove unnecessary usage of creation ops

### What's changed
Removed unnecessary usage of creation ops and updated the ternary composite file


### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11740767855)

