### PR TITLE
#14427: enable routing microperfbenchmark tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
@@ -51,6 +51,13 @@ constexpr uint32_t timeout_cycles = get_compile_time_arg_val(17);
 
 constexpr uint32_t disable_header_check = get_compile_time_arg_val(18);
 
+// Inputs - Update remote rptr
+constexpr uint32_t traffic_gen_input_scratch_buffer_addr = get_compile_time_arg_val(19);
+constexpr uint32_t traffic_gen_input_remote_scratch_buffer_addr = get_compile_time_arg_val(20);
+
+// Outputs
+// None. This is a receiver to check data for testing purposes
+
 // predicts size and payload of packets from each destination, should have
 // the same random seed as the corresponding traffic_gen_tx
 input_queue_rnd_state_t src_rnd_state[num_src_endpoints];
@@ -74,7 +81,9 @@ void kernel_main() {
 
     input_queue->init(input_queue_id, queue_start_addr_words, queue_size_words,
                       remote_tx_x, remote_tx_y, remote_tx_queue_id,
-                      rx_rptr_update_network_type);
+                      rx_rptr_update_network_type,
+                      traffic_gen_input_scratch_buffer_addr,
+                      traffic_gen_input_remote_scratch_buffer_addr);
 
     if (!wait_all_src_dest_ready(input_queue, 1, NULL, 0, timeout_cycles)) {
         test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -68,6 +68,14 @@ packet_output_queue_state_t output_queue;
 constexpr packet_input_queue_state_t* input_queue_ptr = &input_queue;
 constexpr packet_output_queue_state_t* output_queue_ptr = &output_queue;
 
+// Inputs
+constexpr uint32_t traffic_gen_input_scratch_buffer_addr = get_compile_time_arg_val(22);
+constexpr uint32_t traffic_gen_input_mock_remote_scratch_buffer_addr = get_compile_time_arg_val(23);
+
+// Outputs - Update remote wptr
+constexpr uint32_t traffic_gen_output_scratch_buffer_addr = get_compile_time_arg_val(24);
+constexpr uint32_t traffic_gen_output_remote_scratch_buffer_addr = get_compile_time_arg_val(25);
+
 // input_queue_rnd_state_t input_queue_state;
 auto input_queue_state = select_input_queue<pkt_dest_size_choice>();
 
@@ -151,7 +159,9 @@ void kernel_main() {
         0,
         0,
         0,
-        DispatchRemoteNetworkType::NONE);
+        DispatchRemoteNetworkType::NONE,
+        traffic_gen_input_scratch_buffer_addr,
+        traffic_gen_input_mock_remote_scratch_buffer_addr);
 
     output_queue_ptr->init(
         output_queue_id,
@@ -162,7 +172,9 @@ void kernel_main() {
         remote_rx_queue_id,
         tx_network_type,
         input_queue_ptr,
-        1);
+        1, // num_input_queues (one... which is the input from this traffic generator itself)
+        traffic_gen_output_scratch_buffer_addr,
+        traffic_gen_output_remote_scratch_buffer_addr);
 
     if (!wait_all_src_dest_ready(NULL, 0, output_queue_ptr, 1, timeout_cycles)) {
         test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
-#include "tt_metal/third_party/json/json.hpp"
+#include "kernels/traffic_gen_test.hpp"
 #include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/impl/dispatch/cq_commands.hpp"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "tt_metal/third_party/json/json.hpp"
 
 static inline std::string to_string(pkt_dest_size_choices_t choice) {
     switch (choice) {
@@ -23,4 +26,38 @@ static inline void log_phys_coord_to_json(nlohmann::json& config, const std::vec
 
 static inline void log_phys_coord_to_json(nlohmann::json& config, const CoreCoord& phys_core, const std::string& name) {
     config[name] = fmt::format("({}, {})", phys_core.x, phys_core.y);
+}
+
+static std::vector<std::shared_ptr<Buffer>> allocated;
+
+// Make buffer address for test. The address are created continguously on order of the stage_config
+std::map<std::string, std::vector<uint32_t>> make_buffer_addresses_for_test(uint32_t base_address, uint32_t per_buffer_size, const std::vector<std::pair<std::string, uint32_t>>& stage_config) {
+    // Use a vector to make the addresses to keep everything continiguous
+    std::vector<std::vector<uint32_t>> scratch_buffers;
+
+    for (int stage = 0; stage < stage_config.size(); stage++) {
+        assert(stage_config[stage].second > 0 && "Each stage must consist of at least 1 kernel");
+
+        std::vector<uint32_t> addresses_for_stage;
+        if (stage == 0) {
+            addresses_for_stage.push_back(base_address);
+        } else {
+            addresses_for_stage.push_back(scratch_buffers.back().back() + per_buffer_size);
+        }
+
+        // Start at kernel 1 as the address for kernel 0 is already in the addresses_for_stage
+        for (int kernel = 1; kernel < stage_config[stage].second; kernel++) {
+            addresses_for_stage.push_back(addresses_for_stage.back() + per_buffer_size);
+        }
+
+        scratch_buffers.push_back(std::move(addresses_for_stage));
+    }
+
+    // Convert the vector to a map indexed by the stage name
+    std::map<std::string, std::vector<uint32_t>> scratch_buffers_by_stage;
+    for (int stage = 0; stage < stage_config.size(); stage++) {
+        scratch_buffers_by_stage[stage_config[stage].first] = std::move(scratch_buffers[stage]);
+    }
+
+    return scratch_buffers_by_stage;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -5,18 +5,14 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
-#include "kernels/traffic_gen_test.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
-using std::vector;
 using namespace tt;
 using json = nlohmann::json;
 
-int main(int argc, char **argv) {
 
+int main(int argc, char **argv) {
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;
     constexpr uint32_t default_rx_x = 0;
@@ -30,6 +26,9 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_prng_seed = 0x100;
     constexpr uint32_t default_data_kb_per_tx = 1024*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_input_scratch_buffer_base_addr = 0x60000;
+    constexpr uint32_t default_output_scratch_buffer_base_addr = 0x70000;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
     constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
@@ -98,6 +97,8 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
         log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
         log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        log_info(LogTest, "  --input_scratch_buffer_base_addr: Scratch buffer for input queues base address, default = {:#x}", default_input_scratch_buffer_base_addr);
+        log_info(LogTest, "  --output_scratch_buffer_base_addr: Scratch buffer for output queues base address, default = {:#x}", default_output_scratch_buffer_base_addr);
         return 0;
     }
 
@@ -133,11 +134,27 @@ int main(int argc, char **argv) {
     uint8_t tx_pkt_dest_size_choice = (uint8_t) test_args::get_command_option_uint32(input_args, "--tx_pkt_dest_size_choice", default_tx_pkt_dest_size_choice);
     uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
     uint32_t tx_data_sent_per_iter_high = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_high", default_tx_data_sent_per_iter_high);
+    uint32_t input_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--input_scratch_buffer_base_addr", default_input_scratch_buffer_base_addr);
+    uint32_t output_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--output_scratch_buffer_base_addr", default_output_scratch_buffer_base_addr);
 
     assert((pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE && rx_disable_header_check || (pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM);
 
     uint32_t num_src_endpoints = num_endpoints;
     uint32_t num_dest_endpoints = num_endpoints;
+
+    const auto input_scratch_buffers = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "mux", num_src_endpoints },
+        { "demux", 1 },
+        { "traffic_gen_rx", num_dest_endpoints},
+    });
+
+    const auto output_scratch_buffers = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx_mock", num_src_endpoints },
+        { "traffic_gen_tx", num_src_endpoints },
+        { "mux", 1 },
+        { "demux", num_dest_endpoints },
+    });
 
     bool pass = true;
 
@@ -188,7 +205,11 @@ int main(int argc, char **argv) {
                     tx_skip_pkt_content_gen, // 18: skip_pkt_content_gen
                     tx_pkt_dest_size_choice, // 19: pkt_dest_size_choice
                     tx_data_sent_per_iter_low, // 20: data_sent_per_iter_low
-                    tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
+                    tx_data_sent_per_iter_high, // 21: data_sent_per_iter_high
+                    input_scratch_buffers.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers.at("traffic_gen_tx_mock")[i], // 23: traffic_gen_input_mock_remote_scratch_buffer_addr
+                    output_scratch_buffers.at("traffic_gen_tx")[i], // 24: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers.at("mux")[i], // 25: traffic_gen_output_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
@@ -229,7 +250,9 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id, // 15: src_endpoint_start_id
                     dest_endpoint_start_id, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
-                    rx_disable_header_check // 18: disable_header_check
+                    rx_disable_header_check, // 18: disable_header_check
+                    input_scratch_buffers.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers.at("demux")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
@@ -282,7 +305,19 @@ int main(int argc, char **argv) {
                 test_results_addr, // 14: test_results_addr
                 test_results_size, // 15: test_results_size
                 timeout_mcycles * 1000 * 1000, // 16: timeout_cycles,
-                0, 0, 0, 0, 0, 0, 0, 0 // 17-24: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, // 17-24: packetize/depacketize settings
+                input_scratch_buffers.at("mux")[0], // 25: mux_input_scratch_buffers[0]
+                num_src_endpoints > 1 ? input_scratch_buffers.at("mux")[1] : 0, // 26: mux_input_scratch_buffers[1]
+                num_src_endpoints > 2 ? input_scratch_buffers.at("mux")[2] : 0, // 27: mux_input_scratch_buffers[2]
+                num_src_endpoints > 3 ? input_scratch_buffers.at("mux")[3] : 0, // 28: mux_input_scratch_buffers[3]
+
+                output_scratch_buffers.at("traffic_gen_tx")[0], // 29: mux_input_remote_scratch_buffers[0]
+                num_src_endpoints > 1 ? output_scratch_buffers.at("traffic_gen_tx")[1] : 0, // 30: mux_input_remote_scratch_buffers[1]
+                num_src_endpoints > 2 ? output_scratch_buffers.at("traffic_gen_tx")[2] : 0, // 31: mux_input_remote_scratch_buffers[2]
+                num_src_endpoints > 3 ? output_scratch_buffers.at("traffic_gen_tx")[3] : 0, // 32: mux_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers.at("mux")[0], // 33: mux_output_scratch_buffer
+                input_scratch_buffers.at("demux")[0], // 34: mux_output_remote_scratch_buffer
             };
 
         log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
@@ -340,7 +375,18 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
-                0, 0, 0, 0, 0 // 25-29: packetize/depacketize settings
+                0, 0, 0, 0, 0, // 25-29: packetize/depacketize settings
+                input_scratch_buffers.at("demux")[0], // 30: demux_input_scratch_buffer
+                output_scratch_buffers.at("mux")[0], // 31: demux_input_remote_scratch_buffer
+                output_scratch_buffers.at("demux")[0], // 32: demux_output_scratch_buffers[0]
+                num_dest_endpoints > 1 ? output_scratch_buffers.at("demux")[1] : 0, // 33: demux_output_scratch_buffers[1]
+                num_dest_endpoints > 2 ? output_scratch_buffers.at("demux")[2] : 0, // 34: demux_output_scratch_buffers[2]
+                num_dest_endpoints > 3 ? output_scratch_buffers.at("demux")[3] : 0, // 35: demux_output_scratch_buffers[3]
+
+                input_scratch_buffers.at("traffic_gen_rx")[0], // 36: demux_output_remote_scratch_buffers[0]
+                num_dest_endpoints > 1 ? input_scratch_buffers.at("traffic_gen_rx")[1] : 0, // 37: demux_output_remote_scratch_buffers[1]
+                num_dest_endpoints > 2 ? input_scratch_buffers.at("traffic_gen_rx")[2] : 0, // 38: demux_output_remote_scratch_buffers[2]
+                num_dest_endpoints > 3 ? input_scratch_buffers.at("traffic_gen_rx")[3] : 0, // 39: demux_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
@@ -365,8 +411,8 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        vector<vector<uint32_t>> tx_results;
-        vector<vector<uint32_t>> rx_results;
+        std::vector<std::vector<uint32_t>> tx_results;
+        std::vector<std::vector<uint32_t>> rx_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
@@ -384,13 +430,13 @@ int main(int argc, char **argv) {
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
-        vector<uint32_t> mux_results =
+        std::vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> demux_results =
+        std::vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -6,18 +6,18 @@
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
-#include "kernels/traffic_gen_test.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
-using std::vector;
 using namespace tt;
 
 
 int main(int argc, char **argv) {
-
     constexpr uint32_t default_prng_seed = 0x100;
     constexpr uint32_t default_data_kb_per_tx = 64*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_input_scratch_buffer_base_addr = 0x60000;
+    constexpr uint32_t default_output_scratch_buffer_base_addr = 0x70000;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
     constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
@@ -56,6 +56,8 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --test_results_size: test results buffer size, default = 0x{:x}", default_test_results_size);
         log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
         log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        log_info(LogTest, "  --input_scratch_buffer_base_addr: Scratch buffer for input queues base address, default = {:#x}", default_input_scratch_buffer_base_addr);
+        log_info(LogTest, "  --output_scratch_buffer_base_addr: Scratch buffer for output queues base address, default = {:#x}", default_output_scratch_buffer_base_addr);
         return 0;
     }
 
@@ -74,6 +76,8 @@ int main(int argc, char **argv) {
     uint32_t test_results_size = test_args::get_command_option_uint32(input_args, "--test_results_size", default_test_results_size);
     uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
     uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+    uint32_t input_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--input_scratch_buffer_base_addr", default_input_scratch_buffer_base_addr);
+    uint32_t output_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--output_scratch_buffer_base_addr", default_output_scratch_buffer_base_addr);
 
     constexpr uint32_t num_src_endpoints = 16;
     constexpr uint32_t num_dest_endpoints = 16;
@@ -90,6 +94,25 @@ int main(int argc, char **argv) {
     std::map<string, string> defines = {
         {"FD_CORE_TYPE", std::to_string(0)}, // todo, support dispatch on eth
     };
+
+    const auto input_scratch_buffers = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "mux_l1", num_src_endpoints },
+        { "mux_l2", num_mux_l1 },
+        { "demux_l1", num_demux_l1 },
+        { "demux_l2", num_demux_l2 },
+        { "traffic_gen_rx", num_dest_endpoints},
+    });
+
+    const auto output_scratch_buffers = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "mux_l1", num_mux_l1 },
+        { "mux_l2", num_mux_l2 },
+        { "demux_l1", num_demux_l2 },
+        { "demux_l2", num_dest_endpoints },
+        { "demux", num_dest_endpoints },
+        // RX Gen has no output
+    });
 
     try {
         int device_id = 0;
@@ -172,7 +195,10 @@ int main(int argc, char **argv) {
                     0, // 18: skip_pkt_content_gen
                     0, // 19: pkt_dest_size_choice
                     0, // 20: data_sent_per_iter_low
-                    0 // 21: data_sent_per_iter_high
+                    0, // 21: data_sent_per_iter_high
+                    input_scratch_buffers.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers.at("traffic_gen_tx")[i], // 23: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers.at("mux_l1")[i], // 24: traffic_gen_output_remote_scratch_buffer_addr
                 };
             log_info(LogTest, "run TX {} at x={},y={} (phys x={},y={})",
                             i, tx_core[i].x, tx_core[i].y, tx_phys_core[i].x, tx_phys_core[i].y);
@@ -212,7 +238,9 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id, // 15: src_endpoint_start_id
                     dest_endpoint_start_id, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
-                    0 // 18: disable_header_check
+                    0, // 18: disable_header_check
+                    input_scratch_buffers.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers.at("demux_l2")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
             log_info(LogTest, "run RX {} at x={},y={} (phys x={},y={})",
                     i, rx_core[i].x, rx_core[i].y, rx_phys_core[i].x, rx_phys_core[i].y);
@@ -263,7 +291,19 @@ int main(int argc, char **argv) {
                     test_results_addr, // 14: test_results_addr
                     test_results_size, // 15: test_results_size
                     timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
-                    0, 0, 0, 0, 0, 0, 0, 0 // 17-24: packetize/depacketize settings
+                    0, 0, 0, 0, 0, 0, 0, 0, // 17-24: packetize/depacketize settings
+                    input_scratch_buffers.at("mux_l1")[i * MAX_SWITCH_FAN_IN], // 25: mux_input_scratch_buffers[0]
+                    input_scratch_buffers.at("mux_l1")[i * MAX_SWITCH_FAN_IN + 1], // 26: mux_input_scratch_buffers[1]
+                    input_scratch_buffers.at("mux_l1")[i * MAX_SWITCH_FAN_IN + 2], // 27: mux_input_scratch_buffers[2]
+                    input_scratch_buffers.at("mux_l1")[i * MAX_SWITCH_FAN_IN + 3], // 28: mux_input_scratch_buffers[3]
+
+                    output_scratch_buffers.at("traffic_gen_tx")[i * MAX_SWITCH_FAN_IN], // 29: mux_input_remote_scratch_buffers[0]
+                    output_scratch_buffers.at("traffic_gen_tx")[i * MAX_SWITCH_FAN_IN + 1], // 30: mux_input_remote_scratch_buffers[1]
+                    output_scratch_buffers.at("traffic_gen_tx")[i * MAX_SWITCH_FAN_IN + 2], // 31: mux_input_remote_scratch_buffers[2]
+                    output_scratch_buffers.at("traffic_gen_tx")[i * MAX_SWITCH_FAN_IN + 3], // 32: mux_input_remote_scratch_buffers[3]
+
+                    output_scratch_buffers.at("mux_l1")[i], // 33: mux_output_scratch_buffer
+                    input_scratch_buffers.at("mux_l2")[mux_l2_port_index], // 34: mux_output_remote_scratch_buffer
                 };
             log_info(LogTest, "run L1 MUX {} at x={},y={} (phys x={},y={})",
                             i, mux_l1_core[i].x, mux_l1_core[i].y, mux_l1_phys_core[i].x, mux_l1_phys_core[i].y);
@@ -311,7 +351,19 @@ int main(int argc, char **argv) {
                 test_results_addr, // 14: test_results_addr
                 test_results_size, // 15: test_results_size
                 timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0 // 17-24: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, // 17-24: packetize/depacketize settings
+                input_scratch_buffers.at("mux_l2")[0], // 25: mux_input_scratch_buffers[0]
+                input_scratch_buffers.at("mux_l2")[1], // 26: mux_input_scratch_buffers[1]
+                input_scratch_buffers.at("mux_l2")[2], // 27: mux_input_scratch_buffers[2]
+                input_scratch_buffers.at("mux_l2")[3], // 28: mux_input_scratch_buffers[3]
+
+                output_scratch_buffers.at("mux_l1")[0], // 29: mux_input_remote_scratch_buffers[0]
+                output_scratch_buffers.at("mux_l1")[1], // 30: mux_input_remote_scratch_buffers[1]
+                output_scratch_buffers.at("mux_l1")[2], // 31: mux_input_remote_scratch_buffers[2]
+                output_scratch_buffers.at("mux_l1")[3], // 32: mux_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers.at("mux_l2")[0], // 33: mux_output_scratch_buffer
+                input_scratch_buffers.at("demux_l1")[0], // 34: mux_output_remote_scratch_buffer
             };
         log_info(LogTest, "run L2 MUX at x={},y={} (phys x={},y={})",
                  mux_l2_core.x, mux_l2_core.y, mux_l2_phys_core.x, mux_l2_phys_core.y);
@@ -371,7 +423,18 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
-                0, 0, 0, 0, 0 // 25-29: packetize/depacketize settings
+                0, 0, 0, 0, 0, // 25-29: packetize/depacketize settings
+                input_scratch_buffers.at("demux_l1")[0], // 30: demux_input_scratch_buffer
+                output_scratch_buffers.at("mux_l2")[0], // 31: demux_input_remote_scratch_buffer
+                output_scratch_buffers.at("demux_l1")[0], // 32: demux_output_scratch_buffers[0]
+                output_scratch_buffers.at("demux_l1")[1], // 33: demux_output_scratch_buffers[1]
+                output_scratch_buffers.at("demux_l1")[2], // 34: demux_output_scratch_buffers[2]
+                output_scratch_buffers.at("demux_l1")[3], // 35: demux_output_scratch_buffers[3]
+
+                input_scratch_buffers.at("demux_l2")[0], // 36: demux_output_remote_scratch_buffers[0]
+                input_scratch_buffers.at("demux_l2")[1], // 37: demux_output_remote_scratch_buffers[1]
+                input_scratch_buffers.at("demux_l2")[2], // 38: demux_output_remote_scratch_buffers[2]
+                input_scratch_buffers.at("demux_l2")[3], // 39: demux_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run L1 DEMUX at x={},y={} (phys x={},y={})",
@@ -436,11 +499,22 @@ int main(int argc, char **argv) {
                     test_results_addr, // 22: test_results_addr
                     test_results_size, // 23: test_results_size
                     timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
-                    0, 0, 0, 0, 0 // 25-29: packetize/depacketize settings
+                    0, 0, 0, 0, 0, // 25-29: packetize/depacketize settings
+                    input_scratch_buffers.at("demux_l2")[i], // 30: demux_input_scratch_buffer
+                    output_scratch_buffers.at("demux_l1")[i], // 31: demux_input_remote_scratch_buffer
+                    output_scratch_buffers.at("demux_l2")[i * num_demux_l2], // 32: demux_output_scratch_buffers[0]
+                    output_scratch_buffers.at("demux_l2")[i * num_demux_l2 + 1], // 33: demux_output_scratch_buffers[1]
+                    output_scratch_buffers.at("demux_l2")[i * num_demux_l2 + 2], // 34: demux_output_scratch_buffers[2]
+                    output_scratch_buffers.at("demux_l2")[i * num_demux_l2 + 3], // 35: demux_output_scratch_buffers[3]
+
+                    input_scratch_buffers.at("traffic_gen_rx")[i * num_demux_l2], // 36: demux_output_remote_scratch_buffers[0]
+                    input_scratch_buffers.at("traffic_gen_rx")[i * num_demux_l2 + 1], // 37: demux_output_remote_scratch_buffers[1]
+                    input_scratch_buffers.at("traffic_gen_rx")[i * num_demux_l2 + 2], // 38: demux_output_remote_scratch_buffers[2]
+                    input_scratch_buffers.at("traffic_gen_rx")[i * num_demux_l2 + 3], // 39: demux_output_remote_scratch_buffers[3]
                 };
 
-            log_info(LogTest, "run L2 DEMUX at x={},y={} (phys x={},y={})",
-                            demux_l2_core[i].x, demux_l2_core[i].y, demux_l2_phys_core[i].x, demux_l2_phys_core[i].y);
+            log_info(LogTest, "run L2 DEMUX {} at x={},y={} (phys x={},y={})",
+                            i, demux_l2_core[i].x, demux_l2_core[i].y, demux_l2_phys_core[i].x, demux_l2_phys_core[i].y);
             auto demux_kernel = tt_metal::CreateKernel(
                 program,
                 "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
@@ -464,12 +538,12 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        vector<vector<uint32_t>> tx_results;
-        vector<vector<uint32_t>> rx_results;
-        vector<vector<uint32_t>> mux_l1_results;
-        vector<uint32_t> mux_l2_results;
-        vector<vector<uint32_t>> demux_l2_results;
-        vector<uint32_t> demux_l1_results;
+        std::vector<std::vector<uint32_t>> tx_results;
+        std::vector<std::vector<uint32_t>> rx_results;
+        std::vector<std::vector<uint32_t>> mux_l1_results;
+        std::vector<uint32_t> mux_l2_results;
+        std::vector<std::vector<uint32_t>> demux_l2_results;
+        std::vector<uint32_t> demux_l1_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
@@ -31,6 +31,9 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_data_kb_per_tx = 1024*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
 
+    constexpr uint32_t default_input_scratch_buffer_base_addr = 0x50000;
+    constexpr uint32_t default_output_scratch_buffer_base_addr = 0x60000;
+
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
     constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
     constexpr uint32_t default_rx_queue_start_addr = 0xa0000;
@@ -44,9 +47,10 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_test_results_size = 0x40000;
 
     constexpr uint32_t default_tunneler_queue_start_addr = 0x19000;
-    constexpr uint32_t default_tunneler_queue_size_bytes = 0x4000; // * 8 as it is birectional, maximum queue size for ecore L1 (power of 2)
+    constexpr uint32_t default_tunneler_queue_size_bytes = 0x4000;
     constexpr uint32_t default_tunneler_test_results_addr = 0x39000;
-    constexpr uint32_t default_tunneler_test_results_size = 0x7000;
+    constexpr uint32_t default_tunneler_test_results_size = 0x1000;
+    constexpr uint32_t default_tunneler_buffer_base_addr =  0x3A000;
 
     constexpr uint32_t default_timeout_mcycles = 1000;
     constexpr uint32_t default_rx_disable_data_check = 0;
@@ -107,6 +111,9 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
         log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
         log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        log_info(LogTest, "  --input_scratch_buffer_base_addr: Scratch buffer for input queues base address, default = {:#x}", default_input_scratch_buffer_base_addr);
+        log_info(LogTest, "  --output_scratch_buffer_base_addr: Scratch buffer for output queues base address, default = {:#x}", default_output_scratch_buffer_base_addr);
+        log_info(LogTest, "  --tunneler_scratch_buffer_base_addr: Scratch buffer for tunneler queues base address, default = {:#x}", default_tunneler_buffer_base_addr);
         return 0;
     }
 
@@ -146,6 +153,9 @@ int main(int argc, char **argv) {
     uint8_t tx_pkt_dest_size_choice = (uint8_t) test_args::get_command_option_uint32(input_args, "--tx_pkt_dest_size_choice", default_tx_pkt_dest_size_choice);
     uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
     uint32_t tx_data_sent_per_iter_high = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_high", default_tx_data_sent_per_iter_high);
+    uint32_t input_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--input_scratch_buffer_base_addr", default_input_scratch_buffer_base_addr);
+    uint32_t output_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--output_scratch_buffer_base_addr", default_output_scratch_buffer_base_addr);
+    uint32_t tunneler_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--tunneler_buffer_base_addr", default_tunneler_buffer_base_addr);
 
     assert((pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE && rx_disable_header_check || (pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM);
 
@@ -154,6 +164,40 @@ int main(int argc, char **argv) {
     std::map<string, string> defines = {
         {"FD_CORE_TYPE", std::to_string(0)}, // todo, support dispatch on eth
     };
+
+    // Same kernel layout on both devices
+    // The addresses will be the same but on remote noc,
+    // however, still make two arrays for clarity in the compile args
+    // TODO(nhuang): Refactor / cleanup the duplicate code for the kernel setups
+    using topology = std::vector<std::pair<std::string, uint32_t>>;
+
+    const topology input_topology = {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "mux", MAX_SWITCH_FAN_IN },
+        { "demux", MAX_SWITCH_FAN_IN },
+        { "traffic_gen_rx", MAX_SWITCH_FAN_IN },
+    };
+
+    const topology output_topology = {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "traffic_gen_tx_mock", num_src_endpoints },
+        { "mux", MAX_SWITCH_FAN_IN },
+        { "demux", MAX_SWITCH_FAN_IN },
+        { "traffic_gen_rx", MAX_SWITCH_FAN_IN },
+    };
+
+    const topology tunneler_topology = {
+        { "input", MAX_TUNNEL_LANES },
+        { "output", MAX_TUNNEL_LANES },
+    };
+
+    const auto input_scratch_buffers_left = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, input_topology);
+    const auto output_scratch_buffers_left = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, output_topology);
+    const auto tunneler_buffers_left = make_buffer_addresses_for_test(tunneler_buffer_base_addr, packet_queue_scratch_buffer_size, tunneler_topology);
+
+    const auto input_scratch_buffers_right = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, input_topology);
+    const auto output_scratch_buffers_right = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, output_topology);
+    const auto tunneler_buffers_right = make_buffer_addresses_for_test(tunneler_buffer_base_addr, packet_queue_scratch_buffer_size, tunneler_topology);
 
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
@@ -237,7 +281,11 @@ int main(int argc, char **argv) {
                     tx_skip_pkt_content_gen, // 18: skip_pkt_content_gen
                     tx_pkt_dest_size_choice, // 19: pkt_dest_size_choice
                     tx_data_sent_per_iter_low, // 20: data_sent_per_iter_low
-                    tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
+                    tx_data_sent_per_iter_high, // 21: data_sent_per_iter_high
+                    input_scratch_buffers_left.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_left.at("traffic_gen_tx_mock")[i], // 23: traffic_gen_input_mock_remote_scratch_buffer_addr
+                    output_scratch_buffers_left.at("traffic_gen_tx")[i], // 24: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers_left.at("mux")[i], // 25: traffic_gen_output_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
@@ -281,7 +329,11 @@ int main(int argc, char **argv) {
                     tx_skip_pkt_content_gen, // 18: skip_pkt_content_gen
                     tx_pkt_dest_size_choice, // 19: pkt_dest_size_choice
                     tx_data_sent_per_iter_low, // 20: data_sent_per_iter_low
-                    tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
+                    tx_data_sent_per_iter_high, // 21: data_sent_per_iter_high
+                    input_scratch_buffers_right.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_right.at("traffic_gen_tx_mock")[i], // 23: traffic_gen_input_mock_remote_scratch_buffer_addr
+                    output_scratch_buffers_right.at("traffic_gen_tx")[i], // 24: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers_right.at("mux")[i], // 25: traffic_gen_output_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_tx_r at x={},y={}", core.x, core.y);
@@ -322,7 +374,9 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id + i, // 15: src_endpoint_start_id
                     dest_endpoint_start_id + i, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
-                    rx_disable_header_check // 18: disable_header_check
+                    rx_disable_header_check, // 18: disable_header_check
+                    input_scratch_buffers_left.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_left.at("demux")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
@@ -363,7 +417,9 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id + i, // 15: src_endpoint_start_id
                     dest_endpoint_start_id + i, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
-                    rx_disable_header_check // 18: disable_header_check
+                    rx_disable_header_check, // 18: disable_header_check
+                    input_scratch_buffers_right.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_right.at("demux")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_rx_r at x={},y={}", core.x, core.y);
@@ -407,7 +463,6 @@ int main(int argc, char **argv) {
                                       (uint32_t)tunneler_phys_core.y,
                                       3,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: dest 0 info
-
                 (tunneler_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
                 (tunneler_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
                 ((tunneler_queue_start_addr + tunneler_queue_size_bytes) >> 4), // 10: remote_tx_queue_start_addr_words
@@ -432,11 +487,31 @@ int main(int argc, char **argv) {
                                       (uint32_t)tx_phys_core[3].y,
                                       1,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 19: src 3 info
-                0, 0, //20, 21
+                0, 0, // 20, 21
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25 - 35: packetize/depacketize settings
+
+                input_scratch_buffers_left.at("mux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_left.at("mux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_left.at("mux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_left.at("mux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("traffic_gen_tx")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                output_scratch_buffers_left.at("traffic_gen_tx")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                output_scratch_buffers_left.at("traffic_gen_tx")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                output_scratch_buffers_left.at("traffic_gen_tx")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("mux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_left.at("mux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_left.at("mux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_left.at("mux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                tunneler_buffers_left.at("input")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("input")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("input")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("input")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
@@ -499,11 +574,30 @@ int main(int argc, char **argv) {
                                       (uint32_t)tx_phys_core_r[3].y,
                                       1,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 19: src 3 info
-                0, 0, //20, 21
+                0, 0, // 20, 21
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25 - 35: packetize/depacketize settings
+                input_scratch_buffers_right.at("mux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_right.at("mux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_right.at("mux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_right.at("mux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                output_scratch_buffers_right.at("traffic_gen_tx")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                output_scratch_buffers_right.at("traffic_gen_tx")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                output_scratch_buffers_right.at("traffic_gen_tx")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                output_scratch_buffers_right.at("traffic_gen_tx")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_right.at("mux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_right.at("mux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_right.at("mux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_right.at("mux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                tunneler_buffers_right.at("input")[4], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[5], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[6], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[7], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
@@ -525,7 +619,6 @@ int main(int argc, char **argv) {
                 2*num_endpoints, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
                 (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
                 (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
-
                 packet_switch_4B_pack(r_tunneler_phys_core.x,
                                       r_tunneler_phys_core.y,
                                       0,
@@ -546,21 +639,20 @@ int main(int argc, char **argv) {
                 packet_switch_4B_pack(demux_phys_core.x,
                                       demux_phys_core.y,
                                       0,
-                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 8: remote_receiver_1_info
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 8: remote_receiver_4_info
                 packet_switch_4B_pack(demux_phys_core.x,
                                       demux_phys_core.y,
                                       1,
-                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 9: remote_receiver_1_info
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 9: remote_receiver_5_info
                 packet_switch_4B_pack(demux_phys_core.x,
                                       demux_phys_core.y,
                                       2,
-                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 10: remote_receiver_1_info
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 10: remote_receiver_6_info
                 packet_switch_4B_pack(demux_phys_core.x,
                                       demux_phys_core.y,
                                       3,
-                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 11: remote_receiver_1_info
-                0, 0, // 12 - 13: remote_receiver 8 - 9
-
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 11: remote_receiver_7_info
+                0, 0, // 12 - 13: remote_receiver_info[8 - 9]
                 (tunneler_queue_start_addr >> 4), // 14: remote_receiver_queue_start_addr_words 0
                 (tunneler_queue_size_bytes >> 4), // 15: remote_receiver_queue_size_words 0
                 ((tunneler_queue_start_addr + tunneler_queue_size_bytes) >> 4), // 16: remote_receiver_queue_start_addr_words 1
@@ -577,13 +669,9 @@ int main(int argc, char **argv) {
                 (demux_queue_size_bytes >> 4), // 27: remote_receiver_queue_size_words 6
                 ((demux_queue_start_addr + 3 * demux_queue_size_bytes) >> 4), // 28: remote_receiver_queue_start_addr_words 7
                 (demux_queue_size_bytes >> 4), // 29: remote_receiver_queue_size_words 7
-
-                0, 2, // 30 - 31 Settings for remote reciver 8
+                0, 2, // 30 - 31 Settings for remote receiver 8
                 0, // 32: remote_receiver_queue_start_addr_words 9
-                2, // 33: remote_receiver_queue_size_words 9.
-                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
-
-
+                2, // 33: remote_receiver_queue_size_words 9. Unused. Setting to 2 to get around size check assertion that does not allow 0.
                 packet_switch_4B_pack(mux_phys_core.x,
                                       mux_phys_core.y,
                                       num_dest_endpoints,
@@ -616,12 +704,50 @@ int main(int argc, char **argv) {
                                       r_tunneler_phys_core.y,
                                       15,
                                       (uint32_t)DispatchRemoteNetworkType::ETH), // 41: remote_sender_7_info
-                0, 0, // 42 - 43: remote_sender 8 - 9
-
+                0, 0, // 42 - 43: remote_sender[8 - 9]
                 tunneler_test_results_addr, // 44: test_results_addr
                 tunneler_test_results_size, // 45: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 46: timeout_cycles
-                0, //47: inner_stop_mux_d_bypass
+                0, // 47: inner_stop_mux_d_bypass
+                tunneler_buffers_left.at("input")[0], // 48: vc_eth_tunneler_input_scratch_buffers[0]
+                tunneler_buffers_left.at("input")[1], // 49: vc_eth_tunneler_input_scratch_buffers[1]
+                tunneler_buffers_left.at("input")[2], // 50: vc_eth_tunneler_input_scratch_buffers[2]
+                tunneler_buffers_left.at("input")[3], // 51: vc_eth_tunneler_input_scratch_buffers[3]
+                tunneler_buffers_left.at("input")[4], // 52: vc_eth_tunneler_input_scratch_buffers[4]
+                tunneler_buffers_left.at("input")[5], // 53: vc_eth_tunneler_input_scratch_buffers[5]
+                tunneler_buffers_left.at("input")[6], // 54: vc_eth_tunneler_input_scratch_buffers[6]
+                tunneler_buffers_left.at("input")[7], // 55: vc_eth_tunneler_input_scratch_buffers[7]
+                0, 0, // 56 - 57: vc_eth_tunneler_input_scratch_buffers[8 - 9]
+
+                output_scratch_buffers_left.at("mux")[0], // 58: vc_eth_tunneler_input_remote_scratch_buffers[0]
+                output_scratch_buffers_left.at("mux")[1], // 59: vc_eth_tunneler_input_remote_scratch_buffers[1]
+                output_scratch_buffers_left.at("mux")[2], // 60: vc_eth_tunneler_input_remote_scratch_buffers[2]
+                output_scratch_buffers_left.at("mux")[3], // 61: vc_eth_tunneler_input_remote_scratch_buffers[3]
+                tunneler_buffers_right.at("output")[4], // 62: vc_eth_tunneler_input_remote_scratch_buffers[4]
+                tunneler_buffers_right.at("output")[5], // 63: vc_eth_tunneler_input_remote_scratch_buffers[5]
+                tunneler_buffers_right.at("output")[6], // 63: vc_eth_tunneler_input_remote_scratch_buffers[7]
+                tunneler_buffers_right.at("output")[7], // 63: vc_eth_tunneler_input_remote_scratch_buffers[8]
+                0, 0, // 66 - 67: vc_eth_tunneler_input_remote_scratch_buffers[8 - 9]
+
+                tunneler_buffers_left.at("output")[0], // 68: vc_eth_tunneler_output_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[1], // 69: vc_eth_tunneler_output_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[2], // 70: vc_eth_tunneler_output_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[3], // 71: vc_eth_tunneler_output_scratch_buffers[3]
+                tunneler_buffers_left.at("output")[4], // 72: vc_eth_tunneler_output_scratch_buffers[4]
+                tunneler_buffers_left.at("output")[5], // 73: vc_eth_tunneler_output_scratch_buffers[5]
+                tunneler_buffers_left.at("output")[6], // 74: vc_eth_tunneler_output_scratch_buffers[6]
+                tunneler_buffers_left.at("output")[7], // 75: vc_eth_tunneler_output_scratch_buffers[7]
+                0, 0, // 76 - 77: vc_eth_tunneler_output_scratch_buffers[8 - 9]
+
+                tunneler_buffers_right.at("input")[0], // 78: vc_eth_tunneler_output_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[1], // 79: vc_eth_tunneler_output_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[2], // 80: vc_eth_tunneler_output_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[3], // 81: vc_eth_tunneler_output_remote_scratch_buffers[3]
+                input_scratch_buffers_left.at("demux")[0], // 82: vc_eth_tunneler_output_remote_scratch_buffers[4]
+                input_scratch_buffers_left.at("demux")[1], // 83: vc_eth_tunneler_output_remote_scratch_buffers[5]
+                input_scratch_buffers_left.at("demux")[2], // 84: vc_eth_tunneler_output_remote_scratch_buffers[6]
+                input_scratch_buffers_left.at("demux")[3], // 85: vc_eth_tunneler_output_remote_scratch_buffers[7]
+                0, 0, // 86 - 87: vc_eth_tunneler_output_remote_scratch_buffers[8 - 9]
             };
 
         auto tunneler_l_kernel = tt_metal::CreateKernel(
@@ -642,7 +768,6 @@ int main(int argc, char **argv) {
                 2*num_endpoints, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
                 (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
                 (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
-
                 packet_switch_4B_pack(demux_phys_core_r.x,
                                       demux_phys_core_r.y,
                                       0,
@@ -675,8 +800,7 @@ int main(int argc, char **argv) {
                                       tunneler_phys_core.y,
                                       7,
                                       (uint32_t)DispatchRemoteNetworkType::ETH), // 11: remote_receiver_7_info
-                0, 0, // 12 - 13: remote_receiver 8 - 9
-
+                0, 0, // 12 - 13: remote_receiver_info[8 - 9]
                 (demux_queue_start_addr >> 4), // 14: remote_receiver_queue_start_addr_words 0
                 (demux_queue_size_bytes >> 4), // 15: remote_receiver_queue_size_words 0
                 ((demux_queue_start_addr + demux_queue_size_bytes) >> 4), // 16: remote_receiver_queue_start_addr_words 1
@@ -693,11 +817,9 @@ int main(int argc, char **argv) {
                 (tunneler_queue_size_bytes >> 4), // 27: remote_receiver_queue_size_words 6
                 ((tunneler_queue_start_addr + 7 * tunneler_queue_size_bytes) >> 4), // 28: remote_receiver_queue_start_addr_words 7
                 (tunneler_queue_size_bytes >> 4), // 29: remote_receiver_queue_size_words 7
-                0, 2, // 30 - 31 Settings for remote reciver 8
+                0, 2, // 30 - 31 Settings for remote receiver 8
                 0, // 32: remote_receiver_queue_start_addr_words 9
-                2, // 33: remote_receiver_queue_size_words 9.
-                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
-
+                2, // 33: remote_receiver_queue_size_words 9. Unused. Setting to 2 to get around size check assertion that does not allow 0.
                 packet_switch_4B_pack(tunneler_phys_core.x,
                                       tunneler_phys_core.y,
                                       8,
@@ -735,7 +857,46 @@ int main(int argc, char **argv) {
                 tunneler_test_results_addr, // 44: test_results_addr
                 tunneler_test_results_size, // 45: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 46: timeout_cycles
-                0, //47: inner_stop_mux_d_bypass
+                0, // 47: inner_stop_mux_d_bypass,
+                tunneler_buffers_right.at("input")[0], // 48: vc_eth_tunneler_input_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[1], // 49: vc_eth_tunneler_input_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[2], // 50: vc_eth_tunneler_input_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[3], // 51: vc_eth_tunneler_input_scratch_buffers[3]
+                tunneler_buffers_right.at("input")[4], // 52: vc_eth_tunneler_input_scratch_buffers[4]
+                tunneler_buffers_right.at("input")[5], // 53: vc_eth_tunneler_input_scratch_buffers[5]
+                tunneler_buffers_right.at("input")[6], // 54: vc_eth_tunneler_input_scratch_buffers[6]
+                tunneler_buffers_right.at("input")[7], // 55: vc_eth_tunneler_input_scratch_buffers[7]
+                0, 0, // 56 - 57: vc_eth_tunneler_input_scratch_buffers[8 - 9]
+
+                tunneler_buffers_left.at("output")[0], // 58: vc_eth_tunneler_input_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[1], // 59: vc_eth_tunneler_input_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[2], // 60: vc_eth_tunneler_input_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[3], // 61: vc_eth_tunneler_input_remote_scratch_buffers[3]
+                output_scratch_buffers_right.at("mux")[0], // 62: vc_eth_tunneler_input_remote_scratch_buffers[4]
+                output_scratch_buffers_right.at("mux")[1], // 63: vc_eth_tunneler_input_remote_scratch_buffers[5]
+                output_scratch_buffers_right.at("mux")[2], // 64: vc_eth_tunneler_input_remote_scratch_buffers[6]
+                output_scratch_buffers_right.at("mux")[3], // 65: vc_eth_tunneler_input_remote_scratch_buffers[7]
+                0, 0, // 66 - 67: vc_eth_tunneler_input_remote_scratch_buffers[8 - 9]
+
+                tunneler_buffers_right.at("output")[0], // 68: vc_eth_tunneler_output_scratch_buffers[0]
+                tunneler_buffers_right.at("output")[1], // 69: vc_eth_tunneler_output_scratch_buffers[1]
+                tunneler_buffers_right.at("output")[2], // 70: vc_eth_tunneler_output_scratch_buffers[2]
+                tunneler_buffers_right.at("output")[3], // 71: vc_eth_tunneler_output_scratch_buffers[3]
+                tunneler_buffers_right.at("output")[4], // 72: vc_eth_tunneler_output_scratch_buffers[4]
+                tunneler_buffers_right.at("output")[5], // 73: vc_eth_tunneler_output_scratch_buffers[5]
+                tunneler_buffers_right.at("output")[6], // 74: vc_eth_tunneler_output_scratch_buffers[6]
+                tunneler_buffers_right.at("output")[7], // 75: vc_eth_tunneler_output_scratch_buffers[7]
+                0, 0, // 76 - 77: vc_eth_tunneler_output_scratch_buffers[8 - 9]
+
+                input_scratch_buffers_right.at("demux")[0], // 78: vc_eth_tunneler_output_remote_scratch_buffers[0]
+                input_scratch_buffers_right.at("demux")[1], // 79: vc_eth_tunneler_output_remote_scratch_buffers[1]
+                input_scratch_buffers_right.at("demux")[2], // 80: vc_eth_tunneler_output_remote_scratch_buffers[2]
+                input_scratch_buffers_right.at("demux")[3], // 81: vc_eth_tunneler_output_remote_scratch_buffers[3]
+                tunneler_buffers_left.at("input")[4], // 82: vc_eth_tunneler_output_remote_scratch_buffers[4]
+                tunneler_buffers_left.at("input")[5], // 83: vc_eth_tunneler_output_remote_scratch_buffers[5]
+                tunneler_buffers_left.at("input")[6], // 84: vc_eth_tunneler_output_remote_scratch_buffers[6]
+                tunneler_buffers_left.at("input")[7], // 85: vc_eth_tunneler_output_remote_scratch_buffers[7]
+                0, 0, // 86 - 87: vc_eth_tunneler_output_remote_scratch_buffers[8 - 9]
             };
 
         auto tunneler_r_kernel = tt_metal::CreateKernel(
@@ -783,11 +944,6 @@ int main(int argc, char **argv) {
                 (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
                 (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
                 (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
-                //(uint32_t)tunneler_phys_core.x, // 16: remote_rx_x
-                //(uint32_t)tunneler_phys_core.y, // 17: remote_rx_y
-                //3, // 18: remote_rx_queue_id
-                //(uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
-
                 packet_switch_4B_pack(tunneler_phys_core.x,
                                       tunneler_phys_core.y,
                                       12,
@@ -804,13 +960,31 @@ int main(int argc, char **argv) {
                                       tunneler_phys_core.y,
                                       15,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 19: remote_rx_3_info
-
                 (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
                 (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25 - 35: packetize/depacketize settings
+                input_scratch_buffers_left.at("demux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_left.at("demux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_left.at("demux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_left.at("demux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                tunneler_buffers_left.at("output")[4], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[5], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[6], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[7], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("demux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_left.at("demux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_left.at("demux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_left.at("demux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                input_scratch_buffers_left.at("traffic_gen_rx")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                input_scratch_buffers_left.at("traffic_gen_rx")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                input_scratch_buffers_left.at("traffic_gen_rx")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                input_scratch_buffers_left.at("traffic_gen_rx")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
@@ -858,11 +1032,6 @@ int main(int argc, char **argv) {
                 (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
                 (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
                 (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
-                //(uint32_t)tunneler_phys_core.x, // 16: remote_rx_x
-                //(uint32_t)tunneler_phys_core.y, // 17: remote_rx_y
-                //3, // 18: remote_rx_queue_id
-                //(uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
-
                 packet_switch_4B_pack(r_tunneler_phys_core.x,
                                       r_tunneler_phys_core.y,
                                       8,
@@ -879,13 +1048,31 @@ int main(int argc, char **argv) {
                                       r_tunneler_phys_core.y,
                                       11,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 19: remote_rx_3_info
-
                 (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
                 (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25 - 35: packetize/depacketize settings
+                input_scratch_buffers_right.at("demux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_right.at("demux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_right.at("demux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_right.at("demux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                tunneler_buffers_right.at("output")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("output")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("output")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("output")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_right.at("demux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_right.at("demux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_right.at("demux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_right.at("demux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                input_scratch_buffers_right.at("traffic_gen_rx")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                input_scratch_buffers_right.at("traffic_gen_rx")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                input_scratch_buffers_right.at("traffic_gen_rx")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                input_scratch_buffers_right.at("traffic_gen_rx")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run remote demux at x={},y={}", demux_core.x, demux_core.y);
@@ -902,9 +1089,6 @@ int main(int argc, char **argv) {
                 .defines = defines
             }
         );
-
-
-
 
         log_info(LogTest, "Starting test...");
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
@@ -5,18 +5,14 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/cq_commands.hpp"
-#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
-#include "kernels/traffic_gen_test.hpp"
 #include "tt_metal/impl/device/device.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
-using std::vector;
 using namespace tt;
 using json = nlohmann::json;
 
-int main(int argc, char **argv) {
 
+int main(int argc, char **argv) {
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;
     constexpr uint32_t default_rx_x = 0;
@@ -30,6 +26,9 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_prng_seed = 0x100;
     constexpr uint32_t default_data_kb_per_tx = 1024*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_input_scratch_buffer_base_addr = 0x50000;
+    constexpr uint32_t default_output_scratch_buffer_base_addr = 0x60000;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
     constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
@@ -46,7 +45,8 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_tunneler_queue_start_addr = 0x19000;
     constexpr uint32_t default_tunneler_queue_size_bytes = 0x4000; // * 8 as it is birectional, maximum queue size for ecore L1 (power of 2)
     constexpr uint32_t default_tunneler_test_results_addr = 0x39000;
-    constexpr uint32_t default_tunneler_test_results_size = 0x7000;
+    constexpr uint32_t default_tunneler_test_results_size = 0x1000;
+    constexpr uint32_t default_tunneler_buffer_base_addr =  0x3A000;
 
     constexpr uint32_t default_timeout_mcycles = 1000;
     constexpr uint32_t default_rx_disable_data_check = 0;
@@ -107,6 +107,9 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
         log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
         log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        log_info(LogTest, "  --input_scratch_buffer_base_addr: Scratch buffer for input queues base address, default = {:#x}", default_input_scratch_buffer_base_addr);
+        log_info(LogTest, "  --output_scratch_buffer_base_addr: Scratch buffer for output queues base address, default = {:#x}", default_output_scratch_buffer_base_addr);
+        log_info(LogTest, "  --tunneler_scratch_buffer_base_addr: Scratch buffer for tunneler queues base address, default = {:#x}", default_tunneler_buffer_base_addr);
         return 0;
     }
 
@@ -146,6 +149,9 @@ int main(int argc, char **argv) {
     uint8_t tx_pkt_dest_size_choice = (uint8_t) test_args::get_command_option_uint32(input_args, "--tx_pkt_dest_size_choice", default_tx_pkt_dest_size_choice);
     uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
     uint32_t tx_data_sent_per_iter_high = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_high", default_tx_data_sent_per_iter_high);
+    uint32_t input_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--input_scratch_buffer_base_addr", default_input_scratch_buffer_base_addr);
+    uint32_t output_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--output_scratch_buffer_base_addr", default_output_scratch_buffer_base_addr);
+    uint32_t tunneler_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--tunneler_buffer_base_addr", default_tunneler_buffer_base_addr);
 
     assert((pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE && rx_disable_header_check || (pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM);
 
@@ -154,6 +160,40 @@ int main(int argc, char **argv) {
     std::map<string, string> defines = {
         {"FD_CORE_TYPE", std::to_string(0)}, // todo, support dispatch on eth
     };
+
+    // ----- Left Chip -----
+    const auto input_scratch_buffers_left = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "mux", MAX_SWITCH_FAN_IN },
+        { "demux", MAX_SWITCH_FAN_IN },
+        { "traffic_gen_rx", num_dest_endpoints },
+    });
+
+    const auto tunneler_buffers_left = make_buffer_addresses_for_test(tunneler_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "input", MAX_TUNNEL_LANES },
+        { "output", MAX_TUNNEL_LANES },
+    });
+
+    const auto output_scratch_buffers_left = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "traffic_gen_tx_mock", num_src_endpoints },
+        { "mux", MAX_SWITCH_FAN_IN },
+        { "demux", MAX_SWITCH_FAN_IN },
+    });
+
+    // ----- Right Chip -----
+    const auto input_scratch_buffers_right = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "loopback_mux", MAX_SWITCH_FAN_IN },
+    });
+
+    const auto tunneler_buffers_right = make_buffer_addresses_for_test(tunneler_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "input", MAX_TUNNEL_LANES },
+        { "output", MAX_TUNNEL_LANES },
+    });
+
+    const auto output_scratch_buffers_right = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "loopback_mux", MAX_SWITCH_FAN_IN },
+    });
 
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
@@ -240,7 +280,11 @@ int main(int argc, char **argv) {
                     tx_skip_pkt_content_gen, // 18: skip_pkt_content_gen
                     tx_pkt_dest_size_choice, // 19: pkt_dest_size_choice
                     tx_data_sent_per_iter_low, // 20: data_sent_per_iter_low
-                    tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
+                    tx_data_sent_per_iter_high, // 21: data_sent_per_iter_high
+                    input_scratch_buffers_left.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_left.at("traffic_gen_tx_mock")[i], // 23: traffic_gen_input_mock_remote_scratch_buffer_addr
+                    output_scratch_buffers_left.at("traffic_gen_tx")[i], // 24: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers_left.at("mux")[i], // 25: traffic_gen_output_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
@@ -281,7 +325,9 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id + i, // 15: src_endpoint_start_id
                     dest_endpoint_start_id + i, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
-                    rx_disable_header_check // 18: disable_header_check
+                    rx_disable_header_check, // 18: disable_header_check
+                    input_scratch_buffers_left.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_left.at("demux")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
@@ -354,7 +400,27 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25-35: packetize/depacketize settings
+
+                input_scratch_buffers_left.at("mux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_left.at("mux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_left.at("mux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_left.at("mux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("traffic_gen_tx")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                output_scratch_buffers_left.at("traffic_gen_tx")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                output_scratch_buffers_left.at("traffic_gen_tx")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                output_scratch_buffers_left.at("traffic_gen_tx")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("mux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_left.at("mux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_left.at("mux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_left.at("mux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                tunneler_buffers_left.at("input")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("input")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("input")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("input")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
@@ -429,11 +495,10 @@ int main(int argc, char **argv) {
                 ((demux_queue_start_addr + 3 * demux_queue_size_bytes) >> 4), // 28: remote_receiver_queue_start_addr_words 7
                 (demux_queue_size_bytes >> 4), // 29: remote_receiver_queue_size_words 7
 
-                0, 2, // 30 - 31 Settings for remote reciver 8
+                0, 2, // 30 - 31 Settings for remote receiver 8
                 0, // 32: remote_receiver_queue_start_addr_words 9
                 2, // 33: remote_receiver_queue_size_words 9.
                    // Unused. Setting to 2 to get around size check assertion that does not allow 0.
-
 
                 packet_switch_4B_pack(mux_phys_core.x,
                                       mux_phys_core.y,
@@ -472,7 +537,50 @@ int main(int argc, char **argv) {
                 tunneler_test_results_addr, // 44: test_results_addr
                 tunneler_test_results_size, // 45: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 46: timeout_cycles
-                0, //47: inner_stop_mux_d_bypass
+                0, // 47: inner_stop_mux_d_bypass
+                tunneler_buffers_left.at("input")[0], // 48: vc_eth_tunneler_input_scratch_buffers[0]
+                tunneler_buffers_left.at("input")[1], // 49: vc_eth_tunneler_input_scratch_buffers[1]
+                tunneler_buffers_left.at("input")[2], // 50: vc_eth_tunneler_input_scratch_buffers[2]
+                tunneler_buffers_left.at("input")[3], // 51: vc_eth_tunneler_input_scratch_buffers[3]
+                tunneler_buffers_left.at("input")[4], // 52: vc_eth_tunneler_input_scratch_buffers[4]
+                tunneler_buffers_left.at("input")[5], // 53: vc_eth_tunneler_input_scratch_buffers[5]
+                tunneler_buffers_left.at("input")[6], // 54: vc_eth_tunneler_input_scratch_buffers[6]
+                tunneler_buffers_left.at("input")[7], // 55: vc_eth_tunneler_input_scratch_buffers[7]
+                0, 0, // 56 - 57: vc_eth_tunneler_input_scratch_buffers[8 - 9]
+
+                // from left vc packet router mux
+                output_scratch_buffers_left.at("mux")[0], // 58: vc_eth_tunneler_input_remote_scratch_buffers[0]
+                output_scratch_buffers_left.at("mux")[1], // 59: vc_eth_tunneler_input_remote_scratch_buffers[1]
+                output_scratch_buffers_left.at("mux")[2], // 60: vc_eth_tunneler_input_remote_scratch_buffers[2]
+                output_scratch_buffers_left.at("mux")[3], // 61: vc_eth_tunneler_input_remote_scratch_buffers[3]
+                // from right tunneler
+                tunneler_buffers_right.at("output")[4], // 62: vc_eth_tunneler_input_remote_scratch_buffers[4]
+                tunneler_buffers_right.at("output")[5], // 63: vc_eth_tunneler_input_remote_scratch_buffers[5]
+                tunneler_buffers_right.at("output")[6], // 64: vc_eth_tunneler_input_remote_scratch_buffers[6]
+                tunneler_buffers_right.at("output")[7], // 65: vc_eth_tunneler_input_remote_scratch_buffers[7]
+                0, 0, // 66 - 67: vc_eth_tunneler_input_remote_scratch_buffers[8 - 9]
+
+                tunneler_buffers_left.at("output")[0], // 68: vc_eth_tunneler_output_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[1], // 69: vc_eth_tunneler_output_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[2], // 70: vc_eth_tunneler_output_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[3], // 71: vc_eth_tunneler_output_scratch_buffers[3]
+                tunneler_buffers_left.at("output")[4], // 72: vc_eth_tunneler_output_scratch_buffers[4]
+                tunneler_buffers_left.at("output")[5], // 73: vc_eth_tunneler_output_scratch_buffers[5]
+                tunneler_buffers_left.at("output")[6], // 74: vc_eth_tunneler_output_scratch_buffers[6]
+                tunneler_buffers_left.at("output")[7], // 75: vc_eth_tunneler_output_scratch_buffers[7]
+                0, 0, // 76 - 77: vc_eth_tunneler_output_scratch_buffers[8 - 9]
+
+                // to right tunneler
+                tunneler_buffers_right.at("input")[0], // 78: vc_eth_tunneler_output_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[1], // 79: vc_eth_tunneler_output_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[2], // 80: vc_eth_tunneler_output_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[3], // 81: vc_eth_tunneler_output_remote_scratch_buffers[3]
+                // to left vc packet router mux
+                input_scratch_buffers_left.at("demux")[0], // 82: vc_eth_tunneler_output_remote_scratch_buffers[4]
+                input_scratch_buffers_left.at("demux")[1], // 83: vc_eth_tunneler_output_remote_scratch_buffers[5]
+                input_scratch_buffers_left.at("demux")[2], // 84: vc_eth_tunneler_output_remote_scratch_buffers[6]
+                input_scratch_buffers_left.at("demux")[3], // 85: vc_eth_tunneler_output_remote_scratch_buffers[7]
+                0, 0, // 86 - 87: vc_eth_tunneler_output_remote_scratch_buffers[8 - 9]
             };
 
         auto tunneler_l_kernel = tt_metal::CreateKernel(
@@ -526,8 +634,7 @@ int main(int argc, char **argv) {
                                       tunneler_phys_core.y,
                                       7,
                                       (uint32_t)DispatchRemoteNetworkType::ETH), // 11: remote_receiver_7_info
-                0, 0, // 12 - 13: remote_receiver 8 - 9
-
+                0, 0, // 12 - 13: remote_receiver_7_info[8 - 9]
                 (mux_queue_start_addr >> 4), // 14: remote_receiver_queue_start_addr_words 0
                 (mux_queue_size_bytes >> 4), // 15: remote_receiver_queue_size_words 0
                 ((mux_queue_start_addr + mux_queue_size_bytes) >> 4), // 16: remote_receiver_queue_start_addr_words 1
@@ -544,11 +651,9 @@ int main(int argc, char **argv) {
                 (tunneler_queue_size_bytes >> 4), // 27: remote_receiver_queue_size_words 6
                 ((tunneler_queue_start_addr + 7 * tunneler_queue_size_bytes) >> 4), // 28: remote_receiver_queue_start_addr_words 7
                 (tunneler_queue_size_bytes >> 4), // 29: remote_receiver_queue_size_words 7
-                0, 2, // 30 - 31 Settings for remote reciver 8
+                0, 2, // 30 - 31 Settings for remote receiver 8
                 0, // 32: remote_receiver_queue_start_addr_words 9
-                2, // 33: remote_receiver_queue_size_words 9.
-                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
-
+                2, // 33: remote_receiver_queue_size_words 9. Unused. Setting to 2 to get around size check assertion that does not allow 0.
                 packet_switch_4B_pack(tunneler_phys_core.x,
                                       tunneler_phys_core.y,
                                       8,
@@ -581,12 +686,53 @@ int main(int argc, char **argv) {
                                       loopback_mux_phys_core.y,
                                       7,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 41: remote_sender_7_info
-                0, 0, // 42 - 43: remote_sender 8 - 9
-
+                0, 0, // 42 - 43: remote_sender_info[8 - 9]
                 tunneler_test_results_addr, // 44: test_results_addr
                 tunneler_test_results_size, // 45: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 46: timeout_cycles
-                0, //47: inner_stop_mux_d_bypass
+                0, // 47: inner_stop_mux_d_bypass
+                tunneler_buffers_right.at("input")[0], // 48: vc_eth_tunneler_input_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[1], // 49: vc_eth_tunneler_input_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[2], // 50: vc_eth_tunneler_input_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[3], // 51: vc_eth_tunneler_input_scratch_buffers[3]
+                tunneler_buffers_right.at("input")[4], // 52: vc_eth_tunneler_input_scratch_buffers[4]
+                tunneler_buffers_right.at("input")[5], // 53: vc_eth_tunneler_input_scratch_buffers[5]
+                tunneler_buffers_right.at("input")[6], // 54: vc_eth_tunneler_input_scratch_buffers[6]
+                tunneler_buffers_right.at("input")[7], // 55: vc_eth_tunneler_input_scratch_buffers[7]
+                0, 0, // 56 - 57: vc_eth_tunneler_input_scratch_buffers[8 - 9]
+                // from left tunneler
+                tunneler_buffers_left.at("output")[0], // 58: vc_eth_tunneler_input_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[1], // 59: vc_eth_tunneler_input_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[2], // 60: vc_eth_tunneler_input_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[3], // 61: vc_eth_tunneler_input_remote_scratch_buffers[3]
+                // from loopback mux on the right
+                output_scratch_buffers_right.at("loopback_mux")[0], // 62: vc_eth_tunneler_input_remote_scratch_buffers[4]
+                output_scratch_buffers_right.at("loopback_mux")[1], // 63: vc_eth_tunneler_input_remote_scratch_buffers[5]
+                output_scratch_buffers_right.at("loopback_mux")[2], // 64: vc_eth_tunneler_input_remote_scratch_buffers[6]
+                output_scratch_buffers_right.at("loopback_mux")[3], // 65: vc_eth_tunneler_input_remote_scratch_buffers[7]
+                0, 0, // 66 - 67: vc_eth_tunneler_input_remote_scratch_buffers[8 - 9]
+
+                tunneler_buffers_right.at("output")[0], // 68: vc_eth_tunneler_output_scratch_buffers[0]
+                tunneler_buffers_right.at("output")[1], // 69: vc_eth_tunneler_output_scratch_buffers[1]
+                tunneler_buffers_right.at("output")[2], // 70: vc_eth_tunneler_output_scratch_buffers[2]
+                tunneler_buffers_right.at("output")[3], // 71: vc_eth_tunneler_output_scratch_buffers[3]
+                tunneler_buffers_right.at("output")[4], // 72: vc_eth_tunneler_output_scratch_buffers[4]
+                tunneler_buffers_right.at("output")[5], // 73: vc_eth_tunneler_output_scratch_buffers[5]
+                tunneler_buffers_right.at("output")[6], // 74: vc_eth_tunneler_output_scratch_buffers[6]
+                tunneler_buffers_right.at("output")[7], // 75: vc_eth_tunneler_output_scratch_buffers[7]
+                0, 0, // 76 - 77: vc_eth_tunneler_output_scratch_buffers[8 - 9]
+
+                // to loopback mux on the right
+                input_scratch_buffers_right.at("loopback_mux")[0], // 78: vc_eth_tunneler_output_remote_scratch_buffers[0]
+                input_scratch_buffers_right.at("loopback_mux")[1], // 79: vc_eth_tunneler_output_remote_scratch_buffers[1]
+                input_scratch_buffers_right.at("loopback_mux")[2], // 80: vc_eth_tunneler_output_remote_scratch_buffers[2]
+                input_scratch_buffers_right.at("loopback_mux")[3], // 81: vc_eth_tunneler_output_remote_scratch_buffers[3]
+                // to left tunneler
+                tunneler_buffers_left.at("input")[4], // 82: vc_eth_tunneler_output_remote_scratch_buffers[4]
+                tunneler_buffers_left.at("input")[5], // 83: vc_eth_tunneler_output_remote_scratch_buffers[5]
+                tunneler_buffers_left.at("input")[6], // 84: vc_eth_tunneler_output_remote_scratch_buffers[6]
+                tunneler_buffers_left.at("input")[7], // 85: vc_eth_tunneler_output_remote_scratch_buffers[7]
+                0, 0, // 86 - 87: vc_eth_tunneler_output_remote_scratch_buffers[8 - 9]
             };
 
         auto tunneler_r_kernel = tt_metal::CreateKernel(
@@ -651,7 +797,29 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25 - 35: packetize/depacketize settings
+
+                input_scratch_buffers_right.at("loopback_mux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_right.at("loopback_mux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_right.at("loopback_mux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_right.at("loopback_mux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                // from right tunneler
+                tunneler_buffers_right.at("output")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("output")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("output")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("output")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_right.at("loopback_mux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_right.at("loopback_mux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_right.at("loopback_mux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_right.at("loopback_mux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                // to right tunneler
+                tunneler_buffers_right.at("input")[4], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[5], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[6], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[7], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
 
@@ -667,8 +835,6 @@ int main(int argc, char **argv) {
                 .defines = defines
             }
         );
-
-
 
         // Demux
         uint32_t dest_map_array[4] = {0, 1, 2, 3};
@@ -703,11 +869,6 @@ int main(int argc, char **argv) {
                 (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
                 (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
                 (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
-                //(uint32_t)tunneler_phys_core.x, // 16: remote_rx_x
-                //(uint32_t)tunneler_phys_core.y, // 17: remote_rx_y
-                //3, // 18: remote_rx_queue_id
-                //(uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
-
                 packet_switch_4B_pack(tunneler_phys_core.x,
                                       tunneler_phys_core.y,
                                       12,
@@ -730,7 +891,29 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25 - 35: packetize/depacketize settings
+
+                input_scratch_buffers_left.at("demux")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_left.at("demux")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_left.at("demux")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_left.at("demux")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                // from left tunneler
+                tunneler_buffers_left.at("output")[4], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[5], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[6], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[7], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("demux")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_left.at("demux")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_left.at("demux")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_left.at("demux")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                // to rx
+                input_scratch_buffers_left.at("traffic_gen_rx")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                input_scratch_buffers_left.at("traffic_gen_rx")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                input_scratch_buffers_left.at("traffic_gen_rx")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                input_scratch_buffers_left.at("traffic_gen_rx")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
@@ -761,8 +944,8 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        vector<vector<uint32_t>> tx_results;
-        vector<vector<uint32_t>> rx_results;
+        std::vector<std::vector<uint32_t>> tx_results;
+        std::vector<std::vector<uint32_t>> rx_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
@@ -780,19 +963,19 @@ int main(int argc, char **argv) {
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
-        vector<uint32_t> mux_results =
+        std::vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> loopback_mux_results =
+        std::vector<uint32_t> loopback_mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device_r->id(), loopback_mux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "LOOPBACK MUX status = {}", packet_queue_test_status_to_string(loopback_mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (loopback_mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> demux_results =
+        std::vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
@@ -5,18 +5,13 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
-#include "kernels/traffic_gen_test.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
-using std::vector;
 using namespace tt;
 using json = nlohmann::json;
 
 int main(int argc, char **argv) {
-
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;
     constexpr uint32_t default_rx_x = 0;
@@ -30,6 +25,9 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_prng_seed = 0x100;
     constexpr uint32_t default_data_kb_per_tx = 1024*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_input_scratch_buffer_base_addr = 0x60000;
+    constexpr uint32_t default_output_scratch_buffer_base_addr = 0x70000;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
     constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
@@ -98,6 +96,8 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
         log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
         log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        log_info(LogTest, "  --input_scratch_buffer_base_addr: Scratch buffer for input queues base address, default = {:#x}", default_input_scratch_buffer_base_addr);
+        log_info(LogTest, "  --output_scratch_buffer_base_addr: Scratch buffer for output queues base address, default = {:#x}", default_output_scratch_buffer_base_addr);
         return 0;
     }
 
@@ -133,11 +133,28 @@ int main(int argc, char **argv) {
     uint8_t tx_pkt_dest_size_choice = (uint8_t) test_args::get_command_option_uint32(input_args, "--tx_pkt_dest_size_choice", default_tx_pkt_dest_size_choice);
     uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
     uint32_t tx_data_sent_per_iter_high = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_high", default_tx_data_sent_per_iter_high);
+    uint32_t input_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--input_scratch_buffer_base_addr", default_input_scratch_buffer_base_addr);
+    uint32_t output_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--output_scratch_buffer_base_addr", default_output_scratch_buffer_base_addr);
 
     assert((pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE && rx_disable_header_check || (pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM);
 
     uint32_t num_src_endpoints = num_endpoints;
     uint32_t num_dest_endpoints = num_endpoints;
+
+    const auto input_scratch_buffers = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "vc_packet_router_l", MAX_SWITCH_FAN_IN },
+        { "vc_packet_router_r", MAX_SWITCH_FAN_IN },
+        { "traffic_gen_rx", num_dest_endpoints },
+
+    });
+
+    const auto output_scratch_buffers = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx_mock", num_src_endpoints },
+        { "traffic_gen_tx", num_src_endpoints },
+        { "vc_packet_router_l", MAX_SWITCH_FAN_IN},
+        { "vc_packet_router_r", MAX_SWITCH_FAN_IN },
+    });
 
     bool pass = true;
 
@@ -188,10 +205,14 @@ int main(int argc, char **argv) {
                     tx_skip_pkt_content_gen, // 18: skip_pkt_content_gen
                     tx_pkt_dest_size_choice, // 19: pkt_dest_size_choice
                     tx_data_sent_per_iter_low, // 20: data_sent_per_iter_low
-                    tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
+                    tx_data_sent_per_iter_high, // 21: data_sent_per_iter_high
+                    input_scratch_buffers.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers.at("traffic_gen_tx_mock")[i], // 23: traffic_gen_input_mock_remote_scratch_buffer_addr
+                    output_scratch_buffers.at("traffic_gen_tx")[i], // 24: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers.at("vc_packet_router_l")[i], // 25: traffic_gen_output_remote_scratch_buffer_addr
                 };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            log_info(LogTest, "run traffic_gen_tx at x={},y={}", tx_phys_core.back().x, tx_phys_core.back().y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -229,10 +250,12 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id + i, // 15: src_endpoint_start_id
                     dest_endpoint_start_id + i, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
-                    rx_disable_header_check // 18: disable_header_check
+                    rx_disable_header_check, // 18: disable_header_check
+                    input_scratch_buffers.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers.at("vc_packet_router_r")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            log_info(LogTest, "run traffic_gen_rx at x={},y={}", rx_phys_core.back().x, rx_phys_core.back().y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -302,10 +325,30 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000, // 24: timeout_cycles,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25-35: packetize/depacketize settings
+
+                input_scratch_buffers.at("vc_packet_router_l")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers.at("vc_packet_router_l")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers.at("vc_packet_router_l")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers.at("vc_packet_router_l")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                output_scratch_buffers.at("traffic_gen_tx")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                output_scratch_buffers.at("traffic_gen_tx")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                output_scratch_buffers.at("traffic_gen_tx")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                output_scratch_buffers.at("traffic_gen_tx")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers.at("vc_packet_router_l")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers.at("vc_packet_router_l")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers.at("vc_packet_router_l")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers.at("vc_packet_router_l")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                input_scratch_buffers.at("vc_packet_router_r")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                input_scratch_buffers.at("vc_packet_router_r")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                input_scratch_buffers.at("vc_packet_router_r")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                input_scratch_buffers.at("vc_packet_router_r")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        log_info(LogTest, "run mux at x={},y={}", mux_phys_core.x, mux_phys_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -350,10 +393,6 @@ int main(int argc, char **argv) {
                 (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
                 (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
                 (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
-                //(uint32_t)mux_phys_core.x, // 16: remote_rx_x
-                //(uint32_t)mux_phys_core.y, // 17: remote_rx_y
-                //num_dest_endpoints, // 18: remote_rx_queue_id
-                //(uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
                 packet_switch_4B_pack(mux_phys_core.x,
                                       mux_phys_core.y,
                                       num_dest_endpoints,
@@ -375,11 +414,31 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
-                0, 0, 0, 0, 0, // 25-29: depacketize settings
-                0, 0, 0, 0, 0, 0// 30-35: packetize settings
+                0, 0, 0, 0, 0, // 25 - 29: depacketize settings
+                0, 0, 0, 0, 0, 0, // 30 - 35: packetize settings
+
+                input_scratch_buffers.at("vc_packet_router_r")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers.at("vc_packet_router_r")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers.at("vc_packet_router_r")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers.at("vc_packet_router_r")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                output_scratch_buffers.at("vc_packet_router_l")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                output_scratch_buffers.at("vc_packet_router_l")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                output_scratch_buffers.at("vc_packet_router_l")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                output_scratch_buffers.at("vc_packet_router_l")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers.at("vc_packet_router_r")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers.at("vc_packet_router_r")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers.at("vc_packet_router_r")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers.at("vc_packet_router_r")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                input_scratch_buffers.at("traffic_gen_rx")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                input_scratch_buffers.at("traffic_gen_rx")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                input_scratch_buffers.at("traffic_gen_rx")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                input_scratch_buffers.at("traffic_gen_rx")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        log_info(LogTest, "run demux at x={},y={}", demux_phys_core.x, demux_phys_core.y);
         auto demux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -401,8 +460,8 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        vector<vector<uint32_t>> tx_results;
-        vector<vector<uint32_t>> rx_results;
+        std::vector<std::vector<uint32_t>> tx_results;
+        std::vector<std::vector<uint32_t>> rx_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
@@ -420,13 +479,13 @@ int main(int argc, char **argv) {
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
-        vector<uint32_t> mux_results =
+        std::vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> demux_results =
+        std::vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
@@ -6,18 +6,13 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/cq_commands.hpp"
-#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
-#include "kernels/traffic_gen_test.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
-using std::vector;
 using namespace tt;
 using json = nlohmann::json;
 
 
 int main(int argc, char **argv) {
-
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;
     constexpr uint32_t default_rx_x = 0;
@@ -31,6 +26,9 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_prng_seed = 0x100;
     constexpr uint32_t default_data_kb_per_tx = 1024*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_input_scratch_buffer_base_addr = 0x50000;
+    constexpr uint32_t default_output_scratch_buffer_base_addr = 0x60000;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
     constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
@@ -46,8 +44,9 @@ int main(int argc, char **argv) {
 
     constexpr uint32_t default_tunneler_queue_start_addr = 0x19000;
     constexpr uint32_t default_tunneler_queue_size_bytes = 0x8000; // maximum queue (power of 2)
-    constexpr uint32_t default_tunneler_test_results_addr = 0x39000; // 0x8000 * 4 + 0x19000; 0x10000 * 4 + 0x19000 = 0x59000 > 0x40000 (256kB)
-    constexpr uint32_t default_tunneler_test_results_size = 0x7000; // 256kB total L1 in ethernet core - 0x39000
+    constexpr uint32_t default_tunneler_test_results_addr = 0x39000;
+    constexpr uint32_t default_tunneler_test_results_size = 0x1000;
+    constexpr uint32_t default_tunneler_buffer_base_addr =  0x3A000;
 
     constexpr uint32_t default_timeout_mcycles = 1000;
     constexpr uint32_t default_rx_disable_data_check = 0;
@@ -108,6 +107,9 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
         log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
         log_info(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
+        log_info(LogTest, "  --input_scratch_buffer_base_addr: Scratch buffer for input queues base address, default = {:#x}", default_input_scratch_buffer_base_addr);
+        log_info(LogTest, "  --output_scratch_buffer_base_addr: Scratch buffer for output queues base address, default = {:#x}", default_output_scratch_buffer_base_addr);
+        log_info(LogTest, "  --tunneler_scratch_buffer_base_addr: Scratch buffer for tunneler queues base address, default = {:#x}", default_tunneler_buffer_base_addr);
         return 0;
     }
 
@@ -146,6 +148,9 @@ int main(int argc, char **argv) {
     uint8_t tx_pkt_dest_size_choice = (uint8_t) test_args::get_command_option_uint32(input_args, "--tx_pkt_dest_size_choice", default_tx_pkt_dest_size_choice);
     uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
     uint32_t tx_data_sent_per_iter_high = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_high", default_tx_data_sent_per_iter_high);
+    uint32_t input_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--input_scratch_buffer_base_addr", default_input_scratch_buffer_base_addr);
+    uint32_t output_scratch_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--output_scratch_buffer_base_addr", default_output_scratch_buffer_base_addr);
+    uint32_t tunneler_buffer_base_addr = test_args::get_command_option_uint32(input_args, "--tunneler_buffer_base_addr", default_tunneler_buffer_base_addr);
 
     assert((pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::SAME_START_RNDROBIN_FIX_SIZE && rx_disable_header_check || (pkt_dest_size_choices_t)tx_pkt_dest_size_choice == pkt_dest_size_choices_t::RANDOM);
 
@@ -156,6 +161,38 @@ int main(int argc, char **argv) {
     std::map<string, string> defines = {
         {"FD_CORE_TYPE", std::to_string(0)}, // todo, support dispatch on eth
     };
+
+    // ----- Left Chip -----
+    const auto input_scratch_buffers_left = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "vc_packet_router", MAX_SWITCH_FAN_IN },
+    });
+
+    const auto tunneler_buffers_left = make_buffer_addresses_for_test(tunneler_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "input", num_src_endpoints },
+        { "output", num_src_endpoints },
+    });
+
+    const auto output_scratch_buffers_left = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "traffic_gen_tx", num_src_endpoints },
+        { "traffic_gen_tx_mock", num_src_endpoints },
+        { "vc_packet_router", MAX_SWITCH_FAN_IN },
+    });
+
+    // ----- Right Chip -----
+    const auto input_scratch_buffers_right = make_buffer_addresses_for_test(input_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "vc_packet_router", MAX_SWITCH_FAN_IN },
+        { "traffic_gen_rx", num_dest_endpoints },
+    });
+
+    const auto tunneler_buffers_right = make_buffer_addresses_for_test(tunneler_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "input", num_dest_endpoints },
+        { "output", num_dest_endpoints },
+    });
+
+    const auto output_scratch_buffers_right = make_buffer_addresses_for_test(output_scratch_buffer_base_addr, packet_queue_scratch_buffer_size, {
+        { "vc_packet_router", MAX_SWITCH_FAN_IN },
+    });
 
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
@@ -189,10 +226,8 @@ int main(int argc, char **argv) {
         CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(device_id_l)[0];
         CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
 
-
-
-        std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
-        std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
+        log_info(LogTest, "run left vc eth tunneler at x={},y={}", tunneler_phys_core.x, tunneler_phys_core.y);
+        log_info(LogTest, "run right vc eth tunneler at x={},y={}", r_tunneler_phys_core.x, r_tunneler_phys_core.y);
 
         tt_metal::Program program = tt_metal::CreateProgram();
         tt_metal::Program program_r = tt_metal::CreateProgram();
@@ -234,7 +269,11 @@ int main(int argc, char **argv) {
                     tx_skip_pkt_content_gen, // 18: skip_pkt_content_gen
                     tx_pkt_dest_size_choice, // 19: pkt_dest_size_choice
                     tx_data_sent_per_iter_low, // 20: data_sent_per_iter_low
-                    tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
+                    tx_data_sent_per_iter_high, // 21: data_sent_per_iter_high
+                    input_scratch_buffers_left.at("traffic_gen_tx")[i], // 22: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_left.at("traffic_gen_tx_mock")[i], // 23: traffic_gen_input_mock_remote_scratch_buffer_addr
+                    output_scratch_buffers_left.at("traffic_gen_tx")[i], // 24: traffic_gen_output_scratch_buffer_addr
+                    input_scratch_buffers_left.at("vc_packet_router")[i], // 25: traffic_gen_output_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
@@ -275,7 +314,9 @@ int main(int argc, char **argv) {
                     src_endpoint_start_id + i, // 15: src_endpoint_start_id
                     dest_endpoint_start_id + i, // 16: dest_endpoint_start_id
                     timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
-                    rx_disable_header_check // 18: disable_header_check
+                    rx_disable_header_check, // 18: disable_header_check
+                    input_scratch_buffers_right.at("traffic_gen_rx")[i], // 19: traffic_gen_input_scratch_buffer_addr
+                    output_scratch_buffers_right.at("vc_packet_router")[i], // 20: traffic_gen_input_remote_scratch_buffer_addr
                 };
 
             log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
@@ -347,7 +388,27 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25-35: packetize/depacketize settings
+
+                input_scratch_buffers_left.at("vc_packet_router")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_left.at("vc_packet_router")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_left.at("vc_packet_router")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_left.at("vc_packet_router")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("traffic_gen_tx")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                output_scratch_buffers_left.at("traffic_gen_tx")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                output_scratch_buffers_left.at("traffic_gen_tx")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                output_scratch_buffers_left.at("traffic_gen_tx")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_left.at("vc_packet_router")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_left.at("vc_packet_router")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_left.at("vc_packet_router")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_left.at("vc_packet_router")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                tunneler_buffers_left.at("input")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("input")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("input")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("input")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
@@ -385,7 +446,7 @@ int main(int argc, char **argv) {
                                       r_tunneler_phys_core.y,
                                       3,
                                       (uint32_t)DispatchRemoteNetworkType::ETH), // 7: remote_receiver_3_info
-                0, 0, 0, 0, 0, 0, // 8 - 13: remote_receiver 4 - 9
+                0, 0, 0, 0, 0, 0, // 8 - 13: remote_receiver_info[4 - 9]
                 (tunneler_queue_start_addr >> 4), // 14: remote_receiver_queue_start_addr_words 0
                 (tunneler_queue_size_bytes >> 4), // 15: remote_receiver_queue_size_words 0
                 ((tunneler_queue_start_addr + tunneler_queue_size_bytes) >> 4), // 16: remote_receiver_queue_start_addr_words 1
@@ -394,10 +455,9 @@ int main(int argc, char **argv) {
                 (tunneler_queue_size_bytes >> 4), // 19: remote_receiver_queue_size_words 2
                 ((tunneler_queue_start_addr + 3 * tunneler_queue_size_bytes) >> 4), // 20: remote_receiver_queue_start_addr_words 3
                 (tunneler_queue_size_bytes >> 4), // 21: remote_receiver_queue_size_words 3
-                0, 2, 0, 2, 0, 2, 0, 2, 0, 2, // 22 - 31 Settings for remote reciver 4 - 8
+                0, 2, 0, 2, 0, 2, 0, 2, 0, 2, // 22 - 31 Settings for remote receiver[4 - 9]
                 0, // 32: remote_receiver_queue_start_addr_words 9
-                2, // 33: remote_receiver_queue_size_words 9.
-                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
+                2, // 33: remote_receiver_queue_size_words 9. Unused. Setting to 2 to get around size check assertion that does not allow 0.
                 packet_switch_4B_pack(mux_phys_core.x,
                                       mux_phys_core.y,
                                       num_dest_endpoints,
@@ -414,11 +474,34 @@ int main(int argc, char **argv) {
                                       mux_phys_core.y,
                                       num_dest_endpoints + 3,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 37: remote_sender_3_info
-                0, 0, 0, 0, 0, 0, // 38 - 43: remote_sender 4 - 9
+                0, 0, 0, 0, 0, 0, // 38 - 43: remote_sender_info[4 - 9]
                 tunneler_test_results_addr, // 44: test_results_addr
                 tunneler_test_results_size, // 45: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 46: timeout_cycles
-                0, //47: inner_stop_mux_d_bypass
+                0, // 47: inner_stop_mux_d_bypass
+                tunneler_buffers_left.at("input")[0], // 48: vc_eth_tunneler_input_scratch_buffers[0]
+                tunneler_buffers_left.at("input")[1], // 49: vc_eth_tunneler_input_scratch_buffers[1]
+                tunneler_buffers_left.at("input")[2], // 50: vc_eth_tunneler_input_scratch_buffers[2]
+                tunneler_buffers_left.at("input")[3], // 51: vc_eth_tunneler_input_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 52 - 57: vc_eth_tunneler_input_scratch_buffers[4 - 9]
+
+                output_scratch_buffers_left.at("vc_packet_router")[0], // 58: vc_eth_tunneler_input_remote_scratch_buffers[0]
+                output_scratch_buffers_left.at("vc_packet_router")[1], // 59: vc_eth_tunneler_input_remote_scratch_buffers[1]
+                output_scratch_buffers_left.at("vc_packet_router")[2], // 60: vc_eth_tunneler_input_remote_scratch_buffers[2]
+                output_scratch_buffers_left.at("vc_packet_router")[3], // 61: vc_eth_tunneler_input_remote_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 62 - 67: vc_eth_tunneler_input_remote_scratch_buffers[4 - 9]
+
+                tunneler_buffers_left.at("output")[0], // 68: vc_eth_tunneler_output_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[1], // 69: vc_eth_tunneler_output_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[2], // 70: vc_eth_tunneler_output_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[3], // 71: vc_eth_tunneler_output_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 72 - 77: vc_eth_tunneler_output_scratch_buffers[4 - 9]
+
+                tunneler_buffers_right.at("input")[0], // 78: vc_eth_tunneler_output_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[1], // 79: vc_eth_tunneler_output_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[2], // 80: vc_eth_tunneler_output_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[3], // 81: vc_eth_tunneler_output_remote_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 82 - 87: vc_eth_tunneler_output_remote_scratch_buffers[4 - 9]
             };
 
         auto tunneler_l_kernel = tt_metal::CreateKernel(
@@ -432,11 +515,10 @@ int main(int argc, char **argv) {
             }
         );
 
-
         std::vector<uint32_t> tunneler_r_compile_args =
             {
                 dest_endpoint_start_id, // 0: endpoint_id_start_index
-                4,  // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                4, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
                 (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
                 (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
                 packet_switch_4B_pack(demux_phys_core.x,
@@ -455,7 +537,7 @@ int main(int argc, char **argv) {
                                       demux_phys_core.y,
                                       3, //num_dest_endpoints + 3,
                                       (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_receiver_3_info
-                0, 0, 0, 0, 0, 0, // 8 - 13: remote_receiver 4 - 9
+                0, 0, 0, 0, 0, 0, // 8 - 13: remote_receiver_3_info[4 - 9]
                 (demux_queue_start_addr >> 4), // 14: remote_receiver_queue_start_addr_words 0
                 (demux_queue_size_bytes >> 4), // 15: remote_receiver_queue_size_words 0
                 ((demux_queue_start_addr + demux_queue_size_bytes) >> 4), // 16: remote_receiver_queue_start_addr_words 1
@@ -464,10 +546,9 @@ int main(int argc, char **argv) {
                 (demux_queue_size_bytes >> 4), // 19: remote_receiver_queue_size_words 2
                 ((demux_queue_start_addr + 3 * demux_queue_size_bytes) >> 4), // 20: remote_receiver_queue_start_addr_words 3
                 (demux_queue_size_bytes >> 4), // 21: remote_receiver_queue_size_words 3
-                0, 2, 0, 2, 0, 2, 0, 2, 0, 2, // 22 - 31 Settings for remote reciver 4 - 8
+                0, 2, 0, 2, 0, 2, 0, 2, 0, 2, // 22 - 31 Settings for remote receiver 4 - 8
                 0, // 32: remote_receiver_queue_start_addr_words 9
-                2, // 33: remote_receiver_queue_size_words 9
-                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
+                2, // 33: remote_receiver_queue_size_words 9. Unused. Setting to 2 to get around size check assertion that does not allow 0.
                 packet_switch_4B_pack(tunneler_phys_core.x,
                                       tunneler_phys_core.y,
                                       4,
@@ -484,11 +565,34 @@ int main(int argc, char **argv) {
                                       tunneler_phys_core.y,
                                       7,
                                       (uint32_t)DispatchRemoteNetworkType::ETH), // 37: remote_sender_3_info
-                0, 0, 0, 0, 0, 0, // 38 - 43: remote_sender 4 - 9
+                0, 0, 0, 0, 0, 0, // 38 - 43: remote_sender_3_info[4 - 9]
                 tunneler_test_results_addr, // 44: test_results_addr
                 tunneler_test_results_size, // 45: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 46: timeout_cycles
-                0, //47: inner_stop_mux_d_bypass
+                0, // 47: inner_stop_mux_d_bypass
+                tunneler_buffers_right.at("input")[0], // 48: vc_eth_tunneler_input_scratch_buffers[0]
+                tunneler_buffers_right.at("input")[1], // 49: vc_eth_tunneler_input_scratch_buffers[1]
+                tunneler_buffers_right.at("input")[2], // 50: vc_eth_tunneler_input_scratch_buffers[2]
+                tunneler_buffers_right.at("input")[3], // 51: vc_eth_tunneler_input_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 52 - 57: vc_eth_tunneler_input_scratch_buffers[4 - 9]
+
+                tunneler_buffers_left.at("output")[0], // 58: vc_eth_tunneler_input_remote_scratch_buffers[0]
+                tunneler_buffers_left.at("output")[1], // 59: vc_eth_tunneler_input_remote_scratch_buffers[1]
+                tunneler_buffers_left.at("output")[2], // 60: vc_eth_tunneler_input_remote_scratch_buffers[2]
+                tunneler_buffers_left.at("output")[3], // 61: vc_eth_tunneler_input_remote_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 62 - 67: vc_eth_tunneler_input_remote_scratch_buffers[4 - 9]
+
+                tunneler_buffers_right.at("output")[0], // 68: vc_eth_tunneler_output_scratch_buffers[0]
+                tunneler_buffers_right.at("output")[1], // 69: vc_eth_tunneler_output_scratch_buffers[1]
+                tunneler_buffers_right.at("output")[2], // 70: vc_eth_tunneler_output_scratch_buffers[2]
+                tunneler_buffers_right.at("output")[3], // 71: vc_eth_tunneler_output_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 72 - 77: vc_eth_tunneler_output_scratch_buffers[4 - 9]
+
+                input_scratch_buffers_right.at("vc_packet_router")[0], // 78: vc_eth_tunneler_output_remote_scratch_buffers[0]
+                input_scratch_buffers_right.at("vc_packet_router")[1], // 79: vc_eth_tunneler_output_remote_scratch_buffers[1]
+                input_scratch_buffers_right.at("vc_packet_router")[2], // 80: vc_eth_tunneler_output_remote_scratch_buffers[2]
+                input_scratch_buffers_right.at("vc_packet_router")[3], // 81: vc_eth_tunneler_output_remote_scratch_buffers[3]
+                0, 0, 0, 0, 0, 0, // 82 - 87: vc_eth_tunneler_output_remote_scratch_buffers[4 - 9]
             };
 
         auto tunneler_r_kernel = tt_metal::CreateKernel(
@@ -501,7 +605,6 @@ int main(int argc, char **argv) {
                 .defines = defines
             }
         );
-
 
         // Demux
         uint32_t dest_map_array[4] = {0, 1, 2, 3};
@@ -536,10 +639,6 @@ int main(int argc, char **argv) {
                 (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
                 (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
                 (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
-                //(uint32_t)r_tunneler_phys_core.x, // 16: remote_rx_x
-                //(uint32_t)r_tunneler_phys_core.y, // 17: remote_rx_y
-                //2, // 18: remote_rx_queue_id
-                //(uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
                 packet_switch_4B_pack(r_tunneler_phys_core.x,
                                       r_tunneler_phys_core.y,
                                       4,
@@ -561,7 +660,27 @@ int main(int argc, char **argv) {
                 test_results_addr, // 22: test_results_addr
                 test_results_size, // 23: test_results_size
                 timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 25-35: packetize/depacketize settings
+
+                input_scratch_buffers_right.at("vc_packet_router")[0], // 36: vc_packet_router_input_scratch_buffers[0]
+                input_scratch_buffers_right.at("vc_packet_router")[1], // 37: vc_packet_router_input_scratch_buffers[1]
+                input_scratch_buffers_right.at("vc_packet_router")[2], // 38: vc_packet_router_input_scratch_buffers[2]
+                input_scratch_buffers_right.at("vc_packet_router")[3], // 39: vc_packet_router_input_scratch_buffers[3]
+
+                tunneler_buffers_right.at("output")[0], // 40: vc_packet_router_input_remote_scratch_buffers[0]
+                tunneler_buffers_right.at("output")[1], // 41: vc_packet_router_input_remote_scratch_buffers[1]
+                tunneler_buffers_right.at("output")[2], // 42: vc_packet_router_input_remote_scratch_buffers[2]
+                tunneler_buffers_right.at("output")[3], // 43: vc_packet_router_input_remote_scratch_buffers[3]
+
+                output_scratch_buffers_right.at("vc_packet_router")[0], // 44: vc_packet_router_output_scratch_buffers[0]
+                output_scratch_buffers_right.at("vc_packet_router")[1], // 45: vc_packet_router_output_scratch_buffers[1]
+                output_scratch_buffers_right.at("vc_packet_router")[2], // 46: vc_packet_router_output_scratch_buffers[2]
+                output_scratch_buffers_right.at("vc_packet_router")[3], // 47: vc_packet_router_output_scratch_buffers[3]
+
+                input_scratch_buffers_right.at("traffic_gen_rx")[0], // 48: vc_packet_router_output_remote_scratch_buffers[0]
+                input_scratch_buffers_right.at("traffic_gen_rx")[1], // 49: vc_packet_router_output_remote_scratch_buffers[1]
+                input_scratch_buffers_right.at("traffic_gen_rx")[2], // 50: vc_packet_router_output_remote_scratch_buffers[2]
+                input_scratch_buffers_right.at("traffic_gen_rx")[3], // 51: vc_packet_router_output_remote_scratch_buffers[3]
             };
 
         log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
@@ -589,8 +708,8 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        vector<vector<uint32_t>> tx_results;
-        vector<vector<uint32_t>> rx_results;
+        std::vector<std::vector<uint32_t>> tx_results;
+        std::vector<std::vector<uint32_t>> rx_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
@@ -608,13 +727,13 @@ int main(int argc, char **argv) {
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
-        vector<uint32_t> mux_results =
+        std::vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> demux_results =
+        std::vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device_r->id(), demux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14427)

(replace registers with scratch buffers in packet_queue) https://github.com/tenstorrent/tt-metal/pull/15463
(This one) (enable routing microperfbenchmark tests) https://github.com/tenstorrent/tt-metal/pull/15468
(remove pow2 assertions in packet queue) https://github.com/tenstorrent/tt-metal/pull/15504

### Problem description
Packet queue was updated to use scratch buffers instead of registers. This change will pass in the required addresses to the compile args for the micro perfbenchmark tests.

### What's changed
 - Some tests were broken previously
 - Updated all routing tests to work with scratch buffers
 - Added a function in test_common to generate test addresses


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
