### PR TITLE
#15228: Fix error message in BaseShape when index is out of bounds

### DIFF
--- a/ttnn/cpp/ttnn/tensor/shape/shape_base.cpp
+++ b/ttnn/cpp/ttnn/tensor/shape/shape_base.cpp
@@ -24,7 +24,7 @@ int32_t normalized_index(int32_t index, size_t original_size, size_t container_s
     }
 
     if (fixed_index < 0 || fixed_index >= full_size) {
-        TT_THROW("ShapeBase[] index out of range. {} not in [{}, {})", index, -full_size, full_size);
+        TT_THROW("ShapeBase[] index out of range. {} not in [{}, {})", index, -full_size, orig_size);
     }
 
     return fixed_index;


### PR DESCRIPTION
### Ticket
#15228 

### Problem description
BaseShape error message is not correct when out of bounds index is provided

### What's changed
Correcting the message to use the real upper bounds

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/11923957476)
- [x] Tests for OoB exist, not testing a specific message
