### PR TITLE
Add a Debug preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,6 +47,12 @@
         "targets": ["all"]
       },
       {
+        "name": "debug",
+        "configurePreset": "default",
+        "configuration": "Debug",
+        "targets": ["all"]
+      },
+      {
         "name": "clang-tidy",
         "configurePreset": "clang-tidy",
         "configuration": "RelWithDebInfo",


### PR DESCRIPTION
### Ticket
None

### Problem description
The introduction of CMakePresets.json causes VSCode to prefer that and requires a song and dance to deviate from it.  Add a Debug build preset to reduce friction.

### What's changed
Added a new build preset for straight up Debug builds.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
