### PR TITLE
#14826: reorganize crt startup

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -340,8 +340,7 @@ int main() {
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 
-    int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
-    l1_to_local_mem_copy((uint*)__ldm_data_start, (uint tt_l1_ptr*)MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH, num_words);
+    do_crt1((uint32_t*)MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH);
 
     mailboxes->launch_msg_rd_ptr = 0; // Initialize the rdptr to 0
     noc_index = 0;

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -18,9 +18,6 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include <kernel_includes.hpp>
 
-extern uint32_t __kernel_init_local_l1_base[];
-extern uint32_t __fw_export_end_text[];
-
 void kernel_launch(uint32_t kernel_base_addr) {
 
 #if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
@@ -29,7 +26,10 @@ void kernel_launch(uint32_t kernel_base_addr) {
     while (c_tensix_core::read_wall_clock() < end_time);
 #endif
 #else
-    firmware_kernel_common_init((void tt_l1_ptr *)(kernel_base_addr + (uint32_t) __kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
+    extern uint32_t __kernel_init_local_l1_base[];
+    extern uint32_t __fw_export_end_text[];
+    do_crt1((uint32_t tt_l1_ptr
+                 *)(kernel_base_addr + (uint32_t)__kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
 
     if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
         noc_local_state_init(NOC_INDEX);

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -36,15 +36,17 @@ uint32_t tt_l1_ptr *sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used
 
 void __attribute__((noinline)) Application(void) {
     WAYPOINT("I");
-    rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
-    // Not using firmware_kernel_common_init since it is copying to registers
+    // Not using do_crt1 since it is copying to registers???
     // TODO: need to find free space that routing FW is not using
+    extern uint32_t __ldm_bss_start[];
+    extern uint32_t __ldm_bss_end[];
     wzerorange(__ldm_bss_start, __ldm_bss_end);
+
+    rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
     risc_init();
     noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
-    wzerorange(__ldm_bss_start, __ldm_bss_end);
 
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
         noc_local_state_init(n);

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -98,13 +98,8 @@ int main() {
     conditionally_disable_l1_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
-    int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
-    uint32_t *local_mem_ptr = (uint32_t *)__ldm_data_start;
-    uint32_t *l1_data_ptr = (uint32_t *)MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH;
+    do_crt1((uint32_t *)MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);
     uint32_t heartbeat = 0;
-    for (int32_t i = 0; i < num_words; i++) {
-        local_mem_ptr[i] = l1_data_ptr[i];
-    }
 
     risc_init();
 

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -21,13 +21,13 @@
 
 #include <kernel_includes.hpp>
 
-extern uint32_t __kernel_init_local_l1_base[];
-extern uint32_t __fw_export_end_text[];
-
 void kernel_launch(uint32_t kernel_base_addr) {
     DeviceZoneScopedMainChildN("ERISC-KERNEL");
 
-    firmware_kernel_common_init((void tt_l1_ptr *)(kernel_base_addr + (uint32_t) __kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
+    extern uint32_t __kernel_init_local_l1_base[];
+    extern uint32_t __fw_export_end_text[];
+    do_crt1((uint32_t tt_l1_ptr
+                 *)(kernel_base_addr + (uint32_t)__kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
 
     noc_local_state_init(NOC_INDEX);
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -76,8 +76,7 @@ int main(int argc, char *argv[]) {
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 
-    int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
-    l1_to_local_mem_copy((uint *)__ldm_data_start, (uint tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH, num_words);
+    do_crt1((uint32_t tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH);
 
     risc_init();
 

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -26,9 +26,6 @@ uint32_t noc_nonposted_writes_acked[NUM_NOCS];
 uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
 uint32_t noc_posted_writes_num_issued[NUM_NOCS];
 
-extern uint32_t __kernel_init_local_l1_base[];
-extern uint32_t __fw_export_end_text[];
-
 void kernel_launch(uint32_t kernel_base_addr) {
 
   DeviceZoneScopedMainChildN("NCRISC-KERNEL");
@@ -38,11 +35,13 @@ void kernel_launch(uint32_t kernel_base_addr) {
     while (c_tensix_core::read_wall_clock() < KERNEL_RUN_TIME);
 #endif
 #else
+  extern uint32_t __kernel_init_local_l1_base[];
+  extern uint32_t __fw_export_end_text[];
+  do_crt1((
+      uint32_t tt_l1_ptr *)(kernel_base_addr + (uint32_t)__kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
 
-    firmware_kernel_common_init((void tt_l1_ptr *)(kernel_base_addr + (uint32_t) __kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
-
-    if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
-        noc_local_state_init(NOC_INDEX);
+  if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
+      noc_local_state_init(NOC_INDEX);
     } else {
         noc_local_state_init(NOC_0);
         noc_local_state_init(NOC_1);

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -55,9 +55,7 @@ int main(int argc, char *argv[]) {
     conditionally_disable_l1_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
-
-    int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
-    l1_to_local_mem_copy((uint *)__ldm_data_start, (uint tt_l1_ptr *)MEM_SLAVE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH, num_words);
+    do_crt1((uint32_t *)MEM_SLAVE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);
 
     risc_init();
 

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -77,10 +77,7 @@ int main(int argc, char *argv[]) {
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 
-    uint tt_l1_ptr *local_l1_start_addr =
-        (uint tt_l1_ptr *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE_SCRATCH);
-    int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
-    l1_to_local_mem_copy((uint *)__ldm_data_start, local_l1_start_addr, num_words);
+    do_crt1((uint32_t tt_l1_ptr *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE_SCRATCH));
 
     // Initialize GPRs to all 0s
 #pragma GCC unroll 0

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -33,9 +33,6 @@ volatile tt_reg_ptr uint * mailbox_base[4] = {
 };
 }
 
-extern uint32_t __kernel_init_local_l1_base[];
-extern uint32_t __fw_export_end_text[];
-
 void kernel_launch(uint32_t kernel_base_addr)
 {
   DeviceZoneScopedMainChildN("TRISC-KERNEL");
@@ -44,7 +41,10 @@ void kernel_launch(uint32_t kernel_base_addr)
     ckernel::wait(KERNEL_RUN_TIME);
 #endif
 #else
-    firmware_kernel_common_init((void tt_l1_ptr *)(kernel_base_addr + (uint32_t) __kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
+  extern uint32_t __kernel_init_local_l1_base[];
+  extern uint32_t __fw_export_end_text[];
+  do_crt1((
+      uint32_t tt_l1_ptr *)(kernel_base_addr + (uint32_t)__kernel_init_local_l1_base - (uint32_t)__fw_export_end_text));
 
 #if defined(UCK_CHLKC_UNPACK)
     // Make sure DBG_FEATURE_DISABLE register is cleared before every kernel is executed

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -49,7 +49,7 @@ inline void l1_to_local_mem_copy(uint32_t *local_mem_addr, uint32_t tt_l1_ptr *l
     }
 }
 
-inline void firmware_kernel_common_init(void *init_local_l1_base) {
+inline void do_crt1(void *init_local_l1_base) {
 
     // Handle stuff typically done in crt0 in asm.  Easier to do in C
     wzerorange(__ldm_bss_start, __ldm_bss_end);
@@ -61,6 +61,7 @@ inline void firmware_kernel_common_init(void *init_local_l1_base) {
         (**fptr)();
     }
 }
+
 FORCE_INLINE
 uint32_t firmware_config_init(tt_l1_ptr mailboxes_t* const mailboxes, uint32_t core_type_index, uint32_t dispatch_class) {
 

--- a/tt_metal/hw/toolchain/tmu-crt0.S
+++ b/tt_metal/hw/toolchain/tmu-crt0.S
@@ -14,28 +14,11 @@ _start:
 	addi gp,gp,%lo(__global_pointer$)
 	.option pop
 
-	// set stack pointer
-	lui	sp, %hi(__stack_top)
-	addi	sp, sp, %lo(__stack_top)
+	// set stack pointer, reserve 16 bytes for main's arguments
+	lui	sp, %hi(__stack_top - 16)
+	addi	sp, sp, %lo(__stack_top - 16)
 
-	// Clear bss
-	lui	a0, %hi(__ldm_bss_start)
-	addi	a0, a0, %lo(__ldm_bss_start)
-	lui	a1, %hi(__ldm_bss_end)
-	addi	a1, a1, %lo(__ldm_bss_end)
-	call    wzerorange
-
-	// Run global initializers
-	lui	s2, %hi(__init_array_start)
-	addi	s2, s2, %lo(__init_array_start)
-	lui	s3, %hi(__init_array_end)
-	addi	s3, s3, %lo(__init_array_end)
-	beq	s2, s3, 2f
-1:	lw      a0, 0(s2)
-	jalr    a0
-	addi  	s2, s2, 4
-	bne	s2, s3, 1b
-2:
+	// main is responsible for the rest of crt -- clear bss, copy data image, run global constructors
 
   /* Pass in the tensix coordinates as argv[0][0] through argv[0][3].
      argc = 1, envp = NULL. In memory, we'll have
@@ -44,16 +27,15 @@ _start:
    * sp+8: s1
    * sp+c: 0
    */
-  addi    sp, sp, -16 /* (stack is aligned to 16 bytes in riscv calling convention) */
   addi    a0, sp, 8
-  sw      a0, 0(sp)
-  sw      zero, 4(sp)
-  sw      s1, 8(sp)
-  sw      zero, 12(sp)
+  sw      a0, 0(sp) // argv[0]
+  sw      zero, 4(sp) // argv[1]
+  sw      s1, 8(sp) // argv[0][0..3]
+  sw      zero, 12(sp) // argv[0][4..7]
 
-  li      a0, 1 # argc = 1
-  mv      a1, sp
-  mv      a2, zero
+  li      a0, 1 // argc = 1
+  mv      a1, sp // argv
+  mv      a2, zero // env
 
   call    main
   tail    exit


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14826

### Problem description
the original fix for the issue caused a performance regression and was reverted. This more incremental approach will help determine which bit was responsible.  This particular diff moves things around

### What's changed
1) The firmware did bss clearing and global initializer running from assembly startup code, and *then* did initialized data copying.  That only 'works' because we have no global initializers.  Remove the assembly and just do all 3 initializations in the correct order from the conveniently available `firmware_kernel_common_init`, which doesn't seem to be used from firmware, just kernels -- 'firmware-kernels'?
2) Rename that routine as do_crt1, because that's what it's doing.
3) This also catches the case fixed by https://github.com/tenstorrent/tt-metal/pull/15009, where I'd missed a case.

In particular this patch does NOT
*) insert unroll-inhibiting pragmas
*) change the data memory copy
*) change the bss clearing routine (which the optimizer spots is memset, and substitutes that, leading to code bloat).

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
