### PR TITLE
#15297: Allow MeshDevice to be initialized for chips without eth coordinates

### DIFF
--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -19,6 +19,7 @@ rm -rf $kernel_path
 ./build/test/tt_metal/unit_tests_eth
 ./build/test/tt_metal/unit_tests_llk
 ./build/test/tt_metal/unit_tests_stl
+./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=MeshDeviceSuite.*
 
 if [[ ! -z "$TT_METAL_SLOW_DISPATCH_MODE" ]]; then
     env python tests/scripts/run_tt_metal.py --dispatch-mode slow

--- a/tests/tt_metal/distributed/test_distributed.cpp
+++ b/tests/tt_metal/distributed/test_distributed.cpp
@@ -42,4 +42,16 @@ TEST_F(MeshDevice_T3000, SimpleMeshDeviceTest) {
     EXPECT_EQ(mesh_device_->num_cols(), 4);
 }
 
+TEST(MeshDeviceSuite, Test1x1SystemMeshInitialize) {
+    auto& sys = tt::tt_metal::distributed::SystemMesh::instance();
+
+    auto config = tt::tt_metal::distributed::MeshDeviceConfig
+        ({1, 1}, std::pair<size_t, size_t>(0, 0), {}, MeshType::RowMajor);
+
+    EXPECT_NO_THROW({
+        auto mesh = tt::tt_metal::distributed::MeshDevice::create(config, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1,  tt::tt_metal::DispatchCoreType::WORKER);
+        mesh->close_devices();
+    });
+}
+
 }  // namespace tt::tt_metal::distributed::test


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15297

### Problem description
Updating GS and BH to use create-eth-map breaks opening up 1x1 MeshDevice on these archs because they don't have eth chip coordinates. MeshDevice was assuming eth chip coordinates are always available from cluster desc. 

Note: Fabric will assign chip ids for BH. 

### What's changed
Add workaround with dummy chip coordinates if there are no eth coordinates 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12052165609)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12052174032)
- [x] New test provide coverage for changes
