### PR TITLE
Update unary backward docs

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/celu_bw/celu_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/celu_bw/celu_bw.py
@@ -5,18 +5,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -55,8 +49,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_grad_tensor = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), grad_dtype

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/clamp_bw/clamp_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/clamp_bw/clamp_bw.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, gen_low_high_scalars, sanitize_shape_rm
@@ -14,11 +13,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -82,8 +76,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/elu_bw/elu_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/elu_bw/elu_bw.py
@@ -5,18 +5,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -55,8 +49,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_grad_tensor = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), grad_dtype

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/hardshrink_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/hardshrink_bw.py
@@ -6,18 +6,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -56,8 +50,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_grad_tensor = gen_func_with_cast_tt(partial(torch_random, low=-10, high=10, dtype=torch.float32), grad_dtype)(
         input_shape

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/hardtanh_bw/hardtanh_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/hardtanh_bw/hardtanh_bw.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
@@ -14,11 +13,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -46,12 +40,6 @@ parameters = {
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
         return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["grad_dtype"] == ttnn.bfloat8_b or test_vector["input_a_dtype"] == ttnn.bfloat8_b
-    ):
-        return True, "bfloat8_b is only supported on tiled layout"
-    if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
-        return True, "bfloat8_b is not supported on input_tensor_a"
     return False, None
 
 
@@ -70,8 +58,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/leaky_relu_bw/leaky_relu_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/leaky_relu_bw/leaky_relu_bw.py
@@ -6,18 +6,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -29,8 +23,8 @@ parameters = {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 16)
         + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 16)
         + gen_shapes([32, 32], [256, 256], [32, 32], 16),
-        "grad_dtype": [ttnn.bfloat16],
-        "input_a_dtype": [ttnn.bfloat16],
+        "grad_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "grad_layout": [ttnn.TILE_LAYOUT],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "grad_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -56,8 +50,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_grad_tensor = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), grad_dtype

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/pow_bw/pow_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/pow_bw/pow_bw.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
@@ -14,11 +13,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -85,8 +79,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/rdiv_bw/rdiv_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/rdiv_bw/rdiv_bw.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, gen_rand_exclude_range, sanitize_shape_rm
@@ -14,11 +13,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -82,8 +76,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/softplus_bw/softplus_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/softplus_bw/softplus_bw.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
@@ -14,11 +13,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -67,8 +61,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/softshrink_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/softshrink_bw.py
@@ -6,18 +6,12 @@ from typing import Optional, Tuple
 from functools import partial
 
 import torch
-import random
 import ttnn
 from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
-
-# Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
-
-random.seed(0)
 
 
 # Parameters provided to the test vector generator are defined here.
@@ -58,8 +52,7 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
+    torch.manual_seed(0)
 
     torch_grad_tensor = gen_func_with_cast_tt(partial(torch_random, low=-10, high=10, dtype=torch.float32), grad_dtype)(
         input_shape

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -507,9 +507,9 @@ void bind_unary_backward_two_float_with_default(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> output = {1}(grad_tensor, input, {2} = {4}, {5} = {7})
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(grad_tensor, input, {2} = {4}, {5} = {7}
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
@@ -587,8 +587,8 @@ void bind_unary_backward_float_with_default(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(grad_tensor, input, {2} = {4})
         )doc",
         operation.base_name(),
@@ -619,6 +619,7 @@ void bind_unary_backward_float_with_default(
             py::arg("memory_config") = std::nullopt});
 }
 
+
 template <typename unary_backward_operation_t>
 void bind_unary_backward_optional_float_params_with_default(
     py::module& module,
@@ -641,8 +642,8 @@ void bind_unary_backward_optional_float_params_with_default(
             input_tensor (ttnn.Tensor): the input tensor.
 
         Keyword args:
-            {2} (float, optional): {3}. Defaults to `{4}`.
-            {5} (float, optional): {6}. Defaults to `{7}`.
+            {2} (float, optional): {3}. Defaults to `None`.
+            {5} (float, optional): {6}. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
 
         Returns:
@@ -666,9 +667,11 @@ void bind_unary_backward_optional_float_params_with_default(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> output = {1}(grad_tensor, input, {2} = {4}, {5} = {7})
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> {2} = 0.5
+            >>> {5} = 2.0
+            >>> output = {1}(grad_tensor, input, {2}, {5})
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
@@ -764,8 +767,9 @@ void bind_unary_backward_float_string_default(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> {2} = 0.5
             >>> output = {1}(grad_tensor, input, {2}, {4} = {6})
         )doc",
         operation.base_name(),
@@ -800,79 +804,6 @@ void bind_unary_backward_float_string_default(
             py::arg("memory_config") = std::nullopt});
 }
 
-template <typename unary_backward_operation_t>
-void bind_unary_backward_string_default(
-    py::module& module,
-    const unary_backward_operation_t& operation,
-    const std::string& parameter_name_a,
-    const std::string& parameter_a_doc,
-    string parameter_a_value,
-    const std::string_view description,
-    const std::string& supported_dtype = "BFLOAT16",
-    const std::string& note = "") {
-    auto doc = fmt::format(
-        R"doc(
-        {5}
-
-        Args:
-            grad_tensor (ttnn.Tensor): the input gradient tensor.
-            input_tensor (ttnn.Tensor): the input tensor.
-
-        Keyword args:
-            {2} (string, optional): {3}. Defaults to `{4}`.
-            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
-
-        Returns:
-            List of ttnn.Tensor: the output tensor.
-
-        Note:
-            Supported dtypes, layouts, and ranks:
-
-            .. list-table::
-               :header-rows: 1
-
-               * - Dtypes
-                 - Layouts
-                 - Ranks
-               * - {6}
-                 - TILE
-                 - 2, 3, 4
-
-            {7}
-
-        Example:
-
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> output = {1}(grad_tensor, input, {2} = {4})
-        )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        parameter_name_a,
-        parameter_a_doc,
-        parameter_a_value,
-        description,
-        supported_dtype,
-        note);
-
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const unary_backward_operation_t& self,
-               const ttnn::Tensor& grad_tensor,
-               const ttnn::Tensor& input_tensor,
-               string parameter_a,
-               const std::optional<MemoryConfig>& memory_config) {
-                return self(grad_tensor, input_tensor, parameter_a, memory_config);
-            },
-            py::arg("grad_tensor"),
-            py::arg("input_tensor"),
-            py::kw_only(),
-            py::arg(parameter_name_a.c_str()) = parameter_a_value,
-            py::arg("memory_config") = std::nullopt});
-}
 
 template <typename unary_backward_operation_t>
 void bind_unary_backward_unary_optional_float(
@@ -917,8 +848,8 @@ void bind_unary_backward_unary_optional_float(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
-            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(grad_tensor, tensor, {2})
         )doc",
         operation.base_name(),
@@ -994,8 +925,8 @@ void bind_unary_backward_shape(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+            >>> grad_tensor = ttnn.from_torch(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.rand([2, 1, 32, 32], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(grad_tensor, input, {2})
         )doc",
         operation.base_name(),
@@ -1066,8 +997,8 @@ void bind_unary_backward_optional(
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+            >>> grad_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(grad_tensor, tensor)
         )doc",
         operation.base_name(),
@@ -1202,8 +1133,10 @@ void bind_unary_backward_prod_bw(py::module& module, const unary_backward_operat
 
         Example:
 
-            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
-            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device=device)
+            >>> grad_tensor = ttnn.from_torch(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> input = ttnn.from_torch(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> all_dimensions = True
+            >>> dim =0
             >>> output = {1}(grad_tensor, input, all_dimensions, dim)
         )doc",
         operation.base_name(),
@@ -1418,7 +1351,8 @@ void py_module(py::module& module) {
         "max",
         "Maximum value",
         1.0,
-        R"doc(Performs backward operations for hardtanh activation function on :attr:`input_tensor`, :attr:`min`, :attr:`max` with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for hardtanh activation function on :attr:`input_tensor`, :attr:`min`, :attr:`max` with given :attr:`grad_tensor`.)doc",
+        R"doc(BFLOAT16, BFLOAT8_B)doc");
 
 
     detail::bind_unary_backward_float_with_default(
@@ -1436,7 +1370,8 @@ void py_module(py::module& module) {
         "lambd",
         "Lambda value for the softshrink formula ",
         0.5,
-        R"doc(Performs backward operations for softshrink on :attr:`input_tensor`, :attr:`lambd`, with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for softshrink on :attr:`input_tensor`, :attr:`lambd`, with given :attr:`grad_tensor`.)doc",
+        R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     detail::bind_unary_backward_float_with_default(
         module,
@@ -1453,8 +1388,7 @@ void py_module(py::module& module) {
         "alpha",
         "alpha value for the elu formula ",
         1.0,
-        R"doc(Performs backward operations for elu on :attr:`input_tensor`, :attr:`alpha`, with given :attr:`grad_tensor`.)doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(Performs backward operations for elu on :attr:`input_tensor`, :attr:`alpha`, with given :attr:`grad_tensor`.)doc");
 
     detail::bind_unary_backward_float_with_default(
         module,
@@ -1627,7 +1561,7 @@ void py_module(py::module& module) {
     detail::bind_unary_backward_op(
         module,
         ttnn::tan_bw,
-        R"doc(Performs backward operations for tan on :attr:`input_tensor` with given :attr:`grad_tensor`. "Supported input range is (-1.45, 1.45)")doc",
+        R"doc(Performs backward operations for tan on :attr:`input_tensor` with given :attr:`grad_tensor`. Supported input range is (-1.45, 1.45))doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     detail::bind_unary_backward_op(


### PR DESCRIPTION
Ticket

Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/14983

Problem description

Update docs for unary backward ops

### What's changed
Updated docs for the following binary backward ops :

- hardtanh_bw
- softplus_bw
- clamp_bw
- clip_bw
- hardshrink_bw
- softshrink_bw
- leakyrelu_bw
- elu_bw
- celu_bw
- logiteps_bw
- rdiv_bw
- pow_bw
- prod_bw
- exp_bw
- tanh_bw
- sqrt_bw
- fill_bw

### Checklist
- [x] All Post commit CI
