### PR TITLE
#0: Fix debugger install script

### DIFF
--- a/scripts/install_debugger.sh
+++ b/scripts/install_debugger.sh
@@ -1,4 +1,4 @@
 sudo apt update
-sudo apt install software-properties-common build-essential libyaml-cpp-dev libboost-all-dev libhwloc-dev libzmq3-dev libgtest-dev libgmock-dev xxd -y
-pip uninstall -y debuda
-pip install git+https://github.com/tenstorrent/tt-debuda.git
+sudo apt install libzmq3-dev
+pip uninstall -y tt-lens
+pip install git+ssh://git@github.com/tenstorrent/tt-lens.git


### PR DESCRIPTION
### Problem description
install-debugger.sh script is broken.

### What's changed
Removed unnecessary dependencies.
Changed name of debugger package from debuda to tt-lens.
Changed the installation source for the debugger package tt-lens.

