### PR TITLE
#14982: Update Unary ops examples

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/hardsigmoid/hardsigmoid.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/hardsigmoid/hardsigmoid.py
@@ -35,8 +35,8 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT or test_vector["input_a_dtype"] == ttnn.bfloat8_b:
-        return True, "Row Major layout and bfloat8_b are not supported"
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
     return False, None
 
 

--- a/tests/sweep_framework/sweeps/eltwise/unary/hardswish/hardswish.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/hardswish/hardswish.py
@@ -35,8 +35,8 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT or test_vector["input_a_dtype"] == ttnn.bfloat8_b:
-        return True, "Row Major layout and bfloat8_b are not supported"
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
     return False, None
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -318,28 +318,6 @@ def test_unary_composite_hardswish_ttnn(input_shapes, device):
     assert comp_pass
 
 
-def test_hardswish_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn.hardswish)
-    golden_tensor = golden_function(input)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.hardswish(x1_tt)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
-def test_hardsigmoid_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn.hardsigmoid)
-    golden_tensor = golden_function(input)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.hardsigmoid(x1_tt)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -318,6 +318,28 @@ def test_unary_composite_hardswish_ttnn(input_shapes, device):
     assert comp_pass
 
 
+def test_hardswish_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.hardswish)
+    golden_tensor = golden_function(input)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.hardswish(x1_tt)
+    tt_out = ttnn.to_torch(y_tt)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
+def test_hardsigmoid_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.hardsigmoid)
+    golden_tensor = golden_function(input)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.hardsigmoid(x1_tt)
+    tt_out = ttnn.to_torch(y_tt)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1113,7 +1113,7 @@ void bind_unary_composite_floats_with_default(
     const std::string& parameter_name_b,
     const std::string& parameter_b_doc,
     float parameter_b_value,
-    const std::string& supported_dtype = "BFLOAT16",
+    const std::string& supported_dtype = "BFLOAT16, BFLOAT8_B",
     const std::string& info_doc = "") {
     auto doc = fmt::format(
         R"doc(
@@ -1123,8 +1123,8 @@ void bind_unary_composite_floats_with_default(
             input_tensor (ttnn.Tensor): the input tensor.
 
         Keyword args:
-            {2} (float): {3}. Defaults to `{4}`.
-            {5} (float): {6}. Defaults to `{7}`.
+            {2} (float, optional): {3}. Defaults to `{4}`.
+            {5} (float, optional): {6}. Defaults to `{7}`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
         Returns:
@@ -1146,7 +1146,7 @@ void bind_unary_composite_floats_with_default(
             {9}
 
         Example:
-            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor, {2} = {4}, {5} = {7})
         )doc",
         operation.base_name(),


### PR DESCRIPTION
### Ticket
#14982

### Problem description
Update Unary examples docs

### What's changed
Updated Unary examples for the following ops : 

- ttnn.hardsigmoid
- ttnn.hardswish
- ttnn.selu

### Checklist
- [ ] Post commit CI

### Doc screenshots
<img width="957" alt="Screenshot 2024-11-21 at 10 04 39 PM" src="https://github.com/user-attachments/assets/4fdcc3da-6a46-4d73-bdc2-1591111ee0f0">
<img width="960" alt="Screenshot 2024-11-21 at 10 05 09 PM" src="https://github.com/user-attachments/assets/fc21b462-b81d-4f89-83c8-3655c3884243">
<img width="960" alt="Screenshot 2024-11-21 at 10 05 36 PM" src="https://github.com/user-attachments/assets/c9a1b459-6486-4fb6-ac1e-467954957cc1">

 hardsigmoid sweep test : 
<img width="1016" alt="Screenshot 2024-11-21 at 9 34 00 PM" src="https://github.com/user-attachments/assets/2934551b-14e3-4472-8b81-a8e2ec601fbc">
hardswish sweep test : 
<img width="1010" alt="Screenshot 2024-11-21 at 9 36 49 PM" src="https://github.com/user-attachments/assets/a0f36d08-4cf0-4441-aefa-add94545458d">

