### PR TITLE
Add `ttnn.convert_to_chw` operation for CNN channel reordering

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import (
+    skip_for_grayskull,
+    skip_for_blackhole,
+)
+
+
+@skip_for_grayskull()
+@skip_for_blackhole()
+@pytest.mark.parametrize("C", [1, 2, 4])
+@pytest.mark.parametrize(
+    "HW, core_grid",
+    (
+        (32, ttnn.CoreGrid(x=1, y=1)),
+        (64, ttnn.CoreGrid(x=1, y=1)),
+        (64, ttnn.CoreGrid(x=2, y=1)),
+        (1056 * 160, ttnn.CoreGrid(x=8, y=6)),
+    ),
+)
+def test_convert_to_chw(device, C, HW, core_grid):
+    input_tensor = torch.randn([1, 1, HW, C], dtype=torch.bfloat16)
+    expected = input_tensor.transpose(2, 3)
+
+    input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    input_memory_config = ttnn.create_sharded_memory_config(
+        [1, 1, HW, 32], core_grid, ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.ROW_MAJOR
+    )
+    input_tensor = ttnn.to_device(input_tensor, device, input_memory_config)
+
+    output_memory_config = ttnn.create_sharded_memory_config(
+        [1, 1, 32, HW], core_grid, ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.ROW_MAJOR
+    )
+    actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_memory_config)
+    actual = ttnn.to_torch(actual)
+
+    assert_with_pcc(expected, actual, 0.9999999)
+
+
+@skip_for_grayskull()
+@skip_for_blackhole()
+def test_convert_to_chw_with_program_cache(device, use_program_cache):
+    C, HW = 8, 128
+    core_grid = ttnn.CoreGrid(x=2, y=1)
+
+    for _ in range(2):
+        test_convert_to_chw(device, C, HW, core_grid)
+        test_convert_to_chw(device, C, HW, core_grid)
+        dummy_shape = [1, 1, 128, 128]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = (
+            ttnn.Tensor(py_dummy_tensor, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device, ttnn.L1_MEMORY_CONFIG)
+        )
+
+    assert device.num_program_cache_entries() == 1

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -183,6 +183,10 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/bcast/device/multi_core_w/bcast_op_multi_core_w.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/bcast/device/multi_core_hw/bcast_op_multi_core_hw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/experimental_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_chw.hpp"
+
+#include "device/convert_to_chw_op.hpp"
+#include "ttnn/common/constants.hpp"
+
+namespace ttnn::operations::experimental::cnn {
+
+ttnn::Tensor ExecuteConvertToCHW::invoke(
+    uint8_t queue_id,
+    const Tensor& a,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DataType>& dtype) {
+    auto program = ConvertToCHW{memory_config.value_or(a.memory_config()), dtype.value_or(a.dtype())};
+    return operation::run(program, {a}, {}, {}, queue_id).at(0);
+}
+
+ttnn::Tensor ExecuteConvertToCHW::invoke(
+    const Tensor& a, const std::optional<MemoryConfig>& memory_config, const std::optional<DataType>& dtype) {
+    return invoke(DefaultQueueId, a, memory_config, dtype);
+}
+
+}  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ttnn/decorators.hpp>
+#include <ttnn/tensor/tensor.hpp>
+
+namespace ttnn::operations::experimental::cnn {
+
+struct ExecuteConvertToCHW {
+    static ttnn::Tensor invoke(
+        uint8_t queue_id, const Tensor& a, const std::optional<MemoryConfig>& memory_config = std::nullopt, const std::optional<DataType>& dtype = std::nullopt);
+    static ttnn::Tensor invoke(const Tensor& a, const std::optional<MemoryConfig>& memory_config = std::nullopt, const std::optional<DataType>& dtype = std::nullopt);
+};
+
+}  // namespace ttnn::operations::experimental::cnn
+
+namespace ttnn::experimental {
+
+constexpr auto convert_to_chw = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::convert_to_chw",
+    ttnn::operations::experimental::cnn::ExecuteConvertToCHW>();
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_chw_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "convert_to_chw.hpp"
+#include "ttnn/cpp/pybind11/decorators.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+namespace py = pybind11;
+
+void bind_convert_to_chw(py::module& module) {
+    using OperationType = decltype(ttnn::experimental::convert_to_chw);
+
+    const auto doc = R"doc(TODO!)doc";
+
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::experimental::convert_to_chw,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input,
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<DataType> dtype,
+               uint8_t queue_id) { return self(queue_id, input, memory_config, dtype); },
+            py::arg("input"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+void bind_convert_to_chw(pybind11::module& module);
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_op.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_chw_op.hpp"
+
+#include "convert_to_chw_program_factory.hpp"
+#include "tt_metal/common/constants.hpp"
+
+namespace ttnn::operations::experimental::cnn {
+
+void ConvertToCHW::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
+    TT_FATAL(input_tensors.size() == 1, "Expected 1 input tensor");
+
+    const auto& input = input_tensors.at(0);
+    const auto& shape = input.get_logical_shape();
+    const auto& C = shape[-1];
+    const auto& HW = shape[-2];
+
+    TT_FATAL(shape.size() == 4, "Input shape must be rank 4 (was rank {})", shape.size());
+    TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, HW, C]");
+    TT_FATAL(C <= TILE_HEIGHT, "C must be less than or equal to 32 (was {})", C);
+    TT_FATAL(HW % TILE_HEIGHT == 0, "HW must be divisible by tile size");
+
+    TT_FATAL(
+        this->memory_config.is_sharded() && this->memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+        "Output tensor must be width sharded");
+    // TODO: Check that grids match
+}
+
+std::vector<tt::tt_metal::LegacyShape> ConvertToCHW::compute_output_shapes(
+    const std::vector<Tensor>& input_tensors) const {
+    const auto& shape = input_tensors.at(0).get_logical_shape();
+    const auto B = shape[0];
+    const auto HW = shape[2];
+    const auto C = shape[3];
+    return {LegacyShape({B, 1, C, HW}, {B, 1, C, HW})};
+}
+
+std::vector<Tensor> ConvertToCHW::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, this->dtype, Layout::ROW_MAJOR, this->memory_config);
+}
+
+operation::ProgramWithCallbacks ConvertToCHW::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const auto& a = input_tensors.at(0);
+    auto& output = output_tensors.at(0);
+    auto device_compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
+    return detail::multi_core_convert_to_chw(a, output, device_compute_with_storage_grid_size);
+}
+}  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_op.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::cnn {
+
+struct ConvertToCHW {
+    MemoryConfig memory_config;
+    DataType dtype;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_chw_program_factory.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+using namespace tt::constants;
+
+operation::ProgramWithCallbacks multi_core_convert_to_chw(
+    const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    const auto input_shape = a.get_logical_shape();
+    const auto input_core_grid = a.shard_spec()->grid;
+    std::vector<CoreCoord> input_cores = grid_to_cores(
+        input_core_grid.num_cores(), compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, true);
+
+    const auto HW = input_shape[2];
+    const auto C = input_shape[3];
+
+    TT_ASSERT(C < TILE_HEIGHT, "C must be 32 or smaller");
+
+    const uint32_t c_tiles = 1;  // assume C <= 32
+    const uint32_t hw_tiles = HW / TILE_HEIGHT;
+    const uint32_t total_tiles = hw_tiles * c_tiles;
+    const uint32_t total_tiles_per_core = hw_tiles * c_tiles / input_cores.size();
+
+    const auto create_circular_buffer = [&program, &input_core_grid](
+                                            uint32_t index,
+                                            uint32_t num_tiles,
+                                            uint32_t tile_size,
+                                            const tt::DataFormat& format,
+                                            Buffer* buffer = nullptr) -> tt::tt_metal::CBHandle {
+        auto config = CircularBufferConfig(num_tiles * tile_size, {{index, format}}).set_page_size(index, tile_size);
+        if (buffer != nullptr) {
+            config = config.set_globally_allocated_address(*buffer);
+        }
+        return tt::tt_metal::CreateCircularBuffer(program, input_core_grid, config);
+    };
+
+    const tt::DataFormat input_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    const uint32_t input_tile_size = tt::tt_metal::detail::TileSize(input_format);
+
+    const tt::DataFormat intermediary_format = tt::DataFormat::Float16_b;
+    const uint32_t intermediary_tile_size = tt::tt_metal::detail::TileSize(intermediary_format);
+
+    const uint32_t cb_in_id = tt::CB::c_in0;
+    const auto cb_in =
+        create_circular_buffer(cb_in_id, total_tiles_per_core, input_tile_size, input_format, a.buffer());
+
+    const uint32_t cb_out_id = tt::CB::c_out0;
+    const auto cb_out =
+        create_circular_buffer(cb_out_id, total_tiles_per_core, input_tile_size, input_format, output.buffer());
+
+    const uint32_t cb_in_transpose_id = tt::CB::c_intermed0;
+    const auto cb_in_transpose =
+        create_circular_buffer(cb_in_transpose_id, 1, intermediary_tile_size, intermediary_format);
+
+    std::vector<uint32_t> reader_compile_time_args = {cb_in_id};
+    std::vector<uint32_t> writer_compile_time_args = {cb_in_transpose_id, cb_out_id, C};
+    std::vector<uint32_t> compute_compile_time_args = {cb_in_id, cb_in_transpose_id, cb_out_id};
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp",
+        input_core_grid,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp",
+        input_core_grid,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    auto compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp",
+        input_core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compute_compile_time_args});
+
+    auto set_runtime_args =
+        [cb_in, cb_out, input_cores, total_tiles_per_core, reader_kernel_id, writer_kernel_id, compute_kernel_id](
+            Program& program, const Tensor& a, const Tensor& output) {
+            tt::tt_metal::Buffer* a_buffer = a.buffer();
+            tt::tt_metal::Buffer* output_buffer = output.buffer();
+            UpdateDynamicCircularBufferAddress(program, cb_in, *a_buffer);
+            UpdateDynamicCircularBufferAddress(program, cb_out, *output_buffer);
+
+            std::vector<std::vector<uint32_t>> reader_runtime_args = {input_cores.size(), {0}};  // (num_tiles_per_core)
+            std::vector<std::vector<uint32_t>> writer_runtime_args = {input_cores.size(), {0}};  // (num_tiles_per_core)
+            std::vector<std::vector<uint32_t>> compute_runtime_args = {
+                input_cores.size(), {0}};  // (num_tiles_per_core)
+
+            for (uint32_t i = 0; i < input_cores.size(); i++) {
+                const CoreCoord& core = input_cores.at(i);
+                reader_runtime_args[i][0] = total_tiles_per_core;
+                writer_runtime_args[i][0] = total_tiles_per_core;
+                compute_runtime_args[i][0] = total_tiles_per_core;
+            }
+            SetRuntimeArgs(program, reader_kernel_id, input_cores, reader_runtime_args);
+            SetRuntimeArgs(program, writer_kernel_id, input_cores, writer_runtime_args);
+            SetRuntimeArgs(program, compute_kernel_id, input_cores, compute_runtime_args);
+        };
+    set_runtime_args(program, a, output);
+
+    auto override_runtime_arguments_callback = [set_runtime_args](
+                                                   const void* operation,
+                                                   Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
+        const auto& output_tensor = output_tensors.at(0);
+        set_runtime_args(program, input_tensors.at(0), output_tensor);
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+operation::ProgramWithCallbacks multi_core_convert_to_chw(
+    const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size);
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/pack_untilize.h"
+#include "compute_kernel_api/transpose_wh.h"
+
+constexpr uint32_t ONE_TILE = 1;
+
+FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
+    transpose_wh_init_short(cb_in);
+
+    pack_untilize_dst_init_short<ONE_TILE, 1, false, false, 32>(cb_out);
+
+    cb_wait_front(cb_in, ONE_TILE);
+
+    tile_regs_acquire();
+    tile_regs_wait();
+
+    transpose_wh_tile(cb_in, 0, 0);
+
+    cb_reserve_back(cb_out, ONE_TILE);
+
+    pack_untilize_dst<ONE_TILE>(cb_out);
+
+    tile_regs_commit();
+    tile_regs_release();
+
+    pack_untilize_uninit();
+
+    cb_push_back(cb_out, ONE_TILE);
+    cb_pop_front(cb_in, ONE_TILE);
+}
+
+namespace NAMESPACE {
+void MAIN {
+    const uint32_t total_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_transpose_in = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(2);
+
+    transpose_wh_init(cb_in);
+    pack_untilize_init(cb_in, cb_transpose_in);
+
+    for (uint32_t idx = 0; idx < total_tiles; idx++) {
+        transpose(cb_in, cb_transpose_in);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t total_tiles = get_arg_val<uint32_t>(0);
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    cb_push_back(cb_in, total_tiles);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+constexpr uint32_t TILE_SIZE = 32;
+constexpr uint32_t ELEMENT_SIZE_BYTES = 2;
+constexpr uint32_t STICK_SIZE = TILE_SIZE * ELEMENT_SIZE_BYTES;
+
+void kernel_main() {
+    const uint32_t total_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_in_transpose = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(1);
+    constexpr uint32_t C = get_compile_time_arg_val(2);
+
+    const uint32_t base_l1_write_addr = get_write_ptr(cb_out);
+    const uint64_t base_l1_read_addr = get_noc_addr(get_read_ptr(cb_in_transpose));
+    noc_async_read_one_packet_set_state(base_l1_read_addr, STICK_SIZE);
+
+    const uint32_t channel_size = total_tiles * STICK_SIZE;
+
+    for (uint32_t i = 0; i < total_tiles; i++) {
+        cb_wait_front(cb_in_transpose, 1);
+        for (uint32_t j = 0; j < C; j++) {
+            const uint32_t l1_read_addr = base_l1_read_addr + (j * STICK_SIZE);
+            const uint32_t l1_write_addr = base_l1_write_addr + (j * channel_size) + (i * STICK_SIZE);
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+        }
+        cb_pop_front(cb_in_transpose, 1);
+        cb_push_back(cb_out, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -7,6 +7,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/argmax/argmax_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.hpp"
 #include "ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.hpp"
@@ -62,8 +63,9 @@ void py_module(py::module& module) {
 
     ssm::detail::bind_prefix_scan(module);
     ssm::detail::bind_repeat_and_interleave_eltwise_mul(module);
-
     ssm::detail::bind_hc_sum_reduce(module);
+
+    cnn::detail::bind_convert_to_chw(module);
 
     copy::detail::py_bind_typecast(module);
 


### PR DESCRIPTION
### Summary
This PR implements a new experimental op called `ttnn.convert_to_chw` which converts CNN output tensors from channels-last to channels-first ordering. This is necessary for achieving peak performance on CNN models because our convolution op works in HWC channel ordering but most users typically expect models to use CHW ordering on their interfaces.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11954710929, https://github.com/tenstorrent/tt-metal/actions/runs/12148720544
- [x] New/Existing tests provide coverage for changes
