### PR TITLE
Let ttnn.reshape support 0 volume tensors

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -442,6 +442,7 @@ def test_bf8_support(input_shape, output_shape, device):
 
     assert_with_pcc(torch_result, output, 0.9999)
 
+
 @pytest.mark.parametrize(
     "input_shape, output_shape",
     [

--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -441,3 +441,38 @@ def test_bf8_support(input_shape, output_shape, device):
     output = ttnn.to_torch(ttnn_output)
 
     assert_with_pcc(torch_result, output, 0.9999)
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape",
+    [
+        ([0], [0, 1]),
+        ([0], [1, 0]),
+        ([0, 5], [0, 0, 5]),
+        ([5, 0], [0, 5, 0]),
+    ],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
+)
+@pytest.mark.parametrize(
+    "ttnn_reshape",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "use_device, memory_config",
+    [(True, None), (True, ttnn.L1_MEMORY_CONFIG), (False, None)],
+)
+def test_reshape_zero_element(input_shape, output_shape, layout, ttnn_reshape, use_device, memory_config, device):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    if use_device:
+        tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device, memory_config=memory_config)
+    else:
+        tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout)
+    if ttnn_reshape:
+        tt_output_tensor = ttnn.reshape(tt_input_tensor, output_shape)
+    else:
+        tt_output_tensor = tt_input_tensor.reshape(output_shape)
+    tt_output_tensor = ttnn.from_device(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_tensor)
+    assert tt_output_tensor.shape == torch.Size(output_shape)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -379,6 +379,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(
                    "Reshaping a multi-device tensor with 0 volume is not supported");
         return tensor.reshape(shape);
     }
+    TT_ASSERT(shape.volume() != 0 && "tensor's volume is not 0, but shape's volume is 0");
 
     bool this_is_view =
         (tensor_shape[-1] == shape[-1]) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -370,6 +370,12 @@ ttnn::Tensor ReshapeViewOperation::invoke(
 
     const uint32_t shape_second_last_dim = shape.rank() >= 2 ? shape[-2]:1;
     const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2]:1;
+
+    // Just edit shape if shape has a 0 dimension
+    if tensor.volume() == 0 {
+        return tensor.reshape(shape);
+    }
+
     bool this_is_view =
         (tensor_shape[-1] == shape[-1]) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&
         (mem_config.is_l1() == tensor.memory_config().is_l1()) &&

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -372,14 +372,14 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2]:1;
 
     // Just edit shape if shape has a 0 dimension
-    if (tensor.volume() == 0) {
-        TT_FATAL(shape.volume() == 0 , "Tensor volume is 0, but shape's volume is not");
+    if (tensor.get_logical_volume() == 0) {
+        TT_FATAL(shape.logical_shape().volume() == 0 , "Tensor volume is 0, but shape's volume is not");
         TT_FATAL((tensor.storage_type() != StorageType::MULTI_DEVICE &&
                   tensor.storage_type() != StorageType::MULTI_DEVICE_HOST),
                   "Reshaping a multi-device tensor with 0 volume is not supported");
         return tensor.reshape(shape);
     }
-    TT_FATAL(shape.volume() != 0, "Tensor volume is not 0, but shape volume is 0");
+    TT_FATAL(shape.logical_shape().volume() != 0, "Tensor volume is not 0, but shape volume is 0");
 
     bool this_is_view =
         (tensor_shape[-1] == shape[-1]) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -373,13 +373,13 @@ ttnn::Tensor ReshapeViewOperation::invoke(
 
     // Just edit shape if shape has a 0 dimension
     if (tensor.volume() == 0) {
-        TT_ASSERT(shape.volume() == 0 && "tensor's volume is 0, but shape's volume is not 0");
-        TT_ASSERT((tensor.storage_type() != StorageType::MULTI_DEVICE &&
-                   tensor.storage_type() != StorageType::MULTI_DEVICE_HOST) &&
-                   "Reshaping a multi-device tensor with 0 volume is not supported");
+        TT_FATAL(shape.volume() == 0 , "Tensor volume is 0, but shape's volume is not");
+        TT_FATAL((tensor.storage_type() != StorageType::MULTI_DEVICE &&
+                  tensor.storage_type() != StorageType::MULTI_DEVICE_HOST),
+                  "Reshaping a multi-device tensor with 0 volume is not supported");
         return tensor.reshape(shape);
     }
-    TT_ASSERT(shape.volume() != 0 && "tensor's volume is not 0, but shape's volume is 0");
+    TT_FATAL(shape.volume() != 0, "Tensor volume is not 0, but shape volume is 0");
 
     bool this_is_view =
         (tensor_shape[-1] == shape[-1]) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -372,7 +372,11 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     const uint32_t tensor_shape_second_last_dim = tensor_shape.rank() >= 2 ? tensor_shape[-2]:1;
 
     // Just edit shape if shape has a 0 dimension
-    if tensor.volume() == 0 {
+    if (tensor.volume() == 0) {
+        TT_ASSERT(shape.volume() == 0 && "tensor's volume is 0, but shape's volume is not 0");
+        TT_ASSERT((tensor.storage_type() != StorageType::MULTI_DEVICE &&
+                   tensor.storage_type() != StorageType::MULTI_DEVICE_HOST) &&
+                   "Reshaping a multi-device tensor with 0 volume is not supported");
         return tensor.reshape(shape);
     }
 

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
@@ -166,7 +166,7 @@ size_t TensorLayout::compute_packed_buffer_size_bytes(const ttnn::SimpleShape& s
     const auto width_remainder = physical_size.width() % page_shape.width();
     const auto height_remainder = physical_size.height() % page_shape.height();
     TT_FATAL(
-        width_remainder == 0 && height_remainder == 0,
+        (width_remainder == 0 && height_remainder == 0) || ((physical_size.width() * physical_size.height()) == 0),
         "Physical size {} must be multiple of page size {}",
         physical_size,
         page_shape);

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -391,7 +391,9 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                     if (tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
                         DeviceStorage device_storage = std::get<T>(tensor.get_storage());
                         DeviceBuffer device_buffer = device_storage.get_buffer();
-                        device_buffer->set_page_size(new_shape[-1] * tensor.element_size());
+                        if (new_shape[-1] != 0) {
+                            device_buffer->set_page_size(new_shape[-1] * tensor.element_size());
+                        }
                         device_storage.insert_buffer(device_buffer);
                         return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tile);
                     } else {
@@ -402,10 +404,10 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                         auto shard_spec = shard_spec_buffer.tensor_shard_spec;
                         auto shard_shape = shard_spec.shape;
 
-                        uint32_t mul_div = new_shape[-1] > shard_shape[1] ? (new_shape[-1] / shard_shape[1])
-                                                                          : (shard_shape[1] / new_shape[-1]);
-                        shard_spec.shape[0] =
-                            new_shape[-1] > shard_shape[1] ? shard_shape[0] / mul_div : shard_shape[0] * mul_div;
+                        uint32_t mul_div = new_shape[-1] > shard_shape[1] ?
+                                        (new_shape[-1] / shard_shape[1]) :
+                                        (new_shape[-1] != 0 ? (shard_shape[1] / new_shape[-1]) : 0);
+                        shard_spec.shape[0] = new_shape[-1] > shard_shape[1] ? shard_shape[0] / mul_div : shard_shape[0] * mul_div;
                         shard_spec.shape[1] = new_shape[-1];
 
                         shard_spec_buffer.page_shape = {1, new_shape[-1]};

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -394,6 +394,9 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                         if (new_shape[-1] != 0) {
                             device_buffer->set_page_size(new_shape[-1] * tensor.element_size());
                         }
+                        else {
+                            device_buffer->set_page_size(2 * tensor.element_size());
+                        }
                         device_storage.insert_buffer(device_buffer);
                         return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tile);
                     } else {
@@ -404,9 +407,15 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                         auto shard_spec = shard_spec_buffer.tensor_shard_spec;
                         auto shard_shape = shard_spec.shape;
 
-                        uint32_t mul_div = new_shape[-1] > shard_shape[1] ?
+                        uint32_t mul_div;
+                        if (new_shape[-1] == 0 || shard_shape[1] == 0) {
+                            mul_div = 0;
+                        } else {
+                            mul_div = new_shape[-1] > shard_shape[1] ?
                                         (new_shape[-1] / shard_shape[1]) :
-                                        (new_shape[-1] != 0 ? (shard_shape[1] / new_shape[-1]) : 0);
+                                        (shard_shape[1] / new_shape[-1]);
+                        }
+
                         shard_spec.shape[0] = new_shape[-1] > shard_shape[1] ? shard_shape[0] / mul_div : shard_shape[0] * mul_div;
                         shard_spec.shape[1] = new_shape[-1];
 

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -391,12 +391,9 @@ Tensor tensor_reshape(const Tensor& input_tensor, const ttnn::Shape& new_shape) 
                     if (tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
                         DeviceStorage device_storage = std::get<T>(tensor.get_storage());
                         DeviceBuffer device_buffer = device_storage.get_buffer();
-                        if (new_shape[-1] != 0) {
-                            device_buffer->set_page_size(new_shape[-1] * tensor.element_size());
-                        }
-                        else {
-                            device_buffer->set_page_size(2 * tensor.element_size());
-                        }
+                        const auto& tensor_spec = tensor.tensor_spec();
+                        auto page_size_bytes = tensor_spec.compute_page_size_bytes();
+                        device_buffer->set_page_size(page_size_bytes);
                         device_storage.insert_buffer(device_buffer);
                         return Tensor(device_storage, new_shape, tensor.get_dtype(), tensor.get_layout(), tile);
                     } else {

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -632,6 +632,7 @@ const ttnn::SimpleShape infer_dims_for_reshape(const Tensor& tensor, tt::stl::Sp
     int64_t old_volume = tensor.get_logical_volume();
     int64_t new_volume = 1;
     int64_t index_of_negative_1 = -1;
+    bool has_zero = false;
     for (auto index = 0; index < shape.size(); ++index) {
         if (shape[index] == -1) {
             if (index_of_negative_1 != -1) {
@@ -644,9 +645,19 @@ const ttnn::SimpleShape infer_dims_for_reshape(const Tensor& tensor, tt::stl::Sp
             }
             index_of_negative_1 = index;
         } else {
-            TT_FATAL(shape[index] > 0, "New shape entries can only have -1 or positive values");
+            if (shape[index] == 0) {
+                has_zero = true;
+            }
             new_volume *= shape[index];
         }
+    }
+    if (has_zero && index_of_negative_1 != -1) {
+        std::string error_msg = "cannot reshape tensor of 0 elements into shape (";
+        for(auto & s: shape) {
+            error_msg += std::to_string(s) + ",";
+        }
+        error_msg += ") because the unspecified dimension size -1 can be any value and is ambiguous";
+        TT_THROW("{}", error_msg);
     }
 
     ttnn::SmallVector<uint32_t> new_shape(shape.size());


### PR DESCRIPTION
### Ticket
#15284 

### Problem description
torch.reshape support cases with zero element. For example:
```
torch_input_tensor = torch.ones([0, 5])
reshape_tensor = torch.reshape(torch_input_tensor, [0, 0, 5])
print(reshape_tensor.shape)
# torch.Size([0, 0, 5])
```

Similarly, in torch_ttnn, there are scenarios involving zero-element tensors where operations are lowered from a torch operation to ttnn.reshape.

This PR adds support for such cases.


### What's changed
 - Let ttnn.reshape support 0 element
 - Add zero element unittest

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12310606570)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
