### PR TITLE
#0: Remove alignment requirements for Row Major tensors

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: template<typename DType> void tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<DType> &dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids = {})
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<DType> &dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids = {})
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: template<typename DType> void tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<DType> &dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids = {})
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>&, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/tests/tt_metal/tt_metal/unit_tests/ethernet/ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/ethernet/ring_gather_kernels.cpp
@@ -237,7 +237,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         llrt::write_hex_vec_to_core(
             sender_device->id(),
             sender_device->ethernet_core_from_logical_core(eth_sender_core),
-            {INVALID},
+            std::vector{INVALID},
             sem_l1_byte_address);
 
         ////////////////////////////////////////////////////////////////////////////
@@ -260,7 +260,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         llrt::write_hex_vec_to_core(
             receiver_device->id(),
             receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
-            {INVALID},
+            std::vector{INVALID},
             sem_l1_byte_address);
         auto eth_receiver_kernel = tt_metal::CreateKernel(
             receiver_program,
@@ -390,10 +390,10 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
              (uint32_t)cfg.page_size_bytes,
              (uint32_t)sem_l1_byte_address});
         llrt::write_hex_vec_to_core(
-            device->id(), device->ethernet_core_from_logical_core(eth_sender_core), {INVALID}, sem_l1_byte_address);
+            device->id(), device->ethernet_core_from_logical_core(eth_sender_core), std::vector{INVALID}, sem_l1_byte_address);
 
         llrt::write_hex_vec_to_core(
-            device->id(), device->ethernet_core_from_logical_core(eth_receiver_core), {INVALID}, sem_l1_byte_address);
+            device->id(), device->ethernet_core_from_logical_core(eth_receiver_core), std::vector{INVALID}, sem_l1_byte_address);
 
         auto eth_receiver_kernel = tt_metal::CreateKernel(
             program,

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -314,7 +314,7 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(
     bool pass = true;
     vector<uint32_t> dst;
     uint32_t idx = start;
-    for (auto buffer : bufs) {
+    for (const auto& buffer : bufs) {
         EnqueueReadBuffer(cq, buffer, dst, true);
         pass &= dst == unique_vectors[idx % unique_vectors.size()];
         idx++;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_ring_gather_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_ring_gather_EnqueueProgram.cpp
@@ -236,7 +236,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         llrt::write_hex_vec_to_core(
             sender_device->id(),
             sender_device->ethernet_core_from_logical_core(eth_sender_core),
-            {INVALID},
+            std::vector{INVALID},
             sem_l1_byte_address);
 
         ////////////////////////////////////////////////////////////////////////////
@@ -259,7 +259,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         llrt::write_hex_vec_to_core(
             receiver_device->id(),
             receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
-            {INVALID},
+            std::vector{INVALID},
             sem_l1_byte_address);
         auto eth_receiver_kernel = tt_metal::CreateKernel(
             receiver_program,
@@ -394,10 +394,10 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
              (uint32_t)cfg.page_size_bytes,
              (uint32_t)sem_l1_byte_address});
         llrt::write_hex_vec_to_core(
-            device->id(), device->ethernet_core_from_logical_core(eth_sender_core), {INVALID}, sem_l1_byte_address);
+            device->id(), device->ethernet_core_from_logical_core(eth_sender_core), std::vector{INVALID}, sem_l1_byte_address);
 
         llrt::write_hex_vec_to_core(
-            device->id(), device->ethernet_core_from_logical_core(eth_receiver_core), {INVALID}, sem_l1_byte_address);
+            device->id(), device->ethernet_core_from_logical_core(eth_receiver_core), std::vector{INVALID}, sem_l1_byte_address);
 
         auto eth_receiver_kernel = tt_metal::CreateKernel(
             program,

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -121,9 +121,9 @@ INSTANTIATE_TEST_SUITE_P(
     EmptyTensorTest,
     ::testing::Combine(
         ::testing::Values(
-            //ttnn::Shape({}),
-            //ttnn::Shape({0}),
-            //ttnn::Shape({1}),
+            ttnn::Shape({}),
+            ttnn::Shape({0}),
+            ttnn::Shape({1}),
             ttnn::Shape({1, 2}),
             ttnn::Shape({1, 2, 3}),
             ttnn::Shape({1, 2, 3, 4}),

--- a/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
@@ -824,7 +824,8 @@ INSTANTIATE_TEST_SUITE_P(
         // EXAMPLE 2: ROW_MAJOR tensor with different representation for width sharded / interleaved
         // - In this example, (shard) width alignment is 1 because it's row major
         /////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Example 2a: Logical shard shape + alignment after
+        // Example 2a: Logical shard shape that is already aligned
+        // NOTE: ShardMode::PHYSICAL is equivalent in this case
         // - Along width: 5 / 1 is 5 shards; 5 * 1 = 5
         CreateShardedTensorWithAlignmentParams{
             CreateShardedTensorWithAlignmentInputs{

--- a/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
@@ -822,10 +822,10 @@ INSTANTIATE_TEST_SUITE_P(
         },
         /////////////////////////////////////////////////////////////////////////////////////////////////////
         // EXAMPLE 2: ROW_MAJOR tensor with different representation for width sharded / interleaved
-        // - In this example, (shard) width alignment is 4 because UINT8 = 1 bytes and we pack with uint32_t
+        // - In this example, (shard) width alignment is 1 because it's row major
         /////////////////////////////////////////////////////////////////////////////////////////////////////
         // Example 2a: Logical shard shape + alignment after
-        // - Along width: 5 / 1 is 5 shards; 5 * 4 = 20
+        // - Along width: 5 / 1 is 5 shards; 5 * 1 = 5
         CreateShardedTensorWithAlignmentParams{
             CreateShardedTensorWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 10, 5},
@@ -844,15 +844,15 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{20, 20}
+                .physical_size = Size{20, 5}
             }
         },
         // Example 2b: Logical shard shape that is already aligned
         // NOTE: ShardMode::PHYSICAL is equivalent in this case
-        // - Along width: 5 / 4 is 2 shards; 2 * 4 = 8
+        // - Along width: 8 / 4 is 2 shards; 2 * 4 = 8
         CreateShardedTensorWithAlignmentParams{
             CreateShardedTensorWithAlignmentInputs{
-                .shape = SimpleShape{1, 2, 10, 5},
+                .shape = SimpleShape{1, 2, 10, 8},
                 .data_type = DataType::UINT8,
                 .page_config = PageConfig(Layout::ROW_MAJOR),
                 .memory_config =
@@ -872,7 +872,7 @@ INSTANTIATE_TEST_SUITE_P(
             }
         },
         // Example 2c: For interleaved, we treat entire height/width as "logical shard shape" for calculations
-        // 20 "shards" with 5 aligned to 4 for uint32_t alignment
+        // 20 "shards" with 5 aligned to 1
         CreateShardedTensorWithAlignmentParams{
             CreateShardedTensorWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 10, 5},
@@ -886,7 +886,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{20, 8}
+                .physical_size = Size{20, 5}
             }
         },
         ////////////////////////////////////////////////////////////////////

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_layout.cpp
@@ -79,9 +79,9 @@ INSTANTIATE_TEST_SUITE_P(
                 .layout = Layout::ROW_MAJOR
             },
             Expected{
-                .physical_size = {6*5*4, 4},
-                .alignment = Alignment({2}),
-                .strides = Strides({5*4*4, 4*4, 4, 1})
+                .physical_size = {6*5*4, 3},
+                .alignment = Alignment({1}),
+                .strides = Strides({5*4*3, 4*3, 3, 1})
             }
         },
 
@@ -108,7 +108,7 @@ INSTANTIATE_TEST_SUITE_P(
             },
             Expected{
                 .physical_size = {6*5*4, 8},
-                .alignment = Alignment({2}),
+                .alignment = Alignment({1}),
                 .strides = Strides({5*4*8, 4*8, 8, 1})
             }
         },
@@ -135,9 +135,9 @@ INSTANTIATE_TEST_SUITE_P(
                 .layout = Layout::ROW_MAJOR
             },
             Expected{
-                .physical_size = {1, 2},
-                .alignment = Alignment({2}),
-                .strides = Strides({2, 2, 2, 1})
+                .physical_size = {1, 1},
+                .alignment = Alignment({1}),
+                .strides = Strides({1, 1, 1, 1})
             }
         },
 
@@ -163,8 +163,8 @@ INSTANTIATE_TEST_SUITE_P(
                 .layout = Layout::ROW_MAJOR
             },
             Expected{
-                .physical_size = {1, 2},
-                .alignment = Alignment({2}),
+                .physical_size = {1, 1},
+                .alignment = Alignment({1}),
                 .strides = Strides({}),
                 .tensor_creation_works = false
             }
@@ -208,8 +208,8 @@ INSTANTIATE_TEST_SUITE_P(
                 .layout = Layout::ROW_MAJOR
             },
             Expected{
-                .physical_size = {1, 2},
-                .alignment = Alignment({2}),
+                .physical_size = {1, 1},
+                .alignment = Alignment({1}),
                 .strides = Strides({1}),
                 .tensor_creation_works = false
             }

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -100,7 +100,7 @@ inline namespace v0 {
         * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
         * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
         * | buffer      | Buffer to read data from                        | Buffer &                |                                                  | Yes      |
-        * | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
+        * | host_buffer | Buffer on host to copy data into                | std::vector<DType> &    |                                                  | Yes      |
         * | core_id     | ID of core                                      | const uint32_t &        |                                                  | Yes      |
         */
         template<typename DType>

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -37,8 +37,17 @@ inline namespace v0 {
 
         void CloseDevices(std::map<chip_id_t, Device *> devices);
 
-        void WriteToDevice(Buffer &buffer, tt::stl::Span<const uint8_t> host_buffer);
-
+        /**
+        * Copies data from a host buffer into the specified buffer
+        *
+        * Return value: void
+        *
+        * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
+        * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
+        * | buffer      | Buffer to send data to                          | Buffer &                |                                                  | Yes      |
+        * | host_buffer | Buffer on host to copy data from                | Span<const uint8_t> &   | Host buffer size must match buffer               | Yes      |
+        */
+        void WriteToBuffer(Buffer &buffer, tt::stl::Span<const uint8_t> host_buffer);
         /**
         * Copies data from a host buffer into the specified buffer
         *
@@ -51,7 +60,7 @@ inline namespace v0 {
         */
         template<typename DType>
         void WriteToBuffer(Buffer &buffer, const std::vector<DType>& host_buffer) {
-            WriteToDevice(buffer, tt::stl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(DType)));
+            WriteToBuffer(buffer, tt::stl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(DType)));
         }
         template<typename DType>
         void WriteToBuffer(std::shared_ptr<Buffer> buffer, const std::vector<DType>& host_buffer) {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -11,6 +11,7 @@
 #include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
+#include "tt_metal/impl/buffers/buffer.hpp"
 
 namespace tt::tt_metal {
 inline namespace v0 {
@@ -36,6 +37,8 @@ inline namespace v0 {
 
         void CloseDevices(std::map<chip_id_t, Device *> devices);
 
+        void WriteToDevice(Buffer &buffer, tt::stl::Span<const uint8_t> host_buffer);
+
         /**
         * Copies data from a host buffer into the specified buffer
         *
@@ -44,10 +47,18 @@ inline namespace v0 {
         * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
         * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
         * | buffer      | Buffer to send data to                          | Buffer &                |                                                  | Yes      |
-        * | host_buffer | Buffer on host to copy data from                | std::vector<uint32_t> & | Host buffer size must match buffer               | Yes      |
+        * | host_buffer | Buffer on host to copy data from                | std::vector<DType> &    | Host buffer size must match buffer               | Yes      |
         */
-        void WriteToBuffer(Buffer &buffer, const std::vector<uint32_t> &host_buffer);
-        void WriteToBuffer( std::shared_ptr<Buffer> buffer, const std::vector<uint32_t> &host_buffer);
+        template<typename DType>
+        void WriteToBuffer(Buffer &buffer, const std::vector<DType>& host_buffer) {
+            WriteToDevice(buffer, tt::stl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(DType)));
+        }
+        template<typename DType>
+        void WriteToBuffer(std::shared_ptr<Buffer> buffer, const std::vector<DType>& host_buffer) {
+            WriteToBuffer(*buffer, host_buffer);
+        }
+
+        void ReadFromBuffer(Buffer &buffer, uint8_t* host_buffer, bool shard_order = false);
         /**
         * Copies data from a buffer into a host buffer
         *
@@ -56,12 +67,22 @@ inline namespace v0 {
         * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
         * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
         * | buffer      | Buffer to read data from                        | Buffer &                |                                                  | Yes      |
-        * | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
+        * | host_buffer | Buffer on host to copy data into                | std::vector<DType> &    |                                                  | Yes      |
         * | shard_order | For a sharded buffer we can read in shard order | bool                    |                                                  | No       |
         */
-        void ReadFromBuffer(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order = false);
-        void ReadFromBuffer(std::shared_ptr<Buffer> buffer, std::vector<uint32_t> &host_buffer, bool shard_order = false);
+        template<typename DType>
+        void ReadFromBuffer(Buffer &buffer, std::vector<DType> &host_buffer, bool shard_order = false) {
+            auto buffer_size = buffer.size();
+            TT_FATAL(buffer_size % sizeof(DType) == 0, "Buffer size is not divisible by dtype size");
+            host_buffer.resize(buffer.size() / sizeof(DType));
+            ReadFromBuffer(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()), shard_order);
+        }
+        template<typename DType>
+        void ReadFromBuffer(std::shared_ptr<Buffer> buffer, std::vector<DType> &host_buffer, bool shard_order = false) {
+            ReadFromBuffer(*buffer, host_buffer, shard_order);
+        }
 
+        void ReadShard(Buffer &buffer, uint8_t* host_buffer, const uint32_t & core_id);
         /**
         * Copies data from a buffer into a host buffer
         *
@@ -73,9 +94,11 @@ inline namespace v0 {
         * | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
         * | core_id     | ID of core                                      | const uint32_t &        |                                                  | Yes      |
         */
-        void ReadShard(Buffer &buffer, std::vector<uint32_t> &host_buffer, const uint32_t & core_id);
-
-
+        template<typename DType>
+        void ReadShard(Buffer &buffer, std::vector<DType> &host_buffer, const uint32_t & core_id) {
+            host_buffer.resize(buffer.page_size() * buffer.shard_spec().size());
+            ReadShard(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()), core_id);
+        }
 
         // Launches all kernels on cores specified with kernels in the program.
         // All kernels on a given Tensix core must be launched.

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -514,6 +514,26 @@ RuntimeArgsData &GetCommonRuntimeArgs(const Program &program, KernelHandle kerne
  * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
  * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                        | Yes      |
  * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
+ * | dst            | The memory where the result will be stored                                        | void*                               |                                        | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                        | No       |
+ */
+void EnqueueReadBuffer(
+    CommandQueue &cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    void *dst,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
+/**
+ * Reads a buffer from the device
+ *
+ * Return value: void
+ *
+ * | Argument       | Description                                                                       | Type                                | Valid Range                            | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                        | Yes      |
+ * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
  * | dst            | The vector where the results that are read will be stored                         | vector<DType> &                     |                                        | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
  * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
@@ -526,7 +546,7 @@ void EnqueueReadBuffer(
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
     dst.resize(buffer.page_size() * buffer.num_pages() / sizeof(DType));
-    EnqueueReadBuffer(cq, buffer, dst.data(), blocking, sub_device_ids);
+    EnqueueReadBuffer(cq, buffer, static_cast<void*>(dst.data()), blocking, sub_device_ids);
 }
 template<typename DType>
 void EnqueueReadBuffer(
@@ -537,26 +557,6 @@ void EnqueueReadBuffer(
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
     EnqueueReadBuffer(cq, *buffer, dst, blocking, sub_device_ids);
 }
-
-/**
- * Reads a buffer from the device
- *
- * Return value: void
- *
- * | Argument       | Description                                                                       | Type                                | Valid Range                            | Required |
- * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|----------------------------------------|----------|
- * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                        | Yes      |
- * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
- * | dst            | The memory where the result will be stored                                        | void*                               |                                        | Yes      |
- * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                        | No       |
- */
-void EnqueueReadBuffer(
-    CommandQueue &cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
-    void *dst,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 /**
  * Writes a buffer to the device

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -536,7 +536,7 @@ void EnqueueReadBuffer(
  * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
  * | dst            | The vector where the results that are read will be stored                         | vector<DType> &                     |                                        | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                        | No       |
  */
 template<typename DType>
 void EnqueueReadBuffer(

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -56,9 +56,6 @@ void validate_buffer_size_and_page_size(
         "should be divisible by buffer size",
         page_size,
         size);
-    TT_FATAL(
-        page_size % sizeof(uint32_t) == 0,
-        "Page size {} must be divisible by sizeof(uint32_t) because buffers hold uint32_t values", page_size);
 
     if (is_sharded(buffer_layout)) {
         TT_FATAL(

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -343,7 +343,7 @@ void watcher_init(Device *device) {
             } else {
                 data->debug_insert_delays = debug_delays_val_zero;
             }
-            tt::llrt::write_hex_vec_to_core(device->id(), worker_core, watcher_init_val, GET_WATCHER_TENSIX_DEV_ADDR());
+            tt::llrt::write_hex_vec_to_core(device->id(), worker_core, tt::stl::Span<const uint32_t>(watcher_init_val.data(), watcher_init_val.size()), GET_WATCHER_TENSIX_DEV_ADDR());
         }
     }
 

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -68,10 +68,12 @@ static inline void memcpy_to_device(void *__restrict dst, const void *__restrict
                 dst8 += sizeof(int32_t);
             }
             n -= n / sizeof(int32_t) * sizeof(int32_t);
-            for (size_t i = 0; i < n; ++i) {
-                *src8 = *dst8;
-                src8++;
-                dst8++;
+            // Copying the last few bytes (n < 4).
+            // Overrunning dst buffer is safe, because the actual allocated space for dst is guaranteed to be at least 4 byte aligned.
+            if (n > 0) {
+                int32_t val = 0;
+                std::memcpy(&val, src8, n);
+                _mm_stream_si32((int32_t *)dst8, val);
             }
         }
     }

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -18,6 +18,7 @@ template <typename T>
 using vector_memcpy_aligned = std::vector<T, tt::stl::aligned_allocator<T, MEMCPY_ALIGNMENT>>;
 
 // Ideally would work by cachelines, but the min size is less than that
+// Benchmarked to be approximately 1.4x - 1.8x faster than std::memcpy
 // TODO: Revisit this w/ regard to possibly eliminating min sizes and orphan writes at the end
 // TODO: ditto alignment isues
 template <bool debug_sync = false>

--- a/tt_metal/impl/dispatch/memcpy.hpp
+++ b/tt_metal/impl/dispatch/memcpy.hpp
@@ -23,7 +23,6 @@ using vector_memcpy_aligned = std::vector<T, tt::stl::aligned_allocator<T, MEMCP
 template <bool debug_sync = false>
 static inline void memcpy_to_device(void *__restrict dst, const void *__restrict src, size_t n) {
     TT_ASSERT((uintptr_t)dst % MEMCPY_ALIGNMENT == 0);
-    TT_ASSERT(n % sizeof(uint32_t) == 0);
 
     static constexpr uint32_t inner_loop = 8;
     static constexpr uint32_t inner_blk_size = inner_loop * sizeof(__m256i);
@@ -67,6 +66,12 @@ static inline void memcpy_to_device(void *__restrict dst, const void *__restrict
                 _mm_stream_si32((int32_t *)dst8, *(int32_t *)src8);
                 src8 += sizeof(int32_t);
                 dst8 += sizeof(int32_t);
+            }
+            n -= n / sizeof(int32_t) * sizeof(int32_t);
+            for (size_t i = 0; i < n; ++i) {
+                *src8 = *dst8;
+                src8++;
+                dst8++;
             }
         }
     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -793,7 +793,7 @@ void detail::Program_::init_semaphores(const Device &device, const CoreCoord &lo
         llrt::write_hex_vec_to_core(
             device.id(),
             device.physical_core_from_logical_core(logical_core, core_type),
-            {semaphore.get().initial_value()},
+            std::vector{semaphore.get().initial_value()},
             addr + semaphore.get().offset());
     }
 }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -101,12 +101,6 @@ std::vector<uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &co
     return read_hex_vec;
 }
 
-std::vector<uint8_t> read_hex_byte_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t sz_bytes) {
-    std::vector<uint8_t> read_hex_vec;
-    tt::Cluster::instance().read_core(read_hex_vec, sz_bytes, tt_cxy_pair(chip, core), addr);
-    return read_hex_vec;
-}
-
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, const CoreCoord &physical_core) {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(chip_id);
     return soc_desc.get_logical_ethernet_core_from_physical(physical_core);

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -89,14 +89,20 @@ ll_api::memory get_risc_binary(string const &path,
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
 
-void write_hex_vec_to_core(chip_id_t chip, const CoreCoord &core, const std::vector<uint32_t>& hex_vec, uint64_t addr, bool small_access) {
+void write_hex_vec_to_core(chip_id_t chip, const CoreCoord &core, tt::stl::Span<const uint8_t> hex_vec, uint64_t addr, bool small_access) {
     // the API is named "write_core", and its overloaded variant is taking (chip, core) pair, ie. it can write to
     // core's L1
-    tt::Cluster::instance().write_core(hex_vec.data(), hex_vec.size() * sizeof(uint32_t), tt_cxy_pair(chip, core), addr, small_access);
+    tt::Cluster::instance().write_core(hex_vec.data(), hex_vec.size(), tt_cxy_pair(chip, core), addr, small_access);
 }
 
 std::vector<uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t sz_bytes) {
     std::vector<uint32_t> read_hex_vec;
+    tt::Cluster::instance().read_core(read_hex_vec, sz_bytes, tt_cxy_pair(chip, core), addr);
+    return read_hex_vec;
+}
+
+std::vector<uint8_t> read_hex_byte_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t sz_bytes) {
+    std::vector<uint8_t> read_hex_vec;
     tt::Cluster::instance().read_core(read_hex_vec, sz_bytes, tt_cxy_pair(chip, core), addr);
     return read_hex_vec;
 }
@@ -121,8 +127,9 @@ void write_launch_msg_to_core(chip_id_t chip, const CoreCoord core, launch_msg_t
     }
 }
 
+static const uint32_t ERISC_APP_FW_ON_CORE_FLAG = 0x1;
 void launch_erisc_app_fw_on_core(chip_id_t chip, CoreCoord core) {
-    llrt::write_hex_vec_to_core(chip, core, {0x1}, eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
+    llrt::write_hex_vec_to_core(chip, core, tt::stl::Span(&ERISC_APP_FW_ON_CORE_FLAG, 1), eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
 }
 
 void print_worker_cores(chip_id_t chip_id) {
@@ -173,7 +180,7 @@ uint32_t generate_risc_startup_addr(bool is_eth_core) {
 void program_risc_startup_addr(chip_id_t chip_id, const CoreCoord &core) {
     std::vector<uint32_t> jump_to_fw;
     jump_to_fw.push_back(generate_risc_startup_addr(is_ethernet_core(core, chip_id)));
-    write_hex_vec_to_core(chip_id, core, jump_to_fw, 0);
+    write_hex_vec_to_core(chip_id, core, tt::stl::Span<const uint32_t>(jump_to_fw.data(), jump_to_fw.size()), 0);
 }
 
 bool test_load_write_read_risc_binary(

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -82,7 +82,6 @@ void write_hex_vec_to_core(
 }
 
 std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t size);
-std::vector<std::uint8_t> read_hex_byte_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t size);
 
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord &physical_core);
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -62,14 +62,27 @@ ll_api::memory get_risc_binary(string const &path,
 // CoreCoord core --> NOC coordinates ("functional workers" from the SOC descriptor)
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
+template<typename DType>
 void write_hex_vec_to_core(
     chip_id_t chip,
     const CoreCoord &core,
-    const std::vector<uint32_t> &hex_vec,
+    const std::vector<DType>& hex_vec,
     uint64_t addr,
-    bool small_access = false);
+    bool small_access = false) {
+    tt::Cluster::instance().write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
+}
+template<typename DType>
+void write_hex_vec_to_core(
+    chip_id_t chip,
+    const CoreCoord &core,
+    tt::stl::Span<const DType> hex_vec,
+    uint64_t addr,
+    bool small_access = false) {
+    tt::Cluster::instance().write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
+}
 
 std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t size);
+std::vector<std::uint8_t> read_hex_byte_vec_from_core(chip_id_t chip, const CoreCoord &core, uint64_t addr, uint32_t size);
 
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord &physical_core);
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -426,6 +426,12 @@ void Cluster::read_core(
     read_core(data.data(), size_in_bytes, core, addr, small_access);
 }
 
+void Cluster::read_core(
+    std::vector<uint8_t> &data, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access) const {
+    data.resize(size_in_bytes);
+    read_core(data.data(), size_in_bytes, core, addr, small_access);
+}
+
 void Cluster::write_reg(const std::uint32_t *mem_ptr, tt_cxy_pair target, uint64_t addr) const {
     const unsigned int size_in_bytes = sizeof(uint32_t);
     int chip_id = target.chip;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -426,12 +426,6 @@ void Cluster::read_core(
     read_core(data.data(), size_in_bytes, core, addr, small_access);
 }
 
-void Cluster::read_core(
-    std::vector<uint8_t> &data, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access) const {
-    data.resize(size_in_bytes);
-    read_core(data.data(), size_in_bytes, core, addr, small_access);
-}
-
 void Cluster::write_reg(const std::uint32_t *mem_ptr, tt_cxy_pair target, uint64_t addr) const {
     const unsigned int size_in_bytes = sizeof(uint32_t);
     int chip_id = target.chip;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -91,8 +91,6 @@ class Cluster {
         void *mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
     void read_core(
         std::vector<uint32_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
-    void read_core(
-        std::vector<uint8_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair &target) const {
         tt::umd::Cluster *device = dynamic_cast<tt::umd::Cluster *>(driver_.get());

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -91,6 +91,8 @@ class Cluster {
         void *mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
     void read_core(
         std::vector<uint32_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
+    void read_core(
+        std::vector<uint8_t> &data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair &target) const {
         tt::umd::Cluster *device = dynamic_cast<tt::umd::Cluster *>(driver_.get());

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -4,10 +4,11 @@
 
 #include "llrt/llrt.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "tt_metal/tt_stl/span.hpp"
 
 #include <unistd.h>
 
-void memset_l1(std::vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
+void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.
     const metal_SocDescriptor &sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
     for (auto &worker_core : sdesc.physical_workers) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -401,20 +401,15 @@ void print_page(
     std::cout << std::dec << std::endl;
 }
 
-void WriteToDeviceSharded(Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
-    uint32_t host_buffer_size_bytes = host_buffer.size() * sizeof(uint32_t);
+void WriteToDeviceSharded(Buffer &buffer, tt::stl::Span<const uint8_t> host_buffer) {
     TT_FATAL(
-        host_buffer_size_bytes <= buffer.size(),
+        host_buffer.size() <= buffer.size(),
         "Bounds-Error -- Attempting to write {} bytes to a {} byte buffer",
-        host_buffer_size_bytes,
+        host_buffer.size(),
         buffer.size());
 
     uint32_t page_size = buffer.page_size();
     TT_ASSERT(page_size == 0 ? buffer.size() == 0 : buffer.size() % page_size == 0);
-
-    static constexpr uint32_t bytes_per_page_entry = sizeof(uint32_t);
-    TT_ASSERT(page_size % bytes_per_page_entry == 0);
-    uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
 
     auto device = buffer.device();
 
@@ -425,18 +420,18 @@ void WriteToDeviceSharded(Buffer &buffer, const std::vector<uint32_t> &host_buff
         auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
         auto bank_id = device->bank_ids_from_logical_core(buffer.buffer_type(), core)[0];
         auto absolute_address = buffer.sharded_page_address(bank_id, dev_page_id);
-        auto data_index = host_page_id * num_entries_per_page;
-        std::vector<uint32_t> page;
+        auto data_index = host_page_id * page_size;
+        std::vector<uint8_t> page;
         page.insert(
-            page.end(), host_buffer.begin() + data_index, host_buffer.begin() + data_index + num_entries_per_page);
+            page.end(), host_buffer.begin() + data_index, host_buffer.begin() + data_index + page_size);
 
         auto noc_coordinates = buffer.noc_coordinates(bank_id);
         llrt::write_hex_vec_to_core(device->id(), noc_coordinates, page, absolute_address);
     }
 }
 
-void WriteToDeviceInterleavedContiguous(const Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
-    uint32_t host_buffer_size_bytes = host_buffer.size() * sizeof(uint32_t);
+void WriteToDeviceInterleavedContiguous(const Buffer &buffer, tt::stl::Span<const uint8_t> host_buffer) {
+    uint32_t host_buffer_size_bytes = host_buffer.size();
     TT_FATAL(
         host_buffer_size_bytes <= buffer.size(),
         "Bounds-Error -- Attempting to write {} bytes to a {} byte buffer",
@@ -446,20 +441,15 @@ void WriteToDeviceInterleavedContiguous(const Buffer &buffer, const std::vector<
     uint32_t page_size = buffer.page_size();
     uint32_t num_pages = buffer.num_pages();
 
-    static constexpr uint32_t bytes_per_page_entry = sizeof(uint32_t);
-    TT_FATAL(page_size % bytes_per_page_entry == 0,
-        "Invalid page size: {}. Page size  must be a multiple of bytes per page entry {}.", page_size, bytes_per_page_entry);
-    uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
-
     auto device = buffer.device();
     auto num_banks = device->num_banks(buffer.buffer_type());
     uint32_t bank_index = 0;
     int data_index = 0;
     for (int page_index = 0; page_index < num_pages; page_index++) {
         auto absolute_address = buffer.page_address(bank_index, page_index);
-        std::vector<uint32_t> page;
+        std::vector<uint8_t> page;
         page.insert(
-            page.end(), host_buffer.begin() + data_index, host_buffer.begin() + data_index + num_entries_per_page);
+            page.end(), host_buffer.begin() + data_index, host_buffer.begin() + data_index + page_size);
         switch (buffer.buffer_type()) {
             case BufferType::DRAM:
             case BufferType::L1:
@@ -471,11 +461,11 @@ void WriteToDeviceInterleavedContiguous(const Buffer &buffer, const std::vector<
         }
 
         bank_index = (bank_index + 1) % num_banks;
-        data_index += num_entries_per_page;
+        data_index += page_size;
     }
 }
 
-void WriteToDevice(Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
+void WriteToDevice(Buffer &buffer, tt::stl::Span<const uint8_t> host_buffer) {
     ZoneScoped;
     if (buffer.buffer_layout() == TensorMemoryLayout::INTERLEAVED ||
         buffer.buffer_layout() == TensorMemoryLayout::SINGLE_BANK) {
@@ -487,50 +477,32 @@ void WriteToDevice(Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
     }
 }
 
-void WriteToBuffer(std::shared_ptr<Buffer> buffer, const std::vector<uint32_t> &host_buffer) {
-    WriteToBuffer(*buffer, host_buffer);
-}
-
-void WriteToBuffer(Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
-    switch (buffer.buffer_type()) {
-        case BufferType::DRAM:  // fallthrough
-        case BufferType::L1:    // fallthrough
-        case BufferType::L1_SMALL: {
-            WriteToDevice(buffer, host_buffer);
-        } break;
-        case BufferType::SYSTEM_MEMORY: {
-            TT_THROW("Writing to host memory is unsupported!");
-        } break;
-        default: TT_THROW("Unsupported buffer type!");
-    }
-}
-
-void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, std::vector<uint32_t> &host_buffer) {
-    host_buffer.clear();  // overwrite the data
+void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, uint8_t* host_buffer) {
     uint32_t page_size = buffer.page_size();
     uint32_t num_pages = buffer.num_pages();
 
     auto device = buffer.device();
     auto num_banks = device->num_banks(buffer.buffer_type());
+    size_t host_idx = 0;
 
     uint32_t bank_index = 0;
     for (int page_index = 0; page_index < num_pages; page_index++) {
         auto absolute_address = buffer.page_address(bank_index, page_index);
-        std::vector<uint32_t> page;
+        std::vector<uint8_t> page;
         switch (buffer.buffer_type()) {
             case BufferType::DRAM:
             case BufferType::TRACE:
             case BufferType::L1:
             case BufferType::L1_SMALL: {
                 auto noc_coordinates = buffer.noc_coordinates(bank_index);
-                page = llrt::read_hex_vec_from_core(device->id(), noc_coordinates, absolute_address, page_size);
+                page = llrt::read_hex_byte_vec_from_core(device->id(), noc_coordinates, absolute_address, page_size);
             } break;
             default: TT_THROW("Unsupported buffer type to read from device!");
         }
 
         // Copy page into host buffer
         for (uint32_t entry : page) {
-            host_buffer.push_back(entry);
+            host_buffer[host_idx++] = entry;
         }
 
         bank_index = (bank_index + 1) % num_banks;
@@ -540,19 +512,18 @@ void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, std::vector<uint3
 void read_pages_to_host_helper(
     Device *device,
     Buffer &dev_buffer,
-    std::vector<uint32_t> &host_buffer,
+    uint8_t* host_buffer,
     const uint32_t &page_size,
     const uint32_t &host_page_id,
     const uint32_t &dev_page_id,
     const uint32_t &bank_id) {
     auto absolute_address = dev_buffer.sharded_page_address(bank_id, dev_page_id);
     auto noc_coordinates = dev_buffer.noc_coordinates(bank_id);
-    uint32_t num_entries_per_page = page_size / sizeof(uint32_t);
-    uint32_t host_buffer_start = host_page_id * num_entries_per_page;
-    tt::Cluster::instance().read_core(host_buffer.data() + host_buffer_start, page_size, tt_cxy_pair(device->id(), noc_coordinates), absolute_address);
+    uint32_t host_buffer_start = host_page_id * page_size;
+    tt::Cluster::instance().read_core(host_buffer + host_buffer_start, page_size, tt_cxy_pair(device->id(), noc_coordinates), absolute_address);
 }
 
-void ReadFromDeviceSharded(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order) {
+void ReadFromDeviceSharded(Buffer &buffer, uint8_t* host_buffer, bool shard_order) {
     TensorMemoryLayout buffer_layout = buffer.buffer_layout();
 
     auto device = buffer.device();
@@ -560,13 +531,8 @@ void ReadFromDeviceSharded(Buffer &buffer, std::vector<uint32_t> &host_buffer, b
     std::cout << "Reading From Device Height Sharded " << std::endl;
 #endif
 
-    int output_page_index = 0;
     auto total_pages = buffer.num_dev_pages();
     uint32_t page_size = buffer.page_size();
-    uint32_t bytes_per_page_entry = sizeof(uint32_t);
-    uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
-
-    host_buffer = std::vector<uint32_t>(total_pages * num_entries_per_page);
 
     const auto& buffer_page_mapping = *buffer.get_buffer_page_mapping();
     for (int dev_page_id = 0; dev_page_id < total_pages; dev_page_id++) {
@@ -584,9 +550,8 @@ void ReadFromDeviceSharded(Buffer &buffer, std::vector<uint32_t> &host_buffer, b
     }
 }
 
-void ReadFromDevice(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order) {
+void ReadFromDevice(Buffer &buffer, uint8_t* host_buffer, bool shard_order) {
     ZoneScoped;
-    host_buffer.clear();  // overwrite the data
     if (buffer.buffer_layout() == TensorMemoryLayout::INTERLEAVED ||
         buffer.buffer_layout() == TensorMemoryLayout::SINGLE_BANK) {
         ReadFromDeviceInterleavedContiguous(buffer, host_buffer);
@@ -601,7 +566,7 @@ void ReadFromBuffer(std::shared_ptr<Buffer> buffer, std::vector<uint32_t> &host_
     ReadFromBuffer(*buffer, host_buffer, shard_order);
 }
 
-void ReadFromBuffer(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order) {
+void ReadFromBuffer(Buffer &buffer, uint8_t* host_buffer, bool shard_order) {
     Device *device = buffer.device();
     switch (buffer.buffer_type()) {
         case BufferType::DRAM:
@@ -622,14 +587,9 @@ void ReadFromBuffer(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool sha
     }
 }
 
-void ReadShard(Buffer &buffer, std::vector<uint32_t> &host_buffer, const uint32_t &core_id) {
+void ReadShard(Buffer &buffer, uint8_t* host_buffer, const uint32_t &core_id) {
     Device *device = buffer.device();
     TT_ASSERT(is_sharded(buffer.buffer_layout()));
-    host_buffer.clear();  // overwrite the data
-
-    uint32_t num_entries_per_page = buffer.page_size() / sizeof(uint32_t);
-    uint32_t num_entries_per_shard = num_entries_per_page * buffer.shard_spec().size();
-    host_buffer = std::vector<uint32_t>(num_entries_per_shard);
 
     std::vector<uint32_t> page_ids;
     const auto& buffer_page_mapping = *buffer.get_buffer_page_mapping();

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -500,16 +500,18 @@ void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, uint8_t* host_buf
     size_t host_idx = 0;
 
     uint32_t bank_index = 0;
+    std::vector<uint8_t> page;
     for (int page_index = 0; page_index < num_pages; page_index++) {
         auto absolute_address = buffer.page_address(bank_index, page_index);
-        std::vector<uint8_t> page;
+        page.clear();
         switch (buffer.buffer_type()) {
             case BufferType::DRAM:
             case BufferType::TRACE:
             case BufferType::L1:
             case BufferType::L1_SMALL: {
                 auto noc_coordinates = buffer.noc_coordinates(bank_index);
-                page = llrt::read_hex_byte_vec_from_core(device->id(), noc_coordinates, absolute_address, page_size);
+                page.resize(page_size);
+                tt::Cluster::instance().read_core(page.data(), page_size, tt_cxy_pair(device->id(), noc_coordinates), absolute_address);
             } break;
             default: TT_THROW("Unsupported buffer type to read from device!");
         }

--- a/ttnn/cpp/ttnn/operations/numpy/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/numpy/functions.hpp
@@ -80,8 +80,7 @@ static Tensor full(
                     tt::tt_metal::EnqueueWriteBuffer(cmd_queue, device_buffer, owned_buffer.data(), false);
                 }
             } else {
-                auto uint32_data = tt::tt_metal::tensor_impl::pack_vec_into_uint32_vec<T>(owned_buffer);
-                tt::tt_metal::detail::WriteToBuffer(*device_buffer, uint32_data);
+                tt::tt_metal::detail::WriteToBuffer(*device_buffer, owned_buffer.get());
             }
 
             return optional_output_tensor.value();

--- a/ttnn/cpp/ttnn/tensor/layout/page_config.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/page_config.cpp
@@ -119,9 +119,7 @@ Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const Mem
 {
     TT_FATAL(dtype != DataType::BFLOAT4_B && dtype != DataType::BFLOAT8_B, "BFLOAT4_B and BFLOAT8_B data types are not supported for ROW_MAJOR layout");
 
-    const auto element_size = CMAKE_UNIQUE_NAMESPACE::element_size_bytes(dtype);
-    auto width_alignment = sizeof(uint32_t) / element_size;
-
+    uint32_t width_alignment = 1;
     if (memory_config.shard_spec.has_value()) {
         const auto& shard_spec = memory_config.shard_spec.value();
         if (shard_spec.physical_shard_shape.has_value()) {
@@ -130,12 +128,6 @@ Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const Mem
         if (shard_spec.mode == ShardMode::PHYSICAL && memory_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
             const auto& physical_shard_shape = shard_spec.shape;
             const auto physical_shard_width = physical_shard_shape[1];
-            TT_FATAL(
-                (physical_shard_width % width_alignment) == 0,
-                "For Row Major layout and shard mode {}, the width of shard shape {} is treated as physical shard width and must be aligned to {} since we pack buffer data as uint32_t.",
-                    shard_spec.mode, physical_shard_shape, width_alignment
-                );
-
             width_alignment = physical_shard_width;
         }
     }
@@ -145,12 +137,6 @@ Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const Mem
 void RowMajorPageConfig::validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const {
     TT_FATAL(!alignment.empty(), "Alignment must contain at least one dimension for Row Major layout.");
     const uint32_t width_alignment = alignment[-1];
-    const uint32_t element_size = CMAKE_UNIQUE_NAMESPACE::element_size_bytes(dtype);
-    const uint32_t page_alignment = sizeof(uint32_t) / element_size;
-
-    TT_FATAL((width_alignment % page_alignment) == 0,
-        "Incorrect alignment configuration for Row Major layout: innermost dimension alignment must be aligned to {} bytes since we pack buffer data as uint32_t. With element size of {} byte(s), alignment {} must be a multiple of alignment {}.",
-        sizeof(uint32_t), element_size, alignment, page_alignment);
 
     // TODO: Do we need to validate sharded width here if wee are guaranteed that physical_shard_width is set as width_alignment
     if (memory_config.shard_spec.has_value() && memory_config.shard_spec.value().mode == ShardMode::PHYSICAL && memory_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -676,7 +676,7 @@ void write_data_to_device_buffer(
 template <typename T, template <typename> typename BufferType>
 void write_data_to_device_buffer(const BufferType<T>& host_buffer, Buffer& device_buffer) {
     ZoneScoped;
-    ::detail::WriteToDevice(device_buffer, tt::stl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(T)));
+    ::detail::WriteToBuffer(device_buffer, tt::stl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(T)));
 }
 
 template <typename T, template <typename> typename BufferType>

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -141,13 +141,12 @@ void validate_on_device_dtype_and_layout(Device* device, const ttnn::SimpleShape
              dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B),
             "Only UINT32, INT32, FLOAT32, UINT16, UINT8, BFLOAT16, BFLOAT8_B, or BFLOAT4_B dtypes are supported on device!");
     };
-    auto supported_layout = [&shape, &dtype, &layout]() {
+    auto supported_layout = [&dtype, &layout]() {
         switch (dtype) {
             case DataType::UINT32:
             case DataType::INT32:
-            case DataType::FLOAT32: break;
+            case DataType::FLOAT32:
             case DataType::UINT8:
-                break;
             case DataType::UINT16:
             case DataType::BFLOAT16:
                 break;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -147,21 +147,9 @@ void validate_on_device_dtype_and_layout(Device* device, const ttnn::SimpleShape
             case DataType::INT32:
             case DataType::FLOAT32: break;
             case DataType::UINT8:
-                if (layout == Layout::ROW_MAJOR) {
-                    TT_ASSERT(
-                        shape[-1] % 4 == 0,
-                        "For ROW_MAJOR layout tensors with dtype UINT8, tensor width must be divisible by "
-                        "4 since data is packed as uint32_t when creating buffers on device!");
-                }
                 break;
             case DataType::UINT16:
             case DataType::BFLOAT16:
-                if (layout == Layout::ROW_MAJOR) {
-                    TT_ASSERT(
-                        shape[-1] % 2 == 0,
-                        "For ROW_MAJOR layout tensors with dtype BFLOAT16 or UINT16, tensor width must be divisible by "
-                        "2 since data is packed as uint32_t when creating buffers on device!");
-                }
                 break;
             case DataType::BFLOAT8_B:
             case DataType::BFLOAT4_B:
@@ -628,14 +616,12 @@ Tensor to_host_sharded(const Tensor& tensor) {
     auto device_buffer = tensor.buffer();
     auto device = tensor.device();
     TT_ASSERT(device != nullptr && "Need device to be set copy data from device to host!");
-    uint32_t size_in_bytes = device_buffer->size();
-    std::vector<uint32_t> device_data;
+    std::vector<T> data_vec;
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         TT_THROW("FAST_DISPATCH is not supported for to_host_sharded!");
     }
-    ::detail::ReadFromBuffer(*device_buffer, device_data, true);
-    auto data_vec = unpack_uint32_vec<T>(device_data);
+    ::detail::ReadFromBuffer(*device_buffer, data_vec, true);
     auto output_buffer = owned_buffer::create<T>(std::move(data_vec));
     return Tensor(OwnedStorage{output_buffer}, tensor.get_legacy_shape(), tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
 }
@@ -690,11 +676,7 @@ void write_data_to_device_buffer(
 template <typename T, template <typename> typename BufferType>
 void write_data_to_device_buffer(const BufferType<T>& host_buffer, Buffer& device_buffer) {
     ZoneScoped;
-    // TODO(arakhmati): can we use generators in this function to go from `data_to_write` to `uint32_data`?
-    // And effectively get rid of any additional allocation
-
-    auto uint32_data = pack_vec_into_uint32_vec<T>(host_buffer);
-    ::detail::WriteToBuffer(device_buffer, uint32_data);
+    ::detail::WriteToDevice(device_buffer, tt::stl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(T)));
 }
 
 template <typename T, template <typename> typename BufferType>
@@ -1234,11 +1216,10 @@ Tensor extract_shard(const Tensor& tensor, const uint32_t& core_id) {
     auto buffer_shard_shape = buffer->shard_spec().shape();
     std::array<uint32_t, 4> shard_shape_array = {1, 1, buffer_shard_shape[0], buffer_shard_shape[1]};
     tt::tt_metal::LegacyShape shard_shape(shard_shape_array);
-    std::vector<uint32_t> device_data;
+    std::vector<T> device_data;
     ::detail::ReadShard(*buffer, device_data, core_id);
 
-    auto unpacked_data = tensor_impl::unpack_uint32_vec<T>(device_data);
-    auto output_buffer = owned_buffer::create<T>(std::move(unpacked_data));
+    auto output_buffer = owned_buffer::create<T>(std::move(device_data));
     return Tensor(OwnedStorage{output_buffer}, shard_shape, tensor.get_dtype(), tensor.get_layout(), tensor.get_tile());
 }
 


### PR DESCRIPTION
### Ticket

### Problem description
Currently its required that RowMajor tensor size must be aligned to 4 bytes, because the data is transferred to device as a vector of `uint32_t`. This creates limitations in TTNN and complicates handling of Row Major tensors.
This PR is a prerequisite for https://github.com/tenstorrent/tt-metal/pull/15028
Thanks to @abhullar-tt for helping with lifting those restrictions.

### What's changed
Modify Metal API allowing to send an arbitrary vector to device
Modify PageConfig removing alignment restrictions
Remove conversions to/from `vector<uint32_t>` for sending tensor to/from device
Remove asserts on buffer alignment for row major
Enable previously disabled tensor tests

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11944863653)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/11929076543)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11929113643)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11929096855)
- [x] New/Existing tests provide coverage for changes
