### PR TITLE
#15140: Fix UAF error when MeshDevice.close_devices() not invoked

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,5 +18,5 @@ endif(TT_METAL_BUILD_TESTS)
 
 if(TTNN_BUILD_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn)
 endif(TTNN_BUILD_TESTS)

--- a/tests/ttnn/CMakeLists.txt
+++ b/tests/ttnn/CMakeLists.txt
@@ -6,7 +6,6 @@ function(setup_ttnn_test_target target_name)
             test_common_libs
             ttnn
             Metalium::Metal
-            GTest::gtest
             GTest::gtest_main
     )
     target_include_directories(

--- a/tests/ttnn/CMakeLists.txt
+++ b/tests/ttnn/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Common function to set up target properties for TTNN tests
+function(setup_ttnn_test_target target_name)
+    target_link_libraries(
+        ${target_name}
+        PUBLIC
+            test_common_libs
+            ttnn
+            Metalium::Metal
+            GTest::gtest
+            GTest::gtest_main
+    )
+    target_include_directories(
+        ${target_name}
+        PRIVATE
+            ${UMD_HOME}
+            ${PROJECT_SOURCE_DIR}
+            ${PROJECT_SOURCE_DIR}/tt_metal
+            ${PROJECT_SOURCE_DIR}/tests
+            ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_target_properties(
+        ${target_name}
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY
+                ${PROJECT_BINARY_DIR}/test/ttnn
+    )
+endfunction()
+
+add_subdirectory(distributed)
+add_subdirectory(unit_tests/gtests)

--- a/tests/ttnn/distributed/CMakeLists.txt
+++ b/tests/ttnn/distributed/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test_distributed test_distributed.cpp)
+
+# Set up properties for the target
+setup_ttnn_test_target(test_distributed)
+
+# Add test to CTest
+add_test(NAME test_distributed COMMAND test_distributed)

--- a/tests/ttnn/distributed/test_distributed.cpp
+++ b/tests/ttnn/distributed/test_distributed.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <ttnn/core.hpp>
+#include <ttnn/distributed/api.hpp>
+
+namespace ttnn::distributed::test {
+
+class DistributedTest : public ::testing::Test {
+   protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(DistributedTest, TestSystemMeshTearDownWithoutClose) {
+    auto& sys = tt::tt_metal::distributed::SystemMesh::instance();
+    auto mesh = ttnn::distributed::open_mesh_device(
+        {2, 4}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, tt::tt_metal::DispatchCoreType::WORKER);
+
+    auto [rows, cols] = sys.get_shape();
+    EXPECT_GT(rows, 0);
+    EXPECT_GT(cols, 0);
+}
+
+}  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -30,33 +30,7 @@ add_executable(unit_tests_ttnn_tensor ${TTNN_TENSOR_UNIT_TESTS_SRC})
 add_executable(test_multi_device ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_device.cpp)
 add_executable(galaxy_unit_tests_ttnn ${CMAKE_CURRENT_SOURCE_DIR}/test_ccl_on_galaxy.cpp)
 
-# Common function to set up target properties
-function(setup_ttnn_test_target target_name)
-    target_link_libraries(
-        ${target_name}
-        PUBLIC
-            test_common_libs
-            ttnn
-            Metalium::Metal
-    )
-    target_include_directories(
-        ${target_name}
-        PRIVATE
-            ${UMD_HOME}
-            ${PROJECT_SOURCE_DIR}
-            ${PROJECT_SOURCE_DIR}/tt_metal
-            ${PROJECT_SOURCE_DIR}/tests
-            ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-    set_target_properties(
-        ${target_name}
-        PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY
-                ${PROJECT_BINARY_DIR}/test/ttnn
-    )
-endfunction()
-
-# Set up properties for both targets
+# Set up properties for all targets
 setup_ttnn_test_target(unit_tests_ttnn)
 setup_ttnn_test_target(unit_tests_ttnn_ccl)
 setup_ttnn_test_target(unit_tests_ttnn_tensor)

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -368,13 +368,15 @@ std::shared_ptr<MeshDevice> SystemMesh::get_mesh_device(const std::vector<chip_i
     log_trace(LogMetal, "Getting mesh device for {} physical devices: {}", physical_device_ids.size(), physical_device_ids);
     std::unordered_set<chip_id_t> input_set(physical_device_ids.begin(), physical_device_ids.end());
 
-    for (const auto& [mesh_id, mesh_device] : this->assigned_mesh_device_devices) {
-        const auto& assigned_devices = this->assigned_devices.at(mesh_id);
-        std::unordered_set<chip_id_t> assigned_set(assigned_devices.begin(), assigned_devices.end());
-        log_trace(LogMetal, "Assigned devices: {}", assigned_devices);
+    for (const auto& [mesh_id, weak_mesh_device] : this->assigned_mesh_device_devices) {
+        if (auto mesh_device = weak_mesh_device.lock()) {
+            const auto& assigned_devices = this->assigned_devices.at(mesh_id);
+            std::unordered_set<chip_id_t> assigned_set(assigned_devices.begin(), assigned_devices.end());
+            log_trace(LogMetal, "Assigned devices: {}", assigned_devices);
 
-        if (input_set == assigned_set) {
-            return mesh_device;
+            if (input_set == assigned_set) {
+                return mesh_device;
+            }
         }
     }
     TT_THROW("No mesh device found for the provided devices");

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -57,7 +57,7 @@ class SystemMesh {
     // to keep track of this but DevicePool seems to open all devices associated with an MMIO device id
     std::unordered_map<MeshDeviceID, std::map<chip_id_t, Device*>> opened_devices;
     std::unordered_map<MeshDeviceID, std::vector<chip_id_t>> assigned_devices;
-    std::unordered_map<MeshDeviceID, std::shared_ptr<MeshDevice>> assigned_mesh_device_devices;
+    std::unordered_map<MeshDeviceID, std::weak_ptr<MeshDevice>> assigned_mesh_device_devices;
     std::unordered_map<chip_id_t, Device *> assigned_physical_id_to_device;
 
     // Logical mesh shape and coordinates

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -968,6 +968,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                                     dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE,
                                     settings.producer_semaphore_id,  // upstream sem
                                     mux_sem++); // local sem
+                        connections_remaining--;
                     }
                     uint32_t src_id_start = 0xA1 + mux_id * MAX_SWITCH_FAN_IN;
                     uint32_t dst_id_start = 0xB1 + mux_id * MAX_SWITCH_FAN_IN;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15140)

### Problem description
When `MeshDevice::close_devices()` not invoked before program termination, there is a UAF issue with SystemMesh. 

### What's changed
1. The primary fix is changing the held ownership of MeshDevice handles in SystemMesh to be a weak reference to avoid double delete. 
2. Running ASAN build exposed an issue in `device.cpp` which is now fixed. Loop iterations didn't properly decrement `connections_remaining`
3. Added new unit test file in TT-NN.


### Checklist
- [x] Post commit CI passes:
    - https://github.com/tenstorrent/tt-metal/actions/runs/11929924625
    - https://github.com/tenstorrent/tt-metal/actions/runs/11929927118
- [n/a] Blackhole Post commit (if applicable)
- [n/a] Model regression CI testing passes (if applicable)
- [n/a] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
