### PR TITLE
Add a padding-aware, interleaved, tiled transpose HC with a fused padding value parameter

### DIFF
--- a/models/demos/distilbert/tests/test_perf_distilbert.py
+++ b/models/demos/distilbert/tests/test_perf_distilbert.py
@@ -154,7 +154,7 @@ def test_distilbert_perf_device(batch_size, test, reset_seeds):
     if is_grayskull():
         expected_perf = 40.8772
     elif is_wormhole_b0():
-        expected_perf = 90.2505
+        expected_perf = 103.884
 
     command = f"pytest tests/ttnn/integration_tests/distilbert/test_ttnn_distilbert.py::test_distilbert_for_question_answering[sequence_size=768-batch_size=8-model_name=distilbert-base-uncased-distilled-squad]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/vgg/tests/test_perf_vgg.py
+++ b/models/demos/vgg/tests/test_perf_vgg.py
@@ -137,10 +137,10 @@ def test_perf_device_bare_metal_vgg(batch_size, model_name):
     margin = 0.03
 
     if model_name == "ttnn_vgg11":
-        expected_perf = 132.2436 if is_grayskull() else 272.8989
+        expected_perf = 132.2436 if is_grayskull() else 283.289
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg11.py"
     else:
-        expected_perf = 116.1459 if is_grayskull() else 194.4063
+        expected_perf = 116.1459 if is_grayskull() else 201.3867
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg16.py"
 
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -459,10 +459,12 @@ def test_rotary_embedding_llama_with_program_cache(
 
     num_ops = 2  # 2 * rope
     if mode == "decode":
-        num_ops += 3  # embedding + transpose + interleaved_to_sharded
+        num_ops += 4  # embedding + transpose + pad + interleaved_to_sharded
 
         # When batch size is 1, transpose is a no-op
         if batch == 1:
             num_ops -= 1
+        elif batch % 32 == 0:
+            num_ops -= 1  # When batch size is a multiple of 32, no padding
 
     assert device.num_program_cache_entries() == num_ops

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -459,7 +459,7 @@ def test_rotary_embedding_llama_with_program_cache(
 
     num_ops = 2  # 2 * rope
     if mode == "decode":
-        num_ops += 4  # embedding + transpose + pad + interleaved_to_sharded
+        num_ops += 3  # embedding + transpose + interleaved_to_sharded
 
         # When batch size is 1, transpose is a no-op
         if batch == 1:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama_fused_qk.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama_fused_qk.py
@@ -132,6 +132,9 @@ def test_rotary_embedding_llama_fused_qk_with_program_cache(
 
         cache_tensors.append(test_tensor)
 
-    num_ops = 5  # embedding + fused_qk_rope + transpose + pad + interleaved_to_sharded
+    if batch == 32 or batch == 16:
+        num_ops = 4
+    else:
+        num_ops = 5  # embedding + fused_qk_rope + transpose + pad + interleaved_to_sharded
 
     assert device.num_program_cache_entries() == num_ops

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -14,8 +14,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from models.utility_functions import skip_for_grayskull, skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-torch.manual_seed(2005)
-
 
 def transpose(
     input_shape,
@@ -27,6 +25,7 @@ def transpose(
     input_dtype=ttnn.bfloat16,
     expected_program_cache_size=None,
 ):
+    torch.manual_seed(2005)
     output_shape = list(input_shape)
     output_shape[dim0], output_shape[dim1] = input_shape[dim1], input_shape[dim0]
 
@@ -306,6 +305,7 @@ def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
 @pytest.mark.parametrize("h", [230])
 @pytest.mark.parametrize("w", [256])
 def test_tranpose_hw_rm_with_padding(device, n, c, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
     activation_pyt_padded = ttnn.from_torch(
@@ -339,6 +339,7 @@ def test_tranpose_hw_rm_with_padding(device, n, c, h, w):
 @pytest.mark.parametrize("h", [8])
 @pytest.mark.parametrize("w", [256])
 def test_tranpose_hw_rm_no_padding(device, n, c, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
     activation_pyt_padded = ttnn.from_torch(
@@ -356,6 +357,7 @@ def test_tranpose_hw_rm_no_padding(device, n, c, h, w):
 
 
 def run_tranpose_hw_rm_program_cache(device, n, c, h, w, use_program_cache):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
     activation_pyt_padded = ttnn.from_torch(
@@ -400,6 +402,7 @@ def test_tranpose_hw_rm_with_program_cache(device, n, c, h, w, use_program_cache
 @pytest.mark.parametrize("h", [16])
 @pytest.mark.parametrize("w", [112])
 def test_tranpose_hw_sharded_rm(device, n, c, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
     tt_input_tensor = ttnn.from_torch(
@@ -435,6 +438,7 @@ def test_tranpose_hw_sharded_rm(device, n, c, h, w):
 
 
 def run_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
     tt_input_tensor = ttnn.from_torch(
@@ -490,6 +494,7 @@ def test_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w, use_progr
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
 def test_tranpose_hc_rm(device, n, c, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(1, 2)
     activation_pyt_padded = ttnn.from_torch(
@@ -508,6 +513,7 @@ def test_tranpose_hc_rm(device, n, c, h, w):
 
 
 def run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(1, 2)
     activation_pyt_padded = ttnn.from_torch(
@@ -545,6 +551,7 @@ def test_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache
 
 
 def run_tranpose_hc_sharded(device, n, c, h, w, grid_size):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(1, 2)
     tt_input_tensor = ttnn.from_torch(
@@ -618,6 +625,7 @@ def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, u
     ],
 )
 def test_transpose_bfloat8_b(device, shape, swap_dims):
+    torch.manual_seed(2005)
     input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = input.transpose(*swap_dims)
 
@@ -660,6 +668,7 @@ def test_transpose_hc(dtype, shape, device):
     [ttnn.TILE_LAYOUT],
 )
 def test_transpose_2D(dtype, shape, layout, device):
+    torch.manual_seed(2005)
     if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull")
     if layout == ttnn.ROW_MAJOR_LAYOUT and dtype == ttnn.bfloat16 and (shape[-1] % 2 or shape[-2] % 2):
@@ -692,6 +701,7 @@ def test_transpose_2D(dtype, shape, layout, device):
     [[0, 1], [0, 2], [2, 1], [-3, -2], [-3, -1], [-2, -1]],
 )
 def test_transpose_3D(dtype, shape, layout, dims, device):
+    torch.manual_seed(2005)
     if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull")
     if layout == ttnn.ROW_MAJOR_LAYOUT and dtype == ttnn.bfloat16 and (shape[-1] % 2 or shape[dims[-1]] % 2):
@@ -711,6 +721,7 @@ def test_transpose_3D(dtype, shape, layout, dims, device):
     [[4, 3, 1280, 40], [1, 4096, 4096]],
 )
 def test_transpose_4d_wh_rm(shape, device):
+    torch.manual_seed(2005)
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(-1, -2)
 
@@ -725,6 +736,7 @@ def test_transpose_4d_wh_rm(shape, device):
     [[4, 3, 1280, 40], [1, 1, 1200, 1280], [1, 1, 4096, 4096]],
 )
 def test_transpose_4d_wh_tile(shape, device):
+    torch.manual_seed(2005)
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(-1, -2)
 
@@ -745,6 +757,7 @@ def test_transpose_4d_wh_tile(shape, device):
 @pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
 def test_transpose_failures(config, memory_config, device):
     pytest.skip("Failures to fix after #13217 and #13005 are in - 5D, HC PCC issue and unaligned RM tensor")
+    torch.manual_seed(2005)
     torch_input = torch.randn(config[0], dtype=torch.bfloat16)
     torch_output = torch_input.transpose(config[1][0], config[1][1])
 
@@ -790,6 +803,7 @@ def test_transpose_failures(config, memory_config, device):
 )
 @pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
 def test_transpose_unaligned(config, memory_config, device):
+    torch.manual_seed(2005)
     # this will convert to tiled for now
     torch_input = torch.randn(config[0], dtype=torch.bfloat16)
     torch_output = torch_input.transpose(config[1][0], config[1][1])
@@ -830,6 +844,7 @@ def test_transpose_hc_padded_c(shape, device):
     [ttnn.ROW_MAJOR_LAYOUT],
 )
 def test_transpose_5d(shape, dims, layout, device):
+    torch.manual_seed(2005)
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(dims[0], dims[1])
 
@@ -869,6 +884,7 @@ def test_transpose_5d(shape, dims, layout, device):
     [ttnn.float32, ttnn.bfloat16],
 )
 def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
+    torch.manual_seed(2005)
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(dims[0], dims[1])
 
@@ -909,6 +925,7 @@ def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
     [None, float("-inf")],
 )
 def test_transpose_unpadded(shape, dims, layout, dtype, pad_value, device):
+    torch.manual_seed(2005)
     if pad_value is not None and is_blackhole():
         pytest.skip("Blackhole reduce is needed for the full test to work")
     elif dtype == ttnn.float32 and is_grayskull():

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -189,8 +189,8 @@ def test_transpose_wh_program_cache(dtype, device, use_program_cache):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat8_b, ttnn.float32, ttnn.bfloat16),
-    ids=["bfloat8_b", "float", "bfloat16"],
+    (ttnn.bfloat8_b, ttnn.float32),
+    ids=["bfloat8_b", "float"],
 )
 def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
     if is_grayskull() and dtype == ttnn.float32:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -872,5 +872,6 @@ def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
 
     tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=layout, device=device)
     tt_output = ttnn.transpose(tt_input, dims[0], dims[1])
+    print(tt_output)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -911,6 +911,8 @@ def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
 def test_transpose_unpadded(shape, dims, layout, dtype, pad_value, device):
     if pad_value is not None and is_blackhole():
         pytest.skip("Blackhole reduce is needed for the full test to work")
+    elif dtype == ttnn.float32 and is_grayskull():
+        pytest.skip("Grayskull does not support float32")
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(dims[0], dims[1])
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -835,3 +835,30 @@ def test_transpose_5d(shape, dims, layout, device):
     tt_output = ttnn.transpose(tt_input, dims[0], dims[1])
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[1, 5, 10, 15], [1, 1, 1, 2]],
+)
+@pytest.mark.parametrize(
+    "dims",
+    [
+        (1, 2),
+        (0, 2),
+    ],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [ttnn.TILE_LAYOUT],
+)
+def test_transpose_issue_11650_10350(shape, dims, layout, device):
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = torch_input.transpose(dims[0], dims[1])
+
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=layout, device=device)
+    print(tt_input)
+    tt_output = ttnn.transpose(tt_input, dims[0], dims[1])
+    print(tt_output)
+    tt_output = ttnn.to_torch(tt_output)
+    assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -614,6 +614,7 @@ def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, u
         ((32, 32, 32, 32), (0, 3)),
         ((32, 32, 32, 32), (1, 3)),
         ((32, 32, 32, 32), (2, 3)),
+        ((32, 32, 32, 32), (0, 1)),
     ],
 )
 def test_transpose_bfloat8_b(device, shape, swap_dims):
@@ -873,7 +874,5 @@ def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
 
     tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=layout, device=device)
     tt_output = ttnn.transpose(tt_input, dims[0], dims[1])
-    # ttnn.set_printoptions(profile="full")
-    print(tt_output)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -909,7 +909,7 @@ def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
     [None, float("-inf")],
 )
 def test_transpose_unpadded(shape, dims, layout, dtype, pad_value, device):
-    if pad_value is not None and is_blackhole:
+    if pad_value is not None and is_blackhole():
         pytest.skip("Blackhole reduce is needed for the full test to work")
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(dims[0], dims[1])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -613,6 +613,7 @@ def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, u
         ((32, 32, 32, 32), (1, 2)),
         ((32, 32, 32, 32), (0, 3)),
         ((32, 32, 32, 32), (1, 3)),
+        ((32, 32, 32, 32), (2, 3)),
     ],
 )
 def test_transpose_bfloat8_b(device, shape, swap_dims):
@@ -872,6 +873,7 @@ def test_transpose_issue_11650_10350(shape, dims, layout, dtype, device):
 
     tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=layout, device=device)
     tt_output = ttnn.transpose(tt_input, dims[0], dims[1])
+    # ttnn.set_printoptions(profile="full")
     print(tt_output)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -155,8 +155,8 @@ def test_transpose_cn_program_cache(dtype, device, use_program_cache):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat16, ttnn.float32),
-    ids=["bfloat16", "float"],
+    (ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b),
+    ids=["bfloat16", "float", "bfloat8_b"],
 )
 def test_transpose_wh_program_cache(dtype, device, use_program_cache):
     if is_grayskull() and dtype == ttnn.float32:
@@ -189,8 +189,8 @@ def test_transpose_wh_program_cache(dtype, device, use_program_cache):
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.bfloat8_b, ttnn.float32),
-    ids=["bfloat8_b", "float"],
+    (ttnn.bfloat8_b, ttnn.float32, ttnn.bfloat16),
+    ids=["bfloat8_b", "float", "bfloat16"],
 )
 def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
     if is_grayskull() and dtype == ttnn.float32:

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -11,12 +11,11 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import is_blackhole
 
-torch.manual_seed(2005)
-
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 def test_permute(device, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.permute(torch_input_tensor, (0, 1, 3, 2))
 
@@ -33,6 +32,7 @@ def test_permute(device, h, w):
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 def test_transpose(device, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
 
@@ -49,6 +49,7 @@ def test_transpose(device, h, w):
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 def test_permute_on_4D_tensor_with_smaller_tuple_size(device, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor)
     input_tensor = ttnn.to_device(input_tensor, device)
@@ -63,6 +64,7 @@ def test_permute_on_4D_tensor_with_smaller_tuple_size(device, h, w):
     "perm", [(0,), (0, 1), (1, 0), (0, 1, 2), (0, 2, 1), (1, 2, 0), (1, 0, 2), (2, 0, 1), (2, 1, 0)]
 )
 def test_permute_on_less_than_4D(device, perm):
+    torch.manual_seed(2005)
     tuple_shape = tuple([32 * (value + 1) for value in perm])
     torch_input_tensor = torch.rand(tuple_shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.permute(torch_input_tensor, perm)
@@ -82,6 +84,7 @@ def test_permute_on_less_than_4D(device, perm):
 @pytest.mark.parametrize("h", [1500])
 @pytest.mark.parametrize("w", [64])
 def test_permute_for_specific_case(device, b, s, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((b, s, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.permute(torch_input_tensor, (0, 1, 3, 2))
     input_tensor = ttnn.from_torch(torch_input_tensor)
@@ -95,6 +98,7 @@ def test_permute_for_specific_case(device, b, s, h, w):
 
 
 def test_add_after_permute(device):
+    torch.manual_seed(2005)
     torch_a = torch.randn(2, 1280, 8, 8)
     torch_b = torch.randn(1, 1, 2, 1280)
     torch_b_permuted = torch.permute(torch_b, (2, 3, 0, 1))
@@ -111,6 +115,7 @@ def test_add_after_permute(device):
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 def test_permute_negative_dim(device, h, w):
+    torch.manual_seed(2005)
     torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.permute(torch_input_tensor, (0, -3, -1, -2))
 
@@ -125,6 +130,7 @@ def test_permute_negative_dim(device, h, w):
 
 
 def test_permute_bfloat8(device):
+    torch.manual_seed(2005)
     input_a = torch.randn(1, 160, 32, 32)
     torch_output = torch.permute(input_a, (0, 2, 3, 1))
 
@@ -139,6 +145,7 @@ def test_permute_bfloat8(device):
 )
 @pytest.mark.parametrize("perm", [(0, 3, 2, 1, 4), (3, 1, 2, 0, 4), (0, 3, 2, 1, 4), (1, 3, 2, 0, 4), (0, 3, 1, 2, 4)])
 def test_permute_5d(shape, perm, device):
+    torch.manual_seed(2005)
     input_a = torch.randn(shape)
     torch_output = torch.permute(input_a, perm)
 
@@ -153,6 +160,7 @@ def test_permute_5d(shape, perm, device):
 def test_permute_pad_value(device, pad_value):
     if pad_value is not None and is_blackhole():
         pytest.skip("Blackhole reduce is needed for the full test to work")
+    torch.manual_seed(2005)
     input_a = torch.randn((2, 11, 33, 17), dtype=torch.bfloat16)
     torch_output = torch.permute(input_a, (3, 2, 1, 0))
 

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -146,3 +146,17 @@ def test_permute_5d(shape, perm, device):
     tt_output = ttnn.permute(tt_input, perm)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+@pytest.mark.parametrize("pad_value", [float("-inf"), None])
+def test_permute_pad_value(device, pad_value):
+    input_a = torch.randn((2, 11, 33, 17), dtype=torch.bfloat16)
+    torch_output = torch.permute(input_a, (3, 2, 1, 0))
+
+    tt_input = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    tt_output = ttnn.permute(tt_input, (3, 2, 1, 0), pad_value=pad_value)
+    if pad_value is not None:
+        a = ttnn.min(tt_output)
+        assert ttnn.to_torch(a) == float("-inf")
+    tt_output = ttnn.to_torch(tt_output)
+    assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, is_blackhole
 
 torch.manual_seed(2005)
 
@@ -150,6 +150,8 @@ def test_permute_5d(shape, perm, device):
 
 @pytest.mark.parametrize("pad_value", [float("-inf"), None])
 def test_permute_pad_value(device, pad_value):
+    if pad_value is not None and is_blackhole():
+        pytest.skip("Blackhole reduce is needed for the full test to work")
     input_a = torch.randn((2, 11, 33, 17), dtype=torch.bfloat16)
     torch_output = torch.permute(input_a, (3, 2, 1, 0))
 

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -8,7 +8,8 @@ import torch
 
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc, is_blackhole
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import is_blackhole
 
 torch.manual_seed(2005)
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -86,6 +86,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/pad/pad.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/permute.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
@@ -124,6 +125,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize/untilize.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -54,11 +54,14 @@ namespace tt::data_movement::common {
     }
 
     // Utility functions
-    FORCE_INLINE constexpr uint32_t div_up(uint32_t a, uint32_t b) {
+    template<uint32_t a, uint32_t b>
+    FORCE_INLINE constexpr uint32_t div_up() {
+        static_assert(b > 0, "divisor must be greater than 0");
         return static_cast<uint32_t>((a + b - 1) / b);
     }
 
-    FORCE_INLINE constexpr uint32_t round_up(uint32_t a, uint32_t b) {
-        return b * div_up(a, b);
+    template<uint32_t a, uint32_t b>
+    FORCE_INLINE constexpr uint32_t round_up() {
+        return b * div_up<a, b>();
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -9,7 +9,7 @@
 namespace tt::data_movement::common {
 
     // this function is useful for converting bfloat16 values to float32
-    float bfloat16_to_float32(uint16_t bfloat16_data) {
+    FORCE_INLINE float bfloat16_to_float32(uint16_t bfloat16_data) {
         uint32_t bits = static_cast<uint32_t>(bfloat16_data) << 16;
 
         // Extract the sign bit
@@ -43,5 +43,22 @@ namespace tt::data_movement::common {
 
         ieee_float.u = sign | exponent | mantissa;
         return ieee_float.f;
+    }
+
+
+    FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, uint32_t val) {
+        auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
+        for (uint32_t i = 0; i < n; ++i) {
+            ptr[i] = val;
+        }
+    }
+
+    // Utility functions
+    FORCE_INLINE constexpr uint32_t div_up(uint32_t a, uint32_t b) {
+        return static_cast<uint32_t>((a + b - 1) / b);
+    }
+
+    FORCE_INLINE constexpr uint32_t round_up(uint32_t a, uint32_t b) {
+        return b * div_up(a, b);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -161,7 +161,7 @@ MassagedConcat build_prepost_transpose_concat(uint8_t queue_id, const MemoryConf
                     tensors.end(),
                     std::back_inserter(itensors),
                     [dim1, dim2](const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
-                        return ttnn::transpose(input_tensor, dim1, dim2, std::nullopt);
+                        return ttnn::transpose(input_tensor, dim1, dim2);
                     }
                 );
                 auto norm_dim1 = tensors.front().get_shape().get_normalized_index(dim1);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -48,7 +48,7 @@ ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& di
 
     if (a.get_shape().rank() > 4) {
         auto input = a.get_layout() == Layout::TILE ? ttnn::to_layout(a, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (Device*)nullptr) : a;
-        TT_FATAL(!(pad_value.has_value() && pad_value.value() != 0.0f), "pad_value is not supported for rank > 4 ");
+        TT_FATAL(!(pad_value.has_value() && pad_value.value() != 0.0f), "Non-zero padding is not supported for permute on tensors with rank > 4.");
         input = ttnn::prim::permute(input, dims, output_mem_config, std::nullopt);
         return ttnn::to_layout(input, a.get_layout(), std::nullopt, std::nullopt, (Device*)nullptr);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -34,7 +34,7 @@ inline bool has_tile_padding(const Tensor& t) {
     return false;
 }
 
-ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& dims, const MemoryConfig& output_mem_config) {
+ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& dims, const MemoryConfig& output_mem_config, const std::optional<float>& pad_value) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     Device * device;
 
@@ -48,6 +48,7 @@ ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& di
 
     if (a.get_shape().rank() > 4) {
         auto input = a.get_layout() == Layout::TILE ? ttnn::to_layout(a, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (Device*)nullptr) : a;
+        TT_FATAL(!(pad_value.has_value() && pad_value.value() != 0.0f), "pad_value is not supported for rank > 4 ");
         input = ttnn::prim::permute(input, dims, output_mem_config, std::nullopt);
         return ttnn::to_layout(input, a.get_layout(), std::nullopt, std::nullopt, (Device*)nullptr);
     }
@@ -68,9 +69,18 @@ ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& di
     formatted_input_tensor = typecast ? ttnn::typecast(formatted_input_tensor, DataType::BFLOAT16) : formatted_input_tensor;
 
     auto output = formatted_input_tensor;
-    static auto transpose_wh = std::bind(ttnn::transpose, std::placeholders::_1, -2, -1, output_mem_config);
-    static auto transpose_hc = std::bind(ttnn::transpose, std::placeholders::_1, 1, -2, output_mem_config);
-    static auto transpose_cn = std::bind(ttnn::transpose, std::placeholders::_1, 0, 1, output_mem_config);
+    auto transpose_wh = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
+        return ttnn::transpose(input, -2, -1, output_mem_config, std::nullopt);
+    };
+
+    auto transpose_hc = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
+        return ttnn::transpose(input, 1, -2, output_mem_config, pad_value);
+    };
+
+    auto transpose_cn = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
+        return ttnn::transpose(input, 0, 1, output_mem_config, std::nullopt);
+    };
+
     if (N == 0 && C == 1 && H == 2 && W == 3) {
         output = formatted_input_tensor;
     } else if (N == 0 && C == 1 && H == 3 && W == 2) {
@@ -126,10 +136,10 @@ ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& di
     return output;
 }
 
-ttnn::Tensor permute_launch(const ttnn::Tensor &a, tt::stl::Span<const int64_t> dims, const MemoryConfig& output_mem_config) {
+ttnn::Tensor permute_launch(const ttnn::Tensor &a, tt::stl::Span<const int64_t> dims, const MemoryConfig& output_mem_config, const std::optional<float>& pad_value) {
     std::vector<ttnn::Tensor> output_tensors = {ttnn::Tensor(operation::get_workers_for_op_output({a}))};
     operation::launch_with_autoformat(
-        [dims, output_mem_config]  (const std::vector<ttnn::Tensor>& input_tensors, const std::vector<std::optional<const ttnn::Tensor>>& optional_input_tensors, const std::vector<std::optional<ttnn::Tensor>>& optional_output_tensors) mutable -> std::vector<ttnn::Tensor> {
+        [dims, output_mem_config, pad_value]  (const std::vector<ttnn::Tensor>& input_tensors, const std::vector<std::optional<const ttnn::Tensor>>& optional_input_tensors, const std::vector<std::optional<ttnn::Tensor>>& optional_output_tensors) mutable -> std::vector<ttnn::Tensor> {
             auto& a = input_tensors.at(0);
             SmallVector<uint32_t> normalized_dims(dims.size());
             std::transform(dims.begin(), dims.end(), normalized_dims.begin(), [a](std::int64_t idx) {return a.get_legacy_shape().get_normalized_index(idx);});
@@ -138,7 +148,7 @@ ttnn::Tensor permute_launch(const ttnn::Tensor &a, tt::stl::Span<const int64_t> 
             if (normalized_dims == seq_dims) {
                 return {ttnn::operations::experimental::auto_format::AutoFormat::move_tensor_to_mem_config(a, output_mem_config)};
             }
-            return {permute_impl(a, normalized_dims, output_mem_config)};
+            return {permute_impl(a, normalized_dims, output_mem_config, pad_value)};
         }, {a}, output_tensors);
     return output_tensors.at(0);
 }
@@ -146,9 +156,10 @@ ttnn::Tensor permute_launch(const ttnn::Tensor &a, tt::stl::Span<const int64_t> 
 Tensor composite_invoke(
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const int64_t> dims,
-    const std::optional<MemoryConfig>& memory_config) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<float>& pad_value) {
 
-    auto output_tensor = permute_launch(input_tensor, dims, memory_config.value_or(input_tensor.memory_config()));
+    auto output_tensor = permute_launch(input_tensor, dims, memory_config.value_or(input_tensor.memory_config()), pad_value);
     return output_tensor;
 }
 
@@ -159,10 +170,11 @@ ttnn::Tensor ExecutePermute::invoke(
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const int64_t> dims,
     const std::optional<MemoryConfig>& memory_config,
-    bool composite) {
+    bool composite,
+    const std::optional<float>& pad_value) {
 
     if (composite)
-        return detail::composite_invoke(input_tensor, dims, memory_config);
+        return detail::composite_invoke(input_tensor, dims, memory_config, pad_value);
 
     const bool initial_input_tensor_on_device = detail::is_on_device(input_tensor);
     const auto input_layout = input_tensor.get_layout();
@@ -188,7 +200,7 @@ ttnn::Tensor ExecutePermute::invoke(
     auto iorder = dims.size() < 4 ? adjust_order(dims) : dims;  // internals of permute_impl already adjust negative indices
 
     TT_FATAL(detail::is_on_device(itensor), "Error");
-    auto output_tensor = detail::permute_launch(itensor, iorder, memory_config.value_or(input_tensor.memory_config()));
+    auto output_tensor = detail::permute_launch(itensor, iorder, memory_config.value_or(input_tensor.memory_config()), pad_value);
     output_tensor = ttnn::to_layout(output_tensor, input_layout, std::nullopt, std::nullopt, (Device*)nullptr);
 
     if (input_rank < 4) {
@@ -216,12 +228,13 @@ ttnn::Tensor ExecutePermute::invoke(
 ttnn::Tensor ExecutePermute::invoke(
     const ttnn::Tensor& input_tensor,
     tt::stl::Span<const int64_t> dims,
-    const std::optional<MemoryConfig>& memory_config) {
-    return invoke(DefaultQueueId, input_tensor, dims, memory_config);
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<float>& pad_value) {
+    return invoke(DefaultQueueId, input_tensor, dims, memory_config, true, pad_value);
 }
 
-ttnn::Tensor ExecutePermute::invoke(const ttnn::Tensor& input_tensor, tt::stl::Span<const int64_t> dims) {
-    return invoke(input_tensor, dims, std::nullopt);
+ttnn::Tensor ExecutePermute::invoke(const ttnn::Tensor& input_tensor, tt::stl::Span<const int64_t> dims, const std::optional<float>& pad_value) {
+    return invoke(input_tensor, dims, std::nullopt, pad_value);
 }
 
 } // ttnn::operations::data_movement namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -55,13 +55,12 @@ ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& di
     TT_FATAL(dims.size() == 4, "Only 4D tensor are supported for permute.");
     uint32_t N = dims[0], C = dims[1], H = dims[2], W = dims[3];
 
-    bool pad_n = H == 0 || W == 0;
-    bool pad_c = H == 1 || W == 1;
     // Convert tensor back to original
     auto input_shape = a.get_logical_shape();
 
     auto formatted_input_tensor = a;
-    bool typecast = formatted_input_tensor.get_dtype() == DataType::BFLOAT8_B and formatted_input_tensor.get_layout() == Layout::TILE and (pad_n or pad_c) and !a.is_sharded();
+    bool wh = W == 2 && H == 3;
+    bool typecast = formatted_input_tensor.get_dtype() == DataType::BFLOAT8_B and !wh && !a.is_sharded();
     formatted_input_tensor = typecast ? ttnn::typecast(formatted_input_tensor, DataType::BFLOAT16) : formatted_input_tensor;
 
     auto output = formatted_input_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -59,8 +59,12 @@ ttnn::Tensor permute_impl(const ttnn::Tensor &a, const SmallVector<uint32_t>& di
     auto input_shape = a.get_logical_shape();
 
     auto formatted_input_tensor = a;
-    bool wh = W == 2 && H == 3;
-    bool typecast = formatted_input_tensor.get_dtype() == DataType::BFLOAT8_B and !wh && !a.is_sharded();
+    // WH and CN should be supported without typecast
+    bool wh = N == 0 && C == 1 && H == 3 && W == 2;
+    bool cn = N == 1 && C == 0 && H == 2 && W == 3;
+    bool cnwh = N == 1 && C == 0 && H == 3 && W == 2;
+    bool bfloat8_supported = wh || cn || cnwh;
+    bool typecast = formatted_input_tensor.get_dtype() == DataType::BFLOAT8_B and !bfloat8_supported && !a.is_sharded();
     formatted_input_tensor = typecast ? ttnn::typecast(formatted_input_tensor, DataType::BFLOAT16) : formatted_input_tensor;
 
     auto output = formatted_input_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -15,14 +15,16 @@ struct ExecutePermute {
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const int64_t> dims,
         const std::optional<MemoryConfig>& memory_config,
-        bool composite = true);
+        bool composite = true,
+        const std::optional<float>& pad_value = 0.0f);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         tt::stl::Span<const int64_t> dims,
-        const std::optional<MemoryConfig>& memory_config);
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<float>& pad_value = 0.0f);
 
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, tt::stl::Span<const int64_t> dims);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, tt::stl::Span<const int64_t> dims, const std::optional<float>& pad_value = 0.0f);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "permute_pybind.hpp"
+
+namespace ttnn::operations::data_movement::detail {
+namespace py = pybind11;
+
+void bind_permute(py::module& module) {
+    auto doc =
+        R"doc(permute(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+
+            Permutes the dimensions of the input tensor according to the specified permutation.
+
+            Args:
+                input_tensor (ttnn.Tensor): the input tensor.
+                dim (number): tthe permutation of the dimensions of the input tensor.
+
+            Keyword Args:
+                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+                queue_id (int, optional): command queue id. Defaults to `0`.
+
+           Returns:
+               List of ttnn.Tensor: the output tensor.
+
+            Example:
+
+                >>> tensor = ttnn.to_device(ttnn.from_torch(torch.zeros((1, 1, 64, 32), dtype=torch.bfloat16)), device)
+                >>> output = ttnn.permute(tensor, (0, 1, 3, 2))
+                >>> print(output.shape)
+                [1, 1, 32, 64])doc";
+
+    using OperationType = decltype(ttnn::permute);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::permute,
+        doc,
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const ttnn::SmallVector<int64_t> &dims,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                uint8_t queue_id,
+                const std::optional<float>& pad_value) {
+                    return self(queue_id, input_tensor, dims, memory_config, false, pad_value);
+                },
+                py::arg("input_tensor").noconvert(),
+                py::arg("dims"),
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt,
+                py::arg("queue_id") = 0,
+                py::arg("pad_value") = 0.0f,
+                });
+}
+
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
@@ -20,6 +20,7 @@ void bind_permute(py::module& module) {
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 queue_id (int, optional): command queue id. Defaults to `0`.
+                pad_value (float, optional): padding value for when tiles are broken in a transpose. Defaults to `0.0`. If set to None, it will be random garbage values.
 
            Returns:
                List of ttnn.Tensor: the output tensor.

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.hpp
@@ -14,48 +14,6 @@
 namespace ttnn::operations::data_movement::detail {
 namespace py = pybind11;
 
-void bind_permute(py::module& module) {
-    auto doc =
-        R"doc(permute(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
-
-            Permutes the dimensions of the input tensor according to the specified permutation.
-
-            Args:
-                input_tensor (ttnn.Tensor): the input tensor.
-                dim (number): tthe permutation of the dimensions of the input tensor.
-
-            Keyword Args:
-                memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-                queue_id (int, optional): command queue id. Defaults to `0`.
-
-           Returns:
-               List of ttnn.Tensor: the output tensor.
-
-            Example:
-
-                >>> tensor = ttnn.to_device(ttnn.from_torch(torch.zeros((1, 1, 64, 32), dtype=torch.bfloat16)), device)
-                >>> output = ttnn.permute(tensor, (0, 1, 3, 2))
-                >>> print(output.shape)
-                [1, 1, 32, 64])doc";
-
-    using OperationType = decltype(ttnn::permute);
-    ttnn::bind_registered_operation(
-        module,
-        ttnn::permute,
-        doc,
-        ttnn::pybind_overload_t{
-            [] (const OperationType& self,
-                const ttnn::Tensor& input_tensor,
-                const ttnn::SmallVector<int64_t> &dims,
-                const std::optional<ttnn::MemoryConfig>& memory_config,
-                uint8_t queue_id) {
-                    return self(queue_id, input_tensor, dims, memory_config, false);
-                },
-                py::arg("input_tensor").noconvert(),
-                py::arg("dims"),
-                py::kw_only(),
-                py::arg("memory_config") = std::nullopt,
-                py::arg("queue_id") = 0});
-}
+void bind_permute(py::module& module);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_interleaved_start_id_with_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_interleaved_start_id_with_padding.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+#include "debug/dprint.h"
+
+template <typename T>
+FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, T val) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(begin_addr);
+    for (uint32_t i = 0; i < n; ++i) {
+        DPRINT << "fill_with_val: " << i << " " << val << ENDL();
+        ptr[i] = val;
+    }
+}
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    #ifdef BACKWARDS
+    uint32_t end_id = start_id - num_tiles;
+    for (uint32_t i = start_id; i != end_id; -- i) {
+    #else
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+    #endif
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+
+    cb_reserve_back(tt::CB::c_in1, 1);
+    uint32_t l1_write_addr = get_write_ptr(tt::CB::c_in1);
+    fill_with_val<uint32_t>(l1_write_addr, 8, 123123);
+    cb_push_back(tt::CB::c_in1, 1);
+
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -4,13 +4,7 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
-
-FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, uint32_t val) {
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
-    for (uint32_t i = 0; i < n; ++i) {
-        ptr[i] = val;
-    }
-}
+#include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);
@@ -55,7 +49,7 @@ void kernel_main() {
         uint32_t l1_write_addr = get_write_ptr(tt::CB::c_in1);
         // Fill with padding value
         // if bfloat16 num_writes = FACE_WIDTH / (sizeof(uint32_t))/(element_size)
-        fill_with_val(l1_write_addr, num_writes, padding_val_packed);
+        tt::data_movement::common::fill_with_val(l1_write_addr, num_writes, padding_val_packed);
         cb_push_back(tt::CB::c_in1, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -10,7 +10,6 @@
 FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, uint32_t val) {
     auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
     for (uint32_t i = 0; i < n; ++i) {
-        // DPRINT << "fill_with_val: " << i << " " << val << ENDL();
         ptr[i] = val;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -5,8 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
-#include "debug/dprint.h"
-
 FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, uint32_t val) {
     auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
     for (uint32_t i = 0; i < n; ++i) {
@@ -60,5 +58,4 @@ void kernel_main() {
         fill_with_val(l1_write_addr, num_writes, padding_val_packed);
         cb_push_back(tt::CB::c_in1, 1);
     }
-
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 
 // Utility functions
 FORCE_INLINE constexpr uint32_t div_up(uint32_t a, uint32_t b) {
@@ -175,8 +174,6 @@ void kernel_main() {
         cb_wait_front(tt::CB::c_in1, 1);
         uint32_t l1_read_ptr = get_read_ptr(tt::CB::c_in1);
         uint32_t c_t = C_t - 1;
-        DPRINT << "start_padding_tile_idx: " << start_padding_tile_idx << ENDL();
-        DPRINT << "end_padding_tile_idx: " << end_padding_tile_idx << ENDL();
         for (uint32_t tile_idx = start_padding_tile_idx; tile_idx < end_padding_tile_idx; ++tile_idx) {
             // Map tile_idx to (n, h, w_t)
             uint32_t n = tile_idx / (H * W_t);
@@ -186,16 +183,13 @@ void kernel_main() {
             uint8_t C_in_tile = C % TILE_HEIGHT;
             uint8_t face_c_start = C_in_tile/ FACE_HEIGHT;
             if (tile_idx == start_padding_tile_idx) {
-                DPRINT << "N: " << n << " H: " << h << " W: " << w_t << " C_in_tile: " << C_in_tile << " face_c_start: " << (uint32_t) face_c_start << ENDL();
             }
             for (uint8_t face_c = face_c_start; face_c < NUM_FACES_H; ++face_c) {
                 uint8_t sub_tile_line_start = face_c == face_c_start ? C_in_tile % FACE_HEIGHT : 0;
                 if (tile_idx == start_padding_tile_idx) {
-                    DPRINT << "face_c: " << (uint32_t) face_c << " sub_tile_line_start: " << (uint32_t) sub_tile_line_start << ENDL();
                 }
                 for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
                     if (tile_idx == start_padding_tile_idx) {
-                        DPRINT << "face_c: " << (uint32_t) face_c << " face_w: " << (uint32_t) face_w << " sub_tile_line_start: " << (uint32_t) sub_tile_line_start << ENDL();
                     }
                     for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+// Utility functions
+inline constexpr uint32_t div_up(uint32_t a, uint32_t b) {
+    return static_cast<uint32_t>((a + b - 1) / b);
+}
+
+inline constexpr uint32_t round_up(uint32_t a, uint32_t b) {
+    return b * div_up(a, b);
+}
+
+void kernel_main() {
+
+    // Retrieve arguments
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t start_tile_idx  = get_arg_val<uint32_t>(1);
+    uint32_t end_tile_idx  = get_arg_val<uint32_t>(2);
+
+    // Compile-time constants
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t element_size = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(2);
+    constexpr uint32_t C = get_compile_time_arg_val(3);
+    constexpr uint32_t H = get_compile_time_arg_val(4);
+    constexpr uint32_t W = get_compile_time_arg_val(5);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(6);
+    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
+    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
+    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
+
+    // Derived compile-time constants
+    constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
+    constexpr uint8_t NUM_FACES_H = TILE_HEIGHT / FACE_HEIGHT;
+    constexpr uint8_t NUM_FACES_W = TILE_WIDTH / FACE_WIDTH;
+
+    constexpr uint32_t C_p = round_up(C, TILE_HEIGHT);
+    constexpr uint32_t H_p = round_up(H, TILE_HEIGHT);
+    constexpr uint32_t W_p = round_up(W, TILE_WIDTH);
+
+    constexpr uint32_t W_t = W_p / TILE_WIDTH;
+    constexpr uint32_t H_t = H_p / TILE_HEIGHT;
+    constexpr uint32_t C_t = C_p / TILE_HEIGHT;
+
+    constexpr uint32_t SUBTILE_LINE_BYTES = FACE_WIDTH * element_size;
+
+    // Initialize address generator
+    const uint32_t tile_bytes = get_tile_size(cb_id_out0);
+    const auto input_data_format = get_dataformat(cb_id_out0);
+
+    const InterleavedAddrGenFast<dst_is_dram, TILE_HW> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = input_data_format
+    };
+
+    // Calculate actual data height in the last tile
+    constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
+
+    // Calculate real_faces_h
+    uint8_t remainder_faces_h = (H_last_tile + FACE_HEIGHT - 1) / FACE_HEIGHT;
+    if (remainder_faces_h > NUM_FACES_H) {
+        // Ensure it does not exceed maximum number of faces per tile
+        remainder_faces_h = NUM_FACES_H;
+    }
+
+    uint32_t remainder = H_last_tile % FACE_HEIGHT;
+    uint8_t sub_tile_lines_real = (remainder == 0) ? FACE_HEIGHT : static_cast<uint8_t>(remainder);
+
+    // Precompute constants used in inner loops
+    const uint32_t face_height_width = FACE_HEIGHT * FACE_WIDTH;
+    const uint32_t num_faces_wh = NUM_FACES_W * FACE_WIDTH;
+
+    // Main single loop over all tiles
+    for (uint32_t tile_idx = start_tile_idx; tile_idx < end_tile_idx; ++tile_idx) {
+        // Compute n, c, h, w from tile_idx
+        uint32_t w = tile_idx % W_t;
+        uint32_t temp = tile_idx / W_t;
+
+        uint32_t h = temp % H_t;
+        temp /= H_t;
+
+        uint32_t c = temp % C;
+        uint32_t n = temp / C;
+
+        // Recalculate variables from the original loops
+        uint32_t output_ct_index = c / TILE_HEIGHT;
+        uint32_t rem = c % TILE_HEIGHT;
+
+        // Calculate the index inside the face_matrix
+        uint32_t output_face_h = rem / FACE_HEIGHT;
+        uint32_t output_sub_tile_line = rem % FACE_HEIGHT;
+
+        // Calculate the index along the channel dimension for the output tensor
+        uint32_t output_h = h * TILE_HEIGHT;
+
+        // Synchronization and read address retrieval
+        cb_wait_front(cb_id_out0, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+
+        // Determine the number of faces in the height dimension
+        uint8_t num_faces_h = (h == H_t - 1) ? remainder_faces_h : NUM_FACES_H;
+
+        // Precompute parts of linear_idx that remain constant within the inner loops
+        // linear_idx = n * H * C_t * W_t + output_h_face_line * C_t * W_t + output_ct_index * W_t + w
+        // We can precompute n * H * C_t * W_t + output_ct_index * W_t + w
+        uint32_t base_linear_idx = n * H * C_t * W_t + output_ct_index * W_t + w;
+
+        // Iterate over faces in the height dimension
+        for (uint8_t face_h = 0; face_h < num_faces_h; ++face_h) {
+            // Compute output_h_face once per face_h
+            uint32_t output_h_face = output_h + face_h * FACE_HEIGHT;
+
+            // Precompute the additive factor for output_h_face_line
+            uint32_t base_output_h_face_line = output_h_face;
+
+            // Iterate over faces in the width dimension
+            for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                // Compute output_w_face once per face_w
+                uint32_t output_w_face = w + face_w * FACE_WIDTH;
+
+                // Precompute the offset multiplier for the current face_w
+                uint32_t face_w_offset = face_w * face_height_width;
+
+                // Determine the number of sub-tile lines to process
+                bool is_last_sub_tile_line = (h == H_t - 1) && (face_h == num_faces_h - 1);
+                uint8_t sub_tile_lines = is_last_sub_tile_line ? sub_tile_lines_real : FACE_HEIGHT;
+
+                // Precompute offset for the current face_h
+                uint32_t face_h_offset = output_face_h * NUM_FACES_W * face_height_width;
+
+                // Iterate over sub-tile lines
+                for (uint8_t sub_tile_line = 0; sub_tile_line < sub_tile_lines; ++sub_tile_line) {
+                    // Compute the complete output_h_face_line
+                    uint32_t output_h_face_line = base_output_h_face_line + sub_tile_line;
+
+                    // Compute the linear index
+                    uint32_t linear_idx = base_linear_idx + output_h_face_line * C_t * W_t;
+
+                    // Compute the offset
+                    uint32_t offset = (face_h_offset + face_w_offset + output_sub_tile_line * FACE_WIDTH) * element_size;
+
+                    // Compute the write address
+                    uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+
+                    // Perform asynchronous write
+                    noc_async_write(l1_read_addr, write_noc_base_addr, SUBTILE_LINE_BYTES);
+
+                    // Increment the read address
+                    l1_read_addr += SUBTILE_LINE_BYTES;
+                }
+
+                // Skip padding if not all lines are real
+                if (is_last_sub_tile_line) {
+                    l1_read_addr += (FACE_HEIGHT - sub_tile_lines) * SUBTILE_LINE_BYTES;
+                }
+            }
+        }
+
+        // Ensure all asynchronous writes are completed before proceeding
+        noc_async_write_barrier();
+
+        // Remove the processed tile from the front of the buffer
+        cb_pop_front(cb_id_out0, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -32,9 +32,9 @@ void kernel_main() {
     constexpr uint8_t NUM_FACES_H = TILE_HEIGHT / FACE_HEIGHT;
     constexpr uint8_t NUM_FACES_W = TILE_WIDTH / FACE_WIDTH;
 
-    constexpr uint32_t C_p = tt::data_movement::common::round_up(C, TILE_HEIGHT);
-    constexpr uint32_t H_p = tt::data_movement::common::round_up(H, TILE_HEIGHT);
-    constexpr uint32_t W_p = tt::data_movement::common::round_up(W, TILE_WIDTH);
+    constexpr uint32_t C_p = tt::data_movement::common::round_up<C, TILE_HEIGHT>();
+    constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
+    constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
 
     constexpr uint32_t W_t = W_p / TILE_WIDTH;
     constexpr uint32_t H_t = H_p / TILE_HEIGHT;
@@ -56,11 +56,7 @@ void kernel_main() {
     constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
 
     // Calculate real_faces_h
-    uint8_t remainder_faces_h = (H_last_tile + FACE_HEIGHT - 1) / FACE_HEIGHT;
-    if (remainder_faces_h > NUM_FACES_H) {
-        // Ensure it does not exceed maximum number of faces per tile
-        remainder_faces_h = NUM_FACES_H;
-    }
+    uint8_t remainder_faces_h = tt::data_movement::common::div_up<H_last_tile, FACE_HEIGHT>();
 
     uint32_t remainder = H_last_tile % FACE_HEIGHT;
     uint8_t sub_tile_lines_real = (remainder == 0) ? FACE_HEIGHT : static_cast<uint8_t>(remainder);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -33,6 +33,7 @@ void kernel_main() {
     constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(7);
     constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(8);
     constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(9);
+    constexpr bool needs_padding = get_compile_time_arg_val(10) == 1;
 
     // Derived compile-time constants
     constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
@@ -170,8 +171,9 @@ void kernel_main() {
     }
 
     // add padding
-    if constexpr (C_p > C) {
+    if constexpr (needs_padding) {
         cb_wait_front(tt::CB::c_in1, 1);
+
         uint32_t l1_read_ptr = get_read_ptr(tt::CB::c_in1);
 
         constexpr uint32_t c_t = C_t - 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -200,8 +200,13 @@ void kernel_main() {
                     // Offset to the start of the current face along the width of the tile
                     uint32_t face_w_offset = face_w * face_height_width;
                     for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
+                        // offset to the start of the current sub-tile line
                         uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line * FACE_WIDTH) * element_size;
+
+                        // Compute the write address
                         uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+
+                        // Perform asynchronous write
                         noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -3,15 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-
-// Utility functions
-FORCE_INLINE constexpr uint32_t div_up(uint32_t a, uint32_t b) {
-    return static_cast<uint32_t>((a + b - 1) / b);
-}
-
-FORCE_INLINE constexpr uint32_t round_up(uint32_t a, uint32_t b) {
-    return b * div_up(a, b);
-}
+#include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
 void kernel_main() {
 
@@ -40,9 +32,9 @@ void kernel_main() {
     constexpr uint8_t NUM_FACES_H = TILE_HEIGHT / FACE_HEIGHT;
     constexpr uint8_t NUM_FACES_W = TILE_WIDTH / FACE_WIDTH;
 
-    constexpr uint32_t C_p = round_up(C, TILE_HEIGHT);
-    constexpr uint32_t H_p = round_up(H, TILE_HEIGHT);
-    constexpr uint32_t W_p = round_up(W, TILE_WIDTH);
+    constexpr uint32_t C_p = tt::data_movement::common::round_up(C, TILE_HEIGHT);
+    constexpr uint32_t H_p = tt::data_movement::common::round_up(H, TILE_HEIGHT);
+    constexpr uint32_t W_p = tt::data_movement::common::round_up(W, TILE_WIDTH);
 
     constexpr uint32_t W_t = W_p / TILE_WIDTH;
     constexpr uint32_t H_t = H_p / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -18,6 +18,7 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to transpose need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr , "Operands to transpose need to be allocated in buffers on device!");
+    TT_FATAL(!(this->dim != TransposeOpDim::HC && this->pad_value.has_value() && this->pad_value != 0.0f), "pad_value is not supported for for non HC transpose operation");
     const auto shape = input_tensor.get_legacy_shape();
     bool row_major = input_tensor.get_layout() == Layout::ROW_MAJOR;
     uint32_t W = shape[3], H = shape[2], C = shape[1], N = shape[0];
@@ -62,6 +63,9 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
         TT_FATAL(
             !(input_tensor.is_sharded() && input_tensor.get_layout() == Layout::TILE),
             "HC transpose does not support sharded+tilized inputs");
+        TT_FATAL(
+            !(input_tensor.is_sharded() && pad_value.has_value() && pad_value.value() != 0.0f),
+            "HC transpose does not support sharded+row_major inputs");
     } else if (this->dim == TransposeOpDim::CW) {
         TT_FATAL(C % TILE_WIDTH == 0, "Error");
         TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
@@ -162,7 +166,7 @@ operation::ProgramWithCallbacks Transpose::create_program(const std::vector<Tens
             if (input_tensor.is_sharded()) {
                 return detail::transpose_hc_multi_core_sharded(input_tensor, output_tensor);
             } else {
-                return detail::transpose_hc_multi_core(input_tensor, output_tensor);
+                return detail::transpose_hc_multi_core(input_tensor, output_tensor, pad_value);
             }
         case TransposeOpParallelizationStrategy::MULTI_CORE_CN:
             return detail::transpose_cn_multi_core(input_tensor, output_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp
@@ -21,6 +21,7 @@ enum class TransposeOpParallelizationStrategy {
 struct Transpose {
     const TransposeOpDim dim;
     const MemoryConfig output_mem_config;
+    const std::optional<float> pad_value;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.hpp
@@ -8,8 +8,8 @@ namespace ttnn::operations::data_movement::detail {
 operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_wh_multi_core_sharded_rm(const Tensor &a, Tensor &output);
-operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor &output);
-operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(const Tensor &a, Tensor &output);
+operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor &output, const std::optional<float>& pad_value);
+operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(const Tensor &a, Tensor &output, const std::optional<float>& pad_value);
 operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor &output);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.hpp
@@ -9,6 +9,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor &a, Tensor 
 operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_wh_multi_core_sharded_rm(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor &output);
+operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a, Tensor &output);
 operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor &output);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -144,12 +144,10 @@ ttnn::Tensor ExecuteTranspose::invoke(
         return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg);
     }
 
-    std::cout << "normalized_dim1: " << normalized_dim1 << std::endl;
-    std::cout << "normalized_dim2: " << normalized_dim2 << std::endl;
-
     bool wh = (normalized_dim1 == 2 && normalized_dim2 == 3) || (normalized_dim2 == 2 && normalized_dim1 == 3);
-    bool typecast = input_unsqueezed.get_dtype() == DataType::BFLOAT8_B and !wh and !input_unsqueezed.is_sharded();
-    std::cout << "typecast: " << typecast << std::endl << std::endl;
+    bool cn = (normalized_dim1 == 0 && normalized_dim2 == 1) || (normalized_dim2 == 0 && normalized_dim1 == 1);
+    bool bfloat8_supported = cn || wh;
+    bool typecast = input_unsqueezed.get_dtype() == DataType::BFLOAT8_B and !bfloat8_supported and !input_unsqueezed.is_sharded();
     Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_typecasted}))};

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -144,8 +144,12 @@ ttnn::Tensor ExecuteTranspose::invoke(
         return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg);
     }
 
+    std::cout << "normalized_dim1: " << normalized_dim1 << std::endl;
+    std::cout << "normalized_dim2: " << normalized_dim2 << std::endl;
+
     bool wh = (normalized_dim1 == 2 && normalized_dim2 == 3) || (normalized_dim2 == 2 && normalized_dim1 == 3);
-    bool typecast = input_unsqueezed.get_dtype() == DataType::BFLOAT8_B and input_unsqueezed.get_layout() == Layout::TILE and !wh and !input_unsqueezed.is_sharded();
+    bool typecast = input_unsqueezed.get_dtype() == DataType::BFLOAT8_B and !wh and !input_unsqueezed.is_sharded();
+    std::cout << "typecast: " << typecast << std::endl << std::endl;
     Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_typecasted}))};

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -144,7 +144,7 @@ ttnn::Tensor ExecuteTranspose::invoke(
         return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg);
     }
 
-    bool wh = (normalized_dim2 == 2 && normalized_dim1 == 0) || (normalized_dim2 == 0 && normalized_dim1 == 2);
+    bool wh = (normalized_dim1 == 2 && normalized_dim2 == 3) || (normalized_dim2 == 2 && normalized_dim1 == 3);
     bool typecast = input_unsqueezed.get_dtype() == DataType::BFLOAT8_B and input_unsqueezed.get_layout() == Layout::TILE and !wh and !input_unsqueezed.is_sharded();
     Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -52,7 +52,7 @@ inline bool rm_enough_available_space(const Tensor& input_tensor_a) {
     return max_l1_space > estimated_size_of_cbs;
 }
 
-inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const MemoryConfig& output_mem_config) {
+inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const MemoryConfig& output_mem_config, const std::optional<float>& pad_value) {
     bool tiled_only = false;
     constexpr uint32_t FACE_WIDTH = tt::constants::FACE_WIDTH; // this is a highly restrictive constraint on the RM transpose_wh kernel, and with all the other bugs/limitations we should rewrite it
     // use device->get_allocator_alignment when the it reflects the alignment of the buffer and doesn't just default to DRAM
@@ -68,11 +68,11 @@ inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const Me
             break;
         // bubble dim around to make it possible as these implementations don't have a kernel
         case TransposeOpDim::NH:
-            return ttnn::permute((const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config);
+            return ttnn::permute((const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({2, 1, 0, 3}), output_mem_config, pad_value);
         case TransposeOpDim::NW:
-            return ttnn::permute((const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config);
+            return ttnn::permute((const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({3, 1, 2, 0}), output_mem_config, pad_value);
         case TransposeOpDim::CW:
-            return ttnn::permute((const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config);
+            return ttnn::permute((const ttnn::Tensor)a, ttnn::SmallVector<int64_t>({0, 3, 2, 1}), output_mem_config, pad_value);
         case TransposeOpDim::CN:
             tiled_only = true; // CN only has a tiled implementation at the moment
             break;
@@ -89,21 +89,20 @@ inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const Me
         default:
             break;
     }
-
     if (a.get_layout() == Layout::ROW_MAJOR) {
         // the assorted cases where only tiled works right now (HC with stick width constraint, WH with stick width constraint, CN).
         if (tiled_only) {
             // convert to tiled
             Tensor b = ttnn::to_layout(a, Layout::TILE, std::nullopt, std::nullopt, (Device *)nullptr);
             // run the transpose.
-            b = operation::run(Transpose{transpose_dim, output_mem_config}, {b}).at(0);
+            b = operation::run(Transpose{transpose_dim, output_mem_config, pad_value}, {b}).at(0);
             // back to original layout
             b = ttnn::to_layout(b, a.get_layout(), std::nullopt, std::nullopt, (Device *)nullptr);
             return b;
         }
-        return operation::run(Transpose{transpose_dim, output_mem_config}, {a}).at(0);
+        return operation::run(Transpose{transpose_dim, output_mem_config, pad_value}, {a}).at(0);
     } else {
-        return operation::run(Transpose{transpose_dim, output_mem_config}, {a}).at(0);
+        return operation::run(Transpose{transpose_dim, output_mem_config, pad_value}, {a}).at(0);
     }
 }
 
@@ -111,14 +110,15 @@ ttnn::Tensor transpose_nd(
     const ttnn::Tensor& input_tensor,
     const uint32_t dim1,
     const uint32_t dim2,
-    const std::optional<MemoryConfig>& memory_config_arg) {
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<float>& pad_value) {
     std::vector<int64_t> permutation;
     permutation.reserve(input_tensor.get_shape().rank());
     for (uint32_t i = 0; i < input_tensor.get_shape().rank(); ++i) {
         permutation.push_back(i);
     }
     std::swap(permutation[dim1], permutation[dim2]);
-    return ttnn::permute(input_tensor, permutation, memory_config_arg);
+    return ttnn::permute(input_tensor, permutation, memory_config_arg, pad_value);
 }
 
 } //detail namespace
@@ -128,7 +128,8 @@ ttnn::Tensor ExecuteTranspose::invoke(
     const ttnn::Tensor& input_tensor,
     const int64_t& dim1,
     const int64_t& dim2,
-    const std::optional<MemoryConfig>& memory_config_arg) {
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<float>& pad_value) {
 
     uint32_t normalized_dim1 = input_tensor.get_shape().get_normalized_index(dim1);
     uint32_t normalized_dim2 = input_tensor.get_shape().get_normalized_index(dim2);
@@ -141,7 +142,7 @@ ttnn::Tensor ExecuteTranspose::invoke(
         normalized_dim1 += rank_diff;
         normalized_dim2 += rank_diff;
     } else if (initial_rank > 4) {
-        return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg);
+        return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg, pad_value);
     }
 
     bool wh = (normalized_dim1 == 2 && normalized_dim2 == 3) || (normalized_dim2 == 2 && normalized_dim1 == 3);
@@ -151,9 +152,8 @@ ttnn::Tensor ExecuteTranspose::invoke(
     Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_typecasted}))};
-
     operation::launch_with_autoformat(
-        [normalized_dim1, normalized_dim2, memory_config_arg] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [normalized_dim1, normalized_dim2, memory_config_arg, pad_value] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             auto& a = input_tensors.at(0);
             auto memory_config = memory_config_arg.value_or(a.memory_config());
 
@@ -188,7 +188,7 @@ ttnn::Tensor ExecuteTranspose::invoke(
             } else {
                 TT_ASSERT(false, "Unsupported transpose dims");
             }
-            return {detail::transpose_(a, transpose_dim, memory_config)};
+            return {detail::transpose_(a, transpose_dim, memory_config, pad_value)};
         }, {input_typecasted}, output_tensors);
 
     auto output = output_tensors.at(0);
@@ -201,12 +201,13 @@ ttnn::Tensor ExecuteTranspose::invoke(
     const ttnn::Tensor& input_tensor,
     const int64_t& dim1,
     const int64_t& dim2,
-    const std::optional<MemoryConfig>& memory_config) {
-    return invoke(DefaultQueueId, input_tensor, dim1, dim2, memory_config);
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<float>& pad_value) {
+    return invoke(DefaultQueueId, input_tensor, dim1, dim2, memory_config, pad_value);
 }
 
-ttnn::Tensor ExecuteTranspose::invoke(const ttnn::Tensor& input_tensor, const int64_t& dim1, const int64_t& dim2) {
-    return invoke(DefaultQueueId, input_tensor, dim1, dim2, std::nullopt);
+ttnn::Tensor ExecuteTranspose::invoke(const ttnn::Tensor& input_tensor, const int64_t& dim1, const int64_t& dim2, const std::optional<float>& pad_value) {
+    return invoke(DefaultQueueId, input_tensor, dim1, dim2, std::nullopt, pad_value);
 }
 
 } // ttnn::operations::data_movement namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.hpp
@@ -15,15 +15,17 @@ struct ExecuteTranspose {
         const ttnn::Tensor& input_tensor,
         const int64_t& dim1,
         const int64_t& dim2,
-        const std::optional<MemoryConfig>& memory_config_arg);
+        const std::optional<MemoryConfig>& memory_config_arg,
+        const std::optional<float>& pad_value = 0.0f);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const int64_t& dim1,
         const int64_t& dim2,
-        const std::optional<MemoryConfig>& memory_config);
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<float>& pad_value = 0.0f);
 
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const int64_t& dim1, const int64_t& dim2);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const int64_t& dim1, const int64_t& dim2, const std::optional<float>& pad_value = 0.0f);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
@@ -24,6 +24,7 @@ void bind_transpose(py::module& module) {
                 * :attr:`input_tensor`: Input Tensor.
                 * :attr:`dim1`: First dim of transpose.
                 * :attr:`dim2`: Second dim of transpose.
+                * :attr:`pad_value` (Optional[float]): padding value for when tiles are broken in a transpose. Defaults to `0.0`. If set to None, it will be random garbage values.
 
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transpose_pybind.hpp"
+
+namespace ttnn::operations::data_movement::detail {
+namespace py = pybind11;
+
+void bind_transpose(py::module& module) {
+    auto doc =
+        R"doc(
+            transpose(input_tensor: ttnn.Tensor, dim1: int, dim2: int, *, Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Returns a tensor that is transposed along dims dim1 and dim2
+
+            Equivalent pytorch code:
+
+            .. code-block:: python
+
+                output_tensor = torch.transpose(input_tensor, 0, 1)
+
+            Args:
+                * :attr:`input_tensor`: Input Tensor.
+                * :attr:`dim1`: First dim of transpose.
+                * :attr:`dim2`: Second dim of transpose.
+
+            Keyword Args:
+                * :attr:`memory_config`: Memory Config of the output tensor
+                * :attr:`queue_id` (Optional[uint8]): command queue id
+        )doc";
+
+    using OperationType = decltype(ttnn::transpose);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::transpose,
+        doc,
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const int64_t & dim1,
+                const int64_t & dim2,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                uint8_t queue_id,
+                const std::optional<float>& pad_value
+                ) {
+                    return self(queue_id, input_tensor, dim1, dim2, memory_config, pad_value);
+                },
+                py::arg("input_tensor"),
+                py::arg("dim1"),
+                py::arg("dim2"),
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt,
+                py::arg("queue_id") = 0,
+                py::arg("pad_value") = 0.0f,
+                }
+        );
+}
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,50 +14,5 @@
 namespace ttnn::operations::data_movement::detail {
 namespace py = pybind11;
 
-void bind_transpose(py::module& module) {
-    auto doc =
-        R"doc(
-            transpose(input_tensor: ttnn.Tensor, dim1: int, dim2: int, *, Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
-
-            Returns a tensor that is transposed along dims dim1 and dim2 
-
-            Equivalent pytorch code:
-
-            .. code-block:: python
-
-                output_tensor = torch.transpose(input_tensor, 0, 1)
-
-            Args:
-                * :attr:`input_tensor`: Input Tensor.
-                * :attr:`dim1`: First dim of transpose.
-                * :attr:`dim2`: Second dim of transpose.
-
-            Keyword Args:
-                * :attr:`memory_config`: Memory Config of the output tensor
-                * :attr:`queue_id` (Optional[uint8]): command queue id
-        )doc";
-
-    using OperationType = decltype(ttnn::transpose);
-    ttnn::bind_registered_operation(
-        module,
-        ttnn::transpose,
-        doc,
-        ttnn::pybind_overload_t{
-            [] (const OperationType& self,
-                const ttnn::Tensor& input_tensor,
-                const int64_t & dim1,
-                const int64_t & dim2,
-                const std::optional<ttnn::MemoryConfig>& memory_config,
-                uint8_t queue_id) {
-                    return self(queue_id, input_tensor, dim1, dim2, memory_config);
-                },
-                py::arg("input_tensor"),
-                py::arg("dim1"),
-                py::arg("dim2"),
-                py::kw_only(),
-                py::arg("memory_config") = std::nullopt,
-                py::arg("queue_id") = 0,
-                }
-        );
-}
+void bind_transpose(py::module& module);
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
@@ -5,17 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
-#include "debug/dprint.h"
-
-template <typename T>
-FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, T val) {
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(begin_addr);
-    for (uint32_t i = 0; i < n; ++i) {
-        DPRINT << "fill_with_val: " << i << " " << val << ENDL();
-        ptr[i] = val;
-    }
-}
-
 void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
@@ -50,10 +39,4 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
     }
-
-    cb_reserve_back(tt::CB::c_in1, 1);
-    uint32_t l1_write_addr = get_write_ptr(tt::CB::c_in1);
-    fill_with_val<uint32_t>(l1_write_addr, 8, 123123);
-    cb_push_back(tt::CB::c_in1, 1);
-
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
-//#include "debug/dprint.h"
+#include "debug/dprint.h"
 
 void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp
@@ -7,6 +7,15 @@
 
 #include "debug/dprint.h"
 
+template <typename T>
+FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, T val) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(begin_addr);
+    for (uint32_t i = 0; i < n; ++i) {
+        DPRINT << "fill_with_val: " << i << " " << val << ENDL();
+        ptr[i] = val;
+    }
+}
+
 void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);
     uint32_t num_tiles = get_arg_val<uint32_t>(1);
@@ -41,4 +50,10 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
     }
+
+    cb_reserve_back(tt::CB::c_in1, 1);
+    uint32_t l1_write_addr = get_write_ptr(tt::CB::c_in1);
+    fill_with_val<uint32_t>(l1_write_addr, 8, 123123);
+    cb_push_back(tt::CB::c_in1, 1);
+
 }


### PR DESCRIPTION
### Ticket
#14308 
#14790 
#11650 

### Problem description

- Transpose along height and channel for tiled layout is currently padding unaware, meaning that we need to pad channels to a multiple of TILE_HEIGHT, transpose, then slice off any excess on the new channels/height
- This results in excess copies along both channel and height that can be optimized out
- As well, the choice of padding depends on the subsequent ops, some ops can skip padding with specific values to save on performance, and others may want other values padded (-inf, +inf, 1)
- Blackhole transpose HC on tiled requires a scratch pad to be able to deal with the 64B alignment requirement for noc_async_reads, which don't align with the size of each face line for normal tiles (32B).
- Tranpose is also dependent on reshape to be able to account for what is the padding and what is actual data after padding and then transposing
- BFLOAT8 transpose is unnecessary typecasted when it's supported for both transpose CN and transpose WH

### What's changed

- Add a new multicore transpose hc tiled interleaved kernel that is padding aware. This skips extra copies on the padded H values and generates new padding for the channel dimension once it becomes tile height. 
- The new height is padded by default to 0, but you can use the new pad_value parameter to set it to other values. If you explicitly set it to None, it will not set a specific value and just copy the real data into the buffer.
- Shift tile creation workload to writer kernel to avoid the need for a scratch pad on Blackhole ((ake each tile and write out each value to its new position, rather than read in a bunch of values to create each new tile that's written out)
- Remove direct reshape call in transpose
- Re-enable BFLOAT8 transpose WH/CN 
- Add some unit tests for community test cases (these are old issues that got solved unintentionally a few weeks ago)
- Add tricky unit tests
- Make the same changes to permute

### TODO

- In theory these should work with tiny tiles due to the way I've written it, but I haven't tested that yet.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/11918161415
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11916983288/job/33211841677 (failure matches main)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11902351038/job/33207292238
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/11918150453/job/33215940950 (matches failure on main)
- [x] New/Existing tests provide coverage for changes
