### PR TITLE
#15167: explicitly check for rank 4 in reduce special cases

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_max.py
+++ b/tests/ttnn/unit_tests/operations/test_max.py
@@ -54,6 +54,26 @@ def test_max_4d(device, batch_size1, batch_size2, h, w, dim):
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [64])
+@pytest.mark.parametrize("dim", [-2, -1, 0, 1])
+def test_max_2d(device, h, w, dim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch_random((h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.max(input_tensor, dim=dim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor)
+
+
 @pytest.mark.parametrize("batch_size", [1, 16, 1, 16])
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -57,7 +57,7 @@ static Tensor reduce_impl(
             rank);
     }
 
-    if (dim.size() == 1) {
+    if (dim.size() == 1 && rank == 4) {
         if (dim[0] == rank - 3) {
             // Pad before running the op to only pay cost of formatting once
             auto input_tensor_pad_shape = AutoFormat::pad_to_tile_shape(input_tensor_arg.get_legacy_shape(), true);


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/15167

### Problem description
A code path in reduce assumed that rank is 4. This was implicit when negative dimensions were used at that point because the comparison was a dimension against a rank offset. After a change to adjust dimensions to be non-negative earlier in the code, an incorrect code path was taken in some scenarios. 

### What's changed
Explicitly check that the rank is 4.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11899700948/job/33161083860 vs https://github.com/tenstorrent/tt-metal/actions/runs/11899483294/job/33160246174 - unrelated issues, has to be good enough
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes
