### PR TITLE
LlamaVision: Move xattn cache generation to text prefill forward

### DIFF
--- a/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -259,6 +259,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         page_table=None,
         # get_last_token=-1,
         text_only_inference=False,
+        vision_tokens=None,
     ):
         for idx, (
             layer,
@@ -274,6 +275,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
                     full_text_row_masked_out_mask_11SD=full_text_row_masked_out_mask_11SD,
                     mode=mode,
                     user_id=user_id,
+                    vision_tokens=vision_tokens,
                 )
             h = layer(
                 h,

--- a/models/demos/llama3/tt/multimodal/llama_cross_block.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_block.py
@@ -114,9 +114,6 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-    def compute_xattn_kv_cache(self, xattn_tokens, xattn_cache, user_id):
-        return self.attention.compute_xattn_kv_cache(xattn_tokens, xattn_cache, user_id)
-
     def forward(
         self,
         x_11SH,
@@ -127,6 +124,7 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
         xattn_cache,
         mode,
         user_id=0,
+        vision_tokens=None,
     ):
         attn_out = self.attention(
             x_11SH=self.attention_norm(x_11SH, mode=mode),
@@ -135,6 +133,7 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
             full_text_row_masked_out_mask_1NSH=full_text_row_masked_out_mask_1NSH,
             mode=mode,
             user_id=user_id,
+            vision_tokens=vision_tokens,
         )
         attn_out = ttnn.mul(attn_out, ttnn.tanh(self.gate_attn))
 

--- a/models/demos/llama3/tt/multimodal/vision_generator.py
+++ b/models/demos/llama3/tt/multimodal/vision_generator.py
@@ -51,12 +51,10 @@ class LlamaVision:
         Returns (xattn_caches, cross_attention_masks, full_text_row_masked_out_mask, logits)
         """
         B = tokens.shape[0]
-        xattn_caches, cross_attention_masks, full_text_row_masked_out_mask = self.model.compute_vision_tokens_masks(
+        vision_tokens, cross_attention_masks, full_text_row_masked_out_mask = self.model.compute_vision_tokens_masks(
             batch_images=[vision_images],
             batch_masks=[vision_mask],
             total_len=total_len,
-            xattn_caches=xattn_caches,
-            user_id=user_id,
         )
 
         (
@@ -81,6 +79,7 @@ class LlamaVision:
             rot_mats,
             transformation_mats,
             user_id,
+            vision_tokens,
         )
 
         logits = self.model.process_output_prefill(tt_logits, B, prefill_len)


### PR DESCRIPTION
### Ticket
#15008 

### Problem description
From the ticket:
>Currently, xattn caches are generated before running text prefill. This is an issue for vLLM integration since vLLM will provide page tables for the xattn caches which we must respect. If xattn caches are generated before text prefill, then prefill attention SDPA will need to support paged KV.

>In order to allow vLLM integration without changing prefill SDPA to support paged KV, we will modify the model to compute xattn caches during text prefill. That way, text prefill will generate an unpaged cache, use it locally in attention, then do a paged fill cache to store the cache for decode iterations.

### What's changed
I moved xattn cache generation to text model prefill. This is a change to the plumbing, nothing drastic.

### Checklist
- [ ] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/11843122221
  - Note: My changes should have no effect on the post commit tests
- [x] T3K unit, frequent, demo https://github.com/tenstorrent/tt-metal/actions/runs/11843107464
