### PR TITLE
#13944: Prohibit copying memory objects

### DIFF
--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -224,9 +224,9 @@ bool send_over_eth(
 
     // TODO: this should be updated to use kernel api
     uint32_t active_eth_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-    ll_api::memory binary_mem_send = llrt::get_risc_binary(
+    ll_api::memory const& binary_mem_send = llrt::get_risc_binary(
         sender_device->build_firmware_target_path(active_eth_index, 0, 0), active_eth_index, 0, 0);
-    ll_api::memory binary_mem_receive = llrt::get_risc_binary(
+    ll_api::memory const& binary_mem_receive = llrt::get_risc_binary(
         receiver_device->build_firmware_target_path(active_eth_index, 0, 0), active_eth_index, 0, 0);
 
     for (const auto& eth_core : eth_cores) {

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -120,9 +120,9 @@ int main(int argc, char** argv) {
         std::vector<Program> programs;
         std::set<uint32_t> build_keys;
         // kernel->binaries() returns 32B aligned binaries
-        std::map<uint32_t, std::vector<ll_api::memory>> compute_binaries;
-        std::map<uint32_t, std::vector<ll_api::memory>> brisc_binaries;
-        std::map<uint32_t, std::vector<ll_api::memory>> ncrisc_binaries;
+        std::map<uint32_t, std::vector<ll_api::memory const*>> compute_binaries;
+        std::map<uint32_t, std::vector<ll_api::memory const*>> brisc_binaries;
+        std::map<uint32_t, std::vector<ll_api::memory const*>> ncrisc_binaries;
 
         for (int i = 0; i < num_devices; i++) {
             auto device = devices[i];
@@ -211,10 +211,10 @@ int main(int argc, char** argv) {
                             dm_class_idx,
                             0,
                             get_latest_kernel_binary_path(mask, riscv0_kernel));
-                        ll_api::memory brisc_binary = llrt::get_risc_binary(
+                        ll_api::memory const& brisc_binary = llrt::get_risc_binary(
                             brisc_hex_path, 0, 0, 0, ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP);
                         TT_FATAL(
-                            brisc_binary == brisc_binaries.at(mask).at(0),
+                            brisc_binary == *brisc_binaries.at(mask).at(0),
                             "Expected saved BRISC binary to be the same as binary in persistent cache");
                         std::string ncrisc_hex_path = device->build_kernel_target_path(
                             programmable_core_index,
@@ -226,10 +226,10 @@ int main(int argc, char** argv) {
                                 ? ll_api::memory::Relocate::NONE
                                 : ll_api::memory::Relocate::XIP;
 
-                        ll_api::memory ncrisc_binary =
+                        ll_api::memory const& ncrisc_binary =
                             llrt::get_risc_binary(ncrisc_hex_path, 0, 1, 0, ll_api::memory::PackSpans::PACK, relo_type);
                         TT_FATAL(
-                            ncrisc_binary == ncrisc_binaries.at(mask).at(0),
+                            ncrisc_binary == *ncrisc_binaries.at(mask).at(0),
                             "Expected saved NCRISC binary to be the same as binary in persistent cache");
                         for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
                             std::string trisc_id_str = std::to_string(trisc_id);
@@ -238,7 +238,7 @@ int main(int argc, char** argv) {
                                 compute_class_idx,
                                 trisc_id,
                                 get_latest_kernel_binary_path(mask, compute_kernel));
-                            ll_api::memory trisc_binary = llrt::get_risc_binary(
+                            ll_api::memory const& trisc_binary = llrt::get_risc_binary(
                                 trisc_hex_path,
                                 0,
                                 2,
@@ -246,7 +246,7 @@ int main(int argc, char** argv) {
                                 ll_api::memory::PackSpans::PACK,
                                 ll_api::memory::Relocate::XIP);
                             TT_FATAL(
-                                trisc_binary == compute_binaries.at(mask).at(trisc_id),
+                                trisc_binary == *compute_binaries.at(mask).at(trisc_id),
                                 "Expected saved TRISC binary for {} to be the same as binary in persistent cache",
                                 trisc_id_str);
                         }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -420,8 +420,11 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                 auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
                 for (uint32_t riscv_id = build_idx; riscv_id < (build_idx + num_build_states); riscv_id++) {
-                    ll_api::memory binary_mem = llrt::get_risc_binary(
-                        firmware_build_states_[riscv_id]->get_target_out_path(""), core_type_idx, processor_class, (riscv_id - build_idx));
+                    ll_api::memory const& binary_mem = llrt::get_risc_binary(
+                        firmware_build_states_[riscv_id]->get_target_out_path(""),
+                        core_type_idx,
+                        processor_class,
+                        (riscv_id - build_idx));
                     uint32_t fw_size = binary_mem.get_text_size();
                     if (riscv_id == 1) { // TODO: clean up how brisc/ncrisc are handled
                         // In this context, ncrisc_kernel_size16 is the size of the fw
@@ -463,8 +466,11 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                     auto [build_idx, num_build_states] = this->build_processor_type_to_index(core_type_idx, processor_class);
                     for (uint32_t eriscv_id = build_idx; eriscv_id < (build_idx + num_build_states); eriscv_id++) {
-                        ll_api::memory binary_mem = llrt::get_risc_binary(
-                            firmware_build_states_[eriscv_id]->get_target_out_path(""), core_type_idx, processor_class, (eriscv_id - build_idx));
+                        ll_api::memory const& binary_mem = llrt::get_risc_binary(
+                            firmware_build_states_[eriscv_id]->get_target_out_path(""),
+                            core_type_idx,
+                            processor_class,
+                            (eriscv_id - build_idx));
                         uint32_t fw_size = binary_mem.get_text_size();
                         log_debug(LogDevice, "ERISC fw binary size: {} in bytes", fw_size);
                         llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, core_type_idx, processor_class, (eriscv_id - build_idx));

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -151,17 +151,17 @@ uint8_t ComputeKernel::expected_num_binaries() const {
     return 3;
 }
 
-std::vector<ll_api::memory> const &Kernel::binaries(uint32_t build_key) const {
-    int expected_num_binaries = this->expected_num_binaries();
-    if (this->binaries_.find(build_key) != this->binaries_.end() and
-        this->binaries_.at(build_key).size() != expected_num_binaries) {
+std::vector<ll_api::memory const*> const& Kernel::binaries(uint32_t build_key) const {
+    auto iter = binaries_.find(build_key);
+    TT_ASSERT(iter != binaries_.end(), "binary not found");
+    if (iter->second.size() != expected_num_binaries()) {
         TT_THROW(
             "Expected {} binaries but have {} for kernel {}",
-            expected_num_binaries,
-            this->binaries_.at(build_key).size(),
+            expected_num_binaries(),
+            iter->second.size(),
             this->name());
     }
-    return this->binaries_.at(build_key);
+    return iter->second;
 }
 
 std::string DataMovementKernel::config_hash() const {
@@ -310,16 +310,14 @@ bool Kernel::is_idle_eth() const {
 
 uint32_t Kernel::get_binary_packed_size(Device *device, int index) const {
     // In testing situations we can query the size w/o a binary
-    return (this->binaries_.find(device->build_key()) != this->binaries_.end()) ?
-        this->binaries_.at(device->build_key())[index].get_packed_size() :
-        0;
+    auto iter = binaries_.find(device->build_key());
+    return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
 uint32_t Kernel::get_binary_text_size(Device *device, int index) const {
     // In testing situations we can query the size w/o a binary
-    return (this->binaries_.find(device->build_key()) != this->binaries_.end()) ?
-        this->binaries_.at(device->build_key())[index].get_text_size() :
-        0;
+    auto iter = binaries_.find(device->build_key());
+    return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
 }
 
 void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
@@ -357,17 +355,19 @@ void ComputeKernel::generate_binaries(Device *device, JitBuildOptions &build_opt
     jit_build_subset(build_states, this);
 }
 
-void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory> &&binaries) {
-    if (this->binaries_.find(build_key) != this->binaries_.end()) {
-        TT_ASSERT(this->binaries_.at(build_key) == binaries);
-    } else {
-        this->binaries_[build_key] = std::move(binaries);
-    }
+void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory const*>&& binaries) {
+    // Try inserting an empry vector, as that is cheap to construct
+    // and avoids an additonal move.
+    auto pair = binaries_.insert({build_key, {}});
+    if (pair.second)
+        pair.first->second = std::move(binaries);
+    else
+        TT_ASSERT(pair.first->second == binaries);
 }
 
 void DataMovementKernel::read_binaries(Device *device) {
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
-    std::vector<ll_api::memory> binaries;
+    std::vector<ll_api::memory const*> binaries;
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
     // TODO(pgk): consolidate read_binaries where possible
@@ -379,13 +379,15 @@ void DataMovementKernel::read_binaries(Device *device) {
     ll_api::memory::Relocate relo_type =
         (riscv_id == 1 && (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0)) ?
         ll_api::memory::Relocate::NONE : ll_api::memory::Relocate::XIP;
-    ll_api::memory binary_mem = llrt::get_risc_binary(
+    ll_api::memory const& binary_mem = llrt::get_risc_binary(
         build_state.get_target_out_path(this->kernel_full_name_),
         // processor class is BRISC/NCRISC and each have one data movement processor type
-        tensix_core_type, riscv_id, dm_class_idx,
-        ll_api::memory::PackSpans::PACK, relo_type
-    );
-    binaries.push_back(binary_mem);
+        tensix_core_type,
+        riscv_id,
+        dm_class_idx,
+        ll_api::memory::PackSpans::PACK,
+        relo_type);
+    binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, binary_size);
     this->set_binaries(device->build_key(), std::move(binaries));
@@ -394,7 +396,7 @@ void DataMovementKernel::read_binaries(Device *device) {
 void EthernetKernel::read_binaries(Device *device) {
     // untested
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
-    std::vector<ll_api::memory> binaries;
+    std::vector<ll_api::memory const*> binaries;
     uint32_t erisc_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
@@ -403,12 +405,14 @@ void EthernetKernel::read_binaries(Device *device) {
     // TODO: fix when active eth supports relo
     ll_api::memory::Relocate relo_type = (this->config_.eth_mode == Eth::IDLE) ?
         ll_api::memory::Relocate::XIP : ll_api::memory::Relocate::NONE;
-    ll_api::memory binary_mem = llrt::get_risc_binary(
+    ll_api::memory const& binary_mem = llrt::get_risc_binary(
         build_state.get_target_out_path(this->kernel_full_name_),
-        erisc_core_type, erisc_id, dm_class_idx,
-        ll_api::memory::PackSpans::PACK, relo_type
-    );
-   binaries.push_back(binary_mem);
+        erisc_core_type,
+        erisc_id,
+        dm_class_idx,
+        ll_api::memory::PackSpans::PACK,
+        relo_type);
+    binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC {} kernel binary size: {} in bytes", erisc_id, binary_size);
     this->set_binaries(device->build_key(), std::move(binaries));
@@ -416,17 +420,19 @@ void EthernetKernel::read_binaries(Device *device) {
 
 void ComputeKernel::read_binaries(Device *device) {
     TT_ASSERT(!binary_path_.empty(), "Path to Kernel binaries not set!");
-    std::vector<ll_api::memory> binaries;
+    std::vector<ll_api::memory const*> binaries;
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState &build_state = device->build_kernel_state(tensix_core_type, compute_class_idx, trisc_id);
-        ll_api::memory binary_mem = llrt::get_risc_binary(
+        ll_api::memory const& binary_mem = llrt::get_risc_binary(
             build_state.get_target_out_path(this->kernel_full_name_),
-            tensix_core_type, compute_class_idx, trisc_id,
-            ll_api::memory::PackSpans::PACK, ll_api::memory::Relocate::XIP
-        );
-        binaries.push_back(binary_mem);
+            tensix_core_type,
+            compute_class_idx,
+            trisc_id,
+            ll_api::memory::PackSpans::PACK,
+            ll_api::memory::Relocate::XIP);
+        binaries.push_back(&binary_mem);
         uint32_t binary_size = binary_mem.get_packed_size();
         log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", trisc_id + 2, binary_size);
     }
@@ -452,7 +458,7 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
     }
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    ll_api::memory binary_mem = this->binaries(device->build_key()).at(0);
+    ll_api::memory const& binary_mem = *this->binaries(device->build_key())[0];
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     llrt::write_binary_to_address(binary_mem, device_id, worker_core, base_address + offsets[riscv_id]);
 
@@ -462,7 +468,7 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
 bool EthernetKernel::configure(Device *device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const {
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
-    ll_api::memory binary_mem = this->binaries(device->build_key()).at(0);
+    ll_api::memory const& binary_mem = *this->binaries(device->build_key())[0];
 
     if (this->config_.eth_mode == Eth::IDLE) {
         uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
@@ -484,10 +490,10 @@ bool ComputeKernel::configure(Device *device, const CoreCoord &logical_core, uin
     }
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    std::vector<ll_api::memory> binaries = this->binaries(device->build_key());
-
+    std::vector<ll_api::memory const*> const& binaries = this->binaries(device->build_key());
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
-        llrt::write_binary_to_address(binaries.at(trisc_id), device_id, worker_core, base_address + offsets[2 + trisc_id]);
+        llrt::write_binary_to_address(
+            *binaries[trisc_id], device_id, worker_core, base_address + offsets[2 + trisc_id]);
     }
 
     return pass;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -75,7 +75,7 @@ class Kernel : public JitBuildSettings {
 
     bool is_on_logical_core(const CoreCoord &logical_core) const;
 
-    std::vector<ll_api::memory> const &binaries(uint32_t build_key) const;
+    std::vector<ll_api::memory const*> const& binaries(uint32_t build_key) const;
 
     std::vector<uint32_t> compile_time_args() const { return compile_time_args_; }
 
@@ -106,7 +106,7 @@ class Kernel : public JitBuildSettings {
     uint32_t get_binary_packed_size(Device *device, int index) const;
     uint32_t get_binary_text_size(Device *device, int index) const;
     void set_binary_path(const std::string &binary_path) { binary_path_ = binary_path; }
-    void set_binaries(uint32_t build_key, std::vector<ll_api::memory> &&binaries);
+    void set_binaries(uint32_t build_key, std::vector<ll_api::memory const*>&& binaries);
     virtual void read_binaries(Device *device) = 0;
 
     void validate_runtime_args_size(size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core);
@@ -133,7 +133,7 @@ class Kernel : public JitBuildSettings {
     // DataMovement kernels have one binary each and Compute kernels have three binaries
     // Different set of binaries per device because kernel compilation is device dependent
     // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
-    std::unordered_map<chip_id_t, std::vector<ll_api::memory>> binaries_;
+    std::unordered_map<chip_id_t, std::vector<ll_api::memory const*>> binaries_;
     uint8_t dispatch_class_;
     std::vector<uint32_t> compile_time_args_;
     std::vector< std::vector< std::vector<uint32_t>> > core_to_runtime_args_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -953,7 +953,7 @@ void detail::Program_::populate_dispatch_data(Device *device) {
             uint32_t transfer_info_index = 0;
 
             for (size_t sub_kernel_index = 0; sub_kernel_index < binaries.size(); ++sub_kernel_index) {
-                const ll_api::memory &kernel_bin = binaries[sub_kernel_index];
+                const ll_api::memory& kernel_bin = *binaries[sub_kernel_index];
 
                 // Spans are now packed into one
                 // TODO: code below can be simplified w/ a single span
@@ -1231,7 +1231,7 @@ uint32_t detail::Program_::finalize_kernel_bins(Device *device, uint32_t program
             auto& optional_id = kg.kernel_ids[class_id];
             if (optional_id) {
                 const auto kernel = this->get_kernel(optional_id.value());
-                std::vector<ll_api::memory> const &binaries = kernel->binaries(device->build_key());
+                std::vector<ll_api::memory const*> const& binaries = kernel->binaries(device->build_key());
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index == hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
                     uint32_t binary_packed_size = kernel->get_binary_packed_size(device, 0);
@@ -1275,8 +1275,8 @@ uint32_t detail::Program_::finalize_kernel_bins(Device *device, uint32_t program
                         offset += binary_packed_size;
                         offset = align(offset, l1_alignment);
                     } else {
-                        kg.kernel_text_offsets[class_id] = binaries[0].get_text_addr();
-                        kg.launch_msg.kernel_config.kernel_text_offset[class_id] = binaries[0].get_text_addr();
+                        kg.kernel_text_offsets[class_id] = binaries[0]->get_text_addr();
+                        kg.launch_msg.kernel_config.kernel_text_offset[class_id] = binaries[0]->get_text_addr();
                     }
                 }
             }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -44,10 +44,13 @@ using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
 
-ll_api::memory get_risc_binary(string const &path,
-    uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx,
-    ll_api::memory::PackSpans span_type, ll_api::memory::Relocate relo_type) {
-
+ll_api::memory const& get_risc_binary(
+    string const& path,
+    uint32_t core_type_idx,
+    uint32_t processor_class_idx,
+    uint32_t processor_type_idx,
+    ll_api::memory::PackSpans span_type,
+    ll_api::memory::Relocate relo_type) {
     static struct {
       std::unordered_map<std::string, std::unique_ptr<ll_api::memory>> map;
       std::mutex mutex;
@@ -178,7 +181,12 @@ void program_risc_startup_addr(chip_id_t chip_id, const CoreCoord &core) {
 }
 
 bool test_load_write_read_risc_binary(
-    ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx) {
+    ll_api::memory const& mem,
+    chip_id_t chip_id,
+    const CoreCoord& core,
+    uint32_t core_type_idx,
+    uint32_t processor_class_idx,
+    uint32_t processor_type_idx) {
     assert(is_worker_core(core, chip_id) or is_ethernet_core(core, chip_id));
 
     uint64_t local_init_addr = tt::tt_metal::hal.get_binary_local_init_addr(core_type_idx, processor_class_idx, processor_type_idx);
@@ -202,8 +210,7 @@ bool test_load_write_read_risc_binary(
     return true;
 }
 
-void write_binary_to_address(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t address) {
-
+void write_binary_to_address(ll_api::memory const& mem, chip_id_t chip_id, const CoreCoord& core, uint32_t address) {
     log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
         tt::Cluster::instance().write_core(&*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), address);

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -51,11 +51,18 @@ using NUM_REPETITIONS = std::uint32_t;
 using WorkerCore = tt_cxy_pair;
 using WorkerCores = std::vector<WorkerCore>;
 
-ll_api::memory get_risc_binary(string const &path,
-    uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx,
+// Return a reference to a potentially shared binary image.
+// The images are cached by path name, which is never erased.
+// TODO: Remove core_type_idx, processor_class_idx,
+// processor_type_idx -- the information they provide can be
+// obtained directly from the binary image.
+ll_api::memory const& get_risc_binary(
+    string const& path,
+    uint32_t core_type_idx,
+    uint32_t processor_class_idx,
+    uint32_t processor_type_idx,
     ll_api::memory::PackSpans span_type = ll_api::memory::PackSpans::NO_PACK,
     ll_api::memory::Relocate relo_type = ll_api::memory::Relocate::NONE);
-
 
 // TODO: try using "stop" method from device instead, it's the proper way of asserting reset
 
@@ -107,8 +114,13 @@ uint32_t generate_risc_startup_addr(bool is_eth_core);
 void program_risc_startup_addr(chip_id_t chip_id, const CoreCoord &core);
 
 bool test_load_write_read_risc_binary(
-    ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t core_type_idx, uint32_t processor_class_idx, uint32_t processor_type_idx);
-void write_binary_to_address(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, uint32_t address);
+    ll_api::memory const& mem,
+    chip_id_t chip_id,
+    const CoreCoord& core,
+    uint32_t core_type_idx,
+    uint32_t processor_class_idx,
+    uint32_t processor_type_idx);
+void write_binary_to_address(ll_api::memory const& mem, chip_id_t chip_id, const CoreCoord& core, uint32_t address);
 
 // subchannel hard-coded to 0 for now
 CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id = 0);

--- a/tt_metal/llrt/tt_memory.h
+++ b/tt_metal/llrt/tt_memory.h
@@ -41,7 +41,15 @@ class memory {
   memory();
   memory(std::string const &path, Relocate relo_type);
 
- public:
+  public:
+  // These can be large objects, so ban copying ...
+  memory(memory const&) = delete;
+  memory& operator=(memory const&) = delete;
+  // ... but permit moving.
+  memory(memory&&) = default;
+  memory& operator=(memory&&) = default;
+
+  public:
   const std::vector<word_t>& data() const { return this->data_; }
 
   // memory& operator=(memory &&src);
@@ -56,10 +64,6 @@ class memory {
   size_t size() const { return data_.size(); }
 
   size_t num_spans() const { return link_spans_.size(); }
-
-private:
-  // Read from file
-  void fill_from_discontiguous_hex(std::string const &path);
 
 public:
   // Process spans in arg mem to fill data in *this (eg, from device)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13944

### Problem description
I noticed memory objects are passed by value in a lot of places. That's expensive -- they are big

### What's changed
Memory objects are held in a hash table, which has iterator stability and never cleared. Thus we can simply refer to the objects in the hash table.

1) Return and accept const references.
2) Build vector of pointers to same (because vectors of references are not a thing)
3) Delete the copy ctor & assignment
4) Default the move ctor and assignment

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
