### PR TITLE
#15263: Fix incorrect calculation for needed sub_cmds for rtas

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -571,20 +571,53 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
     program_command_sequence.runtime_args_command_sequences = {};
 
     uint32_t command_count = 0;
+    // Unique RTAs
     for (uint32_t programmable_core_type_index = 0;
          programmable_core_type_index < hal.get_programmable_core_type_count();
          programmable_core_type_index++) {
-        uint32_t processor_classes = hal.get_processor_classes_count(programmable_core_type_index);
+        if (hal.get_programmable_core_type(programmable_core_type_index) == HalProgrammableCoreType::IDLE_ETH) {
+            // Fast dispatch not supported on IDLE_ETH yet
+            // TODO: can't just loop here as code below confuses ACTIVE/IDLE
+            continue;
+        }
         for (auto& kg : program.get_kernel_groups(programmable_core_type_index)) {
             if (kg.total_rta_size != 0) {
-                // Reserve 2x for unique rtas as we pontentially split the cmds due to not fitting in one prefetch cmd
-                command_count += 2;
+                uint32_t num_sub_cmds = kg.core_ranges.num_cores();
+                uint32_t max_runtime_args_len = kg.total_rta_size / sizeof(uint32_t);
+                uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<decltype(unique_sub_cmds)::value_type>(
+                    max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
+                command_count += div_up(num_sub_cmds, max_packed_cmds);
             }
         }
-        for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
-            uint32_t common_size = program.get_program_config(programmable_core_type_index).crta_sizes[dispatch_class];
-            if (common_size != 0) {
-                command_count++;
+    }
+    // Common RTAs
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
+        auto kernel = detail::GetKernel(program, kernel_id);
+        auto programmable_core_type = kernel->get_kernel_programmable_core_type();
+        if (programmable_core_type == HalProgrammableCoreType::IDLE_ETH) {
+            // Fast dispatch not supported on IDLE_ETH yet
+            // TODO: can't just loop here as code below confuses ACTIVE/IDLE
+            continue;
+        }
+        uint32_t programmable_core_type_index = hal.get_programmable_core_type_index(programmable_core_type);
+        uint32_t common_size = program.get_program_config(programmable_core_type_index)
+                                   .crta_sizes[kernel->dispatch_class()];
+        if (common_size != 0) {
+            uint32_t max_runtime_args_len = common_size / sizeof(uint32_t);
+            const auto& common_rt_args = kernel->common_runtime_args();
+            if (common_rt_args.size() > 0) {
+                CoreType core_type = hal.get_core_type(programmable_core_type_index);
+                if (core_type == CoreType::ETH) {
+                    uint32_t num_sub_cmds = kernel->logical_cores().size();
+                    uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<CQDispatchWritePackedUnicastSubCmd>(
+                        max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, true);
+                    command_count += div_up(num_sub_cmds, max_packed_cmds);
+                } else {
+                    uint32_t num_sub_cmds = kernel->logical_coreranges().size();
+                    uint32_t max_packed_cmds = get_max_write_packed_sub_cmds<CQDispatchWritePackedMulticastSubCmd>(
+                        max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, true);
+                    command_count += div_up(num_sub_cmds, max_packed_cmds);
+                }
             }
         }
     }
@@ -659,6 +692,9 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
 
         for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
             uint32_t common_size = program.get_program_config(index).crta_sizes[dispatch_class];
+            if (common_size == 0) {
+                continue;
+            }
             for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                 auto kernel = detail::GetKernel(program, kernel_id);
                 if (kernel->get_kernel_core_type() != core_type) {
@@ -710,29 +746,27 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
                 }
             }
 
-            if (common_size != 0) {
-                uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
+            uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
 
-                // Common rtas are always expected to fit in one prefetch cmd
-                // TODO: use a linear write instead of a packed-write
-                std::visit(
-                    [&](auto&& sub_cmds) {
-                        generate_runtime_args_cmds(
-                            program_command_sequence.runtime_args_command_sequences,
-                            crta_offset,
-                            sub_cmds,
-                            common_rt_data_and_sizes,
-                            common_size / sizeof(uint32_t),
-                            common_rt_args_data,
-                            max_prefetch_command_size,
-                            packed_write_max_unicast_sub_cmds,
-                            true,
-                            core_type == CoreType::WORKER ? DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE
-                                                          : DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
-                        sub_cmds.clear();
-                    },
-                    common_sub_cmds);
-            }
+            // Common rtas are always expected to fit in one prefetch cmd
+            // TODO: use a linear write instead of a packed-write
+            std::visit(
+                [&](auto&& sub_cmds) {
+                    generate_runtime_args_cmds(
+                        program_command_sequence.runtime_args_command_sequences,
+                        crta_offset,
+                        sub_cmds,
+                        common_rt_data_and_sizes,
+                        common_size / sizeof(uint32_t),
+                        common_rt_args_data,
+                        max_prefetch_command_size,
+                        packed_write_max_unicast_sub_cmds,
+                        true,
+                        core_type == CoreType::WORKER ? DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE
+                                                        : DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
+                    sub_cmds.clear();
+                },
+                common_sub_cmds);
 
             for (auto& data_per_kernel : common_rt_data_and_sizes) {
                 for (auto& data_and_sizes : data_per_kernel) {
@@ -743,6 +777,11 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
             common_rt_args_data.clear();
         }
     }
+    TT_ASSERT(
+        command_count >= program_command_sequence.runtime_args_command_sequences.size(),
+        "Incorrect number of commands reserved {}, final size {}. Vector reallocation causes cached addresses to be incorrect.",
+        command_count,
+        program_command_sequence.runtime_args_command_sequences.size());
 
     uint32_t runtime_args_fetch_size_bytes = 0;
     for (const auto& cmds : program_command_sequence.runtime_args_command_sequences) {

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -178,7 +178,7 @@ struct dispatch_constants {
         TT_ASSERT(cmddat_q_size_ >= 2 * max_prefetch_command_size_);
         TT_ASSERT(scratch_db_size_ % 2 == 0);
         TT_ASSERT((dispatch_buffer_block_size & (dispatch_buffer_block_size - 1)) == 0);
-        TT_ASSERT(DISPATCH_MESSAGE_ENTRIES <= DISPATCH_MESSAGES_MAX_OFFSET / L1_ALIGNMENT + 1, "Number of dispatch message entries exceeds max representable offset");
+        TT_ASSERT(DISPATCH_MESSAGE_ENTRIES <= DISPATCH_MESSAGES_MAX_OFFSET / l1_alignment + 1, "Number of dispatch message entries exceeds max representable offset");
 
         uint32_t pcie_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST);
         uint32_t l1_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -80,6 +80,18 @@ bool Kernel::is_on_logical_core(const CoreCoord &logical_core) const {
     return this->core_range_set_.contains(logical_core);
 }
 
+HalProgrammableCoreType Kernel::get_kernel_programmable_core_type() const {
+    RISCV riscv_processor = this->processor();
+    switch (riscv_processor) {
+        case RISCV::BRISC:
+        case RISCV::NCRISC:
+        case RISCV::COMPUTE: return HalProgrammableCoreType::TENSIX;
+        case RISCV::ERISC: return this->is_idle_eth() ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
+        default: TT_ASSERT(false, "Unsupported kernel processor!");
+    }
+    return HalProgrammableCoreType::TENSIX;
+}
+
 CoreType Kernel::get_kernel_core_type() const {
     RISCV riscv_processor = this->processor();
     switch (riscv_processor) {
@@ -292,7 +304,7 @@ void Kernel::set_common_runtime_args_count(uint32_t count) {
     this->common_runtime_args_data_.rt_args_count = count;
 }
 
-bool Kernel::is_idle_eth() {
+bool Kernel::is_idle_eth() const {
     return std::holds_alternative<EthernetConfig>(this->config()) && std::get<EthernetConfig>(this->config()).eth_mode == Eth::IDLE;
 }
 
@@ -322,7 +334,7 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 void DataMovementKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
     jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
     device->generate_device_headers(build_options.path);
-    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     jit_build(device->build_kernel_state(tensix_core_type, dm_class_idx, riscv_id), this);
@@ -331,9 +343,7 @@ void DataMovementKernel::generate_binaries(Device *device, JitBuildOptions &buil
 void EthernetKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
     jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_src_);
     device->generate_device_headers(build_options.path);
-    uint32_t erisc_core_type = hal.get_programmable_core_type_index(
-        this->config_.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH
-    );
+    uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
     jit_build(device->build_kernel_state(erisc_core_type, dm_class_idx, erisc_id), this);
@@ -341,7 +351,7 @@ void EthernetKernel::generate_binaries(Device *device, JitBuildOptions &build_op
 
 void ComputeKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
     jit_build_genfiles_triscs_src(device->build_env(), *this, this->kernel_src_);
-    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     JitBuildStateSubset build_states = device->build_kernel_states(tensix_core_type, compute_class_idx);
     jit_build_subset(build_states, this);
@@ -361,7 +371,7 @@ void DataMovementKernel::read_binaries(Device *device) {
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
     // TODO(pgk): consolidate read_binaries where possible
-    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, dm_class_idx, riscv_id);
@@ -385,9 +395,7 @@ void EthernetKernel::read_binaries(Device *device) {
     // untested
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
     std::vector<ll_api::memory> binaries;
-    uint32_t erisc_core_type = hal.get_programmable_core_type_index(
-        this->config_.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH
-    );
+    uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
     const JitBuildState &build_state = device->build_kernel_state(erisc_core_type, dm_class_idx, erisc_id);
@@ -409,7 +417,7 @@ void EthernetKernel::read_binaries(Device *device) {
 void ComputeKernel::read_binaries(Device *device) {
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
     std::vector<ll_api::memory> binaries;
-    uint32_t tensix_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, compute_class_idx, trisc_id);
@@ -460,7 +468,7 @@ bool EthernetKernel::configure(Device *device, const CoreCoord &logical_core, ui
         uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
         llrt::write_binary_to_address(binary_mem, device_id, ethernet_core, base_address + offsets[offset_idx]);
     } else {
-        uint32_t erisc_core_type = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+        uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
         uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
         int erisc_id = magic_enum::enum_integer(this->config_.processor);
         tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, ethernet_core, erisc_core_type, dm_class_idx, erisc_id);

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -113,15 +113,16 @@ class Kernel : public JitBuildSettings {
     void set_runtime_args(const CoreCoord &logical_core, stl::Span<const uint32_t> runtime_args);
     void set_common_runtime_args(stl::Span<const uint32_t> runtime_args);
 
-    int get_watcher_kernel_id() { return watcher_kernel_id_; }
+    int get_watcher_kernel_id() const { return watcher_kernel_id_; }
 
+    HalProgrammableCoreType get_kernel_programmable_core_type() const;
     CoreType get_kernel_core_type() const;
     void set_full_name(const string& s) { kernel_full_name_ = s; }
     const string& get_full_kernel_name() const override;
     void process_defines(const std::function<void (const string& define, const string &value)>) const override;
     void process_compile_time_args(const std::function<void (int i, uint32_t value)>) const override;
 
-    bool is_idle_eth();
+    bool is_idle_eth() const;
 
    protected:
     int watcher_kernel_id_;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15263

### Problem description
We reserve the wrong size for the rtas cmd cache vector. Since we cache the addresses of rtas as we populate the vector, this results in the vector getting resized/reallocated, invalidating our cached addresses.

### What's changed
Calculate the actual size needed for the cached vector instead of approximating. Add a TT_ASSERT to make sure we have a clear error message if this ever happens again instead of segfaulting.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11955840179)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
