### PR TITLE
graph trace update - extract_circular_buffers_peak_size_per_core

### DIFF
--- a/ttnn/cpp/ttnn/graph/graph_consts.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_consts.hpp
@@ -21,6 +21,8 @@ namespace ttnn::graph {
     constexpr auto kShape = "shape";
     constexpr auto kNumCores = "num_cores";
     constexpr auto kPageSize = "page_size";
+    constexpr auto kCoreRangeSet = "core_range_set";
+    constexpr auto kGloballyAllocated = "globally_allocated";
 
     // node names
     constexpr auto kNodeBuffer = "buffer";

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -145,8 +145,8 @@ void GraphProcessor::track_allocate_cb(const CoreRangeSet &core_range_set, uint6
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(size)},
         {kAddress, std::to_string(addr)},
-        {"core_range_set", core_range_set.str()},
-        {"globally_allocated", std::to_string(is_globally_allocated)}
+        {kCoreRangeSet, core_range_set.str()},
+        {kGloballyAllocated, std::to_string(is_globally_allocated)}
     };
     auto counter = graph.size();
     {

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -14,6 +14,7 @@ namespace ttnn::graph {
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
 uint32_t extract_l1_output_buffer_allocation_size_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores);
 uint32_t extract_l1_buffer_allocation_peak_size_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores);
+uint32_t extract_circular_buffers_peak_size_per_core(const nlohmann::json &trace);
 
 // Returns count of intermediate and output tensors
 std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohmann::json& trace);
@@ -30,10 +31,6 @@ struct TensorInfo {
     bool operator==(const TensorInfo& other) const = default;
 };
 
-std::ostream &operator<<(std::ostream &os, const TensorInfo &info) {
-    os << "TensorInfo{shape: " << info.shape << ", size: " << info.size << ", type: " << static_cast<int>(info.type) << "}";
-    return os;
-}
 
 std::vector<TensorInfo> extract_output_info(const nlohmann::json& trace);
 


### PR DESCRIPTION
### Problem description
In the compiler land we need to know peak CB allocation on a given graph trace. 

### What's changed
Adding calculus to extract peak circular buffer allocation per core on given graph trace. Tested locally on multiple examples. Expanded unit test to cover this scenario. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
