### PR TITLE
Add eth chan mapping to generated file

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -324,6 +324,8 @@ void Device::initialize_device_kernel_defines()
     this->device_kernel_defines_.emplace("PCIE_NOC_Y", std::to_string(pcie_cores[0].y));
     this->device_kernel_defines_.emplace("PCIE_NOC1_X", std::to_string(tt::tt_metal::hal.noc_coordinate(NOC::NOC_1, grid_size.x, pcie_cores[0].x)));
     this->device_kernel_defines_.emplace("PCIE_NOC1_Y", std::to_string(tt::tt_metal::hal.noc_coordinate(NOC::NOC_1, grid_size.x, pcie_cores[0].y)));
+
+    this->device_kernel_defines_.emplace("NUM_ETH_CHANS", std::to_string(soc_d.physical_ethernet_cores.size()));
 }
 
 void Device::initialize_build() {
@@ -3563,15 +3565,15 @@ void Device::generate_device_headers(const std::string &path) const
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(this->id());
 
     // Generate header file in proper location
-    jit_build_genfiles_bank_to_noc_coord_descriptor (
+    jit_build_genfiles_bank_to_noc_coord_descriptor(
         path,
         soc_d.grid_size,
         dram_noc_coord_per_bank,
         dram_offsets_per_bank,
         l1_noc_coord_per_bank,
         l1_offset_per_bank,
-        this->get_allocator_alignment()
-    );
+        this->get_allocator_alignment(),
+        soc_d.physical_ethernet_cores);
 }
 
 size_t Device::get_device_kernel_defines_hash() {

--- a/tt_metal/jit_build/genfiles.hpp
+++ b/tt_metal/jit_build/genfiles.hpp
@@ -28,7 +28,8 @@ void jit_build_genfiles_bank_to_noc_coord_descriptor(
     std::vector<int32_t>& dram_bank_offset_map,
     std::vector<CoreCoord>& l1_bank_map,
     std::vector<int32_t>& l1_bank_offset_map,
-    uint32_t allocator_alignment);
+    uint32_t allocator_alignment,
+    const std::vector<CoreCoord>& eth_chan_map);
 
 void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& options);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15460)

### Problem description
Fabric router will need a mapping of ethernet channels to noc_xy_encoding.

### What's changed
Added a generated chan to noc_xy_encoding for ethernet cores.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
