### PR TITLE
#15073: Fix use after move in ttnn run_operation

### DIFF
--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -369,20 +369,21 @@ Tensors run_with_autoformat(
         }
     }
 
+    auto output_specs = operation.compute_output_shapes(input_tensors);
     auto output_tensors = run<Tensors>(std::move(operation), formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors, cq_id);
 
-    auto output_shapes = extract_legacy_shapes(operation.compute_output_shapes(input_tensors), [&](size_t idx) {
+    auto legacy_output_shapes = extract_legacy_shapes(std::move(output_specs), [&](size_t idx) {
         auto tensor = output_tensors[idx];
         return TensorLayout(tensor.get_dtype(), Layout::TILE, tensor.memory_config());
     }, /*use_tensor_layout_from_tensor_spec=*/ true);
 
-    TT_ASSERT(output_tensors.size() == output_shapes.size());
+    TT_ASSERT(output_tensors.size() == legacy_output_shapes.size());
 
     formatted_input_tensors.clear();
     formatted_optional_input_tensors.clear();
 
     for (auto i = 0; i < output_tensors.size(); ++i) {
-        output_tensors[i] = AutoFormat::format_output_tensor(output_tensors[i], output_shapes[i], device, Layout::TILE);
+        output_tensors[i] = AutoFormat::format_output_tensor(output_tensors[i], legacy_output_shapes[i], device, Layout::TILE);
     }
     return output_tensors;
 }
@@ -432,14 +433,15 @@ Tensors run_with_autoformat(
         }
     }
 
+    auto output_specs = operation.compute_output_shapes(input_tensors);
     auto output_tensors = run<Tensors>(std::move(operation), formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors, cq_id);
 
-    auto output_shapes = extract_legacy_shapes(operation.compute_output_shapes(input_tensors), [&](size_t idx) {
+    auto legacy_output_shapes = extract_legacy_shapes(std::move(output_specs), [&](size_t idx) {
         auto tensor = output_tensors[idx];
         return TensorLayout(tensor.get_dtype(), output_layouts[idx], tensor.memory_config());
     }, /*use_tensor_layout_from_tensor_spec=*/ false);
 
-    TT_ASSERT(output_tensors.size() == output_shapes.size());
+    TT_ASSERT(output_tensors.size() == legacy_output_shapes.size());
     TT_ASSERT(output_tensors.size() == output_layouts.size());
 
     formatted_input_tensors.clear();
@@ -447,7 +449,7 @@ Tensors run_with_autoformat(
 
     for (auto i = 0; i < output_tensors.size(); ++i) {
         output_tensors[i] =
-            AutoFormat::format_output_tensor(output_tensors[i], output_shapes[i], device, output_layouts[i]);
+            AutoFormat::format_output_tensor(output_tensors[i], legacy_output_shapes[i], device, output_layouts[i]);
     }
 
     return output_tensors;


### PR DESCRIPTION
### Ticket
#15073 

### Problem description
Recent changes cause a use after move

### What's changed
Fixing the issue.
@blozano-tt @afuller-TT will help to enable a corresponding clang-tidy check
https://github.com/tenstorrent/tt-metal/blob/008c50a744ab398526f12992f9f4902283f9215a/.clang-tidy#L28


### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/11850149066)