### PR TITLE
Reduce dependence on ARCH_NAME in dev_msgs.h

### DIFF
--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -11,18 +11,18 @@
 #pragma once
 
 #include "core_config.h"
-#include "noc/noc_parameters.h"
-#include "dev_mem_map.h"
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
 
 // TODO: move these to processor specific files
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
 #if defined(COMPILE_FOR_ERISC)
 #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
 #elif defined(COMPILE_FOR_IDLE_ERISC)
 #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr *)MEM_IERISC_MAILBOX_BASE)->x))
 #else
 #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr *)MEM_MAILBOX_BASE)->x))
+#endif
 #endif
 
 // Messages for host to tell brisc to go
@@ -229,11 +229,12 @@ enum watcher_enable_msg_t {
 
 // TODO: w/ the hal, this can come from core specific defines
 constexpr static std::uint32_t MAX_RISCV_PER_CORE = 5;
+constexpr static std::uint32_t MAX_NUM_NOCS_PER_CORE = 2;
 
 struct watcher_msg_t {
     volatile uint32_t enable;
     struct debug_waypoint_msg_t debug_waypoint[MAX_RISCV_PER_CORE];
-    struct debug_sanitize_noc_addr_msg_t sanitize_noc[NUM_NOCS];
+    struct debug_sanitize_noc_addr_msg_t sanitize_noc[MAX_NUM_NOCS_PER_CORE];
     struct debug_assert_msg_t assert_status;
     struct debug_pause_msg_t pause_status;
     struct debug_stack_usage_t stack_usage;
@@ -262,8 +263,7 @@ static constexpr uint32_t PROFILER_RISC_COUNT = 1;
 static constexpr uint32_t PROFILER_RISC_COUNT = 5;
 #endif
 
-static constexpr uint32_t LAUNCH_NOC_ALIGMENT_PAD_COUNT = 1;
-static constexpr uint32_t PROFILER_NOC_ALIGMENT_PAD_COUNT = 2;
+static constexpr uint32_t PROFILER_NOC_ALIGNMENT_PAD_COUNT = 2;
 
 struct profiler_msg_t {
     uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
@@ -301,7 +301,7 @@ struct mailboxes_t {
     struct go_msg_t go_message;
     struct watcher_msg_t watcher;
     struct dprint_buf_msg_t dprint_buf;
-    uint32_t pads_2[PROFILER_NOC_ALIGMENT_PAD_COUNT];
+    uint32_t pads_2[PROFILER_NOC_ALIGNMENT_PAD_COUNT];
     struct profiler_msg_t profiler;
     struct core_info_msg_t core_info;
 };
@@ -310,35 +310,6 @@ struct mailboxes_t {
 static_assert(sizeof(watcher_msg_t) % sizeof(uint32_t) == 0);
 static_assert(sizeof(kernel_config_msg_t) % sizeof(uint32_t) == 0);
 static_assert(sizeof(core_info_msg_t) % sizeof(uint32_t) == 0);
-
-// TODO: move these checks into the HAL?
-#ifndef TENSIX_FIRMWARE
-// Validate assumptions on mailbox layout on host compile
-// Constexpr definitions allow for printing of breaking values at compile time
-#ifdef NCRISC_HAS_IRAM
-// These are only used in ncrisc-halt.S
-static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.dm1) == MEM_SLAVE_RUN_MAILBOX_ADDRESS);
-static_assert(
-    MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
-#endif
-#if defined(COMPILE_FOR_ERISC) || defined (COMPILE_FOR_IDLE_ERISC)
-static_assert( eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE + sizeof(mailboxes_t) <= eth_l1_mem::address_map::ERISC_MEM_MAILBOX_END);
-static_assert( MEM_IERISC_MAILBOX_BASE + sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_END);
-static constexpr uint32_t ETH_LAUNCH_CHECK = (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE  + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
-static constexpr uint32_t ETH_PROFILER_CHECK = (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE  + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
-static_assert( ETH_LAUNCH_CHECK == 0);
-static_assert( ETH_PROFILER_CHECK == 0);
-static_assert(MEM_IERISC_FIRMWARE_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
-static_assert(MEM_IERISC_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_IERISC_MAILBOX_END);
-#else
-static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);
-static constexpr uint32_t TENSIX_LAUNCH_CHECK = (MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
-static constexpr uint32_t TENSIX_PROFILER_CHECK = (MEM_MAILBOX_BASE + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
-static_assert( TENSIX_LAUNCH_CHECK == 0);
-static_assert( TENSIX_PROFILER_CHECK == 0);
-static_assert( sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
-#endif
-#endif
 
 struct eth_word_t {
     volatile uint32_t bytes_sent;

--- a/tt_metal/impl/debug/sanitize_noc_host.hpp
+++ b/tt_metal/impl/debug/sanitize_noc_host.hpp
@@ -5,6 +5,9 @@
 #include "noc/noc_parameters.h"
 #include "noc/noc_overlay_parameters.h"
 
+// FIXME: ARCH_NAME specific include
+#include "dev_mem_map.h" // MEM_[L1/ETH]_BASE
+
 #pragma once
 
 namespace tt {

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -7,6 +7,7 @@
 #define COMPILE_FOR_ERISC
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -5,6 +5,7 @@
 #if defined(ARCH_BLACKHOLE)
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/core_config.h"
 #include "hw/inc/blackhole/dev_mem_map.h"

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -5,6 +5,7 @@
 #include "core_config.h"
 #include "noc/noc_parameters.h"
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 
 #if defined (ARCH_GRAYSKULL)

--- a/tt_metal/llrt/hal_asserts.hpp
+++ b/tt_metal/llrt/hal_asserts.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "noc/noc_parameters.h"
+
+// Validate assumptions on mailbox layout on host compile
+// Constexpr definitions allow for printing of breaking values at compile time
+#ifdef NCRISC_HAS_IRAM
+// These are only used in ncrisc-halt.S
+static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.dm1) == MEM_SLAVE_RUN_MAILBOX_ADDRESS);
+static_assert(
+    MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
+#endif
+#if defined(COMPILE_FOR_ERISC) || defined (COMPILE_FOR_IDLE_ERISC)
+#include "eth_l1_address_map.h"
+static_assert( eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE + sizeof(mailboxes_t) <= eth_l1_mem::address_map::ERISC_MEM_MAILBOX_END);
+static_assert( MEM_IERISC_MAILBOX_BASE + sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_END);
+static constexpr uint32_t ETH_LAUNCH_CHECK = (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE  + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static constexpr uint32_t ETH_PROFILER_CHECK = (eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE  + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static_assert( ETH_LAUNCH_CHECK == 0);
+static_assert( ETH_PROFILER_CHECK == 0);
+static_assert(MEM_IERISC_FIRMWARE_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+static_assert(MEM_IERISC_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_IERISC_MAILBOX_END);
+#else
+static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);
+static constexpr uint32_t TENSIX_LAUNCH_CHECK = (MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static constexpr uint32_t TENSIX_PROFILER_CHECK = (MEM_MAILBOX_BASE + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT;
+static_assert( TENSIX_LAUNCH_CHECK == 0);
+static_assert( TENSIX_PROFILER_CHECK == 0);
+static_assert( sizeof(launch_msg_t) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+#endif

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -17,6 +17,9 @@
 #include "llrt/tt_memory.h"
 // clang-format on
 
+// FIXME: ARCH_NAME specific include
+#include "dev_mem_map.h" // MEM_LOCAL_BASE
+
 namespace tt {
 
 // llrt = lower-level runtime

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
 #include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -7,6 +7,7 @@
 #define COMPILE_FOR_IDLE_ERISC
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
 #include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -5,6 +5,7 @@
 #if defined(ARCH_WORMHOLE_B0)
 
 #include "llrt/hal.hpp"
+#include "llrt/hal_asserts.hpp"
 #include "llrt/wormhole/wh_hal.hpp"
 #include "hw/inc/wormhole/core_config.h"
 #include "hw/inc/wormhole/dev_mem_map.h"


### PR DESCRIPTION
### Ticket
#14643 

### Problem description
dev_msgs.h is commonly included in host code, and poisons any translation unit with ARCH_NAME specific code.

### What's changed
- Macro GET_MAILBOX_ADDRESS_DEV is not compiled on host code.
- Static asserts that lived in dev_msgs.h are moved to Hal.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11787808443

- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
