### PR TITLE
#14982: Update Unary examples

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/exp/exp.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/exp/exp.py
@@ -27,20 +27,13 @@ parameters = {
     "nightly": {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 16)
         + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 16)
-        + gen_shapes([32, 32], [256, 256], [32, 32], 32),
+        + gen_shapes([32, 32], [256, 256], [32, 32], 32)
+        + gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 32),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "use_safe_nums": [True],
-    },
-    "xfail": {
-        "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 32),
-        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "use_safe_nums": [False],
+        "use_safe_nums": [True, False],
     },
 }
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -203,6 +203,34 @@ def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device):
         assert comp_pass
 
 
+def test_clamp_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    min = torch.tensor([[0, 2], [0, 4]], dtype=torch.bfloat16)
+    max = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.clamp)
+    golden_tensor = golden_function(input, min, max)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    x2_tt = ttnn.from_torch(min, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    x3_tt = ttnn.from_torch(max, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.clamp(x1_tt, x2_tt, x3_tt)
+    tt_out = ttnn.to_torch(y_tt)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
+def test_rsqrt_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.rsqrt)
+    golden_tensor = golden_function(input)
+    print(golden_tensor)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.rsqrt(x1_tt, fast_and_approximate_mode=True)
+    tt_out = ttnn.to_torch(y_tt)
+    print(tt_out)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -203,32 +203,6 @@ def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device):
         assert comp_pass
 
 
-def test_clamp_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    min = torch.tensor([[0, 2], [0, 4]], dtype=torch.bfloat16)
-    max = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn.clamp)
-    golden_tensor = golden_function(input, min, max)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    x2_tt = ttnn.from_torch(min, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    x3_tt = ttnn.from_torch(max, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.clamp(x1_tt, x2_tt, x3_tt)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
-def test_rsqrt_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn.rsqrt)
-    golden_tensor = golden_function(input)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.rsqrt(x1_tt, fast_and_approximate_mode=True)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -222,11 +222,9 @@ def test_rsqrt_example(device):
     input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.rsqrt)
     golden_tensor = golden_function(input)
-    print(golden_tensor)
     x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.rsqrt(x1_tt, fast_and_approximate_mode=True)
     tt_out = ttnn.to_torch(y_tt)
-    print(tt_out)
     status = torch.allclose(golden_tensor, tt_out)
     assert status
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -44,8 +44,8 @@ void bind_unary_composite_optional_floats_with_default(
             input_tensor (ttnn.Tensor): the input tensor.
 
         Keyword args:
-            {2} (float or ttnn.Tensor): {3}. Defaults to `{4}`.
-            {5} (float or ttnn.Tensor): {6}. Defaults to `{7}`.
+            {2} (float or ttnn.Tensor): {3}. Defaults to `None`.
+            {5} (float or ttnn.Tensor): {6}. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
         Returns:
@@ -67,8 +67,13 @@ void bind_unary_composite_optional_floats_with_default(
             {10}
 
         Example:
-            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> output = {1}(tensor, 5.0, 7.0)
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> min_tensor = ttnn.from_torch(torch.tensor([[0, 2], [0,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> max_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(input_tensor, min_tensor, max_tensor)
+
+            >>> input_tensor = ttnn.from_torch(torch.tensor([[1, 2], [3,4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(input_tensor, min = 2, max = 9)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
@@ -351,7 +356,7 @@ void bind_unary_operation_with_fast_and_approximate_mode(py::module& module, con
             input_tensor (ttnn.Tensor): the input tensor.
 
         Keyword Args:
-            fast_and_approximate_mode (bool): Use the fast and approximate mode.
+            fast_and_approximate_mode (bool, optional): Use the fast and approximate mode. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             queue_id (int, optional): command queue id. Defaults to `0`.
@@ -375,8 +380,8 @@ void bind_unary_operation_with_fast_and_approximate_mode(py::module& module, con
             {3}
 
         Example:
-            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> output = {1}(tensor, fast_and_approximate_mode=true)
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor, fast_and_approximate_mode=True)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1269,17 +1269,30 @@ void bind_unary_composite_int(py::module& module, const unary_operation_t& opera
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
+            {2} (int): {3}.
 
         Keyword args:
-            {2} (int): {3}.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
 
+        Note:
+            Supported dtypes, layouts, and ranks:
+
+            .. list-table::
+               :header-rows: 1
+
+               * - Dtypes
+                 - Layouts
+                 - Ranks
+               * - BFLOAT16
+                 - TILE
+                 - 2, 3, 4
+
         Example:
-            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> output = {1}(tensor, {2})
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            >>> output = {1}(tensor, 3)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),


### PR DESCRIPTION
### Ticket
#14982

### Problem description
Update Unary examples docs

### What's changed
Updated examples, description, sweep tests, supported dtypes for the following ops : 

- ttnn.clip
- ttnn.clamp
- ttnn.exp
  - Moving failed test cases back to nightly as they are passing
<img width="928" alt="Screenshot 2024-11-21 at 7 33 30 PM" src="https://github.com/user-attachments/assets/436e301e-9833-4ea0-b087-de03ed12d4d2">

- ttnn.erf
- ttnn.erfc
- ttnn.gelu
- ttnn.rsqrt
- ttnn.polygamma

### Checklist
- [ ] Post commit CI

### Doc screenshots
<img width="847" alt="Screenshot 2024-11-21 at 5 03 03 PM" src="https://github.com/user-attachments/assets/a335a8ce-6710-4426-850d-684912962818">
<img width="962" alt="Screenshot 2024-11-21 at 5 03 53 PM" src="https://github.com/user-attachments/assets/323521f7-8c99-4611-8c3e-d7b5b24ae32c">
<img width="970" alt="Screenshot 2024-11-21 at 6 27 38 PM" src="https://github.com/user-attachments/assets/c13e4d7a-717c-408c-99e8-2ede8383cab3">
<img width="898" alt="Screenshot 2024-11-21 at 6 28 07 PM" src="https://github.com/user-attachments/assets/f8960fab-bd96-48fb-a6a4-8b53c4f8413b">
<img width="904" alt="Screenshot 2024-11-21 at 6 28 36 PM" src="https://github.com/user-attachments/assets/3abe1129-265f-497b-8295-052e6f0a27cd">
<img width="895" alt="Screenshot 2024-11-21 at 6 28 56 PM" src="https://github.com/user-attachments/assets/5588cf03-f5ab-4e29-83b6-7728cd5cd500">
<img width="902" alt="Screenshot 2024-11-21 at 6 29 15 PM" src="https://github.com/user-attachments/assets/b3e5d08d-c841-407f-adc1-c70001264604">
<img width="963" alt="Screenshot 2024-11-22 at 4 13 44 PM" src="https://github.com/user-attachments/assets/e83a299d-aaaa-42e3-89b7-a6236b278b4a">

