### PR TITLE
Added extra check in reshape for shapes whose less is less than 2 (#15200 fix)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -174,7 +174,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn
     //Tiled: The last two dimensions are the same or there is no padding on the second last dimension
     const uint32_t shape_second_last_dim = shape.rank() >= 2 ? shape[-2] : 1;
     const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2] : 1;
-    bool this_is_view = (tensor_shape[-1] == shape[-1]) &&
+    bool this_is_view = (tensor_shape[-1] == shape[-1]) && (shape.rank() >= 2) && (tensor_shape.rank() >= 2) &&
         ((tensor.get_layout() == ttnn::ROW_MAJOR_LAYOUT) || //Its row major
         (shape_second_last_dim==tensor_shape_second_last_dim) || //Second last dimension is the same
         (shape_second_last_dim%ttnn::types::TILE_SIZE==0 && tensor_shape_second_last_dim%ttnn::types::TILE_SIZE==0)); //There is no padding on the second last dimension

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -114,7 +114,7 @@ ttnn::Shape tiling_reshape_corrector(const ttnn::Shape& shape) {
     const int8_t correction_1 =(ttnn::types::TILE_SIZE - (int)padded[-1] % ttnn::types::TILE_SIZE) % ttnn::types::TILE_SIZE;
     if(rank == 1)
     {
-        return ttnn::Shape({shape[0]},{padded[0]+correction_1});
+        return ttnn::Shape({1, shape[0]}, {32, padded[0]+correction_1});
     }
     const int8_t correction_2 =(ttnn::types::TILE_SIZE - (int)padded[-2] % ttnn::types::TILE_SIZE) % ttnn::types::TILE_SIZE;
     switch(rank)
@@ -174,7 +174,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn
     //Tiled: The last two dimensions are the same or there is no padding on the second last dimension
     const uint32_t shape_second_last_dim = shape.rank() >= 2 ? shape[-2] : 1;
     const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2] : 1;
-    bool this_is_view = (tensor_shape[-1] == shape[-1]) && (shape.rank() >= 2) && (tensor_shape.rank() >= 2) &&
+    bool this_is_view = (tensor_shape[-1] == shape[-1]) &&
         ((tensor.get_layout() == ttnn::ROW_MAJOR_LAYOUT) || //Its row major
         (shape_second_last_dim==tensor_shape_second_last_dim) || //Second last dimension is the same
         (shape_second_last_dim%ttnn::types::TILE_SIZE==0 && tensor_shape_second_last_dim%ttnn::types::TILE_SIZE==0)); //There is no padding on the second last dimension

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -177,7 +177,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn
         (tensor_shape[-2]==shape[-2]) || //Second last dimension is the same
         (shape[-2]%ttnn::types::TILE_SIZE==0 && tensor_shape[-2]%ttnn::types::TILE_SIZE==0)); //There is no padding on the second last dimension
     bool tile_tensor_view_reshape_possible = (layout == ttnn::Layout::TILE and
-        ((shape.with_tile_padding().rank() < 2 or shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0) and (shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0)) and
+        ((shape.with_tile_padding().rank() >= 2 and shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0) and (shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0)) and
         (tensor_shape.with_tile_padding()[-1] == shape.with_tile_padding()[-1])
         );
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -172,13 +172,16 @@ ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn
     //For view the following cases work:
     //RM: The last dimension is the same
     //Tiled: The last two dimensions are the same or there is no padding on the second last dimension
+    const uint32_t shape_second_last_dim = shape.rank() >= 2 ? shape[-2] : 1;
+    const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2] : 1;
     bool this_is_view = (tensor_shape[-1] == shape[-1]) &&
         ((tensor.get_layout() == ttnn::ROW_MAJOR_LAYOUT) || //Its row major
-        (tensor_shape[-2]==shape[-2]) || //Second last dimension is the same
-        (shape[-2]%ttnn::types::TILE_SIZE==0 && tensor_shape[-2]%ttnn::types::TILE_SIZE==0)); //There is no padding on the second last dimension
+        (shape_second_last_dim==tensor_shape_second_last_dim) || //Second last dimension is the same
+        (shape_second_last_dim%ttnn::types::TILE_SIZE==0 && tensor_shape_second_last_dim%ttnn::types::TILE_SIZE==0)); //There is no padding on the second last dimension
+
     bool tile_tensor_view_reshape_possible = (layout == ttnn::Layout::TILE and
-        ((shape.with_tile_padding().rank() >= 2 and shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0) and (shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0)) and
-        (tensor_shape.with_tile_padding()[-1] == shape.with_tile_padding()[-1])
+        shape.with_tile_padding().rank() >= 2 and shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0 and shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0 and
+        tensor_shape.with_tile_padding()[-1] == shape.with_tile_padding()[-1]
         );
 
     if (!(ttnn::has_storage_type_of(tensor, ttnn::StorageType::DEVICE)) or tile_tensor_view_reshape_possible) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -177,7 +177,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(const ttnn::Tensor& tensor, const ttnn
         (tensor_shape[-2]==shape[-2]) || //Second last dimension is the same
         (shape[-2]%ttnn::types::TILE_SIZE==0 && tensor_shape[-2]%ttnn::types::TILE_SIZE==0)); //There is no padding on the second last dimension
     bool tile_tensor_view_reshape_possible = (layout == ttnn::Layout::TILE and
-        ((shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0) and (shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0)) and
+        ((shape.with_tile_padding().rank() < 2 or shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0) and (shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0)) and
         (tensor_shape.with_tile_padding()[-1] == shape.with_tile_padding()[-1])
         );
 


### PR DESCRIPTION
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15200)

### Problem description:
Due to a tiling check in ReshapeViewOperation::invoke which indexes -2 index of the shape of the tensor, the check fails if the shape rank is 1, this MR just adds an additional check.

### What's changed
Added an additional check in `ReshapeViewOperation::invoke`

