### PR TITLE
Temp workaround for perf improvement on out of box MM

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -7,6 +7,7 @@ import ttnn
 from models.utility_functions import nearest_32
 from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 from models.common.lightweightmodule import LightweightModule
+from loguru import logger
 
 
 class TtMixtralAttention(LightweightModule):
@@ -141,6 +142,7 @@ class TtMixtralAttention(LightweightModule):
         )
 
         self.compute_kernel = self.model_args.get_compute_kernel_config()
+        self.compute_kernel_reduce = self.model_args.get_compute_kernel_config_reduce()
         self.compute_kernel_attn = self.model_args.get_compute_kernel_attn_config()
 
         self.core_grid = self.model_args.max_grid_size
@@ -274,7 +276,10 @@ class TtMixtralAttention(LightweightModule):
         dense_outputs_11BH = ttnn.all_gather(dense_out_11BH, dim=2, num_links=1)
 
         # return the sum of the outputs
-        dense_outputs_11BH = ttnn.matmul(self.reduce_mask, dense_outputs_11BH)
+
+        dense_outputs_11BH = ttnn.matmul(
+            self.reduce_mask, dense_outputs_11BH, compute_kernel_config=self.compute_kernel_reduce
+        )
         return dense_outputs_11BH
 
     def forward_prefill(self, xs_11SH, attn_masks, rot_mats, transformation_mats, user_id: int = 0):

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -7,7 +7,6 @@ import ttnn
 from models.utility_functions import nearest_32
 from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 from models.common.lightweightmodule import LightweightModule
-from loguru import logger
 
 
 class TtMixtralAttention(LightweightModule):

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -59,7 +59,6 @@ class TtTransformer(LightweightModule):
         )
 
         self.compute_kernel = self.args.get_compute_kernel_config()
-        self.compute_kernel_reduce = self.args.get_compute_kernel_config_reduce()
 
         if self.rotary_on_host:
             self.current_rot_mat, self.rot_matrix = get_single_rot_mat_torch(self.args.head_dim, start_pos_ids)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -59,6 +59,7 @@ class TtTransformer(LightweightModule):
         )
 
         self.compute_kernel = self.args.get_compute_kernel_config()
+        self.compute_kernel_reduce = self.args.get_compute_kernel_config_reduce()
 
         if self.rotary_on_host:
             self.current_rot_mat, self.rot_matrix = get_single_rot_mat_torch(self.args.head_dim, start_pos_ids)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -49,6 +49,7 @@ class TtMoeLayer(LightweightModule):
 
         self.tile_size = 32
         self.compute_kernel = args.get_compute_kernel_attn_config()
+        self.compute_kernel_reduce = args.get_compute_kernel_config_reduce()
 
         top8_mask = torch.full((1, 1, 1, 64), fill_value=torch.finfo(torch.float).min)
         top8_mask[:, :, :, :8] = 0.0
@@ -140,6 +141,8 @@ class TtMoeLayer(LightweightModule):
             output_11BH_gathered = ttnn.all_gather(results_11BH, dim=2, num_links=1)
             results_11BH.deallocate(True)
             # Reduction
-            output_11BH_reduced = ttnn.matmul(self.reduce_mask, output_11BH_gathered)
+            output_11BH_reduced = ttnn.matmul(
+                self.reduce_mask, output_11BH_gathered, compute_kernel_config=self.compute_kernel_reduce
+            )
 
         return output_11BH_reduced

--- a/models/demos/t3000/mixtral8x7b/tt/model_config.py
+++ b/models/demos/t3000/mixtral8x7b/tt/model_config.py
@@ -424,6 +424,12 @@ class TtModelArgs:
             packer_l1_acc=True,
         )
 
+        self.compute_kernel_config_reduce = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
         self.compute_kernel_attn_config = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi2,
             fp32_dest_acc_en=True,
@@ -471,6 +477,9 @@ class TtModelArgs:
 
     def get_compute_kernel_config(self):
         return self.compute_kernel_config
+
+    def get_compute_kernel_config_reduce(self):
+        return self.compute_kernel_config_reduce
 
     def get_compute_kernel_attn_config(self):
         return self.compute_kernel_attn_config

--- a/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
+++ b/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
@@ -72,8 +72,11 @@ Ideal cycles = (m * k * n) / (tile_height * tile_width * tile_height) * (cycle_p
 - For utilization of user-specified grid size, num_cores is the user-specified number of cores. In this microbenchmark, it's 8x8.
 - For utilization of full grid size, num_cores is the maximum number of cores available for compute. Currently the max available is 8x8, but will be extended to 8x9 soon.
 
+### Manually tuned Performance
 
-### Resuls: Peak FLOPS
+Here we show the peak results we can get based on manually selected matmul configuturations, including packer l1 enablement, math fidelity, input output sharding, and input ouput L1/DRAM selection.
+
+#### Peak FLOPS
 
 Depending on the fidelity, datatype, and matrix shape chosen, different peak teraflop values can be achieved.
 
@@ -284,6 +287,96 @@ Given input matrix A of 512x1024 and B of 1024x2048 to produce output matrix 512
 |  1024 |  1024 |  1024 | True        | (8, 8)      | True          | True          | L1                 | DRAM               | L1                 | DataType.BFLOAT16  | MathFidelity.HiFi2 |           36845.2         |          58.28 | 44.47%                       | 44.47%       
 
 ![A simple bar chart of the TFLOPS on WH when using square vs rectangular matrcies](images/effects_of_shapes.png "Square vs rectangular Matrix TFLOPS on WH from SRAM")
+
+
+### Out of Box performance
+
+We also show the peak results we can get based on auto-selected matmul configuturations, which the matmul op itself chooses the configuraitons. It currently is not perfect and we'll continue improve it so that it can match or even surpass the manually selected ones. We show the results from 512x512x512 to 4096x4096x4096. The reason we are not testing shapes larger is due to the wrong selections of matmul configuturations.
+
+As we can see, the results are comprable to the manutally selected.
+
+#### The full results table
+
+| m | k | n | use_trace | grid_size | in0_storage_type | in1_storage_type | out_storage_type | dtype | math_fidelity | inference_time_avg (ns) | TFLOPs (avg) | Utilization (vs user grid) | Utilization (vs 8x8 full grid) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 512 | 512 | 512 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 400640.96 | 0.67 | 0.51% | 0.51% |
+| 512 | 1024 | 1024 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 296726.23 | 3.62 | 2.76% | 2.76% |
+| 512 | 1024 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 297236.44 | 7.22 | 5.51% | 5.51% |
+| 1024 | 1024 | 1024 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 299668.31 | 7.17 | 5.47% | 5.47% |
+| 1024 | 1024 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 300722.12 | 14.28 | 10.90% | 10.90% |
+| 1024 | 2048 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 300738.81 | 28.56 | 21.79% | 21.79% |
+| 2048 | 2048 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 305151.94 | 56.3 | 42.95% | 42.95% |
+| 2048 | 2048 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 460939.41 | 55.91 | 42.65% | 42.65% |
+| 2048 | 3072 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 596759.32 | 64.77 | 49.42% | 49.42% |
+| 3072 | 3072 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 902006.63 | 64.28 | 49.04% | 49.04% |
+| 3072 | 3072 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 1180622.58 | 65.48 | 49.96% | 49.96% |
+| 3072 | 4096 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 1516034.6 | 67.99 | 51.87% | 51.87% |
+| 4096 | 4096 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 2168009.28 | 63.39 | 48.37% | 48.37% |
+| 512 | 512 | 512 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 393490.79 | 0.68 | 0.52% | 0.52% |
+| 512 | 1024 | 1024 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 114793.78 | 9.35 | 7.14% | 7.14% |
+| 512 | 1024 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 141630.17 | 15.16 | 11.57% | 11.57% |
+| 1024 | 1024 | 1024 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 70357.32 | 30.52 | 23.29% | 23.29% |
+| 1024 | 1024 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 115475.65 | 37.19 | 28.38% | 28.38% |
+| 1024 | 2048 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 163207.05 | 52.63 | 40.16% | 40.16% |
+| 2048 | 2048 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 302982.33 | 56.7 | 43.26% | 43.26% |
+| 2048 | 2048 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 451309.68 | 57.1 | 43.56% | 43.56% |
+| 2048 | 3072 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 580670.83 | 66.57 | 50.79% | 50.79% |
+| 3072 | 3072 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 873718.26 | 66.36 | 50.63% | 50.63% |
+| 3072 | 3072 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 1135830.88 | 68.06 | 51.93% | 51.93% |
+| 3072 | 4096 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 1455934.05 | 70.8 | 54.02% | 54.02% |
+| 4096 | 4096 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT16 | MathFidelity.HiFi2 | 2048006.06 | 67.11 | 51.20% | 51.20% |
+| 512 | 512 | 512 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 371801.85 | 0.72 | 0.28% | 0.28% |
+| 512 | 1024 | 1024 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 300638.68 | 3.57 | 1.36% | 1.36% |
+| 512 | 1024 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 293450.36 | 7.32 | 2.79% | 2.79% |
+| 1024 | 1024 | 1024 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 300242.9 | 7.15 | 2.73% | 2.73% |
+| 1024 | 1024 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 299191.47 | 14.36 | 5.48% | 5.48% |
+| 1024 | 2048 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 300562.38 | 28.58 | 10.90% | 10.90% |
+| 2048 | 2048 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 300052.17 | 57.26 | 21.84% | 21.84% |
+| 2048 | 2048 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 303642.75 | 84.87 | 32.37% | 32.37% |
+| 2048 | 3072 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 304903.98 | 126.78 | 48.36% | 48.36% |
+| 3072 | 3072 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 451674.46 | 128.37 | 48.97% | 48.97% |
+| 3072 | 3072 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 585849.29 | 131.96 | 50.34% | 50.34% |
+| 3072 | 4096 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 749573.71 | 137.52 | 52.46% | 52.46% |
+| 4096 | 4096 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 1039688.59 | 132.19 | 50.43% | 50.43% |
+| 512 | 512 | 512 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 365591.05 | 0.73 | 0.28% | 0.28% |
+| 512 | 1024 | 1024 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 73513.98 | 14.61 | 5.57% | 5.57% |
+| 512 | 1024 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 86894.04 | 24.71 | 9.43% | 9.43% |
+| 1024 | 1024 | 1024 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 41377.54 | 51.9 | 19.80% | 19.80% |
+| 1024 | 1024 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 67162.51 | 63.95 | 24.39% | 24.39% |
+| 1024 | 2048 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 91803.07 | 93.57 | 35.69% | 35.69% |
+| 2048 | 2048 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 159378.05 | 107.79 | 41.12% | 41.12% |
+| 2048 | 2048 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 235373.97 | 109.48 | 41.77% | 41.77% |
+| 2048 | 3072 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 300071.24 | 128.82 | 49.14% | 49.14% |
+| 3072 | 3072 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 441164.97 | 131.43 | 50.14% | 50.14% |
+| 3072 | 3072 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 570080.28 | 135.61 | 51.73% | 51.73% |
+| 3072 | 4096 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 736315.25 | 139.99 | 53.40% | 53.40% |
+| 4096 | 4096 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT8_B | MathFidelity.LoFi | 996146.2 | 137.97 | 52.63% | 52.63% |
+| 512 | 512 | 512 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 367822.65 | 0.73 | 0.28% | 0.28% |
+| 512 | 1024 | 1024 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 295593.74 | 3.63 | 1.39% | 1.39% |
+| 512 | 1024 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 294413.57 | 7.29 | 2.78% | 2.78% |
+| 1024 | 1024 | 1024 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 299553.87 | 7.17 | 2.73% | 2.73% |
+| 1024 | 1024 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 299890.04 | 14.32 | 5.46% | 5.46% |
+| 1024 | 2048 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 301394.46 | 28.5 | 10.87% | 10.87% |
+| 2048 | 2048 | 2048 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 299687.39 | 57.33 | 21.87% | 21.87% |
+| 2048 | 2048 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 299446.58 | 86.06 | 32.83% | 32.83% |
+| 2048 | 3072 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 300545.69 | 128.62 | 49.06% | 49.06% |
+| 3072 | 3072 | 3072 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 338408.95 | 171.34 | 65.36% | 65.36% |
+| 3072 | 3072 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 447473.53 | 172.77 | 65.91% | 65.91% |
+| 3072 | 4096 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 564715.86 | 182.53 | 69.63% | 69.63% |
+| 4096 | 4096 | 4096 | False | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 766568.18 | 179.29 | 68.39% | 68.39% |
+| 512 | 512 | 512 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 361955.17 | 0.74 | 0.28% | 0.28% |
+| 512 | 1024 | 1024 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 58608.06 | 18.32 | 6.99% | 6.99% |
+| 512 | 1024 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 65336.23 | 32.87 | 12.54% | 12.54% |
+| 1024 | 1024 | 1024 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 28140.54 | 76.31 | 29.11% | 29.11% |
+| 1024 | 1024 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 44860.84 | 95.74 | 36.52% | 36.52% |
+| 1024 | 2048 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 64001.08 | 134.22 | 51.20% | 51.20% |
+| 2048 | 2048 | 2048 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 115413.67 | 148.85 | 56.78% | 56.78% |
+| 2048 | 2048 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 171816.35 | 149.98 | 57.21% | 57.21% |
+| 2048 | 3072 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 232594.01 | 166.19 | 63.40% | 63.40% |
+| 3072 | 3072 | 3072 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 333464.15 | 173.88 | 66.33% | 66.33% |
+| 3072 | 3072 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 437791.35 | 176.59 | 67.36% | 67.36% |
+| 3072 | 4096 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 551083.09 | 187.05 | 71.35% | 71.35% |
+| 4096 | 4096 | 4096 | True | (8, 8) | DRAM | DRAM | DRAM | DataType.BFLOAT4_B | MathFidelity.LoFi | 728187.56 | 188.74 | 72.00% | 72.00% |
 
 
 

--- a/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
+++ b/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
@@ -25,7 +25,7 @@ Alternatively, to test on an N300 card, use the following command:
 
 ```bash
 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf
-``` 
+```
 
 
 ## Design of Experiments
@@ -47,28 +47,28 @@ For example, when changing the precision of the matrix, for a given size of matr
 
 ### Matrix Multiplication TFLOPs on Wormhole (WH)
 
-The WH matrix engine performs 8x16 x 16x16 = 8x16 in a single cycle. 
-- This is 2*8\*16\*16 = 4096 muladds in a single cycle. 
-- At 1GHz, this is 4 TFLOPs per matrix engine. 
+The WH matrix engine performs 8x16 x 16x16 = 8x16 in a single cycle.
+- This is 2*8\*16\*16 = 4096 muladds in a single cycle.
+- At 1GHz, this is 4 TFLOPs per matrix engine.
 - The 8x16 is the smallest matrix that can be fed into in0, and 16x16 is the smallest matrix that can be fed into in1.
 
 If the input matrices fed into the engine are "shorter" than 8x16, for example 1x16, the engine will still perform 8x16 x 16x16 = 8x16, but the effective throughput will be 1/8.
 Thus, for 1x16 x 16x16 matrices, the effective throughput is 0.5 TFLOP per matrix engine.
 
 MATH_FIDELITY is used for higher precision, and TFLOPs are calculated by dividing by the MATH_FIDELITY value.
-- LoFi ->  ~4 TFLOPs 
-- HiFi2 -> ~2 TFLOPs 
-- HiFi3 -> ~1.33 TFLOPs 
+- LoFi ->  ~4 TFLOPs
+- HiFi2 -> ~2 TFLOPs
+- HiFi3 -> ~1.33 TFLOPs
 - HiFi4 -> ~1 TFLOPs
 
 
 ### Utilization derivation formula
 
 ```
-Utilization = ideal cycles / actual cycles. 
+Utilization = ideal cycles / actual cycles.
 Ideal cycles = (m * k * n) / (tile_height * tile_width * tile_height) * (cycle_per_tile / num_cores)
 ```
-- Cycle_per_tile is the ideal compute cycle for each tile, which depends on math fidelity (LoFi: 16, HiFi2: 32, HiFi3: 48, HiFi4: 64). 
+- Cycle_per_tile is the ideal compute cycle for each tile, which depends on math fidelity (LoFi: 16, HiFi2: 32, HiFi3: 48, HiFi4: 64).
 - For utilization of user-specified grid size, num_cores is the user-specified number of cores. In this microbenchmark, it's 8x8.
 - For utilization of full grid size, num_cores is the maximum number of cores available for compute. Currently the max available is 8x8, but will be extended to 8x9 soon.
 
@@ -84,7 +84,7 @@ Below is the results generated from running the benchmark script, showcasing the
 
 We also show the results with and without trace (see [AdvancedPerformanceOptimizationsForModels](../AdvancedPerformanceOptimizationsForModels/AdvancedPerformanceOptimizationsForModels.md) for details of trace). With trace, we can minimize the overhead of host which can reflect the actual device performance better.
 
-Finally, we present the results in terms of device time, device throughput in TFLOPs, device utilization compared to the user-specified grid size and device utilization compared to the full grid size (8x8 in Wormhole). Utilization is calculated with 
+Finally, we present the results in terms of device time, device throughput in TFLOPs, device utilization compared to the user-specified grid size and device utilization compared to the full grid size (8x8 in Wormhole). Utilization is calculated with
 
 
 #### TFLOPS plot across all matrix sizes and configurations
@@ -284,7 +284,7 @@ Given input matrix A of 512x1024 and B of 1024x2048 to produce output matrix 512
 |     m |     k |     n | use_trace   | grid_size   | in0_sharded   | out_sharded   | in0_storage_type   | in1_storage_type   | out_storage_type   | dtype              | math_fidelity      |   inference_time_avg (ns) |   TFLOPs (avg) | Utilization (vs user grid)   | Utilization (vs 8x8 full grid)   |
 |------:|------:|------:|:------------|:------------|:--------------|:--------------|:-------------------|:-------------------|:-------------------|:-------------------|:-------------------|--------------------------:|---------------:|:-----------------------------|:---------------------------------|
 |   512 |  1024 |  2048 | True        | (8, 8)      | True          | True          | L1                 | DRAM               | L1                 | DataType.BFLOAT16  | MathFidelity.HiFi2 |           52824           |          40.65 | 31.02%                       | 31.02%                           |
-|  1024 |  1024 |  1024 | True        | (8, 8)      | True          | True          | L1                 | DRAM               | L1                 | DataType.BFLOAT16  | MathFidelity.HiFi2 |           36845.2         |          58.28 | 44.47%                       | 44.47%       
+|  1024 |  1024 |  1024 | True        | (8, 8)      | True          | True          | L1                 | DRAM               | L1                 | DataType.BFLOAT16  | MathFidelity.HiFi2 |           36845.2         |          58.28 | 44.47%                       | 44.47%
 
 ![A simple bar chart of the TFLOPS on WH when using square vs rectangular matrcies](images/effects_of_shapes.png "Square vs rectangular Matrix TFLOPS on WH from SRAM")
 

--- a/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
+++ b/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
@@ -18,14 +18,30 @@ Therefore, the peak achieved flops changes based on the datatype, the size of th
 The matrix multiply TFLOPS results can be tested on N150 card using:
 
 ```bash
-pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf
+TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf
 ```
+
+for manually selected matmul configurations, or using:
+
+```bash
+TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf_out_of_box
+```
+
+for out-of-box matmul configurations.
 
 Alternatively, to test on an N300 card, use the following command:
 
 ```bash
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf
 ```
+
+for manually selected matmul configurations, or using:
+
+```bash
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf_out_of_box
+```
+
+for out-of-box matmul configurations.
 
 
 ## Design of Experiments

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -403,7 +403,7 @@ def test_matmul_2d_host_perf(
                 )
 
 
-matmul_shapes_bfloat16_oob = [
+matmul_shapes_oob = [
     (512, 512, 512),
     (512, 1024, 1024),
     (512, 1024, 2048),
@@ -422,6 +422,10 @@ matmul_shapes_bfloat16_oob = [
 matmul_configs_oob = [
     (ttnn.bfloat16, False),
     (ttnn.bfloat16, True),
+    (ttnn.bfloat8_b, False),
+    (ttnn.bfloat8_b, True),
+    (ttnn.bfloat4_b, False),
+    (ttnn.bfloat4_b, True),
 ]
 
 
@@ -472,11 +476,14 @@ def test_matmul_2d_host_perf_out_of_box(
             ]
         )
 
-        math_fidelity = ttnn.MathFidelity.HiFi2
-
         for dtype, use_trace in matmul_configs_oob:
+            matmul_shapes = matmul_shapes_oob
             if dtype == ttnn.bfloat16:
-                matmul_shapes = matmul_shapes_bfloat16_oob
+                math_fidelity = ttnn.MathFidelity.HiFi2
+            elif dtype == ttnn.bfloat8_b:
+                math_fidelity = ttnn.MathFidelity.LoFi
+            elif dtype == ttnn.bfloat4_b:
+                math_fidelity = ttnn.MathFidelity.LoFi
             for m, k, n in matmul_shapes:
                 profiler.clear()
 

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -401,3 +401,179 @@ def test_matmul_2d_host_perf(
                         utilization_full_grid_percentage,
                     ]
                 )
+
+
+matmul_shapes_bfloat16_oob = [
+    (512, 512, 512),
+    (512, 1024, 1024),
+    (512, 1024, 2048),
+    (1024, 1024, 1024),
+    (1024, 1024, 2048),
+    (1024, 2048, 2048),
+    (2048, 2048, 2048),
+    (2048, 2048, 3072),
+    (2048, 3072, 3072),
+    (3072, 3072, 3072),
+    (3072, 3072, 4096),
+    (3072, 4096, 4096),
+    (4096, 4096, 4096),
+]
+
+matmul_configs_oob = [
+    (ttnn.bfloat16, False),
+    (ttnn.bfloat16, True),
+]
+
+
+@pytest.mark.skip(reason="WH didt hang, need to skip CI and run locally only")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
+@pytest.mark.parametrize("grid_size", [(8, 8)])
+@pytest.mark.parametrize("tile_h", [32])
+@pytest.mark.parametrize("tile_w", [32])
+@pytest.mark.parametrize("num_warmup_iterations", [5])
+@pytest.mark.parametrize("num_measurement_iterations", [100])
+def test_matmul_2d_host_perf_out_of_box(
+    device,
+    grid_size,
+    tile_h,
+    tile_w,
+    num_warmup_iterations,
+    num_measurement_iterations,
+    use_program_cache,
+):
+    ENVS = dict(os.environ)
+    TT_METAL_HOME = Path(ENVS["TT_METAL_HOME"])
+    ARTIFACTS_DIR = TT_METAL_HOME / "generated"
+    FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_out_of_box_report.csv"
+
+    LoFi_cycle = 16
+    HiFi2_cycle = LoFi_cycle * 2
+    HiFi3_cycle = LoFi_cycle * 3
+    HiFi4_cycle = LoFi_cycle * 4
+
+    with open(FILE_NAME, mode="w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(
+            [
+                "m",
+                "k",
+                "n",
+                "use_trace",
+                "grid_size",
+                "in0_storage_type",
+                "in1_storage_type",
+                "out_storage_type",
+                "dtype",
+                "math_fidelity",
+                "inference_time_avg (ns)",
+                "TFLOPs (avg)",
+                "Utilization (vs user grid)",
+                "Utilization (vs 8x8 full grid)",
+            ]
+        )
+
+        math_fidelity = ttnn.MathFidelity.HiFi2
+
+        for dtype, use_trace in matmul_configs_oob:
+            if dtype == ttnn.bfloat16:
+                matmul_shapes = matmul_shapes_bfloat16_oob
+            for m, k, n in matmul_shapes:
+                profiler.clear()
+
+                in0_shape = [1, 1, m, k]
+                in1_shape = [1, 1, k, n]
+
+                in0 = torch.ones(in0_shape).bfloat16()
+                in1 = torch.randn(in1_shape).bfloat16()
+
+                in0_storage_type = "DRAM"
+                in1_storage_type = "DRAM"
+                out_storage_type = "DRAM"
+
+                in0_t = ttnn.from_torch(
+                    in0,
+                    tile=ttnn.Tile((tile_h, 32)),
+                    dtype=dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+                in1_t = ttnn.from_torch(
+                    in1,
+                    tile=ttnn.Tile((32, tile_w)),
+                    dtype=dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+
+                output_t = in0_t @ in1_t
+
+                for iter in range(0, num_warmup_iterations):
+                    output_t = in0_t @ in1_t
+
+                if use_trace:
+                    tid = ttnn.begin_trace_capture(device, cq_id=0)
+                    for iter in range(0, num_measurement_iterations):
+                        output_t = in0_t @ in1_t
+                    ttnn.end_trace_capture(device, tid, cq_id=0)
+                    profiler.start(f"run")
+                    ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+                    ttnn.synchronize_device(device)
+                    profiler.end(f"run")
+                    ttnn.release_trace(device, tid)
+                else:
+                    profiler.start(f"run")
+                    for iter in range(0, num_measurement_iterations):
+                        output_t = in0_t @ in1_t
+                    ttnn.synchronize_device(device)
+                    profiler.end(f"run")
+
+                ttnn.DumpDeviceProfiler(device)
+
+                inference_time_avg = profiler.get("run") / num_measurement_iterations
+                tflops = 2 * m * k * n / 1e12 / inference_time_avg
+                if math_fidelity == ttnn.MathFidelity.LoFi:
+                    cycle_per_tile = LoFi_cycle
+                elif math_fidelity == ttnn.MathFidelity.HiFi2:
+                    cycle_per_tile = HiFi2_cycle
+                elif math_fidelity == ttnn.MathFidelity.HiFi3:
+                    cycle_per_tile = HiFi3_cycle
+                elif math_fidelity == ttnn.MathFidelity.HiFi4:
+                    cycle_per_tile = HiFi4_cycle
+                num_cores_user_grid = grid_size[0] * grid_size[1]
+                compute_grid_size = device.compute_with_storage_grid_size()
+                num_cores_full_grid = compute_grid_size.x * compute_grid_size.y
+                ideal_cycle_full_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_full_grid
+                ideal_cycle_user_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_user_grid
+                inference_cycle = inference_time_avg * get_device_freq() * 1e6
+                utilization_full_grid = ideal_cycle_full_grid / inference_cycle
+                utilization_user_grid = ideal_cycle_user_grid / inference_cycle
+                utilization_full_grid_percentage = f"{utilization_full_grid * 100:.2f}%"
+                utilization_user_grid_percentage = f"{utilization_user_grid * 100:.2f}%"
+                logger.info(
+                    f"M*K*N = {m}*{k}*{n} == inference time (avg): {inference_time_avg}, tflops (avg): {tflops}, utilization (vs user grid): {utilization_user_grid_percentage}, utilization (vs 8x8 grid): {utilization_full_grid_percentage}"
+                )
+
+                output_tensor = ttnn.to_torch(output_t)
+                ttnn.deallocate(output_t)
+                ttnn.deallocate(in0_t)
+                ttnn.deallocate(in1_t)
+                writer.writerow(
+                    [
+                        m,
+                        k,
+                        n,
+                        f"{True}" if use_trace else f"{False}",
+                        grid_size,
+                        in0_storage_type,
+                        in1_storage_type,
+                        out_storage_type,
+                        dtype,
+                        math_fidelity,
+                        f"{inference_time_avg * 1e9:.2f}",
+                        f"{tflops:.2f}",
+                        utilization_user_grid_percentage,
+                        utilization_full_grid_percentage,
+                    ]
+                )

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -436,7 +436,8 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
                 && input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED
                 && input_tensor_a.memory_config().buffer_type == BufferType::DRAM
                 && input_tensor_b.memory_config().buffer_type == BufferType::DRAM
-                && mem_config.buffer_type == BufferType::DRAM) {
+                && mem_config.buffer_type == BufferType::DRAM
+                && num_cores_x == 8 && num_cores_y == 8) {
 
                 in0_block_w = !transpose_mcast ? Kt / num_cores_x : Kt / num_cores_y;
                 per_core_M = !transpose_mcast ? Mt / num_cores_y : Mt / num_cores_x;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -154,7 +154,9 @@ inline uint32_t get_estimated_size_of_cbs(
     uint32_t in0_block_w,
     uint32_t in0_single_tile_size,
     uint32_t in1_single_tile_size,
-    uint32_t output_single_tile_size) {
+    uint32_t output_single_tile_size,
+    uint32_t interm_single_tile_size = 0
+    ) {
     // Circular Buffer sizes:
     // src0 CB: per_core_M * in0_block_w * 2 (for double buffer)
     // src1 CB: per_core_N * in0_block_w * 2 (for double buffer)
@@ -163,7 +165,8 @@ inline uint32_t get_estimated_size_of_cbs(
     uint32_t in0_size = per_core_M * in0_block_w * 2 * in0_single_tile_size;
     uint32_t in1_size = per_core_M * in0_block_w * 2 * in1_single_tile_size;
     uint32_t out_size = per_core_M * per_core_N * output_single_tile_size;
-    return in0_size + in1_size + out_size;
+    uint32_t interm_size = per_core_M * per_core_N * interm_single_tile_size;
+    return in0_size + in1_size + out_size + interm_size;
 }
 
 inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
@@ -213,7 +216,7 @@ inline uint32_t get_per_core_factor(const Tensor& input_tensor_a, const Tensor& 
     return 1;
 }
 
-inline std::vector<uint32_t> get_mutlti_dim_per_core_factor(const Tensor& input_tensor_a, const Tensor& input_tensor_b, uint32_t per_core_M, uint32_t per_core_N, uint32_t in0_block_w) {
+inline std::vector<uint32_t> get_mutlti_dim_per_core_factor(const Tensor& input_tensor_a, const Tensor& input_tensor_b, uint32_t per_core_M, uint32_t per_core_N, uint32_t in0_block_w, uint32_t interm_cb_size) {
     uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
@@ -228,7 +231,8 @@ inline std::vector<uint32_t> get_mutlti_dim_per_core_factor(const Tensor& input_
                     per_core_factor_k,
                     in0_single_tile_size,
                     in1_single_tile_size,
-                    in0_single_tile_size);
+                    in0_single_tile_size,
+                    interm_cb_size);
                 if (size < max_l1_space) {
                     return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
                 }
@@ -438,7 +442,7 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
                 per_core_M = !transpose_mcast ? Mt / num_cores_y : Mt / num_cores_x;
                 per_core_N = !transpose_mcast ? Nt / num_cores_x : Nt / num_cores_y;
 
-                auto mutlti_dim_per_core_factor = get_mutlti_dim_per_core_factor(input_tensor_a, input_tensor_b, per_core_M, per_core_N, in0_block_w);
+                auto mutlti_dim_per_core_factor = get_mutlti_dim_per_core_factor(input_tensor_a, input_tensor_b, per_core_M, per_core_N, in0_block_w, tt_metal::detail::TileSize(tt::DataFormat::Float16_b));
                 out_block_h = mutlti_dim_per_core_factor[0];
                 out_block_w = mutlti_dim_per_core_factor[1];
                 in0_block_w = mutlti_dim_per_core_factor[2];
@@ -968,7 +972,10 @@ Matmul create_matmul_struct(
     auto arch = input_tensor_a.device()->arch();
     const bool has_user_grid = parameters.user_core_coord.has_value();
     const bool has_program_config = parameters.program_config.has_value();
-    const auto increase_fidelity = !has_program_config && !has_user_grid;
+    bool are_inputs_low_precision_df =
+            ((input_tensor_a.get_dtype() == DataType::BFLOAT8_B || input_tensor_a.get_dtype() == DataType::BFLOAT4_B) &&
+            (input_tensor_b.get_dtype() == DataType::BFLOAT8_B || input_tensor_b.get_dtype() == DataType::BFLOAT4_B));
+    const auto increase_fidelity = !has_program_config && !has_user_grid && !are_inputs_low_precision_df;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
     auto kernel_config_val = init_device_compute_kernel_config(arch, parameters.compute_kernel_config, math_fidelity, false /*default_approx_mode*/, false /*default_fp32_acc*/, true /*default_l1_acc*/);
     bool broadcast_batch =

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -213,6 +213,31 @@ inline uint32_t get_per_core_factor(const Tensor& input_tensor_a, const Tensor& 
     return 1;
 }
 
+inline std::vector<uint32_t> get_mutlti_dim_per_core_factor(const Tensor& input_tensor_a, const Tensor& input_tensor_b, uint32_t per_core_M, uint32_t per_core_N, uint32_t in0_block_w) {
+    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
+    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well
+    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
+    for (uint32_t per_core_factor_m = per_core_M; per_core_factor_m > 1; per_core_factor_m /= 2) {
+        for (uint32_t per_core_factor_n = per_core_N; per_core_factor_n > 1; per_core_factor_n /= 2) {
+            for (uint32_t per_core_factor_k = in0_block_w; per_core_factor_k > 1; per_core_factor_k /= 2) {
+                uint32_t size = get_estimated_size_of_cbs(
+                    per_core_factor_m,
+                    per_core_factor_n,
+                    per_core_factor_k,
+                    in0_single_tile_size,
+                    in1_single_tile_size,
+                    in0_single_tile_size);
+                if (size < max_l1_space) {
+                    return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
+                }
+            }
+        }
+    }
+    return {1, 1, 1};
+}
+
 MatmulProgramConfig create_matmul_1d_systolic_array_program_config(
     const ttnn::types::Shape& input_shape_a,
     const ttnn::types::Shape& input_shape_b,
@@ -395,18 +420,41 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
                 (use_mcast_config and mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED)) {
             bool transpose_mcast = input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED &&
                                    input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+            uint32_t out_block_h = per_core_M;
+            uint32_t out_block_w = per_core_N;
             out_subblock_h = 4;
             out_subblock_w = 2;
             if (out_subblock_w != per_core_N) {
                 out_subblock_h = 1;
+            }
+            if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED
+                && mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED
+                && input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED
+                && input_tensor_a.memory_config().buffer_type == BufferType::DRAM
+                && input_tensor_b.memory_config().buffer_type == BufferType::DRAM
+                && mem_config.buffer_type == BufferType::DRAM) {
+
+                in0_block_w = !transpose_mcast ? Kt / num_cores_x : Kt / num_cores_y;
+                per_core_M = !transpose_mcast ? Mt / num_cores_y : Mt / num_cores_x;
+                per_core_N = !transpose_mcast ? Nt / num_cores_x : Nt / num_cores_y;
+
+                auto mutlti_dim_per_core_factor = get_mutlti_dim_per_core_factor(input_tensor_a, input_tensor_b, per_core_M, per_core_N, in0_block_w);
+                out_block_h = mutlti_dim_per_core_factor[0];
+                out_block_w = mutlti_dim_per_core_factor[1];
+                in0_block_w = mutlti_dim_per_core_factor[2];
+
+                auto subblock_hw = bmm_op_utils::get_matmul_subblock_params(
+                    per_core_M, per_core_N, false, false, false);
+                out_subblock_h = std::get<0>(subblock_hw);
+                out_subblock_w = std::get<1>(subblock_hw);
             }
             return MatmulMultiCoreReuseMultiCastProgramConfig{
                 .compute_with_storage_grid_size = {num_cores_x, num_cores_y},
                 .in0_block_w = in0_block_w,
                 .out_subblock_h = out_subblock_h,
                 .out_subblock_w = out_subblock_w,
-                .out_block_h = per_core_M,
-                .out_block_w = per_core_N,
+                .out_block_h = out_block_h,
+                .out_block_w = out_block_w,
                 .per_core_M = per_core_M,
                 .per_core_N = per_core_N,
                 .transpose_mcast = transpose_mcast,
@@ -922,7 +970,7 @@ Matmul create_matmul_struct(
     const bool has_program_config = parameters.program_config.has_value();
     const auto increase_fidelity = !has_program_config && !has_user_grid;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
-    auto kernel_config_val = init_device_compute_kernel_config(arch, parameters.compute_kernel_config, math_fidelity);
+    auto kernel_config_val = init_device_compute_kernel_config(arch, parameters.compute_kernel_config, math_fidelity, false /*default_approx_mode*/, false /*default_fp32_acc*/, true /*default_l1_acc*/);
     bool broadcast_batch =
         parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
     TT_FATAL(!(has_user_grid && has_program_config), "Cannot use both user core grid/coordinates and a program config");


### PR DESCRIPTION
### Problem description
out of box MM 2d gives bad perf. this PR gives a temp workaround for customers to have better perf. We will refactor code for a proper fix later.

Changes are limited to 8x8 grid, all tensors interleaved into dram, packer l1 enable by default, and lower fidelity for low precision inputs.

performance is updated/compared in the [GEMM_FLOPS.md](https://github.com/tenstorrent/tt-metal/pull/15214/commits/99ef5897596a464c233a5b69d162f83a8ed613dc)

TFLOPS compare: 4k x 4k x4k, 36 -> 67

### Checklist
- [x] Post commit CI 
- [x] nightly 
- [x] model
- [x] t3k freq
- [x] blackhole
