### PR TITLE
#15361: Conv2d width sharded fails with tilized input

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -516,21 +516,22 @@ def test_conv_features_multi_device(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize(
-    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, pad_h, pad_w, act_block_w_div",
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, pad_h, pad_w, act_block_w_div",
     (
-        (128, 128, 8, 8, 3, 3, 0, 0, 1),
-        (128, 256, 8, 8, 3, 3, 1, 1, 1),
-        (576, 576, 8, 8, 3, 3, 0, 0, 1),
-        (960, 960, 4, 4, 3, 3, 0, 0, 1),
-        (256, 2048, 8, 8, 3, 3, 1, 1, 1),
-        (512, 2048, 16, 16, 3, 3, 1, 1, 1),
-        (768, 768, 16, 16, 3, 3, 0, 0, 1),
-        (1280, 2560, 16, 16, 3, 3, 1, 1, 2),
-        (1280, 2560, 16, 16, 3, 3, 0, 0, 2),
-        (1280, 1280, 16, 16, 3, 3, 1, 1, 1),
-        (768, 32, 8, 8, 3, 3, 1, 1, 1),
-        (64, 128, 8, 8, 3, 3, 1, 1, 1),
-        (32, 128, 8, 8, 3, 3, 1, 1, 1),
+        (2, 128, 128, 9, 9, 3, 3, 0, 0, 1),
+        (2, 128, 256, 9, 9, 3, 3, 1, 1, 1),
+        (2, 576, 576, 9, 9, 3, 3, 0, 0, 1),
+        (2, 960, 960, 5, 5, 3, 3, 0, 0, 1),
+        (2, 256, 2048, 9, 9, 3, 3, 1, 1, 1),
+        (2, 512, 2048, 17, 17, 3, 3, 1, 1, 1),
+        (2, 768, 768, 17, 17, 3, 3, 0, 0, 1),
+        (2, 1280, 2560, 15, 15, 3, 3, 1, 1, 2),
+        (2, 1280, 2560, 15, 15, 3, 3, 0, 0, 2),
+        (2, 1280, 1280, 17, 17, 3, 3, 1, 1, 1),
+        (2, 768, 32, 9, 9, 3, 3, 1, 1, 1),
+        (2, 64, 128, 9, 9, 3, 3, 1, 1, 1),
+        (2, 32, 128, 9, 9, 3, 3, 1, 1, 1),
+        (1, 256, 256, 7, 7, 3, 3, 1, 1, 1),
     ),
 )
 @pytest.mark.parametrize(
@@ -546,9 +547,11 @@ def test_conv_features_multi_device(
     [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
+@pytest.mark.parametrize("tilized_input", [True, False], ids=["tilized", "row_major"])
 def test_conv_ws(
     device,
     use_program_cache,
+    batch_size,
     output_channels,
     input_channels,
     input_height,
@@ -563,13 +566,13 @@ def test_conv_ws(
     weights_dtype,
     activations_dtype,
     auto_shard,
+    tilized_input,
 ):
     if device.core_grid.y != 8:
         pytest.skip("Needs 8x8 Grid")
 
     stride_h = stride
     stride_w = stride
-    batch_size = 2
     fp32_accum = True
     packer_l1_acc = True
     deallocate_activation = False
@@ -603,21 +606,17 @@ def test_conv_ws(
         padding=(pad_h, pad_w),
         groups=groups,
     )
-    output_shape_nhwc = [
-        torch_out_golden_tensor.shape[0],
-        torch_out_golden_tensor.shape[2],
-        torch_out_golden_tensor.shape[3],
-        torch_out_golden_tensor.shape[1],
-    ]
 
     reader_patterns_cache = {}
     tt_weight_tensor = ttnn.from_torch(
         torch_weight_tensor, weights_dtype if weights_dtype != ttnn.bfloat8_b else ttnn.float32
     )
 
-    tt_input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16)
 
     tt_input_tensor = ttnn.reshape(tt_input_tensor, [1, 1, input_height * input_width * batch_size, input_channels])
+    if tilized_input:
+        tt_input_tensor = ttnn.to_layout(tt_input_tensor, ttnn.TILE_LAYOUT)
 
     if auto_shard and (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         if input_channels == 2048:

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -40,7 +40,7 @@ void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
         if (this->output_mem_config.is_sharded()) {
             TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Error");
         }
-        if (input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
+        if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1, "Error");
         }
         TT_FATAL(this->use_multicore == true, "Error");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -34,8 +34,6 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
             // What else?
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             auto output_shape = this->compute_output_shapes(input_tensors).at(0);
-            // Minor host code changes required to remove this restriction
-            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1, "Error");
             for (uint32_t i = 0; i < output_shape.rank() - 2; i++) {
                 TT_FATAL(input_tensor_a.get_legacy_shape()[i] == output_shape[i], "Error");
             }


### PR DESCRIPTION
Width-sharded convs or convs where auto-sharding selects width sharding, fail when input tensor is tilized.
1. Width sharded code-path decides to skip halo, but halo is not doing just halo but also untilize. In this case we need to call explicit untilize.
2. Code-path when halo is skipped for width sharded input doesn't respect user provided memory_config.
3. Explicit untilize led to new issues where untilize and untilize_with_padding seem to have bogus asserts for width sharded use cases.
4. When selecting shard spec for input tensor width sharded code-path wouldn't pad the shard height up-to 32 which fails in case input is tilized.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15361)


### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/11986020060
- [x] Nightly fast dispatch tests - https://github.com/tenstorrent/tt-metal/actions/runs/11986025136 (same shade of red as on main)
