### PR TITLE
Fix double deallocate in llama3 attention

### DIFF
--- a/models/demos/llama3/tt/llama_attention.py
+++ b/models/demos/llama3/tt/llama_attention.py
@@ -351,7 +351,6 @@ class TtLlamaAttention(LightweightModule):
             dense_out_sharded, ttnn.L1_MEMORY_CONFIG
         )  # TODO: remove as soon as we have sharded support in for all CCL
 
-        ttnn.deallocate(attn_output_cat)
         ttnn.deallocate(dense_out_sharded)
 
         # All reduce


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Llama 3 attention was deallocating the same tensor twice.

### What's changed
Only deallocate `attn_output_cat` once.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11796342111)
- [ ] [Model demo CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11796349539)
- [ ] [T3K unit and demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/11796362315)
