### PR TITLE
#11795: Temporarily disable async dispatch

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1939,7 +1939,8 @@ HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC noc_index) :
         }
         // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the previous
         // launch message.
-        this->config_buffer_mgr[i].init_add_buffer(0, launch_msg_buffer_num_entries - 1);
+        // TODO(jbauman): Give correct number once async bug is fixed.
+        this->config_buffer_mgr[i].init_add_buffer(0, 1);
     }
 }
 


### PR DESCRIPTION
### Ticket
#15018

### Problem description
The async ring buffer change seems to have caused some hangs in the LLAMA 3 70b tests, for unknown reasons.

### What's changed
Reduce the number of launch messages that can be outstanding at once to 1, to avoid concurrency.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
