### PR TITLE
Fix CMake re-configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ unset(SANITIZER_ENABLED)
 ############################################################################################################################
 # Find all required libraries to build
 ############################################################################################################################
+set(ENV{CPM_SOURCE_CACHE} "${PROJECT_SOURCE_DIR}/.cpmcache")
+include(CPM)
 if(CMAKE_VERSION VERSION_LESS 3.25)
     # FIXME(14681): `SYSTEM` was introduced in v3.25; remove this when we can require v3.25
     add_subdirectory(dependencies EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Ticket
None

### Problem description
I broke re-configure in CMake with an earlier refactor.  Lost (or perhaps no longer inheriting the value from UMD?) for CPM_SOURCE_CACHE.  On re-run CPM would think itself in a different location and early-exit without providing the functions it was supposed to.

### What's changed
Ensure that our top-level project sets up CPM correctly.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
