### PR TITLE
Update .clang-format-ignore

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -128,6 +128,4 @@ ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
 ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
 ttnn/cpp/ttnn/tensor/types.hpp
 
-tt-train/*
-
 tests/*


### PR DESCRIPTION
Allow clang-format to run on tt-train

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
