### PR TITLE
#0: Restrict forced single core untilize on BH to non-sharded cases

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -110,8 +110,9 @@ operation::ProgramWithCallbacks Untilize::create_program(
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
     auto device_is_blackhole = input_tensor_a.device()->arch() == tt::ARCH::BLACKHOLE;
+    auto in_or_out_sharded = input_tensor_a.memory_config().is_sharded() || output_tensor.memory_config().is_sharded();
     // FIXME: Remove this restriction once multicore untilize is supported on blackhole
-    if (this->use_multicore && !device_is_blackhole) {
+    if (this->use_multicore && (in_or_out_sharded || !device_is_blackhole)) {
         return detail::untilize_multi_core(input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
     } else {
         return detail::untilize_single_core(input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);


### PR DESCRIPTION
### Problem description
Forcing single core on BH for sharded tensors was causing failures in recently-enabled tests in BH post-commit.

### What's changed
This commit adds another check that only forces single core on BH when the input and output tensors are not sharded.

### Checklist
- [ ] Post commit CI passes
- [x] Blackhole Post commit (https://github.com/tenstorrent/tt-metal/actions/runs/11963996332)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
