### PR TITLE
#14895: enable gp-rel in kernels

### DIFF
--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -23,7 +23,7 @@
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 
-void kernel_launch(uint32_t) {
+extern "C" [[gnu::section(".start")]] void _start(uint32_t) {
     DeviceZoneScopedMainChildN("ERISC-KERNEL");
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 

--- a/tt_metal/hw/toolchain/sections.ld
+++ b/tt_metal/hw/toolchain/sections.ld
@@ -86,7 +86,9 @@ SECTIONS
   __kernel_init_local_l1_base = .;
 #endif
 
+#if defined(TYPE_FIRMWARE)
   PROVIDE(__global_pointer$ = ORIGIN(REGION_DATA) + 0x7f0);
+#endif
   .data DATA_START : ALIGN(4)
   {
      . = .; /* Force section emission.  */

--- a/tt_metal/hw/toolchain/tmu-crt0k.S
+++ b/tt_metal/hw/toolchain/tmu-crt0k.S
@@ -3,5 +3,8 @@
 .type   _start, @function
 
 _start:
+	// kernel_launch is responsible for the rest of crt -- clear bss, copy data image, run global constructors
+	// Enable GPREL optimizations
+	.reloc _start, R_RISCV_NONE, __global_pointer$
 	tail    _Z13kernel_launchm
 	.size  _start, .-_start

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -188,7 +188,9 @@ void JitBuildState::finish_init() {
             this->link_objs_ += build_dir + "ncrisc-halt.o ";
         }
     } else {
-        this->link_objs_ += build_dir + "tmu-crt0k.o ";
+        if (this->target_name_ != "erisc") {
+            this->link_objs_ += build_dir + "tmu-crt0k.o ";
+        }
     }
     if (this->target_name_ == "brisc" or this->target_name_ == "idle_erisc") {
         this->link_objs_ += build_dir + "noc.o ";
@@ -600,7 +602,7 @@ void JitBuildState::weaken(const string& log_file, const string& out_dir) const 
 
     ll_api::ElfFile elf;
     elf.ReadImage(pathname_in);
-    static std::string_view const strong_names[] = {"__fw_export_*"};
+    static std::string_view const strong_names[] = {"__fw_export_*", "__global_pointer$"};
     elf.WeakenDataSymbols(strong_names);
     elf.WriteImage(pathname_out);
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14895

### Problem description
The compiler does not know that extern global variables are placed near each other, and thus generates each address separately.  This can be aleviated by enabling GP-relative addressing in kernels (it is already enabled in firmware)

### What's changed
1) Export `__global_pointer$` from the firmware's linker script. Do not recompute it in the kernel.
2) Refer to `__global_pointer$` from the kernel's startup -- this is sufficient to tell the linker to do the relaxation we want.
3) Do not do such relaxation in erisc kernels, that didn't work, so such kernels no longer use `tmu-crt0k`.

Of the 4 kernels I looked at, this reduced the text size between 4 and 10% -- in particular the issue's assembly becomes:
```
    3b98:       ffb207b7                lui     a5, 0xffb20
    3b9c:       2087a703                lw      a4, 520(a5) # ffb20208 <__global_pointer$+0x1fa18>
    3ba0:       98e1aa23                sw      a4, -1644(gp) # ffb00184 <noc_reads_num_issued>
    3ba4:       2287a603                lw      a2, 552(a5)
    3ba8:       98c1a623                sw      a2, -1652(gp) # ffb0017c <noc_nonposted_writes_num_issued>
    3bac:       2047a603                lw      a2, 516(a5)
    3bb0:       98c1a223                sw      a2, -1660(gp) # ffb00174 <noc_nonposted_writes_acked>
    3bb4:       2007a603                lw      a2, 512(a5)
    3bb8:       9ac1a423                sw      a2, -1624(gp) # ffb00198 <noc_nonposted_atomics_acked>
    3bbc:       22c7a703                lw      a4, 556(a5)
    3bc0:       96e1ae23                sw      a4, -1668(gp) # ffb0016c <noc_posted_writes_num_issued>
    3bc4:       ffb487b7                lui     a5, 0xffb48
    3bc8:       0107a583                lw      a1, 16(a5) # ffb48010 <__global_pointer$+0x47820>
    3bcc:       ffb007b7                lui     a5, 0xffb00
    3bd0:       1a478713                addi    a4, a5, 420 # ffb001a4 <__global_pointer$+0xfffff9b4>
    3bd4:       00c75503                lhu     a0, 12(a4)
    3bd8:       99418693                addi    a3, gp, -1644 # ffb00184 <noc_reads_num_issued>
    3bdc:       ffb48837                lui     a6, 0xffb48
    3be0:       0ff00613                li      a2, 255
```

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
