### PR TITLE
Build with unity in build-artifact.yaml, don't use unity in build.yaml

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -137,7 +137,6 @@ jobs:
             # NOTE: may be inaccurate if we have >1 build runner on the same machine, using the same local cache
             ccache -z
 
-            # Disable Unity builds to detect any bitrot from not building each TU independently
             build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache"
             echo "${{ inputs.tracy }}"
             if [ "${{ inputs.tracy }}" = "true" ]; then

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -138,7 +138,7 @@ jobs:
             ccache -z
 
             # Disable Unity builds to detect any bitrot from not building each TU independently
-            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache --disable-unity-builds"
+            build_command="./build_metal.sh --build-type ${{ inputs.build-type }} --build-all --enable-ccache"
             echo "${{ inputs.tracy }}"
             if [ "${{ inputs.tracy }}" = "true" ]; then
               build_command="$build_command --enable-profiler"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,9 +43,8 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            nice -n 19 cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UMD_BUILD_TESTS=ON
-            nice -n 19 cmake --build build
-
+            build_command="./build_metal.sh --build-type ${{ matrix.build-type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-all"
+            nice -n 19 $build_command
       - name: Check disk space
         run: |
           df -h

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            build_command="./build_metal.sh --build-type ${{ matrix.build-type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-all"
+            build_command="./build_metal.sh --build-type ${{ matrix.build-type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-all --disable-unity-builds"
             nice -n 19 $build_command
       - name: Check disk space
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            build_command="./build_metal.sh --build-type ${{ matrix.build.type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-all --disable-unity-builds"
+            build_command="./build_metal.sh --build-type ${{ matrix.build.type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-tests --build-programming-examples --disable-unity-builds"
             nice -n 19 $build_command
       - name: Check disk space
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.arch }}
           docker_os_arch: ${{ matrix.build.os }}-amd64
           run_args: |
-            build_command="./build_metal.sh --build-type ${{ matrix.build-type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-all --disable-unity-builds"
+            build_command="./build_metal.sh --build-type ${{ matrix.build.type }} --cxx-compiler-path ${{ matrix.build.cxx_compiler }} --c-compiler-path ${{ matrix.build.c_compiler }} --build-all --disable-unity-builds"
             nice -n 19 $build_command
       - name: Check disk space
         run: |

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -22,12 +22,15 @@ show_help() {
     echo "  --build-umd-tests                Build umd Testcases."
     echo "  --build-programming-examples     Build programming examples."
     echo "  --build-tt-train                 Build tt-train."
+    echo "  --build-all                      Build all optional components."
     echo "  --release                        Set the build type as Release."
     echo "  --development                    Set the build type as RelWithDebInfo."
     echo "  --debug                          Set the build type as Debug."
     echo "  --clean                          Remove build workspaces."
     echo "  --build-static-libs              Build tt_metal (not ttnn) as a static lib (BUILD_SHARED_LIBS=OFF)"
     echo "  --disable-unity-builds           Disable Unity builds"
+    echo "  --cxx-compiler-path              Set path to C++ compiler."
+    echo "  --c-compiler-path                Set path to C++ compiler."
 }
 
 clean() {
@@ -54,11 +57,13 @@ build_tt_train="OFF"
 build_static_libs="OFF"
 unity_builds="ON"
 build_all="OFF"
+cxx_compiler_path=""
+c_compiler_path=""
 
 declare -a cmake_args
 
 OPTIONS=h,e,c,t,a,m,s,u,b:,p
-LONGOPTIONS=help,build-all,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,build-tt-train,build-static-libs,disable-unity-builds,release,development,debug,clean
+LONGOPTIONS=help,build-all,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,build-tt-train,build-static-libs,disable-unity-builds,release,development,debug,clean,cxx-compiler-path:,c-compiler-path:
 
 # Parse the options
 PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTIONS --name "$0" -- "$@")
@@ -112,6 +117,10 @@ while true; do
             build_all="ON";;
         --disable-unity-builds)
 	    unity_builds="OFF";;
+        --cxx-compiler-path)
+            cxx_compiler_path="$2";shift;;
+        --c-compiler-path)
+            c_compiler_path="$2";shift;;
         --release)
             build_type="Release";;
         --development)
@@ -174,6 +183,15 @@ cmake_args+=("-B" "$build_dir")
 cmake_args+=("-G" "Ninja")
 cmake_args+=("-DCMAKE_BUILD_TYPE=$build_type")
 cmake_args+=("-DCMAKE_INSTALL_PREFIX=$cmake_install_prefix")
+
+if [ "$cxx_compiler_path" != "" ]; then
+    echo "INFO: C++ compiler: $cxx_compiler_path"
+    cmake_args+=("-DCMAKE_CXX_COMPILER=$cxx_compiler_path")
+fi
+if [ "$c_compiler_path" != "" ]; then
+    echo "INFO: C compiler: $c_compiler_path"
+    cmake_args+=("-DCMAKE_C_COMPILER=$c_compiler_path")
+fi
 
 if [ "$enable_ccache" = "ON" ]; then
     cmake_args+=("-DCMAKE_DISABLE_PRECOMPILE_HEADERS=TRUE")


### PR DESCRIPTION
### Ticket
NA

### Problem description
Optimize CI throughput by using Unity for main CI build steps.
Don't use unity in the test builds.
This way we have builds that verify with or without unity.

### What's changed
build-artifact.yaml
build.yaml
build-metal.sh

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11831764036
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
