### PR TITLE
#0: Use logical shape in validation check

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -136,14 +136,20 @@ void UnaryDeviceOperation::validate_on_program_cache_miss(
     }
 
     if (preallocated_output_tensor.has_value()) {
-        const auto compited_output_shape = compute_output_shapes(args, tensor_args);
-        const auto preallocated_output_shape = preallocated_output_tensor->get_shape();
+        const auto computed_output_shape = compute_output_shapes(args, tensor_args);
+        const auto preallocated_output_shape = preallocated_output_tensor.value().get_logical_shape();
         TT_FATAL(
-            preallocated_output_shape == compited_output_shape,
+            preallocated_output_shape == computed_output_shape,
             "When preallocted output tensor is used, Unary operation requires its shape to match the computed "
             "shape. Computed shape: {}, Shape in preallocated output tensor: {}",
-            compited_output_shape,
+            computed_output_shape,
             preallocated_output_shape);
+
+        if(!input_tensor.is_sharded()){
+            TT_FATAL(
+                (preallocated_output_tensor.value().get_layout() == Layout::TILE),
+                "Unary operation requires output tensor to be in Tile layout when working with non-sharded tensor.");
+        }
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- The  return type of  `compute_output_shapes` was changed to `SimpleShape` recently in #14777 but it wasn't handled in a validation check against a `ttnn::Shape` 
- This is causing problems in composite/bwd ops with optional output tensor functionality for padded inputs.
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/bb2f8d12-aad8-4ad1-b340-f10ba60ca43c">


![Screenshot 2024-11-15 at 7 04 52 PM](https://github.com/user-attachments/assets/3a292443-e3ac-4f08-8746-3399ed5c08a0)

### What's changed
1. perform the validation using SimpleShape 
2. add a layout check for optional output tensor since the shape is checked without padding information

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11856775129
https://github.com/tenstorrent/tt-metal/actions/runs/11880322709
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
