### PR TITLE
Fix use-after-move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ runtime
 test_hlk_args_init_gen
 tt_build
 tt_debug
+.build/
 build
 build_*
 /python_env/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,7 +40,8 @@
       {
         "name": "clang-tidy",
         "configurePreset": "clang-tidy",
-        "configuration": "RelWithDebInfo"
+        "configuration": "RelWithDebInfo",
+        "nativeToolOptions": ["-k0"]
       }
     ]
   }

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -214,7 +214,6 @@ TEST_F(CommonFixture, TestAsyncRefCountManager) {
             ttnn::numpy::full<float>(tt::tt_metal::LegacyShape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16).to(device);
         Tensor tensor2 = std::move(tensor1);
         EXPECT_EQ(tensor2.tensor_attributes->main_thread_ref_count, 1);
-        EXPECT_EQ(tensor1.tensor_attributes, nullptr);
     }
 
     log_info(LogTest, "Testing Device tensor self-assignment");

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -97,7 +97,7 @@ bool test_tensor_move_semantics(Device *device) {
     Tensor dev_a = Tensor(OwnedStorage{bfloat_data}, single_tile_shape, DataType::BFLOAT16, Layout::TILE).to(device);
     auto og_buffer_a = dev_a.buffer();
     Tensor dev_a_copy = std::move(dev_a);
-    pass &= (dev_a.tensor_attributes == nullptr and dev_a_copy.buffer() == og_buffer_a);
+    pass &= dev_a_copy.buffer() == og_buffer_a;
     auto dev_a_copy_on_host = dev_a_copy.cpu();
     auto dev_a_copy_data = owned_buffer::get_as<bfloat16>(dev_a_copy_on_host);
     pass &= dev_a_copy_data == bfloat_data;

--- a/tests/tt_metal/tt_metal/unit_tests/tt_stl/test_any_range.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/tt_stl/test_any_range.cpp
@@ -251,12 +251,6 @@ TEST(AnyRangeTest, CanTransferOwnershipFromRangeOfNonTrivialElements) {
         {
             const SharedIntRange range = std::move(foo);
 
-            // ownership transferred from array to range
-            EXPECT_EQ(foo[0], nullptr);
-            EXPECT_EQ(foo[1], nullptr);
-            EXPECT_EQ(foo[2], nullptr);
-            EXPECT_EQ(foo[3], nullptr);
-
             // no extra copies stored
             EXPECT_EQ(range[0].use_count(), 1);
             EXPECT_EQ(range[1].use_count(), 1);

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -39,7 +39,7 @@ std::vector<Tensor> run_operation(
     std::vector<Tensor> outputs(output_shapes_size);
     // Populate the workers of the output tensors, based on the input tensors. This is needed for the async engine.
     for (int i = 0; i < outputs.size(); i++) {
-        outputs[i] = Tensor(operation::get_workers_for_op_output(std::move(input_tensors), std::move(optional_input_tensors)));
+        outputs[i] = Tensor(operation::get_workers_for_op_output(input_tensors, optional_input_tensors));
     }
     // Send the operation to the async engine, which will populate the output tensors.
     for (auto worker : outputs.at(0).workers) {


### PR DESCRIPTION
### Ticket
#15073 

### Problem description
Issue #15073 identified a different one (fixed in #15074), and the check was enabled in #15105. But this instance was still outstanding.
Now post-commit is failing: https://github.com/tenstorrent/tt-metal/actions/runs/11861088096

### What's changed
Remove the use after move.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11863971283
