### PR TITLE
#0: Fix typo causing spurious perf warnings for concat

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -42,7 +42,7 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor> &input_tensors) c
         TT_FATAL(curr_shape.rank() == shape_first.rank(), "Input tensor ranks must be equal");
         curr_shape[this->dim] = 0;
             // last tensor can support without any kernel changes
-        if(in_ref.get_layout() == Layout::TILE and !in_ref.get_shape().has_tile_padding(this->dim)) {
+        if(in_ref.get_layout() == Layout::TILE and in_ref.get_shape().has_tile_padding(this->dim)) {
             warn_about_alignment = true;
         }
         TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");


### PR DESCRIPTION
Flipped a bit while converting from TT_FATAL to a warning. No functional/perf implications expected, just added console noise. Thanks to @dmakoviichuk-tt for catching this.