### PR TITLE
Fix the test for whether to install the wheel, and also exit the script on the first error

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -86,8 +86,12 @@ runs:
           ${{ inputs.device }}
           -w ${{ github.workspace }}
         run: |
-          if [ ${{ inputs.install_wheel }} ]; then
+          set -eu
+
+          install_wheel=${{ inputs.install_wheel }}
+          if [[ "${install_wheel,,}" == "true" ]]; then
             WHEEL_FILENAME=$(ls -1 *.whl)
-            pip3 install $WHEEL_FILENAME
+            pip3 install "$WHEEL_FILENAME"
           fi
+
           ${{ inputs.run_args }}


### PR DESCRIPTION
### Ticket
None

### Problem description
docker-run doesn't exit on error, it keeps running (which raises more errors).
Also, it was ALWAYS installing the wheel, even when set to 'false'.

### What's changed
* `set -eu` for shell hygiene
* test the inputs.install_wheel for "true"

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12043537637
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
