### PR TITLE
#6659: remove dead code

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -759,13 +759,6 @@ void Device::clear_l1_state() {
             zero_vec_above_tile_header_buffer,
             eth_l1_mem::address_map::TILE_HEADER_BUFFER_BASE);
 
-        /* TODO: removing this section of code fixes the n300 hangs, what's the proper fix?
-        std::vector<uint32_t> zero_vec_below_command_q_base(
-            (eth_l1_mem::address_map::COMMAND_Q_BASE - eth_l1_mem::address_map::FIRMWARE_BASE) / sizeof(uint32_t), 0);
-
-        llrt::write_hex_vec_to_core(
-            this->id(), physical_core, zero_vec_below_command_q_base, eth_l1_mem::address_map::FIRMWARE_BASE);
-        */
     }
     // TODO: clear idle eriscs as well
 }


### PR DESCRIPTION
Confirmed that commented out L1 clear is zeroing out erisc base FW, leading to hangs

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/6659#issuecomment-2494857998)

### Problem description
Remove commented out code, that was originally a workaround for hanging N300 tests.

### What's changed
Confirmed commenting out code was necessary. It was writing to erisc base FW L1 region.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
