### PR TITLE
#14985: Update div_bw op

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/binary_backward/div_bw/div_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary_backward/div_bw/div_bw.py
@@ -29,7 +29,7 @@ parameters = {
         "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
         + gen_shapes([1, 1], [256, 256], [1, 1], 8),
-        "round_mode": ["None", "floor", "trunc"],
+        "round_mode": [None, "floor", "trunc"],
         "grad_dtype": [ttnn.bfloat8_b],
         "input_a_dtype": [ttnn.bfloat16],
         "input_b_dtype": [ttnn.bfloat16],
@@ -43,7 +43,7 @@ parameters = {
         "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 4)
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 4)
         + gen_shapes([1, 1], [256, 256], [1, 1], 4),
-        "round_mode": ["None", "floor", "trunc"],
+        "round_mode": [None, "floor", "trunc"],
         "grad_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -360,7 +360,7 @@ def softshrink_bw(x, y):
 
 
 def unary_div_bw(x, y):
-    ttnn.div_bw(x, y, 3.0, round_mode="None")
+    ttnn.div_bw(x, y, 3.0, round_mode=None)
 
 
 all_binary_ops = [
@@ -2502,7 +2502,7 @@ def subalpha_bw(x, y, z):
 
 
 def div_bw(x, y, z):
-    ttnn.div_bw(x, y, z, round_mode="None")
+    ttnn.div_bw(x, y, z, round_mode=None)
 
 
 def add_bw(x, y, z):

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -41,9 +41,6 @@ def test_bw_div_binary(input_shapes, round_mode, device):
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
 
-    if round_mode == None:
-        round_mode = "None"
-
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
@@ -80,7 +77,7 @@ def test_bw_div_example(device):
     grad_tt = ttnn.from_torch(grad_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     x1_tt = ttnn.from_torch(x1_torch, layout=ttnn.TILE_LAYOUT, device=device)
     x2_tt = ttnn.from_torch(x2_torch, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.div_bw(grad_tt, x1_tt, x2_tt, round_mode="None")
+    y_tt = ttnn.div_bw(grad_tt, x1_tt, x2_tt, round_mode=None)
     tt_out_1 = ttnn.to_torch(y_tt[1])
     tt_out_0 = ttnn.to_torch(y_tt[0])
     comp_pass_1 = torch.allclose(tt_out_1, golden_tensor[1])
@@ -99,7 +96,7 @@ def test_bw_div_example(device):
 @pytest.mark.parametrize(
     "round_mode",
     (
-        "None",
+        None,
         "trunc",
         "floor",
     ),
@@ -111,9 +108,6 @@ def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
-
-    if round_mode == "None":
-        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -132,7 +126,7 @@ def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
 @pytest.mark.parametrize(
     "round_mode",
     (
-        "None",
+        None,
         "trunc",
         "floor",
     ),
@@ -143,11 +137,6 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
-
-    in_data.retain_grad()
-
-    if round_mode == "None":
-        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -233,7 +222,7 @@ def test_bw_unary_div_bf8b(input_shapes, scalar, device):
 @pytest.mark.parametrize(
     "round_mode",
     (
-        "None",
+        None,
         "trunc",
         "floor",
     ),
@@ -250,9 +239,6 @@ def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
     ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode, input_grad=input_grad, queue_id=cq_id)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
     tt_output_tensor_on_device = [input_grad]
-
-    if round_mode == "None":
-        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -271,7 +257,7 @@ def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
 @pytest.mark.parametrize(
     "round_mode",
     (
-        "None",
+        None,
         "trunc",
         "floor",
     ),
@@ -306,9 +292,6 @@ def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
     )
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
     tt_output_tensor_on_device = [input_grad, other_grad]
-
-    if round_mode == "None":
-        round_mode = None
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -68,23 +68,6 @@ def test_bw_div_binary_default(input_shapes, device):
     assert status
 
 
-def test_bw_div_example(device):
-    grad_tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    x1_torch = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True)
-    x2_torch = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True)
-    golden_function = ttnn.get_golden_function(ttnn.div_bw)
-    golden_tensor = golden_function(grad_tensor, x1_torch, x2_torch, None)
-    grad_tt = ttnn.from_torch(grad_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    x1_tt = ttnn.from_torch(x1_torch, layout=ttnn.TILE_LAYOUT, device=device)
-    x2_tt = ttnn.from_torch(x2_torch, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.div_bw(grad_tt, x1_tt, x2_tt, round_mode=None)
-    tt_out_1 = ttnn.to_torch(y_tt[1])
-    tt_out_0 = ttnn.to_torch(y_tt[0])
-    comp_pass_1 = torch.allclose(tt_out_1, golden_tensor[1])
-    comp_pass_0 = torch.allclose(tt_out_0, golden_tensor[0])
-    assert comp_pass_1 and comp_pass_0
-
-
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -71,6 +71,23 @@ def test_bw_div_binary_default(input_shapes, device):
     assert status
 
 
+def test_bw_div_example(device):
+    grad_tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    x1_torch = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True)
+    x2_torch = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True)
+    golden_function = ttnn.get_golden_function(ttnn.div_bw)
+    golden_tensor = golden_function(grad_tensor, x1_torch, x2_torch, None)
+    grad_tt = ttnn.from_torch(grad_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    x1_tt = ttnn.from_torch(x1_torch, layout=ttnn.TILE_LAYOUT, device=device)
+    x2_tt = ttnn.from_torch(x2_torch, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.div_bw(grad_tt, x1_tt, x2_tt, round_mode="None")
+    tt_out_1 = ttnn.to_torch(y_tt[1])
+    tt_out_0 = ttnn.to_torch(y_tt[0])
+    comp_pass_1 = torch.allclose(tt_out_1, golden_tensor[1])
+    comp_pass_0 = torch.allclose(tt_out_0, golden_tensor[0])
+    assert comp_pass_1 and comp_pass_0
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -28,7 +28,7 @@ from models.utility_functions import (
 @pytest.mark.parametrize(
     "round_mode",
     (
-        "None",
+        None,
         "trunc",
         "floor",
     ),
@@ -40,6 +40,9 @@ def test_bw_div_binary(input_shapes, round_mode, device):
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
+
+    if round_mode == None:
+        round_mode = "None"
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
 
@@ -91,6 +94,9 @@ def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
+
+    if round_mode == "None":
+        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -120,6 +126,11 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
+
+    in_data.retain_grad()
+
+    if round_mode == "None":
+        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -222,6 +233,9 @@ def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
     ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode, input_grad=input_grad, queue_id=cq_id)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
     tt_output_tensor_on_device = [input_grad]
+
+    if round_mode == "None":
+        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -275,6 +289,9 @@ def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
     )
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
     tt_output_tensor_on_device = [input_grad, other_grad]
+
+    if round_mode == "None":
+        round_mode = None
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -28,7 +28,7 @@ from models.utility_functions import (
 @pytest.mark.parametrize(
     "round_mode",
     (
-        None,
+        "None",
         "trunc",
         "floor",
     ),
@@ -40,9 +40,6 @@ def test_bw_div_binary(input_shapes, round_mode, device):
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
-
-    if round_mode == None:
-        round_mode = "None"
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
 
@@ -94,9 +91,6 @@ def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
-
-    if round_mode == "None":
-        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -126,11 +120,6 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
-
-    in_data.retain_grad()
-
-    if round_mode == "None":
-        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -233,9 +222,6 @@ def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
     ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode, input_grad=input_grad, queue_id=cq_id)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
     tt_output_tensor_on_device = [input_grad]
-
-    if round_mode == "None":
-        round_mode = None
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, scalar, round_mode)
 
@@ -289,9 +275,6 @@ def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
     )
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
     tt_output_tensor_on_device = [input_grad, other_grad]
-
-    if round_mode == "None":
-        round_mode = None
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -75,7 +75,7 @@ autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::Tens
 
     out->set_value(ttnn::divide(a->get_value(), b->get_value()));
     autograd::GradFunction grad = [a, b, out]() {
-        auto res = ttnn::div_bw(out->get_grad(), a->get_value(), b->get_value(), std::nullopt);
+        auto res = ttnn::div_bw(out->get_grad(), a->get_value(), b->get_value());
         a->add_grad(res[0].value());
         b->add_grad(res[1].value());
     };

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -75,7 +75,7 @@ autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::Tens
 
     out->set_value(ttnn::divide(a->get_value(), b->get_value()));
     autograd::GradFunction grad = [a, b, out]() {
-        auto res = ttnn::div_bw(out->get_grad(), a->get_value(), b->get_value(), "None");
+        auto res = ttnn::div_bw(out->get_grad(), a->get_value(), b->get_value(), std::nullopt);
         a->add_grad(res[0].value());
         b->add_grad(res[1].value());
     };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -603,13 +603,13 @@ std::vector<ttnn::Tensor> ExecuteBackwardMin::invoke(const Tensor& grad, const T
 }
 
 std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
-    uint8_t queue_id, const Tensor& grad, const Tensor& input, float scalar, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
-    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
+    uint8_t queue_id, const Tensor& grad, const Tensor& input, float scalar, const std::optional<std::string> round_mode, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    TT_FATAL((round_mode == std::nullopt || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
 
     std::vector<std::optional<Tensor>> result;
     input_grad = input_grad.value_or(ttnn::empty_like(input));
 
-    if (round_mode == "None") {
+    if (round_mode == std::nullopt) {
         float t_inf = std::numeric_limits<float>::infinity();
         if (scalar == 0.0) {
             float t_nan = std::nanf("");
@@ -628,7 +628,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
 }
 
 std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
-    const Tensor& grad, const Tensor& input, float scalar, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    const Tensor& grad, const Tensor& input, float scalar, const std::optional<std::string> round_mode, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
     return ExecuteBackwardDiv::invoke(DefaultQueueId, grad, input, scalar, round_mode, output_mem_config, input_grad);
 }
 
@@ -637,15 +637,16 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
     const Tensor& grad,
     const Tensor& input,
     const Tensor& other,
-    std::string round_mode,
+    const std::optional<std::string> round_mode,
     const std::vector<bool>& are_required_outputs,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     preallocated_tensors_check(input_grad, other_grad, input, other, {are_required_outputs[0], are_required_outputs[1]});
+    TT_FATAL((round_mode == std::nullopt || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
 
-    if (round_mode == "None") {
+    if (round_mode == std::nullopt) {
         float t_nan = std::nanf("");
         float t_inf = std::numeric_limits<float>::infinity();
         float neg_inf = -std::numeric_limits<float>::infinity();
@@ -714,7 +715,7 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteBackwardDiv::invoke(
     const Tensor& grad,
     const Tensor& input,
     const Tensor& other,
-    std::string round_mode,
+    const std::optional<std::string> round_mode,
     const std::vector<bool>& are_required_outputs,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -314,7 +314,7 @@ struct ExecuteBackwardDiv  {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float scalar,
-        string round_mode = "None",
+        const std::optional<string> round_mode = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt);
 
@@ -323,7 +323,7 @@ struct ExecuteBackwardDiv  {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         const Tensor &other_tensor_arg,
-        string round_mode = "None",
+        const std::optional<string> round_mode = std::nullopt,
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt,
@@ -333,7 +333,7 @@ struct ExecuteBackwardDiv  {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         float scalar,
-        string round_mode = "None",
+        const std::optional<string> round_mode = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt);
 
@@ -341,7 +341,7 @@ struct ExecuteBackwardDiv  {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         const Tensor &other_tensor_arg,
-        string round_mode = "None",
+        const std::optional<string> round_mode = std::nullopt,
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> input_grad = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -771,7 +771,7 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             input_tensor_b (ComplexTensor or ttnn.Tensor or Number): the input tensor.
 
         Keyword args:
-            round_mode (str, optional): Round mode for the operation ( when input tensors are not ComplexTensor type ). Defaults to `None`.
+            round_mode (str, optional): Round mode for the operation (when input tensors are not ComplexTensor type). Defaults to `None`.
             are_required_outputs (List[bool], optional): List of required outputs. Defaults to `[True, True]`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor`. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -771,7 +771,7 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             input_tensor_b (ComplexTensor or ttnn.Tensor or Number): the input tensor.
 
         Keyword args:
-            round_mode (str, optional): Round mode for the operation (when input tensors are not ComplexTensor type). Defaults to `None`.
+            round_mode (str, optional): Round mode for the operation (when input tensors are not ComplexTensor type). Can be  None, "trunc", "floor". Defaults to `None`.
             are_required_outputs (List[bool], optional): List of required outputs. Defaults to `[True, True]`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor`. Defaults to `None`.
@@ -802,12 +802,12 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
-            >>> output = ttnn.div_bw(grad_tensor, tensor1, tensor2, round_mode = "None")
+            >>> output = ttnn.div_bw(grad_tensor, tensor1, tensor2, round_mode = None)
 
             >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> scalar = 2
-            >>> output = ttnn.div_bw(grad_tensor, tensor, scalar, round_mode = "None")
+            >>> output = ttnn.div_bw(grad_tensor, tensor, scalar, round_mode = None)
 
         )doc",
         operation.base_name(),
@@ -825,7 +825,7 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
                const Tensor& grad_tensor,
                const Tensor& input_tensor_a,
                const float scalar,
-               std::string round_mode,
+               const std::optional<std::string> round_mode,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
                const uint8_t& queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
@@ -835,7 +835,7 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             py::arg("input_tensor_a"),
             py::arg("scalar"),
             py::kw_only(),
-            py::arg("round_mode") = "None",
+            py::arg("round_mode") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
             py::arg("queue_id") = ttnn::DefaultQueueId},
@@ -846,7 +846,7 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const ttnn::Tensor& other_tensor,
-               std::string round_mode,
+               const std::optional<std::string> round_mode,
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& input_grad,
@@ -858,7 +858,7 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             py::arg("input_tensor"),
             py::arg("other_tensor"),
             py::kw_only(),
-            py::arg("round_mode") = "None",
+            py::arg("round_mode") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
             py::arg("memory_config") = std::nullopt,
             py::arg("input_grad") = std::nullopt,
@@ -1084,7 +1084,7 @@ void py_module(py::module& module) {
     detail::bind_binary_bw_div(
         module,
         ttnn::div_bw,
-        R"doc(Performs backward operations for divide on :attr:`input_tensor`, :attr:`alpha` or :attr:`input_tensor_a`, :attr:`input_tensor_b`, :attr:`round_mode`,  with given :attr:`grad_tensor`. :attr:`round_mode` can be  "None", "trunc", "floor".)doc",
+        R"doc(Performs backward operations for divide on :attr:`input_tensor`, :attr:`alpha` or :attr:`input_tensor_a`, :attr:`input_tensor_b`, :attr:`round_mode`,  with given :attr:`grad_tensor`.)doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     detail::bind_binary_backward_overload(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -771,12 +771,12 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             input_tensor_b (ComplexTensor or ttnn.Tensor or Number): the input tensor.
 
         Keyword args:
+            round_mode (str, optional): Round mode for the operation ( when input tensors are not ComplexTensor type ). Defaults to `None`.
             are_required_outputs (List[bool], optional): List of required outputs. Defaults to `[True, True]`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             input_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `input_tensor`. Defaults to `None`.
             other_grad (ttnn.Tensor, optional): Preallocated output tensor for gradient of `other_tensor`. Defaults to `None`.
             queue_id (int, optional): command queue id. Defaults to `0`.
-            round_mode (str, optional): Round mode for the operation. Defaults to `None`.
 
         Returns:
             List of ttnn.Tensor: the output tensor.
@@ -799,10 +799,10 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             bfloat8_b/bfloat4_b is only supported on TILE_LAYOUT
 
         Example:
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
-            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
-            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
-            >>> output = {1}(grad_tensor, tensor1, tensor2/scalar)
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = ttnn.div_bw(grad_tensor, tensor1, tensor2, round_mode = "None")
 
         )doc",
         operation.base_name(),
@@ -1079,7 +1079,7 @@ void py_module(py::module& module) {
     detail::bind_binary_bw_div(
         module,
         ttnn::div_bw,
-        R"doc(Performs backward operations for divide on :attr:`input_tensor`, :attr:`alpha` or :attr:`input_tensor_a`, :attr:`input_tensor_b`, :attr:`round_mode`,  with given :attr:`grad_tensor`.)doc",
+        R"doc(Performs backward operations for divide on :attr:`input_tensor`, :attr:`alpha` or :attr:`input_tensor_a`, :attr:`input_tensor_b`, :attr:`round_mode`,  with given :attr:`grad_tensor`. :attr:`round_mode` can be  "None", "trunc", "floor".)doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     detail::bind_binary_backward_overload(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -804,6 +804,11 @@ void bind_binary_bw_div(py::module& module, const binary_backward_operation_t& o
             >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = ttnn.div_bw(grad_tensor, tensor1, tensor2, round_mode = "None")
 
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> scalar = 2
+            >>> output = ttnn.div_bw(grad_tensor, tensor, scalar, round_mode = "None")
+
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -125,6 +125,8 @@ def _golden_function_backward_with_string(
             golden_tensor = [sum_result.grad, sum_result.grad]
         return golden_tensor
     elif torch_op == torch.div:
+        if value == "None":
+            value = None
         pyt_y = torch_op(input_tensor_a, input_tensor_b, rounding_mode=value)
     else:
         pyt_y = torch_op(input_tensor_a, input_tensor_b, value=value)

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -125,8 +125,6 @@ def _golden_function_backward_with_string(
             golden_tensor = [sum_result.grad, sum_result.grad]
         return golden_tensor
     elif torch_op == torch.div:
-        if value == "None":
-            value = None
         pyt_y = torch_op(input_tensor_a, input_tensor_b, rounding_mode=value)
     else:
         pyt_y = torch_op(input_tensor_a, input_tensor_b, value=value)


### PR DESCRIPTION
### Ticket
#14985, #15242

### Problem description

- Update divide backward example, documentation
- Update golden function to avoid this error
<img width="797" alt="Screenshot 2024-11-18 at 9 12 39 PM" src="https://github.com/user-attachments/assets/59270241-85af-4a8e-ad5f-89d03c9ca6ef">

### What's changed
The following updates were made : 

- Updated bindings with `round_mode` values with acceptable values
- Updated the example for `div_bw`
- Updated golden function for `round_mode = None` to match PyTorch

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/11949465827) - passes

<img width="873" alt="Screenshot 2024-11-20 at 8 09 28 PM" src="https://github.com/user-attachments/assets/85c33c6c-ee0a-4eb5-aa53-e06021569bd1">

