### PR TITLE
[skip ci] #14001: Add an ALIAS target for consuming TTNN

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -654,6 +654,7 @@ if(WITH_PYTHON_BINDINGS)
 endif()
 
 add_library(ttnn SHARED ${TTNN_FINAL_SRC})
+add_library(Metalium::TTNN ALIAS ttnn)
 target_compile_options(
     ttnn
     PUBLIC


### PR DESCRIPTION
### Ticket
#14371 

### Problem description
tt-train is joining the mono repo party; it should have a proper namespace'd target to consume

### What's changed
New ALIAS target for TTNN with a namespace.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
