### PR TITLE
ttnn.angle op fix

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/angle/angle.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/angle/angle.py
@@ -76,16 +76,16 @@ def run(
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
 
-    torch_real = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype)(
+    torch_real = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype)(
         input_shape
     ).to(torch.float32)
-    torch_imag = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype)(
+    torch_imag = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch.bfloat16), input_a_dtype)(
         input_shape
     ).to(torch.float32)
     torch_input_tensor_a = torch.complex(torch_real, torch_imag)
 
     golden_function = ttnn.get_golden_function(ttnn.angle)
-    torch_output_tensor = golden_function(torch_input_tensor_a)
+    torch_output_tensor = golden_function(torch_input_tensor_a).to(torch.bfloat16)
 
     input_tensor_a_real = ttnn.from_torch(
         torch_real,

--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/angle/angle.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/angle/angle.py
@@ -110,20 +110,3 @@ def run(
     output_tensor = ttnn.to_torch(output_tensor)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
-
-
-from tests.sweep_framework.framework.permutations import *
-
-for suite in parameters.keys():
-    device_id = 0
-    device = ttnn.open_device(device_id=device_id)
-    suite_vectors = list(permutations(parameters[suite]))
-    print(len(suite_vectors))
-    for vector in suite_vectors:
-        if invalidate_vector(vector)[0]:
-            continue
-        passed, _ = run(**vector, device=device)
-        if passed[0] != True:
-            print(passed)
-
-    ttnn.close_device(device)

--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/angle_bw/angle_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/angle_bw/angle_bw.py
@@ -44,7 +44,7 @@ parameters = {
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Inputs to eltwise binary must be tilized"
+        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
     if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is not supported on input_tensor_a"
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:

--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/polar/polar.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/polar/polar.py
@@ -42,7 +42,7 @@ parameters = {
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Inputs to eltwise binary must be tilized"
+        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
     return False, None

--- a/tests/sweep_framework/sweeps/eltwise/unary_complex/polar_bw/polar_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_complex/polar_bw/polar_bw.py
@@ -44,7 +44,7 @@ parameters = {
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Inputs to eltwise binary must be tilized"
+        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
     if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is not supported on input_tensor_a"
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
@@ -22,7 +22,7 @@ Tensor _imag(const ComplexTensor& input, const MemoryConfig& output_mem_config) 
 }
 
 Tensor _angle(const ComplexTensor& input, const MemoryConfig& output_mem_config) {
-    return atan2(input[0],input[1],output_mem_config);
+    return ttnn::atan2(input[0],input[1],output_mem_config);
 }
 
 Tensor _is_imag(const ComplexTensor& input, const MemoryConfig& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
@@ -22,7 +22,7 @@ Tensor _imag(const ComplexTensor& input, const MemoryConfig& output_mem_config) 
 }
 
 Tensor _angle(const ComplexTensor& input, const MemoryConfig& output_mem_config) {
-    return ttnn::atan2(input[0],input[1],output_mem_config);
+    return atan2(input[0],input[1],output_mem_config);
 }
 
 Tensor _is_imag(const ComplexTensor& input, const MemoryConfig& output_mem_config) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14088)

### Problem description
ttnn.angle op incorrect implementation.

### What's changed
1. Fixed the op in ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
2. Added nightly suite in tests/sweep_framework/sweeps/eltwise/unary_complex/angle/angle.py sweep
3. Minor modficiations inside unary_complex sweeps invalidate vector functions

### Checklist
Unit test from the issue link now fails if the mentioned code lines are not removed/commented.