### PR TITLE
Populate the version based on Git Describe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+
+/cmake/version.cmake export-subst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,14 +24,18 @@ else()
     FIND_AND_SET_CLANG17()
 endif()
 
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+include(version)
+ParseGitDescribe()
 project(
     Metalium
-    VERSION 0.50.0
+    VERSION ${VERSION_NUMERIC}
     DESCRIPTION "Tenstorrent Metalium"
     HOMEPAGE_URL "https://github.com/tenstorrent/tt-metal"
     LANGUAGES
         CXX
 )
+message(STATUS "Metalium version: ${PROJECT_VERSION}")
 
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
     message(
@@ -39,8 +43,6 @@ if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
         "CMake generation is not allowed within source directory!! Please set a build folder with '-B'!!"
     )
 endif()
-
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(project_options)
 include(unity)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# May be called prior to project()
+function(ParseGitDescribe)
+    set(version "")
+    # These will be filled in by `git archive`.
+    # Building the source outside of git from something that was not exported via `git archive`
+    # is left as an exercise to whoever is wanting to do that.
+    set(fallbackVersion "$Format:%(describe)$")
+    set(fallbackHash "$Format:%h$")
+
+    find_package(Git)
+    if(Git_FOUND)
+        execute_process(
+            COMMAND
+                ${GIT_EXECUTABLE} describe --abbrev=10 --first-parent --dirty=-dirty
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE version
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+        execute_process(
+            COMMAND
+                ${GIT_EXECUTABLE} rev-parse --short=10 HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE VERSION_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+    endif()
+    if(NOT version)
+        set(version ${fallbackVersion})
+        set(VERSION_HASH ${fallbackHash})
+    endif()
+
+    # Local modifications (dirty), or not
+    set(dirtyFlagRegex "\\-dirty")
+    set(VERSION_DIRTY FALSE)
+    if("${version}" MATCHES "${dirtyFlagRegex}$")
+        set(VERSION_DIRTY TRUE)
+        string(REGEX REPLACE "^(.*)${dirtyFlagRegex}$" "\\1" version "${version}")
+    endif()
+
+    # On a Tagged commit, or not
+    set(untaggedRegex "^(.*)\\-([0-9]+)\\-g([0-9a-f]+)$") # tag-count-ghash
+    if("${version}" MATCHES "${untaggedRegex}")
+        set(VERSION_TAGGED FALSE)
+        string(REGEX REPLACE "${untaggedRegex}" "\\1" tagname "${version}")
+        string(REGEX REPLACE "${untaggedRegex}" "\\2" VERSION_COMMIT_COUNT "${version}")
+    else()
+        set(VERSION_TAGGED TRUE)
+        set(tagname "${version}")
+    endif()
+
+    set(major "([0-9]+)")
+    set(segment "\\.[0-9]+")
+    set(status "\\-([a-zA-Z]+[0-9]+)") # eg: alpha, beta, RC
+    set(tagRegex "^[^0-9]*(${major}(${segment}(${segment}(${segment})?)?)?)(${status})?$")
+    if(NOT "${tagname}" MATCHES "${tagRegex}")
+        message(WARNING "Cannot parse tag ${tagname}")
+        return()
+    endif()
+
+    # Major[.Minor[.Patch[.Tweak]]] suitable for CMake
+    string(REGEX REPLACE "${tagRegex}" "\\1" VERSION_NUMERIC "${tagname}")
+
+    # Build a new regex because we cannot access a capture group that was not matched.
+    # And also only the first 9 capture groups are referencable.
+    set(statusRegex ".*(${status})$")
+    if("${tagname}" MATCHES "${statusRegex}")
+        string(REGEX REPLACE "${statusRegex}" "\\2" VERSION_STATUS "${tagname}")
+    endif()
+
+    set(VERSION_FULL "${VERSION_NUMERIC}")
+    if(VERSION_STATUS)
+        string(APPEND VERSION_FULL "-${VERSION_STATUS}")
+    endif()
+    if(VERSION_COMMIT_COUNT)
+        string(APPEND VERSION_FULL "+${VERSION_COMMIT_COUNT}.${VERSION_HASH}")
+    endif()
+    if(VERSION_DIRTY)
+        string(APPEND VERSION_FULL "+m")
+    endif()
+
+    message(STATUS "Version: ${VERSION_FULL}")
+
+    # Output variables
+    set(VERSION_FULL "${VERSION_FULL}" PARENT_SCOPE)
+    set(VERSION_NUMERIC "${VERSION_NUMERIC}" PARENT_SCOPE)
+endfunction()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -89,4 +89,5 @@ function(ParseGitDescribe)
     # Output variables
     set(VERSION_FULL "${VERSION_FULL}" PARENT_SCOPE)
     set(VERSION_NUMERIC "${VERSION_NUMERIC}" PARENT_SCOPE)
+    set(VERSION_HASH "${VERSION_HASH}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
### Ticket
None

### Problem description
Prep work for packaging.  We need to know our EXACT version.  That means an up-to-date version string on every commit.

### What's changed
Added a helper function that parses `git describe`
Integrated `export-subst` to obtain version information after generating a tarball of the repo

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
