### PR TITLE
Fix Circular Buffer Allocation in untilize_with_halo

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.cpp
@@ -144,22 +144,23 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     TT_ASSERT(remote_config.get_dtype() == DataType::UINT16);
 
     Buffer* padding_config_buffer = padding_config.buffer();
+    const uint32_t num_cores = all_cores.num_cores();
     auto padding_config_cb_config =
-        CircularBufferConfig(padding_config_buffer->size(), {{padding_config_cb_id, kernel_config_df}})
+        CircularBufferConfig(padding_config_buffer->size() / num_cores, {{padding_config_cb_id, kernel_config_df}})
             .set_page_size(padding_config_cb_id, padding_config_buffer->page_size())
             .set_globally_allocated_address(*padding_config_buffer);
     CBHandle padding_config_cb = CreateCircularBuffer(program, all_cores, padding_config_cb_config);
 
     Buffer* local_config_buffer = local_config.buffer();
     auto local_config_cb_config =
-        CircularBufferConfig(local_config_buffer->size(), {{local_config_cb_id, kernel_config_df}})
+        CircularBufferConfig(local_config_buffer->size() / num_cores, {{local_config_cb_id, kernel_config_df}})
             .set_page_size(local_config_cb_id, local_config_buffer->page_size())
             .set_globally_allocated_address(*local_config_buffer);
     CBHandle local_config_cb = CreateCircularBuffer(program, all_cores, local_config_cb_config);
 
     Buffer* remote_config_buffer = remote_config.buffer();
     auto remote_config_cb_config =
-        CircularBufferConfig(remote_config_buffer->size(), {{remote_config_cb_id, kernel_config_df}})
+        CircularBufferConfig(remote_config_buffer->size() / num_cores, {{remote_config_cb_id, kernel_config_df}})
             .set_page_size(remote_config_cb_id, remote_config_buffer->page_size())
             .set_globally_allocated_address(*remote_config_buffer);
     CBHandle remote_config_cb = CreateCircularBuffer(program, all_cores, remote_config_cb_config);


### PR DESCRIPTION
This commit addresses and reduces warnings related to the halo operation of type "Circular buffer size 54784 B exceeds allocated L1 buffer bank size of 54720 B." By fixing the allocation of circular buffers, we mitigate the risk of writing outside the allocated buffer space. While some issues persist, resolving these more obvious problems will facilitate tackling the subtler ones in subsequent updates.

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12049675074
