### PR TITLE
Remove LFS from tt-train

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*tokenizer.json filter=lfs diff=lfs merge=lfs -text
-tt-train/sources/examples/nano_gpt/data/shakespeare.txt filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -151,7 +151,7 @@ jobs:
           cat build/ccache.stats >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: 'Tar files'
-        run: tar -cvhf ttm_${{ matrix.arch }}.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train runtime
+        run: tar -cvhf ttm_${{ matrix.arch }}.tar ttnn/ttnn/*.so build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools build/tt-train build/data runtime
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -47,7 +47,7 @@ jobs:
       ARCH_NAME: ${{ inputs.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-      TEST_DATA_DIR: ${{ github.workspace }}/tt-train/tests/test_data
+      TEST_DATA_DIR: ${{ github.workspace }}/build/data
     runs-on:
       - ${{ inputs.runner-label }}
       - cloud-virtual-machine

--- a/tt-train/sources/examples/nano_gpt/CMakeLists.txt
+++ b/tt-train/sources/examples/nano_gpt/CMakeLists.txt
@@ -9,4 +9,21 @@ set(SOURCES
 add_executable(nano_gpt ${SOURCES})
 target_link_libraries(nano_gpt PRIVATE ttml)
 
-add_definitions(-DDATA_FOLDER="${CMAKE_CURRENT_SOURCE_DIR}/data")
+add_definitions(-DDATA_FOLDER="${CMAKE_BINARY_DIR}/data")
+
+# Define the target file location
+set(SHAKESPEARE_URL "https://www.cs.princeton.edu/courses/archive/spring20/cos302/files/shakespeare.txt")
+set(SHAKESPEARE_FILE "${CMAKE_BINARY_DIR}/data/shakespeare.txt")
+
+# Check if the file already exists before downloading
+if(NOT EXISTS "${SHAKESPEARE_FILE}")
+    message(STATUS "Downloading Shakespeare text file to ${SHAKESPEARE_FILE}")
+    file(
+        DOWNLOAD
+            ${SHAKESPEARE_URL}
+            ${SHAKESPEARE_FILE}
+        SHOW_PROGRESS
+    )
+else()
+    message(STATUS "Shakespeare text file already exists at ${SHAKESPEARE_FILE}, skipping download.")
+endif()

--- a/tt-train/sources/examples/nano_gpt/data/shakespeare.txt
+++ b/tt-train/sources/examples/nano_gpt/data/shakespeare.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:434c0554a8c4c53dc17e56a0abb0f30b88f83cbceb0289cb897db68c25e89eba
-size 1115390

--- a/tt-train/sources/ttml/data/tokenizers/data/tokenizers/gpt2-tokenizer.json
+++ b/tt-train/sources/ttml/data/tokenizers/data/tokenizers/gpt2-tokenizer.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2dd4a144b04bdc21cbf27834f05628de4e6bc511a59b3c1bd9679c7cef7c665
-size 2113739

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -16,7 +16,24 @@ target_link_libraries(
     GTest::gtest_main
     ttml
 )
-add_definitions(-DTEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test_data")
+add_definitions(-DTEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data")
+
+# Define the target file location
+set(TOKENIZER_URL "https://huggingface.co/togethercomputer/RedPajama-INCITE-Chat-3B-v1/resolve/main/tokenizer.json")
+set(TOKENIZER_FILE "${CMAKE_BINARY_DIR}/data/tokenizer.json")
+
+# Check if the file already exists before downloading
+if(NOT EXISTS "${TOKENIZER_FILE}")
+    message(STATUS "Downloading Tokenizer text file to ${TOKENIZER_FILE}")
+    file(
+        DOWNLOAD
+            ${TOKENIZER_URL}
+            ${TOKENIZER_FILE}
+        SHOW_PROGRESS
+    )
+else()
+    message(STATUS "Tokenizer text file already exists at ${TOKENIZER_FILE}, skipping download.")
+endif()
 
 include(GoogleTest)
 gtest_discover_tests(ttml_tests)

--- a/tt-train/tests/test_data/tokenizer.json
+++ b/tt-train/tests/test_data/tokenizer.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2dd4a144b04bdc21cbf27834f05628de4e6bc511a59b3c1bd9679c7cef7c665
-size 2113739


### PR DESCRIPTION
### Ticket
NA

### Problem description
LFS usage costs money.

### What's changed
Download the files at cmake configure time into the build tree.
build tree is bundled and sent over to test machines.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11876512760
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
