### PR TITLE
Add support to change FD cores from row to col placement

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -103,6 +103,18 @@ def get_dispatch_core_type():
     return dispatch_core_type
 
 
+def get_dispatch_core_config(device_params):
+    import ttnn
+
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    return dispatch_core_config
+
+
 @pytest.fixture(scope="function")
 def device_params(request):
     return getattr(request, "param", {})
@@ -117,12 +129,7 @@ def device(request, device_params):
 
     num_devices = ttnn.GetNumPCIeDevices()
     assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     device = ttnn.CreateDevice(device_id=device_id, dispatch_core_config=dispatch_core_config, **device_params)
     ttnn.SetDefaultDevice(device)
 
@@ -143,12 +150,7 @@ def pcie_devices(request, device_params):
     request.node.pci_ids = device_ids
 
     # Get only physical devices
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     devices = ttnn.CreateDevices(device_ids, dispatch_core_config=dispatch_core_config, **device_params)
 
     yield [devices[i] for i in range(num_devices)]
@@ -168,12 +170,7 @@ def all_devices(request, device_params):
     request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids]
 
     # Get only physical devices
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     devices = ttnn.CreateDevices(device_ids, dispatch_core_config=dispatch_core_config, **device_params)
 
     yield [devices[i] for i in range(num_devices)]
@@ -225,12 +222,7 @@ def mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device_par
 
     request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
 
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=mesh_shape, dispatch_core_config=dispatch_core_config, **device_params
     )
@@ -260,12 +252,7 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
     request.node.pci_ids = device_ids[:num_pcie_devices_requested]
 
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(2, 2),
         dispatch_core_config=dispatch_core_config,
@@ -291,12 +278,7 @@ def n300_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
     if ttnn.get_num_devices() < 2:
         pytest.skip()
 
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(1, 2),
         dispatch_core_config=dispatch_core_config,
@@ -321,12 +303,7 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
         pytest.skip()
 
     request.node.pci_ids = ttnn.get_pcie_device_ids()
-    dispatch_core_type = get_dispatch_core_type()
-    dispatch_core_axis = device_params.pop(
-        "dispatch_core_axis",
-        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
-    )
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    dispatch_core_config = get_dispatch_core_config(device_params)
     mesh_device = ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(2, 4),
         dispatch_core_config=dispatch_core_config,

--- a/conftest.py
+++ b/conftest.py
@@ -117,7 +117,13 @@ def device(request, device_params):
 
     num_devices = ttnn.GetNumPCIeDevices()
     assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
-    device = ttnn.CreateDevice(device_id=device_id, dispatch_core_type=get_dispatch_core_type(), **device_params)
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    device = ttnn.CreateDevice(device_id=device_id, dispatch_core_config=dispatch_core_config, **device_params)
     ttnn.SetDefaultDevice(device)
 
     yield device
@@ -137,7 +143,13 @@ def pcie_devices(request, device_params):
     request.node.pci_ids = device_ids
 
     # Get only physical devices
-    devices = ttnn.CreateDevices(device_ids, dispatch_core_type=get_dispatch_core_type(), **device_params)
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    devices = ttnn.CreateDevices(device_ids, dispatch_core_config=dispatch_core_config, **device_params)
 
     yield [devices[i] for i in range(num_devices)]
 
@@ -156,7 +168,13 @@ def all_devices(request, device_params):
     request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids]
 
     # Get only physical devices
-    devices = ttnn.CreateDevices(device_ids, dispatch_core_type=get_dispatch_core_type(), **device_params)
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    devices = ttnn.CreateDevices(device_ids, dispatch_core_config=dispatch_core_config, **device_params)
 
     yield [devices[i] for i in range(num_devices)]
 
@@ -207,7 +225,15 @@ def mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device_par
 
     request.node.pci_ids = [ttnn.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
 
-    mesh_device = ttnn.open_mesh_device(mesh_shape, dispatch_core_type=get_dispatch_core_type(), **device_params)
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
+    mesh_device = ttnn.open_mesh_device(
+        mesh_shape=mesh_shape, dispatch_core_config=dispatch_core_config, **device_params
+    )
 
     logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
     yield mesh_device
@@ -234,9 +260,15 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
     request.node.pci_ids = device_ids[:num_pcie_devices_requested]
 
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
     mesh_device = ttnn.open_mesh_device(
-        ttnn.MeshShape(2, 2),
-        dispatch_core_type=get_dispatch_core_type(),
+        mesh_shape=ttnn.MeshShape(2, 2),
+        dispatch_core_config=dispatch_core_config,
         **device_params,
         offset=(0, 1),
         mesh_type=ttnn.MeshType.Ring,
@@ -259,9 +291,15 @@ def n300_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
     if ttnn.get_num_devices() < 2:
         pytest.skip()
 
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
     mesh_device = ttnn.open_mesh_device(
-        ttnn.MeshShape(1, 2),
-        dispatch_core_type=get_dispatch_core_type(),
+        mesh_shape=ttnn.MeshShape(1, 2),
+        dispatch_core_config=dispatch_core_config,
         **device_params,
     )
 
@@ -283,9 +321,15 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
         pytest.skip()
 
     request.node.pci_ids = ttnn.get_pcie_device_ids()
+    dispatch_core_type = get_dispatch_core_type()
+    dispatch_core_axis = device_params.pop(
+        "dispatch_core_axis",
+        ttnn.DispatchCoreAxis.COL if os.environ["ARCH_NAME"] == "blackhole" else ttnn.DispatchCoreAxis.ROW,
+    )
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
     mesh_device = ttnn.open_mesh_device(
-        ttnn.MeshShape(2, 4),
-        dispatch_core_type=get_dispatch_core_type(),
+        mesh_shape=ttnn.MeshShape(2, 4),
+        dispatch_core_config=dispatch_core_config,
         **device_params,
         mesh_type=ttnn.MeshType.Ring,
     )

--- a/tests/scripts/test_moreh_microbenchmark.py
+++ b/tests/scripts/test_moreh_microbenchmark.py
@@ -863,7 +863,6 @@ def test_dram_read_all_core(arch, freq, test_vector, num_tests, nblock, data_for
 def test_dram_read_l1_write_core(
     arch, test_vector, num_tests, nblock, data_format, num_banks, bank_start_id, bw_target
 ):
-    dev_freq = get_device_freq()
     data = []
     cycle_list = []
     time_list = []
@@ -879,6 +878,7 @@ def test_dram_read_l1_write_core(
             input_size = k * n * 2048 // 1024
         run_dram_read_l1_write_cmd(k, n, nblock, data_format, num_banks, bank_start_id)
         cycle = profile_results_kernel_duration()
+        dev_freq = get_device_freq()
         time = cycle / dev_freq / 1000.0 / 1000.0
         throughput = input_size / cycle * dev_freq / 1000.0
         cycle_list.append(cycle)

--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -13,8 +13,8 @@ namespace unit_tests::test_l1_banking_allocator {
 uint64_t get_alloc_limit(const tt::tt_metal::Device *device) {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
     uint32_t l1_unreserved_base = device->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
-    auto storage_core_bank_size = tt::get_storage_core_bank_size(device->id(), device->num_hw_cqs(), dispatch_core_type);
+    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+    auto storage_core_bank_size = tt::get_storage_core_bank_size(device->id(), device->num_hw_cqs(), dispatch_core_config);
     const uint32_t allocator_alignment = device->get_allocator_alignment();
     const uint32_t interleaved_l1_bank_size = storage_core_bank_size.has_value() ? storage_core_bank_size.value() : (soc_desc.worker_l1_size - l1_unreserved_base);
     uint32_t storage_core_unreserved_base = ((MEM_MAILBOX_BASE + allocator_alignment - 1) / allocator_alignment) * allocator_alignment;

--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -10,22 +10,25 @@
 
 namespace unit_tests::test_l1_banking_allocator {
 
-uint64_t get_alloc_limit(const tt::tt_metal::Device *device) {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
+uint64_t get_alloc_limit(const tt::tt_metal::Device* device) {
+    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
     uint32_t l1_unreserved_base = device->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
-    auto storage_core_bank_size = tt::get_storage_core_bank_size(device->id(), device->num_hw_cqs(), dispatch_core_config);
+    auto storage_core_bank_size =
+        tt::get_storage_core_bank_size(device->id(), device->num_hw_cqs(), dispatch_core_config);
     const uint32_t allocator_alignment = device->get_allocator_alignment();
-    const uint32_t interleaved_l1_bank_size = storage_core_bank_size.has_value() ? storage_core_bank_size.value() : (soc_desc.worker_l1_size - l1_unreserved_base);
-    uint32_t storage_core_unreserved_base = ((MEM_MAILBOX_BASE + allocator_alignment - 1) / allocator_alignment) * allocator_alignment;
+    const uint32_t interleaved_l1_bank_size = storage_core_bank_size.has_value()
+                                                  ? storage_core_bank_size.value()
+                                                  : (soc_desc.worker_l1_size - l1_unreserved_base);
+    uint32_t storage_core_unreserved_base =
+        ((MEM_MAILBOX_BASE + allocator_alignment - 1) / allocator_alignment) * allocator_alignment;
     uint64_t alloc_limit = interleaved_l1_bank_size - storage_core_unreserved_base;
     return alloc_limit;
 }
 
-}   // namespace unit_tests::test_l1_banking_allocator
+}  // namespace unit_tests::test_l1_banking_allocator
 
 TEST_F(DeviceSingleCardBufferFixture, TestL1BuffersAllocatedTopDown) {
-
     std::vector<uint32_t> alloc_sizes = {32 * 1024, 64 * 1024, 128 * 1024};
     size_t total_size_bytes = 0;
 
@@ -40,7 +43,8 @@ TEST_F(DeviceSingleCardBufferFixture, TestL1BuffersAllocatedTopDown) {
         if (total_buffer_size + buffer_size >= alloc_limit) {
             break;
         }
-        auto buffer = tt::tt_metal::Buffer::create(this->device_, buffer_size, buffer_size, tt::tt_metal::BufferType::L1);
+        auto buffer =
+            tt::tt_metal::Buffer::create(this->device_, buffer_size, buffer_size, tt::tt_metal::BufferType::L1);
         buffers.emplace_back(std::move(buffer));
         total_buffer_size += buffer_size;
         EXPECT_EQ(buffers.back()->address(), this->device_->l1_size_per_core() - total_buffer_size);
@@ -52,13 +56,10 @@ TEST_F(DeviceSingleCardBufferFixture, TestL1BuffersDoNotGrowBeyondBankSize) {
     uint64_t alloc_limit = unit_tests::test_l1_banking_allocator::get_alloc_limit(this->device_);
 
     tt::tt_metal::InterleavedBufferConfig l1_config{
-                    .device=this->device_,
-                    .size = alloc_limit + 64,
-                    .page_size = alloc_limit + 64,
-                    .buffer_type = tt::tt_metal::BufferType::L1
-        };
+        .device = this->device_,
+        .size = alloc_limit + 64,
+        .page_size = alloc_limit + 64,
+        .buffer_type = tt::tt_metal::BufferType::L1};
 
-    EXPECT_ANY_THROW(
-        auto buffer = tt::tt_metal::CreateBuffer(l1_config);
-    );
+    EXPECT_ANY_THROW(auto buffer = tt::tt_metal::CreateBuffer(l1_config););
 }

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -21,7 +21,8 @@ TEST_F(DispatchFixture, TensixCreateKernelsOnComputeCores) {
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
                 CoreRange(CoreCoord(0, 0), CoreCoord(compute_grid.x, compute_grid.y)),
-                DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}););
+                DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}););
     }
 }
 
@@ -42,7 +43,8 @@ TEST_F(DispatchFixture, DISABLED_TensixCreateKernelsOnStorageCores) {
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
                 storage_core_range_set,
-                DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}););
+                DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}););
     }
 }
 
@@ -53,21 +55,23 @@ TEST_F(DispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) {
     for (unsigned int id = 0; id < this->devices_.size(); id++) {
         tt_metal::Program program = CreateProgram();
         Device* device = this->devices_.at(id);
-        const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+        const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
         CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-        std::vector<CoreCoord> dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
+        std::vector<CoreCoord> dispatch_cores =
+            tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
         std::set<CoreRange> dispatch_core_ranges;
         for (CoreCoord core : dispatch_cores) {
             dispatch_core_ranges.emplace(core);
         }
         CoreRangeSet dispatch_core_range_set(dispatch_core_ranges);
         if (dispatch_core_type == CoreType::WORKER) {
-            EXPECT_ANY_THROW(
-                auto test_kernel = tt_metal::CreateKernel(
-                    program,
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
-                    CoreRangeSet(dispatch_core_range_set),
-                    DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}););
+            EXPECT_ANY_THROW(auto test_kernel = tt_metal::CreateKernel(
+                                 program,
+                                 "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+                                 CoreRangeSet(dispatch_core_range_set),
+                                 DataMovementConfig{
+                                     .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                                     .noc = tt_metal::NOC::RISCV_0_default}););
         } else if (dispatch_core_type == CoreType::ETH) {
             EXPECT_ANY_THROW(auto test_kernel = tt_metal::CreateKernel(
                                  program,
@@ -79,14 +83,14 @@ TEST_F(DispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) {
 }
 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDir) {
-    const string &kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
+    const string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
     create_kernel(kernel_file);
     detail::CompileProgram(this->device_, this->program_);
 }
 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderKernelRootDir) {
-    const string &orig_kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
-    const string &new_kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/new_kernel.cpp";
+    const string& orig_kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
+    const string& new_kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/new_kernel.cpp";
     this->setup_kernel_dir(orig_kernel_file, new_kernel_file);
     this->create_kernel(new_kernel_file);
     detail::CompileProgram(this->device_, this->program_);
@@ -94,7 +98,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderKernelRootDir
 }
 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDirAndKernelRootDir) {
-    const string &kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
+    const string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
     this->setup_kernel_dir(kernel_file, kernel_file);
     this->create_kernel(kernel_file);
     detail::CompileProgram(this->device_, this->program_);
@@ -102,7 +106,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDirA
 }
 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixNonExistentKernel) {
-    const string &kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/non_existent_kernel.cpp";
+    const string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/non_existent_kernel.cpp";
     this->create_kernel(kernel_file);
     EXPECT_THROW(detail::CompileProgram(this->device_, this->program_), std::exception);
 }

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -53,8 +53,9 @@ TEST_F(DispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) {
     for (unsigned int id = 0; id < this->devices_.size(); id++) {
         tt_metal::Program program = CreateProgram();
         Device* device = this->devices_.at(id);
-        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
-        std::vector<CoreCoord> dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_type);
+        const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+        CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+        std::vector<CoreCoord> dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
         std::set<CoreRange> dispatch_core_ranges;
         for (CoreCoord core : dispatch_cores) {
             dispatch_core_ranges.emplace(core);

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -17,8 +17,8 @@
 #include "tt_metal/llrt/rtoptions.hpp"
 
 class CommandQueueFixture : public DispatchFixture {
-   protected:
-    tt::tt_metal::Device *device_;
+protected:
+    tt::tt_metal::Device* device_;
     void SetUp() override {
         this->validate_dispatch_mode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -44,7 +44,7 @@ class CommandQueueFixture : public DispatchFixture {
 
     void create_device(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
         const chip_id_t device_id = 0;
-        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
         this->device_ =
             tt::tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
     }
@@ -57,19 +57,17 @@ class CommandQueueBufferFixture : public CommandQueueFixture {};
 class CommandQueueProgramFixture : public CommandQueueFixture {};
 
 class CommandQueueTraceFixture : public CommandQueueFixture {
-    protected:
+protected:
     void SetUp() override {
         this->validate_dispatch_mode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     }
 
-    void CreateDevice(const size_t trace_region_size) {
-        this->create_device(trace_region_size);
-    }
+    void CreateDevice(const size_t trace_region_size) { this->create_device(trace_region_size); }
 };
 
 class CommandQueueSingleCardFixture : virtual public DispatchFixture {
-   protected:
+protected:
     void SetUp() override {
         this->validate_dispatch_mode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -90,13 +88,13 @@ class CommandQueueSingleCardFixture : virtual public DispatchFixture {
     }
 
     void create_devices(const std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
-        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
         const chip_id_t mmio_device_id = 0;
         this->reserved_devices_ = tt::tt_metal::detail::CreateDevices(
             {mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
         auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
         if (enable_remote_chip) {
-            for (const auto &[id, device] : this->reserved_devices_) {
+            for (const auto& [id, device] : this->reserved_devices_) {
                 this->devices_.push_back(device);
             }
         } else {
@@ -104,14 +102,14 @@ class CommandQueueSingleCardFixture : virtual public DispatchFixture {
         }
     }
 
-    std::vector<tt::tt_metal::Device *> devices_;
-    std::map<chip_id_t, tt::tt_metal::Device *> reserved_devices_;
+    std::vector<tt::tt_metal::Device*> devices_;
+    std::map<chip_id_t, tt::tt_metal::Device*> reserved_devices_;
 };
 
 class CommandQueueSingleCardBufferFixture : public CommandQueueSingleCardFixture {};
 
 class CommandQueueSingleCardTraceFixture : virtual public CommandQueueSingleCardFixture {
-   protected:
+protected:
     void SetUp() override {
         this->validate_dispatch_mode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -122,12 +120,13 @@ class CommandQueueSingleCardTraceFixture : virtual public CommandQueueSingleCard
 class CommandQueueSingleCardProgramFixture : virtual public CommandQueueSingleCardFixture {};
 
 class CommandQueueMultiDeviceFixture : public DispatchFixture {
-   protected:
+protected:
     void SetUp() override {
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            tt::log_info(
+                tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = true;
             GTEST_SKIP();
         }
@@ -135,7 +134,7 @@ class CommandQueueMultiDeviceFixture : public DispatchFixture {
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (num_devices_ < 2 ) {
+        if (num_devices_ < 2) {
             GTEST_SKIP();
         }
 
@@ -144,9 +143,10 @@ class CommandQueueMultiDeviceFixture : public DispatchFixture {
             chip_ids.push_back(id);
         }
 
-        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
-        reserved_devices_ = tt::tt_metal::detail::CreateDevices(chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
-        for (const auto &[id, device] : reserved_devices_) {
+        const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        reserved_devices_ = tt::tt_metal::detail::CreateDevices(
+            chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
+        for (const auto& [id, device] : reserved_devices_) {
             devices_.push_back(device);
         }
     }

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -44,9 +44,9 @@ class CommandQueueFixture : public DispatchFixture {
 
     void create_device(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
         const chip_id_t device_id = 0;
-        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
         this->device_ =
-            tt::tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_type);
+            tt::tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
     }
 };
 
@@ -90,10 +90,10 @@ class CommandQueueSingleCardFixture : virtual public DispatchFixture {
     }
 
     void create_devices(const std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
-        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
         const chip_id_t mmio_device_id = 0;
         this->reserved_devices_ = tt::tt_metal::detail::CreateDevices(
-            {mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_type);
+            {mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
         auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
         if (enable_remote_chip) {
             for (const auto &[id, device] : this->reserved_devices_) {
@@ -144,8 +144,8 @@ class CommandQueueMultiDeviceFixture : public DispatchFixture {
             chip_ids.push_back(id);
         }
 
-        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-        reserved_devices_ = tt::tt_metal::detail::CreateDevices(chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        reserved_devices_ = tt::tt_metal::detail::CreateDevices(chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
         for (const auto &[id, device] : reserved_devices_) {
             devices_.push_back(device);
         }

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -44,8 +44,8 @@ class DeviceFixture : public DispatchFixture {
     }
 
     void create_devices(const std::vector<chip_id_t>& device_ids) {
-        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-        tt::DevicePool::initialize(device_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        tt::DevicePool::initialize(device_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
         this->devices_ = tt::DevicePool::instance().get_all_active_devices();
         this->num_devices_ = this->devices_.size();
     }

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -71,8 +71,8 @@ protected:
                 continue;
             ids.push_back(id);
         }
-        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-        tt::DevicePool::initialize(ids, tt::llrt::OptionsG.get_num_hw_cqs(), DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        tt::DevicePool::initialize(ids, tt::llrt::OptionsG.get_num_hw_cqs(), DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
         devices_ = tt::DevicePool::instance().get_all_active_devices();
     }
 

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -15,7 +15,7 @@
 
 // A dispatch-agnostic test fixture
 class DispatchFixture : public ::testing::Test {
-   public:
+public:
     // A function to run a program, according to which dispatch mode is set.
     void RunProgram(tt::tt_metal::Device* device, tt::tt_metal::Program& program, const bool skip_finish = false) {
         const uint64_t program_id = program.get_id();
@@ -35,7 +35,8 @@ class DispatchFixture : public ::testing::Test {
             tt::tt_metal::Finish(cq);
         }
     }
-    void WriteBuffer(tt::tt_metal::Device* device, std::shared_ptr<tt::tt_metal::Buffer> in_buffer, std::vector<uint32_t> &src_vec){
+    void WriteBuffer(
+        tt::tt_metal::Device* device, std::shared_ptr<tt::tt_metal::Buffer> in_buffer, std::vector<uint32_t>& src_vec) {
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::WriteToBuffer(in_buffer, src_vec);
         } else {
@@ -43,7 +44,10 @@ class DispatchFixture : public ::testing::Test {
             tt::tt_metal::EnqueueWriteBuffer(cq, in_buffer, src_vec, false);
         }
     }
-    void ReadBuffer(tt::tt_metal::Device* device, std::shared_ptr<tt::tt_metal::Buffer> out_buffer, std::vector<uint32_t> &dst_vec){
+    void ReadBuffer(
+        tt::tt_metal::Device* device,
+        std::shared_ptr<tt::tt_metal::Buffer> out_buffer,
+        std::vector<uint32_t>& dst_vec) {
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::ReadFromBuffer(out_buffer, dst_vec);
         } else {
@@ -53,7 +57,6 @@ class DispatchFixture : public ::testing::Test {
     }
     int NumDevices() { return this->devices_.size(); }
     bool IsSlowDispatch() { return this->slow_dispatch_; }
-
 
 protected:
     tt::ARCH arch_;
@@ -67,12 +70,18 @@ protected:
         auto num_devices = tt::tt_metal::GetNumAvailableDevices();
         std::vector<chip_id_t> ids;
         for (unsigned int id = 0; id < num_devices; id++) {
-            if (SkipTest(id))
+            if (SkipTest(id)) {
                 continue;
+            }
             ids.push_back(id);
         }
-        const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
-        tt::DevicePool::initialize(ids, tt::llrt::OptionsG.get_num_hw_cqs(), DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
+        const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+        tt::DevicePool::initialize(
+            ids,
+            tt::llrt::OptionsG.get_num_hw_cqs(),
+            DEFAULT_L1_SMALL_SIZE,
+            DEFAULT_TRACE_REGION_SIZE,
+            dispatch_core_config);
         devices_ = tt::DevicePool::instance().get_all_active_devices();
     }
 
@@ -81,8 +90,9 @@ protected:
         // Close all opened devices
         for (unsigned int id = 0; id < devices_.size(); id++) {
             // The test may ahve closed the device already, so only close if active.
-            if (devices_.at(id)->is_initialized())
+            if (devices_.at(id)->is_initialized()) {
                 tt::tt_metal::CloseDevice(devices_.at(id));
+            }
         }
     }
 
@@ -91,23 +101,17 @@ protected:
         // targetting device 0 by default (and to not cause issues with BMs that have E300s).
         // TODO: when we can detect only supported devices, this check can be removed.
         if (this->arch_ == tt::ARCH::GRAYSKULL && device_id > 0) {
-            log_info(
-                tt::LogTest,
-                "Skipping test on device {} due to unsupported E300",
-                device_id
-            );
+            log_info(tt::LogTest, "Skipping test on device {} due to unsupported E300", device_id);
             return true;
         }
 
         return false;
     }
 
-    void RunTestOnDevice(
-        const std::function<void()>& run_function,
-        tt::tt_metal::Device* device
-    ) {
-        if (SkipTest(device->id()))
+    void RunTestOnDevice(const std::function<void()>& run_function, tt::tt_metal::Device* device) {
+        if (SkipTest(device->id())) {
             return;
+        }
         log_info(tt::LogTest, "Running test on device {}.", device->id());
         run_function();
         log_info(tt::LogTest, "Finished running test on device {}.", device->id());

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -13,14 +13,12 @@
 #include "tt_metal/impl/device/device_pool.hpp"
 
 class MultiDeviceFixture : public DispatchFixture {
-   protected:
-    void SetUp() override {
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-    }
+protected:
+    void SetUp() override { this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()); }
 };
 
 class N300DeviceFixture : public MultiDeviceFixture {
-   protected:
+protected:
     void SetUp() override {
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -40,7 +38,7 @@ class N300DeviceFixture : public MultiDeviceFixture {
                 ids.push_back(id);
             }
 
-            const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+            const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
             tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
             this->devices_ = tt::DevicePool::instance().get_all_active_devices();
         } else {

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -40,8 +40,8 @@ class N300DeviceFixture : public MultiDeviceFixture {
                 ids.push_back(id);
             }
 
-            const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-            tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+            const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+            tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
             this->devices_ = tt::DevicePool::instance().get_all_active_devices();
         } else {
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -77,8 +77,8 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
@@ -96,8 +96,8 @@ TEST_P(DeviceParamFixture, TensixDeviceLoadBlankKernels) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(unit_tests_common::basic::test_device_init::load_all_blank_kernels(device));

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -16,17 +16,17 @@ using namespace tt;
 using namespace tt::test_utils;
 
 class DeviceParamFixture : public ::testing::TestWithParam<int> {
-   protected:
+protected:
     tt::ARCH arch = tt::get_arch_from_string(get_umd_arch_name());
 };
 
 namespace unit_tests_common::basic::test_device_init {
 
-void launch_program(tt_metal::Device *device, tt_metal::Program &program) {
+void launch_program(tt_metal::Device* device, tt_metal::Program& program) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
         tt_metal::detail::LaunchProgram(device, program);
     } else {
-        CommandQueue &cq = device->command_queue();
+        CommandQueue& cq = device->command_queue();
         EnqueueProgram(cq, program, false);
         Finish(cq);
     }
@@ -35,7 +35,7 @@ void launch_program(tt_metal::Device *device, tt_metal::Program &program) {
 /// @brief load_blank_kernels into all cores and will launch
 /// @param device
 /// @return
-bool load_all_blank_kernels(tt_metal::Device *device) {
+bool load_all_blank_kernels(tt_metal::Device* device) {
     bool pass = true;
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord compute_grid_size = device->compute_with_storage_grid_size();
@@ -67,7 +67,7 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
         GTEST_SKIP();
     }
 
-    //see issue #9594
+    // see issue #9594
     if (arch == tt::ARCH::WORMHOLE_B0 && num_devices > 1) {
         GTEST_SKIP();
     }
@@ -77,7 +77,7 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
@@ -96,7 +96,7 @@ TEST_P(DeviceParamFixture, TensixDeviceLoadBlankKernels) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -13,8 +13,8 @@ TEST(DevicePool, DevicePoolOpenClose) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_type = llrt::OptionsG.get_dispatch_core_type();
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto& dispatch_core_config = llrt::OptionsG.get_dispatch_core_config();
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
         ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -41,8 +41,8 @@ TEST(DevicePool, DevicePoolReconfigDevices) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_type = llrt::OptionsG.get_dispatch_core_type();
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto& dispatch_core_config = llrt::OptionsG.get_dispatch_core_config();
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
         ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -55,7 +55,7 @@ TEST(DevicePool, DevicePoolReconfigDevices) {
         dev->close();
     }
     l1_small_size = 2048;
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
         ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -73,8 +73,8 @@ TEST(DevicePool, DevicePoolAddDevices) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_type = llrt::OptionsG.get_dispatch_core_type();
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto& dispatch_core_config = llrt::OptionsG.get_dispatch_core_config();
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
         ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -87,7 +87,7 @@ TEST(DevicePool, DevicePoolAddDevices) {
         dev->close();
     }
     device_ids = {0, 1, 2, 3};
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     devices = DevicePool::instance().get_all_active_devices();
     ASSERT_TRUE(devices.size() >= 4);
     for (const auto& dev : devices) {
@@ -107,8 +107,8 @@ TEST(DevicePool, DevicePoolReduceDevices) {
     std::vector<chip_id_t> device_ids{0, 1, 2, 3};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_type = llrt::OptionsG.get_dispatch_core_type();
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto& dispatch_core_config = llrt::OptionsG.get_dispatch_core_config();
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
         ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -121,7 +121,7 @@ TEST(DevicePool, DevicePoolReduceDevices) {
         dev->close();
     }
     device_ids = {0};
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto dev = DevicePool::instance().get_active_device(0);
     ASSERT_TRUE(dev->id() == 0);
     ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -872,7 +872,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
         tt_metal::DispatchCoreConfig dispatch_core_config;
-        if (std::strcmp(getenv("ARCH_NAME"), "grayskull") != 0) {
+        if (tt::tt_metal::get_platform_architecture() == tt::ARCH::GRAYSKULL) {
             dispatch_core_config = tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::ROW};
         } else {
             dispatch_core_config = tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::COL};
@@ -883,8 +883,8 @@ int main(int argc, char **argv) {
         auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
         uint32_t num_cores_x = compute_with_storage_grid_size.x;
         uint32_t num_cores_y = compute_with_storage_grid_size.y;
-        tt::log_info("device x : {}", num_cores_x);
-        tt::log_info("device y : {}", num_cores_y);
+        tt::log_debug("device x : {}", num_cores_x);
+        tt::log_debug("device y : {}", num_cores_y);
 
 
         int clock_freq_mhz = get_tt_npu_clock(device);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -54,10 +54,8 @@ using std::chrono::microseconds;
 //     --bypass-check (set to bypass checking performance criteria fulfillment)
 ////////////////////////////////////////////////////////////////////////////////
 
-
-
 template <typename T>
-std::vector<T> slice_vec(std::vector<T> const &v, int m, int n) {
+std::vector<T> slice_vec(std::vector<T> const& v, int m, int n) {
     auto first = v.cbegin() + m;
     auto last = v.cbegin() + n + 1;
 
@@ -65,7 +63,13 @@ std::vector<T> slice_vec(std::vector<T> const &v, int m, int n) {
     return vec;
 }
 
-void get_max_page_size_and_num_pages(uint32_t num_tiles_w, uint32_t num_tiles_h, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages, uint32_t& num_pages_w_per_receiver) {
+void get_max_page_size_and_num_pages(
+    uint32_t num_tiles_w,
+    uint32_t num_tiles_h,
+    uint32_t tile_size,
+    uint32_t& page_size,
+    uint32_t& num_pages,
+    uint32_t& num_pages_w_per_receiver) {
     uint64_t half_row_bytes = static_cast<uint64_t>(num_tiles_w / 2) * tile_size;
     TT_ASSERT(num_tiles_w % 2 == 0, "num_tiles_w {} must be divisible by 2", num_tiles_w);
 
@@ -80,21 +84,21 @@ void get_max_page_size_and_num_pages(uint32_t num_tiles_w, uint32_t num_tiles_h,
 }
 
 std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
-    tt_metal::Device *device,
-    const CoreRangeSet &all_dram_reader_cores,
-    const CoreRangeSet &all_l1_receiver_cores,
-    const uint32_t &single_tile_size,
-    const tt::DataFormat &tile_format,
+    tt_metal::Device* device,
+    const CoreRangeSet& all_dram_reader_cores,
+    const CoreRangeSet& all_l1_receiver_cores,
+    const uint32_t& single_tile_size,
+    const tt::DataFormat& tile_format,
     uint32_t num_tiles_cb,
     uint32_t num_tiles_per_core,
     uint32_t k,
     uint32_t n,
     uint32_t num_blocks,
     uint32_t num_banks,
-    std::vector<CoreCoord>all_dram_reader_cores_ordered,
-    std::vector<CoreCoord>all_l1_writer_cores_ordered,
+    std::vector<CoreCoord> all_dram_reader_cores_ordered,
+    std::vector<CoreCoord> all_l1_writer_cores_ordered,
     uint32_t bank_start_id,
-    const uint32_t &input_buffer_addr) {
+    const uint32_t& input_buffer_addr) {
     tt_metal::Program program = tt_metal::Program();
 
     uint32_t start_tile_id = 0;
@@ -111,7 +115,11 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
     get_max_page_size_and_num_pages(block_w, block_h, single_tile_size, page_size, num_pages, num_pages_w_per_receiver);
 
     log_info("Input block size: {}x{}, num_blocks: {}", block_h, block_w, num_blocks);
-    log_info("Pages set up as page_size: {}, num_pages: {}, num_pages_w_per_receiver: {}", page_size, num_pages, num_pages_w_per_receiver);
+    log_info(
+        "Pages set up as page_size: {}, num_pages: {}, num_pages_w_per_receiver: {}",
+        page_size,
+        num_pages,
+        num_pages_w_per_receiver);
 
     uint32_t reader_cb_addr = device->get_base_allocator_addr(HalMemType::L1);
     tt_metal::CircularBufferConfig reader_cb_config =
@@ -120,14 +128,13 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
     auto reader_cb = tt_metal::CreateCircularBuffer(program, all_dram_reader_cores, reader_cb_config);
 
     std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t) input_buffer_addr,
-        (std::uint32_t) start_tile_id,
-        (std::uint32_t) num_blocks,
-        (std::uint32_t) num_pages,
-        (std::uint32_t) block_num_tiles,
-        (std::uint32_t) page_size,
-        (std::uint32_t) tt_metal::NOC::RISCV_0_default
-    };
+        (std::uint32_t)input_buffer_addr,
+        (std::uint32_t)start_tile_id,
+        (std::uint32_t)num_blocks,
+        (std::uint32_t)num_pages,
+        (std::uint32_t)block_num_tiles,
+        (std::uint32_t)page_size,
+        (std::uint32_t)tt_metal::NOC::RISCV_0_default};
 
     auto reader_kernel = tt_metal::CreateKernel(
         program,
@@ -140,13 +147,12 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
             .compile_args = reader_compile_time_args});
 
     std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t) num_blocks,
-        (std::uint32_t) num_pages_w_per_receiver,
-        (std::uint32_t) block_h,
-        (std::uint32_t) block_num_tiles,
-        (std::uint32_t) page_size,
-        (std::uint32_t) tt_metal::NOC::RISCV_0_default
-    };
+        (std::uint32_t)num_blocks,
+        (std::uint32_t)num_pages_w_per_receiver,
+        (std::uint32_t)block_h,
+        (std::uint32_t)block_num_tiles,
+        (std::uint32_t)page_size,
+        (std::uint32_t)tt_metal::NOC::RISCV_0_default};
 
     auto writer_kernel = tt_metal::CreateKernel(
         program,
@@ -159,48 +165,44 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
             .compile_args = writer_compile_time_args});
 
     std::vector<uint32_t> bank_ids;
-    for (int i=0; i < all_dram_reader_cores_ordered.size(); i++) {
+    for (int i = 0; i < all_dram_reader_cores_ordered.size(); i++) {
         auto core = all_dram_reader_cores_ordered[i];
         uint32_t bank_id = i + bank_start_id;
         uint32_t vc = bank_id & 0x1;
 
         bank_ids.push_back(bank_id);
 
-        for (int j=0; j<i; ++j) {
+        for (int j = 0; j < i; ++j) {
             auto core_ = all_dram_reader_cores_ordered[j];
 
-            if (core_.y == core.y and ((bank_id & 0x1) == (bank_ids[j] & 0x1))) { // same vc and same row
+            if (core_.y == core.y and ((bank_id & 0x1) == (bank_ids[j] & 0x1))) {  // same vc and same row
                 vc = (vc + 1) & 0x1;
                 break;
             }
         }
 
-        const std::array reader_rt_args = {
-            (std::uint32_t) bank_id,
-            (std::uint32_t) vc
-        };
+        const std::array reader_rt_args = {(std::uint32_t)bank_id, (std::uint32_t)vc};
 
         log_info("core: {}, vc: {}", core, vc);
 
         tt_metal::SetRuntimeArgs(program, reader_kernel, core, reader_rt_args);
 
-        auto writer_core1 = all_l1_writer_cores_ordered[i*2];
+        auto writer_core1 = all_l1_writer_cores_ordered[i * 2];
         auto writer_core_phy1 = device->worker_core_from_logical_core(writer_core1);
-        auto writer_core2 = all_l1_writer_cores_ordered[(i*2)+1];
+        auto writer_core2 = all_l1_writer_cores_ordered[(i * 2) + 1];
         auto writer_core_phy2 = device->worker_core_from_logical_core(writer_core2);
 
         log_info("writer_core_phy1: {}", writer_core_phy1);
         log_info("writer_core_phy2: {}", writer_core_phy2);
 
         const std::array writer_rt_args = {
-            (std::uint32_t) (vc + 2) & 0x3,
+            (std::uint32_t)(vc + 2) & 0x3,
             // First L1 receiver core coordinates
-            (std::uint32_t) writer_core_phy1.x,
-            (std::uint32_t) writer_core_phy1.y,
+            (std::uint32_t)writer_core_phy1.x,
+            (std::uint32_t)writer_core_phy1.y,
             // Second L1 receiver core coordinates
-            (std::uint32_t) writer_core_phy2.x,
-            (std::uint32_t) writer_core_phy2.y
-        };
+            (std::uint32_t)writer_core_phy2.x,
+            (std::uint32_t)writer_core_phy2.y};
 
         tt_metal::SetRuntimeArgs(program, writer_kernel, core, writer_rt_args);
     }
@@ -216,8 +218,7 @@ bool validate_data(
     uint32_t block_w,
     uint32_t datums_per_tile,
     uint32_t num_banks,
-    uint32_t input_start_index_for_core)
-{
+    uint32_t input_start_index_for_core) {
     for (uint32_t r = 0; r < block_h; ++r) {
         for (uint32_t c = 0; c < block_w_per_receiver; ++c) {
             uint32_t one_row_bytes = block_w * datums_per_tile * num_banks;
@@ -239,13 +240,12 @@ bool validate_data(
     return true;
 }
 
-
 bool validation(
-    tt_metal::Device *device,
-    tt_metal::Buffer &input_buffer,
-    std::vector<uint32_t> &input_vec,
+    tt_metal::Device* device,
+    tt_metal::Buffer& input_buffer,
+    std::vector<uint32_t>& input_vec,
     uint32_t num_cores,
-    std::vector<CoreCoord> &all_cores,
+    std::vector<CoreCoord>& all_cores,
     uint32_t num_tiles_per_core,
     uint32_t cb_addr,
     uint32_t single_tile_size,
@@ -253,54 +253,71 @@ bool validation(
     uint32_t df,
     uint32_t num_banks,
     uint32_t num_blocks,
-    uint32_t block_h, // block_h per core
-    uint32_t block_w, // block_w per core
+    uint32_t block_h,  // block_h per core
+    uint32_t block_w,  // block_w per core
     uint32_t block_w_per_receiver,
-    uint32_t datums_per_tile) { // 32x32
+    uint32_t datums_per_tile) {  // 32x32
 
     uint32_t core_id = 0;
     uint32_t num_datum_per_block = block_h * block_w * num_cores * datums_per_tile;
     uint32_t last_block_offset = (num_blocks - 1) * num_datum_per_block;
-    uint32_t tiles_per_core = block_h * block_w_per_receiver; // Num slices=tiles per core to verify
-    for (auto core: all_cores | std::views::take(num_cores*2)) {
-
-        uint32_t dram_bank_id = core_id / 2; // A pair of two cores share a dram bank
+    uint32_t tiles_per_core = block_h * block_w_per_receiver;  // Num slices=tiles per core to verify
+    for (auto core : all_cores | std::views::take(num_cores * 2)) {
+        uint32_t dram_bank_id = core_id / 2;  // A pair of two cores share a dram bank
         uint32_t tile_stride_over_dram_banks = dram_bank_id * datums_per_tile;
         uint32_t is_second_core = core_id % 2;
-         // Second core in a dram bank pair has an offset of half a block from that dram bank
+        // Second core in a dram bank pair has an offset of half a block from that dram bank
         uint32_t receiver_core_pair_offset = is_second_core * datums_per_tile * block_w_per_receiver * num_banks;
-        uint32_t input_start_index_for_core = last_block_offset + tile_stride_over_dram_banks + receiver_core_pair_offset;
+        uint32_t input_start_index_for_core =
+            last_block_offset + tile_stride_over_dram_banks + receiver_core_pair_offset;
 
         std::vector<uint32_t> result_vec;
-        tt_metal::detail::ReadFromDeviceL1(
-            device, core, cb_addr, num_tiles_cb / 2 * single_tile_size, result_vec);
+        tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, num_tiles_cb / 2 * single_tile_size, result_vec);
 
-        if (df == 0) { // BFP4
+        if (df == 0) {  // BFP4
             auto result_bfp4 = unpack_bfp4_tiles_into_float_vec(result_vec, true, true);
             auto input_bfp4 = unpack_bfp4_tiles_into_float_vec(input_vec, true, true);
             if (!validate_data<float>(
-                result_bfp4, input_bfp4, block_h, block_w_per_receiver, block_w,
-                datums_per_tile, num_banks, input_start_index_for_core)) {
+                    result_bfp4,
+                    input_bfp4,
+                    block_h,
+                    block_w_per_receiver,
+                    block_w,
+                    datums_per_tile,
+                    num_banks,
+                    input_start_index_for_core)) {
                 return false;
             }
-        } else if (df == 1) { // BFP8
+        } else if (df == 1) {  // BFP8
             auto result_bfp8 = unpack_bfp8_tiles_into_float_vec(result_vec, true, true);
             auto input_bfp8 = unpack_bfp8_tiles_into_float_vec(input_vec, true, true);
             if (!validate_data<float>(
-                result_bfp8, input_bfp8, block_h, block_w_per_receiver, block_w,
-                datums_per_tile, num_banks, input_start_index_for_core)) {
+                    result_bfp8,
+                    input_bfp8,
+                    block_h,
+                    block_w_per_receiver,
+                    block_w,
+                    datums_per_tile,
+                    num_banks,
+                    input_start_index_for_core)) {
                 return false;
             }
-        } else if (df == 2) { // BFLOAT16
+        } else if (df == 2) {  // BFLOAT16
             auto result_bf16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
             auto input_bf16 = unpack_uint32_vec_into_bfloat16_vec(input_vec);
             if (!validate_data<bfloat16>(
-                result_bf16, input_bf16, block_h, block_w_per_receiver, block_w,
-                datums_per_tile, num_banks, input_start_index_for_core)) {
+                    result_bf16,
+                    input_bf16,
+                    block_h,
+                    block_w_per_receiver,
+                    block_w,
+                    datums_per_tile,
+                    num_banks,
+                    input_start_index_for_core)) {
                 return false;
             }
         }
-        core_id ++;
+        core_id++;
     }
     log_info("Validation passed.");
     return true;
@@ -319,10 +336,8 @@ uint32_t get_dram_bandwidth(tt::ARCH arch) {
     return dram_bandwidth_gb_per_sec;
 }
 
-
 void get_dram_reader_core_coords_blackhole(
     tt_metal::Device* device, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());
     uint32_t full_grid_size_x = soc_d.grid_size.x;
 
@@ -379,7 +394,8 @@ void get_dram_reader_core_coords_blackhole(
         auto x = coord.x;
 
         // if row is harvested, move core down by 1
-        while (std::find(harvested_cols.begin(), harvested_cols.end(), x) != harvested_cols.end() and x < (full_grid_size_x - 1)) {
+        while (std::find(harvested_cols.begin(), harvested_cols.end(), x) != harvested_cols.end() and
+               x < (full_grid_size_x - 1)) {
             x += 1;
         }
 
@@ -406,10 +422,11 @@ void get_dram_reader_core_coords_blackhole(
     all_cores_ordered = adj_core_logical_realloc;
 }
 
-
 void get_l1_writer_core_coords_blackhole(
-    tt_metal::Device* device, std::vector<CoreCoord>& all_dram_reader_cores, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-
+    tt_metal::Device* device,
+    std::vector<CoreCoord>& all_dram_reader_cores,
+    CoreRangeSet& all_cores,
+    std::vector<CoreCoord>& all_cores_ordered) {
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());
     uint32_t full_grid_size_x = soc_d.grid_size.x;
 
@@ -462,7 +479,8 @@ void get_l1_writer_core_coords_blackhole(
         auto x = coord.x;
 
         // if row is harvested, move core down by 1
-        while (std::find(harvested_cols.begin(), harvested_cols.end(), x) != harvested_cols.end() and x < (full_grid_size_x - 1)) {
+        while (std::find(harvested_cols.begin(), harvested_cols.end(), x) != harvested_cols.end() and
+               x < (full_grid_size_x - 1)) {
             x += 1;
         }
 
@@ -491,7 +509,6 @@ void get_l1_writer_core_coords_blackhole(
 
 void get_dram_reader_core_coords_grayskull(
     tt_metal::Device* device, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());
     uint32_t full_grid_size_y = soc_d.grid_size.y;
 
@@ -548,7 +565,8 @@ void get_dram_reader_core_coords_grayskull(
         auto y = coord.y;
 
         // if row is harvested, move core down by 1
-        while (std::find(harvested_rows.begin(), harvested_rows.end(), y) != harvested_rows.end() and y < (full_grid_size_y - 1)) {
+        while (std::find(harvested_rows.begin(), harvested_rows.end(), y) != harvested_rows.end() and
+               y < (full_grid_size_y - 1)) {
             y += 1;
         }
 
@@ -576,8 +594,10 @@ void get_dram_reader_core_coords_grayskull(
 }
 
 void get_l1_writer_core_coords_grayskull(
-    tt_metal::Device* device, std::vector<CoreCoord>& all_dram_reader_cores, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-
+    tt_metal::Device* device,
+    std::vector<CoreCoord>& all_dram_reader_cores,
+    CoreRangeSet& all_cores,
+    std::vector<CoreCoord>& all_cores_ordered) {
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());
     uint32_t full_grid_size_y = soc_d.grid_size.y;
 
@@ -630,7 +650,8 @@ void get_l1_writer_core_coords_grayskull(
         auto y = coord.y;
 
         // if row is harvested, move core down by 1
-        while (std::find(harvested_rows.begin(), harvested_rows.end(), y) != harvested_rows.end() and y < (full_grid_size_y - 1)) {
+        while (std::find(harvested_rows.begin(), harvested_rows.end(), y) != harvested_rows.end() and
+               y < (full_grid_size_y - 1)) {
             y += 1;
         }
 
@@ -659,7 +680,6 @@ void get_l1_writer_core_coords_grayskull(
 
 void get_dram_reader_core_coords_wormhole_b0(
     tt_metal::Device* device, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-
     // get all the logical coord
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -668,13 +688,15 @@ void get_dram_reader_core_coords_wormhole_b0(
     // get dram banks and coords
     uint32_t num_banks = device->num_dram_channels();
     uint32_t max_bank_id = num_banks - 1;
-    std::vector<CoreCoord> dram_coord_phy; dram_coord_phy.reserve(num_banks);
+    std::vector<CoreCoord> dram_coord_phy;
+    dram_coord_phy.reserve(num_banks);
     for (int i = 0; i < num_banks; ++i) {
         dram_coord_phy.push_back(device->dram_core_from_dram_channel(i));
     }
 
     // get worker logical coords
-    std::vector<CoreCoord> all_worker_cores_logical; all_worker_cores_logical.reserve(num_cores_x * num_cores_y);
+    std::vector<CoreCoord> all_worker_cores_logical;
+    all_worker_cores_logical.reserve(num_cores_x * num_cores_y);
     for (int i = 0; i < num_cores_x; ++i) {
         for (int j = 0; j < num_cores_y; ++j) {
             all_worker_cores_logical.push_back(CoreCoord(i, j));
@@ -682,7 +704,8 @@ void get_dram_reader_core_coords_wormhole_b0(
     }
 
     // get the ajacent cores of DRAM banks
-    std::vector<CoreCoord> adj_core_physical; adj_core_physical.reserve(num_banks);
+    std::vector<CoreCoord> adj_core_physical;
+    adj_core_physical.reserve(num_banks);
     for (int i = 0; i < num_banks; ++i) {
         auto dram_core = dram_coord_phy[i];
         uint32_t adj_core_x = dram_core.x + 1;
@@ -691,7 +714,8 @@ void get_dram_reader_core_coords_wormhole_b0(
     }
 
     // find the logical coord from physical coord
-    std::vector<CoreCoord> adj_core_logical; adj_core_logical.reserve(num_banks);
+    std::vector<CoreCoord> adj_core_logical;
+    adj_core_logical.reserve(num_banks);
     for (int i = 0; i < adj_core_physical.size(); ++i) {
         for (int j = 0; j < all_worker_cores_logical.size(); ++j) {
             auto core = device->worker_core_from_logical_core(all_worker_cores_logical[j]);
@@ -710,10 +734,11 @@ void get_dram_reader_core_coords_wormhole_b0(
     all_cores_ordered = adj_core_logical;
 }
 
-
 void get_l1_writer_core_coords_wormhole_b0(
-    tt_metal::Device* device, std::vector<CoreCoord>& all_dram_reader_cores, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-
+    tt_metal::Device* device,
+    std::vector<CoreCoord>& all_dram_reader_cores,
+    CoreRangeSet& all_cores,
+    std::vector<CoreCoord>& all_cores_ordered) {
     // get all the logical coord
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -760,7 +785,7 @@ void get_l1_writer_core_coords_wormhole_b0(
     all_cores_ordered = adj_core_logical_realloc;
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         log_error("Test not supported w/ slow dispatch, exiting");
     }
@@ -785,11 +810,10 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<std::string> input_args(argv, argv + argc);
         try {
-            std::tie(k, input_args) =
-                test_args::get_command_option_uint64_and_remaining_args(input_args, "--k", 8192);
+            std::tie(k, input_args) = test_args::get_command_option_uint64_and_remaining_args(input_args, "--k", 8192);
 
             std::tie(n, input_args) =
-                test_args::get_command_option_uint64_and_remaining_args(input_args, "--n", 12*128);
+                test_args::get_command_option_uint64_and_remaining_args(input_args, "--n", 12 * 128);
 
             std::tie(num_blocks, input_args) =
                 test_args::get_command_option_uint64_and_remaining_args(input_args, "--num-blocks", 8);
@@ -813,7 +837,7 @@ int main(int argc, char **argv) {
                 test_args::get_command_option_uint32_and_remaining_args(input_args, "--bank-start-id", 0);
 
             test_args::validate_remaining_args(input_args);
-        } catch (const std::exception &e) {
+        } catch (const std::exception& e) {
             log_error(tt::LogTest, "Command line arguments found exception", e.what());
             TT_ASSERT(false);
         }
@@ -838,13 +862,13 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         uint32_t input_size = 0;
         tt::DataFormat tile_format = tt::DataFormat::Bfp8_b;
-        if (df == 0) { // BFP4
-            input_size = k * n * (512+64) / 1024;
+        if (df == 0) {  // BFP4
+            input_size = k * n * (512 + 64) / 1024;
             tile_format = tt::DataFormat::Bfp4_b;
-        } else if (df == 1) { // BFP8
+        } else if (df == 1) {  // BFP8
             input_size = k * n * 1088 / 1024;
             tile_format = tt::DataFormat::Bfp8_b;
-        } else if (df == 2) { // BFLOAT16
+        } else if (df == 2) {  // BFLOAT16
             input_size = k * n * 2;
             tile_format = tt::DataFormat::Float16_b;
         } else {
@@ -873,11 +897,13 @@ int main(int argc, char **argv) {
         int device_id = 0;
         tt_metal::DispatchCoreConfig dispatch_core_config;
         if (tt::tt_metal::get_platform_architecture() == tt::ARCH::GRAYSKULL) {
-            dispatch_core_config = tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::ROW};
+            dispatch_core_config =
+                tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::ROW};
         } else {
-            dispatch_core_config = tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::COL};
+            dispatch_core_config =
+                tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::COL};
         }
-        tt_metal::Device *device = tt_metal::CreateDevice(device_id, 1, 0, 0, dispatch_core_config);
+        tt_metal::Device* device = tt_metal::CreateDevice(device_id, 1, 0, 0, dispatch_core_config);
         dram_bandwidth_spec = get_dram_bandwidth(device->arch());
 
         auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -886,11 +912,10 @@ int main(int argc, char **argv) {
         tt::log_debug("device x : {}", num_cores_x);
         tt::log_debug("device y : {}", num_cores_y);
 
-
         int clock_freq_mhz = get_tt_npu_clock(device);
 
         uint32_t num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
-        uint32_t num_cores = num_banks; // number of DRAM banks
+        uint32_t num_cores = num_banks;  // number of DRAM banks
 
         CoreRangeSet all_dram_reader_cores;
         std::vector<CoreCoord> all_dram_reader_cores_ordered;
@@ -898,25 +923,28 @@ int main(int argc, char **argv) {
         std::vector<CoreCoord> all_l1_writer_cores_ordered;
         if (device->arch() == tt::ARCH::BLACKHOLE) {
             get_dram_reader_core_coords_blackhole(device, all_dram_reader_cores, all_dram_reader_cores_ordered);
-            get_l1_writer_core_coords_blackhole(device, all_dram_reader_cores_ordered, all_l1_receiver_cores, all_l1_writer_cores_ordered);
+            get_l1_writer_core_coords_blackhole(
+                device, all_dram_reader_cores_ordered, all_l1_receiver_cores, all_l1_writer_cores_ordered);
         } else if (device->arch() == tt::ARCH::WORMHOLE_B0) {
             get_dram_reader_core_coords_wormhole_b0(device, all_dram_reader_cores, all_dram_reader_cores_ordered);
-            get_l1_writer_core_coords_wormhole_b0(device, all_dram_reader_cores_ordered, all_l1_receiver_cores, all_l1_writer_cores_ordered);
+            get_l1_writer_core_coords_wormhole_b0(
+                device, all_dram_reader_cores_ordered, all_l1_receiver_cores, all_l1_writer_cores_ordered);
         } else {
             get_dram_reader_core_coords_grayskull(device, all_dram_reader_cores, all_dram_reader_cores_ordered);
-            get_l1_writer_core_coords_grayskull(device, all_dram_reader_cores_ordered, all_l1_receiver_cores, all_l1_writer_cores_ordered);
+            get_l1_writer_core_coords_grayskull(
+                device, all_dram_reader_cores_ordered, all_l1_receiver_cores, all_l1_writer_cores_ordered);
         }
 
         uint32_t num_tiles_per_core = num_tiles / num_cores;
         uint32_t num_tiles_cb = num_tiles_per_core / num_blocks;
 
         log_info("all_dram_reader_cores");
-        for (auto core: all_dram_reader_cores_ordered) {
+        for (auto core : all_dram_reader_cores_ordered) {
             auto phys_core = device->worker_core_from_logical_core(core);
             log_info("logical core: {}, physical core: {}", core, phys_core);
         }
         log_info("all_l1_writer_cores");
-        for (auto core: all_l1_writer_cores_ordered) {
+        for (auto core : all_l1_writer_cores_ordered) {
             auto phys_core = device->worker_core_from_logical_core(core);
             log_info("logical core: {}, physical core: {}", core, phys_core);
         }
@@ -937,14 +965,11 @@ int main(int argc, char **argv) {
 
         std::vector<uint32_t> input_vec;
         if (tile_format == tt::DataFormat::Bfp4_b) {
-            input_vec = create_random_vector_of_bfp4(
-                input_size, false, 100, 1234);
+            input_vec = create_random_vector_of_bfp4(input_size, false, 100, 1234);
         } else if (tile_format == tt::DataFormat::Bfp8_b) {
-            input_vec = create_random_vector_of_bfp8(
-                input_size, false, 100, 1234);
+            input_vec = create_random_vector_of_bfp8(input_size, false, 100, 1234);
         } else {
-            input_vec = create_random_vector_of_bfloat16(
-                input_size, 100, 1234);
+            input_vec = create_random_vector_of_bfloat16(input_size, 100, 1234);
         }
 
         auto input_buffer = tt_metal::Buffer::create(
@@ -953,7 +978,22 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Application Setup
         ////////////////////////////////////////////////////////////////////////////
-        auto [program, kernel, output_cb_addr] = create_program(device, all_dram_reader_cores, all_l1_receiver_cores, single_tile_size, tile_format, num_tiles_cb, num_tiles_per_core, k, n, num_blocks, num_banks, all_dram_reader_cores_ordered, all_l1_writer_cores_ordered, bank_start_id, input_buffer->address());
+        auto [program, kernel, output_cb_addr] = create_program(
+            device,
+            all_dram_reader_cores,
+            all_l1_receiver_cores,
+            single_tile_size,
+            tile_format,
+            num_tiles_cb,
+            num_tiles_per_core,
+            k,
+            n,
+            num_blocks,
+            num_banks,
+            all_dram_reader_cores_ordered,
+            all_l1_writer_cores_ordered,
+            bank_start_id,
+            input_buffer->address());
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Copy Input To DRAM or L1
@@ -1008,7 +1048,7 @@ int main(int argc, char **argv) {
         }
 
         pass &= tt_metal::CloseDevice(device);
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         pass = false;
         // Capture the exception error message
         log_error(LogTest, "{}", e.what());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -47,20 +47,24 @@ bool use_global_g;
 bool use_trace_g;
 bool dispatch_from_eth_g;
 
-void init(int argc, char **argv) {
+void init(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
 
-    if (test_args::has_command_option(input_args, "-h") ||
-        test_args::has_command_option(input_args, "--help")) {
+    if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
         log_info(LogTest, "Usage:");
         log_info(LogTest, "  -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
         log_info(LogTest, "  -i: iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, "  -s: size of kernels in powers of 2 bytes (default {}, min {})", DEFAULT_KERNEL_SIZE_K * 1024, MIN_KERNEL_SIZE_BYTES);
+        log_info(
+            LogTest,
+            "  -s: size of kernels in powers of 2 bytes (default {}, min {})",
+            DEFAULT_KERNEL_SIZE_K * 1024,
+            MIN_KERNEL_SIZE_BYTES);
         log_info(LogTest, "  -x: X end of inclusive core range (default {})", 0);
         log_info(LogTest, "  -y: Y end of inclusive core range (default {})", 0);
         log_info(LogTest, "  -c: number of CBs (default {}, max {})", 0, MAX_CBS);
         log_info(LogTest, "  -a: number of runtime args (default {}, max {})", 0, MAX_ARGS);
-        log_info(LogTest, " -ca: number of common runtime args multicast to all cores (default {}, max {})", 0, MAX_ARGS);
+        log_info(
+            LogTest, " -ca: number of common runtime args multicast to all cores (default {}, max {})", 0, MAX_ARGS);
         log_info(LogTest, "  -S: number of semaphores (default {}, max {})", 0, NUM_SEMAPHORES);
         log_info(LogTest, " -kg: number of kernel groups (default 1)");
         log_info(LogTest, "  -g: use a 4 byte global variable (additional spans");
@@ -130,14 +134,17 @@ void init(int argc, char **argv) {
     workers_g = CoreRange({0, 0}, {core_x, core_y});
 
     if (nfast_kernels_g != 0 && slow_kernel_cycles_g <= fast_kernel_cycles_g) {
-        log_error("The number of fast kernels is non-zero, but slow_kernel_ cycles ({}) is <= fast_kernel_cycles ({})",
-                  slow_kernel_cycles_g, fast_kernel_cycles_g );
+        log_error(
+            "The number of fast kernels is non-zero, but slow_kernel_ cycles ({}) is <= fast_kernel_cycles ({})",
+            slow_kernel_cycles_g,
+            fast_kernel_cycles_g);
         log_error("For meaningful results, run multiple fast kernels between single slow kernels");
         exit(0);
     }
 }
 
-void set_runtime_args(tt_metal::Program& program, tt_metal::KernelHandle kernel_id, vector<uint32_t>& args, CoreRange kg) {
+void set_runtime_args(
+    tt_metal::Program& program, tt_metal::KernelHandle kernel_id, vector<uint32_t>& args, CoreRange kg) {
     for (int core_idx_y = kg.start_coord.y; core_idx_y <= kg.end_coord.y; core_idx_y++) {
         for (int core_idx_x = kg.start_coord.x; core_idx_x <= kg.end_coord.x; core_idx_x++) {
             CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
@@ -149,9 +156,7 @@ void set_runtime_args(tt_metal::Program& program, tt_metal::KernelHandle kernel_
 void initialize_program(tt_metal::Device* device, tt_metal::Program& program, uint32_t run_cycles) {
     program = tt_metal::CreateProgram();
 
-    std::map<string, string> defines = {
-        {"KERNEL_BYTES", std::to_string(kernel_size_g)}
-    };
+    std::map<string, string> defines = {{"KERNEL_BYTES", std::to_string(kernel_size_g)}};
     if (run_cycles != 0) {
         defines.insert(std::pair<string, string>("KERNEL_RUN_TIME", std::to_string(run_cycles)));
     }
@@ -169,13 +174,13 @@ void initialize_program(tt_metal::Device* device, tt_metal::Program& program, ui
     common_args.resize(n_common_args_g);
 
     for (int i = 0; i < n_cbs_g; i++) {
-        tt_metal::CircularBufferConfig cb_config = tt_metal::CircularBufferConfig(16, {{i, tt::DataFormat::Float16_b}})
-            .set_page_size(i, 16);
+        tt_metal::CircularBufferConfig cb_config =
+            tt_metal::CircularBufferConfig(16, {{i, tt::DataFormat::Float16_b}}).set_page_size(i, 16);
         auto cb = tt_metal::CreateCircularBuffer(program, workers_g, cb_config);
     }
 
     // first kernel group is possibly wide, remaining kernel groups are 1 column each
-    CoreRange kg = { workers_g.start_coord, { workers_g.end_coord.x - n_kgs_g + 1, workers_g.end_coord.y }};
+    CoreRange kg = {workers_g.start_coord, {workers_g.end_coord.x - n_kgs_g + 1, workers_g.end_coord.y}};
     for (uint32_t i = 0; i < n_kgs_g; i++) {
         defines.insert(std::pair<string, string>(string("KG_") + std::to_string(i), ""));
 
@@ -184,7 +189,10 @@ void initialize_program(tt_metal::Device* device, tt_metal::Program& program, ui
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/pgm_dispatch_perf.cpp",
                 kg,
-                tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default, .defines = defines});
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .defines = defines});
             set_runtime_args(program, dm0, args, kg);
             tt_metal::SetCommonRuntimeArgs(program, dm0, common_args);
         }
@@ -194,7 +202,10 @@ void initialize_program(tt_metal::Device* device, tt_metal::Program& program, ui
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/pgm_dispatch_perf.cpp",
                 kg,
-                tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default, .defines = defines});
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = tt_metal::NOC::RISCV_1_default,
+                    .defines = defines});
             set_runtime_args(program, dm1, args, kg);
             tt_metal::SetCommonRuntimeArgs(program, dm1, common_args);
         }
@@ -239,7 +250,7 @@ void initialize_program(tt_metal::Device* device, tt_metal::Program& program, ui
     }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     init(argc, argv);
 
     tt::llrt::OptionsG.set_kernels_nullified(true);
@@ -248,8 +259,8 @@ int main(int argc, char **argv) {
     try {
         const chip_id_t device_id = 0;
         DispatchCoreType dispatch_core_type = dispatch_from_eth_g ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
-        tt_metal::Device* device =
-            tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, 900000000, DispatchCoreConfig{dispatch_core_type});
+        tt_metal::Device* device = tt_metal::CreateDevice(
+            device_id, 1, DEFAULT_L1_SMALL_SIZE, 900000000, DispatchCoreConfig{dispatch_core_type});
         CommandQueue& cq = device->command_queue();
 
         tt_metal::Program program[2];
@@ -302,7 +313,12 @@ int main(int argc, char **argv) {
         }
         log_info(LogTest, "Warmup iterations: {}", warmup_iterations_g);
         log_info(LogTest, "Iterations: {}", iterations_g);
-        log_info(LogTest, "Grid: ({}-{}) ({} cores)", workers_g.start_coord.str(), workers_g.end_coord.str(), workers_g.size());
+        log_info(
+            LogTest,
+            "Grid: ({}-{}) ({} cores)",
+            workers_g.start_coord.str(),
+            workers_g.end_coord.str(),
+            workers_g.size());
         log_info(LogTest, "Kernel size: {}", kernel_size_g);
         if (nfast_kernels_g != 0) {
             log_info(LogTest, "Fast kernel cycles: {}", fast_kernel_cycles_g);
@@ -318,7 +334,7 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Sems: {}", n_sems_g);
         log_info(LogTest, "Lazy: {}", lazy_g);
 
-        std::chrono::duration<double> elapsed_seconds = (end-start);
+        std::chrono::duration<double> elapsed_seconds = (end - start);
         log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
         log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -249,7 +249,7 @@ int main(int argc, char **argv) {
         const chip_id_t device_id = 0;
         DispatchCoreType dispatch_core_type = dispatch_from_eth_g ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
         tt_metal::Device* device =
-            tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, 900000000, dispatch_core_type);
+            tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, 900000000, DispatchCoreConfig{dispatch_core_type});
         CommandQueue& cq = device->command_queue();
 
         tt_metal::Program program[2];

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -38,8 +38,8 @@ int main(int argc, char **argv) {
     }
 
 
-    const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+    const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
 
     for (int device_id = 0; device_id < num_devices; device_id++) {

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -12,23 +12,23 @@
 /*
  * Similar to loopback programming example, except run on al devices and skip device teardown to check if we can
  * recover from a "bad" state.
-*/
+ */
 
 using std::vector;
 using namespace tt::tt_metal;
 
-int main(int argc, char **argv) {
-
+int main(int argc, char** argv) {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
     }
 
     // Any arg means that we shouldn't do teardown.
     bool skip_teardown = (argc > 1);
-    if (skip_teardown)
+    if (skip_teardown) {
         tt::log_info("Running loopback test with no teardown, to see if we can recover next run.");
-    else
+    } else {
         tt::log_info("Running loopback test with proper teardown");
+    }
 
     bool pass = true;
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
@@ -37,102 +37,92 @@ int main(int argc, char **argv) {
         ids.push_back(id);
     }
 
-
-    const auto &dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::llrt::OptionsG.get_dispatch_core_config();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
 
     for (int device_id = 0; device_id < num_devices; device_id++) {
-    try {
-        /*
-        * Silicon accelerator setup
-        */
-        Device *device = devices[device_id];
+        try {
+            /*
+             * Silicon accelerator setup
+             */
+            Device* device = devices[device_id];
 
-        /*
-        * Setup program and command queue to execute along with its buffers and kernels to use
-        */
-        CommandQueue& cq = device->command_queue();
-        Program program = CreateProgram();
+            /*
+             * Setup program and command queue to execute along with its buffers and kernels to use
+             */
+            CommandQueue& cq = device->command_queue();
+            Program program = CreateProgram();
 
-        constexpr CoreCoord core = {0, 0};
+            constexpr CoreCoord core = {0, 0};
 
-        KernelHandle dram_copy_kernel_id = CreateKernel(
-            program,
-            "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}
-        );
+            KernelHandle dram_copy_kernel_id = CreateKernel(
+                program,
+                "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
+                core,
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-        constexpr uint32_t single_tile_size = 2 * (32 * 32);
-        constexpr uint32_t num_tiles = 50;
-        constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
+            constexpr uint32_t single_tile_size = 2 * (32 * 32);
+            constexpr uint32_t num_tiles = 50;
+            constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-        tt::tt_metal::InterleavedBufferConfig dram_config{
-                    .device= device,
-                    .size = dram_buffer_size,
-                    .page_size = dram_buffer_size,
-                    .buffer_type = tt::tt_metal::BufferType::DRAM
-        };
-        tt::tt_metal::InterleavedBufferConfig l1_config{
-                    .device= device,
-                    .size = dram_buffer_size,
-                    .page_size = dram_buffer_size,
-                    .buffer_type = tt::tt_metal::BufferType::L1
-        };
+            tt::tt_metal::InterleavedBufferConfig dram_config{
+                .device = device,
+                .size = dram_buffer_size,
+                .page_size = dram_buffer_size,
+                .buffer_type = tt::tt_metal::BufferType::DRAM};
+            tt::tt_metal::InterleavedBufferConfig l1_config{
+                .device = device,
+                .size = dram_buffer_size,
+                .page_size = dram_buffer_size,
+                .buffer_type = tt::tt_metal::BufferType::L1};
 
-        auto l1_buffer = CreateBuffer(l1_config);
+            auto l1_buffer = CreateBuffer(l1_config);
 
-        auto input_dram_buffer = CreateBuffer(dram_config);
-        const uint32_t input_dram_buffer_addr = input_dram_buffer->address();
+            auto input_dram_buffer = CreateBuffer(dram_config);
+            const uint32_t input_dram_buffer_addr = input_dram_buffer->address();
 
-        auto output_dram_buffer = CreateBuffer(dram_config);
-        const uint32_t output_dram_buffer_addr = output_dram_buffer->address();
+            auto output_dram_buffer = CreateBuffer(dram_config);
+            const uint32_t output_dram_buffer_addr = output_dram_buffer->address();
 
-        /*
-        * Create input data and runtime arguments, then execute
-        */
-        std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
-            dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        EnqueueWriteBuffer(cq, input_dram_buffer, input_vec, false);
+            /*
+             * Create input data and runtime arguments, then execute
+             */
+            std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
+                dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+            EnqueueWriteBuffer(cq, input_dram_buffer, input_vec, false);
 
-        const std::array<uint32_t, 8> runtime_args = {
-            l1_buffer->address(),
-            input_dram_buffer->address(),
-            static_cast<uint32_t>(input_dram_buffer->noc_coordinates().x),
-            static_cast<uint32_t>(input_dram_buffer->noc_coordinates().y),
-            output_dram_buffer->address(),
-            static_cast<uint32_t>(output_dram_buffer->noc_coordinates().x),
-            static_cast<uint32_t>(output_dram_buffer->noc_coordinates().y),
-            l1_buffer->size()
-        };
+            const std::array<uint32_t, 8> runtime_args = {
+                l1_buffer->address(),
+                input_dram_buffer->address(),
+                static_cast<uint32_t>(input_dram_buffer->noc_coordinates().x),
+                static_cast<uint32_t>(input_dram_buffer->noc_coordinates().y),
+                output_dram_buffer->address(),
+                static_cast<uint32_t>(output_dram_buffer->noc_coordinates().x),
+                static_cast<uint32_t>(output_dram_buffer->noc_coordinates().y),
+                l1_buffer->size()};
 
-        SetRuntimeArgs(
-            program,
-            dram_copy_kernel_id,
-            core,
-            runtime_args
-        );
+            SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
 
-        EnqueueProgram(cq, program, false);
-        tt::log_info("Started program");
-        Finish(cq);
-        tt::log_info("Finished program");
+            EnqueueProgram(cq, program, false);
+            tt::log_info("Started program");
+            Finish(cq);
+            tt::log_info("Finished program");
 
-        /*
-        * Validation & Teardown
-        */
-        std::vector<uint32_t> result_vec;
-        EnqueueReadBuffer(cq, output_dram_buffer, result_vec, true);
+            /*
+             * Validation & Teardown
+             */
+            std::vector<uint32_t> result_vec;
+            EnqueueReadBuffer(cq, output_dram_buffer, result_vec, true);
 
-        pass &= input_vec == result_vec;
+            pass &= input_vec == result_vec;
 
-    } catch (const std::exception &e) {
-        tt::log_error(tt::LogTest, "Test failed with exception!");
-        tt::log_error(tt::LogTest, "{}", e.what());
+        } catch (const std::exception& e) {
+            tt::log_error(tt::LogTest, "Test failed with exception!");
+            tt::log_error(tt::LogTest, "{}", e.what());
 
-        throw;
-    }
+            throw;
+        }
     }
 
     if (pass) {

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
+        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{});
         auto devices = tt::DevicePool::instance().get_all_active_devices();
         std::vector<Program> programs;
         std::set<uint32_t> build_keys;

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -119,7 +119,7 @@ TEST(GalaxyTests, TestAllGatherDeadlock) {
     validate_num_tunnels_and_tunnel_depth();
 
     ttnn::MeshShape mesh_shape = get_mesh_shape();
-    std::shared_ptr<ttnn::MeshDevice> mesh = ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreType::WORKER);
+    std::shared_ptr<ttnn::MeshDevice> mesh = ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreConfig{});
 
     // Setup input data and output data containers
     MemoryConfig mem_cfg = MemoryConfig{
@@ -198,7 +198,7 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
     validate_num_tunnels_and_tunnel_depth();
 
     ttnn::MeshShape mesh_shape = get_mesh_shape();
-    std::shared_ptr<ttnn::MeshDevice> mesh = ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreType::WORKER);
+    std::shared_ptr<ttnn::MeshDevice> mesh = ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreConfig{});
     // Create the outer ring on which Reduce Scatter will be run. This allows us to verify that there are no deadlocks when we send CCLs to the
     // first tunnel (forward path).
     auto view = ttnn::MeshDeviceView(*mesh);

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -18,16 +18,18 @@ using namespace tt_metal;
 
 // We use this to dispatch a single device operation asynchronously
 // Needed to reproduce the deadlock scenario with a very specific pattern of commands
-// This can go away once device_operation::run will be made async and ccl op is moved to the new tmp-based DeviceOperation
+// This can go away once device_operation::run will be made async and ccl op is moved to the new tmp-based
+// DeviceOperation
 namespace async_detail {
-template<typename OpConfig>
+template <typename OpConfig>
 std::vector<Tensor> run_operation(
     uint8_t cq_id,
     OpConfig devop,
     const operation::Tensors& input_tensors,
     const operation::OptionalConstTensors& optional_input_tensors = {},
     const operation::OptionalTensors& optional_output_tensors = {}) {
-    static_assert(operation::detail::is_device_operation<OpConfig>(), "ttnn::run_operation can only dispatch Device Operations!");
+    static_assert(
+        operation::detail::is_device_operation<OpConfig>(), "ttnn::run_operation can only dispatch Device Operations!");
     // Create output tensor vector by examining the number of output shapes created by the device operation
     auto output_shapes = operation::DeviceOperation<operation::Tensors>(devop).compute_output_shapes(input_tensors);
     size_t output_shapes_size = 0;
@@ -44,71 +46,69 @@ std::vector<Tensor> run_operation(
     // Send the operation to the async engine, which will populate the output tensors.
     for (auto worker : outputs.at(0).workers) {
         tt::tt_metal::operation::launch_op(
-            [devop, worker, cq_id] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-                return operation::run(std::move(devop), input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
-            }, input_tensors, outputs, optional_input_tensors, optional_output_tensors);
+            [devop, worker, cq_id](
+                const std::vector<Tensor>& input_tensors,
+                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+                return operation::run(
+                    std::move(devop), input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
+            },
+            input_tensors,
+            outputs,
+            optional_input_tensors,
+            optional_output_tensors);
     }
     return outputs;
 }
-} // namespace async_detail
+}  // namespace async_detail
 
-bool is_tg_system()
-{
+bool is_tg_system() {
     const bool is_galaxy_system = tt::Cluster::instance().is_galaxy_cluster();
     const size_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
     const size_t num_devices = tt::Cluster::instance().number_of_user_devices();
     return is_galaxy_system && (num_mmio_devices == 4) && (num_devices == 32);
 }
 
-bool is_tgg_system()
-{
+bool is_tgg_system() {
     const bool is_galaxy_system = tt::Cluster::instance().is_galaxy_cluster();
     const size_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
     const size_t num_devices = tt::Cluster::instance().number_of_user_devices();
     return is_galaxy_system && (num_mmio_devices == 8) && (num_devices == 64);
 }
 
-ttnn::MeshShape get_mesh_shape()
-{
+ttnn::MeshShape get_mesh_shape() {
     ttnn::MeshShape shape;
-    if (is_tg_system())
-    {
+    if (is_tg_system()) {
         shape = {8, 4};
-    }
-    else {
+    } else {
         TT_FATAL(is_tgg_system(), "Unsupported Galaxy system");
         shape = {8, 8};
     }
     return shape;
 }
 
-void validate_num_tunnels_and_tunnel_depth()
-{
+void validate_num_tunnels_and_tunnel_depth() {
     const uint32_t num_devices_in_tunnel = tt::Cluster::instance().get_mmio_device_max_tunnel_depth(0);
     const uint32_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
     const uint32_t cluster_tunnel_count = tt::Cluster::instance().get_mmio_device_tunnel_count(0);
-    TT_FATAL(num_devices_in_tunnel == 4, "Expected Galaxy to have tunnel depth of 4, detected tunnel depth of {}", num_devices_in_tunnel);
+    TT_FATAL(
+        num_devices_in_tunnel == 4,
+        "Expected Galaxy to have tunnel depth of 4, detected tunnel depth of {}",
+        num_devices_in_tunnel);
     const uint32_t num_tunnels = num_mmio_devices * cluster_tunnel_count;
-    if (is_tg_system())
-    {
+    if (is_tg_system()) {
         TT_FATAL(num_tunnels == 8, "Expected 8 tunnels in a TG system, detected {} tunnels", num_tunnels);
-    }
-    else if (is_tgg_system())
-    {
+    } else if (is_tgg_system()) {
         TT_FATAL(num_tunnels == 16, "Expected 16 tunnels in a TGG system, detected {} tunnels", num_tunnels);
     }
 }
 
-std::shared_ptr<bfloat16 []> create_container_for_readback_data(const uint32_t buf_size_datums)
-{
-    if (is_tg_system())
-    {
-        return std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums * 4]);
-    }
-    else
-    {
+std::shared_ptr<bfloat16[]> create_container_for_readback_data(const uint32_t buf_size_datums) {
+    if (is_tg_system()) {
+        return std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums * 4]);
+    } else {
         TT_FATAL(is_tgg_system(), "Unsupported Galaxy system");
-        return std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums * 8]);
+        return std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums * 8]);
     }
 }
 
@@ -119,18 +119,17 @@ TEST(GalaxyTests, TestAllGatherDeadlock) {
     validate_num_tunnels_and_tunnel_depth();
 
     ttnn::MeshShape mesh_shape = get_mesh_shape();
-    std::shared_ptr<ttnn::MeshDevice> mesh = ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreConfig{});
+    std::shared_ptr<ttnn::MeshDevice> mesh =
+        ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreConfig{});
 
     // Setup input data and output data containers
     MemoryConfig mem_cfg = MemoryConfig{
-        .memory_layout = TensorMemoryLayout::INTERLEAVED,
-        .buffer_type = BufferType::DRAM,
-        .shard_spec = std::nullopt};
+        .memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::DRAM, .shard_spec = std::nullopt};
     ttnn::SimpleShape shape{1, 1, 32, 16384};
     const uint32_t buf_size_datums = 32 * 16384;
     const uint32_t datum_size_bytes = 2;
-    auto host_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
-    std::shared_ptr<bfloat16 []> readback_data = create_container_for_readback_data(buf_size_datums);
+    auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
+    std::shared_ptr<bfloat16[]> readback_data = create_container_for_readback_data(buf_size_datums);
     const uint32_t outer_loops = 200;
 
     // Input to CCL is a tensor of 1s. The output should contain 4x the amount of data, but all values should be 1.
@@ -167,12 +166,22 @@ TEST(GalaxyTests, TestAllGatherDeadlock) {
                 uint32_t receiver_device_id = device_ids[(dev_idx) + 1 % num_devices_in_row];
                 uint32_t sender_device_id = device_ids[(dev_idx + num_devices_in_row - 1) % num_devices_in_row];
                 auto all_gather_op = ttnn::AllGather{
-                                        3, 2, num_devices_in_row, dev_idx, std::nullopt, std::nullopt, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::ccl::Topology::Linear};
+                    3,
+                    2,
+                    num_devices_in_row,
+                    dev_idx,
+                    std::nullopt,
+                    std::nullopt,
+                    receiver_device_id,
+                    sender_device_id,
+                    input_tensor.memory_config(),
+                    ttnn::ccl::Topology::Linear};
                 // Send CCL to this device. All CCLs will complete simultaneously.
                 output_tensors.push_back(async_detail::run_operation(0, all_gather_op, {input_tensor}).at(0));
-                // Expose deadlock: After the CCL is sent to the first device in the tunnel, send enough data to it to backpressure prefetch_h. This will block the
-                // demux, which will prevent the CCL from being sent to additional chips. If the CCL has been tagged as having multi-device dependencies, deadlock should
-                // get bypassed.
+                // Expose deadlock: After the CCL is sent to the first device in the tunnel, send enough data to it to
+                // backpressure prefetch_h. This will block the demux, which will prevent the CCL from being sent to
+                // additional chips. If the CCL has been tagged as having multi-device dependencies, deadlock should get
+                // bypassed.
                 if (!dev_idx) {
                     ttnn::write_buffer(0, input_tensor, {host_data});
                 }
@@ -180,7 +189,9 @@ TEST(GalaxyTests, TestAllGatherDeadlock) {
             }
             // Readback data and verify correctness.
             for (auto& tensor : output_tensors) {
-                ASSERT_EQ(tensor.get_shape(), ttnn::Shape(LegacyShape({1, 1, 32, static_cast<uint32_t>(16384 * device_ids.size())})));
+                ASSERT_EQ(
+                    tensor.get_shape(),
+                    ttnn::Shape(LegacyShape({1, 1, 32, static_cast<uint32_t>(16384 * device_ids.size())})));
                 ttnn::read_buffer(0, tensor, {readback_data});
                 for (int j = 0; j < device_ids.size() * 32 * 16384; j++) {
                     ASSERT_EQ(readback_data[j].to_float(), 1);
@@ -198,17 +209,20 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
     validate_num_tunnels_and_tunnel_depth();
 
     ttnn::MeshShape mesh_shape = get_mesh_shape();
-    std::shared_ptr<ttnn::MeshDevice> mesh = ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreConfig{});
-    // Create the outer ring on which Reduce Scatter will be run. This allows us to verify that there are no deadlocks when we send CCLs to the
-    // first tunnel (forward path).
+    std::shared_ptr<ttnn::MeshDevice> mesh =
+        ttnn::distributed::open_mesh_device(mesh_shape, 0, 0, 1, DispatchCoreConfig{});
+    // Create the outer ring on which Reduce Scatter will be run. This allows us to verify that there are no deadlocks
+    // when we send CCLs to the first tunnel (forward path).
     auto view = ttnn::MeshDeviceView(*mesh);
-    std::vector<Device*> ring_devices = view.get_devices_on_row(0); // Tunnel 0
-    std::vector<Device*> ring_devices_1 = view.get_devices_on_column(mesh_shape.second - 1); // Orthogonal to tunnel .. no deadlocks
+    std::vector<Device*> ring_devices = view.get_devices_on_row(0);  // Tunnel 0
+    std::vector<Device*> ring_devices_1 =
+        view.get_devices_on_column(mesh_shape.second - 1);  // Orthogonal to tunnel .. no deadlocks
     ring_devices_1 = std::vector<Device*>(ring_devices_1.begin() + 1, ring_devices_1.end());
-    std::vector<Device*> ring_devices_2 = view.get_devices_on_row(7); // Tunnel 7 .. potential deadlocks with lack of buffering
+    std::vector<Device*> ring_devices_2 =
+        view.get_devices_on_row(7);  // Tunnel 7 .. potential deadlocks with lack of buffering
     std::reverse(ring_devices_2.begin(), ring_devices_2.end());
     ring_devices_2 = std::vector<Device*>(ring_devices_2.begin() + 1, ring_devices_2.end());
-    std::vector<Device*> ring_devices_3 = view.get_devices_on_column(0); // Orthogonal to tunnel .. no deadlocks
+    std::vector<Device*> ring_devices_3 = view.get_devices_on_column(0);  // Orthogonal to tunnel .. no deadlocks
     std::reverse(ring_devices_3.begin(), ring_devices_3.end());
     ring_devices_3 = std::vector<Device*>(ring_devices_3.begin() + 1, ring_devices_3.end() - 1);
 
@@ -218,15 +232,13 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
 
     // Setup input data and output data containers
     MemoryConfig mem_cfg = MemoryConfig{
-        .memory_layout = TensorMemoryLayout::INTERLEAVED,
-        .buffer_type = BufferType::DRAM,
-        .shard_spec = std::nullopt};
+        .memory_layout = TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::DRAM, .shard_spec = std::nullopt};
     ttnn::SimpleShape shape{1, 2, 256, static_cast<uint32_t>(256 * ring_devices.size())};
     const uint32_t buf_size_datums = 2 * 256 * 256 * ring_devices.size();
     const uint32_t datum_size_bytes = 2;
     // Output of reduce scatter is input_numel / num_devices_used_in_scatter_op
-    auto host_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
-    auto readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums / ring_devices.size()]);
+    auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
+    auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums / ring_devices.size()]);
     uint32_t scatter_dim = 3;
     uint32_t outer_loops = 500;
 
@@ -265,16 +277,24 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
             uint32_t receiver_device_id = device_ids[(dev_idx + 1) % ring_devices.size()];
             uint32_t sender_device_id = device_ids[(dev_idx + ring_devices.size() - 1) % ring_devices.size()];
             auto all_gather_op = ttnn::ReduceScatter{
-                                    ttnn::operations::binary::BinaryOpType::ADD, scatter_dim, 1, static_cast<uint32_t>(ring_devices.size()), dev_idx, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::ccl::Topology::Ring};
+                ttnn::operations::binary::BinaryOpType::ADD,
+                scatter_dim,
+                1,
+                static_cast<uint32_t>(ring_devices.size()),
+                dev_idx,
+                receiver_device_id,
+                sender_device_id,
+                input_tensor.memory_config(),
+                ttnn::ccl::Topology::Ring};
             // Send CCL to this device. All CCLs will complete simultaneously.
             output_tensors.push_back(async_detail::run_operation(0, all_gather_op, {input_tensor}).at(0));
-            // Expose deadlock: After the CCL is sent to a device in the first tunnel, send enough data to it to backpressure prefetch_h. This will block the
-            // demux, which will prevent the CCL from being sent to additional chips on the tunnel. If the CCL has been tagged as having multi-device dependencies, deadlock should
-            // get bypassed.
-            // if (dev_idx < 3) {
-                for (int j = 0; j < 16; j++) {
-                    ttnn::write_buffer(0, input_tensor, {host_data});
-                }
+            // Expose deadlock: After the CCL is sent to a device in the first tunnel, send enough data to it to
+            // backpressure prefetch_h. This will block the demux, which will prevent the CCL from being sent to
+            // additional chips on the tunnel. If the CCL has been tagged as having multi-device dependencies, deadlock
+            // should get bypassed. if (dev_idx < 3) {
+            for (int j = 0; j < 16; j++) {
+                ttnn::write_buffer(0, input_tensor, {host_data});
+            }
             // }
             dev_idx++;
         }

--- a/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
@@ -14,7 +14,7 @@
 namespace ttnn {
 
 class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
-   protected:
+protected:
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -25,15 +25,15 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
 
         DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
         if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ != 1) {
-            tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+            tt::log_warning(
+                tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_ = tt::tt_metal::CreateDevice(0, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{dispatch_core_type});
+        device_ = tt::tt_metal::CreateDevice(
+            0, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{dispatch_core_type});
     }
 
-    void TearDown() override {
-        tt::tt_metal::CloseDevice(device_);
-    }
+    void TearDown() override { tt::tt_metal::CloseDevice(device_); }
 
     tt::tt_metal::Device* device_;
     tt::ARCH arch_;
@@ -41,7 +41,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
 };
 
 class MultiCommandQueueT3KFixture : public ::testing::Test {
-   protected:
+protected:
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -54,16 +54,19 @@ class MultiCommandQueueT3KFixture : public ::testing::Test {
         }
         // Enable Ethernet Dispatch for Multi-CQ tests.
 
-        devs = tt::tt_metal::detail::CreateDevices({0, 1, 2, 3, 4, 5, 6, 7}, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{DispatchCoreType::ETH});
+        devs = tt::tt_metal::detail::CreateDevices(
+            {0, 1, 2, 3, 4, 5, 6, 7},
+            2,
+            DEFAULT_L1_SMALL_SIZE,
+            DEFAULT_TRACE_REGION_SIZE,
+            DispatchCoreConfig{DispatchCoreType::ETH});
     }
 
-    void TearDown() override {
-        tt::tt_metal::detail::CloseDevices(devs);
-    }
+    void TearDown() override { tt::tt_metal::detail::CloseDevices(devs); }
 
     std::map<chip_id_t, tt::tt_metal::Device*> devs;
     tt::ARCH arch_;
     size_t num_devices_;
 };
 
-}
+}  // namespace ttnn

--- a/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
@@ -28,7 +28,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_ = tt::tt_metal::CreateDevice(0, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
+        device_ = tt::tt_metal::CreateDevice(0, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{dispatch_core_type});
     }
 
     void TearDown() override {
@@ -54,7 +54,7 @@ class MultiCommandQueueT3KFixture : public ::testing::Test {
         }
         // Enable Ethernet Dispatch for Multi-CQ tests.
 
-        devs = tt::tt_metal::detail::CreateDevices({0, 1, 2, 3, 4, 5, 6, 7}, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::ETH);
+        devs = tt::tt_metal::detail::CreateDevices({0, 1, 2, 3, 4, 5, 6, 7}, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreConfig{DispatchCoreType::ETH});
     }
 
     void TearDown() override {

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -92,6 +92,7 @@ def test_pytorch_2_0_failed_cases(device, m, k, n):
     z_t = torch.matmul(x, y)
     assert_with_pcc(z_t, z)
 
+
 @pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [256])

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -92,6 +92,106 @@ def test_pytorch_2_0_failed_cases(device, m, k, n):
     z_t = torch.matmul(x, y)
     assert_with_pcc(z_t, z)
 
+@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
+@pytest.mark.parametrize("m", [256])
+@pytest.mark.parametrize("k", [256])
+@pytest.mark.parametrize("n", [256])
+@pytest.mark.parametrize("tile_h", [32])
+@pytest.mark.parametrize("tile_w", [32])
+@pytest.mark.parametrize("in0_sharded", [True])
+@pytest.mark.parametrize("in1_sharded", [True])
+@pytest.mark.parametrize("out_sharded", [True])
+@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("transpose_tile", [False])
+def test_matmul_reuse_config_sharded_fd_column(
+    device, m, k, n, tile_h, tile_w, in0_sharded, in1_sharded, out_sharded, in1_dtype, transpose_tile
+):
+    torch.manual_seed(0)
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+    b = compute_grid_size.x
+    h = compute_grid_size.y
+
+    grid_size = (b, h)
+
+    in0 = torch.randn((b, h, m, k), dtype=torch.bfloat16)
+    in1 = torch.randn((b, h, k, n), dtype=torch.bfloat16)
+
+    if in0_sharded:
+        in0_memory_config = ttnn.create_sharded_memory_config(
+            (b, h, m, k),
+            core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+    else:
+        in0_memory_config = ttnn.L1_MEMORY_CONFIG
+    in0_t = ttnn.from_torch(
+        in0,
+        tile=ttnn.Tile((tile_h, 32)),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in0_memory_config,
+    )
+
+    if in1_sharded:
+        in1_memory_config = ttnn.create_sharded_memory_config(
+            (b, h, k, n),
+            core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+    else:
+        in1_memory_config = ttnn.L1_MEMORY_CONFIG
+    in1_t = ttnn.from_torch(
+        in1,
+        tile=ttnn.Tile((32, tile_w), transpose_tile=transpose_tile),
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in1_memory_config,
+    )
+
+    out_block_h = m // tile_h
+    out_block_w = n // tile_w
+    out_subblock_h, out_subblock_w, _ = find_max_subblock(out_block_h, out_block_w)
+
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=k // 32,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=out_block_h,
+        per_core_N=out_block_w,
+    )
+    if out_sharded:
+        out_mem_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+        )
+    else:
+        out_mem_config = ttnn.L1_MEMORY_CONFIG
+    # override the tile width for later ops
+    if out_sharded and tile_h <= 16:
+        output_tile = ttnn.Tile([tile_h, 32])
+    else:
+        output_tile = ttnn.Tile([tile_h, tile_w])
+    output_tile = ttnn.Tile([tile_h, tile_w])
+    output_t = ttnn.matmul(
+        in0_t, in1_t, program_config=program_config, memory_config=out_mem_config, output_tile=output_tile
+    )
+    output_tensor = ttnn.to_torch(output_t)
+    pt_out = in0 @ in1
+    if in1_dtype == ttnn.bfloat8_b:
+        expected_pcc = 0.999
+    elif in1_dtype == ttnn.bfloat4_b:
+        expected_pcc = 0.993
+
+    pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
+    logger.info(pcc_message)
+    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize("b", [2])

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -95,6 +95,11 @@ def test_multi_device_open_close_galaxy_mesh(silicon_arch_name, silicon_arch_wor
 #######
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
@@ -116,6 +121,11 @@ def test_ttnn_to_multi_device_multiple_times(mesh_device, layout, memory_config,
     assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -136,6 +146,11 @@ def test_ttnn_to_and_from_multi_device_shard(mesh_device, layout, memory_config,
     assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -159,6 +174,11 @@ def test_multi_device_check_per_device_shard(mesh_device, layout, memory_config,
         shard_offset += shard_size
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("shape", [(1, 1, 32, 128), (1, 1, 16, 32)])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
@@ -182,6 +202,11 @@ def test_multi_device_replicate(mesh_device, shape, layout, memory_config):
         assert torch.all(full_tensor == loopback_replicated_tensor)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_ttnn_multi_device_all_gather(pcie_mesh_device):
     """Multidevice API test for ttnn.all_gather CCL operation"""
     if pcie_mesh_device.get_num_devices() <= 1:
@@ -198,6 +223,11 @@ def test_ttnn_multi_device_all_gather(pcie_mesh_device):
         assert torch.all(device_tensor_torch == full_tensor)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_multi_device_single_op_unary(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device single-op unary"""
     torch_input_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
@@ -215,6 +245,11 @@ def test_multi_device_single_op_unary(mesh_device):
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_multi_device_single_op_binary(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device single-op binary"""
     torch_input_a_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
@@ -239,6 +274,11 @@ def test_multi_device_single_op_binary(mesh_device):
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_multi_device_multi_op(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device multi-op"""
     torch_input_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
@@ -258,6 +298,11 @@ def test_multi_device_multi_op(mesh_device):
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_multi_device_data_parallel_matmul_op(mesh_device):
     """Multidevice API: Data Parallel on matmul"""
     torch_input_a_tensor = torch.rand((mesh_device.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
@@ -282,6 +327,11 @@ def test_multi_device_data_parallel_matmul_op(mesh_device):
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.993)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
@@ -333,6 +383,11 @@ def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype):
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.991)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
@@ -364,6 +419,11 @@ def test_multi_device_as_tensor_api_sharded_tensor(mesh_device, layout, memory_c
         assert_with_pcc(input_tensor, torch_loaded_tensor, pcc=expected_pcc)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
@@ -385,6 +445,11 @@ def test_multi_device_permute(mesh_device, layout, memory_config, dtype):
     assert_with_pcc(torch_golden, torch_loop_back_tensor, pcc=0.9999)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_max(mesh_device):
     gate_logits_1SB8 = ttnn.from_torch(
         torch.randn(1, 1, 32, 8),
@@ -398,6 +463,11 @@ def test_max(mesh_device):
     print(weights_ex0_1SB1)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_ttnn_multi_device_all_gather_all_devices(t3k_mesh_device):
     """Multidevice API test for ttnn.all_gather CCL operation for full 8-device T3K"""
     if t3k_mesh_device.get_num_devices() < 8:
@@ -417,6 +487,11 @@ def test_ttnn_multi_device_all_gather_all_devices(t3k_mesh_device):
         assert torch.all(device_tensor_torch == full_tensor)
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}, {"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
 def test_sharded_matmul(t3k_mesh_device):
     q_heads_1B4D = ttnn.from_torch(
         torch.randn(1, 32, 32, 128),

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -8,7 +8,7 @@
 
 namespace ttml::core {
 
-MeshDevice::MeshDevice([[maybe_unused]]int device_index) :
+MeshDevice::MeshDevice([[maybe_unused]] int device_index) :
     m_mesh_device(ttnn::distributed::api::open_mesh_device(
         ttnn::distributed::MeshShape(1, 1),
         DEFAULT_L1_SMALL_SIZE,

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -14,7 +14,7 @@ MeshDevice::MeshDevice([[maybe_unused]]int device_index) :
         DEFAULT_L1_SMALL_SIZE,
         DEFAULT_TRACE_REGION_SIZE,
         /* num_command_queues*/ 1,
-        DispatchCoreType::WORKER,
+        DispatchCoreConfig{},
         ttnn::distributed::MeshType::RowMajor)) {
     assert(m_mesh_device);
 }

--- a/tt_metal/common/core_descriptor.cpp
+++ b/tt_metal/common/core_descriptor.cpp
@@ -9,15 +9,15 @@
 namespace tt {
 
 const core_descriptor_t& get_core_descriptor_config(
-    chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
     // {arch : {product : {num hardware command queues : config}}}
     static std::unordered_map<ARCH, std::unordered_map<std::string, std::unordered_map<uint8_t, core_descriptor_t>>>
         config_by_arch;
     // TODO: is there a better way to do this?
     static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_type) {
+    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
         config_by_arch.clear();
-        previous_dispatch_core_type = dispatch_core_type;
+        previous_dispatch_core_type = dispatch_core_config.get_core_type();
     }
 
     ARCH arch = tt::Cluster::instance().arch();
@@ -54,8 +54,8 @@ const core_descriptor_t& get_core_descriptor_config(
         config_by_arch[arch];
     std::unordered_map<uint8_t, core_descriptor_t>& config_by_num_cqs = config_by_product[product_name];
 
-    YAML::Node core_descriptor_yaml = YAML::LoadFile(get_core_descriptor_file(arch, dispatch_core_type));
-    YAML::Node desc_yaml = core_descriptor_yaml[product_name][std::to_string(num_hw_cqs)];
+    YAML::Node core_descriptor_yaml = YAML::LoadFile(get_core_descriptor_file(arch, dispatch_core_config));
+    YAML::Node desc_yaml = core_descriptor_yaml[product_name][(dispatch_core_config.get_dispatch_core_axis() == tt_metal::DispatchCoreAxis::ROW) ? "row" : "col"][std::to_string(num_hw_cqs)];
 
     // Parse the yaml into core_descriptor_t
     std::vector<RelativeCoreCoord> storage_cores;
@@ -130,13 +130,13 @@ const core_descriptor_t& get_core_descriptor_config(
 }
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    chip_id_t chip, uint8_t num_hw_cqs, CoreType dispatch_core_type) {
+    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
     // Get logical compute grid dimensions and num workers
     static std::unordered_map<uint32_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
     // Unique hash generated based on the config that's being queried
-    uint32_t config_hash = ((uint8_t)(dispatch_core_type)) | (num_hw_cqs << 8) | (chip << 16);
+    uint32_t config_hash = ((uint8_t)(dispatch_core_config.get_core_type())) | ((uint8_t)(dispatch_core_config.get_dispatch_core_axis()) << 4) | (num_hw_cqs << 8) | (chip << 16);
     if (physical_grid_config_cache.find(config_hash) == physical_grid_config_cache.end()) {
-        auto worker_grid = tt::get_compute_grid_size(chip, num_hw_cqs, dispatch_core_type);
+        auto worker_grid = tt::get_compute_grid_size(chip, num_hw_cqs, dispatch_core_config);
         std::size_t tensix_num_worker_cols = worker_grid.x;
         std::size_t tensix_num_worker_rows = worker_grid.y;
         uint32_t tensix_num_worker_cores = tensix_num_worker_cols * tensix_num_worker_rows;

--- a/tt_metal/common/core_descriptor.cpp
+++ b/tt_metal/common/core_descriptor.cpp
@@ -9,7 +9,7 @@
 namespace tt {
 
 const core_descriptor_t& get_core_descriptor_config(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // {arch : {product : {num hardware command queues : config}}}
     static std::unordered_map<ARCH, std::unordered_map<std::string, std::unordered_map<uint8_t, core_descriptor_t>>>
         config_by_arch;
@@ -55,7 +55,11 @@ const core_descriptor_t& get_core_descriptor_config(
     std::unordered_map<uint8_t, core_descriptor_t>& config_by_num_cqs = config_by_product[product_name];
 
     YAML::Node core_descriptor_yaml = YAML::LoadFile(get_core_descriptor_file(arch, dispatch_core_config));
-    YAML::Node desc_yaml = core_descriptor_yaml[product_name][(dispatch_core_config.get_dispatch_core_axis() == tt_metal::DispatchCoreAxis::ROW) ? "row" : "col"][std::to_string(num_hw_cqs)];
+    YAML::Node desc_yaml =
+        core_descriptor_yaml[product_name]
+                            [(dispatch_core_config.get_dispatch_core_axis() == tt_metal::DispatchCoreAxis::ROW) ? "row"
+                                                                                                                : "col"]
+                            [std::to_string(num_hw_cqs)];
 
     // Parse the yaml into core_descriptor_t
     std::vector<RelativeCoreCoord> storage_cores;
@@ -130,11 +134,13 @@ const core_descriptor_t& get_core_descriptor_config(
 }
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // Get logical compute grid dimensions and num workers
     static std::unordered_map<uint32_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
     // Unique hash generated based on the config that's being queried
-    uint32_t config_hash = ((uint8_t)(dispatch_core_config.get_core_type())) | ((uint8_t)(dispatch_core_config.get_dispatch_core_axis()) << 4) | (num_hw_cqs << 8) | (chip << 16);
+    uint32_t config_hash = ((uint8_t)(dispatch_core_config.get_core_type())) |
+                           ((uint8_t)(dispatch_core_config.get_dispatch_core_axis()) << 4) | (num_hw_cqs << 8) |
+                           (chip << 16);
     if (physical_grid_config_cache.find(config_hash) == physical_grid_config_cache.end()) {
         auto worker_grid = tt::get_compute_grid_size(chip, num_hw_cqs, dispatch_core_config);
         std::size_t tensix_num_worker_cols = worker_grid.x;

--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -19,7 +19,8 @@ struct core_descriptor_t {
     std::vector<RelativeCoreCoord> relative_dispatch_cores;
 };
 
-inline std::string get_core_descriptor_file(const tt::ARCH& arch, const tt::tt_metal::DispatchCoreConfig &dispatch_core_config) {
+inline std::string get_core_descriptor_file(
+    const tt::ARCH& arch, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
     string core_desc_dir;
     if (getenv("TT_METAL_HOME")) {
@@ -50,11 +51,13 @@ inline std::string get_core_descriptor_file(const tt::ARCH& arch, const tt::tt_m
                     "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
             case tt::ARCH::GRAYSKULL: return core_desc_dir + "grayskull_120_arch.yaml";
             case tt::ARCH::WORMHOLE_B0:
-                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH ? "wormhole_b0_80_arch_eth_dispatch.yaml"
-                                                                            : "wormhole_b0_80_arch.yaml");
+                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH
+                                            ? "wormhole_b0_80_arch_eth_dispatch.yaml"
+                                            : "wormhole_b0_80_arch.yaml");
             case tt::ARCH::BLACKHOLE:
-                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH ? "blackhole_140_arch_eth_dispatch.yaml"
-                                                                            : "blackhole_140_arch.yaml");
+                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH
+                                            ? "blackhole_140_arch_eth_dispatch.yaml"
+                                            : "blackhole_140_arch.yaml");
             default: throw std::runtime_error("Unsupported device arch");
         };
     }
@@ -72,13 +75,13 @@ inline const std::string get_product_name(tt::ARCH arch, uint32_t num_harvested_
 }
 
 const core_descriptor_t& get_core_descriptor_config(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config);
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config);
+    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
 inline std::optional<uint32_t> get_storage_core_bank_size(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
     if (core_desc.storage_core_bank_size.has_value()) {
@@ -91,7 +94,7 @@ inline std::optional<uint32_t> get_storage_core_bank_size(
 }
 
 inline const std::vector<CoreCoord>& get_logical_storage_cores(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
         logical_storage_cores_by_device;
     static CoreType previous_dispatch_core_type;
@@ -114,13 +117,14 @@ inline const std::vector<CoreCoord>& get_logical_storage_cores(
     return logical_storage_cores;
 }
 
-inline CoreCoord get_compute_grid_size(chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+inline CoreCoord get_compute_grid_size(
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.compute_grid_size;
 }
 
 inline const std::vector<CoreCoord>& get_logical_compute_cores(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
         logical_compute_cores_by_device;
     static CoreType previous_dispatch_core_type;
@@ -144,7 +148,7 @@ inline const std::vector<CoreCoord>& get_logical_compute_cores(
 }
 
 inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
-    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
         logical_dispatch_cores_by_device;
     static CoreType previous_dispatch_core_type;

--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -7,6 +7,7 @@
 #include "core_coord.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include "llrt/hal.hpp"
+#include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 
 namespace tt {
 
@@ -18,7 +19,7 @@ struct core_descriptor_t {
     std::vector<RelativeCoreCoord> relative_dispatch_cores;
 };
 
-inline std::string get_core_descriptor_file(const tt::ARCH& arch, CoreType dispatch_core_type) {
+inline std::string get_core_descriptor_file(const tt::ARCH& arch, const tt::tt_metal::DispatchCoreConfig &dispatch_core_config) {
     // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
     string core_desc_dir;
     if (getenv("TT_METAL_HOME")) {
@@ -49,10 +50,10 @@ inline std::string get_core_descriptor_file(const tt::ARCH& arch, CoreType dispa
                     "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
             case tt::ARCH::GRAYSKULL: return core_desc_dir + "grayskull_120_arch.yaml";
             case tt::ARCH::WORMHOLE_B0:
-                return core_desc_dir + (dispatch_core_type == CoreType::ETH ? "wormhole_b0_80_arch_eth_dispatch.yaml"
+                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH ? "wormhole_b0_80_arch_eth_dispatch.yaml"
                                                                             : "wormhole_b0_80_arch.yaml");
             case tt::ARCH::BLACKHOLE:
-                return core_desc_dir + (dispatch_core_type == CoreType::ETH ? "blackhole_140_arch_eth_dispatch.yaml"
+                return core_desc_dir + (dispatch_core_config.get_core_type() == CoreType::ETH ? "blackhole_140_arch_eth_dispatch.yaml"
                                                                             : "blackhole_140_arch.yaml");
             default: throw std::runtime_error("Unsupported device arch");
         };
@@ -71,14 +72,14 @@ inline const std::string get_product_name(tt::ARCH arch, uint32_t num_harvested_
 }
 
 const core_descriptor_t& get_core_descriptor_config(
-    chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type);
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config);
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    chip_id_t chip, uint8_t num_hw_cqs, CoreType dispatch_core_type);
+    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config);
 
 inline std::optional<uint32_t> get_storage_core_bank_size(
-    chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_type);
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
     if (core_desc.storage_core_bank_size.has_value()) {
         TT_FATAL(
@@ -90,13 +91,13 @@ inline std::optional<uint32_t> get_storage_core_bank_size(
 }
 
 inline const std::vector<CoreCoord>& get_logical_storage_cores(
-    chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
     static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
         logical_storage_cores_by_device;
     static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_type) {
+    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
         logical_storage_cores_by_device.clear();
-        previous_dispatch_core_type = dispatch_core_type;
+        previous_dispatch_core_type = dispatch_core_config.get_core_type();
     }
     auto& logical_storage_cores_by_cq = logical_storage_cores_by_device[device_id];
     if (auto it = logical_storage_cores_by_cq.find(num_hw_cqs); it != logical_storage_cores_by_cq.end()) {
@@ -104,7 +105,7 @@ inline const std::vector<CoreCoord>& get_logical_storage_cores(
     }
     CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
     std::vector<CoreCoord>& logical_storage_cores = logical_storage_cores_by_cq[num_hw_cqs];
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_type);
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     std::transform(
         core_desc.relative_storage_cores.cbegin(),
         core_desc.relative_storage_cores.cend(),
@@ -113,19 +114,19 @@ inline const std::vector<CoreCoord>& get_logical_storage_cores(
     return logical_storage_cores;
 }
 
-inline CoreCoord get_compute_grid_size(chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type) {
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_type);
+inline CoreCoord get_compute_grid_size(chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.compute_grid_size;
 }
 
 inline const std::vector<CoreCoord>& get_logical_compute_cores(
-    chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
     static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
         logical_compute_cores_by_device;
     static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_type) {
+    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
         logical_compute_cores_by_device.clear();
-        previous_dispatch_core_type = dispatch_core_type;
+        previous_dispatch_core_type = dispatch_core_config.get_core_type();
     }
     auto& logical_compute_cores_by_cq = logical_compute_cores_by_device[device_id];
     if (auto it = logical_compute_cores_by_cq.find(num_hw_cqs); it != logical_compute_cores_by_cq.end()) {
@@ -133,7 +134,7 @@ inline const std::vector<CoreCoord>& get_logical_compute_cores(
     }
     CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
     std::vector<CoreCoord>& logical_compute_cores = logical_compute_cores_by_cq[num_hw_cqs];
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_type);
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     std::transform(
         core_desc.relative_compute_cores.cbegin(),
         core_desc.relative_compute_cores.cend(),
@@ -143,13 +144,13 @@ inline const std::vector<CoreCoord>& get_logical_compute_cores(
 }
 
 inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
-    chip_id_t device_id, const uint8_t num_hw_cqs, CoreType dispatch_core_type) {
+    chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig &dispatch_core_config) {
     static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
         logical_dispatch_cores_by_device;
     static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_type) {
+    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
         logical_dispatch_cores_by_device.clear();
-        previous_dispatch_core_type = dispatch_core_type;
+        previous_dispatch_core_type = dispatch_core_config.get_core_type();
     }
     auto& logical_dispatch_cores_by_cq = logical_dispatch_cores_by_device[device_id];
     if (auto it = logical_dispatch_cores_by_cq.find(num_hw_cqs); it != logical_dispatch_cores_by_cq.end()) {
@@ -157,7 +158,7 @@ inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
     }
     CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
     std::vector<CoreCoord>& logical_dispatch_cores = logical_dispatch_cores_by_cq[num_hw_cqs];
-    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_type);
+    const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     std::transform(
         core_desc.relative_dispatch_cores.cbegin(),
         core_desc.relative_dispatch_cores.cend(),

--- a/tt_metal/core_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch.yaml
@@ -6,30 +6,31 @@
 #     core descriptor config
 
 blackhole:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [12, 9]
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [12, 9]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [12, 9]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [12, 9]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7], [-1, 8], [-1, 9]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/core_descriptors/blackhole_140_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_eth_dispatch.yaml
@@ -6,30 +6,31 @@
 #     core descriptor config
 
 blackhole:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [13, 9]
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [13, 9]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [13, 9]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [13, 9]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"

--- a/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
@@ -6,29 +6,30 @@
 #     core descriptor config
 
 blackhole:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 1]
-      end: [1, 1]
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 1]
+        end: [1, 1]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 1]
-      end: [1, 1]
+      dispatch_core_type:
+        "tensix"
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 1]
+        end: [1, 1]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/core_descriptors/blackhole_versim_1x1_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_versim_1x1_arch.yaml
@@ -6,13 +6,14 @@
 #     core descriptor config
 
 blackhole:
-  1:
-    compute_with_storage_grid_range:
-      start: [0, 0]
-      end: [0, 0]
+  col:
+    1:
+      compute_with_storage_grid_range:
+        start: [0, 0]
+        end: [0, 0]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []

--- a/tt_metal/core_descriptors/grayskull_120_arch.yaml
+++ b/tt_metal/core_descriptors/grayskull_120_arch.yaml
@@ -6,57 +6,59 @@
 #     core descriptor config
 
 E150:
-  1:
-    storage_core_bank_size:
-      524288
+  row:
+    1:
+      storage_core_bank_size:
+        524288
 
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [11, 8]
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [11, 8]
 
-    storage_cores: # Relative to grid of tensix cores
-      [[1, -1],[2, -1],[3, -1],[4, -1],[5, -1],[7, -1],[8, -1],[9, -1],[10, -1],[11, -1]]
+      storage_cores: # Relative to grid of tensix cores
+        [[1, -1],[2, -1],[3, -1],[4, -1],[5, -1],[7, -1],[8, -1],[9, -1],[10, -1],[11, -1]]
 
-    dispatch_cores:
-      [[0, -1], [6, -1]]
-  2:
-    storage_core_bank_size:
-      524288
+      dispatch_cores:
+        [[0, -1], [6, -1]]
+    2:
+      storage_core_bank_size:
+        524288
 
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [11, 8]
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [11, 8]
 
-    storage_cores: # Relative to grid of tensix cores
-      [[2, -1],[3, -1],[4, -1],[5, -1],[8, -1],[9, -1],[10, -1],[11, -1]]
+      storage_cores: # Relative to grid of tensix cores
+        [[2, -1],[3, -1],[4, -1],[5, -1],[8, -1],[9, -1],[10, -1],[11, -1]]
 
-    dispatch_cores:
-      [[0, -1], [6, -1], [1, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [6, -1], [1, -1], [7, -1]]
 
 E75:
-  1:
-    storage_core_bank_size:
-      1048576
+  row:
+    1:
+      storage_core_bank_size:
+        1048576
 
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [10, 7]
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [10, 7]
 
-    storage_cores: # Relative to grid of tensix cores
-      [[11, 1], [11, 2], [11, 3], [11, 5], [11, 6], [11, 7]]
+      storage_cores: # Relative to grid of tensix cores
+        [[11, 1], [11, 2], [11, 3], [11, 5], [11, 6], [11, 7]]
 
-    dispatch_cores:
-      [[11, 0], [11, 4]]
-  2:
-    storage_core_bank_size:
-      1048576
+      dispatch_cores:
+        [[11, 0], [11, 4]]
+    2:
+      storage_core_bank_size:
+        1048576
 
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [10, 7]
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [10, 7]
 
-    storage_cores: # Relative to grid of tensix cores
-      [[11, 2], [11, 3], [11, 6], [11, 7]]
+      storage_cores: # Relative to grid of tensix cores
+        [[11, 2], [11, 3], [11, 6], [11, 7]]
 
-    dispatch_cores:
-      [[11, 0], [11, 4], [11, 1], [11, 5]]
+      dispatch_cores:
+        [[11, 0], [11, 4], [11, 1], [11, 5]]

--- a/tt_metal/core_descriptors/grayskull_versim_1x1_arch.yaml
+++ b/tt_metal/core_descriptors/grayskull_versim_1x1_arch.yaml
@@ -6,13 +6,14 @@
 #     core descriptor config
 
 E150:
-  1:
-    compute_with_storage_grid_range:
-      start: [0, 0]
-      end: [0, 0]
+  row:
+    1:
+      compute_with_storage_grid_range:
+        start: [0, 0]
+        end: [0, 0]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -6,112 +6,223 @@
 #     core descriptor config
 
 galaxy:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [6, 9]
+
+      storage_cores:
+        []
+
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [6, 9]
+
+      storage_cores:
+        []
+
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"
 
 nebula_x1:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 1]
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
-    tg_dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
-       [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
-       [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
-       [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
-       [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
-       [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 1]
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
-    tg_dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
-       [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
-       [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
-       [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
-       [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
-       [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [6, 9]
+
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
+
+      storage_cores:
+        []
+
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [6, 9]
+
+      tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 1]
+
+      storage_cores:
+        []
+
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      tg_dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+        [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+        [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3],
+        [0, -4], [1, -4], [2, -4], [3, -4], [4, -4], [5, -4], [6, -4], [7, -4],
+        [0, -5], [1, -5], [2, -5], [3, -5], [4, -5], [5, -5], [6, -5], [7, -5],
+        [0, -6], [1, -6], [2, -6], [3, -6], [4, -6], [5, -6], [6, -6], [7, -6]]
+
+      dispatch_core_type:
+        "tensix"
 
 nebula_x2:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 6]
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 6]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 6]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 6]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      dispatch_cores:
+        [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
+  col:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [6, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [6, 8]
+
+      storage_cores: # Relative to grid of tensix cores
+        []
+
+      dispatch_cores:
+        [[-1, 0], [-1, 1], [-1, 2], [-1, 3], [-1, 4], [-1, 5], [-1, 6], [-1, 7]]
+
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
@@ -6,88 +6,91 @@
 #     core descriptor config
 
 galaxy:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"
 
 nebula_x1:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"
 
 nebula_x2:
-  1:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"
 
-  2:
-    compute_with_storage_grid_range: # Logical only start and end [x, y]
-      start: [0, 0]
-      end: [7, 7]
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 7]
 
-    storage_cores: # Relative to grid of tensix cores
-      []
+      storage_cores: # Relative to grid of tensix cores
+        []
 
-    dispatch_cores:
-      [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
+      dispatch_cores:
+        [[0, 4], [0, 5], [0, 10], [0, 11], [0, 12], [0, 13]]
 
-    dispatch_core_type:
-      "ethernet"
+      dispatch_core_type:
+        "ethernet"

--- a/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
@@ -6,85 +6,88 @@
 #     core descriptor config
 
 galaxy:
-  1:
-    compute_with_storage_grid_range:
-      start: [1, 1]
-      end: [1, 1]
+  row:
+    1:
+      compute_with_storage_grid_range:
+        start: [1, 1]
+        end: [1, 1]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
-  2:
-    compute_with_storage_grid_range:
-      start: [1, 1]
-      end: [1, 1]
+      dispatch_core_type:
+        "tensix"
+    2:
+      compute_with_storage_grid_range:
+        start: [1, 1]
+        end: [1, 1]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
 
 nebula_x1:
-  1:
-    compute_with_storage_grid_range:
-      start: [0, 0]
-      end: [0, 0]
+  row:
+    1:
+      compute_with_storage_grid_range:
+        start: [0, 0]
+        end: [0, 0]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
-  2:
-    compute_with_storage_grid_range:
-      start: [1, 1]
-      end: [1, 1]
+      dispatch_core_type:
+        "tensix"
+    2:
+      compute_with_storage_grid_range:
+        start: [1, 1]
+        end: [1, 1]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"
 
 nebula_x2:
-  1:
-    compute_with_storage_grid_range:
-      start: [0, 0]
-      end: [0, 0]
+  row:
+    1:
+      compute_with_storage_grid_range:
+        start: [0, 0]
+        end: [0, 0]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
-  2:
-    compute_with_storage_grid_range:
-      start: [1, 1]
-      end: [1, 1]
+      dispatch_core_type:
+        "tensix"
+    2:
+      compute_with_storage_grid_range:
+        start: [1, 1]
+        end: [1, 1]
 
-    storage_cores:
-      []
+      storage_cores:
+        []
 
-    dispatch_cores:
-      []
+      dispatch_cores:
+        []
 
-    dispatch_core_type:
-      "tensix"
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -32,7 +32,7 @@ std::map<chip_id_t, Device*> CreateDevices(
     const uint8_t num_hw_cqs = 1,
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    const tt_metal::DispatchCoreConfig &dispatch_core_config = tt_metal::DispatchCoreConfig{},
+    const tt_metal::DispatchCoreConfig& dispatch_core_config = tt_metal::DispatchCoreConfig{},
     const std::vector<uint32_t>& l1_bank_remap = {});
 
 void CloseDevices(const std::map<chip_id_t, Device*>& devices);

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -32,7 +32,7 @@ std::map<chip_id_t, Device*> CreateDevices(
     const uint8_t num_hw_cqs = 1,
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    tt_metal::DispatchCoreType dispatch_core_type = tt_metal::DispatchCoreType::WORKER,
+    const tt_metal::DispatchCoreConfig &dispatch_core_config = tt_metal::DispatchCoreConfig{},
     const std::vector<uint32_t>& l1_bank_remap = {});
 
 void CloseDevices(const std::map<chip_id_t, Device*>& devices);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -163,7 +163,7 @@ std::vector<Device*> SystemMesh::map_mesh_device(
     size_t num_command_queues,
     size_t l1_small_size,
     size_t trace_region_size,
-    DispatchCoreType dispatch_core_type,
+    const DispatchCoreConfig &dispatch_core_config,
     const MeshDeviceConfig& config) {
 
     auto [requested_num_rows, requested_num_cols] = mesh_device->shape();
@@ -180,7 +180,7 @@ std::vector<Device*> SystemMesh::map_mesh_device(
         config.physical_device_ids;
 
     this->opened_devices[mesh_device->get_mesh_id()] = tt::tt_metal::detail::CreateDevices(
-        physical_device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type);
+        physical_device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
 
     std::vector<Device*> mapped_devices;
     for (auto physical_device_id : physical_device_ids) {
@@ -229,10 +229,10 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    DispatchCoreType dispatch_core_type)
+    const DispatchCoreConfig &dispatch_core_config)
 {
     auto mesh_device = std::make_shared<MeshDevice>(config.mesh_shape, config.mesh_type);
-    mesh_device->initialize(l1_small_size, trace_region_size, num_command_queues, dispatch_core_type, config);
+    mesh_device->initialize(l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, config);
 
     return mesh_device;
 }
@@ -289,7 +289,7 @@ void MeshDevice::initialize(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    DispatchCoreType dispatch_core_type,
+    const DispatchCoreConfig &dispatch_core_config,
     const MeshDeviceConfig& config)
 {
     auto [num_rows, num_cols] = this->shape();
@@ -302,7 +302,7 @@ void MeshDevice::initialize(
 
     auto& instance = SystemMesh::instance();
     this->devices = instance.map_mesh_device(
-        shared_from_this(), num_command_queues, l1_small_size, trace_region_size, dispatch_core_type, config);
+        shared_from_this(), num_command_queues, l1_small_size, trace_region_size, dispatch_core_config, config);
     this->primary_view = std::make_shared<MeshDeviceView>(*this);
 }
 

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -94,7 +94,7 @@ public:
         size_t num_command_queues,
         size_t l1_small_size,
         size_t trace_region_size,
-        const DispatchCoreConfig &dispatch_core_config,
+        const DispatchCoreConfig& dispatch_core_config,
         const MeshDeviceConfig& config);
 
     // Unmap MeshDevice, releasing the associated physical devices.
@@ -117,7 +117,7 @@ private:
         size_t l1_small_size,
         size_t trace_region_size,
         size_t num_command_queues,
-        const DispatchCoreConfig &dispatch_core_config,
+        const DispatchCoreConfig& dispatch_core_config,
         const MeshDeviceConfig& config);
 
 public:
@@ -177,7 +177,7 @@ public:
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
-        const DispatchCoreConfig &dispatch_core_config = DispatchCoreConfig{});
+        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{});
 };
 
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -94,7 +94,7 @@ public:
         size_t num_command_queues,
         size_t l1_small_size,
         size_t trace_region_size,
-        DispatchCoreType dispatch_core_type,
+        const DispatchCoreConfig &dispatch_core_config,
         const MeshDeviceConfig& config);
 
     // Unmap MeshDevice, releasing the associated physical devices.
@@ -117,7 +117,7 @@ private:
         size_t l1_small_size,
         size_t trace_region_size,
         size_t num_command_queues,
-        DispatchCoreType dispatch_core_type,
+        const DispatchCoreConfig &dispatch_core_config,
         const MeshDeviceConfig& config);
 
 public:
@@ -177,7 +177,7 @@ public:
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
-        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER);
+        const DispatchCoreConfig &dispatch_core_config = DispatchCoreConfig{});
 };
 
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -83,7 +83,7 @@ Device* CreateDevice(
     const uint8_t num_hw_cqs = 1,
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    const DispatchCoreConfig &dispatch_core_config = DispatchCoreConfig{},
+    const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
     const std::vector<uint32_t>& l1_bank_remap = {});
 
 /**
@@ -96,7 +96,9 @@ Device* CreateDevice(
  * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
 Device* CreateDeviceMinimal(
-    chip_id_t device_id, const uint8_t num_hw_cqs = 1, const DispatchCoreConfig &dispatch_core_config = DispatchCoreConfig{});
+    chip_id_t device_id,
+    const uint8_t num_hw_cqs = 1,
+    const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{});
 
 /**
  * Resets device and closes device

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -83,7 +83,7 @@ Device* CreateDevice(
     const uint8_t num_hw_cqs = 1,
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER,
+    const DispatchCoreConfig &dispatch_core_config = DispatchCoreConfig{},
     const std::vector<uint32_t>& l1_bank_remap = {});
 
 /**
@@ -96,7 +96,7 @@ Device* CreateDevice(
  * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
 Device* CreateDeviceMinimal(
-    chip_id_t device_id, const uint8_t num_hw_cqs = 1, DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER);
+    chip_id_t device_id, const uint8_t num_hw_cqs = 1, const DispatchCoreConfig &dispatch_core_config = DispatchCoreConfig{});
 
 /**
  * Resets device and closes device

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -46,7 +46,8 @@ static CoreDescriptorSet GetAllCores(tt::tt_metal::Device* device) {
 static CoreDescriptorSet GetDispatchCores(tt::tt_metal::Device* device) {
     CoreDescriptorSet dispatch_cores;
     unsigned num_cqs = device->num_hw_cqs();
-    const auto &dispatch_core_config = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+    const auto& dispatch_core_config =
+        tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_config(device->id());
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
     tt::log_warning("Dispatch Core Type = {}", dispatch_core_type);
     for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_config)) {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -46,9 +46,10 @@ static CoreDescriptorSet GetAllCores(tt::tt_metal::Device* device) {
 static CoreDescriptorSet GetDispatchCores(tt::tt_metal::Device* device) {
     CoreDescriptorSet dispatch_cores;
     unsigned num_cqs = device->num_hw_cqs();
-    CoreType dispatch_core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    const auto &dispatch_core_config = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
     tt::log_warning("Dispatch Core Type = {}", dispatch_core_type);
-    for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_type)) {
+    for (auto logical_core : tt::get_logical_dispatch_cores(device->id(), num_cqs, dispatch_core_config)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});
     }
     return dispatch_cores;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3678,7 +3678,7 @@ v1::DeviceHandle v1::CreateDevice(chip_id_t device_id, CreateDeviceOptions optio
         options.num_hw_cqs,
         options.l1_small_size,
         options.trace_region_size,
-        options.dispatch_core_type,
+        options.dispatch_core_config,
         options.l1_bank_remap);
 
     return tt::DevicePool::instance().get_active_device(device_id);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -224,7 +224,8 @@ void Device::initialize_default_sub_device_state(size_t l1_small_size, size_t tr
 std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     ZoneScoped;
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->id_);
+    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(this->id_);
+    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
     // Construct allocator config from soc_desc
     // Take max alignment to satisfy NoC rd/wr constraints
     // Tensix/Eth -> PCIe/DRAM src and dst addrs must be L1_ALIGNMENT aligned
@@ -241,7 +242,7 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
          .l1_unreserved_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED),
          .worker_grid = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(logical_size.x - 1, logical_size.y - 1))),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
-         .storage_core_bank_size = get_storage_core_bank_size(id_, num_hw_cqs_, dispatch_core_type),
+         .storage_core_bank_size = get_storage_core_bank_size(id_, num_hw_cqs_, dispatch_core_config),
          .l1_small_size = align(l1_small_size, hal.get_alignment(HalMemType::L1)),
          .trace_region_size = align(trace_region_size, hal.get_alignment(HalMemType::DRAM)),
          .core_type_from_noc_coord_table = {},  // Populated later
@@ -266,17 +267,17 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
         config.core_type_from_noc_coord_table.insert({core.first, AllocCoreType::Invalid});
     }
 
-    for (const CoreCoord& core : tt::get_logical_compute_cores(id_, num_hw_cqs_, dispatch_core_type)) {
+    for (const CoreCoord& core : tt::get_logical_compute_cores(id_, num_hw_cqs_, dispatch_core_config)) {
         this->compute_cores_.insert(core);
         const auto noc_coord = this->worker_core_from_logical_core(core);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::ComputeAndStore;
     }
-    for (const CoreCoord& core : tt::get_logical_storage_cores(id_, num_hw_cqs_, dispatch_core_type)) {
+    for (const CoreCoord& core : tt::get_logical_storage_cores(id_, num_hw_cqs_, dispatch_core_config)) {
         this->storage_only_cores_.insert(core);
         const auto noc_coord = this->worker_core_from_logical_core(core);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::StorageOnly;
     }
-    for (const CoreCoord &core : tt::get_logical_dispatch_cores(id_, num_hw_cqs_, dispatch_core_type)) {
+    for (const CoreCoord &core : tt::get_logical_dispatch_cores(id_, num_hw_cqs_, dispatch_core_config)) {
         const auto noc_coord = this->physical_core_from_logical_core(core, dispatch_core_type);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::Dispatch;
     }
@@ -1818,6 +1819,7 @@ void Device::setup_tunnel_for_remote_devices() {
             uint8_t num_hw_cqs = this->num_hw_cqs_;
             uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
             CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(mmio_device_id);
+            const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_type(mmio_device_id);
             uint32_t cq_start = dispatch_constants::get(dispatch_core_type).get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
 
             dispatch_worker_build_settings_t settings = {};
@@ -2188,7 +2190,8 @@ void Device::compile_command_queue_programs() {
         uint32_t cq_size = this->sysmem_manager().get_cq_size();
 
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device_id);
+            const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
+            CoreType dispatch_core_type = dispatch_core_config.get_core_type();
             tt_cxy_pair prefetch_core = dispatch_core_manager::instance().prefetcher_core(device_id, channel, cq_id);
             tt_cxy_pair dispatch_core = dispatch_core_manager::instance().dispatcher_core(device_id, channel, cq_id);
             CoreCoord prefetch_physical_core = get_physical_core_coordinate(prefetch_core, dispatch_core_type);
@@ -3058,8 +3061,8 @@ CoreCoord Device::logical_grid_size() const {
 }
 
 CoreCoord Device::compute_with_storage_grid_size() const {
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(id_);
-    return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_type);
+    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(id_);
+    return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_config);
 }
 
 CoreCoord Device::dram_grid_size() const {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -184,7 +184,7 @@ void DevicePool::initialize(
     const uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
-    const DispatchCoreConfig &dispatch_core_config,
+    const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> l1_bank_remap) noexcept {
     ZoneScoped;
     log_debug(tt::LogMetal, "DevicePool initialize");

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -184,11 +184,11 @@ void DevicePool::initialize(
     const uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
-    DispatchCoreType dispatch_core_type,
+    const DispatchCoreConfig &dispatch_core_config,
     tt::stl::Span<const std::uint32_t> l1_bank_remap) noexcept {
     ZoneScoped;
     log_debug(tt::LogMetal, "DevicePool initialize");
-    tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_type, num_hw_cqs);
+    tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_config, num_hw_cqs);
 
     if (_inst == nullptr) {
         static DevicePool device_pool{};

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -38,7 +38,7 @@ public:
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
         size_t trace_region_size,
-        const tt_metal::DispatchCoreConfig &dispatch_core_config,
+        const tt_metal::DispatchCoreConfig& dispatch_core_config,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {}) noexcept;
 
     tt_metal::v1::DeviceHandle get_active_device(chip_id_t device_id) const;

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -38,7 +38,7 @@ public:
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
         size_t trace_region_size,
-        tt_metal::DispatchCoreType dispatch_core_type,
+        const tt_metal::DispatchCoreConfig &dispatch_core_config,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {}) noexcept;
 
     tt_metal::v1::DeviceHandle get_active_device(chip_id_t device_id) const;

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -43,14 +43,20 @@ private:
     DispatchCoreType type_;
     DispatchCoreAxis axis_;
 
+    static DispatchCoreAxis get_default_axis() {
+        return (tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE)
+            ? DispatchCoreAxis::COL
+            : DispatchCoreAxis::ROW;
+    }
+
 public:
     DispatchCoreConfig()
     : type_(DispatchCoreType::WORKER),
-      axis_(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
+      axis_(get_default_axis()) {}
 
     DispatchCoreConfig(DispatchCoreType type)
         : type_(type),
-          axis_(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
+          axis_(get_default_axis()) {}
 
     DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
 

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -38,48 +38,51 @@ enum class DispatchCoreAxis {
     COL,
 };
 
-struct DispatchCoreConfig {
+class DispatchCoreConfig {
 private:
-    DispatchCoreType type;
-    DispatchCoreAxis axis;
+    DispatchCoreType type_;
+    DispatchCoreAxis axis_;
 
 public:
     DispatchCoreConfig()
-    : type(DispatchCoreType::WORKER),
-      axis(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
+    : type_(DispatchCoreType::WORKER),
+      axis_(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
 
     DispatchCoreConfig(DispatchCoreType type)
-        : type(type),
-          axis(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
+        : type_(type),
+          axis_(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
 
-    DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type(type), axis(axis) {}
+    DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
 
     CoreType get_core_type() const {
-        const std::unordered_map<DispatchCoreType, CoreType> dispatch_core_type_map = {
-            {DispatchCoreType::WORKER, CoreType::WORKER},
-            {DispatchCoreType::ETH, CoreType::ETH}
-        };
-        return dispatch_core_type_map.at(type);
+        switch (type_) {
+            case DispatchCoreType::WORKER:
+                return CoreType::WORKER;
+            case DispatchCoreType::ETH:
+                return CoreType::ETH;
+            default:
+                TT_THROW("invalid dispatch core type");
+        }
     }
 
     DispatchCoreType get_dispatch_core_type() const {
-        return type;
+        return type_;
     }
 
     void set_dispatch_core_type(DispatchCoreType new_type) {
-        type = new_type;
+        type_ = new_type;
     }
 
     DispatchCoreAxis get_dispatch_core_axis() const {
-        return axis;
+        return axis_;
     }
 
     void set_dispatch_core_axis(DispatchCoreAxis new_axis) {
-        axis = new_axis;
+        axis_ = new_axis;
     }
 
     bool operator==(const DispatchCoreConfig& other) const {
-        return (type == other.type) && (axis == other.axis);
+        return (type_ == other.type_) && (axis_ == other.axis_);
     }
 };
 

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "common/core_descriptor.hpp"
+#include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/llrt/get_platform_architecture.hpp"
+#include <list>
+
+namespace tt::tt_metal {
+
+enum DispatchWorkerType : uint32_t {
+    PREFETCH = 0,
+    PREFETCH_D = 1,
+    DISPATCH = 2,
+    DISPATCH_D = 3,
+    DISPATCH_S = 4,
+    MUX = 5,
+    MUX_D = 6,
+    DEMUX = 7,
+    DEMUX_D = 8,
+    US_TUNNELER_LOCAL = 9,
+    US_TUNNELER_REMOTE = 10,
+    DS_TUNNELER_LOCAL = 11,
+    DS_TUNNELER_REMOTE = 12,
+    COUNT = 13
+};
+
+enum DispatchCoreType: uint32_t {
+    WORKER = 0,
+    ETH = 1,
+};
+
+enum class DispatchCoreAxis {
+    ROW,
+    COL,
+};
+
+struct DispatchCoreConfig {
+private:
+    DispatchCoreType type;
+    DispatchCoreAxis axis;
+
+public:
+    DispatchCoreConfig()
+    : type(DispatchCoreType::WORKER),
+      axis(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
+
+    DispatchCoreConfig(DispatchCoreType type)
+        : type(type),
+          axis(tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE ? DispatchCoreAxis::COL : DispatchCoreAxis::ROW) {}
+
+    DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type(type), axis(axis) {}
+
+    CoreType get_core_type() const {
+        const std::unordered_map<DispatchCoreType, CoreType> dispatch_core_type_map = {
+            {DispatchCoreType::WORKER, CoreType::WORKER},
+            {DispatchCoreType::ETH, CoreType::ETH}
+        };
+        return dispatch_core_type_map.at(type);
+    }
+
+    DispatchCoreType get_dispatch_core_type() const {
+        return type;
+    }
+
+    void set_dispatch_core_type(DispatchCoreType new_type) {
+        type = new_type;
+    }
+
+    DispatchCoreAxis get_dispatch_core_axis() const {
+        return axis;
+    }
+
+    void set_dispatch_core_axis(DispatchCoreAxis new_axis) {
+        axis = new_axis;
+    }
+
+    bool operator==(const DispatchCoreConfig& other) const {
+        return (type == other.type) && (axis == other.axis);
+    }
+};
+
+}   // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -28,7 +28,7 @@ enum DispatchWorkerType : uint32_t {
     COUNT = 13
 };
 
-enum DispatchCoreType: uint32_t {
+enum DispatchCoreType : uint32_t {
     WORKER = 0,
     ETH = 1,
 };
@@ -44,52 +44,34 @@ private:
     DispatchCoreAxis axis_;
 
     static DispatchCoreAxis get_default_axis() {
-        return (tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE)
-            ? DispatchCoreAxis::COL
-            : DispatchCoreAxis::ROW;
+        return (tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE) ? DispatchCoreAxis::COL
+                                                                                  : DispatchCoreAxis::ROW;
     }
 
 public:
-    DispatchCoreConfig()
-    : type_(DispatchCoreType::WORKER),
-      axis_(get_default_axis()) {}
+    DispatchCoreConfig() : type_(DispatchCoreType::WORKER), axis_(get_default_axis()) {}
 
-    DispatchCoreConfig(DispatchCoreType type)
-        : type_(type),
-          axis_(get_default_axis()) {}
+    DispatchCoreConfig(DispatchCoreType type) : type_(type), axis_(get_default_axis()) {}
 
     DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
 
     CoreType get_core_type() const {
         switch (type_) {
-            case DispatchCoreType::WORKER:
-                return CoreType::WORKER;
-            case DispatchCoreType::ETH:
-                return CoreType::ETH;
-            default:
-                TT_THROW("invalid dispatch core type");
+            case DispatchCoreType::WORKER: return CoreType::WORKER;
+            case DispatchCoreType::ETH: return CoreType::ETH;
+            default: TT_THROW("invalid dispatch core type");
         }
     }
 
-    DispatchCoreType get_dispatch_core_type() const {
-        return type_;
-    }
+    DispatchCoreType get_dispatch_core_type() const { return type_; }
 
-    void set_dispatch_core_type(DispatchCoreType new_type) {
-        type_ = new_type;
-    }
+    void set_dispatch_core_type(DispatchCoreType new_type) { type_ = new_type; }
 
-    DispatchCoreAxis get_dispatch_core_axis() const {
-        return axis_;
-    }
+    DispatchCoreAxis get_dispatch_core_axis() const { return axis_; }
 
-    void set_dispatch_core_axis(DispatchCoreAxis new_axis) {
-        axis_ = new_axis;
-    }
+    void set_dispatch_core_axis(DispatchCoreAxis new_axis) { axis_ = new_axis; }
 
-    bool operator==(const DispatchCoreConfig& other) const {
-        return (type_ == other.type_) && (axis_ == other.axis_);
-    }
+    bool operator==(const DispatchCoreConfig& other) const { return (type_ == other.type_) && (axis_ == other.axis_); }
 };
 
-}   // namespace tt::tt_metal
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1426,8 +1426,9 @@ void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
         //      - eth kernels cannot be on idle eth cores
         bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
 
-        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
-        const std::vector<CoreCoord> &storage_cores = tt::get_logical_storage_cores(device->id(), device->num_hw_cqs(), dispatch_core_type);
+        const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+        CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+        const std::vector<CoreCoord> &storage_cores = tt::get_logical_storage_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
         bool on_storage_only_core =  std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
             return kernel->is_on_logical_core(storage_core);
         });
@@ -1435,7 +1436,7 @@ void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
 
         // Kernels used to implement fast dispatch can be placed on dispatch cores
         if (not slow_dispatch and not fd_bootloader_mode) {
-            const std::vector<CoreCoord> &dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_type);
+            const std::vector<CoreCoord> &dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
 
             bool on_dispatch_core = std::any_of(dispatch_cores.begin(), dispatch_cores.end(), [&kernel, &dispatch_core_type](const CoreCoord &dispatch_core) {
                 if (kernel->get_kernel_core_type() != dispatch_core_type) {

--- a/tt_metal/include/tt_metal/device.hpp
+++ b/tt_metal/include/tt_metal/device.hpp
@@ -56,9 +56,9 @@ struct CreateDeviceOptions {
      */
     std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE;
     /**
-     * Dispatch core type to use (default: DispatchCoreType::WORKER).
+     * Dispatch core config to use (default: DispatchCoreType::WORKER, DispatchCoreAxis::ROW).
      */
-    DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
+    DispatchCoreConfig dispatch_core_config = DispatchCoreConfig{};
     /**
      * For shuffling bank id offsets
      */

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -119,7 +119,7 @@ RunTimeOptions::RunTimeOptions() {
     }
 
     if (getenv("TT_METAL_GTEST_ETH_DISPATCH")) {
-        this->dispatch_core_type = tt_metal::DispatchCoreType::ETH;
+        this->dispatch_core_config.set_dispatch_core_type(tt_metal::DispatchCoreType::ETH);
     }
 
     if (getenv("TT_METAL_SKIP_LOADING_FW")) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -124,7 +124,7 @@ class RunTimeOptions {
 
     bool enable_dispatch_data_collection = false;
 
-    tt_metal::DispatchCoreType dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
+    tt_metal::DispatchCoreConfig dispatch_core_config = tt_metal::DispatchCoreConfig{};
 
    public:
     RunTimeOptions();
@@ -280,7 +280,7 @@ class RunTimeOptions {
     inline bool get_dispatch_data_collection_enabled() { return enable_dispatch_data_collection; }
     inline void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
 
-    inline tt_metal::DispatchCoreType get_dispatch_core_type() { return dispatch_core_type; }
+    inline tt_metal::DispatchCoreConfig get_dispatch_core_config() { return dispatch_core_config; }
 
    private:
     // Helper functions to parse feature-specific environment vaiables.

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -328,7 +328,7 @@ void DumpDeviceProfileResults(Device* device, bool lastDump) {
     std::vector<CoreCoord> workerCores;
     auto device_id = device->id();
     auto device_num_hw_cqs = device->num_hw_cqs();
-    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
+    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
     for (const CoreCoord& core : tt::get_logical_compute_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
         const CoreCoord curr_core = device->worker_core_from_logical_core(core);
         workerCores.push_back(curr_core);
@@ -348,12 +348,13 @@ void DumpDeviceProfileResults(Device* device, std::vector<CoreCoord>& worker_cor
     ZoneScoped;
 
     std::scoped_lock<std::mutex> lock(device_mutex);
-    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
     auto dispatch_core_type = dispatch_core_config.get_core_type();
     if (tt::llrt::OptionsG.get_profiler_do_dispatch_cores()) {
         auto device_id = device->id();
         auto device_num_hw_cqs = device->num_hw_cqs();
-        for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
+        for (const CoreCoord& core :
+             tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
             const auto curr_core = device->physical_core_from_logical_core(core, dispatch_core_type);
             worker_cores.push_back(curr_core);
         }

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -328,8 +328,8 @@ void DumpDeviceProfileResults(Device* device, bool lastDump) {
     std::vector<CoreCoord> workerCores;
     auto device_id = device->id();
     auto device_num_hw_cqs = device->num_hw_cqs();
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device_id);
-    for (const CoreCoord& core : tt::get_logical_compute_cores(device_id, device_num_hw_cqs, dispatch_core_type)) {
+    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device_id);
+    for (const CoreCoord& core : tt::get_logical_compute_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
         const CoreCoord curr_core = device->worker_core_from_logical_core(core);
         workerCores.push_back(curr_core);
     }
@@ -348,11 +348,12 @@ void DumpDeviceProfileResults(Device* device, std::vector<CoreCoord>& worker_cor
     ZoneScoped;
 
     std::scoped_lock<std::mutex> lock(device_mutex);
-    auto dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device->id());
+    auto dispatch_core_type = dispatch_core_config.get_core_type();
     if (tt::llrt::OptionsG.get_profiler_do_dispatch_cores()) {
         auto device_id = device->id();
         auto device_num_hw_cqs = device->num_hw_cqs();
-        for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_type)) {
+        for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
             const auto curr_core = device->physical_core_from_logical_core(core, dispatch_core_type);
             worker_cores.push_back(curr_core);
         }
@@ -390,7 +391,7 @@ void DumpDeviceProfileResults(Device* device, std::vector<CoreCoord>& worker_cor
                         break;
                     }
                     for (const CoreCoord& core :
-                         tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_type)) {
+                         tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
                         const auto curr_core = device->physical_core_from_logical_core(core, dispatch_core_type);
                         profiler_msg_t* profiler_msg =
                             device->get_dev_addr<profiler_msg_t*>(curr_core, HalL1MemAddrType::PROFILER);

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -52,7 +52,7 @@ void dump_data(
         std::ofstream iq_file = std::ofstream(iq_fname);
         // Minimal setup, since we'll be attaching to a potentially hanging chip.
         Device* device = tt::tt_metal::CreateDeviceMinimal(
-            id, num_hw_cqs, eth_dispatch ? DispatchCoreType::ETH : DispatchCoreType::WORKER);
+            id, num_hw_cqs, DispatchCoreConfig{eth_dispatch ? DispatchCoreType::ETH : DispatchCoreType::WORKER});
         devices.push_back(device);
         if (dump_cqs) {
             std::unique_ptr<SystemMemoryManager> sysmem_manager = std::make_unique<SystemMemoryManager>(id, num_hw_cqs);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -338,11 +338,11 @@ std::map<chip_id_t, Device *> CreateDevices(
     const uint8_t num_hw_cqs,
     const size_t l1_small_size,
     const size_t trace_region_size,
-    DispatchCoreType dispatch_core_type,
+    const DispatchCoreConfig &dispatch_core_config,
     const std::vector<uint32_t> &l1_bank_remap) {
     ZoneScoped;
     bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     std::map<chip_id_t, Device *> ret_devices;
     //Only include the mmio device in the active devices set returned to the caller if we are not running
@@ -912,18 +912,18 @@ Device *CreateDevice(
     const uint8_t num_hw_cqs,
     const size_t l1_small_size,
     const size_t trace_region_size,
-    DispatchCoreType dispatch_core_type,
+    const DispatchCoreConfig &dispatch_core_config,
     const std::vector<uint32_t> &l1_bank_remap) {
     ZoneScoped;
 
-    tt::DevicePool::initialize({device_id}, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type, l1_bank_remap);
+    tt::DevicePool::initialize({device_id}, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config, l1_bank_remap);
     auto dev = tt::DevicePool::instance().get_active_device(device_id);
     return dev;
 }
 
-Device *CreateDeviceMinimal(chip_id_t device_id, const uint8_t num_hw_cqs, DispatchCoreType dispatch_core_type) {
+Device *CreateDeviceMinimal(chip_id_t device_id, const uint8_t num_hw_cqs, const DispatchCoreConfig &dispatch_core_config) {
     ZoneScoped;
-    tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_type, num_hw_cqs);
+    tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_config, num_hw_cqs);
     Device *dev = new Device(device_id, num_hw_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     return dev;

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -81,15 +81,19 @@ void py_device_module_types(py::module& m_device) {
         .value("WORKER", tt::tt_metal::DispatchCoreType::WORKER)
         .value("ETH", tt::tt_metal::DispatchCoreType::ETH);
 
-    py::enum_<tt::tt_metal::DispatchCoreAxis>(m_device, "DispatchCoreAxis", "Enum of axis (row or col) of dispatch cores.")
+    py::enum_<tt::tt_metal::DispatchCoreAxis>(
+        m_device, "DispatchCoreAxis", "Enum of axis (row or col) of dispatch cores.")
         .value("ROW", tt::tt_metal::DispatchCoreAxis::ROW)
         .value("COL", tt::tt_metal::DispatchCoreAxis::COL);
 
-    py::class_<tt::tt_metal::DispatchCoreConfig>(m_device, "DispatchCoreConfig", "Class representing dispatch core configuration.")
+    py::class_<tt::tt_metal::DispatchCoreConfig>(
+        m_device, "DispatchCoreConfig", "Class representing dispatch core configuration.")
         .def(py::init<>(), "Default constructor initializing type to WORKER and axis to ROW.")
-        .def(py::init<tt::tt_metal::DispatchCoreType, tt::tt_metal::DispatchCoreAxis>(),
-             "Constructor with specified dispatch core type and axis.",
-             py::arg("type"), py::arg("axis"));
+        .def(
+            py::init<tt::tt_metal::DispatchCoreType, tt::tt_metal::DispatchCoreAxis>(),
+            "Constructor with specified dispatch core type and axis.",
+            py::arg("type"),
+            py::arg("axis"));
 
     py::class_<Device, std::unique_ptr<Device, py::nodelete>>(
         m_device, "Device", "Class describing a Tenstorrent accelerator device.");
@@ -161,7 +165,7 @@ void device_module(py::module& m_device) {
            uint8_t num_command_queues,
            size_t l1_small_size,
            size_t trace_region_size,
-           const tt::tt_metal::DispatchCoreConfig &dispatch_core_config) {
+           const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
             return tt::tt_metal::CreateDevice(
                 device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
         },
@@ -185,7 +189,7 @@ void device_module(py::module& m_device) {
            uint8_t num_command_queues,
            size_t l1_small_size,
            size_t trace_region_size,
-           const tt::tt_metal::DispatchCoreConfig &dispatch_core_config) {
+           const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
             return tt::tt_metal::detail::CreateDevices(
                 device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
         },

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -10,8 +10,8 @@ namespace ttnn {
 namespace device {
 
 Device& open_device(
-    int device_id, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
-    tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, dispatch_core_type, {});
+    int device_id, size_t l1_small_size, size_t trace_region_size, const tt::tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, dispatch_core_config, {});
     return *(tt::DevicePool::instance().get_active_device(device_id));
 }
 

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -10,7 +10,10 @@ namespace ttnn {
 namespace device {
 
 Device& open_device(
-    int device_id, size_t l1_small_size, size_t trace_region_size, const tt::tt_metal::DispatchCoreConfig &dispatch_core_config) {
+    int device_id,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, dispatch_core_config, {});
     return *(tt::DevicePool::instance().get_active_device(device_id));
 }

--- a/ttnn/cpp/ttnn/device.hpp
+++ b/ttnn/cpp/ttnn/device.hpp
@@ -15,7 +15,7 @@ Device& open_device(
     int device_id,
     size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    tt::tt_metal::DispatchCoreType dispatch_core_type = tt::tt_metal::DispatchCoreType::WORKER);
+    const tt::tt_metal::DispatchCoreConfig &dispatch_core_config = tt::tt_metal::DispatchCoreConfig{});
 void close_device(Device& device);
 void enable_program_cache(Device& device);
 void disable_and_clear_program_cache(Device& device);

--- a/ttnn/cpp/ttnn/device.hpp
+++ b/ttnn/cpp/ttnn/device.hpp
@@ -15,7 +15,7 @@ Device& open_device(
     int device_id,
     size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    const tt::tt_metal::DispatchCoreConfig &dispatch_core_config = tt::tt_metal::DispatchCoreConfig{});
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = tt::tt_metal::DispatchCoreConfig{});
 void close_device(Device& device);
 void enable_program_cache(Device& device);
 void disable_and_clear_program_cache(Device& device);

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    const DispatchCoreConfig &dispatch_core_config,
+    const DispatchCoreConfig& dispatch_core_config,
     MeshType mesh_type,
     const std::pair<size_t, size_t>& offset,
     const std::vector<int>& physical_device_ids) {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -19,12 +19,12 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    DispatchCoreType dispatch_core_type,
+    const DispatchCoreConfig &dispatch_core_config,
     MeshType mesh_type,
     const std::pair<size_t, size_t>& offset,
     const std::vector<int>& physical_device_ids) {
     auto config = MeshDeviceConfig(mesh_shape, offset, physical_device_ids, mesh_type);
-    return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_type);
+    return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
 }
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_device->close_devices(); }

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -16,7 +16,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    tt::tt_metal::DispatchCoreType dispatch_core_type,
+    const tt::tt_metal::DispatchCoreConfig &dispatch_core_config,
     MeshType mesh_type = MeshType::RowMajor,
     const std::pair<size_t, size_t>& offset = std::pair<size_t, size_t>(0, 0),
     const std::vector<int>& physical_device_ids = {});

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -16,7 +16,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    const tt::tt_metal::DispatchCoreConfig &dispatch_core_config,
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config,
     MeshType mesh_type = MeshType::RowMajor,
     const std::pair<size_t, size_t>& offset = std::pair<size_t, size_t>(0, 0),
     const std::vector<int>& physical_device_ids = {});

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -32,7 +32,7 @@ void py_module(py::module& module) {
                         size_t l1_small_size,
                         size_t trace_region_size,
                         size_t num_command_queues,
-                        const DispatchCoreConfig &dispatch_core_config,
+                        const DispatchCoreConfig& dispatch_core_config,
                         const std::pair<size_t, size_t>& offset,
                         const std::vector<chip_id_t>& physical_device_ids,
                         MeshType mesh_type) {

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -32,7 +32,7 @@ void py_module(py::module& module) {
                         size_t l1_small_size,
                         size_t trace_region_size,
                         size_t num_command_queues,
-                        DispatchCoreType dispatch_core_type,
+                        const DispatchCoreConfig &dispatch_core_config,
                         const std::pair<size_t, size_t>& offset,
                         const std::vector<chip_id_t>& physical_device_ids,
                         MeshType mesh_type) {
@@ -41,14 +41,14 @@ void py_module(py::module& module) {
                     l1_small_size,
                     trace_region_size,
                     num_command_queues,
-                    dispatch_core_type);
+                    dispatch_core_config);
             }),
             py::kw_only(),
             py::arg("mesh_shape"),
             py::arg("l1_small_size"),
             py::arg("trace_region_size"),
             py::arg("num_command_queues"),
-            py::arg("dispatch_core_type"),
+            py::arg("dispatch_core_config"),
             py::arg("offset"),
             py::arg("physical_device_ids"),
             py::arg("mesh_type"))
@@ -147,10 +147,11 @@ void py_module(py::module& module) {
         py::arg("l1_small_size"),
         py::arg("trace_region_size"),
         py::arg("num_command_queues"),
-        py::arg("dispatch_core_type"),
+
         py::arg("offset"),
         py::arg("physical_device_ids"),
-        py::arg("mesh_type"));
+        py::arg("mesh_type"),
+        py::arg("dispatch_core_config"));
 
     module.def("close_mesh_device", &close_mesh_device, py::arg("mesh_device"), py::kw_only());
     module.def(

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -35,8 +35,8 @@ struct DeviceInfo {
 
 DeviceInfo get_device_info(const Device& device) {
     DeviceInfo info{};
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device.id());
-    const auto descriptor = tt::get_core_descriptor_config(device.id(), device.num_hw_cqs(), dispatch_core_type);
+    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device.id());
+    const auto descriptor = tt::get_core_descriptor_config(device.id(), device.num_hw_cqs(), dispatch_core_config);
     info.num_y_cores = device.logical_grid_size().y;
     info.num_x_cores = device.logical_grid_size().x;
     info.num_y_compute_cores = descriptor.compute_grid_size.y;

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -35,7 +35,7 @@ struct DeviceInfo {
 
 DeviceInfo get_device_info(const Device& device) {
     DeviceInfo info{};
-    const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device.id());
+    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(device.id());
     const auto descriptor = tt::get_core_descriptor_config(device.id(), device.num_hw_cqs(), dispatch_core_config);
     info.num_y_cores = device.logical_grid_size().y;
     info.num_x_cores = device.logical_grid_size().x;

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -153,6 +153,8 @@ from ttnn.types import (
 from ttnn.device import (
     Device,
     DispatchCoreType,
+    DispatchCoreAxis,
+    DispatchCoreConfig,
     open_device,
     close_device,
     enable_program_cache,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -17,6 +17,8 @@ def get_device_core_grid(device):
 Device = ttnn._ttnn.device.Device
 Device.core_grid = property(get_device_core_grid)
 DispatchCoreType = ttnn._ttnn.device.DispatchCoreType
+DispatchCoreAxis = ttnn._ttnn.device.DispatchCoreAxis
+DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig
 Arch = ttnn._ttnn.device.Arch
 EPS_GS = ttnn._ttnn.device.EPS_GS
 EPS_WHB0 = ttnn._ttnn.device.EPS_WHB0
@@ -63,10 +65,10 @@ def CreateDevice(
     num_command_queues: int = 1,
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
-    dispatch_core_type: int = DispatchCoreType.WORKER,
+    dispatch_core_config: DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig(),
 ):
     return ttnn._ttnn.device.CreateDevice(
-        device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type
+        device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config
     )
 
 
@@ -75,10 +77,10 @@ def CreateDevices(
     num_command_queues: int = 1,
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
-    dispatch_core_type: int = DispatchCoreType.WORKER,
+    dispatch_core_config: DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig(),
 ):
     return ttnn._ttnn.device.CreateDevices(
-        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type
+        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config
     )
 
 

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -138,7 +138,7 @@ def open_mesh_device(
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
-    dispatch_core_type: int = DispatchCoreType.WORKER,
+    dispatch_core_config: ttnn.DispatchCoreConfig = ttnn.DispatchCoreConfig(),
     offset: Tuple[int, int] = (0, 0),
     physical_device_ids: List[int] = [],
     mesh_type: "MeshType" = MeshType.RowMajor,
@@ -164,7 +164,7 @@ def open_mesh_device(
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
-        dispatch_core_type=dispatch_core_type,
+        dispatch_core_config=dispatch_core_config,
         offset=offset,
         physical_device_ids=physical_device_ids,
         mesh_type=mesh_type,
@@ -187,7 +187,7 @@ def create_mesh_device(
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
-    dispatch_core_type: int = DispatchCoreType.WORKER,
+    dispatch_core_config: ttnn._ttnn.device.DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig(),
 ):
     """
     create_mesh_device(mesh_shape: ttnn.MeshShape, device_ids: List[int]) -> ttnn.MeshDevice
@@ -200,7 +200,7 @@ def create_mesh_device(
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
-        dispatch_core_type=dispatch_core_type,
+        dispatch_core_type=dispatch_core_config,
     )
     try:
         yield mesh_device


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/14569)


### Problem description
previously all fd cores are at bottom rows or on ETH cores. we need to update it to be on the last column.

current soc desc for WHB0 galaxy has a compute grid of 8x8, and use the last row for Fast Dispatch.
Need to have a 10x8 compute grid for the new Llama decode, and move FD to last column.


### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/12016717121/job/33501766212
- [x] Blackhole Post  https://github.com/tenstorrent/tt-metal/actions/runs/12017564217
- [x] Model regression 
- [ ] ubench
- [x] nightly https://github.com/tenstorrent/tt-metal/actions/runs/12017574912
- [x] t3k freq https://github.com/tenstorrent/tt-metal/actions/runs/12018214607
- [x] t3k unit https://github.com/tenstorrent/tt-metal/actions/runs/12019861962
