### PR TITLE
#14546: Fix moreh_adamw power_tile reduce performance

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
@@ -136,9 +136,8 @@ void MAIN {
         // bias_correction2 = 1 - pow(beta2, step);
         // cb_beta2_exponent = pow(beta2, step); Calculated from host
 
-        // cb_tmp1 = 1 / (1 - cb_tmp1);
+        // cb_tmp1 = 1 / (1 - cb_beta2_exponent);
         tile_regs_acquire();
-        // cb_wait_front(cb_tmp1, onetile);
         cb_reserve_back(cb_tmp1, onetile);
         sub_tiles_init_with_dt(cb_one, cb_beta2_exponent);
         sub_tiles(cb_one, cb_beta2_exponent, first_tile, first_tile, dst0);
@@ -216,7 +215,7 @@ void MAIN {
         // bias_correction1 = 1 - pow(beta1, step);
         // cb_beta1_exponent = pow(beta1, step); Calculated from host
 
-        // cb_tmp2 = 1 / (1 - cb_tmp2);
+        // cb_tmp2 = 1 / (1 - cb_beta1_exponent);
         tile_regs_acquire();
         cb_reserve_back(cb_tmp2, onetile);
         sub_tiles_init_with_dt(cb_one, cb_beta1_exponent);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
@@ -4,13 +4,13 @@
 
 #include <cstdint>
 
-#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/recip.h"
 #include "compute_kernel_api/eltwise_unary/sqrt.h"
 #include "compute_kernel_api/tile_move_copy.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
 
 namespace NAMESPACE {
 void MAIN {
@@ -40,6 +40,8 @@ void MAIN {
 #ifdef AMSGRAD
     constexpr auto tmp_cb_max_exp_avg_sq = tt::CB::c_intermed3;
 #endif
+    constexpr auto cb_beta1_exponent = tt::CB::c_intermed4;
+    constexpr auto cb_beta2_exponent = tt::CB::c_intermed5;
     constexpr auto cb_tmp1 = tt::CB::c_intermed6;
     constexpr auto cb_tmp2 = tt::CB::c_intermed7;
 
@@ -56,6 +58,8 @@ void MAIN {
 
     cb_wait_front(cb_scalar_args, 5);
     cb_wait_front(cb_one, onetile);
+    cb_wait_front(cb_beta1_exponent, onetile);
+    cb_wait_front(cb_beta2_exponent, onetile);
 
     binary_op_init_common(cb_param_in, cb_scalar_args);
 
@@ -116,7 +120,8 @@ void MAIN {
         mul_tiles_to_cb(cb_tmp1, cb_tmp2, cb_tmp1, first_tile, first_tile);
 
         // tmp_cb_exp_avg_sq = cb_exp_avg_sq_in * beta2
-        mul_tiles_to_cb(cb_exp_avg_sq_in, cb_scalar_args, tmp_cb_exp_avg_sq, first_tile, beta2_tile, /*pop0=*/0, /*pop1=*/0);
+        mul_tiles_to_cb(
+            cb_exp_avg_sq_in, cb_scalar_args, tmp_cb_exp_avg_sq, first_tile, beta2_tile, /*pop0=*/0, /*pop1=*/0);
 
         // tmp_cb_exp_avg_sq = tmp_cb_exp_avg_sq + cb_tmp1
         add_tiles_to_cb(tmp_cb_exp_avg_sq, cb_tmp1, tmp_cb_exp_avg_sq, first_tile, first_tile);
@@ -129,33 +134,20 @@ void MAIN {
         // denom = sqrt(max_exp_avg_sq) / sqrt(bias_correction2) + eps;
         // denom = sqrt(exp_avg_sq) / sqrt(bias_correction2) + eps;
         // bias_correction2 = 1 - pow(beta2, step);
-        // cb_tmp1 = pow(beta2, step);
-        tile_regs_acquire();
-        cb_reserve_back(cb_tmp1, onetile);
-        copy_tile_init_with_dt(cb_scalar_args);
-        copy_tile(cb_scalar_args, beta2_tile, dst0);
-        power_tile_init();
-        power_tile(dst0, step);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp1);
-        cb_push_back(cb_tmp1, onetile);
-        tile_regs_release();
+        // cb_beta2_exponent = pow(beta2, step); Calculated from host
 
         // cb_tmp1 = 1 / (1 - cb_tmp1);
         tile_regs_acquire();
-        cb_wait_front(cb_tmp1, onetile);
+        // cb_wait_front(cb_tmp1, onetile);
         cb_reserve_back(cb_tmp1, onetile);
-        sub_tiles_init_with_dt(cb_one, cb_tmp1);
-        sub_tiles(cb_one, cb_tmp1, first_tile, first_tile, dst0);
+        sub_tiles_init_with_dt(cb_one, cb_beta2_exponent);
+        sub_tiles(cb_one, cb_beta2_exponent, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
         pack_tile_with_dt(dst0, cb_tmp1);
-        cb_pop_front(cb_tmp1, onetile);
         cb_push_back(cb_tmp1, onetile);
         tile_regs_release();
 
@@ -222,33 +214,19 @@ void MAIN {
         tile_regs_release();
 
         // bias_correction1 = 1 - pow(beta1, step);
-        // cb_tmp2 = pow(beta1, step);
-        tile_regs_acquire();
-        cb_reserve_back(cb_tmp2, onetile);
-        copy_tile_init_with_dt(cb_scalar_args);
-        copy_tile(cb_scalar_args, beta1_tile, dst0);
-        power_tile_init();
-        power_tile(dst0, step);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile_with_dt(dst0, cb_tmp2);
-        cb_push_back(cb_tmp2, onetile);
-        tile_regs_release();
+        // cb_beta1_exponent = pow(beta1, step); Calculated from host
 
         // cb_tmp2 = 1 / (1 - cb_tmp2);
         tile_regs_acquire();
-        cb_wait_front(cb_tmp2, onetile);
         cb_reserve_back(cb_tmp2, onetile);
-        sub_tiles_init_with_dt(cb_one, cb_tmp2);
-        sub_tiles(cb_one, cb_tmp2, first_tile, first_tile, dst0);
+        sub_tiles_init_with_dt(cb_one, cb_beta1_exponent);
+        sub_tiles(cb_one, cb_beta1_exponent, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
         tile_regs_commit();
 
         tile_regs_wait();
         pack_tile_with_dt(dst0, cb_tmp2);
-        cb_pop_front(cb_tmp2, onetile);
         cb_push_back(cb_tmp2, onetile);
         tile_regs_release();
 
@@ -275,5 +253,7 @@ void MAIN {
 
     cb_pop_front(cb_scalar_args, 5);
     cb_pop_front(cb_one, onetile);
+    cb_pop_front(cb_beta1_exponent, onetile);
+    cb_pop_front(cb_beta2_exponent, onetile);
 }  // void MAIN
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/reader_moreh_adamw.cpp
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
-
 #include <stdint.h>
 
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
     uint32_t i = 0;
@@ -21,6 +20,8 @@ void kernel_main() {
     const auto beta2 = get_arg_val<uint32_t>(i++);
     const auto eps = get_arg_val<uint32_t>(i++);
     const auto weight_decay = get_arg_val<uint32_t>(i++);
+    const auto beta1_exponent = get_arg_val<uint32_t>(i++);
+    const auto beta2_exponent = get_arg_val<uint32_t>(i++);
 
     const auto step = get_arg_val<uint32_t>(i++);
     const auto amsgrad = get_arg_val<uint32_t>(i++) == 1;
@@ -35,6 +36,9 @@ void kernel_main() {
     // lr, beta1, beta2, eps, weight_decay
     constexpr uint32_t cb_scalar_args = tt::CB::c_in5;
     constexpr uint32_t cb_id_one = tt::CB::c_in6;
+
+    constexpr uint32_t cb_beta1_exponent = tt::CB::c_intermed4;
+    constexpr uint32_t cb_beta2_exponent = tt::CB::c_intermed5;
 
     const uint32_t param_tile_bytes = get_tile_size(cb_id_param);
     const auto param_data_format = get_dataformat(cb_id_param);
@@ -55,9 +59,7 @@ void kernel_main() {
     constexpr bool max_exp_avg_sq_is_dram = get_compile_time_arg_val(4) == 1;
 
     const InterleavedAddrGenFast<param_is_dram> param_addrg = {
-        .bank_base_address = param_addr,
-        .page_size = param_tile_bytes,
-        .data_format = param_data_format};
+        .bank_base_address = param_addr, .page_size = param_tile_bytes, .data_format = param_data_format};
 
     const InterleavedAddrGenFast<grad_is_dram> grad_addrg = {
         .bank_base_address = grad_addr, .page_size = grad_tile_bytes, .data_format = grad_data_format};
@@ -66,14 +68,18 @@ void kernel_main() {
         .bank_base_address = exp_avg_addr, .page_size = exp_avg_tile_bytes, .data_format = exp_avg_data_format};
 
     const InterleavedAddrGenFast<exp_avg_sq_is_dram> exp_avg_sq_addrg = {
-        .bank_base_address = exp_avg_sq_addr, .page_size = exp_avg_sq_tile_bytes, .data_format = exp_avg_sq_data_format};
+        .bank_base_address = exp_avg_sq_addr,
+        .page_size = exp_avg_sq_tile_bytes,
+        .data_format = exp_avg_sq_data_format};
 
 #ifdef AMSGRAD
     constexpr uint32_t cb_id_max_exp_avg_sq = tt::CB::c_in4;
     const uint32_t max_exp_avg_sq_tile_bytes = get_tile_size(cb_id_max_exp_avg_sq);
     const auto max_exp_avg_sq_data_format = get_dataformat(cb_id_max_exp_avg_sq);
     const InterleavedAddrGenFast<max_exp_avg_sq_is_dram> max_exp_avg_sq_addrg = {
-        .bank_base_address = max_exp_avg_sq_addr, .page_size = max_exp_avg_sq_tile_bytes, .data_format = max_exp_avg_sq_data_format};
+        .bank_base_address = max_exp_avg_sq_addr,
+        .page_size = max_exp_avg_sq_tile_bytes,
+        .data_format = max_exp_avg_sq_data_format};
 #endif
 
     fill_cb_with_value(cb_scalar_args, lr);
@@ -81,6 +87,8 @@ void kernel_main() {
     fill_cb_with_value(cb_scalar_args, beta2);
     fill_cb_with_value(cb_scalar_args, eps);
     fill_cb_with_value(cb_scalar_args, weight_decay);
+    fill_cb_with_value(cb_beta1_exponent, beta1_exponent);
+    fill_cb_with_value(cb_beta2_exponent, beta2_exponent);
     union {
         float f;
         uint32_t u;
@@ -90,7 +98,7 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
     uint32_t end_id = start_id + num_tiles_per_core;
-    for (uint32_t i = start_id; i < end_id; ++ i) {
+    for (uint32_t i = start_id; i < end_id; ++i) {
         cb_reserve_back(cb_id_param, onetile);
         uint32_t param_l1_write_addr = get_write_ptr(cb_id_param);
         noc_async_read_tile(i, param_addrg, param_l1_write_addr);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -81,8 +81,8 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
             {CB::c_intermed1, 1, intermed_cb_format},  // tmp_exp_avg
             {CB::c_intermed2, 1, intermed_cb_format},  // tmp_exp_avg_sq
             {CB::c_intermed3, 1, intermed_cb_format},  // tmp_max_exp_avg_sq
-            {CB::c_intermed4, 1, intermed_cb_format},  //
-            {CB::c_intermed5, 1, intermed_cb_format},  //
+            {CB::c_intermed4, 1, intermed_cb_format},  // beta1_exponent
+            {CB::c_intermed5, 1, intermed_cb_format},  // beta2_exponent
             {CB::c_intermed6, 1, intermed_cb_format},  // tmp1
             {CB::c_intermed7, 1, intermed_cb_format},  // tmp2
 
@@ -100,15 +100,13 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
         static_cast<uint32_t>(is_dram(grad)),
         static_cast<uint32_t>(is_dram(exp_avg_in)),
         static_cast<uint32_t>(is_dram(exp_avg_sq_in)),
-        static_cast<uint32_t>(
-            max_exp_avg_sq_in.has_value() ? is_dram(max_exp_avg_sq_in.value()) : false)};
+        static_cast<uint32_t>(max_exp_avg_sq_in.has_value() ? is_dram(max_exp_avg_sq_in.value()) : false)};
 
     const std::vector<uint32_t> writer_compile_time_args{
         static_cast<uint32_t>(is_dram(param_out)),
         static_cast<uint32_t>(is_dram(exp_avg_out)),
         static_cast<uint32_t>(is_dram(exp_avg_sq_out)),
-        static_cast<uint32_t>(
-            max_exp_avg_sq_out.has_value() ? is_dram(max_exp_avg_sq_out.value()) : false)};
+        static_cast<uint32_t>(max_exp_avg_sq_out.has_value() ? is_dram(max_exp_avg_sq_out.value()) : false)};
 
     const auto reader_kernel_file =
         "ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/"
@@ -128,10 +126,10 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
         compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
-    const auto reader_kernel_id = CreateReadKernel(
-        program, reader_kernel_file, all_cores, reader_compile_time_args, data_movement_defines);
-    const auto writer_kernel_id = CreateWriteKernel(
-        program, writer_kernel_file, all_cores, writer_compile_time_args, data_movement_defines);
+    const auto reader_kernel_id =
+        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, data_movement_defines);
+    const auto writer_kernel_id =
+        CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args, data_movement_defines);
 
     const std::vector<uint32_t> compute_args_group_1{num_units_per_core_group_1};
     const std::vector<uint32_t> compute_args_group_2{num_units_per_core_group_2};
@@ -163,16 +161,20 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
     const uint32_t exp_avg_sq_out_addr = exp_avg_sq_out.buffer()->address();
     const uint32_t max_exp_avg_sq_out_addr =
         max_exp_avg_sq_out.has_value() ? max_exp_avg_sq_out.value().buffer()->address() : 0;
+    float beta1_exponent = std::pow(beta1, step);
+    float beta2_exponent = std::pow(beta2, step);
 
     union {
         float f;
         uint32_t u;
-    } f2u_lr, f2u_beta1, f2u_beta2, f2u_eps, f2u_weight_decay;
+    } f2u_lr, f2u_beta1, f2u_beta2, f2u_eps, f2u_weight_decay, f2u_beta1_exponent, f2u_beta2_exponent;
     f2u_lr.f = lr;
     f2u_beta1.f = beta1;
     f2u_beta2.f = beta2;
     f2u_eps.f = eps;
     f2u_weight_decay.f = weight_decay;
+    f2u_beta1_exponent.f = beta1_exponent;
+    f2u_beta2_exponent.f = beta2_exponent;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -197,6 +199,8 @@ MorehAdamWDeviceOperation::MultiCore::cached_program_t MorehAdamWDeviceOperation
             f2u_beta2.u,
             f2u_eps.u,
             f2u_weight_decay.u,
+            f2u_beta1_exponent.u,
+            f2u_beta2_exponent.u,
             step,
             static_cast<uint32_t>(amsgrad),
             num_tiles_per_core,
@@ -273,9 +277,12 @@ void MorehAdamWDeviceOperation::MultiCore::override_runtime_arguments(
     union {
         float f;
         uint32_t u;
-    } f2u_lr;
+    } f2u_lr, f2u_beta1_exponent, f2u_beta2_exponent;
 
     f2u_lr.f = operation_attributes.lr;
+    // Recalculate pow(beta, step)
+    f2u_beta1_exponent.f = std::pow(operation_attributes.beta1, operation_attributes.step);
+    f2u_beta2_exponent.f = std::pow(operation_attributes.beta2, operation_attributes.step);
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -287,7 +294,9 @@ void MorehAdamWDeviceOperation::MultiCore::override_runtime_arguments(
             runtime_args[3] = exp_avg_sq_in_addr;
             runtime_args[4] = max_exp_avg_sq_in_addr;
             runtime_args[5] = f2u_lr.u;
-            runtime_args[10] = operation_attributes.step;
+            runtime_args[10] = f2u_beta1_exponent.u;
+            runtime_args[11] = f2u_beta2_exponent.u;
+            runtime_args[12] = operation_attributes.step;
         }
 
         {


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/14546

### Problem description
The current power_tile implementation has a time complexity that grows linearly with the increment step. As a result, a larger step value significantly increases the kernel’s runtime.

```cpp
        // bias_correction1 = 1 - pow(beta1, step);
        // cb_tmp2 = pow(beta1, step);
        tile_regs_acquire();
        cb_reserve_back(cb_tmp2, onetile);
        copy_tile_init_with_dt(cb_scalar_args);
        copy_tile(cb_scalar_args, beta1_tile, dst0);
        power_tile_init();
        power_tile(dst0, step);
        tile_regs_commit();
```

### What's changed
The exponent of beta1 and beta2 is now computed on the host (program factory) and then passed to the reader kernel. cb_beta1_exponent and cb_beta2_exponent is the intermed cb for compute kernel to use. For cached_program, I overwrite the beta1_exponent and beta2_exponent values in the reader kernel runtime args.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11850545658
- [x] Blackhole Post commit (if applicable): NA
- [x] Model regression CI testing passes (if applicable): NA
- [x] Device performance regression CI testing passes (if applicable): NA
- [x] New/Existing tests provide coverage for changes: All tests passed
