### PR TITLE
#14982: Update Unary examples docs

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/hardtanh/hardtanh.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/hardtanh/hardtanh.py
@@ -35,8 +35,8 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT or test_vector["input_a_dtype"] == ttnn.bfloat8_b:
-        return True, "Row Major layout and bfloat8_b are not supported"
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
     return False, None
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -665,43 +665,6 @@ def test_unary_composite_trunc_ttnn_opt(input_shapes, device):
     assert comp_pass
 
 
-def test_trunc_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    golden_function = ttnn.get_golden_function(ttnn.trunc)
-    golden_tensor = golden_function(input)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.trunc(x1_tt)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
-def test_rdiv_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    scalar = 2
-    round_mode = None
-    golden_function = ttnn.get_golden_function(ttnn.rdiv)
-    golden_tensor = golden_function(input, scalar, round_mode=round_mode)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.rdiv(x1_tt, scalar, round_mode=round_mode)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
-def test_hardtanh_example(device):
-    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
-    min = 2
-    max = 8
-    golden_function = ttnn.get_golden_function(ttnn.hardtanh)
-    golden_tensor = golden_function(input, min, max)
-    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    y_tt = ttnn.hardtanh(x1_tt, min, max)
-    tt_out = ttnn.to_torch(y_tt)
-    status = torch.allclose(golden_tensor, tt_out)
-    assert status
-
-
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -665,6 +665,43 @@ def test_unary_composite_trunc_ttnn_opt(input_shapes, device):
     assert comp_pass
 
 
+def test_trunc_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn.trunc)
+    golden_tensor = golden_function(input)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.trunc(x1_tt)
+    tt_out = ttnn.to_torch(y_tt)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
+def test_rdiv_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    scalar = 2
+    round_mode = None
+    golden_function = ttnn.get_golden_function(ttnn.rdiv)
+    golden_tensor = golden_function(input, scalar, round_mode=round_mode)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.rdiv(x1_tt, scalar, round_mode=round_mode)
+    tt_out = ttnn.to_torch(y_tt)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
+def test_hardtanh_example(device):
+    input = torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16)
+    min = 2
+    max = 8
+    golden_function = ttnn.get_golden_function(ttnn.hardtanh)
+    golden_tensor = golden_function(input, min, max)
+    x1_tt = ttnn.from_torch(input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.hardtanh(x1_tt, min, max)
+    tt_out = ttnn.to_torch(y_tt)
+    status = torch.allclose(golden_tensor, tt_out)
+    assert status
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1928,7 +1928,7 @@ void py_module(py::module& module) {
     detail::bind_unary_composite(module, ttnn::normalize_global, R"doc(Performs normalize_global function on :attr:`input_tensor`.)doc", "", R"doc(BFLOAT16)doc",
         R"doc(ROW_MAJOR, TILE)doc", R"doc(4)doc", "", R"doc(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16))doc");
     detail::bind_unary_composite(module, ttnn::frac, R"doc(Performs frac function on :attr:`input_tensor`.)doc",  "", R"doc(BFLOAT16, BFLOAT8_B)doc");
-    detail::bind_unary_composite_operation(module, ttnn::trunc, R"doc(Not supported for grayskull.)doc");
+    detail::bind_unary_composite_trunc(module, ttnn::trunc, R"doc(Not supported for grayskull.)doc");
 
     detail::bind_unary_composite_floats_with_default(
         module,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14982

### Problem description
Update Unary examples docs

### What's changed
Updated examples, description, sweep tests, supported dtypes for the following ops :

- trunc
- rpow
- hardtanh
- rdiv
- softplus

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12094193572) 
<img width="966" alt="Screenshot 2024-11-25 at 4 23 58 PM" src="https://github.com/user-attachments/assets/ae23a68d-e4e9-45e6-8f85-b65124e6e8df">
<img width="965" alt="Screenshot 2024-11-25 at 10 47 54 PM" src="https://github.com/user-attachments/assets/535b1484-bf73-4fb3-b67b-b44a40e38e27">
<img width="982" alt="Screenshot 2024-11-25 at 10 51 23 PM" src="https://github.com/user-attachments/assets/518c550a-851a-4e7e-977a-37942e0d778c">
<img width="965" alt="Screenshot 2024-11-25 at 11 10 14 PM" src="https://github.com/user-attachments/assets/634900fc-c6f9-4448-a849-7070fa527dfd">
<img width="961" alt="Screenshot 2024-11-25 at 11 59 57 PM" src="https://github.com/user-attachments/assets/12bb297b-4188-4a25-abc9-b1a243ee39f6">
