### PR TITLE
#13186: adjust negative dims in reduce

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_max.py
+++ b/tests/ttnn/unit_tests/operations/test_max.py
@@ -32,6 +32,28 @@ def test_max(device, batch_size, h, w, dim):
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.parametrize("batch_size1", [2])
+@pytest.mark.parametrize("batch_size2", [32])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [64])
+@pytest.mark.parametrize("dim", [-3])
+def test_max_4d(device, batch_size1, batch_size2, h, w, dim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch_random((batch_size1, batch_size2, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.max(input_tensor, dim=dim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor)
+
+
 @pytest.mark.parametrize("batch_size", [1, 16, 1, 16])
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -21,6 +21,9 @@ static Tensor reduce_impl(
     float scalar,
     bool reshape) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
+    if (not keepdim) {
+        TT_THROW("keepdim=False is not supported");
+    }
 
     auto input_shape = input_tensor_arg.get_shape();
     auto rank = input_shape.size();


### PR DESCRIPTION
### Ticket
Link to Github Issue #13186

### Problem description
ttnn.max op throws Unsupported dim error while reducing along the channel dimension for 4d input and batch dimension for both 4d and 3d input.

### What's changed
Push the check for the dimension earlier and update the dim array with the change.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11744609127
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes
