### PR TITLE
Supporting non-overlapping output core grid for create_qkv_heads

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
-// #include "debug/dprint.h"  // required in all kernels using DPRINT
 
 void kernel_main() {
     uint32_t in_tile_offset_by_batch = get_arg_val<uint32_t>(0);
@@ -20,10 +19,11 @@ void kernel_main() {
     constexpr uint32_t num_q_heads = get_compile_time_arg_val(6);
     constexpr uint32_t num_kv_heads = get_compile_time_arg_val(7);
     constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(8);
-    constexpr uint32_t PHASES_TO_READ =
-        get_compile_time_arg_val(9);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
-    constexpr uint32_t num_x = get_compile_time_arg_val(10);
-    constexpr uint32_t num_y = get_compile_time_arg_val(11);
+    constexpr uint32_t PHASES_TO_READ      = get_compile_time_arg_val(9);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+    constexpr uint32_t num_x               = get_compile_time_arg_val(10);
+    constexpr uint32_t num_y               = get_compile_time_arg_val(11);
+    constexpr uint32_t PROCESS_QV          = get_compile_time_arg_val(12);
+    constexpr uint32_t PROCESS_K           = get_compile_time_arg_val(13);
 
     tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
     tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + num_x));
@@ -33,116 +33,126 @@ void kernel_main() {
     uint32_t qkv_y = 0;
     uint32_t total_input_cores = num_x * num_y;
     uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / total_input_cores;
+    uint32_t num_q_cores = num_tiles_per_core * num_q_heads * head_size_num_tiles;
+    uint32_t num_kv_cores = num_tiles_per_core * num_kv_heads * head_size_num_tiles;
 
     uint64_t qkv_read_addr =
         get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
     uint32_t num_tiles_read_cur_core = 0;
     uint32_t q_write_addr = 0;
-    uint32_t tile_size = head_size / head_size_num_tiles;
+    uint32_t tile_size = head_size/head_size_num_tiles;
+    constexpr uint32_t HALF_TILE_ELEMENTS = 16 * 32;
+    uint32_t SUBTILE_ROWS = 16;
 
-    for (uint32_t q = 0; q < num_q_heads; ++q) {
-        uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
-        uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
-        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            // Read first phase
-            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
-                noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
-            }
-            // Read second phase
-            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
-                noc_async_read(
-                    qkv_read_addr + 256 * ELEMENT_SIZE, q_write_addr + 256 * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
-            }
-
-            qkv_read_addr += tile_size;
-            q_write_addr += tile_size;
-            num_tiles_read_cur_core++;
-
-            if (num_tiles_read_cur_core == num_tiles_per_core) {
-                qkv_x++;
-                if (qkv_x == num_x) {
-                    qkv_x = 0;
-                    qkv_y++;
+    // Skip Q section if PROCESS_QV is False
+    if constexpr (PROCESS_QV == 1) {
+        for (uint32_t q = 0; q < num_q_heads; ++q) {
+            uint32_t wptr_offset = q < SUBTILE_ROWS ? q * SUBTILE_LINE_BYTES : (q - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
+            for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+                // Read first phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                    noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
                 }
-                qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
-                                in_tile_offset_by_batch;
-                num_tiles_read_cur_core = 0;
+                // Read second phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                    noc_async_read(qkv_read_addr+256*ELEMENT_SIZE, q_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                }
+
+                qkv_read_addr += tile_size;
+                q_write_addr += tile_size;
+                num_tiles_read_cur_core++;
+
+                if (num_tiles_read_cur_core == num_tiles_per_core) {
+                    qkv_x++;
+                    if (qkv_x == num_x) {
+                        qkv_x = 0;
+                        qkv_y++;
+                    }
+                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+                    num_tiles_read_cur_core = 0;
+                }
             }
         }
     }
+    else {
+        qkv_x = num_q_cores % num_x;
+        qkv_y = num_q_cores / num_x;
+        qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
 
-    // K
-    uint32_t k_write_addr = 0;
+    }
 
-    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
-    for (uint32_t k = 0; k < num_kv_heads; ++k) {
-        uint32_t wptr_offset = k < 16 ? k * SUBTILE_LINE_BYTES : (k - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
-        uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
-        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            // Read first phase
-            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
-                noc_async_read(qkv_read_addr, k_write_addr, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
-            }
-            // Read second phase
-            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
-                noc_async_read(
-                    qkv_read_addr + 256 * ELEMENT_SIZE, k_write_addr + 256 * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
-            }
+    if constexpr (PROCESS_K == 1) {
+        // K
+        uint32_t k_write_addr = 0;
 
-            qkv_read_addr += tile_size;
-            k_write_addr += tile_size;
-            num_tiles_read_cur_core++;
-
-            if (num_tiles_read_cur_core == num_tiles_per_core) {
-                qkv_x++;
-                if (qkv_x == num_x) {
-                    qkv_x = 0;
-                    qkv_y++;
+        // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+        for (uint32_t k = 0; k < num_kv_heads; ++k) {
+            uint32_t wptr_offset = k < SUBTILE_ROWS ? k * SUBTILE_LINE_BYTES : (k - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
+            for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+                // Read first phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                    noc_async_read(qkv_read_addr, k_write_addr, SUBTILE_LINE_BYTES);
                 }
-                qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
-                                in_tile_offset_by_batch;
-                num_tiles_read_cur_core = 0;
+                // Read second phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                    noc_async_read(qkv_read_addr+256*ELEMENT_SIZE, k_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                }
+
+                qkv_read_addr += tile_size;
+                k_write_addr += tile_size;
+                num_tiles_read_cur_core++;
+
+                if (num_tiles_read_cur_core == num_tiles_per_core) {
+                    qkv_x++;
+                    if (qkv_x == num_x) {
+                        qkv_x = 0;
+                        qkv_y++;
+                    }
+                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+                    num_tiles_read_cur_core = 0;
+                }
             }
         }
     }
+    else {
+        qkv_x += (num_kv_cores % num_x);
+        qkv_y += (num_kv_cores / num_x);
+        qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+    }
 
-    // v
-    uint32_t v_write_addr = 0;
+    if constexpr (PROCESS_QV == 1) {
+        // v
+        uint32_t v_write_addr = 0;
 
-    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
-    for (uint32_t v = 0; v < num_kv_heads; ++v) {
-        uint32_t wptr_offset = v < 16 ? v * SUBTILE_LINE_BYTES : (v - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
-        uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
-        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            // Read first phase
-            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
-                noc_async_read(qkv_read_addr, v_write_addr, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
-            }
-            // Read second phase
-            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
-                noc_async_read(
-                    qkv_read_addr + 256 * ELEMENT_SIZE, v_write_addr + 256 * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
-            }
-
-            qkv_read_addr += tile_size;
-            v_write_addr += tile_size;
-            num_tiles_read_cur_core++;
-
-            if (num_tiles_read_cur_core == num_tiles_per_core) {
-                qkv_x++;
-                if (qkv_x == num_x) {
-                    qkv_x = 0;
-                    qkv_y++;
+        // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+        for (uint32_t v = 0; v < num_kv_heads; ++v) {
+            uint32_t wptr_offset = v < SUBTILE_ROWS ? v * SUBTILE_LINE_BYTES : (v - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
+            for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+                // Read first phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                    noc_async_read(qkv_read_addr, v_write_addr, SUBTILE_LINE_BYTES);
                 }
-                qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
-                                in_tile_offset_by_batch;
-                num_tiles_read_cur_core = 0;
+                // Read second phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                    noc_async_read(qkv_read_addr+256*ELEMENT_SIZE, v_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                }
+
+                qkv_read_addr += tile_size;
+                v_write_addr += tile_size;
+                num_tiles_read_cur_core++;
+
+                if (num_tiles_read_cur_core == num_tiles_per_core) {
+                    qkv_x++;
+                    if (qkv_x == num_x) {
+                        qkv_x = 0;
+                        qkv_y++;
+                    }
+                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+                    num_tiles_read_cur_core = 0;
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::transformer {
 void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
     const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape = input_tensor.get_shape();
     // TODO: Rewrite validation for this decode case
     // NOTE: Checks for head_dim and shape[3] is done in nlp_create_qkv_heads because it's needed to infer head_dim
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
@@ -25,8 +25,10 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
     // input
+    uint32_t num_users_supported = 32;
+    uint32_t num_users = input_shape[2];
     TT_FATAL(input_shape[3] % TILE_WIDTH == 0, "Unsupported input shape");  // head_dim must be multiple of TILE_WIDTH
-    TT_FATAL(input_shape[2] == 32, "Unsupported input shape");              // 32 users
+    TT_FATAL(num_users <= num_users_supported, "Unsupported input shape");  // 32 users
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
     TT_FATAL(input_shape[0] == 1, "Unsupported input shape");
     const auto QKV_memcfg = input_tensor.memory_config();
@@ -48,8 +50,17 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     // Support maximum 32 heads for now
     TT_FATAL(this->num_q_heads <= 32, "Error");
     // 1 User Per Core Max and 32 users for now
-    TT_FATAL(num_cores >= 32, "Need at least 32 cores for decode");
+    if (this->overlap_qk_coregrid) {
+        TT_FATAL(num_cores >= num_users, "Need at least 32 cores for decode");
+    } else {
+        TT_FATAL(num_cores >= 2 * num_users, "Need cores atleast double of num_users for decode when q and k heads are not overlapping coregrid");
+    }
     TT_FATAL(this->num_q_heads >= this->num_kv_heads, "Error");
+
+    if (!this->overlap_qk_coregrid) {
+        // Validate that q, k, v shards does not overlap each other
+        TT_FATAL(this->head_dim % input_tensor.shard_spec().value().shape[1] == 0, "We don't support overlapping q, k, v shards when overlap_qk_coregrid is false");
+    }
 }
 
 std::vector<tt::tt_metal::LegacyShape> NLPCreateHeadsDecodeDeviceOperation::compute_output_shapes(
@@ -90,25 +101,23 @@ std::vector<Tensor> NLPCreateHeadsDecodeDeviceOperation::create_output_tensors(
     ShardSpec q_shard_spec{q_shard_grid, {num_q_heads_padded, this->head_dim}};
     auto q_mem_config = this->output_mem_config;
     q_mem_config.shard_spec = q_shard_spec;
-    auto kv_shard_grid = num_cores_to_corerangeset(batch, core_grid, true);
-    ShardSpec kv_shard_spec{kv_shard_grid, {num_kv_heads_padded, this->head_dim}};
-    auto kv_mem_config = this->output_mem_config;
-    kv_mem_config.shard_spec = kv_shard_spec;
+    auto v_shard_grid = q_shard_grid;
+    ShardSpec v_shard_spec{v_shard_grid, {num_kv_heads_padded, this->head_dim}};
+    auto v_mem_config = this->output_mem_config;
+    v_mem_config.shard_spec = v_shard_spec;
+    auto k_shard_grid = v_shard_grid;
+    if (!this->overlap_qk_coregrid) {
+        k_shard_grid = num_cores_to_corerangeset(CoreCoord{batch%core_grid.x, batch/core_grid.x}, batch, core_grid, true);
+    }
+    ShardSpec k_shard_spec{k_shard_grid, {num_kv_heads_padded, this->head_dim}};
+    auto k_mem_config = this->output_mem_config;
+    k_mem_config.shard_spec = k_shard_spec;
+
     return {
-        create_device_tensor(
-            output_shapes[0], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), q_mem_config),
-        create_device_tensor(
-            output_shapes[1],
-            input_tensor.get_dtype(),
-            input_tensor.get_layout(),
-            input_tensor.device(),
-            kv_mem_config),
-        create_device_tensor(
-            output_shapes[2],
-            input_tensor.get_dtype(),
-            input_tensor.get_layout(),
-            input_tensor.device(),
-            kv_mem_config)};
+        create_device_tensor(output_shapes[0], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), q_mem_config),
+        create_device_tensor(output_shapes[1], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), k_mem_config),
+        create_device_tensor(output_shapes[2], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), v_mem_config)
+    };
 }
 
 operation::ProgramWithCallbacks NLPCreateHeadsDecodeDeviceOperation::create_program(
@@ -117,13 +126,7 @@ operation::ProgramWithCallbacks NLPCreateHeadsDecodeDeviceOperation::create_prog
     auto& output_tensor = output_tensors.at(0);
 
     CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-    return multi_core_nlp_create_qkv_heads_decode(
-        input_tensor,
-        this->num_q_heads,
-        this->num_kv_heads,
-        this->head_dim,
-        output_tensors,
-        compute_with_storage_grid_size);
+    return  multi_core_nlp_create_qkv_heads_decode(input_tensor, this->num_q_heads, this->num_kv_heads, this->head_dim, this->overlap_qk_coregrid, output_tensors, compute_with_storage_grid_size);
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -25,7 +25,7 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
     // input
-    uint32_t num_users_supported = 32;
+    const uint32_t num_users_supported = 32;
     uint32_t num_users = input_shape[2];
     TT_FATAL(input_shape[3] % TILE_WIDTH == 0, "Unsupported input shape");  // head_dim must be multiple of TILE_WIDTH
     TT_FATAL(num_users <= num_users_supported, "Unsupported input shape");  // 32 users

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
@@ -11,33 +11,17 @@
 
 namespace ttnn::operations::experimental::transformer {
 
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(
-    const Tensor& input_tensor,
-    const uint32_t num_q_heads,
-    const uint32_t num_kv_heads,
-    const uint32_t head_dim,
-    std::vector<Tensor>& output,
-    CoreCoord compute_with_storage_grid_size);
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(
-    const Tensor& input_tensor,
-    const uint32_t num_q_heads,
-    const uint32_t num_kv_heads,
-    const uint32_t head_dim,
-    std::vector<Tensor>& output,
-    CoreCoord compute_with_storage_grid_size);
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(
-    const Tensor& input_tensor,
-    const uint32_t num_q_heads,
-    const uint32_t num_kv_heads,
-    const uint32_t head_dim,
-    std::vector<Tensor>& output,
-    CoreCoord compute_with_storage_grid_size);
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
 
-struct NLPCreateHeadsDecodeDeviceOperation {
-    const uint32_t num_q_heads;
-    const uint32_t num_kv_heads;
-    const uint32_t head_dim;
-    MemoryConfig output_mem_config;
+
+    struct NLPCreateHeadsDecodeDeviceOperation {
+        const uint32_t num_q_heads;
+        const uint32_t num_kv_heads;
+        const uint32_t head_dim;
+        MemoryConfig output_mem_config;
+        const bool overlap_qk_coregrid;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::transformer {
         const uint32_t num_q_heads;
         const uint32_t num_kv_heads;
         const uint32_t head_dim;
-        MemoryConfig output_mem_config;
         const bool overlap_qk_coregrid;
+        MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -13,22 +13,14 @@ using namespace tt;
 
 namespace ttnn::operations::experimental::transformer {
 
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(
-    const Tensor& input_tensor,
-    const uint32_t num_q_heads,
-    const uint32_t num_kv_heads,
-    const uint32_t head_dim,
-    std::vector<Tensor>& output,
-    CoreCoord compute_with_storage_grid_size) {
-    bool is_input_sharded = input_tensor.is_sharded();
-    if (is_input_sharded) {
-        return multi_core_nlp_create_qkv_heads_decode_sharded_input(
-            input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
-    } else {
-        return multi_core_nlp_create_qkv_heads_decode_interleaved_input(
-            input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+        bool is_input_sharded = input_tensor.is_sharded();
+        if (is_input_sharded) {
+            return multi_core_nlp_create_qkv_heads_decode_sharded_input(input_tensor, num_q_heads, num_kv_heads, head_dim, overlap_qk_coregrid, output, compute_with_storage_grid_size);
+        } else {
+            return multi_core_nlp_create_qkv_heads_decode_interleaved_input(input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
+        }
     }
-}
 
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(
     const Tensor& input_tensor,
@@ -187,14 +179,9 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleav
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(
-    const Tensor& input_tensor,
-    const uint32_t num_q_heads,
-    const uint32_t num_kv_heads,
-    const uint32_t head_dim,
-    std::vector<Tensor>& output,
-    CoreCoord compute_with_storage_grid_size) {
-    tt_metal::Program program = tt_metal::CreateProgram();
+
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+        tt_metal::Program program = tt_metal::CreateProgram();
 
     const auto& input_shape = input_tensor.get_legacy_shape();
 
@@ -247,87 +234,151 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
 
     uint32_t q_base_addr = input_tensor.buffer()->address();
 
-    // cores to read and write to output
-    uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
-    auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
-    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
+        // cores for q
+        uint32_t q_num_cores = q_cores.num_cores(); // number of cores of the output
+        auto q_core_grid = q_cores.bounding_box();
+        uint32_t q_num_cores_x = q_core_grid.end_coord.x + 1, q_num_cores_y = q_core_grid.end_coord.y + 1;
+        const auto &q_cores_vector = grid_to_cores(q_num_cores, q_num_cores_x, q_num_cores_y, true);
+
+        // cores for k
+        uint32_t k_num_cores = k_cores.num_cores(); // number of cores of the output
+        auto k_core_grid = k_cores.bounding_box();
+        const auto &k_cores_vector = corerange_to_cores(k_cores, k_num_cores, true);
 
     // cores for input
     uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
     auto in_core_grid = in_cores.bounding_box();
     uint32_t in_num_cores_x = in_core_grid.end_coord.x + 1, in_num_cores_y = in_core_grid.end_coord.y + 1;
 
-    std::vector<uint32_t> noc_x_coords;
-    noc_x_coords.reserve(in_num_cores_x);
-    for (uint32_t x = 0; x < in_num_cores_x; ++x) {
-        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
-    }
-    std::vector<uint32_t> noc_y_coords;
-    noc_y_coords.reserve(in_num_cores_y);
-    for (uint32_t y = 0; y < in_num_cores_y; ++y) {
-        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
-    }
+        std::vector<uint32_t> noc_x_coords;
+        noc_x_coords.reserve(in_num_cores_x);
+        for (uint32_t x = 0; x < in_num_cores_x; ++x) {
+            noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        }
+        std::vector<uint32_t> noc_y_coords;
+        noc_y_coords.reserve(in_num_cores_y);
+        for (uint32_t y = 0; y < in_num_cores_y; ++y) {
+            noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        }
 
-    // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a
-    // tile respectively)
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)element_size,
-        (std::uint32_t)sub_tile_line_bytes,
-        q_output_cb_index,
-        k_output_cb_index,
-        v_output_cb_index,
-        head_size,
-        num_q_heads,
-        num_kv_heads,
-        head_tiles,
-        1,  // read the first phase
-        in_num_cores_x,
-        in_num_cores_y};
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-        q_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    reader_compile_time_args[9] = 2;  // read the second phase
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
-        "reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
-        q_cores,
-        tt_metal::WriterDataMovementConfig(reader_compile_time_args));
+        uint32_t process_qv = 1, process_k = 1;
+        // In case of overlapping qk coregrid, we create a single set of kernels for q which also process k and v heads from the input and write to the respective output buffers
+        // while if q and k are not overlapped, we create two sets of kernels in different coregrids
+        // one set of kernels for q which also process v heads but skips k heads from the input and write to the respective output buffers
+        // another set of kernels for k which reads k heads from the input and write to the respective output buffers while skipping q and v heads
+        if (!overlap_qk_coregrid) {
+            process_qv = 1;
+            process_k = 0;
+        }
+
+        // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)
+        std::vector<uint32_t> q_reader_compile_time_args = {
+            (std::uint32_t) element_size,
+            (std::uint32_t) sub_tile_line_bytes,
+            q_output_cb_index,
+            k_output_cb_index,
+            v_output_cb_index,
+            head_size,
+            num_q_heads,
+            num_kv_heads,
+            head_tiles,
+            1, // read the first phase
+            in_num_cores_x,
+            in_num_cores_y,
+            process_qv, //read and write q and v heads
+            process_k  // read and write k heads
+        };
+        auto q_reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
+            q_cores,
+            tt_metal::ReaderDataMovementConfig(q_reader_compile_time_args));
+        std::vector<uint32_t> q_writer_compile_time_args = q_reader_compile_time_args;
+        q_writer_compile_time_args[9] = 2;  // read the second phase
+        auto q_writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
+            q_cores,
+            tt_metal::WriterDataMovementConfig(q_writer_compile_time_args));
+
+        KernelHandle k_reader_kernel_id = 0, k_writer_kernel_id = 0;
+        if (!overlap_qk_coregrid) {
+            // Switch process_qv and process_k for k kernels
+            process_qv = 0;
+            process_k = 1;
+            std::vector<uint32_t> k_reader_compile_time_args = q_reader_compile_time_args;
+            k_reader_compile_time_args[12] = process_qv;
+            k_reader_compile_time_args[13] = process_k;
+            k_reader_kernel_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
+                k_cores,
+                tt_metal::ReaderDataMovementConfig(k_reader_compile_time_args));
+
+            std::vector<uint32_t> k_writer_compile_time_args = k_reader_compile_time_args;
+            k_writer_compile_time_args[9] = 2; // read the second phase
+            k_writer_kernel_id = tt_metal::CreateKernel(
+                program,
+                "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
+                k_cores,
+                tt_metal::WriterDataMovementConfig(k_writer_compile_time_args));
+        }
 
     uint32_t q_start_addr = q_base_addr;
 
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        uint32_t in_tile_offset_by_batch =
-            i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+        for (uint32_t i = 0; i < q_num_cores; ++i) {
+            uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
 
-        const auto& core = cores[i];
-        std::vector<uint32_t> reader_runtime_args;
-        reader_runtime_args.reserve(2 + in_num_cores_x + in_num_cores_y);
-        reader_runtime_args = {
-            in_tile_offset_by_batch,
-            q_start_addr,
-        };
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+            const auto& core = q_cores_vector[i];
+            std::vector<uint32_t> q_reader_runtime_args;
+            q_reader_runtime_args.reserve(2 + in_num_cores_x + in_num_cores_y);
+            q_reader_runtime_args = {
+                in_tile_offset_by_batch,
+                q_start_addr,
+            };
+            q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+            q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
-    }
+            tt_metal::SetRuntimeArgs(program, q_reader_kernel_id, core, q_reader_runtime_args);
+            tt_metal::SetRuntimeArgs(program, q_writer_kernel_id, core, q_reader_runtime_args);
+        }
 
-    auto override_runtime_arguments_callback =
-        [reader_kernel_id,
-         writer_kernel_id,
-         num_cores,
-         cb_q_output,
-         cb_k_output,
-         cb_v_output,
-         cores,
-         element_size,
-         sub_tile_line_bytes](
+        if (!overlap_qk_coregrid) {
+            for (uint32_t i = 0; i < k_num_cores; ++i) {
+                uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
+
+                const auto& core = k_cores_vector[i];
+                std::vector<uint32_t> k_reader_runtime_args;
+                k_reader_runtime_args.reserve(2 + in_num_cores_x + in_num_cores_y);
+                k_reader_runtime_args = {
+                    in_tile_offset_by_batch,
+                    q_start_addr,
+                };
+                k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+                k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+
+                tt_metal::SetRuntimeArgs(program, k_reader_kernel_id, core, k_reader_runtime_args);
+                tt_metal::SetRuntimeArgs(program, k_writer_kernel_id, core, k_reader_runtime_args);
+            }
+        }
+
+        auto override_runtime_arguments_callback = [
+                q_reader_kernel_id,
+                q_writer_kernel_id,
+                k_reader_kernel_id,
+                k_writer_kernel_id,
+                q_num_cores,
+                k_num_cores,
+                cb_q_output,
+                cb_k_output,
+                cb_v_output,
+                q_cores_vector,
+                k_cores_vector,
+                element_size,
+                sub_tile_line_bytes,
+                overlap_qk_coregrid
+        ]
+        (
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
@@ -348,21 +399,35 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
             uint32_t q_base_addr = input_tensors[0].buffer()->address();
             uint32_t q_start_addr = q_base_addr;
 
-            for (uint32_t i = 0; i < num_cores; ++i) {
-                uint32_t in_tile_offset_by_batch =
-                    i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
-                const auto& core = cores[i];
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            for (uint32_t i = 0; i < q_num_cores; ++i) {
+                uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
+                const auto& core = q_cores_vector[i];
+                auto &runtime_args = GetRuntimeArgs(program, q_reader_kernel_id, core);
                 runtime_args[0] = in_tile_offset_by_batch;
                 runtime_args[1] = q_start_addr;
 
-                auto& runtime_args_writer = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args_writer = GetRuntimeArgs(program, q_writer_kernel_id, core);
                 runtime_args_writer[0] = in_tile_offset_by_batch;
                 runtime_args_writer[1] = q_start_addr;
             }
+
+            if (!overlap_qk_coregrid) {
+                for (uint32_t i = 0; i < k_num_cores; ++i) {
+                    uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
+                    const auto& core = k_cores_vector[i];
+                    auto &runtime_args = GetRuntimeArgs(program, k_reader_kernel_id, core);
+                    runtime_args[0] = in_tile_offset_by_batch;
+                    runtime_args[1] = q_start_addr;
+
+                    auto &runtime_args_writer = GetRuntimeArgs(program, k_writer_kernel_id, core);
+                    runtime_args_writer[0] = in_tile_offset_by_batch;
+                    runtime_args_writer[1] = q_start_addr;
+                }
+            }
         };
 
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-}
+        return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+    }
 
-}  // namespace ttnn::operations::experimental::transformer
+
+} // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
@@ -12,41 +12,40 @@
 
 namespace ttnn::operations::experimental::transformer {
 
-std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperation::invoke(
-    uint8_t queue_id,
-    const Tensor& input_tensor,
-    const uint32_t num_heads,
-    const std::optional<const uint32_t> num_kv_heads,
-    const std::optional<MemoryConfig>& memory_config,
-    std::optional<std::array<Tensor, 3>> optional_output_tensors) {
-    const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_heads);
-    // Infer head_dim
-    TT_FATAL(input_tensor.get_legacy_shape()[3] % (num_heads + 2 * num_kv_heads_val) == 0, "Unsupported input shape");
-    uint32_t head_dim = input_tensor.get_legacy_shape()[3] / (num_heads + 2 * num_kv_heads_val);
-    auto optional_outputs = std::vector<std::optional<Tensor>>{};
-    if (optional_output_tensors.has_value()) {
-        optional_outputs = {optional_output_tensors.value().begin(), optional_output_tensors.value().end()};
-    } else {
-        optional_outputs = {};
-    }
-    auto out = operation::run(
-        NLPCreateHeadsDecodeDeviceOperation{
-            num_heads, num_kv_heads_val, head_dim, memory_config.value_or(input_tensor.memory_config())},
-        {input_tensor},
-        {},
-        optional_outputs,
-        queue_id);
-    return {out.at(0), out.at(1), out.at(2)};
-}
+    std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperation::invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor,
+        const uint32_t num_heads,
+        const std::optional<const uint32_t> num_kv_heads,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::array<Tensor, 3>> optional_output_tensors,
+        const std::optional<const bool> overlap_qk_coregrid) {
 
-std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperation::invoke(
-    const Tensor& input_tensor,
-    const uint32_t num_heads,
-    const std::optional<const uint32_t> num_kv_heads,
-    const std::optional<MemoryConfig>& memory_config,
-    std::optional<std::array<Tensor, 3>> optional_output_tensors) {
-    return invoke(
-        ttnn::DefaultQueueId, input_tensor, num_heads, num_kv_heads, memory_config, std::move(optional_output_tensors));
-}
+        const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_heads);
+        const bool overlap_qk_coregrid_val = overlap_qk_coregrid.value_or(true);
+        // Infer head_dim
+        TT_FATAL(input_tensor.get_legacy_shape()[3] % (num_heads + 2 * num_kv_heads_val) == 0, "Unsupported input shape");
+        uint32_t head_dim = input_tensor.get_legacy_shape()[3] / (num_heads + 2 * num_kv_heads_val);
+        auto optional_outputs = std::vector<std::optional<Tensor>>{};
+        if (optional_output_tensors.has_value()) {
+            optional_outputs = {optional_output_tensors.value().begin(), optional_output_tensors.value().end()};
+        }
+        else {
+            optional_outputs = {};
+        }
+        auto out = operation::run(NLPCreateHeadsDecodeDeviceOperation{num_heads, num_kv_heads_val, head_dim, memory_config.value_or(input_tensor.memory_config()), overlap_qk_coregrid_val}, {input_tensor}, {}, optional_outputs, queue_id);
+        return {out.at(0), out.at(1), out.at(2)};
+    }
+
+    std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NLPCreateHeadsDecodeOperation::invoke(
+        const Tensor& input_tensor,
+        const uint32_t num_heads,
+        const std::optional<const uint32_t> num_kv_heads,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::array<Tensor, 3>> optional_output_tensors,
+        const std::optional<const bool> overlap_qk_coregrid) {
+        return invoke(
+            ttnn::DefaultQueueId, input_tensor, num_heads, num_kv_heads, memory_config, std::move(optional_output_tensors), overlap_qk_coregrid);
+    }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.cpp
@@ -17,9 +17,9 @@ namespace ttnn::operations::experimental::transformer {
         const Tensor& input_tensor,
         const uint32_t num_heads,
         const std::optional<const uint32_t> num_kv_heads,
+        const std::optional<const bool> overlap_qk_coregrid,
         const std::optional<MemoryConfig>& memory_config,
-        std::optional<std::array<Tensor, 3>> optional_output_tensors,
-        const std::optional<const bool> overlap_qk_coregrid) {
+        std::optional<std::array<Tensor, 3>> optional_output_tensors) {
 
         const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_heads);
         const bool overlap_qk_coregrid_val = overlap_qk_coregrid.value_or(true);
@@ -33,7 +33,7 @@ namespace ttnn::operations::experimental::transformer {
         else {
             optional_outputs = {};
         }
-        auto out = operation::run(NLPCreateHeadsDecodeDeviceOperation{num_heads, num_kv_heads_val, head_dim, memory_config.value_or(input_tensor.memory_config()), overlap_qk_coregrid_val}, {input_tensor}, {}, optional_outputs, queue_id);
+        auto out = operation::run(NLPCreateHeadsDecodeDeviceOperation{num_heads, num_kv_heads_val, head_dim, overlap_qk_coregrid_val, memory_config.value_or(input_tensor.memory_config())}, {input_tensor}, {}, optional_outputs, queue_id);
         return {out.at(0), out.at(1), out.at(2)};
     }
 
@@ -41,11 +41,11 @@ namespace ttnn::operations::experimental::transformer {
         const Tensor& input_tensor,
         const uint32_t num_heads,
         const std::optional<const uint32_t> num_kv_heads,
+        const std::optional<const bool> overlap_qk_coregrid,
         const std::optional<MemoryConfig>& memory_config,
-        std::optional<std::array<Tensor, 3>> optional_output_tensors,
-        const std::optional<const bool> overlap_qk_coregrid) {
+        std::optional<std::array<Tensor, 3>> optional_output_tensors) {
         return invoke(
-            ttnn::DefaultQueueId, input_tensor, num_heads, num_kv_heads, memory_config, std::move(optional_output_tensors), overlap_qk_coregrid);
+            ttnn::DefaultQueueId, input_tensor, num_heads, num_kv_heads, overlap_qk_coregrid, memory_config, std::move(optional_output_tensors));
     }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
@@ -17,14 +17,16 @@ struct NLPCreateHeadsDecodeOperation {
         const uint32_t num_heads,
         const std::optional<const uint32_t> num_kv_heads,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt);
+        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt,
+        const std::optional<const bool> overlap_qk_coregrid = true);
 
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
         const Tensor& input_tensor,
         const uint32_t num_heads,
         const std::optional<const uint32_t> num_kv_heads,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt);
+        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt,
+        const std::optional<const bool> overlap_qk_coregrid = true);
 };
 
 }  // namespace operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
@@ -16,17 +16,17 @@ struct NLPCreateHeadsDecodeOperation {
         const Tensor& input_tensor,
         const uint32_t num_heads,
         const std::optional<const uint32_t> num_kv_heads,
+        const std::optional<const bool> overlap_qk_coregrid = true,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt,
-        const std::optional<const bool> overlap_qk_coregrid = true);
+        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt);
 
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
         const Tensor& input_tensor,
         const uint32_t num_heads,
         const std::optional<const uint32_t> num_kv_heads,
+        const std::optional<const bool> overlap_qk_coregrid = true,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt,
-        const std::optional<const bool> overlap_qk_coregrid = true);
+        std::optional<std::array<Tensor, 3>> optional_output_tensors = std::nullopt);
 };
 
 }  // namespace operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_pybind.cpp
@@ -15,24 +15,27 @@ void bind_nlp_create_qkv_heads_decode(pybind11::module& module) {
         ttnn::experimental::nlp_create_qkv_heads_decode,
         R"doc(
             Shuffles [1, S=1, B, head_dim * (num_heads + 2*num_kv_heads)] fused qkv matrix into Q, K, and V heads with shape [S, B, num_heads, head_dim] for Q and [S, B, num_kv_heads, head_dim] for K and V, where num_heads and num_kv_heads will be padded to nearest 32. Input must be sharded, B=32 and S=1. If ttnn pads B from some number < 32 to 32, this op respects the unpadded B.
+            overlap_qk_coregrid is a boolean flag that determines whether the output Q and K heads are on same core grid. If true, then Q, K, and V heads are on the same core grid. If false, the Q and K heads are on non-overlapping core-grid useful for processing Q and K in parallel.
         )doc",
         ttnn::pybind_overload_t{
-            [](const OperationType& self,
-               const ttnn::Tensor& input_tensor,
-               const uint32_t num_q_heads,
-               const std::optional<uint32_t> num_kv_heads,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               std::optional<std::array<Tensor, 3>> optional_output_tensors,
-               uint8_t queue_id) {
-                return self(queue_id, input_tensor, num_q_heads, num_kv_heads, memory_config, optional_output_tensors);
-            },
-            pybind11::arg("input_tensor").noconvert(),
-            pybind11::kw_only(),
-            pybind11::arg("num_heads").noconvert(),
-            pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
-            pybind11::arg("memory_config") = std::nullopt,
-            pybind11::arg("output_tensors") = std::nullopt,
-            pybind11::arg("queue_id") = 0});
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const uint32_t num_q_heads,
+                const std::optional<uint32_t> num_kv_heads,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                std::optional<std::array<Tensor, 3>> optional_output_tensors,
+                uint8_t queue_id,
+                const std::optional<const bool> overlap_qk_coregrid) {
+                    return self(queue_id, input_tensor, num_q_heads, num_kv_heads, memory_config, optional_output_tensors, overlap_qk_coregrid);
+                },
+                pybind11::arg("input_tensor").noconvert(),
+                pybind11::kw_only(),
+                pybind11::arg("num_heads").noconvert(),
+                pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
+                pybind11::arg("memory_config") = std::nullopt,
+                pybind11::arg("output_tensors") = std::nullopt,
+                pybind11::arg("queue_id") = 0,
+                pybind11::arg("overlap_qk_coregrid").noconvert() = true});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_pybind.cpp
@@ -22,20 +22,20 @@ void bind_nlp_create_qkv_heads_decode(pybind11::module& module) {
                 const ttnn::Tensor& input_tensor,
                 const uint32_t num_q_heads,
                 const std::optional<uint32_t> num_kv_heads,
+                const std::optional<const bool> overlap_qk_coregrid,
                 const std::optional<ttnn::MemoryConfig>& memory_config,
                 std::optional<std::array<Tensor, 3>> optional_output_tensors,
-                uint8_t queue_id,
-                const std::optional<const bool> overlap_qk_coregrid) {
-                    return self(queue_id, input_tensor, num_q_heads, num_kv_heads, memory_config, optional_output_tensors, overlap_qk_coregrid);
+                uint8_t queue_id) {
+                    return self(queue_id, input_tensor, num_q_heads, num_kv_heads, overlap_qk_coregrid, memory_config, optional_output_tensors);
                 },
                 pybind11::arg("input_tensor").noconvert(),
                 pybind11::kw_only(),
                 pybind11::arg("num_heads").noconvert(),
                 pybind11::arg("num_kv_heads").noconvert() = std::nullopt,
+                pybind11::arg("overlap_qk_coregrid").noconvert() = true,
                 pybind11::arg("memory_config") = std::nullopt,
                 pybind11::arg("output_tensors") = std::nullopt,
-                pybind11::arg("queue_id") = 0,
-                pybind11::arg("overlap_qk_coregrid").noconvert() = true});
+                pybind11::arg("queue_id") = 0});
 }
 
 }  // namespace ttnn::operations::experimental::transformer::detail


### PR DESCRIPTION
### Problem description
Presently, `create_qkv_heads_decode` split input tensors into q, k, and v heads on same output core grid. But this restricts processing q and k heads in parallel for following Ops. This PR adds support to output q and k heads on different core-grids.

### What's changed
1. Added boolean for overlap_qk_coregrid
2. Updated program_factory and reader/writer kernel
2. Updated pytest

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12035866113/attempts/2) Non relevant pipelines crashed/failed
- [x] New/Existing tests provide coverage for changes
