### PR TITLE
#14474: Fix OoO issues for Llama3 tests on CI

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -49,13 +49,12 @@ run_python_model_tests_wormhole_b0() {
     llama1b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-1B-Instruct/
     # Llama3.2-3B
     llama3b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-3B-Instruct/
-    # Llama3.2-11B  (#Skip: Weights too big for single-chip ci VM)
+    # Llama3.2-11B
     llama11b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-11B-Vision-Instruct/
 
-    # FIXME Issue #14474
     # Run all Llama3 tests for 8B, 1B, and 3B weights - dummy weights with tight PCC check
-    # for llama_dir in "$llama8b" "$llama1b" "$llama3b"; do
-    #     LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/llama3/tests/test_llama_model.py -k "quick" ; fail+=$?
-    #     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
-    # done
+    for llama_dir in  "$llama1b" "$llama3b" "$llama8b" "$llama11b"; do
+        LLAMA_DIR=$llama_dir WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/llama3/tests/test_llama_model.py -k "quick" ; fail+=$?
+        echo "LOG_METAL: Llama3 tests for $llama_dir completed"
+    done
 }


### PR DESCRIPTION
### Ticket
#14474

### Problem description
Reduce the LLama3 max sequence length for N150/N300 and for Llama3 small tests.
This fix is a temporary patch while we work on finishing functionality of Llama3. A follow-up PR will include automatic sequence length setup based on model params, chosen architecture and type of test.

### What's changed
- Re-add Llama3 1B/3B/8B/11B post-commit tests to CI.

### Checklist
- [x] [All-post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/11871851940/job/33085015036)
  - This one was previously failing on CI-VM-120. Now passes.
- [x] [Single-chip tests](https://github.com/tenstorrent/tt-metal/actions/runs/11862115193/job/33061019935)
  - Llama3.2-1B failed, but I've since reduced the 16K seqlen to 4K.
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/11862118428)
