### PR TITLE
#0: Fix grabbing data from ethernet cores

### DIFF
--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -433,8 +433,7 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
                     }
                     for (const CoreCoord& core : tt::Cluster::instance().get_soc_desc(device_id).physical_ethernet_cores)
                     {
-                        const auto curr_core = device->physical_core_from_logical_core(core, CoreType::ETH);
-                        profiler_msg_t *profiler_msg = device->get_dev_addr<profiler_msg_t *>(curr_core, HalL1MemAddrType::PROFILER);
+                        profiler_msg_t *profiler_msg = device->get_dev_addr<profiler_msg_t *>(core, HalL1MemAddrType::PROFILER);
                         std::vector<std::uint32_t> control_buffer = tt::llrt::read_hex_vec_from_core(
                                 device_id,
                                 core,


### PR DESCRIPTION




### Problem description
I'm seeing `Always | FATAL    | Bounds-Error -- Logical_core=(x=9,y=0) is
outside of ethernet logical grid` in test_pgm_dispatch with TT_METAL_DEVICE_PROFILER_DISPATCH=1 TT_METAL_DEVICE_PROFILER=1`.

### What's changed
tt::Cluster::instance().get_soc_desc(device_id).physical_ethernet_cores returns
a physical coordinates, so we can remove the conversion from logical to physical.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
