### PR TITLE
#15395: update CB to accept 2 byte page size; Should run post-commits

### DIFF
--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -68,7 +68,7 @@ class CircularBufferConfig {
                 this->total_size_,
                 page_size);
         }
-        if (page_size % sizeof(uint16_t) != 0) {
+        if (page_size % 16 != 0) {
             TT_THROW("Page size must be divisible by sizeof(uint32_t) because buffers holds uint32_t values");
         }
 

--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -68,7 +68,7 @@ class CircularBufferConfig {
                 this->total_size_,
                 page_size);
         }
-        if (page_size % sizeof(uint32_t) != 0) {
+        if (page_size % sizeof(uint16_t) != 0) {
             TT_THROW("Page size must be divisible by sizeof(uint32_t) because buffers holds uint32_t values");
         }
 


### PR DESCRIPTION
### Ticket
[#15395](https://github.com/tenstorrent/tt-metal/issues/15395)

### Problem description
CBs don't support page size for single bfloat16/uint16

### What's changed
Updated the Assert to enable 2 byte page sizes

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/11981174869
