### PR TITLE
Update Lerp op

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/ternary/lerp/lerp.py
+++ b/tests/sweep_framework/sweeps/eltwise/ternary/lerp/lerp.py
@@ -42,6 +42,18 @@ parameters = {
 }
 
 
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if (
+        test_vector["input_b_dtype"] != test_vector["input_a_dtype"]
+        or test_vector["input_c_dtype"] != test_vector["input_a_dtype"]
+    ):
+        return True, "Dtype for lerp operands needs to be same"
+    return False, None
+
+
 # This is the run instructions for the test, defined by the developer.
 # The run function must take the above-defined parameters as inputs.
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.

--- a/tests/sweep_framework/sweeps/eltwise/ternary/lerp/lerp.py
+++ b/tests/sweep_framework/sweeps/eltwise/ternary/lerp/lerp.py
@@ -61,9 +61,6 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
-
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
@@ -76,7 +73,8 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_c_dtype
     )(input_shape)
 
-    torch_output_tensor = torch.lerp(torch_input_tensor_a, torch_input_tensor_b, torch_input_tensor_c)
+    golden_function = ttnn.get_golden_function(ttnn.lerp)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, torch_input_tensor_c)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
@@ -31,12 +31,12 @@ template <TernaryCompositeOpType ternary_comp_op_type>
 struct ExecuteTernaryCompositeLerp
 {
     static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        const Tensor& input_tensor_c,
+        const Tensor& input_tensor,
+        const Tensor& end,
+        const Tensor& weight,
         const std::optional<MemoryConfig>& memory_config = std::nullopt)
         {
-            return OpHandler<ternary_comp_op_type>::handle(input_tensor_a, input_tensor_b, input_tensor_c, memory_config);
+            return OpHandler<ternary_comp_op_type>::handle(input_tensor, end, weight, memory_config);
         }
 
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -52,6 +52,7 @@ Tensor _addcdiv(
 
 // lerp(input, end, weight) = start   weight * (end - start)
 Tensor _lerp_overload(const Tensor& input_a, const Tensor& input_b, float value, const std::optional<MemoryConfig>& output_mem_config) {
+    TT_FATAL(input_a.dtype() == input_b.dtype(), "Expected the same dtype as start (input_a), for end (input_b)");
     Tensor t_diff = ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config);
     Tensor t_mul = ttnn::multiply(t_diff, value, std::nullopt, output_mem_config);
     Tensor result = ttnn::add(input_a, t_mul, std::nullopt, output_mem_config);
@@ -59,6 +60,8 @@ Tensor _lerp_overload(const Tensor& input_a, const Tensor& input_b, float value,
 }
 
 Tensor _lerp(const Tensor& input_a, const Tensor& input_b, const Tensor& input_c, const std::optional<MemoryConfig>& output_mem_config) {
+    TT_FATAL(input_a.dtype() == input_b.dtype(), "Expected the same dtype as start (input_a), for end (input_b)");
+    TT_FATAL(input_a.dtype() == input_c.dtype(), "Expected the same dtype as start (input_a), for weight (input_c)");
     Tensor t_diff = ttnn::multiply(
         ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config), input_c, std::nullopt, output_mem_config);
     Tensor result = ttnn::add(input_a, t_diff, std::nullopt, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -51,20 +51,20 @@ Tensor _addcdiv(
 }
 
 // lerp(input, end, weight) = start   weight * (end - start)
-Tensor _lerp_overload(const Tensor& input_a, const Tensor& input_b, float value, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL(input_a.dtype() == input_b.dtype(), "Expected the same dtype as start (input_a), for end (input_b)");
-    Tensor t_diff = ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config);
-    Tensor t_mul = ttnn::multiply(t_diff, value, std::nullopt, output_mem_config);
-    Tensor result = ttnn::add(input_a, t_mul, std::nullopt, output_mem_config);
+Tensor _lerp_overload(const Tensor& input, const Tensor& end, float weight, const std::optional<MemoryConfig>& output_mem_config) {
+    TT_FATAL(input.dtype() == end.dtype(), "Expected the same dtype as start (input), for end");
+    Tensor t_diff = ttnn::subtract(end, input, std::nullopt, output_mem_config);
+    Tensor t_mul = ttnn::multiply(t_diff, weight, std::nullopt, output_mem_config);
+    Tensor result = ttnn::add(input, t_mul, std::nullopt, output_mem_config);
     return result;
 }
 
-Tensor _lerp(const Tensor& input_a, const Tensor& input_b, const Tensor& input_c, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL(input_a.dtype() == input_b.dtype(), "Expected the same dtype as start (input_a), for end (input_b)");
-    TT_FATAL(input_a.dtype() == input_c.dtype(), "Expected the same dtype as start (input_a), for weight (input_c)");
+Tensor _lerp(const Tensor& input, const Tensor& end, const Tensor& weight, const std::optional<MemoryConfig>& output_mem_config) {
+    TT_FATAL(input.dtype() == end.dtype(), "Expected the same dtype as start (input), for end");
+    TT_FATAL(input.dtype() == weight.dtype(), "Expected the same dtype as start (input), for weight");
     Tensor t_diff = ttnn::multiply(
-        ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config), input_c, std::nullopt, output_mem_config);
-    Tensor result = ttnn::add(input_a, t_diff, std::nullopt, output_mem_config);
+        ttnn::subtract(end, input, std::nullopt, output_mem_config), weight, std::nullopt, output_mem_config);
+    Tensor result = ttnn::add(input, t_diff, std::nullopt, output_mem_config);
     return result;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
@@ -213,12 +213,12 @@ void bind_ternary_lerp(py::module& module, const ternary_operation_t& operation,
         {2}
 
         .. math::
-            \mathrm{{output\_tensor}} = \verb|{0}|(\mathrm{{input\_tensor\_a, input\_tensor\_b, input\_tensor\_c}})
+            \mathrm{{output\_tensor}} = \verb|{0}|(\mathrm{{input, end, weight}})
 
         Args:
-            input_tensor_a (ttnn.Tensor): the input tensor.
-            input_tensor_b (ttnn.Tensor): the input tensor.
-            input_tensor_c (ttnn.Tensor or Number): the input tensor.
+            input  (ttnn.Tensor): the input tensor with the starting points.
+            end    (ttnn.Tensor): the tensor with the ending points.
+            weight (ttnn.Tensor or float): the weight for the interpolation formula.
 
 
         Keyword Args:
@@ -240,7 +240,7 @@ void bind_ternary_lerp(py::module& module, const ternary_operation_t& operation,
 
             bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
 
-            input_tensor_b, input_tensor_c should have same dtype as input_tensor_a
+            end, weight tensors should have same dtype as input
 
         Example:
             >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 0], [1, 0]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
@@ -258,29 +258,29 @@ void bind_ternary_lerp(py::module& module, const ternary_operation_t& operation,
         doc,
         ttnn::pybind_overload_t{
             [](const ternary_operation_t& self,
-            const Tensor& input_tensor_a,
-            const Tensor& input_tensor_b,
-            const Tensor& input_tensor_c,
+            const Tensor& input,
+            const Tensor& end,
+            const Tensor& weight,
             const std::optional<MemoryConfig>& memory_config) {
-                    return self(input_tensor_a, input_tensor_b, input_tensor_c, memory_config);
+                    return self(input, end, weight, memory_config);
                 },
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("input_tensor_c"),
+            py::arg("input"),
+            py::arg("end"),
+            py::arg("weight"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt},
 
         ttnn::pybind_overload_t{
             [](const ternary_operation_t& self,
-            const Tensor& input_tensor_a,
-            const Tensor& input_tensor_b,
-            float value,
+            const Tensor& input,
+            const Tensor& end,
+            float weight,
             const std::optional<MemoryConfig>& memory_config) {
-                    return self(input_tensor_a, input_tensor_b, value, memory_config);
+                    return self(input, end, weight, memory_config);
                 },
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("value"),
+            py::arg("input"),
+            py::arg("end"),
+            py::arg("weight"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt});
 }
@@ -383,7 +383,7 @@ void py_module(py::module& module) {
     detail::bind_ternary_lerp(
         module,
         ttnn::lerp,
-        R"doc(Computes Lerp on :attr:`input_tensor_a`, :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
+        R"doc(Computes Lerp on :attr:`input`, :attr:`end` and :attr:`weight` and returns the tensor with the same layout as :attr:`input`)doc");
 
     detail::bind_ternary_mac(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
@@ -240,6 +240,8 @@ void bind_ternary_lerp(py::module& module, const ternary_operation_t& operation,
 
             bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
 
+            input_tensor_b, input_tensor_c should have same dtype as input_tensor_a
+
         Example:
             >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 0], [1, 0]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)

--- a/ttnn/ttnn/operations/ternary.py
+++ b/ttnn/ttnn/operations/ternary.py
@@ -37,7 +37,7 @@ ttnn.attach_golden_function(ttnn.addcdiv, golden_function=_golden_function_addcd
 def _golden_function_lerp(input_tensor_a, input_tensor_b, input_tensor_c, *args, **kwargs):
     import torch
 
-    return torch.lerp(input_tensor_a, input_tensor_b, input_tensor_c)
+    return torch.lerp(input_tensor_a, input_tensor_b.to(input_tensor_a.dtype), input_tensor_c.to(input_tensor_a.dtype))
 
 
 ttnn.attach_golden_function(ttnn.lerp, golden_function=_golden_function_lerp)

--- a/ttnn/ttnn/operations/ternary.py
+++ b/ttnn/ttnn/operations/ternary.py
@@ -37,7 +37,10 @@ ttnn.attach_golden_function(ttnn.addcdiv, golden_function=_golden_function_addcd
 def _golden_function_lerp(input_tensor_a, input_tensor_b, input_tensor_c, *args, **kwargs):
     import torch
 
-    return torch.lerp(input_tensor_a, input_tensor_b.to(input_tensor_a.dtype), input_tensor_c.to(input_tensor_a.dtype))
+    if torch.is_tensor(input_tensor_c):
+        input_tensor_c = input_tensor_c.to(input_tensor_a.dtype)
+
+    return torch.lerp(input_tensor_a, input_tensor_b.to(input_tensor_a.dtype), input_tensor_c)
 
 
 ttnn.attach_golden_function(ttnn.lerp, golden_function=_golden_function_lerp)


### PR DESCRIPTION
### Ticket
#13625 

### Problem description
Lerp throws error in mixed dtype

### What's changed
- Torch lerp op needs end and weight tensors to be of same dtype as input dtype. An error was thrown from torch call. Hence updated the golden function accordingly
- Added TT_FATAL for lerp op
- Updated in the doc

![image](https://github.com/user-attachments/assets/b87ff136-149c-4b72-bc26-5827f03bd010)



<img width="1229" alt="image" src="https://github.com/user-attachments/assets/6ef8ed81-0f4d-4dbb-8dce-172f26435749">

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11856547160)
- [x] [Sweep tests](https://github.com/tenstorrent/tt-metal/actions/runs/11855707975)
