### PR TITLE
Mchiou/14961 disable gs profiler ring buffer

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -200,6 +200,7 @@ def test_dispatch_cores():
     os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
 
 
+@skip_for_grayskull()
 def test_profiler_host_device_sync():
     TOLERANCE = 0.1
 

--- a/tests/ttnn/tracy/test_profiler_sync.py
+++ b/tests/ttnn/tracy/test_profiler_sync.py
@@ -40,6 +40,7 @@ def test_with_ops(device):
     output = ttnn.matmul(a, b, memory_config=ttnn.L1_MEMORY_CONFIG, core_grid=ttnn.CoreGrid(y=8, x=8))
 
 
+@pytest.mark.skip("#14961 - Ring Buffer issue")
 @pytest.mark.parametrize("num_devices", [(8)])
 def test_all_devices(
     all_devices,

--- a/tests/ttnn/tracy/test_profiler_sync.py
+++ b/tests/ttnn/tracy/test_profiler_sync.py
@@ -40,7 +40,6 @@ def test_with_ops(device):
     output = ttnn.matmul(a, b, memory_config=ttnn.L1_MEMORY_CONFIG, core_grid=ttnn.CoreGrid(y=8, x=8))
 
 
-@pytest.mark.skip("#14961 - Ring Buffer issue")
 @pytest.mark.parametrize("num_devices", [(8)])
 def test_all_devices(
     all_devices,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/14961
Does not close this ticket but is step 1. "disabling offending tests"

### Problem description
GS profiler issue

### What's changed
Disabled the test

### Checklist
profiler run
https://github.com/tenstorrent/tt-metal/actions/runs/11804447024
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
