### PR TITLE
#12979: Merge erisc data & bss sections

### DIFF
--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -38,9 +38,9 @@ void __attribute__((noinline)) Application(void) {
     WAYPOINT("I");
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
-    // Not using firmware_kernel_common_init since it is copying to registers
+    // Not using do_crt1 since it is copying to registers???
+    // bss already cleared in entry code.
     // TODO: need to find free space that routing FW is not using
-    wzerorange(__ldm_bss_start, __ldm_bss_end);
 
     risc_init();
     noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);

--- a/tt_metal/hw/inc/ethernet/erisc.h
+++ b/tt_metal/hw/inc/ethernet/erisc.h
@@ -6,8 +6,8 @@
 
 #include "noc_nonblocking_api.h"
 
-void (*rtos_context_switch_ptr)();
-volatile uint32_t *flag_disable = (uint32_t *)(eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
+inline void (*rtos_context_switch_ptr)();
+volatile inline uint32_t *flag_disable = (uint32_t *)(eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
 
 namespace internal_ {
 inline __attribute__((always_inline))

--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -44,47 +44,34 @@ SECTIONS
 
   .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_CODE :text
   .rodata1        : { *(.rodata1) } > REGION_APP_CODE :text
-  .sdata2         :
-  {
+
+  .data : ALIGN(4) {
+    *(.dynamic)
+    *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*)
+
+    *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata .srodata.*)
+    *(.sdata .sdata.* .gnu.linkonce.s.*)
     *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
-  } > REGION_APP_DATA :data
-  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) } > REGION_APP_DATA :data
 
-.data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) } > REGION_APP_DATA :data
-  .dynamic        : { *(.dynamic) } > REGION_APP_DATA :data
-  .data           :
-  {
     *(.data .data.* .gnu.linkonce.d.*)
-    SORT(CONSTRUCTORS)
+    *(.data1)
+
+    *(.got.plt) *(.igot.plt) *(.got) *(.igot)
+    . = ALIGN(4);
   } > REGION_APP_DATA :data
 
-  . = ALIGN(4); /* startup code will use word writes to zero bss */
-  __l1_bss_start = .;
-  .sbss           :
-  {
+  .bss : ALIGN(4) {
+    __ldm_bss_start = .;
+    *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*)
     *(.dynsbss)
     *(.sbss .sbss.* .gnu.linkonce.sb.*)
     *(.scommon)
+    *(.dynbss)
+    *(.bss .bss.* .gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __ldm_bss_end = .;
   } > REGION_APP_DATA :data
-  . = ALIGN(4);
-  __l1_bss_end = .;
-
-  .bss            :
-  {
-   __ldm_bss_start = .;
-   *(.dynbss)
-   *(.bss .bss.* .gnu.linkonce.b.*)
-   *(COMMON)
-
-   /* Align here to ensure that the .bss section occupies space up to
-      _end.  Align after .bss to ensure correct alignment even if the
-      .bss section disappears because there are no input sections.
-      FIXME: Why do we need it? When there is no .bss section, we don't
-      pad the .data section.  */
-   . = ALIGN(4);
-   __ldm_bss_end = .;
-  } > REGION_APP_DATA :data
-  . = ALIGN(32 / 8);
 
   .riscv.attributes 0 : { *(.riscv.attributes) } :attributes
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12979

### Problem description
The erisc app data-like sections are confused

### What's changed
1) Have single .data and .bss output sections
2) Correctly clear all of bss before writing to it (in erisc-crt0.cc) (this was a doozy to find, because crt0 only worked because the small-data bss wasn't being cleared).
3) Fix `rtos_context_switch_ptr` and `flag_disable` definitions -- these need to be inline, as they are in a header file.

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
