### PR TITLE
Force single core untilize on BH

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -508,9 +508,9 @@ def untilize(x):
     ) == 0, "The last two dimensions of the tensor must be divisible by 32"
 
     if isinstance(x, torch.Tensor):
-        ret = torch.zeros(x.shape)
+        ret = torch.zeros(x.shape, dtype=x.dtype)
     else:
-        ret = np.zeros(x.shape)
+        ret = np.zeros(x.shape, dtype=x.dtype)
 
     for B in range(x.shape[0]):
         for C in range(x.shape[1]):

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py
@@ -11,7 +11,6 @@ from models.utility_functions import untilize, comp_pcc
 from models.utility_functions import is_grayskull, skip_for_blackhole
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -109,7 +109,9 @@ operation::ProgramWithCallbacks Untilize::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    if (this->use_multicore) {
+    auto device_is_blackhole = input_tensor_a.device()->arch() == tt::ARCH::BLACKHOLE;
+    // FIXME: Remove this restriction once multicore untilize is supported on blackhole
+    if (this->use_multicore && !device_is_blackhole) {
         return detail::untilize_multi_core(input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
     } else {
         return detail::untilize_single_core(input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14061

### Problem description
The multicore untilize op is currently broken on BH.

### What's changed
- Temporary change to force untilize to use the single core op on BH to unblock bringup efforts.
- Change to the Python reference implementation of untilize so that it doesn't modify the dtype when untilizing. I came across this problem while debugging #14061 and decided to roll the fix into this PR.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11941777312)
- [ ] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11941778139)
- [ ] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/11941778941)
- [ ] [Blackhole post commit passes](https://github.com/tenstorrent/tt-metal/actions/runs/11941930513)
- [ ] New/Existing tests provide coverage for changes
