### PR TITLE
#14826: Reimplement wzerorange

### DIFF
--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -14,8 +14,6 @@
 #include "hostdevcommon/kernel_structs.h"
 #include "dev_msgs.h"
 
-extern uint32_t __ldm_bss_start[];
-extern uint32_t __ldm_bss_end[];
 extern void (* __init_array_start[])();
 extern void (* __init_array_end[])();
 
@@ -53,7 +51,9 @@ inline void l1_to_local_mem_copy(uint32_t *dst, uint32_t tt_l1_ptr *src, int32_t
 
 inline void do_crt1(uint32_t tt_l1_ptr *data_image) {
 
-    // Handle stuff typically done in crt0 in asm.  Easier to do in C
+    // Clear bss.
+    extern uint32_t __ldm_bss_start[];
+    extern uint32_t __ldm_bss_end[];
     wzerorange(__ldm_bss_start, __ldm_bss_end);
 
     // Copy initialized data.

--- a/tt_metal/hw/toolchain/substitutes.cpp
+++ b/tt_metal/hw/toolchain/substitutes.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023, 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,22 +7,18 @@
 
 using namespace std;
 
-extern "C" int atexit(void (*f)(void))
-{
-    return 0;
-}
+extern "C" int atexit(void (*f)(void)) { return 0; }
 
-extern "C" void exit(int ec)
-{
+extern "C" void exit(int ec) {
     while (1) { asm volatile ("" ::: "memory"); }
 }
 
-extern "C" void wzerorange(uint32_t *start, uint32_t *end) __attribute__((aligned(16)));
-
-extern "C" void wzerorange(uint32_t *start, uint32_t *end)
-{
-    for (; start != end; start++)
-    {
+extern "C" void wzerorange(uint32_t *start, uint32_t *end) {
+#pragma GCC unroll 0
+    while (start != end) {
         *start = 0;
+        // Prevent optimizer considering this loop equivalent to
+        // memset (start, 0, end - start) -- that's code bloat.
+        asm inline("addi %0,%0,%1" : "+r"(start) : "i"(sizeof(*start)));
     }
 }

--- a/tt_metal/hw/toolchain/substitutes.cpp
+++ b/tt_metal/hw/toolchain/substitutes.cpp
@@ -14,11 +14,23 @@ extern "C" void exit(int ec) {
 }
 
 extern "C" void wzerorange(uint32_t *start, uint32_t *end) {
+    // manually unrolled 4 times.
+    start += 4;
 #pragma GCC unroll 0
-    while (start != end) {
-        *start = 0;
+    while (start <= end) {
+        start[-4] = start[-3] = start[-2] = start[-1] = 0;
         // Prevent optimizer considering this loop equivalent to
-        // memset (start, 0, end - start) -- that's code bloat.
-        asm inline("addi %0,%0,%1" : "+r"(start) : "i"(sizeof(*start)));
+        // memset (start, 0, (end - start) * sizeof (*start)) -- that's code bloat.
+        asm inline("addi %0,%0,4 * %1" : "+r"(start) : "i"(sizeof(*start)));
     }
+    // There are 0, 1, 2 or 3 words of residue.
+    // We get better code layout expecting the conditions to be true.
+    start -= 2;
+    if (__builtin_expect(start <= end, true)) {
+        start[-2] = start[-1] = 0;
+        start += 2;
+    }
+    start -= 1;
+    if (__builtin_expect(start <= end, true))
+        start[-1] = 0;
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14826

### Problem description
The compiler spots that wzerorange is memset, and subtitutes the latter, leading to code bloat. The original patch caused a performance regression, presumably because memset is faster than wzerorange

### What's changed
1) Use the same ASM trick to hide wzerorange's memset equivalence
2) Unroll the loop 4 fold, changing 1 write per 3 insns to 1 write per 1.5 insns

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
