### PR TITLE
Allow Concrete Hal Translation Units to have unique include paths

### DIFF
--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -1,3 +1,49 @@
+# Provide unique architecture specific translation units and include paths for each ARCH
+
+set(GS_HAL_SRC grayskull/gs_hal.cpp)
+
+set(WH_HAL_SRC
+    wormhole/wh_hal.cpp
+    wormhole/wh_hal_tensix.cpp
+    wormhole/wh_hal_active_eth.cpp
+    wormhole/wh_hal_idle_eth.cpp
+)
+
+set(BH_HAL_SRC
+    blackhole/bh_hal.cpp
+    blackhole/bh_hal_tensix.cpp
+    blackhole/bh_hal_active_eth.cpp
+    blackhole/bh_hal_idle_eth.cpp
+)
+
+add_library(gs_hal OBJECT ${GS_HAL_SRC})
+add_library(HAL::grayskull ALIAS gs_hal)
+target_include_directories(
+    gs_hal
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/grayskull
+)
+target_link_directories(gs_hal PRIVATE hw)
+
+add_library(wh_hal OBJECT ${WH_HAL_SRC})
+add_library(HAL::wormhole ALIAS wh_hal)
+target_include_directories(
+    wh_hal
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole
+    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
+)
+target_link_directories(wh_hal PRIVATE hw)
+
+add_library(bh_hal OBJECT ${BH_HAL_SRC})
+add_library(HAL::blackhole ALIAS bh_hal)
+target_include_directories(
+    bh_hal
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/blackhole
+)
+target_link_directories(bh_hal PRIVATE hw)
+
 set(LLRT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/llrt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rtoptions.cpp
@@ -6,15 +52,6 @@ set(LLRT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_elffile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tt_memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hal.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/grayskull/gs_hal.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/wormhole/wh_hal.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/wormhole/wh_hal_tensix.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/wormhole/wh_hal_active_eth.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/wormhole/wh_hal_idle_eth.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/blackhole/bh_hal.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/blackhole/bh_hal_tensix.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/blackhole/bh_hal_active_eth.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/blackhole/bh_hal_idle_eth.cpp
 )
 
 add_library(llrt STATIC ${LLRT_SRC}) # FIXME(14541): Should be OBJECT, but can't handle circular deps between Object libs
@@ -26,5 +63,9 @@ target_link_libraries(
         Metalium::Metal::Common
         umd::device
         Metalium::Metal::Hardware
+    PRIVATE
+        HAL::grayskull
+        HAL::wormhole
+        HAL::blackhole
 )
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -16,33 +16,58 @@ set(BH_HAL_SRC
     blackhole/bh_hal_idle_eth.cpp
 )
 
+set(HAL_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd
+)
+
 add_library(gs_hal OBJECT ${GS_HAL_SRC})
 add_library(HAL::grayskull ALIAS gs_hal)
 target_include_directories(
     gs_hal
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/grayskull
+    PRIVATE
+        ${HAL_INCLUDE_DIRS}
+        ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/grayskull
 )
-target_link_directories(gs_hal PRIVATE hw)
+target_link_libraries(
+    gs_hal
+    PRIVATE
+        hw
+        fmt::fmt-header-only
+)
 
 add_library(wh_hal OBJECT ${WH_HAL_SRC})
 add_library(HAL::wormhole ALIAS wh_hal)
 target_include_directories(
     wh_hal
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole
-    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
+    PRIVATE
+        ${HAL_INCLUDE_DIRS}
+        ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole
+        ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
 )
-target_link_directories(wh_hal PRIVATE hw)
+target_link_libraries(
+    wh_hal
+    PRIVATE
+        hw
+        fmt::fmt-header-only
+)
 
 add_library(bh_hal OBJECT ${BH_HAL_SRC})
 add_library(HAL::blackhole ALIAS bh_hal)
 target_include_directories(
     bh_hal
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/blackhole
+    PRIVATE
+        ${HAL_INCLUDE_DIRS}
+        ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/blackhole
 )
-target_link_directories(bh_hal PRIVATE hw)
+target_link_libraries(
+    bh_hal
+    PRIVATE
+        hw
+        fmt::fmt-header-only
+)
 
 set(LLRT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/llrt.cpp

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -1,30 +1,16 @@
 # Provide unique architecture specific translation units and include paths for each ARCH
 
-set(GS_HAL_SRC grayskull/gs_hal.cpp)
-
-set(WH_HAL_SRC
-    wormhole/wh_hal.cpp
-    wormhole/wh_hal_tensix.cpp
-    wormhole/wh_hal_active_eth.cpp
-    wormhole/wh_hal_idle_eth.cpp
-)
-
-set(BH_HAL_SRC
-    blackhole/bh_hal.cpp
-    blackhole/bh_hal_tensix.cpp
-    blackhole/bh_hal_active_eth.cpp
-    blackhole/bh_hal_idle_eth.cpp
-)
-
+# FIXME: Don't want to be reaching above to project dir
+# Prefer a library target to be explicit about the dependency in CMake
 set(HAL_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/tt_metal
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd
 )
 
-add_library(gs_hal OBJECT ${GS_HAL_SRC})
+add_library(gs_hal OBJECT)
 add_library(HAL::grayskull ALIAS gs_hal)
+target_sources(gs_hal PRIVATE grayskull/gs_hal.cpp)
 target_include_directories(
     gs_hal
     PRIVATE
@@ -36,10 +22,19 @@ target_link_libraries(
     PRIVATE
         hw
         fmt::fmt-header-only
+        umd::device
 )
 
-add_library(wh_hal OBJECT ${WH_HAL_SRC})
+add_library(wh_hal OBJECT)
 add_library(HAL::wormhole ALIAS wh_hal)
+target_sources(
+    wh_hal
+    PRIVATE
+        wormhole/wh_hal.cpp
+        wormhole/wh_hal_tensix.cpp
+        wormhole/wh_hal_active_eth.cpp
+        wormhole/wh_hal_idle_eth.cpp
+)
 target_include_directories(
     wh_hal
     PRIVATE
@@ -52,10 +47,19 @@ target_link_libraries(
     PRIVATE
         hw
         fmt::fmt-header-only
+        umd::device
 )
 
 add_library(bh_hal OBJECT ${BH_HAL_SRC})
 add_library(HAL::blackhole ALIAS bh_hal)
+target_sources(
+    bh_hal
+    PRIVATE
+        blackhole/bh_hal.cpp
+        blackhole/bh_hal_tensix.cpp
+        blackhole/bh_hal_active_eth.cpp
+        blackhole/bh_hal_idle_eth.cpp
+)
 target_include_directories(
     bh_hal
     PRIVATE
@@ -67,6 +71,7 @@ target_link_libraries(
     PRIVATE
         hw
         fmt::fmt-header-only
+        umd::device
 )
 
 set(LLRT_SRC

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "core_config.h"
+#include <cstddef>
+#include <cstdint>
+
+#include "core_config.h" // ProgrammableCoreType
 #include "noc/noc_parameters.h"
-#include "llrt/hal.hpp"
-#include "llrt/blackhole/bh_hal.hpp"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
+
+#include "hal.hpp"
+#include "blackhole/bh_hal.hpp"
 
 // Reserved DRAM addresses
 // Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been committed
@@ -17,12 +20,7 @@ namespace tt {
 
 namespace tt_metal {
 
-static inline int hv (enum HalL1MemAddrType v) {
-    return static_cast<int>(v);
-}
-
 void Hal::initialize_bh() {
-#if defined(ARCH_BLACKHOLE)
     static_assert(static_cast<int>(HalProgrammableCoreType::TENSIX) == static_cast<int>(ProgrammableCoreType::TENSIX));
     static_assert(static_cast<int>(HalProgrammableCoreType::ACTIVE_ETH) == static_cast<int>(ProgrammableCoreType::ACTIVE_ETH));
     static_assert(static_cast<int>(HalProgrammableCoreType::IDLE_ETH) == static_cast<int>(ProgrammableCoreType::IDLE_ETH));
@@ -36,16 +34,15 @@ void Hal::initialize_bh() {
     HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
     this->core_info_.push_back(idle_eth_mem_map);
 
-    this->dram_bases_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
-    this->dram_sizes_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
-    this->dram_bases_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
-    this->dram_sizes_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
+    this->dram_bases_.resize(static_cast<std::size_t>(HalDramMemAddrType::COUNT));
+    this->dram_sizes_.resize(static_cast<std::size_t>(HalDramMemAddrType::COUNT));
+    this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
+    this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
 
-    this->mem_alignments_.resize(utils::underlying_type<HalMemType>(HalMemType::COUNT));
-    this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::L1)] = L1_ALIGNMENT;
-    this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::DRAM)] = DRAM_ALIGNMENT;
-    this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::HOST)] = PCIE_ALIGNMENT;
-#endif
+    this->mem_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
+    this->mem_alignments_[static_cast<std::size_t>(HalMemType::L1)] = L1_ALIGNMENT;
+    this->mem_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = DRAM_ALIGNMENT;
+    this->mem_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = PCIE_ALIGNMENT;
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -25,13 +25,13 @@ void Hal::initialize_bh() {
     static_assert(static_cast<int>(HalProgrammableCoreType::ACTIVE_ETH) == static_cast<int>(ProgrammableCoreType::ACTIVE_ETH));
     static_assert(static_cast<int>(HalProgrammableCoreType::IDLE_ETH) == static_cast<int>(ProgrammableCoreType::IDLE_ETH));
 
-    HalCoreInfoType tensix_mem_map = create_tensix_mem_map();
+    HalCoreInfoType tensix_mem_map = blackhole::create_tensix_mem_map();
     this->core_info_.push_back(tensix_mem_map);
 
-    HalCoreInfoType active_eth_mem_map = create_active_eth_mem_map();
+    HalCoreInfoType active_eth_mem_map = blackhole::create_active_eth_mem_map();
     this->core_info_.push_back(active_eth_mem_map);
 
-    HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
+    HalCoreInfoType idle_eth_mem_map = blackhole::create_idle_eth_mem_map();
     this->core_info_.push_back(idle_eth_mem_map);
 
     this->dram_bases_.resize(static_cast<std::size_t>(HalDramMemAddrType::COUNT));

--- a/tt_metal/llrt/blackhole/bh_hal.hpp
+++ b/tt_metal/llrt/blackhole/bh_hal.hpp
@@ -4,9 +4,7 @@
 
 #pragma once
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::blackhole {
 
 // If you are trying to include this file and you aren't hal...you are doing something wrong
 
@@ -14,5 +12,4 @@ HalCoreInfoType create_tensix_mem_map();
 HalCoreInfoType create_active_eth_mem_map();
 HalCoreInfoType create_idle_eth_mem_map();
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -16,7 +16,7 @@
 #include "hal_asserts.hpp"
 #include "blackhole/bh_hal.hpp"
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((std::uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -21,9 +21,7 @@
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((std::uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::blackhole {
 
 HalCoreInfoType create_active_eth_mem_map() {
 
@@ -73,5 +71,4 @@ HalCoreInfoType create_active_eth_mem_map() {
     return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -2,26 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(ARCH_BLACKHOLE)
-
 #define COMPILE_FOR_ERISC
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <vector>
 
-#include "llrt/hal.hpp"
-#include "llrt/hal_asserts.hpp"
-#include "llrt/blackhole/bh_hal.hpp"
-#include "hw/inc/blackhole/core_config.h"
-#include "hw/inc/blackhole/dev_mem_map.h"
-#include "hw/inc/blackhole/eth_l1_address_map.h"
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
-#include "hw/inc/dev_msgs.h"
+#include "dev_msgs.h"
+#include "eth_l1_address_map.h"
 
-#include <magic_enum.hpp>
+#include "hal.hpp"
+#include "hal_asserts.hpp"
+#include "blackhole/bh_hal.hpp"
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
-    ((uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
+    ((std::uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
 
 namespace tt {
 
@@ -31,39 +29,39 @@ HalCoreInfoType create_active_eth_mem_map() {
 
     std::vector<DeviceAddr> mem_map_bases;
 
-    mem_map_bases.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = 0x0; // Anything better to use?
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = GET_ETH_MAILBOX_ADDRESS_HOST(profiler);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::CORE_INFO)] = GET_ETH_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_message);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::FW_VERSION_ADDR)] = eth_l1_mem::address_map::FW_VERSION_ADDR;
+    mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = 0x0; // Anything better to use?
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_ETH_MAILBOX_ADDRESS_HOST(profiler);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_ETH_MAILBOX_ADDRESS_HOST(core_info);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::FW_VERSION_ADDR)] = eth_l1_mem::address_map::FW_VERSION_ADDR;
 
-    std::vector<uint32_t> mem_map_sizes;
-    mem_map_sizes.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = eth_l1_mem::address_map::MAX_SIZE; // Anything better to use?
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::MAX_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::FW_VERSION_ADDR)] = sizeof(std::uint32_t);
+    std::vector<std::uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = eth_l1_mem::address_map::MAX_SIZE; // Anything better to use?
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::MAX_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::FW_VERSION_ADDR)] = sizeof(std::uint32_t);
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses - 1);
     std::vector<HalJitBuildConfig> processor_types(1);
-    for (uint8_t processor_class_idx = 0; processor_class_idx < processor_classes.size(); processor_class_idx++) {
+    for (std::uint8_t processor_class_idx = 0; processor_class_idx < processor_classes.size(); processor_class_idx++) {
         // BH active ethernet runs idle erisc FW on the second ethernet
         processor_types[0] = HalJitBuildConfig{
             .fw_base_addr = eth_l1_mem::address_map::FIRMWARE_BASE,
@@ -77,4 +75,3 @@ HalCoreInfoType create_active_eth_mem_map() {
 
 }  // namespace tt_metal
 }  // namespace tt
-#endif

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -60,7 +60,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = MEM_ETH_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
 

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -24,9 +24,7 @@
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::blackhole {
 
 HalCoreInfoType create_idle_eth_mem_map() {
 
@@ -92,5 +90,4 @@ HalCoreInfoType create_idle_eth_mem_map() {
     return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -2,23 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(ARCH_BLACKHOLE)
-
 #define COMPILE_FOR_ERISC
 
-#include "llrt/hal.hpp"
-#include "llrt/hal_asserts.hpp"
-#include "llrt/blackhole/bh_hal.hpp"
-#include "hw/inc/blackhole/core_config.h"
-#include "hw/inc/blackhole/dev_mem_map.h"
-#include "hw/inc/blackhole/eth_l1_address_map.h"
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
-#include "hw/inc/dev_msgs.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
-#include <magic_enum.hpp>
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "noc/noc_parameters.h"
 
-#define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
+#include "hal.hpp"
+#include "hal_asserts.hpp"
+#include "blackhole/bh_hal.hpp"
+
+// FIXME: Eventually this file will be gone
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_SIZE
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+
+#define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 
 namespace tt {
 
@@ -26,43 +30,43 @@ namespace tt_metal {
 
 HalCoreInfoType create_idle_eth_mem_map() {
 
-    uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
+    std::uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     static_assert(MEM_IERISC_MAP_END % L1_ALIGNMENT == 0);
 
     std::vector<DeviceAddr> mem_map_bases;
 
-    mem_map_bases.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_ETH_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = GET_IERISC_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(profiler);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_IERISC_MAP_END;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = ((MEM_IERISC_MAP_END + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::CORE_INFO)] = GET_IERISC_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_message);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
+    mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_ETH_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_IERISC_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(profiler);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_IERISC_MAP_END;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = ((MEM_IERISC_MAP_END + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_IERISC_MAILBOX_ADDRESS_HOST(core_info);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
 
-    std::vector<uint32_t> mem_map_sizes;
-    mem_map_sizes.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_ETH_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = sizeof(uint32_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = MEM_ETH_SIZE - mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)];
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
+    std::vector<std::uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_ETH_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = sizeof(std::uint32_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses);
     std::vector<HalJitBuildConfig> processor_types(1);
-    for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+    for (std::uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
         DeviceAddr fw_base, local_init;
         switch (processor_class_idx) {
             case 0: {
@@ -90,5 +94,3 @@ HalCoreInfoType create_idle_eth_mem_map() {
 
 }  // namespace tt_metal
 }  // namespace tt
-
-#endif

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -20,7 +20,7 @@
 // FIXME: Eventually this file will be gone
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_SIZE
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -18,7 +18,7 @@
 // FIXME: Eventually this file will be gone
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_BASE
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -2,19 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(ARCH_BLACKHOLE)
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
-#include "llrt/hal.hpp"
-#include "llrt/hal_asserts.hpp"
-#include "llrt/blackhole/bh_hal.hpp"
-#include "hw/inc/blackhole/core_config.h"
-#include "hw/inc/blackhole/dev_mem_map.h"
-#include "hw/inc/blackhole/eth_l1_address_map.h"  // XXXX FIXME
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
-#include "hw/inc/dev_msgs.h"
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "noc/noc_parameters.h"
 
-#include <magic_enum.hpp>
+#include "hal.hpp"
+#include "hal_asserts.hpp"
+#include "blackhole/bh_hal.hpp"
+
+// FIXME: Eventually this file will be gone
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_BASE
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
@@ -28,34 +32,34 @@ HalCoreInfoType create_tensix_mem_map() {
 
     std::vector<DeviceAddr> mem_map_bases;
 
-    mem_map_bases.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_L1_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = ((L1_KERNEL_CONFIG_BASE + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
+    mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_L1_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = ((L1_KERNEL_CONFIG_BASE + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
 
 
     std::vector<uint32_t> mem_map_sizes;
-    mem_map_sizes.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_L1_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = sizeof(uint32_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = MEM_L1_SIZE - mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)];
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
+    mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_L1_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumTensixDispatchClasses);
     std::vector<HalJitBuildConfig> processor_types;
@@ -112,5 +116,3 @@ HalCoreInfoType create_tensix_mem_map() {
 
 }  // namespace tt_metal
 }  // namespace tt
-
-#endif

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -22,9 +22,7 @@
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::blackhole {
 
 HalCoreInfoType create_tensix_mem_map() {
 
@@ -114,5 +112,4 @@ HalCoreInfoType create_tensix_mem_map() {
     return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true};
 }
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -57,7 +57,7 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = MEM_L1_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
 

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -20,7 +20,7 @@
 // FIXME: Eventually this file will be gone
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_BASE
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -8,16 +8,19 @@
 #include <numeric>
 #include <vector>
 
-#include "hal.hpp"
-
 #include "core_config.h" // ProgrammableCoreType
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"
+
+#include "hal.hpp"
+
 #include "hal_asserts.hpp"
 
 // FIXME: Eventually this file will be gone
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_BASE
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -25,13 +25,13 @@ void Hal::initialize_wh() {
     static_assert(static_cast<int>(HalProgrammableCoreType::ACTIVE_ETH) == static_cast<int>(ProgrammableCoreType::ACTIVE_ETH));
     static_assert(static_cast<int>(HalProgrammableCoreType::IDLE_ETH) == static_cast<int>(ProgrammableCoreType::IDLE_ETH));
 
-    HalCoreInfoType tensix_mem_map = create_tensix_mem_map();
+    HalCoreInfoType tensix_mem_map = wormhole::create_tensix_mem_map();
     this->core_info_.push_back(tensix_mem_map);
 
-    HalCoreInfoType active_eth_mem_map = create_active_eth_mem_map();
+    HalCoreInfoType active_eth_mem_map = wormhole::create_active_eth_mem_map();
     this->core_info_.push_back(active_eth_mem_map);
 
-    HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
+    HalCoreInfoType idle_eth_mem_map = wormhole::create_idle_eth_mem_map();
     this->core_info_.push_back(idle_eth_mem_map);
 
     this->dram_bases_.resize(static_cast<std::size_t>(HalDramMemAddrType::COUNT));

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstddef>
 #include <cstdint>
 
 #include "core_config.h" // ProgrammableCoreType
+#include "noc/noc_parameters.h"
 
 #include "hal.hpp"
 #include "wormhole/wh_hal.hpp"

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "core_config.h"
-#include "noc/noc_parameters.h"
-#include "llrt/hal.hpp"
-#include "llrt/wormhole/wh_hal.hpp"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
+#include <cstdint>
+
+#include "core_config.h" // ProgrammableCoreType
+
+#include "hal.hpp"
+#include "wormhole/wh_hal.hpp"
 
 // Reserved DRAM addresses
 // Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been committed
@@ -18,7 +19,6 @@ namespace tt {
 namespace tt_metal {
 
 void Hal::initialize_wh() {
-#if defined(ARCH_WORMHOLE_B0)
     static_assert(static_cast<int>(HalProgrammableCoreType::TENSIX) == static_cast<int>(ProgrammableCoreType::TENSIX));
     static_assert(static_cast<int>(HalProgrammableCoreType::ACTIVE_ETH) == static_cast<int>(ProgrammableCoreType::ACTIVE_ETH));
     static_assert(static_cast<int>(HalProgrammableCoreType::IDLE_ETH) == static_cast<int>(ProgrammableCoreType::IDLE_ETH));
@@ -32,16 +32,15 @@ void Hal::initialize_wh() {
     HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
     this->core_info_.push_back(idle_eth_mem_map);
 
-    this->dram_bases_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
-    this->dram_sizes_.resize(utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::COUNT));
-    this->dram_bases_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
-    this->dram_sizes_[utils::underlying_type<HalDramMemAddrType>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
+    this->dram_bases_.resize(static_cast<std::size_t>(HalDramMemAddrType::COUNT));
+    this->dram_sizes_.resize(static_cast<std::size_t>(HalDramMemAddrType::COUNT));
+    this->dram_bases_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_BASE;
+    this->dram_sizes_[static_cast<std::size_t>(HalDramMemAddrType::DRAM_BARRIER)] = DRAM_BARRIER_SIZE;
 
-    this->mem_alignments_.resize(utils::underlying_type<HalMemType>(HalMemType::COUNT));
-    this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::L1)] = L1_ALIGNMENT;
-    this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::DRAM)] = DRAM_ALIGNMENT;
-    this->mem_alignments_[utils::underlying_type<HalMemType>(HalMemType::HOST)] = PCIE_ALIGNMENT;
-#endif
+    this->mem_alignments_.resize(static_cast<std::size_t>(HalMemType::COUNT));
+    this->mem_alignments_[static_cast<std::size_t>(HalMemType::L1)] = L1_ALIGNMENT;
+    this->mem_alignments_[static_cast<std::size_t>(HalMemType::DRAM)] = DRAM_ALIGNMENT;
+    this->mem_alignments_[static_cast<std::size_t>(HalMemType::HOST)] = PCIE_ALIGNMENT;
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/wormhole/wh_hal.hpp
+++ b/tt_metal/llrt/wormhole/wh_hal.hpp
@@ -4,9 +4,7 @@
 
 #pragma once
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::wormhole {
 
 // If you are trying to include this file and you aren't hal...you are doing something wrong
 
@@ -14,5 +12,4 @@ HalCoreInfoType create_tensix_mem_map();
 HalCoreInfoType create_active_eth_mem_map();
 HalCoreInfoType create_idle_eth_mem_map();
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -18,9 +18,7 @@
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::wormhole {
 
 HalCoreInfoType create_active_eth_mem_map() {
 
@@ -69,5 +67,4 @@ HalCoreInfoType create_active_eth_mem_map() {
     return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -2,23 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(ARCH_WORMHOLE_B0)
-
 #define COMPILE_FOR_ERISC
 
 #include <cstdint>
 
-#include "llrt/hal.hpp"
-#include "llrt/hal_asserts.hpp"
-#include "llrt/wormhole/wh_hal.hpp"
-#include "hw/inc/wormhole/core_config.h"
-#include "hw/inc/wormhole/dev_mem_map.h"
-#include "hw/inc/wormhole/eth_l1_address_map.h"
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
-#include "hw/inc/dev_msgs.h"
+#include "core_config.h"
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "eth_l1_address_map.h"
 
-#include <magic_enum.hpp>
+#include "hal.hpp"
+#include "hal_asserts.hpp"
+#include "wormhole/wh_hal.hpp"
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
@@ -31,35 +28,35 @@ HalCoreInfoType create_active_eth_mem_map() {
 
     std::vector<DeviceAddr> mem_map_bases;
 
-    mem_map_bases.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = 0x0; // Anything better to use?
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = GET_ETH_MAILBOX_ADDRESS_HOST(profiler);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::CORE_INFO)] = GET_ETH_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_message);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::FW_VERSION_ADDR)] = eth_l1_mem::address_map::FW_VERSION_ADDR;
+    mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = 0x0; // Anything better to use?
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_ETH_MAILBOX_ADDRESS_HOST(profiler);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_ETH_MAILBOX_ADDRESS_HOST(core_info);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_ETH_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::FW_VERSION_ADDR)] = eth_l1_mem::address_map::FW_VERSION_ADDR;
 
     std::vector<uint32_t> mem_map_sizes;
-    mem_map_sizes.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = eth_l1_mem::address_map::MAX_SIZE; // Anything better to use?
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::MAX_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::FW_VERSION_ADDR)] = sizeof(std::uint32_t);
+    mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = eth_l1_mem::address_map::MAX_SIZE; // Anything better to use?
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = eth_l1_mem::address_map::ERISC_BARRIER_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = eth_l1_mem::address_map::MAX_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::FW_VERSION_ADDR)] = sizeof(std::uint32_t);
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses);
     std::vector<HalJitBuildConfig> processor_types(1);
@@ -76,4 +73,3 @@ HalCoreInfoType create_active_eth_mem_map() {
 
 }  // namespace tt_metal
 }  // namespace tt
-#endif

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -6,8 +6,6 @@
 
 #include <cstdint>
 
-#include "core_config.h"
-#include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "eth_l1_address_map.h"
 

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -13,7 +13,7 @@
 #include "hal_asserts.hpp"
 #include "wormhole/wh_hal.hpp"
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((uint64_t) & (((mailboxes_t *)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -60,7 +60,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = MEM_ETH_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];;
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
 

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <vector>
 
-#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -2,23 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(ARCH_WORMHOLE_B0)
-
 #define COMPILE_FOR_IDLE_ERISC
 
-#include "llrt/hal.hpp"
-#include "llrt/hal_asserts.hpp"
-#include "llrt/wormhole/wh_hal.hpp"
-#include "hw/inc/wormhole/core_config.h"
-#include "hw/inc/wormhole/dev_mem_map.h"
-#include "hw/inc/wormhole/eth_l1_address_map.h"
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
-#include "hw/inc/dev_msgs.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
-#include <magic_enum.hpp>
+#include "core_config.h"
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "noc/noc_parameters.h"
 
-#define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
+#include "hal.hpp"
+#include "hal_asserts.hpp"
+#include "wormhole/wh_hal.hpp"
+
+// FIXME: Eventually this file will be gone
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+
+#define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 
 namespace tt {
 
@@ -26,43 +31,43 @@ namespace tt_metal {
 
 HalCoreInfoType create_idle_eth_mem_map() {
 
-    uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
+    std::uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     static_assert(MEM_IERISC_MAP_END % L1_ALIGNMENT == 0);
 
     std::vector<DeviceAddr> mem_map_bases;
 
-    mem_map_bases.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_ETH_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = GET_IERISC_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(profiler);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_IERISC_MAP_END;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = ((MEM_IERISC_MAP_END + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::CORE_INFO)] = GET_IERISC_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_message);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
+    mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_ETH_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_IERISC_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(profiler);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_IERISC_MAP_END;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = ((MEM_IERISC_MAP_END + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_IERISC_MAILBOX_ADDRESS_HOST(core_info);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_IERISC_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
 
     std::vector<uint32_t> mem_map_sizes;
-    mem_map_sizes.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_ETH_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = sizeof(uint32_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = MEM_ETH_SIZE - mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)];
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
+    mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_ETH_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = sizeof(std::uint32_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_IERISC_MAILBOX_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses);
     std::vector<HalJitBuildConfig> processor_types(1);
-    for (uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
+    for (std::uint8_t processor_class_idx = 0; processor_class_idx < NumEthDispatchClasses; processor_class_idx++) {
         processor_types[0] = HalJitBuildConfig{
             .fw_base_addr = MEM_IERISC_FIRMWARE_BASE,
             .local_init_addr = MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH,
@@ -75,5 +80,3 @@ HalCoreInfoType create_idle_eth_mem_map() {
 
 }  // namespace tt_metal
 }  // namespace tt
-
-#endif

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -20,7 +20,7 @@
 // FIXME: Eventually this file will be gone
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -24,9 +24,7 @@
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::wormhole {
 
 HalCoreInfoType create_idle_eth_mem_map() {
 
@@ -77,5 +75,4 @@ HalCoreInfoType create_idle_eth_mem_map() {
     return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
 }
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -23,9 +23,7 @@
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
-namespace tt {
-
-namespace tt_metal {
+namespace tt::tt_metal::wormhole {
 
 HalCoreInfoType create_tensix_mem_map() {
 
@@ -114,5 +112,4 @@ HalCoreInfoType create_tensix_mem_map() {
     return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true};
 }
 
-}  // namespace tt_metal
-}  // namespace tt
+}  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -57,7 +57,7 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = MEM_L1_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
 

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -19,7 +19,7 @@
 // FIXME: Eventually this file will be gone
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_BASE
 
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+#include "tt_soc_descriptor.h" // CoreType
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -8,7 +8,6 @@
 #include <numeric>
 #include <vector>
 
-#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -2,21 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(ARCH_WORMHOLE_B0)
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <vector>
 
-#include "llrt/hal.hpp"
-#include "llrt/hal_asserts.hpp"
-#include "llrt/wormhole/wh_hal.hpp"
-#include "hw/inc/wormhole/core_config.h"
-#include "hw/inc/wormhole/dev_mem_map.h"
-#include "hw/inc/wormhole/eth_l1_address_map.h"  // XXXX FIXME
-#include "hostdevcommon/common_runtime_address_map.h"
-#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
-#include "hw/inc/dev_msgs.h"
+#include "core_config.h"
+#include "dev_mem_map.h"
+#include "dev_msgs.h"
+#include "noc/noc_parameters.h"
 
-#include <magic_enum.hpp>
+#include "hal.hpp"
+#include "hal_asserts.hpp"
+#include "wormhole/wh_hal.hpp"
 
-#define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
+// FIXME: Eventually this file will be gone
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h" // L1_KERNEL_CONFIG_BASE
+
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // CoreType
+
+#define GET_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
 
 namespace tt {
 
@@ -24,44 +30,44 @@ namespace tt_metal {
 
 HalCoreInfoType create_tensix_mem_map() {
 
-    uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
+    std::uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     std::vector<DeviceAddr> mem_map_bases;
 
-    mem_map_bases.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_L1_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = ((L1_KERNEL_CONFIG_BASE + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
-    mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
+    mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_L1_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] = ((L1_KERNEL_CONFIG_BASE + L1_KERNEL_CONFIG_SIZE - 1) | (max_alignment - 1)) + 1;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
 
     std::vector<uint32_t> mem_map_sizes;
-    mem_map_sizes.resize(utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::COUNT));
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BASE)] = MEM_L1_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::BARRIER)] = sizeof(uint32_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)] = MEM_L1_SIZE - mem_map_bases[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::UNRESERVED)];
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
-    mem_map_sizes[utils::underlying_type<HalL1MemAddrType>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
+    mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_L1_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BARRIER)] = sizeof(std::uint32_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::MAILBOX)] = MEM_MAILBOX_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(std::uint32_t);
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumTensixDispatchClasses);
     std::vector<HalJitBuildConfig> processor_types;
-    for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
-        uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
+    for (std::uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
+        std::uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        for (uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+        for (std::uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
             DeviceAddr fw_base, local_init;
             switch (processor_class_idx) {
                 case 0: {
@@ -111,5 +117,3 @@ HalCoreInfoType create_tensix_mem_map() {
 
 }  // namespace tt_metal
 }  // namespace tt
-
-#endif


### PR DESCRIPTION
### Ticket
#596

### Problem description
Concrete instances of Hal are allowed to have unique include paths.
However, the project currently forces them all to have the same ARCH_NAME specific include paths, and uses ifdefs

### What's changed
Create object libraries for each ARCH_NAME specific concrete hal.
Remove ifdefs inside concrete hal.
Cleanup includes used in cpp.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/11928088941 (Latest commit)
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11906902051)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11922696648)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
