### PR TITLE
15178: fix dprint race condition

### DIFF
--- a/tt_metal/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/dprint_common.h
@@ -89,21 +89,22 @@ enum DPrintTypeID : uint8_t {
 static_assert(DPrintTypeID_Count < 64, "Exceeded number of dprint types");
 
 
-// We need to set thw wpos, rpos pointers to 0 in the beginning of the kernel startup
+// We need to set the wpos, rpos pointers to 0 in the beginning of the kernel startup
 // Because there's no mechanism (known to me) to initialize values at fixed mem locations in kernel code,
 // in order to initialize the pointers in the buffers we use a trick with print server writing
 // a magic value to a fixed location, we look for it on device, and only if it's present we initialize
 // the read and write ptrs to 0 in DebugPrinter() constructor. This check is actually done every time
 // a DebugPrinter() object is created (which can be many times), but results in resetting the pointers
 // only once.
-constexpr int DEBUG_PRINT_SERVER_STARTING_MAGIC = 0x12341234;
-constexpr int DEBUG_PRINT_SERVER_DISABLED_MAGIC = 0x23455432;
+// These magic values must not be equal to any real wpos/rpos values.
+constexpr uint32_t DEBUG_PRINT_SERVER_STARTING_MAGIC = 0x98989898;
+constexpr uint32_t DEBUG_PRINT_SERVER_DISABLED_MAGIC = 0xf8f8f8f8;
 
 // In case a single argument to operator << (such as a string) is larger than the buffer size
 // (making it impossible to print) we will instead print this message.
 constexpr const char* debug_print_overflow_error_message = "*** INTERNAL DEBUG PRINT BUFFER OVERFLOW ***\n\n";
 
-#define ATTR_PACK   __attribute__((packed))
+#define ATTR_PACK __attribute__((packed))
 
 struct DebugPrintMemLayout {
     struct Aux {

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -376,6 +376,20 @@ void WriteInitMagic(Device *device, const CoreCoord& phys_core, int hart_id, boo
     std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);
     initbuf[0] = uint32_t(enabled ? DEBUG_PRINT_SERVER_STARTING_MAGIC : DEBUG_PRINT_SERVER_DISABLED_MAGIC);
     tt::llrt::write_hex_vec_to_core(device->id(), phys_core, initbuf, base_addr);
+
+    // Prevent race conditions during runtime by waiting until the init value is actually written
+    // DPrint is only used for debug purposes so this delay should not be a big issue.
+    // 1. host will read remote and think the wpos is 0. so it'll go and poll the data
+    // 2. the packet will arrive to set the wpos = DEBUG_PRINT_SERVER_STARTING_MAGIC
+    // 3. the actual host polling function will read wpos = DEBUG_PRINT_SERVER_STARTING_MAGIC
+    // 4. now we will access wpos at the starting magic which is incorrect
+    uint32_t num_tries = 100000;
+    while (num_tries-- > 0) {
+        auto result = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, 4);
+        if (result[0] == DEBUG_PRINT_SERVER_STARTING_MAGIC && enabled) return;
+        else if (result[0] == DEBUG_PRINT_SERVER_DISABLED_MAGIC && !enabled) return;
+    }
+    TT_THROW("Timed out writing init magic");
 } // WriteInitMagic
 
 // Checks if our magic value was cleared by the device code
@@ -386,9 +400,8 @@ bool CheckInitMagicCleared(Device *device, const CoreCoord& phys_core, int hart_
     // compute the buffer address for the requested hart
     uint32_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
 
-    std::vector<uint32_t> initbuf = { DEBUG_PRINT_SERVER_STARTING_MAGIC };
     auto result = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, 4);
-    return (result[0] != initbuf[0]);
+    return (result[0] != DEBUG_PRINT_SERVER_STARTING_MAGIC && result[0] != DEBUG_PRINT_SERVER_DISABLED_MAGIC);
 } // CheckInitMagicCleared
 
 DebugPrintServerContext::DebugPrintServerContext() {
@@ -953,7 +966,8 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                     }
                 break;
                 default:
-                    TT_THROW("Unexpected debug print type code");
+                    TT_THROW("Unexpected debug print type wpos {:#x} rpos {:#x} code {} chip {} phy {}, {}",
+                        wpos, rpos, (uint32_t)code, chip_id, phys_core.x, phys_core.y);
             }
 
             // TODO(AP): this is slow but leaving here for now for debugging the debug prints themselves


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15178)

### Problem description

`DPrint token size (0) did not match expected (1), potential data corruption in the DPrint buffer` OR `Unexpected debug print type code`. In both cases, the wpos will return one of the magic values.

There's a race condition happening on the host in the DPrint server in `bool DebugPrintServerContext::PeekOneHartNonBlocking`. It only happens with multi chip -- when ethernet is needed.

The [first read to check the magic value](https://github.com/tenstorrent/tt-metal/blob/919d46aeb7c2cf99d77dc9b7962b19a9b13a4eb4/tt_metal/impl/debug/dprint_server.cpp#L685) (`CheckInitMagicCleared`) returned True so it continued. But on the [second read](https://github.com/tenstorrent/tt-metal/blob/919d46aeb7c2cf99d77dc9b7962b19a9b13a4eb4/tt_metal/impl/debug/dprint_server.cpp#L699) `auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, eightbytes);` the init magic value was there even though the first read said it wasn't. 

It typically happens when running a test immediately after the ethernet core has been hammered by many requests going both ways. Something might be backed up in the queues.

Sometime between the first and second read for the magic value is when the write actually completed even though the llrt methods being used have `wait_for_non_mmio_flush` (I'm not exactly too sure what that does, but it sounds like it should wait for the write to finish). I guess it means "flushed" but not completed to L1.


### What's changed

- Fix the function that was not properly checking for magic init cleared. It forgot to also check for the disabled value.

- Do a readback for the value that was written and timeout if unsuccesful. Since DPrint is only used for development&debug, this will not affect any production software.

- Increase the magic init values to a very uint32_t as these values must never collide with the real read/write pointers.

- Improve the error message that gets thrown to have some helpful debug info.


### Checklist
- [ X] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/11945685757
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
