### PR TITLE
CB Size Validation Fix Rollout

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/dispatcher_kernel_size_and_runtime.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/dispatcher_kernel_size_and_runtime.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 #include "c_tensix_core.h"
-#include "circular_buffer.h"
 #include "core_config.h"
 #include "dataflow_api.h"
 #include "debug/dprint.h"

--- a/tt_metal/hw/inc/circular_buffer.h
+++ b/tt_metal/hw/inc/circular_buffer.h
@@ -6,15 +6,8 @@
 
 #include <cstdint>
 
-#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+#include "circular_buffer_constants.h"
 #include "risc_attribs.h"
-#else
-#define tt_l1_ptr
-#define tt_reg_ptr
-#endif
-
-constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 32;
-constexpr static std::uint32_t UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG = 4;
 
 // The command queue read interface controls reads from the issue region, host owns the issue region write interface
 // Commands and data to send to device are pushed into the issue region
@@ -62,9 +55,7 @@ extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 // TRISC sets up read or write
 inline void setup_cb_read_write_interfaces(uint32_t tt_l1_ptr *cb_l1_base, uint32_t start_cb_index, uint32_t max_cb_index, bool read, bool write, bool init_wr_tile_ptr) {
 
-    constexpr uint32_t WORDS_PER_CIRCULAR_BUFFER_CONFIG = 4;
-
-    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = cb_l1_base + start_cb_index * WORDS_PER_CIRCULAR_BUFFER_CONFIG;
+    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = cb_l1_base + start_cb_index * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
 
     for (uint32_t cb_id = start_cb_index; cb_id < max_cb_index; cb_id++) {
 
@@ -93,6 +84,6 @@ inline void setup_cb_read_write_interfaces(uint32_t tt_l1_ptr *cb_l1_base, uint3
             cb_interface[cb_id].fifo_wr_tile_ptr = 0;
         }
 
-        circular_buffer_config_addr += WORDS_PER_CIRCULAR_BUFFER_CONFIG;
+        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
     }
 }

--- a/tt_metal/hw/inc/circular_buffer_constants.h
+++ b/tt_metal/hw/inc/circular_buffer_constants.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 32;
+constexpr static std::uint32_t UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG = 4;
+constexpr static std::uint32_t CIRCULAR_BUFFER_WORD_SIZE_BYTES = 16;
+constexpr static std::uint32_t CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES = 4;

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -461,6 +461,11 @@ DeviceAddr Buffer::aligned_size() const {
     return this->num_dev_pages() * this->aligned_page_size();
 }
 
+DeviceAddr Buffer::aligned_size_per_bank() const {
+    uint32_t num_banks = is_sharded(this->buffer_layout_) ? this->num_cores().value() : this->device_->num_banks(this->buffer_type());
+    return tt::tt_metal::detail::SizeBytesPerBank(this->size_, this->page_size_, num_banks, this->alignment());
+}
+
 DeviceAddr Buffer::sharded_page_address(uint32_t bank_id, uint32_t page_index) const {
     TT_FATAL(is_sharded(this->buffer_layout()), "Buffer not sharded");
     auto shard_spec = this->shard_spec();

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -231,6 +231,7 @@ class Buffer final {
     uint32_t alignment() const;
     DeviceAddr aligned_page_size() const;
     DeviceAddr aligned_size() const;
+    DeviceAddr aligned_size_per_bank() const;
 
     // SHARDED API STARTS HERE
     // TODO: WILL SEPARATE INTO SHARDED BUFFER CLASS

--- a/tt_metal/impl/buffers/circular_buffer_types.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.cpp
@@ -43,6 +43,7 @@ CircularBufferConfig& CircularBufferConfig::set_page_size(uint8_t buffer_index, 
     if (this->total_size_ % page_size != 0) {
         TT_THROW("Total circular buffer size {} B must be divisible by page size {} B", this->total_size_, page_size);
     }
+    // TODO: Should use CIRCULAR_BUFFER_WORD_SIZE_BYTES here
     if (page_size % sizeof(uint32_t) != 0) {
         TT_THROW("Page size must be divisible by sizeof(uint32_t) because buffers holds uint32_t values");
     }

--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -16,7 +16,7 @@
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/impl/tile/tile.hpp"
 
-#include "tt_metal/hw/inc/circular_buffer.h"
+#include "tt_metal/hw/inc/circular_buffer_constants.h"
 
 namespace tt::tt_metal {
 inline namespace v0 {

--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -89,7 +89,10 @@ class CircularBufferConfig {
     std::unordered_set<uint8_t> buffer_indices_;
     bool dynamic_cb_ = false;
     // `max_size_` is used to ensure that total size does not grow beyond associated buffer size
-    std::optional<uint32_t> max_size_ = std::nullopt;
+    // `buffer_size_` is tracked to enforce the old size assertions.
+    // Will be removed once tests are updated to respect the correct `max_size_` constraint
+    uint32_t max_size_ = 0;
+    uint32_t buffer_size_ = 0;
 };
 
 bool operator==(const CircularBufferConfig& lhs, const CircularBufferConfig& rhs);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -24,6 +24,7 @@
 #include "tt_metal/common/logger.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/hw/inc/circular_buffer_constants.h"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
 #include "tt_metal/impl/buffers/semaphore.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"
@@ -903,8 +904,8 @@ void EnqueueProgramCommand::assemble_device_commands(
                 circular_buffers_on_corerange.size());
             for (const shared_ptr<CircularBuffer>& cb : circular_buffers_on_corerange) {
                 program_command_sequence.circular_buffers_on_core_ranges[i].emplace_back(cb);
-                const uint32_t cb_address = cb->address() >> 4;
-                const uint32_t cb_size = cb->size() >> 4;
+                const uint32_t cb_address = cb->address() >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
+                const uint32_t cb_size = cb->size() >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
                 for (const auto& buffer_index : cb->buffer_indices()) {
                     // 1 cmd for all 32 buffer indices, populate with real data for specified indices
 
@@ -913,7 +914,7 @@ void EnqueueProgramCommand::assemble_device_commands(
                     cb_config_payload[base_index] = cb_address;
                     cb_config_payload[base_index + 1] = cb_size;
                     cb_config_payload[base_index + 2] = cb->num_pages(buffer_index);
-                    cb_config_payload[base_index + 3] = cb->page_size(buffer_index) >> 4;
+                    cb_config_payload[base_index + 3] = cb->page_size(buffer_index) >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
                     max_base_index = std::max(max_base_index, base_index);
                 }
             }
@@ -1359,8 +1360,8 @@ void EnqueueProgramCommand::update_device_commands(
     for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
         uint32_t* cb_config_payload = cached_program_command_sequence.cb_configs_payloads[i];
         for (const shared_ptr<CircularBuffer>& cb : cbs_on_core_range) {
-            const uint32_t cb_address = cb->address() >> 4;
-            const uint32_t cb_size = cb->size() >> 4;
+            const uint32_t cb_address = cb->address() >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
+            const uint32_t cb_size = cb->size() >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
             for (const auto& buffer_index : cb->buffer_indices()) {
                 // 1 cmd for all 32 buffer indices, populate with real data for specified indices
 
@@ -1369,7 +1370,7 @@ void EnqueueProgramCommand::update_device_commands(
                 cb_config_payload[base_index] = cb_address;
                 cb_config_payload[base_index + 1] = cb_size;
                 cb_config_payload[base_index + 2] = cb->num_pages(buffer_index);
-                cb_config_payload[base_index + 3] = cb->page_size(buffer_index) >> 4;
+                cb_config_payload[base_index + 3] = cb->page_size(buffer_index) >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
             }
         }
         i++;

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -13,7 +13,7 @@
 #include "fmt/base.h"                                  // for format_string
 #include "tt_metal/common/assert.hpp"                  // for tt_throw, TT_FATAL
 #include "tt_metal/common/base_types.hpp"              // for UnpackToDestMode
-#include "tt_metal/hw/inc/circular_buffer.h"
+#include "tt_metal/hw/inc/circular_buffer_constants.h"
 
 namespace tt {
 

--- a/tt_metal/jit_build/data_format.hpp
+++ b/tt_metal/jit_build/data_format.hpp
@@ -7,7 +7,8 @@
 #include <vector>
 #include "common/tt_backend_api_types.hpp"  // for DataFormat
 #include "device/tt_arch_types.h"           // for ARCH
-#include "circular_buffer.h"         // for NUM_CIRCULAR_BUFFERS
+#include "tt_metal/hw/inc/circular_buffer_constants.h"        // for NUM_CIRCULAR_BUFFERS
+
 enum class UnpackToDestMode : std::uint8_t;
 
 namespace tt {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -16,7 +16,7 @@
 #include "jit_build/data_format.hpp"
 #include "jit_build/settings.hpp"
 
-#include "tt_metal/hw/inc/circular_buffer.h"
+#include "tt_metal/hw/inc/circular_buffer_constants.h"
 
 namespace fs = std::filesystem;
 

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -6,12 +6,12 @@
 
 #include <string>
 
-#include "circular_buffer.h"         // for NUM_CIRCULAR_BUFFERS
 #include "hostdevcommon/kernel_structs.h"
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/base_types.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/common/utils.hpp"
+#include "tt_metal/hw/inc/circular_buffer_constants.h"         // for NUM_CIRCULAR_BUFFERS
 
 namespace tt
 {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -19,6 +19,7 @@
 #include "tools/profiler/profiler.hpp"
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/hw/inc/circular_buffer_constants.h"
 #include "tt_metal/impl/trace/trace.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
@@ -724,11 +725,11 @@ bool ConfigureDeviceWithProgram(Device *device, Program &program, bool fd_bootlo
                         uint32_t num_pages = circular_buffer->num_pages(buffer_index);
                         uint32_t page_size = size_in_bytes / num_pages;
                         circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index) =
-                            addr_in_bytes >> 4;  // convert to addr in 16B words
+                            addr_in_bytes >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;  // convert to addr in 16B words
                         circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 1) =
-                            size_in_bytes >> 4;  // convert to addr in 16B words
+                            size_in_bytes >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;  // convert to addr in 16B words
                         circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 2) = num_pages;
-                        circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 3) = page_size >> 4;
+                        circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 3) = page_size >> CIRCULAR_BUFFER_LOG2_WORD_SIZE_BYTES;
                     }
                 }  // PROF_END("CBS")
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/reader_ssm_prefix_scan.cpp
@@ -8,7 +8,7 @@ constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
-    uint32_t num_chunks_per_row = get_arg_val<uint32_t>(1);
+    uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
@@ -16,5 +16,5 @@ void kernel_main() {
 
     cb_push_back(cb_a_in, num_tiles_per_core);
     cb_push_back(cb_bx_in, num_tiles_per_core);
-    cb_push_back(cb_h_in, num_chunks_per_row);
+    cb_push_back(cb_h_in, total_tiles_per_row);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -107,13 +107,13 @@ FORCE_INLINE void sum(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
     cb_pop_front(cb_b, 1);
 }
 
-FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out) {
+FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out, uint32_t num_input_units = 1) {
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
     copy_tile_to_dst_init_short();
 
-    cb_wait_front(cb_in, 1);
+    cb_wait_front(cb_in, num_input_units);
     cb_reserve_back(cb_out, 1);
 
     tile_regs_acquire();
@@ -150,11 +150,16 @@ void MAIN {
     const uint32_t num_chunks_per_row = get_arg_val<uint32_t>(3);
 
     binary_op_init_common(cb_a_in, cb_bx_in);
+    const uint32_t num_tiles_last_chunk = total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK == 0 ? NUM_TILES_IN_TILIZED_CHUNK : total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK;
 
     // Fill initial hidden states
     for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_chunks_per_row; tilized_chunk_idx++) {
-        copy(cb_h_in, cb_h_acc);
-        cb_pop_front(cb_h_in, 1);
+        const uint32_t remaining_tiles_in_chunk =
+            tilized_chunk_idx == num_chunks_per_row - 1
+                ? num_tiles_last_chunk
+                : NUM_TILES_IN_TILIZED_CHUNK;
+        copy(cb_h_in, cb_h_acc, remaining_tiles_in_chunk);
+        cb_pop_front(cb_h_in, remaining_tiles_in_chunk);
     }
 
     // For each row of tiles we want to tilize chunks of 32 tiles to pack the rows into tiles
@@ -167,8 +172,8 @@ void MAIN {
             // If we don't have a full chunk (NUM_TILES_IN_TILIZED_CHUNK tiles) we should figure out how many tiles we
             // have left. This only runs 2-3 tiles per shard so no need to unroll.
             const uint32_t remaining_tiles_in_chunk =
-                tilized_chunk_idx == num_chunks_per_row - 1 && total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK != 0
-                    ? total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK
+                tilized_chunk_idx == num_chunks_per_row - 1
+                    ? num_tiles_last_chunk
                     : NUM_TILES_IN_TILIZED_CHUNK;
 
             pack_block_rows_into_tiles(cb_a_in, cb_a_tilize_in, remaining_tiles_in_chunk);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15337

### Problem description
When associating a sharded L1 buffer with a CB, the validation of the user specified total size was incorrect. It was comparing the total_size to the buffer's total size, when it should be compared against the bank size of the buffer.

### What's changed
Staged rollout of fixing the validation.
We will currently only enable the correct assert in debug mode first, and log a warning in release mode until the failures are addressed, and then enable the assert in release mode as well.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/11994572534)
- [x] Blackhole Post commit (if applicable) (https://github.com/tenstorrent/tt-metal/actions/runs/12003314615)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
