### PR TITLE
[WIP][tt-train] Substitute workaround for moreh_clip_grad_norm

### DIFF
--- a/tt-train/sources/ttml/autograd/clip_gradient_norm.cpp
+++ b/tt-train/sources/ttml/autograd/clip_gradient_norm.cpp
@@ -4,27 +4,23 @@
 
 #include "autograd/clip_gradient_norm.hpp"
 
-#include "autograd/auto_context.hpp"
-#include "core/tt_tensor_utils.hpp"
+#include <core/ttnn_all_includes.hpp>
 
 namespace ttml::autograd {
 
-void clip_tensor_norm_(tt::tt_metal::Tensor& tensor, float max_norm) {
+void clip_tensor_norm_(const std::vector<tt::tt_metal::Tensor>& tensors, float max_norm, float norm_type) {
     if (max_norm <= 0.F) {
         throw std::logic_error(fmt::format("max_norm should be positive, current max norm {}", max_norm));
     }
 
-    auto squared = ttnn::multiply(tensor, tensor);
-    auto shape = core::create_shape({1, 1, 1, 1});
-    auto out = ttml::core::from_vector({0.F}, shape, &ttml::autograd::ctx().get_device());
-    ttnn::moreh_sum(squared, std::nullopt, true, out, squared.memory_config(), std::nullopt);
-    auto grad_norm_tensor = ttnn::sqrt(out);
-
-    // this is workaround before ttnn::repeat is fixed
-    auto grad_norm_tensor_float = ttml::core::to_vector(grad_norm_tensor)[0];
-    if (grad_norm_tensor_float > max_norm) {
-        auto scale = max_norm / grad_norm_tensor_float;
-        tensor = ttnn::multiply(tensor, scale);
-    }
+    ttnn::moreh_clip_grad_norm(
+        tensors,
+        max_norm,
+        /* norm_type */ norm_type,
+        /* error_if_nonfinite */ true,
+        /* total_norm */ std::nullopt,
+        /* memory_config */ std::nullopt,
+        /* compute_kernel_config */ std::nullopt);
 }
+
 }  // namespace ttml::autograd

--- a/tt-train/sources/ttml/autograd/clip_gradient_norm.hpp
+++ b/tt-train/sources/ttml/autograd/clip_gradient_norm.hpp
@@ -8,16 +8,20 @@
 
 namespace ttml::autograd {
 
-void clip_tensor_norm_(tt::tt_metal::Tensor& tensor, float max_norm);
+void clip_tensor_norm_(const std::vector<tt::tt_metal::Tensor>& tensors, float max_norm, float norm_type);
 
 template <typename Model>
-void clip_gradient_norm_(Model& model, float max_norm) {
+void clip_gradient_norm_(Model& model, float max_norm, float norm_type = 2.F) {
+    std::vector<tt::tt_metal::Tensor> tensors;
+    tensors.reserve(model.parameters().size());
     for (auto& [name, param] : model.parameters()) {
         auto& grad = param->get_grad();
         if (core::is_tensor_initialized(grad)) {
-            clip_tensor_norm_(grad, max_norm);
+            tensors.push_back(grad);
         }
     }
+
+    clip_tensor_norm_(tensors, max_norm, norm_type);
 };
 
 }  // namespace ttml::autograd

--- a/tt-train/sources/ttml/core/ttnn_all_includes.hpp
+++ b/tt-train/sources/ttml/core/ttnn_all_includes.hpp
@@ -43,6 +43,7 @@
 #include <ttnn/operations/full_like/full_like.hpp>                                                 // NOLINT
 #include <ttnn/operations/matmul/matmul.hpp>                                                       // NOLINT
 #include <ttnn/operations/moreh/moreh_adamw/moreh_adamw.hpp>                                       // NOLINT
+#include <ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp>                     // NOLINT
 #include <ttnn/operations/moreh/moreh_layer_norm/moreh_layer_norm.hpp>                             // NOLINT
 #include <ttnn/operations/moreh/moreh_layer_norm_backward/moreh_layer_norm_backward.hpp>           // NOLINT
 #include <ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.hpp>                   // NOLINT

--- a/tt-train/tests/autograd/clip_gradient_norm_test.cpp
+++ b/tt-train/tests/autograd/clip_gradient_norm_test.cpp
@@ -16,7 +16,8 @@ TEST(ClipGradientNormTest, GradNormTensor_0) {
     auto shape = ttml::core::create_shape({1, 1, 9, 9});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    ttml::autograd::clip_tensor_norm_(tensor, 3.F);
+    std::vector<tt::tt_metal::Tensor> tensors = {tensor};
+    ttml::autograd::clip_tensor_norm_(tensors, 3.F, 2.F);
 
     auto clipped_vec = ttml::core::to_vector(tensor);
     auto norm = 0.F;
@@ -37,7 +38,8 @@ TEST(ClipGradientNormTest, GradNormTensor_1) {
     auto shape = ttml::core::create_shape({1, 1, 9, 9});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    ttml::autograd::clip_tensor_norm_(tensor, 10.F);
+    std::vector<tt::tt_metal::Tensor> tensors = {tensor};
+    ttml::autograd::clip_tensor_norm_(tensors, 10.F, 2.F);
 
     auto clipped_vec = ttml::core::to_vector(tensor);
     auto norm = 0.F;
@@ -58,7 +60,8 @@ TEST(ClipGradientNormTest, GradNormTensor_2) {
     auto shape = ttml::core::create_shape({1, 1, 9, 9});
     auto tensor = ttml::core::from_vector(data, shape, device);
 
-    ttml::autograd::clip_tensor_norm_(tensor, 1.F);
+    std::vector<tt::tt_metal::Tensor> tensors = {tensor};
+    ttml::autograd::clip_tensor_norm_(tensors, 1.F, 2.F);
 
     auto clipped_vec = ttml::core::to_vector(tensor);
     auto norm = 0.F;


### PR DESCRIPTION
### Problem description
Remove existing clip gradient norm and substitute with `moreh_clip_grad_norm`. 
Blocked by [issue 15390](https://github.com/tenstorrent/tt-metal/issues/15390)

### What's changed
* Substitute workaround with method call
* modify tests

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
