### PR TITLE
Update remove-stale-branches.yaml

### DIFF
--- a/.github/workflows/remove-stale-branches.yaml
+++ b/.github/workflows/remove-stale-branches.yaml
@@ -9,7 +9,7 @@ jobs:
   remove-stale-branches:
     runs-on: ubuntu-latest
     steps:
-      - uses: fpicalausa/remove-stale-branches@v2.0.1
+      - uses: blozano-tt/remove-stale-branches@5286c692f7f58cc0b4fc5b096c834e013616587b
         with:
           dry-run: false
           days-before-branch-stale: 180 # Branches stale for ~6 months

--- a/.github/workflows/remove-stale-branches.yaml
+++ b/.github/workflows/remove-stale-branches.yaml
@@ -9,7 +9,7 @@ jobs:
   remove-stale-branches:
     runs-on: ubuntu-latest
     steps:
-      - uses: blozano-tt/remove-stale-branches@5286c692f7f58cc0b4fc5b096c834e013616587b
+      - uses: blozano-tt/remove-stale-branches@379c5b1430ca2951a1365427e7eb6574cfc4c7dd
         with:
           dry-run: false
           days-before-branch-stale: 180 # Branches stale for ~6 months

--- a/.github/workflows/remove-stale-branches.yaml
+++ b/.github/workflows/remove-stale-branches.yaml
@@ -2,7 +2,7 @@ name: "[internal] Remove Stale Branches"
 
 on:
   schedule:
-    - cron: "0 */6 * * *"   # Runs at midnight, 6AM, noon, 6pm
+    - cron: "0 0,12 * * *"   # Runs at midnight (0:00) and noon (12:00)
   workflow_dispatch: # Allows manual trigger
 
 jobs:


### PR DESCRIPTION
### Problem description
Existing action scans the same branches every time it runs until they are deleted which won't happen for 7 days based on settings. We might as well run it once per week.

### What's changed
Using @blozano-tt fork of action
New version will continue scanning until it either marks stale or deletes X 


