### PR TITLE
[tt-train] Free graph during backward pass 

### DIFF
--- a/tt-train/sources/ttml/autograd/graph.cpp
+++ b/tt-train/sources/ttml/autograd/graph.cpp
@@ -15,7 +15,7 @@ const std::vector<std::vector<size_t>>& Graph::get_edges() const {
     return m_links;
 }
 
-const std::vector<GraphNode>& Graph::get_graph_nodes() const {
+std::vector<GraphNode>& Graph::get_graph_nodes() {
     return m_graph_nodes;
 }
 

--- a/tt-train/sources/ttml/autograd/graph.hpp
+++ b/tt-train/sources/ttml/autograd/graph.hpp
@@ -37,7 +37,7 @@ private:
 
 public:
     [[nodiscard]] const std::vector<std::vector<size_t>>& get_edges() const;
-    [[nodiscard]] const std::vector<GraphNode>& get_graph_nodes() const;
+    [[nodiscard]] std::vector<GraphNode>& get_graph_nodes();
     NodeId add_node(GradFunction&& grad_function, std::span<NodeId> links);
 
     void reset();

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -71,10 +71,12 @@ void Tensor::backward(bool retain_graph) {
     for (const auto& node_id : sorted_nodes) {
         graph_nodes[node_id].grad_function();
         if (!retain_graph) {
-            // setting grad function to nullptr releases context of the function
-            // it is often includes multiple tensors and if we don't need to retain them
-            // at this point of backward pass, we can release them
-            graph_nodes[node_id].grad_function = nullptr;
+            graph_nodes[node_id].grad_function = [] {
+                throw std::runtime_error(
+                    "[Tensor::backward] This backward function should not be called! Memory from the node is released! "
+                    "Please consider tweaking the retain_graph parameter if you need to call backward twice on the "
+                    "same graph nodes.");
+            };
         }
     }
 }

--- a/tt-train/sources/ttml/autograd/tensor.hpp
+++ b/tt-train/sources/ttml/autograd/tensor.hpp
@@ -42,7 +42,7 @@ public:
     bool get_requires_grad() const;
     const std::optional<NodeId> &get_node() const;
 
-    void backward();
+    void backward(bool retain_graph = false);
 
     bool is_grad_initialized() const;
 


### PR DESCRIPTION
### Description
Add option to discard graph during backward pass. Improves DRAM memory consumption for deep networks by dropping tensors that won't be required in next steps of gradients calculation. Performance is not affected. 

### Changes Made
- [ ] **New Feature:** Describe the new feature and its purpose.
- [x] **Improvement:** Summarize the enhancements implemented.
- [ ] **Bug Fix:** Detail the issue that was addressed.
- [ ] **Refactor:** Outline any significant code refactoring efforts.

### Testing
- [x] Unit tests added or updated
- [x] Manual testing conducted

### Review Checklist
- [x] No breaking changes introduced
- [x] All tests pass successfully
- [x] Code complies with project style guidelines

Post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/11938966657