### PR TITLE
#15079: make ProgramCache::is_enabled_ initialized out-of-line

### DIFF
--- a/tt_metal/impl/device/program_cache.hpp
+++ b/tt_metal/impl/device/program_cache.hpp
@@ -56,8 +56,8 @@ struct ProgramCache {
     std::size_t num_entries() const { return this->cache_.size(); }
 
    private:
-    inline static bool is_enabled_ = false;
+    bool is_enabled_ = false;
     std::unordered_map<uint64_t, CachedProgramFactory> cache_{};
 };
 
-}  // namespace tt::tt_metal::program_cache
+}  // namespace tt::tt_metal::program_cache::detail


### PR DESCRIPTION
### Ticket
Closes #15079

### Problem description
`is_enabled_` being initialized inline causes weird inconsistent behavior when compiled with clang-17

### What's changed
- Create a new translation unit for `program_cache`
- Initialize the static variable out-of-line

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
