### PR TITLE
#0: New RiscV architecture extension attributes

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -22,8 +22,8 @@ include(FetchContent)
 FetchContent_Declare(
     sfpi
     URL
-        https://github.com/tenstorrent/sfpi/releases/download/v5.0.0/sfpi-release.tgz
-    URL_HASH MD5=10cacabe92846076cb4d7596e46d06be
+        https://github.com/tenstorrent/sfpi/releases/download/v6.0.0/sfpi-release.tgz
+    URL_HASH MD5=d837d26a2312d27815179995fdea83bd
     SOURCE_DIR
     ${PROJECT_SOURCE_DIR}/runtime/sfpi
 )
@@ -79,24 +79,9 @@ set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-unknown-elf-
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
 
 # Define flags for each architecture
-set(GPP_FLAGS_grayskull
-    -mgrayskull
-    -march=rv32iy
-    -mtune=rvtt-b1
-    -mabi=ilp32
-)
-set(GPP_FLAGS_wormhole
-    -mwormhole
-    -march=rv32imw
-    -mtune=rvtt-b1
-    -mabi=ilp32
-)
-set(GPP_FLAGS_blackhole
-    -mblackhole
-    -march=rv32iml
-    -mtune=rvtt-b1
-    -mabi=ilp32
-)
+set(GPP_FLAGS_grayskull -mcpu=tt-gs)
+set(GPP_FLAGS_wormhole -mcpu=tt-wh)
+set(GPP_FLAGS_blackhole -mcpu=tt-bh)
 
 # Define common flags for all architectures
 set(GPP_FLAGS_common

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -58,9 +58,9 @@ void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch, const std::map<std::st
     // Flags
     string common_flags;
     switch (arch) {
-        case ARCH::GRAYSKULL: common_flags = "-mgrayskull -march=rv32iy -mtune=rvtt-b1 -mabi=ilp32 "; break;
-        case ARCH::WORMHOLE_B0: common_flags = "-mwormhole -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32 "; break;
-        case ARCH::BLACKHOLE: common_flags = "-mblackhole -march=rv32iml -mtune=rvtt-b1 -mabi=ilp32 "; break;
+        case ARCH::GRAYSKULL: common_flags = "-mcpu=tt-gs "; break;
+        case ARCH::WORMHOLE_B0: common_flags = "-mcpu=tt-wh "; break;
+        case ARCH::BLACKHOLE: common_flags = "-mcpu=tt-bh "; break;
         default: TT_ASSERT(false, "Invalid arch"); break;
     }
     common_flags += "-std=c++17 -flto -ffast-math ";

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -38,12 +38,6 @@ enum {
 };
 #endif
 
-// Sadly the toolchain's usurped some machine numbers.  With any luck
-// this will go away at some point.
-#define EM_RISCV_GRAYSKULL 242
-#define EM_RISCV_WORMHOLE 0x5151
-#define EM_RISCV_BLACKHOLE 0x6151
-
 // We have to translate these two instructions
 static constexpr uint32_t insn_opc_auipc = 0x00000017;
 static constexpr uint32_t insn_opc_lui = 0x00000037;
@@ -220,10 +214,7 @@ void ElfFile::Impl::LoadImage() {
     if (hdr.e_type != ET_EXEC)
         TT_THROW("{}: not an executable", path_);
 
-    if (hdr.e_machine != EM_RISCV
-        // Hopefully these can go way at some point.
-        && hdr.e_machine != EM_RISCV_GRAYSKULL && hdr.e_machine != EM_RISCV_WORMHOLE &&
-        hdr.e_machine != EM_RISCV_BLACKHOLE)
+    if (hdr.e_machine != EM_RISCV)
         TT_THROW("{}: incompatible architecture {}", path_, hdr.e_machine);
 
     if (!hdr.e_phoff || hdr.e_phoff & (sizeof(address_t) - 1) || hdr.e_phentsize != sizeof(Elf32_Phdr) ||


### PR DESCRIPTION
### Ticket
NA

### Problem description
The gnu toolchain used adhoc riscv attributes and non-standard elf machine numbers.

### What's changed
SFPI release notes describe the toolchain changes:
https://github.com/tenstorrent/sfpi/releases/tag/v6.0.0

For tt-metal it's a matter of adjusting command line options passed to the toolchain, and removing duplication

### Checklist
- [YES] Post commit CI passes
- [YES] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
