### PR TITLE
Move UMD tests after build artifact

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -75,6 +75,7 @@ jobs:
     secrets: inherit
   # UMD Unit Tests
   umd-unit-tests:
+    needs: build-artifact
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -4,7 +4,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  static-checks:
+    uses: ./.github/workflows/all-static-checks.yaml
+    secrets: inherit
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
   umd-unit-tests:
+    needs: build-artifact
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -51,10 +51,9 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build UMD device and tests
-        run: |
-          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON
-          cmake --build build --target umd_tests
+      - uses: ./.github/actions/prepare-metal-run
+        with:
+          arch: ${{ inputs.arch }}
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/test/umd/${{ inputs.arch }}/unit_tests

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -45,6 +45,7 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ inputs.arch }}
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
       LOGURU_LEVEL: INFO
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0


### PR DESCRIPTION
### Ticket
NA

### Problem description
UMD Tests were running independent of the rest of all post commit.
Many times I've seen UMD tests running, even if the global build of the project fails.
UMD Tests were getting built in the existing workflow on VMs that aren't really fast for building, and no ccache.
By putting UMD Tests after build-artifact we might be able to save on test machine usage.

**  UMD TESTS CURRENTLY FAILING DUE TO MISSING FILE??? **

### What's changed
UMD tests moved after build-artifact

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11864188038
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
