### PR TITLE
Added support for basic OP unit test using didt testing framework

### DIFF
--- a/tests/didt/README.md
+++ b/tests/didt/README.md
@@ -66,6 +66,15 @@ FF1 with gelu: `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/
 LM head: `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_falcon_hang.py -k "test_reproduce_lm_head_nd_32 and 8chips"`
 
 
+## OP unit test
+
+In order to support basic OPs unit testing use case, `EltwiseOpTest` and `UnaryOpTest` classes are added in their respective .py files(test_eltwise.py and test_unary.py). Two example test cases `test_eltwise_add` and `test_unary_sqrt` are added to demonstrate how any ttnn supported eltwise/unary operation can be tested within this framework. Hera are examples of commands that can be used to run supported unit tests:
+
+Eltwise add: `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/didt/test_eltwise.py::test_eltwise_add -k "1chips"`
+
+Unary sqrt: `WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/didt/test_unary.py::test_unary_sqrt -k "1chips"`
+
+Supported variations of tests: [Supported systems](#supported-systems), [Targeting specific device](#targetting-specific-device), [Targeting specific board](#targetting-specific-board), [Iterations](#iterations), [Determinism](#determinism). Blackhole support is TBD.
 
 
 # Adding another suspected repro test

--- a/tests/didt/README.md
+++ b/tests/didt/README.md
@@ -79,6 +79,6 @@ Supported variations of tests: [Supported systems](#supported-systems), [Targeti
 
 # Adding another suspected repro test
 
-`tests/didt/matmul_test_base.py` defines a base class for all tests that encapsulates common behavior - how we run iterations, deallocate, check determinism, sync, etc.  To add a new test, create a new file under the same directory, and then either:
-- instantiate object of the base class in case you don't need to change any behavior, just populate dimensions, configs etc (example in `test_ff1_matmul.py`)
-- extend the base class to override any behavior that needs to be changed (for now we allow to change the way we generate activations & weights, and setting the seed), and then instantiate object of the new class
+`tests/didt/op_test_base.py` defines a base class for all tests that encapsulates common behavior - how we run iterations, deallocate, check determinism, sync, etc.  To add a new test, create a new file under the same directory, and then either:
+- instantiate object of the base class in case you don't need to change any behavior, just populate dimensions, configs etc...
+- extend the base class to override any behavior that needs to be changed (for now we allow to change the way we generate activations & weights, and setting the seed), and then instantiate object of the new class.

--- a/tests/didt/test_eltwise.py
+++ b/tests/didt/test_eltwise.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 import ttnn
 from tests.didt.op_test_base import OpTestBase
+from models.utility_functions import skip_for_blackhole
 
 
 class EltwiseOpTest(OpTestBase):
@@ -44,12 +45,15 @@ class EltwiseOpTest(OpTestBase):
         )
         self.eltwise_ttn_function = eltwise_ttnn_function
 
+    # Override base class to generate random numbers in uniform distribution
     def generate_torch_activations(self, shape):
         return torch.rand(shape)
 
+    # Override base class to generate random numbers in uniform distribution
     def generate_torch_weights(self, shape):
         return torch.rand(shape)
 
+    # Override base class to execute eltwise ttnn operation instead of default ttnn matmul
     def run_device_operation(self):
         return self.eltwise_ttn_function(
             self.activations,
@@ -59,6 +63,7 @@ class EltwiseOpTest(OpTestBase):
         )
 
 
+@skip_for_blackhole("Not tested for Blackhole")
 @pytest.mark.parametrize(
     "mesh_device",
     [
@@ -74,14 +79,17 @@ def test_eltwise_add(
     iterations,
     determinism_check_iterations,
 ):
+    # Initialize in1 and in2 shape, data type, memory configuration and layout
     in_shape = [640, 1280]
     in_dtype = ttnn.DataType.BFLOAT16
     in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
     in_layout = ttnn.TILE_LAYOUT
 
+    # Initialize output data type and memory configuration
     out_dtype = ttnn.DataType.BFLOAT16
     out_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
 
+    # Instance EltwiseOpTest class object and pass ttnn.add as eltwise ttnn function
     eltwise_test = EltwiseOpTest(
         mesh_device,
         in0_shape=in_shape,
@@ -100,4 +108,58 @@ def test_eltwise_add(
         eltwise_ttnn_function=ttnn.add,
     )
 
+    # Run eltwise operation test
     eltwise_test.run_op_test()
+
+
+@skip_for_blackhole("Multi-chip Blackhole has not been tested")
+@pytest.mark.parametrize("logical_chip_id", range(36), ids=[f"logical_chip_{i}_" for i in range(36)])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param(1, id="1chips"),
+        pytest.param(2, id="2chips"),
+        pytest.param(8, id="8chips"),
+        pytest.param((8, 4), id="galaxy"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_specific_chip_eltwise_add(
+    mesh_device,
+    logical_chip_id,
+    iterations,
+    determinism_check_iterations,
+):
+    # Special case for galaxy:
+    #   MeshDevice contains 32 chips, but their ids go from 4 - 35
+    if len(mesh_device.get_device_ids()) == 32:
+        assert (
+            logical_chip_id >= 4 and logical_chip_id <= 35
+        ), f"For TG configuration, logical chip id needs to be in range [4, 35] inclusive, but is {logical_chip_id}"
+    else:
+        assert len(mesh_device.get_device_ids()) > logical_chip_id, "Not enough devices!"
+
+    test_eltwise_add(
+        mesh_device.get_device(logical_chip_id),
+        iterations,
+        determinism_check_iterations,
+    )
+
+
+@skip_for_blackhole("Multi-board Blackhole has not been tested")
+@pytest.mark.parametrize(
+    "board_mesh_device",
+    range(4),
+    ids=[f"board_id_{i}" for i in range(4)],
+    indirect=["board_mesh_device"],
+)
+def test_specific_board_eltwise_add(
+    board_mesh_device,
+    iterations,
+    determinism_check_iterations,
+):
+    test_eltwise_add(
+        board_mesh_device,
+        iterations,
+        determinism_check_iterations,
+    )

--- a/tests/didt/test_eltwise.py
+++ b/tests/didt/test_eltwise.py
@@ -1,0 +1,103 @@
+from loguru import logger
+import pytest
+import torch
+import ttnn
+from tests.didt.op_test_base import OpTestBase
+
+
+class EltwiseOpTest(OpTestBase):
+    def __init__(
+        self,
+        mesh_device,
+        in0_shape,
+        in1_shape,
+        in0_mem_config,
+        in1_mem_config,
+        out_mem_config,
+        in0_dtype,
+        in1_dtype,
+        out_dtype,
+        in0_layout,
+        in1_layout,
+        loop_count=1000,
+        determinism_check_enabled=False,
+        determinism_check_iterations=False,
+        eltwise_ttnn_function=ttnn.add,
+    ):
+        super().__init__(
+            mesh_device,
+            in0_shape,
+            in1_shape,
+            in0_mem_config,
+            in1_mem_config,
+            out_mem_config,
+            in0_dtype,
+            in1_dtype,
+            out_dtype,
+            in0_layout,
+            in1_layout,
+            program_config=None,
+            compute_config=None,
+            loop_count=loop_count,
+            determinism_check_enabled=determinism_check_enabled,
+            determinism_check_iterations=determinism_check_iterations,
+        )
+        self.eltwise_ttn_function = eltwise_ttnn_function
+
+    def generate_torch_activations(self, shape):
+        return torch.rand(shape)
+
+    def generate_torch_weights(self, shape):
+        return torch.rand(shape)
+
+    def run_device_operation(self):
+        return self.eltwise_ttn_function(
+            self.activations,
+            self.weights,
+            memory_config=self.out_mem_config,
+            dtype=self.out_dtype,
+        )
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param(1, id="1chips"),
+        pytest.param(2, id="2chips"),
+        pytest.param(8, id="8chips"),
+        pytest.param((8, 4), id="galaxy"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_eltwise_add(
+    mesh_device,
+    iterations,
+    determinism_check_iterations,
+):
+    in_shape = [640, 1280]
+    in_dtype = ttnn.DataType.BFLOAT16
+    in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    in_layout = ttnn.TILE_LAYOUT
+
+    out_dtype = ttnn.DataType.BFLOAT16
+    out_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+    eltwise_test = EltwiseOpTest(
+        mesh_device,
+        in0_shape=in_shape,
+        in1_shape=in_shape,
+        in0_mem_config=in_mem_config,
+        in1_mem_config=in_mem_config,
+        out_mem_config=out_mem_config,
+        in0_dtype=in_dtype,
+        in1_dtype=in_dtype,
+        out_dtype=out_dtype,
+        in0_layout=in_layout,
+        in1_layout=in_layout,
+        loop_count=iterations,
+        determinism_check_enabled=True if determinism_check_iterations > 0 else False,
+        determinism_check_iterations=determinism_check_iterations,
+        eltwise_ttnn_function=ttnn.add,
+    )
+
+    eltwise_test.run_op_test()

--- a/tests/didt/test_unary.py
+++ b/tests/didt/test_unary.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 import ttnn
 from tests.didt.op_test_base import OpTestBase
+from models.utility_functions import skip_for_blackhole
 
 
 class UnaryOpTest(OpTestBase):
@@ -39,12 +40,15 @@ class UnaryOpTest(OpTestBase):
         )
         self.unary_ttnn_function = unary_ttnn_function
 
+    # Override base class to generate random numbers in uniform distribution
     def generate_torch_activations(self, shape):
         return torch.rand(shape)
 
+    # Override base class to generate random numbers in uniform distribution
     def generate_torch_weights(self, shape):
         return torch.rand(shape)
 
+    # Override base class to execute unary ttnn operation instead of default ttnn matmul
     def run_device_operation(self):
         return self.unary_ttnn_function(
             self.activations,
@@ -52,6 +56,7 @@ class UnaryOpTest(OpTestBase):
         )
 
 
+@skip_for_blackhole("Not tested for Blackhole")
 @pytest.mark.parametrize(
     "mesh_device",
     [
@@ -67,11 +72,13 @@ def test_unary_sqrt(
     iterations,
     determinism_check_iterations,
 ):
+    # Initialize input shape, data type, memory configuration and layout
     in_shape = [640, 1280]
     in_dtype = ttnn.DataType.BFLOAT16
     in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
     in_layout = ttnn.TILE_LAYOUT
 
+    # Instance UnaryOpTest class object and pass ttnn.sqrt as unary ttnn function
     unary_test = UnaryOpTest(
         mesh_device,
         in0_shape=in_shape,
@@ -84,4 +91,58 @@ def test_unary_sqrt(
         unary_ttnn_function=ttnn.sqrt,
     )
 
+    # Run unary operation test
     unary_test.run_op_test()
+
+
+@skip_for_blackhole("Multi-chip Blackhole has not been tested")
+@pytest.mark.parametrize("logical_chip_id", range(36), ids=[f"logical_chip_{i}_" for i in range(36)])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param(1, id="1chips"),
+        pytest.param(2, id="2chips"),
+        pytest.param(8, id="8chips"),
+        pytest.param((8, 4), id="galaxy"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_specific_chip_unary_sqrt(
+    mesh_device,
+    logical_chip_id,
+    iterations,
+    determinism_check_iterations,
+):
+    # Special case for galaxy:
+    #   MeshDevice contains 32 chips, but their ids go from 4 - 35
+    if len(mesh_device.get_device_ids()) == 32:
+        assert (
+            logical_chip_id >= 4 and logical_chip_id <= 35
+        ), f"For TG configuration, logical chip id needs to be in range [4, 35] inclusive, but is {logical_chip_id}"
+    else:
+        assert len(mesh_device.get_device_ids()) > logical_chip_id, "Not enough devices!"
+
+    test_unary_sqrt(
+        mesh_device.get_device(logical_chip_id),
+        iterations,
+        determinism_check_iterations,
+    )
+
+
+@skip_for_blackhole("Multi-board Blackhole has not been tested")
+@pytest.mark.parametrize(
+    "board_mesh_device",
+    range(4),
+    ids=[f"board_id_{i}" for i in range(4)],
+    indirect=["board_mesh_device"],
+)
+def test_specific_board_unary_sqrt(
+    board_mesh_device,
+    iterations,
+    determinism_check_iterations,
+):
+    test_unary_sqrt(
+        board_mesh_device,
+        iterations,
+        determinism_check_iterations,
+    )

--- a/tests/didt/test_unary.py
+++ b/tests/didt/test_unary.py
@@ -1,0 +1,87 @@
+from loguru import logger
+import pytest
+import torch
+import ttnn
+from tests.didt.op_test_base import OpTestBase
+
+
+class UnaryOpTest(OpTestBase):
+    def __init__(
+        self,
+        mesh_device,
+        in0_shape,
+        in0_mem_config,
+        in0_dtype,
+        in0_layout,
+        loop_count=1000,
+        determinism_check_enabled=False,
+        determinism_check_iterations=False,
+        unary_ttnn_function=ttnn.sqrt,
+    ):
+        super().__init__(
+            mesh_device,
+            in0_shape,
+            in1_shape=None,
+            in0_mem_config=in0_mem_config,
+            in1_mem_config=None,
+            out_mem_config=None,
+            in0_dtype=in0_dtype,
+            in1_dtype=None,
+            out_dtype=None,
+            in0_layout=in0_layout,
+            in1_layout=None,
+            program_config=None,
+            compute_config=None,
+            loop_count=loop_count,
+            determinism_check_enabled=determinism_check_enabled,
+            determinism_check_iterations=determinism_check_iterations,
+            unary_op=True,
+        )
+        self.unary_ttnn_function = unary_ttnn_function
+
+    def generate_torch_activations(self, shape):
+        return torch.rand(shape)
+
+    def generate_torch_weights(self, shape):
+        return torch.rand(shape)
+
+    def run_device_operation(self):
+        return self.unary_ttnn_function(
+            self.activations,
+            memory_config=self.out_mem_config,
+        )
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param(1, id="1chips"),
+        pytest.param(2, id="2chips"),
+        pytest.param(8, id="8chips"),
+        pytest.param((8, 4), id="galaxy"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_unary_sqrt(
+    mesh_device,
+    iterations,
+    determinism_check_iterations,
+):
+    in_shape = [640, 1280]
+    in_dtype = ttnn.DataType.BFLOAT16
+    in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    in_layout = ttnn.TILE_LAYOUT
+
+    unary_test = UnaryOpTest(
+        mesh_device,
+        in0_shape=in_shape,
+        in0_mem_config=in_mem_config,
+        in0_dtype=in_dtype,
+        in0_layout=in_layout,
+        loop_count=iterations,
+        determinism_check_enabled=True if determinism_check_iterations > 0 else False,
+        determinism_check_iterations=determinism_check_iterations,
+        unary_ttnn_function=ttnn.sqrt,
+    )
+
+    unary_test.run_op_test()


### PR DESCRIPTION
### Ticket
This is internal request using PR to conduct official code review before merging with owners branch.

### Problem description
Adding support for basic OP(eltwise and unary) unit tests inside didt testing framework. Idea is to have set of basic OP tests (eltwise binary, unary and matmul) that can run in large number of iterations together with option to check results for deterministic behavior. didt testing framework already supports running repeated iterations of tests with output deterministic behavior check, so this framework is extended to support eltwise and unary OPs. Two basic classes are created to support unit testing of any eltwise and unary operation with two simple tests for eltwise add and unary sqrt operations added. 

### What's changed
Added `EltwiseOpTest` and `UnaryOpTest` classes tu support unit testing of eltwise and unary operations.
Added `test_eltwise_add` and `test_unary_sqrt` as examples how classes can be used to implement unit test for basic operations.
Updated `README.md`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
