### PR TITLE
Manually address an issue that local clang-tidy trips over

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -268,8 +268,9 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
             TT_ASSERT(num_cores_c % num_batches == 0 && "for CM shard, when each batch is split across cores, num_cores_c must be divisible by num_batches!");
         }
     } else { // height sharded
-        if (num_batches_per_core == 1)
+        if (num_batches_per_core == 1) {
             TT_ASSERT((num_cores_c*num_cores_r) % num_batches == 0 && "for height shard, number of cores must be divisible by num_batches!");
+        }
     }
 
     if (input_mask.has_value()) {


### PR DESCRIPTION
### Ticket
#15123 

### Problem description
My local clang-tidy trips over this.  Not sure why CI doesn't, but rather than investigate why the discrepency, I'll just manually address it.

### What's changed
Braces for the body of the `if`.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
