### PR TITLE
Allow builds to run to their natural end

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-lib:
     strategy:
+      fail-fast: false
       matrix:
         build: [
           {type: Debug, cxx_compiler: clang++-17, c_compiler: clang-17, runs-on: ["build", "in-service"], os: ubuntu-20.04},


### PR DESCRIPTION
### Ticket
None

### Problem description
When an intermittent failure rears its ugly head, all the other builds are caught in the crossfire.

### What's changed
Do not kill innocent builds.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
