### PR TITLE
Relase metadata blocks on allocator destruction

### DIFF
--- a/tt_metal/impl/allocator/algorithms/free_list.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.cpp
@@ -20,7 +20,21 @@ FreeList::FreeList(DeviceAddr max_size_bytes, DeviceAddr offset_bytes, DeviceAdd
     this->init();
 }
 
+FreeList::~FreeList() {
+    this->clear();
+}
+
 void FreeList::init() {
+    boost::local_shared_ptr<FreeList::Block> curr_block = this->block_head_;
+    while (curr_block != nullptr) {
+        auto next_block = curr_block->next_block;
+        curr_block->prev_block = nullptr;
+        curr_block->next_block = nullptr;
+        curr_block->prev_free = nullptr;
+        curr_block->next_free = nullptr;
+        curr_block = next_block;
+    }
+
     this->shrink_size_ = 0;
     auto block = boost::make_local_shared<Block>(0, this->max_size_bytes_);
     this->block_head_ = block;

--- a/tt_metal/impl/allocator/algorithms/free_list.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.hpp
@@ -19,6 +19,7 @@ class FreeList : public Algorithm {
     };
 
     FreeList(DeviceAddr max_size_bytes, DeviceAddr offset_bytes, DeviceAddr min_allocation_size, DeviceAddr alignment, SearchPolicy search_policy);
+    ~FreeList();
     void init();
 
     std::vector<std::pair<DeviceAddr, DeviceAddr>> available_addresses(DeviceAddr size_bytes) const;


### PR DESCRIPTION
### Ticket
#15407

### Problem description
Device memory allocator does not deallocate metadata blocks on program exit due to circular references in the node list.

### What's changed

After some investigation, the deallocate() function is working correctly. Only upon destruction, the free list is not being freed via RAII due to circular references. The solution is to manually walk the node list and free everything. I have another version that replaces `local_shared_ptr` with [raw pointers and manual memory management](https://github.com/marty1885/tt-metal/blob/34ebd83f6d2c2452214b77dc2d346c33cf4f8444/tt_metal/impl/allocator/algorithms/free_list.cpp). Which should provide better performance as ref counting is removed. It's easy enough to prove the correctness as linked list is a simple structure (I've tried `unique_ptr`, but the ownership model is too complicated to make it clean and without performance impact). Please LMK if that version is preferred.


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
