### PR TITLE
Fix some namespace issues in ttnn header files

### DIFF
--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -73,7 +73,7 @@ inline auto create_async_output_tensors(
         return operation_t::create_async_optional_output_tensors(std::forward<decltype(args)>(args)...);
     } else if constexpr (std::is_same_v<std::decay_t<execute_on_worker_thread_return_t>, Tensor>) {
         return std::vector{
-            Tensor(operation::get_workers_for_op_output(inputs, optional_inputs, enable_autoformat_device))};
+            Tensor(tt::tt_metal::operation::get_workers_for_op_output(inputs, optional_inputs, enable_autoformat_device))};
 
     } else if constexpr (detail::is_homogenous_tuple<execute_on_worker_thread_return_t, Tensor>()) {
         Tensors output_tensors;

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -259,7 +259,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
         device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
     }
 
-    const auto enqueue_or_launch_program = [=](Program& program) {
+    const auto enqueue_or_launch_program = [=](tt::tt_metal::Program& program) {
         if (USE_FAST_DISPATCH) {
             ZoneScopedN("EnqueueProgram");
             auto& queue = device->command_queue(cq_id);
@@ -276,8 +276,8 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
 
         program.set_runtime_id(device_operation_id);
 
-        GraphTracker::instance().track_program(&program);
-        if(GraphTracker::instance().hook_program(&program)) {
+        tt::tt_metal::GraphTracker::instance().track_program(&program);
+        if(tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
             return;
         }
 
@@ -305,8 +305,8 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
 
         program->set_runtime_id(device_operation_id);
 
-        GraphTracker::instance().track_program(program.get());
-        if(GraphTracker::instance().hook_program(program.get())) {
+        tt::tt_metal::GraphTracker::instance().track_program(program.get());
+        if(tt::tt_metal::GraphTracker::instance().hook_program(program.get())) {
             return;
         }
 
@@ -456,7 +456,7 @@ typename device_operation_t::tensor_return_value_t invoke(
     ZoneScopedN("Run Device Operation");
 
     // TODO: Add GraphTracker::instance().track_device_operation to track device operations specifically?
-    GraphTracker::instance().track_function_start(get_operation_name<device_operation_t>(operation_attributes), operation_attributes, tensor_args);
+    tt::tt_metal::GraphTracker::instance().track_function_start(get_operation_name<device_operation_t>(operation_attributes), operation_attributes, tensor_args);
 
 
     using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
@@ -487,7 +487,7 @@ typename device_operation_t::tensor_return_value_t invoke(
     }
     */
 
-    GraphTracker::instance().track_function_end(tensor_return_value);
+    tt::tt_metal::GraphTracker::instance().track_function_end(tensor_return_value);
     return tensor_return_value;
 }
 

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -16,7 +16,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
-    DispatchCoreType dispatch_core_type,
+    tt::tt_metal::DispatchCoreType dispatch_core_type,
     MeshType mesh_type = MeshType::RowMajor,
     const std::pair<size_t, size_t>& offset = std::pair<size_t, size_t>(0, 0),
     const std::vector<int>& physical_device_ids = {});
@@ -33,10 +33,10 @@ std::vector<int> get_t3k_physical_device_ids_ring();
 std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, MeshDevice& mesh_device);
 
 // Get the distributed tensor config from a tensor.
-DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
+tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
 
 // Given a multi-device tensor and a device, returns the tensor on the given device.
-Tensor get_device_tensor(const Tensor& multi_device_tensor, const Device* device);
+Tensor get_device_tensor(const Tensor& multi_device_tensor, const tt::tt_metal::Device* device);
 Tensor get_device_tensor(const Tensor& multi_device_tensor, const int device_id);
 
 
@@ -48,7 +48,7 @@ std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_de
 
 // Given a list of per-device shards, return a multi-device tensor
 Tensor create_multi_device_tensor(
-    const std::vector<Tensor>& tensors, StorageType storage_type, const DistributedTensorConfig& strategy);
+    const std::vector<Tensor>& tensors, tt::tt_metal::StorageType storage_type, const tt::tt_metal::DistributedTensorConfig& strategy);
 
 }  // namespace ttnn::distributed::api
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -29,7 +29,7 @@ std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_dev
 // Eventual home: ccl_topology_descriptors
 struct RingTopology {
     RingTopology(
-        Device const* device,
+        tt::tt_metal::Device const* device,
         Topology topology,
         std::optional<uint32_t> sender_device_id,
         std::optional<uint32_t> receiver_device_id,
@@ -40,7 +40,7 @@ struct RingTopology {
     bool is_first_device_in_line(bool in_clockwise_direction) const;
     bool is_last_device_in_line(bool in_clockwise_direction) const;
 
-    const Device *device;
+    const tt::tt_metal::Device *device;
 
     std::vector<CoreCoord> eth_sender_cores;
     std::vector<CoreCoord> eth_receiver_cores;
@@ -81,11 +81,11 @@ class CclOpShardedTensorConfig final : public virtual CclOpTensorConfig {
    public:
     CclOpShardedTensorConfig(Tensor const& tensor);
 
-    ShardSpec const& get_shard_spec() const;
+    tt::tt_metal::ShardSpec const& get_shard_spec() const;
 
    private:
     uint32_t page_size;
-    ShardSpec const shard_spec;
+    tt::tt_metal::ShardSpec const shard_spec;
 };
 
 struct CclTensorSlicer {
@@ -398,7 +398,7 @@ class InterleavedRingAllGatherTensorSlicer : public LegacyCclTensorSlicer {
     InterleavedRingAllGatherTensorSlicer(
         Tensor const& input_tensor, Tensor const& output_tensor, int slice_dim, uint32_t slice_idx) :
         LegacyCclTensorSlicer() {
-        this->row_major = input_tensor.get_layout() == Layout::ROW_MAJOR;
+        this->row_major = input_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR;
         this->slice_dim_is_width = input_tensor.get_legacy_shape().rank() - 1 == slice_dim;
         this->is_sharded = input_tensor.is_sharded();
 
@@ -472,14 +472,14 @@ class InterleavedRingAllGatherTensorSlicer : public LegacyCclTensorSlicer {
 };
 
 
-KernelHandle generate_edm_kernel(
+tt::tt_metal::KernelHandle generate_edm_kernel(
    tt::tt_metal::Program& program,
-    Device const* device,
+    tt::tt_metal::Device const* device,
     FabricEriscDatamoverBuilder const& edm_builder,
     CoreCoord const& eth_core,
     NOC noc_id);
 
-KernelHandle generate_edm_kernel(
+tt::tt_metal::KernelHandle generate_edm_kernel(
    tt::tt_metal::Program& program,
     Device const* device,
     EriscDatamoverBuilder const& edm_builder,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -50,8 +50,8 @@ struct AllGatherFusedOpSignaler {
     );
 
     void init_all_gather(
-        Program& program,
-        Device const* device,
+        tt::tt_metal::Program& program,
+        tt::tt_metal::Device const* device,
 
         CoreRangeSet const& all_gather_workers,
         std::vector<CoreCoord>& all_gather_worker_cores
@@ -100,8 +100,8 @@ struct MatmulFusedOpSignaler {
     );
 
     void init_fused_op(
-        Program& program,
-        Device const* device,
+        tt::tt_metal::Program& program,
+        tt::tt_metal::Device const* device,
         const std::variant<CoreRange, CoreRangeSet>& core_range_to_signal,
         FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI
     );

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -107,8 +107,8 @@ class FabricEriscDatamoverBuilder {
         FabricEriscDatamoverConfig const& config);
 
     static FabricEriscDatamoverBuilder build(
-        Device* device,
-        Program& program,
+        tt::tt_metal::Device* device,
+        tt::tt_metal::Program& program,
         CoreCoord const& ethernet_core,
         chip_id_t local_chip_id,
         chip_id_t peer_chip_id,
@@ -209,7 +209,7 @@ struct EdmLineFabricOpInterface {
     // Will create a connection adapter for a worker which can be used to pass args to the worker kernel talking to the
     // corresponding fabric endpoint. This interface will guarantee unique connections only so requesting more unique connections
     // than available will result in an error.
-    SenderWorkerAdapterSpec uniquely_connect_worker(Device* device, Direction direction);
+    SenderWorkerAdapterSpec uniquely_connect_worker(tt::tt_metal::Device* device, Direction direction);
 
     // builds the ethernet kernels for all EDMs in the "fabric"
     void build_kernels() const;

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -177,7 +177,7 @@ struct FullRep {
 };
 
 inline std::vector<std::vector<BlockRep>> distribute_work(
-    const ttnn::SimpleShape& logical_shape, const Padding& padding, uint32_t num_cores, uint32_t blocks_per_core, bool has_cliff, uint32_t nblocks_per_core_cliff) {
+    const ttnn::SimpleShape& logical_shape, const tt::tt_metal::Padding& padding, uint32_t num_cores, uint32_t blocks_per_core, bool has_cliff, uint32_t nblocks_per_core_cliff) {
     TT_FATAL(logical_shape.rank() >= 2 && logical_shape.rank() <= 4, "Only 2D, 3D, and 4D tensors are supported. Shape: {}", "Error", logical_shape, padding);
 
     auto input_w = logical_shape.rank() >= 4 ? logical_shape[-4] : 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
@@ -25,13 +25,13 @@ enum class BcastOpParallelizationStrategy {
 struct EltwiseBinaryBroadcast {
     const ttnn::BcastOpMath math_op;
     const ttnn::BcastOpDim dim;
-    const MemoryConfig output_mem_config;
+    const tt::tt_metal::MemoryConfig output_mem_config;
     const bool in_place;
 
     void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
     BcastOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -18,18 +18,18 @@ enum class MoveOpParallelizationStrategy {
 };
 
 struct MoveDeviceOperation {
-    const MemoryConfig output_mem_config;
+    const tt::tt_metal::MemoryConfig output_mem_config;
     const MoveOpParallelizationStrategy move_op_parallelization_strategy;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<ttnn::SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     MoveOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
 };
 
-operation::ProgramWithCallbacks move_multi_core(const Tensor &input, Tensor &output);
-operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input, Tensor &output);
-operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor &input, Tensor &output);
+tt::tt_metal::operation::ProgramWithCallbacks move_multi_core(const Tensor &input, Tensor &output);
+tt::tt_metal::operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input, Tensor &output);
+tt::tt_metal::operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor &input, Tensor &output);
 
 }  // namespace tt_metal

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -11,13 +11,13 @@
 namespace ttnn::operations::data_movement {
 
 struct InterleavedToShardedDeviceOperation {
-    const MemoryConfig output_mem_config;
-    const DataType output_dtype;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+    const tt::tt_metal::DataType output_dtype;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
 
     static constexpr auto attribute_names =

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.hpp
@@ -11,12 +11,12 @@
 namespace ttnn::operations::data_movement {
 
 struct ReshardDeviceOperation {
-    const MemoryConfig output_mem_config;
+    const tt::tt_metal::MemoryConfig output_mem_config;
 
     void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
 
     static constexpr auto attribute_names = std::make_tuple("output_mem_config");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_op.hpp
@@ -11,13 +11,13 @@
 namespace ttnn::operations::data_movement {
 
 struct ShardedToInterleavedDeviceOperation {
-    const MemoryConfig output_mem_config;
-    const DataType output_dtype;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+    const tt::tt_metal::DataType output_dtype;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
 
     static constexpr auto attribute_names =

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
@@ -12,15 +12,15 @@
 namespace ttnn::operations::data_movement {
 
 struct Tilize {
-    const MemoryConfig output_mem_config;
-    const DataType output_dtype;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+    const tt::tt_metal::DataType output_dtype;
     const bool use_multicore;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.hpp
@@ -8,8 +8,8 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& output);
-operation::ProgramWithCallbacks tilize_multi_core(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks tilize_multi_core(const Tensor& a, Tensor& output);
 
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
@@ -15,15 +15,15 @@ namespace ttnn::operations::data_movement {
 struct TilizeWithValPadding {
     const tt::tt_metal::LegacyShape output_tensor_shape;
     const PadValue pad_value;
-    const MemoryConfig output_mem_config;
-    const DataType output_dtype;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+    const tt::tt_metal::DataType output_dtype;
     const bool use_multicore;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_program_factory.hpp
@@ -10,11 +10,11 @@
 using namespace tt::constants;
 
 namespace ttnn::operations::data_movement::detail {
-operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
+tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value);
 
 
-operation::ProgramWithCallbacks tilize_with_val_padding_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks tilize_with_val_padding_multi_core(
     const Tensor& a, Tensor& output, const ttnn::PadValue pad_value);
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.hpp
@@ -18,17 +18,17 @@ namespace ttnn::operations::experimental::auto_format{
 struct FormatParams {
     tt::tt_metal::LegacyShape pad_shape;
     float pad_value;
-    Layout target_layout;
+    tt::tt_metal::Layout target_layout;
 };
 
 class AutoFormat {
     private:
-        inline static Device* device = nullptr;
+        inline static tt::tt_metal::Device* device = nullptr;
 
         AutoFormat() {}
     public:
-        static void SetDefaultDevice(Device * dev) { device = dev; }
-        static Device * GetDefaultDevice() { return device; }
+        static void SetDefaultDevice(tt::tt_metal::Device * dev) { device = dev; }
+        static tt::tt_metal::Device * GetDefaultDevice() { return device; }
 
 
         static tt::tt_metal::LegacyShape pad_to_tile_shape(const tt::tt_metal::LegacyShape& unpadded_shape,
@@ -68,7 +68,7 @@ class AutoFormat {
             return padded_shape;
         }
 
-        static tt::tt_metal::LegacyShape pad_to_legal_shape(const tt::tt_metal::LegacyShape& unpadded_shape, Layout layout) {
+        static tt::tt_metal::LegacyShape pad_to_legal_shape(const tt::tt_metal::LegacyShape& unpadded_shape, tt::tt_metal::Layout layout) {
             tt::tt_metal::LegacyShape padded_shape = unpadded_shape;
             switch (layout) {
                 case Layout::ROW_MAJOR: padded_shape = pad_to_rm_shape(unpadded_shape); break;
@@ -87,7 +87,7 @@ class AutoFormat {
             return (shape[3] % 2 == 0);
         }
 
-        static bool legal_device_shape(const tt::tt_metal::LegacyShape& shape, Layout layout) {
+        static bool legal_device_shape(const tt::tt_metal::LegacyShape& shape, tt::tt_metal::Layout layout) {
             switch (layout) {
                 case Layout::ROW_MAJOR: return legal_rm_shape(shape);
                 case Layout::TILE: return legal_tile_shape(shape);
@@ -96,7 +96,7 @@ class AutoFormat {
         }
 
 
-        static bool check_input_tensor_format(const Tensor &a, const tt::tt_metal::LegacyShape& shape, Layout target_layout = Layout::TILE) {
+        static bool check_input_tensor_format(const Tensor &a, const tt::tt_metal::LegacyShape& shape, tt::tt_metal::Layout target_layout = Layout::TILE) {
             if (a.get_layout() == target_layout && a.get_legacy_shape() == shape && a.storage_type() == StorageType::DEVICE) {
                 return true;
             }
@@ -107,15 +107,15 @@ class AutoFormat {
         // are not quite ready. So here we basically just put the tensor back on device.
         // Used in backward_ops.cpp
         // See: Remove auto format within permute_op.cpp #9404
-        static Tensor move_tensor_to_device_and_pad(const Tensor& input, Device *device, Layout target_layout, std::optional<MemoryConfig> target_mem_config);
+        static Tensor move_tensor_to_device_and_pad(const Tensor& input, tt::tt_metal::Device *device, tt::tt_metal::Layout target_layout, std::optional<tt::tt_metal::MemoryConfig> target_mem_config);
 
-        static Tensor move_tensor_to_device(const Tensor &input, Device * device, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+        static Tensor move_tensor_to_device(const Tensor &input, tt::tt_metal::Device * device, const tt::tt_metal::MemoryConfig& mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-        static Tensor move_tensor_to_mem_config(const Tensor &input, const MemoryConfig& mem_config);
+        static Tensor move_tensor_to_mem_config(const Tensor &input, const tt::tt_metal::MemoryConfig& mem_config);
 
-        static Tensor format_input_tensor(const Tensor &input, Device * device, const tt::tt_metal::LegacyShape& padded_shape, float pad_value, Layout target_layout, std::optional<MemoryConfig> target_mem_config = std::nullopt);
+        static Tensor format_input_tensor(const Tensor &input, tt::tt_metal::Device * device, const tt::tt_metal::LegacyShape& padded_shape, float pad_value, tt::tt_metal::Layout target_layout, std::optional<tt::tt_metal::MemoryConfig> target_mem_config = std::nullopt);
 
-        static Tensor format_output_tensor(const Tensor &output, const tt::tt_metal::LegacyShape& shape, Device* device, Layout target_layout, std::optional<MemoryConfig> target_mem_config = std::nullopt);
+        static Tensor format_output_tensor(const Tensor &output, const tt::tt_metal::LegacyShape& shape, tt::tt_metal::Device* device, Layout target_layout, std::optional<MemoryConfig> target_mem_config = std::nullopt);
 };
 
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -15,8 +15,8 @@ namespace ttnn::operations::sliding_window {
 
 struct ParallelConfig {
     CoreRangeSet grid = {};
-    TensorMemoryLayout shard_scheme;
-    ShardOrientation shard_orientation;
+    tt::tt_metal::TensorMemoryLayout shard_scheme;
+    tt::tt_metal::ShardOrientation shard_orientation;
 
     bool operator==(const ParallelConfig &other) {
         return (grid == other.grid && shard_scheme == other.shard_scheme && shard_orientation == other.shard_orientation);
@@ -86,11 +86,11 @@ std::vector<uint32_t> generate_op_trace_metadata(const SlidingWindowConfig& conf
 std::vector<std::pair<uint32_pair_t, uint32_pair_t>> generate_shard_boundaries(const SlidingWindowConfig& config, const std::vector<uint32_t>& op_trace_metadata);
 std::vector<std::pair<bool, uint32_pair_t>> generate_tensor_metadata(const std::vector<bool>& pad_metadata, const SlidingWindowConfig& config, uint32_t reshard_num_cores_nhw = 0, bool is_in_tiled = true);
 uint32_t generate_max_out_nsticks_per_core(const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries);
-std::tuple<std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tensors(const std::vector<std::pair<bool, uint32_pair_t>>& tensor_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool is_block_sharded, bool transpose_mcast, bool remote_read, Device* device);
+std::tuple<std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>, std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tensors(const std::vector<std::pair<bool, uint32_pair_t>>& tensor_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool is_block_sharded, bool transpose_mcast, bool remote_read, tt::tt_metal::Device* device);
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(const std::vector<uint32_t>& op_trace_metadata, const std::vector<std::pair<uint32_pair_t, uint32_pair_t>>& shard_boundaries, bool pad_tile = false, bool pad_cores = false);
 std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input);
 Tensor construct_on_host_config_tensor(const std::vector<std::vector<uint16_t>>& config, const SlidingWindowConfig& sw_config, const ParallelConfig& p_config);
-Tensor move_config_tensor_to_device(const Tensor& config_tensor, const ParallelConfig& p_config, bool is_block_sharded, Device* device);
+Tensor move_config_tensor_to_device(const Tensor& config_tensor, const ParallelConfig& p_config, bool is_block_sharded, tt::tt_metal::Device* device);
 
 } // namespace ttnn::operations::sliding_window
 

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -464,10 +464,10 @@ struct Shape {
     explicit Shape(const std::initializer_list<uint32_t> shape, const std::initializer_list<uint32_t> shape_with_tile_padding) :
         value{tt::tt_metal::LegacyShape{shape, shape_with_tile_padding}} {}
 
-    explicit Shape(tt::stl::Span<const uint32_t> shape, const Padding &padding) :
+    explicit Shape(tt::stl::Span<const uint32_t> shape, const tt::tt_metal::Padding &padding) :
         value{tt::tt_metal::LegacyShape{shape, padding}} {}
 
-    explicit Shape(const Shape &shape, const Padding &padding) :
+    explicit Shape(const Shape &shape, const tt::tt_metal::Padding &padding) :
         value{tt::tt_metal::LegacyShape{shape.value, padding}} {}
 
     Shape(const SimpleShape& shape): value{shape.view()} {}


### PR DESCRIPTION
### Ticket
#12743

### Problem description
ttnn takes advantage of tt_metal leak: `using namespace tt::tt_metal`
https://github.com/tenstorrent/tt-metal/blob/cbe17c327193babce1a93c00396e835bb04fdc99/tt_metal/impl/dispatch/command_queue_interface.hpp#L19

### What's changed
Fully qualify many uses of tt_metal classes/structs.

Note that this is not comprehensive, just the occurrences that clang-tidy was able to fix.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/11993404756)
- [x] New/Existing tests provide coverage for changes
