### PR TITLE
Reduce dependence on ARCH_NAME in dev_msgs.h

### DIFF
--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -10,7 +10,7 @@
 
 void assert_and_hang(uint32_t line_num) {
     // Write the line number into the memory mailbox for host to read.
-    debug_assert_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(watcher.assert_status);
+    debug_assert_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.assert_status);
     if (v->tripped == DebugAssertOK) {
         v->line_num = line_num;
         v->tripped = DebugAssertTripped;
@@ -21,7 +21,7 @@ void assert_and_hang(uint32_t line_num) {
 #if defined(COMPILE_FOR_ERISC)
     // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
     // still running and try to make it exit.
-    tt_l1_ptr go_msg_t *go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
+    tt_l1_ptr go_msg_t *go_message_ptr = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), go_message);
     go_message_ptr->signal = RUN_MSG_DONE;
 
     // This exits to base FW

--- a/tt_metal/hw/inc/debug/dprint_buffer.h
+++ b/tt_metal/hw/inc/debug/dprint_buffer.h
@@ -6,27 +6,27 @@
 
 #include "tt_metal/hostdevcommon/dprint_common.h"
 #include <dev_msgs.h>
-
 #include "hostdevcommon/dprint_common.h"
+#include "mailbox_base.h" // get_mailbox_base()
 
 // Returns the buffer address for current thread+core. Differs for NC/BR/ER/TR0-2.
 inline volatile tt_l1_ptr DebugPrintMemLayout* get_debug_print_buffer() {
 #if defined(COMPILE_FOR_NCRISC)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_NC]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_NC]);
 #elif defined(COMPILE_FOR_BRISC)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_BR]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_BR]);
 #elif defined(COMPILE_FOR_ERISC)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
 #elif (defined(COMPILE_FOR_IDLE_ERISC) && COMPILE_FOR_IDLE_ERISC == 0)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_ER]);
 #elif (defined(COMPILE_FOR_IDLE_ERISC) && COMPILE_FOR_IDLE_ERISC == 1)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_ER1]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_ER1]);
 #elif defined(UCK_CHLKC_UNPACK)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_TR0]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_TR0]);
 #elif defined(UCK_CHLKC_MATH)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_TR1]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_TR1]);
 #elif defined(UCK_CHLKC_PACK)
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.data[DPRINT_RISCV_INDEX_TR2]);
+    return GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), dprint_buf.data[DPRINT_RISCV_INDEX_TR2]);
 #else
     return 0;
 #endif

--- a/tt_metal/hw/inc/debug/pause.h
+++ b/tt_metal/hw/inc/debug/pause.h
@@ -12,7 +12,7 @@
 
 void watcher_pause() {
     // Write the pause flag for this core into the memory mailbox for host to read.
-    debug_pause_msg_t tt_l1_ptr *pause_msg = GET_MAILBOX_ADDRESS_DEV(watcher.pause_status);
+    debug_pause_msg_t tt_l1_ptr *pause_msg = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.pause_status);
     pause_msg->flags[debug_get_which_riscv()] = 1;
 
     // Wait for the pause flag to be cleared.

--- a/tt_metal/hw/inc/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/debug/ring_buffer.h
@@ -12,11 +12,11 @@ constexpr static int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #include "dev_msgs.h"
-
+#include "mailbox_base.h" // get_mailbox_base()
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
 void push_to_ring_buffer(uint32_t val) {
-    auto buf = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+    auto buf = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.debug_ring_buf);
     volatile tt_l1_ptr int16_t* curr_ptr = &buf->current_ptr;
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
     uint32_t* data = buf->data;

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -42,7 +42,7 @@ typedef bool debug_sanitize_noc_which_core_t;
 
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y) {
-    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
+    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), core_info);
 
     for (uint32_t idx = 0; idx < MAX_NON_WORKER_CORES; idx++) {
         uint8_t core_x = core_info->non_worker_cores[idx].x;
@@ -102,7 +102,7 @@ inline uint16_t debug_valid_pcie_addr(uint64_t addr, uint64_t len) {
     if (addr + len <= addr)
         return DebugSanitizeNocAddrZeroLength;
 
-    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
+    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), core_info);
     if (addr < core_info->noc_pcie_addr_base)
         return DebugSanitizeNocAddrUnderflow;
     if (addr + len > core_info->noc_pcie_addr_end)
@@ -113,7 +113,7 @@ inline uint16_t debug_valid_dram_addr(uint64_t addr, uint64_t len) {
     if (addr + len <= addr)
         return DebugSanitizeNocAddrZeroLength;
 
-    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
+    core_info_msg_t tt_l1_ptr *core_info = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), core_info);
     if (addr < core_info->noc_dram_addr_base)
         return DebugSanitizeNocAddrUnderflow;
     if (addr + len > core_info->noc_dram_addr_end)
@@ -146,7 +146,7 @@ inline void debug_sanitize_post_noc_addr_and_hang(
     if (return_code == DebugSanitizeNocOK)
         return;
 
-    debug_sanitize_noc_addr_msg_t tt_l1_ptr *v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize_noc);
+    debug_sanitize_noc_addr_msg_t tt_l1_ptr *v = *GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.sanitize_noc);
 
     if (v[noc_id].return_code == DebugSanitizeNocOK) {
         v[noc_id].noc_addr = noc_addr;
@@ -162,7 +162,7 @@ inline void debug_sanitize_post_noc_addr_and_hang(
 #if defined(COMPILE_FOR_ERISC)
     // Update launch msg to show that we've exited. This is required so that the next run doesn't think there's a kernel
     // still running and try to make it exit.
-    tt_l1_ptr go_msg_t *go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_message);
+    tt_l1_ptr go_msg_t *go_message_ptr = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), go_message);
     go_message_ptr->signal = RUN_MSG_DONE;
 
     // For erisc, we can't hang the kernel/fw, because the core doesn't get restarted when a new
@@ -345,7 +345,7 @@ void debug_sanitize_noc_and_worker_addr(
 // Delay for debugging purposes
 inline void debug_insert_delay(uint8_t transaction_type) {
 #if defined(WATCHER_DEBUG_DELAY)
-    debug_insert_delays_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(watcher.debug_insert_delays);
+    debug_insert_delays_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.debug_insert_delays);
 
     bool delay = false;
     switch (transaction_type) {

--- a/tt_metal/hw/inc/debug/stack_usage.h
+++ b/tt_metal/hw/inc/debug/stack_usage.h
@@ -83,9 +83,9 @@ void dirty_stack_memory() {
 
 void record_stack_usage() {
     // Write the pause flag for this core into the memory mailbox for host to read.
-    debug_stack_usage_t tt_l1_ptr *stack_usage_msg = GET_MAILBOX_ADDRESS_DEV(watcher.stack_usage);
-    uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
-    launch_msg_t tt_l1_ptr *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_msg_rd_ptr]);
+    debug_stack_usage_t tt_l1_ptr *stack_usage_msg = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.stack_usage);
+    uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch_msg_rd_ptr);
+    launch_msg_t tt_l1_ptr *launch_msg = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch[launch_msg_rd_ptr]);
     uint32_t stack_size = get_stack_size();
 
     uint32_t tt_l1_ptr *stack_ptr = (uint32_t tt_l1_ptr *) get_stack_base();

--- a/tt_metal/hw/inc/debug/watcher_common.h
+++ b/tt_metal/hw/inc/debug/watcher_common.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "dev_msgs.h"
+#include "mailbox_base.h" // get_mailbox_base()
 
 #if defined(WATCHER_ENABLED)
 
@@ -36,11 +37,11 @@ inline uint32_t debug_get_which_riscv()
 }
 
 void clear_previous_launch_message_entry_for_watcher() {
-    uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
+    uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch_msg_rd_ptr);
     // Before the read pointer has been incremented, clear the watcher info 1 entries before to ensure that we don't
     // report stale data
     uint32_t prev_rd_ptr = (launch_msg_rd_ptr - 1 + launch_msg_buffer_num_entries) % launch_msg_buffer_num_entries;
-    launch_msg_t tt_l1_ptr *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[prev_rd_ptr]);
+    launch_msg_t tt_l1_ptr *launch_msg = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch[prev_rd_ptr]);
     // Clear kernel ids and NOC ID used by stale program entry, since these are queried by watcher
     for (int idx = 0; idx < DISPATCH_CLASS_MAX; idx++) {
         launch_msg->kernel_config.watcher_kernel_ids[idx] = 0;

--- a/tt_metal/hw/inc/debug/waypoint.h
+++ b/tt_metal/hw/inc/debug/waypoint.h
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "dev_msgs.h"
+#include "mailbox_base.h" // get_mailbox_base()
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_WAYPOINT) && !defined(FORCE_WATCHER_OFF)
 #include <cstddef>
@@ -49,7 +50,7 @@ inline void write_debug_waypoint(volatile tt_l1_ptr uint32_t *debug_waypoint) {
 #endif
 
 #define WATCHER_WAYPOINT_MAILBOX \
-    (volatile tt_l1_ptr uint32_t *)&((*GET_MAILBOX_ADDRESS_DEV(watcher.debug_waypoint))[WATCHER_WAYPOINT_MAILBOX_OFFSET])
+    (volatile tt_l1_ptr uint32_t *)&((*GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), watcher.debug_waypoint))[WATCHER_WAYPOINT_MAILBOX_OFFSET])
 
 #define WAYPOINT(x) write_debug_waypoint<helper(x)>(WATCHER_WAYPOINT_MAILBOX)
 

--- a/tt_metal/hw/inc/mailbox_base.h
+++ b/tt_metal/hw/inc/mailbox_base.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#ifndef _MAILBOX_BASE_H_
+#define _MAILBOX_BASE_H_
+
+#include <cstdint>
+
+#include "eth_l1_address_map.h" // ERISC_MEM_MAILBOX_BASE
+#include "dev_mem_map.h" // MEM_MAILBOX_BASE, MEM_IERISC_MAILBOX_BASE
+
+constexpr inline std::uint32_t get_mailbox_base() {
+
+#ifdef COMPILE_FOR_ERISC
+    return eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE;
+#elif COMPILE_FOR_IDLE_ERISC
+    return MEM_IERISC_MAILBOX_BASE;
+#else
+    return MEM_MAILBOX_BASE;
+#endif
+}
+
+#endif

--- a/tt_metal/impl/debug/sanitize_noc_host.hpp
+++ b/tt_metal/impl/debug/sanitize_noc_host.hpp
@@ -5,6 +5,9 @@
 #include "noc/noc_parameters.h"
 #include "noc/noc_overlay_parameters.h"
 
+// FIXME: ARCH_NAME specific include
+#include "dev_mem_map.h" // MEM_[L1/ETH]_BASE
+
 #pragma once
 
 namespace tt {

--- a/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
@@ -4,6 +4,7 @@
 
 // clang-format off
 #include "dataflow_api.h"
+#include "mailbox_base.h" // get_mailbox_base()
 #include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
 // clang-format on
 
@@ -147,8 +148,8 @@ void kernel_main() {
             }
             all_outputs_finished &= output_finished;
         }
-        uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
-        tt_l1_ptr launch_msg_t * const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_msg_rd_ptr]);
+        uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch_msg_rd_ptr);
+        tt_l1_ptr launch_msg_t * const launch_msg = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch[launch_msg_rd_ptr]);
         if (launch_msg->kernel_config.exit_erisc_kernel) {
             return;
         }

--- a/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
@@ -4,6 +4,7 @@
 
 // clang-format off
 #include "dataflow_api.h"
+#include "mailbox_base.h" // get_mailbox_base()
 #include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
 // clang-format on
 
@@ -257,8 +258,8 @@ void kernel_main() {
                 all_outputs_finished &= output_finished;
             }
         }
-        uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
-        tt_l1_ptr launch_msg_t * const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_msg_rd_ptr]);
+        uint32_t launch_msg_rd_ptr = *GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch_msg_rd_ptr);
+        tt_l1_ptr launch_msg_t * const launch_msg = GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), launch[launch_msg_rd_ptr]);
         if (launch_msg->kernel_config.exit_erisc_kernel) {
             return;
         }

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -7,6 +7,7 @@
 #define COMPILE_FOR_ERISC
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -5,6 +5,7 @@
 #if defined(ARCH_BLACKHOLE)
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -5,6 +5,7 @@
 #include "core_config.h"
 #include "noc/noc_parameters.h"
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 
 #if defined (ARCH_GRAYSKULL)

--- a/tt_metal/llrt/hal_asserts.hpp
+++ b/tt_metal/llrt/hal_asserts.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "noc/noc_parameters.h"
+
+#ifndef TENSIX_FIRMWARE
+// Validate assumptions on mailbox layout on host compile
+// Constexpr definitions allow for printing of breaking values at compile time
+#ifdef NCRISC_HAS_IRAM
+// These are only used in ncrisc-halt.S
+static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.dm1) == MEM_SLAVE_RUN_MAILBOX_ADDRESS);
+static_assert(
+    MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
+#endif
+#if defined(COMPILE_FOR_ERISC) || defined (COMPILE_FOR_IDLE_ERISC)
+#include "eth_l1_address_map.h"
+static_assert( eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE + sizeof(mailboxes_t) <= eth_l1_mem::address_map::ERISC_MEM_MAILBOX_END);
+static_assert( MEM_IERISC_MAILBOX_BASE + sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_END);
+static constexpr uint32_t ETH_LAUNCH_CHECK = (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE  + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static constexpr uint32_t ETH_PROFILER_CHECK = (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE  + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static_assert( ETH_LAUNCH_CHECK == 0);
+static_assert( ETH_PROFILER_CHECK == 0);
+static_assert(MEM_IERISC_FIRMWARE_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+static_assert(MEM_IERISC_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_IERISC_MAILBOX_END);
+#else
+static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);
+static constexpr uint32_t TENSIX_LAUNCH_CHECK = (MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static constexpr uint32_t TENSIX_PROFILER_CHECK = (MEM_MAILBOX_BASE + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static_assert( TENSIX_LAUNCH_CHECK == 0);
+static_assert( TENSIX_PROFILER_CHECK == 0);
+static_assert( sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+#endif
+#endif

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -17,6 +17,9 @@
 #include "llrt/tt_memory.h"
 // clang-format on
 
+// FIXME: ARCH_NAME specific include
+#include "dev_mem_map.h" // MEM_LOCAL_BASE
+
 namespace tt {
 
 // llrt = lower-level runtime

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
 #include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -7,6 +7,7 @@
 #define COMPILE_FOR_IDLE_ERISC
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
 #include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -5,6 +5,7 @@
 #if defined(ARCH_WORMHOLE_B0)
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
 #include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -17,6 +17,7 @@
 #include "risc_attribs.h"
 
 #include "dev_msgs.h"
+#include "mailbox_base.h" // get_mailbox_base()
 
 #define DO_PRAGMA(x) _Pragma (#x)
 
@@ -43,10 +44,10 @@ namespace kernel_profiler{
     constexpr int WALL_CLOCK_LOW_INDEX = 0;
 
     volatile tt_l1_ptr uint32_t *profiler_control_buffer =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(GET_MAILBOX_ADDRESS_DEV(profiler.control_vector));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), profiler.control_vector));
 
     volatile tt_l1_ptr uint32_t (*profiler_data_buffer)[kernel_profiler::PROFILER_L1_VECTOR_SIZE] =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t (*)[kernel_profiler::PROFILER_L1_VECTOR_SIZE]>(GET_MAILBOX_ADDRESS_DEV(profiler.buffer));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t (*)[kernel_profiler::PROFILER_L1_VECTOR_SIZE]>(GET_MAILBOX_ADDRESS_DEV(get_mailbox_base(), profiler.buffer));
 
 #if defined(COMPILE_FOR_BRISC)
     constexpr uint32_t myRiscID = 0;


### PR DESCRIPTION
### Ticket
#14643 

### Problem description
`dev_msgs.h` is commonly included in host code, and poisons any translation unit with ARCH_NAME specific code.

### What's changed
- Macro GET_MAILBOX_ADDRESS_DEV has been changed to accept an additional parameter `mailbox_base`
  - This allows the macro caller to bring in the ARCH_NAME specific mailbox base address, and gets the problem out of host code.
-  Static asserts that lived in `dev_msgs.h` are moved to Hal.

Doing this required the introduction of two new files:
- `mailbox_base.h`: Gives ARCH_NAME / Processor specific mailbox_base address
- `hal_asserts.hpp`:  Gives ARCH_NAME / Processor specific static asserts to hal.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11786865891
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
