### PR TITLE
#13127: Clean up layout conversion

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
@@ -77,15 +77,13 @@ def test_tensor_conversion_with_tt_dtype(python_lib, shape, tt_dtype, device):
     tt_tensor = ttnn.Tensor(py_tensor, tt_dtype)
     if tt_dtype in {ttnn.bfloat8_b, ttnn.bfloat4_b}:
         assert tt_tensor.storage_type() == ttnn.StorageType.OWNED
-        tt_tensor = tt_tensor.to(ttnn.TILE_LAYOUT)
+        assert tt_tensor.layout == ttnn.TILE_LAYOUT
     else:
         assert tt_tensor.storage_type() == ttnn.StorageType.BORROWED
+        assert tt_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
 
     tt_tensor = tt_tensor.to(device)
     tt_tensor = tt_tensor.cpu()
-
-    if tt_dtype in {ttnn.bfloat8_b, ttnn.bfloat4_b}:
-        tt_tensor = tt_tensor.to(ttnn.ROW_MAJOR_LAYOUT)
 
     if python_lib == torch:
         py_tensor_after_round_trip = tt_tensor.to_torch()

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -822,21 +822,21 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
         return tensor;
     }
 
-    auto shape = tensor.get_legacy_shape();
     auto source_layout = tensor.get_layout();
     auto tile = tensor.tensor_spec().tile();
-    auto convert = [tile, &shape, source_layout, target_layout](const auto& input_data) -> std::vector<T> {
+    auto physical_shape = tensor.tensor_spec().physical_shape();
+    auto convert = [tile, &physical_shape, source_layout, target_layout](const auto& input_data) -> std::vector<T> {
         switch (source_layout) {
             case Layout::ROW_MAJOR:
                 if (target_layout == Layout::TILE) {
-                    return convert_layout_row_major_to_tile(shape, tile, input_data);
+                    return convert_layout_row_major_to_tile(physical_shape, tile, input_data);
                 } else {
                     TT_THROW("Unsupported layout conversion");
                 }
                 break;
             case Layout::TILE:
                 if (target_layout == Layout::ROW_MAJOR) {
-                    return convert_layout_tile_to_row_major(shape, tile, input_data);
+                    return convert_layout_tile_to_row_major(physical_shape, tile, input_data);
                 } else {
                     TT_THROW("Unsupported layout conversion");
                 }
@@ -916,91 +916,18 @@ inline std::vector<uint32_t> pack_fp32_vec_as_bfloat_tiles(const bfloat4_b&, Arg
     return pack_fp32_vec_as_bfp4_tiles(std::forward<Args>(args)...);
 }
 
-// Template specialization for BFloatLayout based on type T
-template <typename T>
-struct bfloat_enum;
-
-template <>
-struct bfloat_enum<bfloat8_b> {
-    static constexpr DataType value = DataType::BFLOAT8_B;
-};
-
-template <>
-struct bfloat_enum<bfloat4_b> {
-    static constexpr DataType value = DataType::BFLOAT4_B;
-};
-
 template <typename T>
 Tensor to_layout_bfloat(const Tensor& tensor, Layout target_layout) {
     static_assert(std::is_same_v<T, bfloat8_b> || std::is_same_v<T, bfloat4_b>, "Invalid type T");
-
-    // TODO(arakhmati): do not convert to FLOA32
-
-    if (tensor.get_layout() == target_layout) {
-        return tensor;
+    // TODO: Flip to assert when we remove use cases in python and c++
+    if (tensor.get_layout() != target_layout or tensor.get_layout() != Layout::TILE) {
+        log_warning(
+            tt::LogAlways,
+            "Tensor layout must be Layout::TILE for bfloat8_b or bfloat4_b! Conversion from {} to {} was not executed!",
+            tensor.get_layout(),
+            target_layout);
     }
-    auto tile = tensor.get_tensor_spec().tile();
-    return std::visit(
-        [&tensor, &target_layout, &tile](auto&& storage) -> Tensor {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
-                std::vector<OwnedBuffer> output_buffers;
-                for (int i = 0; i < storage.num_buffers(); i++) {
-                    // Convert to FLOAT32 tensor and change layout
-                    auto input_packed_data = owned_buffer::get_as<uint32_t>(storage.get_buffer(i)).get();
-                    auto input_float_data = unpack_bfloat_tiles_into_float_vec(
-                        T{}, input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-                    auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
-                    auto float_tensor = Tensor(
-                                            OwnedStorage{input_float_buffer},
-                                            tensor.get_legacy_shape(),
-                                            DataType::FLOAT32,
-                                            tensor.get_layout(),
-                                            tile)
-                                            .to(target_layout);
-
-                    // Convert back to BFLOAT8_B
-                    auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
-                    auto output_packed_data = pack_fp32_vec_as_bfloat_tiles(
-                        T{}, output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
-                    auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
-                    output_buffers.push_back(output_uint32_buffer);
-                }
-                return Tensor(
-                    std::move(MultiDeviceHostStorage{storage.strategy, output_buffers, storage.shapes}),
-                    tensor.get_legacy_shape(),
-                    bfloat_enum<T>::value,
-                    target_layout,
-                    tile);
-
-            } else {
-                // Convert to FLOAT32 tensor and change layout
-                auto input_packed_data = owned_buffer::get_as<uint32_t>(tensor).get();
-                auto input_float_data = unpack_bfloat_tiles_into_float_vec(
-                    T{}, input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-                auto input_float_buffer = owned_buffer::create<float>(std::move(input_float_data));
-                auto float_tensor = Tensor(
-                                        OwnedStorage{input_float_buffer},
-                                        tensor.get_legacy_shape(),
-                                        DataType::FLOAT32,
-                                        tensor.get_layout(),
-                                        tile)
-                                        .to(target_layout);
-
-                // Convert back to BFLOAT
-                auto output_float_data = owned_buffer::get_as<float>(float_tensor).get();
-                auto output_packed_data = pack_fp32_vec_as_bfloat_tiles(
-                    T{}, output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
-                auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
-                return Tensor(
-                    std::move(OwnedStorage{std::move(output_uint32_buffer)}),
-                    tensor.get_legacy_shape(),
-                    bfloat_enum<T>::value,
-                    target_layout,
-                    tile);
-            }
-        },
-        tensor.get_storage());
+    return tensor;
 }
 
 template <>

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -98,22 +98,23 @@ static ttnn::SmallVector<uint32_t> to_4D_shape(const tt::tt_metal::LegacyShape& 
 
 template <typename T, template <typename> typename BufferType>
 inline std::vector<T> convert_layout_row_major_to_tile(
-    const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
+    const Size& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
     TT_FATAL(
-        (shape[-2] % tile.get_tile_shape()[0] == 0 && shape[-1] % tile.get_tile_shape()[1] == 0),
+        (shape.height() % tile.get_tile_shape()[0] == 0 && shape.width() % tile.get_tile_shape()[1] == 0),
         "Unsupported shape for tensor conversion from row-major to tile layout. The tensor shape height and width must "
         "be a multiple of tile height ({}) and width ({}), but the provided shape is {}",
         tile.get_tile_shape()[0],
         tile.get_tile_shape()[1],
         shape);
 
-    auto tile_shape = ttnn::SmallVector<uint32_t>{tile.get_tile_shape()[0], tile.get_tile_shape()[1]};
-    auto face_shape = ttnn::SmallVector<uint32_t>{tile.get_face_shape()[0], tile.get_face_shape()[1]};
+    auto tile_shape = tile.get_tile_shape();
+    auto face_shape = tile.get_face_shape();
     auto transpose_within_face = tile.get_transpose_within_face();
     auto transpose_of_faces = tile.get_transpose_of_faces();
+
     return convert_layout(
         data_to_convert,
-        tt::stl::Span(shape.begin(), shape.end()),
+        shape,
         tests::utils::TensorLayoutType::LIN_ROW_MAJOR,
         tests::utils::TensorLayoutType::TILED_NFACES,
         tile_shape,
@@ -124,14 +125,15 @@ inline std::vector<T> convert_layout_row_major_to_tile(
 
 template <typename T, template <typename> typename BufferType>
 inline std::vector<T> convert_layout_tile_to_row_major(
-    const tt::tt_metal::LegacyShape& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
-    auto tile_shape = ttnn::SmallVector<uint32_t>{tile.get_tile_shape()[0], tile.get_tile_shape()[1]};
-    auto face_shape = ttnn::SmallVector<uint32_t>{tile.get_face_shape()[0], tile.get_face_shape()[1]};
+    const Size& shape, const Tile& tile, const BufferType<T>& data_to_convert) {
+    auto tile_shape = tile.get_tile_shape();
+    auto face_shape = tile.get_face_shape();
     auto transpose_within_face = tile.get_transpose_within_face();
     auto transpose_of_faces = tile.get_transpose_of_faces();
+
     return convert_layout(
         data_to_convert,
-        tt::stl::Span(shape.begin(), shape.end()),
+        shape,
         tests::utils::TensorLayoutType::TILED_NFACES,
         tests::utils::TensorLayoutType::LIN_ROW_MAJOR,
         tile_shape,

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -248,7 +248,14 @@ Tensor tensor_pad(
         input_tensor.storage_type() == StorageType::OWNED or
         input_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST or
         input_tensor.storage_type() == StorageType::BORROWED && "Tensor must be on host for padding");
-    TT_ASSERT(input_tensor.get_layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for padding");
+    // TODO: Flip to assert when we remove use cases in python and c++
+    if (input_tensor.get_layout() != Layout::ROW_MAJOR) {
+        log_warning(
+            tt::LogOp,
+            "Tensor layout {} must be ROW_MAJOR for padding! Returning original tensor!",
+            input_tensor.get_layout());
+        return input_tensor;
+    }
 
     auto input_shape = input_tensor.get_legacy_shape();
     auto dimensions_pads = std::vector<Padding::PadDimension>();

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -45,29 +45,21 @@ Tensor to_weight_special_padding_tile_layout(
             }
         }
         if constexpr (std::is_same<T, float>::value) {
-            if (output_dtype == DataType::BFLOAT8_B) {
-                auto output_float_data = output_buffer.get();
+            if (output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B) {
+                auto tensor = Tensor(
+                                  std::move(OwnedStorage{std::move(output_buffer)}),
+                                  output_shape,
+                                  DataType::FLOAT32,
+                                  Layout::ROW_MAJOR)
+                                  .to(Layout::TILE);
+                auto output_float_data = owned_buffer::get_as<float>(tensor).get();
                 auto output_packed_data =
-                    pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+                    output_dtype == DataType::BFLOAT8_B
+                        ? pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false)
+                        : pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
                 auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
-                auto rm_tensor = Tensor(
-                    std::move(OwnedStorage{std::move(output_uint32_buffer)}),
-                    output_shape,
-                    output_dtype,
-                    Layout::ROW_MAJOR);
-                return rm_tensor.to(Layout::TILE);
-            }
-            if (output_dtype == DataType::BFLOAT4_B) {
-                auto output_float_data = output_buffer.get();
-                auto output_packed_data =
-                    pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
-                auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
-                auto rm_tensor = Tensor(
-                    std::move(OwnedStorage{std::move(output_uint32_buffer)}),
-                    output_shape,
-                    output_dtype,
-                    Layout::ROW_MAJOR);
-                return rm_tensor.to(Layout::TILE);
+                return Tensor(
+                    std::move(OwnedStorage{std::move(output_uint32_buffer)}), output_shape, output_dtype, Layout::TILE);
             }
         } else {
             TT_ASSERT((output_dtype != DataType::BFLOAT8_B) || (output_dtype != DataType::BFLOAT4_B));
@@ -130,29 +122,21 @@ Tensor to_weight_tile_layout(
             }
         }
         if constexpr (std::is_same<T, float>::value) {
-            if (output_dtype == DataType::BFLOAT8_B) {
-                auto output_float_data = output_buffer.get();
+            if (output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B) {
+                auto tensor = Tensor(
+                                  std::move(OwnedStorage{std::move(output_buffer)}),
+                                  output_shape,
+                                  DataType::FLOAT32,
+                                  Layout::ROW_MAJOR)
+                                  .to(Layout::TILE);
+                auto output_float_data = owned_buffer::get_as<float>(tensor).get();
                 auto output_packed_data =
-                    pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
+                    output_dtype == DataType::BFLOAT8_B
+                        ? pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false)
+                        : pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
                 auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
-                auto rm_tensor = Tensor(
-                    std::move(OwnedStorage{std::move(output_uint32_buffer)}),
-                    output_shape,
-                    output_dtype,
-                    Layout::ROW_MAJOR);
-                return rm_tensor.to(Layout::TILE);
-            }
-            if (output_dtype == DataType::BFLOAT4_B) {
-                auto output_float_data = output_buffer.get();
-                auto output_packed_data =
-                    pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
-                auto output_uint32_buffer = owned_buffer::create<uint32_t>(std::move(output_packed_data));
-                auto rm_tensor = Tensor(
-                    std::move(OwnedStorage{std::move(output_uint32_buffer)}),
-                    output_shape,
-                    output_dtype,
-                    Layout::ROW_MAJOR);
-                return rm_tensor.to(Layout::TILE);
+                return Tensor(
+                    std::move(OwnedStorage{std::move(output_uint32_buffer)}), output_shape, output_dtype, Layout::TILE);
             }
         } else {
             TT_ASSERT((output_dtype != DataType::BFLOAT8_B) || (output_dtype != DataType::BFLOAT4_B));


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Cleaning up how we handle data conversion for python <-> tt tensors.

### What's changed
- Deprecate support for ROW_MAJOR BFLOAT8_B/BFLOAT4_B tensors on host
  - Throw warning when users try to convert layout for BFLOAT8_B/BFLOAT4_B dtypes
  - Throw warning and return original input tensor instead of assert in pad op if input is not ROW_MAJOR layout
    - This is a workaround to support old test code that tries to:
       1. Create BFLOAT8_B tensors in ROW_MAJOR
       2. Pad up to tile sizes
       3. Convert layout to TILE
    - Now, we just directly pad and return in TILE layout on the first step
  - Update tensor creation with float vectors to always output TILE layout for BFLOAT8_B/BFLOAT4_B dtypes
    - Automatically add padding to tile sizes if needed
    - Throw warning if requested layout is not TILE
    - Remove duplicate code by calling a helper function for the different pybinds
    - Remove support for BFLOAT8_B/BFLOAT4_B in create_owned_buffer_from_vector_of_floats
  - Update conv weights utils to do layout conversion in FLOAT32, then unpack and re-pack into BFLOAT8_B/BFLOAT4_B
    - This is strictly better for host-side perf since we eliminate one unecessary pack
  - Remove duplicate code in handling of BFLOAT8_B/BFLOAT4_B dtypes in pytensor
- Update convert_layout to use 2D physical shape for all underlying conversions
  - Top level convert layout has a pass to flatten shape for existing use cases
  - Remove padding support for tilize_nchw since this is unused at this level
  - Remove recursive calls inside convert layout to simplify logic
  - Switch convert_layout_row_major_to_tile and convert_layout_tile_to_row_major to use 2D physical shape
  - Update tests/tt_metal/tt_metal/test_bcast.cpp to handle padding for tile externally

### Checklist
- [x] Post commit CI passes
  - Post-commit all: https://github.com/tenstorrent/tt-metal/actions/runs/12110164523
  - Nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/12037520925
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
