### PR TITLE
#0: Disable llama test_model from all-post-commit CI pipeline

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -52,9 +52,10 @@ run_python_model_tests_wormhole_b0() {
     # Llama3.2-11B  (#Skip: Weights too big for single-chip ci VM)
     llama11b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-11B-Vision-Instruct/
 
+    # FIXME Issue #14474
     # Run all Llama3 tests for 8B, 1B, and 3B weights - dummy weights with tight PCC check
-    for llama_dir in "$llama8b" "$llama1b" "$llama3b"; do
-        LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/llama3/tests/test_llama_model.py -k "quick" ; fail+=$?
-        echo "LOG_METAL: Llama3 tests for $llama_dir completed"
-    done
+    # for llama_dir in "$llama8b" "$llama1b" "$llama3b"; do
+    #     LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/llama3/tests/test_llama_model.py -k "quick" ; fail+=$?
+    #     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
+    # done
 }


### PR DESCRIPTION
### Ticket
#14474 

### Problem description
The llama3 `test_llama_model.py` and ``test_llama_model_prefill.py` in all-post-commit CI pipelines crash ND sometimes.
We're disabling the tests for now to avoid failing pipelines while we debug the issue.

The issue at this point in time has not been able to be replicated on a lab machine nor locally on a CI VM. Will test on specific CI VMs that show the crash.