### PR TITLE
[skip ci] Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -95,7 +95,6 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReferenceAlignment: Left
 RawStringFormats:
   - Language:        Cpp
     Delimiters:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,10 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
+.clang-format @tt-rkim @afuller-TT @blozano-tt @tt-aho
+
+.clang-tidy @tt-rkim @afuller-TT @blozano-tt @tt-aho
+
 .github/ @tt-rkim @ttmchiou @TT-billteng @blozano-tt @afuller-TT
 .github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT
 


### PR DESCRIPTION
Don't use parameter that requires new clang-format