### PR TITLE
#14826: small cleanup

### DIFF
--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -14,9 +14,6 @@
 #include "hostdevcommon/kernel_structs.h"
 #include "dev_msgs.h"
 
-extern void (* __init_array_start[])();
-extern void (* __init_array_end[])();
-
 extern void kernel_init(uint32_t kernel_init);
 extern void kernel_launch(uint32_t kernel_base_addr);
 
@@ -61,6 +58,9 @@ inline void do_crt1(uint32_t tt_l1_ptr *data_image) {
     extern uint32_t __ldm_data_end[];
     l1_to_local_mem_copy(__ldm_data_start, data_image, __ldm_data_end - __ldm_data_start);
 
+    extern void (* __init_array_start[])();
+    extern void (* __init_array_end[])();
+#pragma GCC unroll 0
     for (void (** fptr)() = __init_array_start; fptr < __init_array_end; fptr++) {
         (**fptr)();
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14826

### Problem description
We should encapsulate the init array variable decarations.

This is the final remaining bit of tidying from the original patchset (which had a performance regression)

### What's changed
1) prevent unrolling
2) move declarations into function

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
