### PR TITLE
Remove ARCH_NAME sp header tensix.h from tt_memory.cpp

### DIFF
--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -4,13 +4,10 @@
 
 #include "tt_memory.h"
 
-#include <cassert>
-#include <cstdio>
-#include <fstream>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
-#include <stdexcept>
 
-#include "tensix.h"
 #include "tt_elffile.hpp"
 #include "tt_metal/common/assert.hpp"
 

--- a/tt_metal/llrt/tt_memory.h
+++ b/tt_metal/llrt/tt_memory.h
@@ -4,15 +4,11 @@
 
 #pragma once
 
-#include <functional>
-#include <cassert>
+#include <cstddef>
 #include <cstdint>
-#include <istream>
-#include <sstream>
+#include <functional>
 #include <string>
 #include <vector>
-
-// #include "command_assembler/memory.h"
 
 namespace ll_api {
 


### PR DESCRIPTION
### Ticket
#596 

### Problem description
Can't include tensix.h and build independent of ARCH_NAME.

### What's changed
Remove dead include.
Include what you use.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11959850474)
- [x] New/Existing tests provide coverage for changes
