### PR TITLE
Add build config struct to HAL with base FW and local init addrs

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -204,7 +204,8 @@ int main(int argc, char **argv) {
                             dm_class_idx,
                             0,
                             get_latest_kernel_binary_path(mask, riscv0_kernel));
-                        ll_api::memory brisc_binary = llrt::get_risc_binary(brisc_hex_path, 0, ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP);
+                        ll_api::memory brisc_binary = llrt::get_risc_binary(
+                            brisc_hex_path, 0, 0, 0, ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP);
                         TT_FATAL(
                             brisc_binary == brisc_binaries.at(mask).at(0),
                             "Expected saved BRISC binary to be the same as binary in persistent cache");
@@ -217,7 +218,8 @@ int main(int argc, char **argv) {
                             (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0) ?
                             ll_api::memory::Relocate::NONE : ll_api::memory::Relocate::XIP;
 
-                        ll_api::memory ncrisc_binary = llrt::get_risc_binary(ncrisc_hex_path, 1, ll_api::memory::PackSpans::PACK, relo_type);
+                        ll_api::memory ncrisc_binary = llrt::get_risc_binary(
+                            ncrisc_hex_path, 0, 1, 0, ll_api::memory::PackSpans::PACK, relo_type);
                         TT_FATAL(
                             ncrisc_binary == ncrisc_binaries.at(mask).at(0),
                             "Expected saved NCRISC binary to be the same as binary in persistent cache");
@@ -228,7 +230,8 @@ int main(int argc, char **argv) {
                                 compute_class_idx,
                                 trisc_id,
                                 get_latest_kernel_binary_path(mask, compute_kernel));
-                            ll_api::memory trisc_binary = llrt::get_risc_binary(trisc_hex_path, 2, ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP);
+                            ll_api::memory trisc_binary = llrt::get_risc_binary(
+                                trisc_hex_path, 0, 2, trisc_id, ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP);
                             TT_FATAL(
                                 trisc_binary == compute_binaries.at(mask).at(trisc_id),
                                 "Expected saved TRISC binary for {} to be the same as binary in persistent cache", trisc_id_str);

--- a/tests/tt_metal/tt_metal/unit_tests/ethernet/erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/ethernet/erisc_app_direct_send.cpp
@@ -104,8 +104,10 @@ bool send_over_eth(
 
     // TODO: this should be updated to use kernel api
     uint32_t active_eth_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-    ll_api::memory binary_mem_send = llrt::get_risc_binary(sender_device->build_firmware_target_path(active_eth_index, 0, 0));
-    ll_api::memory binary_mem_receive = llrt::get_risc_binary(receiver_device->build_firmware_target_path(active_eth_index, 0, 0));
+    ll_api::memory binary_mem_send = llrt::get_risc_binary(
+        sender_device->build_firmware_target_path(active_eth_index, 0, 0), active_eth_index, 0, 0);
+    ll_api::memory binary_mem_receive = llrt::get_risc_binary(
+        receiver_device->build_firmware_target_path(active_eth_index, 0, 0), active_eth_index, 0, 0);
 
     for (const auto& eth_core : eth_cores) {
         llrt::write_hex_vec_to_core(

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -418,7 +418,8 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                 auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
                 for (uint32_t riscv_id = build_idx; riscv_id < (build_idx + num_build_states); riscv_id++) {
-                    ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[riscv_id]->get_target_out_path(""), riscv_id);
+                    ll_api::memory binary_mem = llrt::get_risc_binary(
+                        firmware_build_states_[riscv_id]->get_target_out_path(""), core_type_idx, processor_class, (riscv_id - build_idx));
                     uint32_t fw_size = binary_mem.get_text_size();
                     if (riscv_id == 1) { // TODO: clean up how brisc/ncrisc are handled
                         // In this context, ncrisc_kernel_size16 is the size of the fw
@@ -426,7 +427,7 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                     }
                     log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
                     if (not llrt::OptionsG.get_skip_loading_fw()) {
-                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
+                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, core_type_idx, processor_class, (riscv_id - build_idx));
                     }
                 }
             }
@@ -460,10 +461,11 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                     auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
                     for (uint32_t eriscv_id = build_idx; eriscv_id < (build_idx + num_build_states); eriscv_id++) {
-                        ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""), eriscv_id);
+                        ll_api::memory binary_mem = llrt::get_risc_binary(
+                            firmware_build_states_[eriscv_id]->get_target_out_path(""), core_type_idx, processor_class, (eriscv_id - build_idx));
                         uint32_t fw_size = binary_mem.get_text_size();
                         log_debug(LogDevice, "ERISC fw binary size: {} in bytes", fw_size);
-                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+                        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, core_type_idx, processor_class, (eriscv_id - build_idx));
                     }
                 }
             }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -369,7 +369,12 @@ void DataMovementKernel::read_binaries(Device *device) {
     ll_api::memory::Relocate relo_type =
         (riscv_id == 1 && (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0)) ?
         ll_api::memory::Relocate::NONE : ll_api::memory::Relocate::XIP;
-    ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), riscv_id, ll_api::memory::PackSpans::PACK, relo_type);
+    ll_api::memory binary_mem = llrt::get_risc_binary(
+        build_state.get_target_out_path(this->kernel_full_name_),
+        // processor class is BRISC/NCRISC and each have one data movement processor type
+        tensix_core_type, riscv_id, dm_class_idx,
+        ll_api::memory::PackSpans::PACK, relo_type
+    );
     binaries.push_back(binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, binary_size);
@@ -390,7 +395,11 @@ void EthernetKernel::read_binaries(Device *device) {
     // TODO: fix when active eth supports relo
     ll_api::memory::Relocate relo_type = (this->config_.eth_mode == Eth::IDLE) ?
         ll_api::memory::Relocate::XIP : ll_api::memory::Relocate::NONE;
-    ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), risc_id, ll_api::memory::PackSpans::PACK, relo_type);
+    ll_api::memory binary_mem = llrt::get_risc_binary(
+        build_state.get_target_out_path(this->kernel_full_name_),
+        erisc_core_type, erisc_id, dm_class_idx,
+        ll_api::memory::PackSpans::PACK, relo_type
+    );
    binaries.push_back(binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC {} kernel binary size: {} in bytes", erisc_id, binary_size);
@@ -404,7 +413,11 @@ void ComputeKernel::read_binaries(Device *device) {
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, compute_class_idx, trisc_id);
-        ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), trisc_id + 2, ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP);
+        ll_api::memory binary_mem = llrt::get_risc_binary(
+            build_state.get_target_out_path(this->kernel_full_name_),
+            tensix_core_type, compute_class_idx, trisc_id,
+            ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP
+        );
         binaries.push_back(binary_mem);
         uint32_t binary_size = binary_mem.get_packed_size();
         log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", trisc_id + 2, binary_size);
@@ -447,8 +460,10 @@ bool EthernetKernel::configure(Device *device, const CoreCoord &logical_core, ui
         uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
         llrt::write_binary_to_address(binary_mem, device_id, ethernet_core, base_address + offsets[offset_idx]);
     } else {
-        int riscv_id = 5;
-        tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, ethernet_core, riscv_id);
+        uint32_t erisc_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+        uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
+        int erisc_id = magic_enum::enum_integer(this->config_.processor);
+        tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, ethernet_core, erisc_core_type, dm_class_idx, erisc_id);
     }
 
     return true;

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -4,7 +4,7 @@
 
 #if defined(ARCH_BLACKHOLE)
 
-#define COMPILE_FOR_IDLE_ERISC
+#define COMPILE_FOR_ERISC
 
 #include <cstdint>
 
@@ -59,10 +59,14 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::FW_VERSION_ADDR)] = sizeof(std::uint32_t);
 
-    // TODO (abhullar): This should be NumEthDispatchClasses
-    std::vector<std::vector<uint8_t>> processor_classes(1);
-    std::vector<uint8_t> processor_types{0};
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses - 1);
+    std::vector<HalJitBuildConfig> processor_types(1);
     for (uint8_t processor_class_idx = 0; processor_class_idx < processor_classes.size(); processor_class_idx++) {
+        // BH active ethernet runs idle erisc FW on the second ethernet
+        processor_types[0] = HalJitBuildConfig{
+            .fw_base_addr = eth_l1_mem::address_map::FIRMWARE_BASE,
+            .local_init_addr = eth_l1_mem::address_map::FIRMWARE_BASE, // this will be uplifted in subsequent commits enabling active erisc
+        };
         processor_classes[processor_class_idx] = processor_types;
     }
 

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -58,9 +58,28 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
-    std::vector<uint8_t> processor_types{0};
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses);
+    std::vector<HalJitBuildConfig> processor_types(1);
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        DeviceAddr fw_base, local_init;
+        switch (processor_class_idx) {
+            case 0: {
+                fw_base = MEM_IERISC_FIRMWARE_BASE;
+                local_init = MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH;
+            }
+            break;
+            case 1: {
+                fw_base = MEM_SLAVE_IERISC_FIRMWARE_BASE;
+                local_init = MEM_SLAVE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH;
+            }
+            break;
+            default:
+                TT_THROW("Unexpected processor class {} for Blackhole Idle Ethernet", processor_class_idx);
+        }
+        processor_types[0] = HalJitBuildConfig{
+            .fw_base_addr = fw_base,
+            .local_init_addr = local_init
+        };
         processor_classes[processor_class_idx] = processor_types;
     }
 

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -15,7 +15,6 @@
 #include "hw/inc/dev_msgs.h"
 
 #include <magic_enum.hpp>
-#include <numeric>
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
@@ -56,12 +55,53 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    std::vector<std::vector<uint8_t>> processor_classes(NumTensixDispatchClasses);
-    std::vector<uint8_t> processor_types;
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumTensixDispatchClasses);
+    std::vector<HalJitBuildConfig> processor_types;
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
         uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        std::iota(processor_types.begin(), processor_types.end(), 0);
+        for (uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+            DeviceAddr fw_base, local_init;
+            switch (processor_class_idx) {
+                case 0: {
+                    fw_base = MEM_BRISC_FIRMWARE_BASE;
+                    local_init = MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH;
+                }
+                break;
+                case 1: {
+                    fw_base = MEM_NCRISC_FIRMWARE_BASE;
+                    local_init = MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH;
+                }
+                break;
+                case 2: {
+                    switch (processor_type_idx) {
+                        case 0: {
+                            fw_base = MEM_TRISC0_FIRMWARE_BASE;
+                            local_init = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                        case 1: {
+                            fw_base = MEM_TRISC1_FIRMWARE_BASE;
+                            local_init = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                        case 2: {
+                            fw_base = MEM_TRISC2_FIRMWARE_BASE;
+                            local_init = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                    }
+                }
+                break;
+                default:
+                    TT_THROW("Unexpected processor class {} for Blackhole Tensix", processor_class_idx);
+            }
+
+            processor_types[processor_type_idx] = HalJitBuildConfig{
+                .fw_base_addr = fw_base,
+                .local_init_addr = local_init
+            };
+        }
         processor_classes[processor_class_idx] = processor_types;
     }
 

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -17,7 +17,6 @@
 #include "hw/inc/dev_msgs.h"
 
 #include <magic_enum.hpp>
-#include <numeric>
 
 #endif
 
@@ -66,12 +65,53 @@ void Hal::initialize_gs() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    std::vector<std::vector<uint8_t>> processor_classes(NumTensixDispatchClasses);
-    std::vector<uint8_t> processor_types;
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumTensixDispatchClasses);
+    std::vector<HalJitBuildConfig> processor_types;
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
         uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        std::iota(processor_types.begin(), processor_types.end(), 0);
+        for (uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+            DeviceAddr fw_base, local_init;
+            switch (processor_class_idx) {
+                case 0: {
+                    fw_base = MEM_BRISC_FIRMWARE_BASE;
+                    local_init = MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH;
+                }
+                break;
+                case 1: {
+                    fw_base = MEM_NCRISC_FIRMWARE_BASE;
+                    local_init = MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH;
+                }
+                break;
+                case 2: {
+                    switch (processor_type_idx) {
+                        case 0: {
+                            fw_base = MEM_TRISC0_FIRMWARE_BASE;
+                            local_init = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                        case 1: {
+                            fw_base = MEM_TRISC1_FIRMWARE_BASE;
+                            local_init = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                        case 2: {
+                            fw_base = MEM_TRISC2_FIRMWARE_BASE;
+                            local_init = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                    }
+                }
+                break;
+                default:
+                    TT_THROW("Unexpected processor class {} for Blackhole Tensix", processor_class_idx);
+            }
+
+            processor_types[processor_type_idx] = HalJitBuildConfig{
+                .fw_base_addr = fw_base,
+                .local_init_addr = local_init
+            };
+        }
         processor_classes[processor_class_idx] = processor_types;
     }
 

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -69,7 +69,7 @@ uint32_t Hal::get_num_risc_processors() const {
 
 HalCoreInfoType::HalCoreInfoType(HalProgrammableCoreType programmable_core_type,
                                  CoreType core_type,
-                                 const std::vector<std::vector<uint8_t>> &processor_classes,
+                                 const std::vector<std::vector<HalJitBuildConfig>> &processor_classes,
                                  const std::vector<DeviceAddr>& mem_map_bases,
                                  const std::vector<uint32_t>& mem_map_sizes,
                                  bool supports_cbs) :

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -70,6 +70,11 @@ enum class HalMemType : uint8_t {
 
 using DeviceAddr = std::uint64_t;
 
+struct HalJitBuildConfig {
+    DeviceAddr fw_base_addr;
+    DeviceAddr local_init_addr;
+};
+
 class Hal;
 
 // Core information instanced once per core type
@@ -79,14 +84,14 @@ class HalCoreInfoType {
   private:
     HalProgrammableCoreType programmable_core_type_;
     CoreType core_type_;
-    // index represents processor class position, value is the specific processor class
-    std::vector<std::vector<uint8_t>> processor_classes_;
+    // indices represents processor class and type positions, value is build configuration params
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes_;
     std::vector<DeviceAddr> mem_map_bases_;
     std::vector<uint32_t> mem_map_sizes_;
     bool supports_cbs_;
 
   public:
-    HalCoreInfoType(HalProgrammableCoreType programmable_core_type, CoreType core_type, const std::vector<std::vector<uint8_t>> &processor_classes,
+    HalCoreInfoType(HalProgrammableCoreType programmable_core_type, CoreType core_type, const std::vector<std::vector<HalJitBuildConfig>> &processor_classes,
         const std::vector<DeviceAddr>& mem_map_bases, const std::vector<uint32_t>& mem_map_sizes, bool supports_cbs);
 
     template <typename T = DeviceAddr>
@@ -94,6 +99,10 @@ class HalCoreInfoType {
     uint32_t get_dev_size(HalL1MemAddrType addr_type) const;
     uint32_t get_processor_classes_count() const;
     uint32_t get_processor_types_count(uint32_t processor_class_idx) const;
+    template <typename T = DeviceAddr>
+    T get_base_firmware_addr(uint32_t processor_class_idx, uint32_t processor_type_idx) const;
+    template <typename T = DeviceAddr>
+    T get_binary_local_init_addr(uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 };
 
 template <typename T>
@@ -116,6 +125,20 @@ inline uint32_t HalCoreInfoType::get_processor_classes_count() const {
 inline uint32_t HalCoreInfoType::get_processor_types_count(uint32_t processor_class_idx) const {
     TT_ASSERT(processor_class_idx < this->processor_classes_.size());
     return this->processor_classes_[processor_class_idx].size();
+}
+
+template <typename T>
+inline T HalCoreInfoType::get_base_firmware_addr(uint32_t processor_class_idx, uint32_t processor_type_idx) const {
+    TT_ASSERT(processor_class_idx < this->processor_classes_.size());
+    TT_ASSERT(processor_type_idx < this->processor_classes_[processor_class_idx].size());
+    return this->processor_classes_[processor_class_idx][processor_type_idx].fw_base_addr;
+}
+
+template <typename T>
+inline T HalCoreInfoType::get_binary_local_init_addr(uint32_t processor_class_idx, uint32_t processor_type_idx) const {
+    TT_ASSERT(processor_class_idx < this->processor_classes_.size());
+    TT_ASSERT(processor_type_idx < this->processor_classes_[processor_class_idx].size());
+    return this->processor_classes_[processor_class_idx][processor_type_idx].local_init_addr;
 }
 
 class Hal {
@@ -170,6 +193,11 @@ class Hal {
     bool get_supports_cbs(uint32_t programmable_core_type_index) const;
 
     uint32_t get_num_risc_processors() const;
+
+    template <typename T = DeviceAddr>
+    T get_base_firmware_addr(uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
+    template <typename T = DeviceAddr>
+    T get_binary_local_init_addr(uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 };
 
 inline uint32_t Hal::get_programmable_core_type_count() const {
@@ -257,6 +285,18 @@ inline uint32_t Hal::get_alignment(HalMemType memory_type) const {
 
 inline bool Hal::get_supports_cbs(uint32_t programmable_core_type_index) const {
     return this->core_info_[programmable_core_type_index].supports_cbs_;
+}
+
+template <typename T>
+inline T Hal::get_base_firmware_addr(uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const {
+    TT_ASSERT(programmable_core_type_index < this->core_info_.size());
+    return this->core_info_[programmable_core_type_index].get_base_firmware_addr(processor_class_idx, processor_type_idx);
+}
+
+template <typename T>
+inline T Hal::get_binary_local_init_addr(uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const {
+    TT_ASSERT(programmable_core_type_index < this->core_info_.size());
+    return this->core_info_[programmable_core_type_index].get_binary_local_init_addr(processor_class_idx, processor_type_idx);
 }
 
 extern Hal hal;

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -44,21 +44,9 @@ using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
 
-ll_api::memory get_risc_binary(string const &path, uint32_t riscv_id,
+ll_api::memory get_risc_binary(string const &path,
+    uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx,
     ll_api::memory::PackSpans span_type, ll_api::memory::Relocate relo_type) {
-
-    static const uint32_t processor_to_fw_base_addr[] = {
-        MEM_BRISC_FIRMWARE_BASE,
-        MEM_NCRISC_FIRMWARE_BASE,
-        MEM_TRISC0_FIRMWARE_BASE,
-        MEM_TRISC1_FIRMWARE_BASE,
-        MEM_TRISC2_FIRMWARE_BASE,
-        eth_l1_mem::address_map::FIRMWARE_BASE,
-        MEM_IERISC_FIRMWARE_BASE,
-#ifdef ARCH_BLACKHOLE
-        MEM_SLAVE_IERISC_FIRMWARE_BASE,
-#endif
-    };
 
     static struct {
       std::unordered_map<std::string, std::unique_ptr<ll_api::memory>> map;
@@ -79,7 +67,7 @@ ll_api::memory get_risc_binary(string const &path, uint32_t riscv_id,
           uint64_t data_start = MEM_LOCAL_BASE;
           uint64_t text_start = (relo_type == ll_api::memory::Relocate::XIP) ?
               0 :
-              processor_to_fw_base_addr[riscv_id];
+              tt::tt_metal::hal.get_base_firmware_addr(core_type_idx, processor_class_idx, processor_type_idx);
           ptr->pack_data_into_text(text_start, data_start);
       }
 
@@ -188,22 +176,11 @@ void program_risc_startup_addr(chip_id_t chip_id, const CoreCoord &core) {
     write_hex_vec_to_core(chip_id, core, jump_to_fw, 0);
 }
 
-bool test_load_write_read_risc_binary(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int riscv_id) {
+bool test_load_write_read_risc_binary(
+    ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx) {
     assert(is_worker_core(core, chip_id) or is_ethernet_core(core, chip_id));
 
-    uint64_t local_init_addr;
-    switch (riscv_id) {
-        case 0: local_init_addr = MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH; break;
-        case 1: local_init_addr = MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH; break;
-        case 2: local_init_addr = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH; break;
-        case 3: local_init_addr = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH; break;
-        case 4: local_init_addr = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH; break;
-        case 5: local_init_addr = eth_l1_mem::address_map::FIRMWARE_BASE; break;
-        case 6: local_init_addr = MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH; break;
-#ifdef ARCH_BLACKHOLE
-        case 7: local_init_addr = MEM_SLAVE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH; break;
-#endif
-    }
+    uint64_t local_init_addr = tt::tt_metal::hal.get_binary_local_init_addr(core_type_idx, processor_class_idx, processor_type_idx);
 
     log_debug(tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size()*sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
@@ -222,12 +199,6 @@ bool test_load_write_read_risc_binary(ll_api::memory &mem, chip_id_t chip_id, co
     }
 
     return true;
-}
-
-bool test_load_write_read_trisc_binary(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int triscv_id) {
-
-    assert(triscv_id >= 0 and triscv_id <= 2);
-    return test_load_write_read_risc_binary(mem, chip_id, core, triscv_id + 2);
 }
 
 void write_binary_to_address(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t address) {

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -51,7 +51,8 @@ using NUM_REPETITIONS = std::uint32_t;
 using WorkerCore = tt_cxy_pair;
 using WorkerCores = std::vector<WorkerCore>;
 
-ll_api::memory get_risc_binary(string const &path, uint32_t riscv_id = 0,
+ll_api::memory get_risc_binary(string const &path,
+    uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx,
     ll_api::memory::PackSpans span_type = ll_api::memory::PackSpans::NO_PACK,
     ll_api::memory::Relocate relo_type = ll_api::memory::Relocate::NONE);
 
@@ -93,8 +94,8 @@ inline bool is_ethernet_core(const CoreCoord &core, chip_id_t chip_id) {
 uint32_t generate_risc_startup_addr(bool is_eth_core);
 void program_risc_startup_addr(chip_id_t chip_id, const CoreCoord &core);
 
-bool test_load_write_read_risc_binary(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int riscv_id);
-bool test_load_write_read_trisc_binary(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int triscv_id);
+bool test_load_write_read_risc_binary(
+    ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx);
 void write_binary_to_address(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t address);
 
 // subchannel hard-coded to 0 for now

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -59,9 +59,13 @@ HalCoreInfoType create_active_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::FW_VERSION_ADDR)] = sizeof(std::uint32_t);
 
-    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
-    std::vector<uint8_t> processor_types{0};
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses);
+    std::vector<HalJitBuildConfig> processor_types(1);
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        processor_types[0] = HalJitBuildConfig{
+            .fw_base_addr = eth_l1_mem::address_map::FIRMWARE_BASE,
+            .local_init_addr = eth_l1_mem::address_map::FIRMWARE_BASE,
+        };
         processor_classes[processor_class_idx] = processor_types;
     }
 

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -58,9 +58,13 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    std::vector<std::vector<uint8_t>> processor_classes(NumEthDispatchClasses);
-    std::vector<uint8_t> processor_types{0};
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses);
+    std::vector<HalJitBuildConfig> processor_types(1);
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+        processor_types[0] = HalJitBuildConfig{
+            .fw_base_addr = MEM_IERISC_FIRMWARE_BASE,
+            .local_init_addr = MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH,
+        };
         processor_classes[processor_class_idx] = processor_types;
     }
 

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -15,7 +15,6 @@
 #include "hw/inc/dev_msgs.h"
 
 #include <magic_enum.hpp>
-#include <numeric>
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
@@ -55,12 +54,53 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
-    std::vector<std::vector<uint8_t>> processor_classes(NumTensixDispatchClasses);
-    std::vector<uint8_t> processor_types;
+    std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumTensixDispatchClasses);
+    std::vector<HalJitBuildConfig> processor_types;
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
         uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        std::iota(processor_types.begin(), processor_types.end(), 0);
+        for (uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+            DeviceAddr fw_base, local_init;
+            switch (processor_class_idx) {
+                case 0: {
+                    fw_base = MEM_BRISC_FIRMWARE_BASE;
+                    local_init = MEM_BRISC_INIT_LOCAL_L1_BASE_SCRATCH;
+                }
+                break;
+                case 1: {
+                    fw_base = MEM_NCRISC_FIRMWARE_BASE;
+                    local_init = MEM_NCRISC_INIT_LOCAL_L1_BASE_SCRATCH;
+                }
+                break;
+                case 2: {
+                    switch (processor_type_idx) {
+                        case 0: {
+                            fw_base = MEM_TRISC0_FIRMWARE_BASE;
+                            local_init = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                        case 1: {
+                            fw_base = MEM_TRISC1_FIRMWARE_BASE;
+                            local_init = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                        case 2: {
+                            fw_base = MEM_TRISC2_FIRMWARE_BASE;
+                            local_init = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH;
+                        }
+                        break;
+                    }
+                }
+                break;
+                default:
+                    TT_THROW("Unexpected processor class {} for Blackhole Tensix", processor_class_idx);
+            }
+
+            processor_types[processor_type_idx] = HalJitBuildConfig{
+                .fw_base_addr = fw_base,
+                .local_init_addr = local_init
+            };
+        }
         processor_classes[processor_class_idx] = processor_types;
     }
 


### PR DESCRIPTION
### Ticket
No issue, this is broken out of https://github.com/tenstorrent/tt-metal/pull/14944 which enable programming active erisc1 on BH

EDIT by @blozano-tt:
This PR closes https://github.com/tenstorrent/tt-metal/issues/14689

### Problem description
BH and WH active eth mem maps are diverging and they have different base fw/local init addr so wanted this info to be extracted from the HAL. 

### What's changed
Adding base fw addr and local init addrs to processor arrays in the HAL. 

FYI @nathan-TT this was the change that @pgkeller mentioned could contend with your changes

@blozano-tt removed another ifdef :) 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11887184658)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11897068681)
