### PR TITLE
#14900: Disable ComputeCopyBlockSingle Until Solved

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
@@ -112,7 +112,7 @@ void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const 
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
-        dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+        dram_buffer_size, 100, 0);
 
     if (test_config.fp32_dest_acc_en) {
         auto src_vec_float = generate_uniform_random_vector<float>(

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
@@ -112,7 +112,7 @@ void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const 
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
-        dram_buffer_size, 100, 0);
+        dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
     if (test_config.fp32_dest_acc_en) {
         auto src_vec_float = generate_uniform_random_vector<float>(
@@ -170,7 +170,7 @@ void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const 
 // - matmul_pack_tile
 ////////////////////////////////////////////////////////////////////////////
 
-TEST_F(DeviceFixture, ComputeCopyBlockSingle) {
+TEST_F(DeviceFixture, DISABLED_ComputeCopyBlockSingle) {
     for (bool fp32_dest_acc_en : {true, false}) {
         // FP32 dest acc not possible for GS
         if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) continue;


### PR DESCRIPTION
### Ticket
#14900  

### Problem description
There's an issue in 3% or 4% of ComputeCopyBlockSingle test runs.

### What's changed
Disable ComputeCopyBlockSingle until the solution is found.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
