### PR TITLE
#15020: Add full single-card models pipeline for contractors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,5 @@ Summarize the changes made and its impact.
 - [ ] Blackhole Post commit (if applicable)
 - [ ] Model regression CI testing passes (if applicable)
 - [ ] Device performance regression CI testing passes (if applicable)
+- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
 - [ ] New/Existing tests provide coverage for changes

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -23,6 +23,7 @@ on:
       - "(Single-card) Device perf tests"
       - "(Single-card) Demo tests"
       - "Nightly fast dispatch tests"
+      - "(Single-card) Tests for new models"
       - "(T3K) T3000 demo tests"
       - "(T3K) T3000 model perf tests"
       - "(T3K) T3000 perplexity tests"

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -2,6 +2,11 @@ name: "All post-commit tests"
 
 on:
   workflow_call:
+    inputs:
+      build-type:
+        required: false
+        default: Release
+        type: string
   workflow_dispatch:
     inputs:
       build-type:

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -12,6 +12,9 @@ on:
           - Debug
           - RelWithDebInfo
           - CI
+  push:
+    branches:
+      - rkim/15020-full-pipe
 
 permissions:
   actions: read

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -25,18 +25,39 @@ permissions:
   packages: write
 
 jobs:
-  all-post-commit-tests:
-    uses: ./.github/workflows/all-post-commit-workflows.yaml
+  build-docker-image-2004:
+    uses: ./.github/workflows/build-docker-artifact.yaml
+    secrets: inherit
+    with:
+      os: ubuntu-20.04-amd64
+  build-artifact:
+    needs: build-docker-image-2004
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-docker: false
+      build-type: ${{ inputs.build-type || 'Release' }}
+  build-artifact-profiler:
+    needs: build-docker-image-2004
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      tracy: true
+      build-docker: false
+      build-type: ${{ inputs.build-type || 'Release' }}
     secrets: inherit
   device-perf-single-card:
+    needs: build-artifact-profiler
     uses: ./.github/workflows/perf-device-models-impl.yaml
     secrets: inherit
   e2e-model-perf-single-card:
+    needs: build-artifact
     uses: ./.github/workflows/perf-models-impl.yaml
     secrets: inherit
   nightly-single-card:
+    needs: build-artifact
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
   demos-single-card:
+    needs: build-artifact
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml
     secrets: inherit

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -1,0 +1,39 @@
+name: "(Single-card) Tests for new models"
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-type:
+        required: false
+        default: Release
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - CI
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
+  packages: write
+
+jobs:
+  all-post-commit-tests:
+    uses: ./.github/workflows/all-post-commit-workflows.yaml
+    secrets: inherit
+  device-perf-single-card:
+    uses: ./.github/workflows/perf-device-models-impl.yaml
+    secrets: inherit
+  e2e-model-perf-single-card:
+    uses: ./.github/workflows/perf-models-impl.yaml
+    secrets: inherit
+  nightly-single-card:
+    uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+    secrets: inherit
+  demos-single-card:
+    uses: ./.github/workflows/single-card-demo-tests-impl.yaml
+    secrets: inherit

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -12,9 +12,6 @@ on:
           - Debug
           - RelWithDebInfo
           - CI
-  push:
-    branches:
-      - rkim/15020-full-pipe
 
 permissions:
   actions: read


### PR DESCRIPTION
### Ticket

#15020 

### Problem description

Which pipelines to run aren't always socialized well amongst contractors who bring up models for us.

### What's changed

Add new pipeline that will run the gamut of:

- single-card Device perf
- single-card demos
- single-card nightly fast dispatch
- single-card e2e model perf

This should reduce the number of steps single-card models writers need to take to validate their changes.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
