### PR TITLE
Enable clang-tidy check for use after move

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,6 @@ Checks: >
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-self-assignment,
   -bugprone-unused-raii,
-  -bugprone-use-after-move,
   -cert-env33-c,
   -cert-err09-cpp,
   -cert-err33-c,


### PR DESCRIPTION
### Ticket
#15073 

### Problem description
Clang tidy check for use after move was disabled

### What's changed
Enable the check.

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/11860351908)