### PR TITLE
#14427: remove pow2 assertions in packet queue

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
@@ -22,8 +22,6 @@ constexpr uint32_t input_queue_id = 0;
 constexpr uint32_t queue_start_addr_words = get_compile_time_arg_val(3);
 constexpr uint32_t queue_size_words = get_compile_time_arg_val(4);
 
-static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
-
 constexpr uint32_t remote_tx_x = get_compile_time_arg_val(5);
 constexpr uint32_t remote_tx_y = get_compile_time_arg_val(6);
 constexpr uint32_t remote_tx_queue_id = get_compile_time_arg_val(7);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -18,12 +18,8 @@ constexpr uint32_t queue_start_addr_words = get_compile_time_arg_val(2);
 constexpr uint32_t queue_size_words = get_compile_time_arg_val(3);
 constexpr uint32_t queue_size_bytes = queue_size_words * PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
-
 constexpr uint32_t remote_rx_queue_start_addr_words = get_compile_time_arg_val(4);
 constexpr uint32_t remote_rx_queue_size_words = get_compile_time_arg_val(5);
-
-static_assert(is_power_of_2(remote_rx_queue_size_words), "remote_rx_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_rx_x = get_compile_time_arg_val(6);
 constexpr uint32_t remote_rx_y = get_compile_time_arg_val(7);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -100,9 +100,6 @@ int main(int argc, char **argv) {
         uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
         uint32_t tx_data_sent_per_iter_high = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_high", default_tx_data_sent_per_iter_high);
 
-        assert(is_power_of_2(tx_queue_size_bytes) && (tx_queue_size_bytes >= 1024));
-        assert(is_power_of_2(rx_queue_size_bytes) && (rx_queue_size_bytes >= 1024));
-
         tt_metal::Program program = tt_metal::CreateProgram();
 
         CoreCoord traffic_gen_tx_core = {tx_x, tx_y};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
@@ -14,8 +14,8 @@
 using namespace tt;
 using json = nlohmann::json;
 
-int main(int argc, char **argv) {
 
+int main(int argc, char **argv) {
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;
     constexpr uint32_t default_rx_x = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
@@ -11,12 +11,11 @@
 #include "tt_metal/impl/device/device.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
-using std::vector;
 using namespace tt;
 using json = nlohmann::json;
 
-int main(int argc, char **argv) {
 
+int main(int argc, char **argv) {
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;
     constexpr uint32_t default_rx_x = 0;
@@ -1102,10 +1101,10 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        vector<vector<uint32_t>> tx_results;
-        vector<vector<uint32_t>> tx_results_r;
-        vector<vector<uint32_t>> rx_results;
-        vector<vector<uint32_t>> rx_results_r;
+        std::vector<std::vector<uint32_t>> tx_results;
+        std::vector<std::vector<uint32_t>> tx_results_r;
+        std::vector<std::vector<uint32_t>> rx_results;
+        std::vector<std::vector<uint32_t>> rx_results_r;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
@@ -1138,25 +1137,25 @@ int main(int argc, char **argv) {
             pass &= (rx_results_r[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
-        vector<uint32_t> mux_results =
+        std::vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> mux_results_r =
+        std::vector<uint32_t> mux_results_r =
             tt::llrt::read_hex_vec_from_core(
                 device_r->id(), mux_phys_core_r, test_results_addr, test_results_size);
         log_info(LogTest, "R MUX status = {}", packet_queue_test_status_to_string(mux_results_r[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results_r[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> demux_results =
+        std::vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
         log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
-        vector<uint32_t> demux_results_r =
+        std::vector<uint32_t> demux_results_r =
             tt::llrt::read_hex_vec_from_core(
                 device_r->id(), demux_phys_core_r, test_results_addr, test_results_size);
         log_info(LogTest, "R DEMUX status = {}", packet_queue_test_status_to_string(demux_results_r[PQ_TEST_STATUS_INDEX]));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
@@ -11,6 +11,7 @@
 using namespace tt;
 using json = nlohmann::json;
 
+
 int main(int argc, char **argv) {
     constexpr uint32_t default_tx_x = 0;
     constexpr uint32_t default_tx_y = 0;

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -16,8 +16,6 @@ constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
-
 constexpr uint32_t demux_fan_out = get_compile_time_arg_val(3);
 
 // FIXME imatosevic - is there a way to do this without explicit indexes?
@@ -73,11 +71,6 @@ constexpr uint32_t remote_tx_queue_size_words[MAX_SWITCH_FAN_OUT] =
         get_compile_time_arg_val(13),
         get_compile_time_arg_val(15)
     };
-
-static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((demux_fan_out < 2) || is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((demux_fan_out < 3) || is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((demux_fan_out < 4) || is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_rx_x = get_compile_time_arg_val(16);
 constexpr uint32_t remote_rx_y = get_compile_time_arg_val(17);

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -18,8 +18,6 @@ constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
-
 constexpr uint32_t mux_fan_in = get_compile_time_arg_val(3);
 
 // FIXME imatosevic - is there a way to do this without explicit indexes?
@@ -62,8 +60,6 @@ constexpr DispatchRemoteNetworkType remote_rx_network_type[MAX_SWITCH_FAN_IN] =
 
 constexpr uint32_t remote_tx_queue_start_addr_words = get_compile_time_arg_val(8);
 constexpr uint32_t remote_tx_queue_size_words = get_compile_time_arg_val(9);
-
-static_assert(is_power_of_2(remote_tx_queue_size_words), "remote_tx_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_tx_x = get_compile_time_arg_val(10);
 constexpr uint32_t remote_tx_y = get_compile_time_arg_val(11);

--- a/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_eth_tunneler.cpp
@@ -14,7 +14,6 @@ constexpr uint32_t tunnel_lanes = get_compile_time_arg_val(1);
 constexpr uint32_t in_queue_start_addr_words = get_compile_time_arg_val(2);
 constexpr uint32_t in_queue_size_words = get_compile_time_arg_val(3);
 constexpr uint32_t in_queue_size_bytes = in_queue_size_words * PACKET_WORD_SIZE_BYTES;
-static_assert(is_power_of_2(in_queue_size_words), "in_queue_size_words must be a power of 2");
 static_assert(tunnel_lanes <= MAX_TUNNEL_LANES, "cannot have more than 2 tunnel directions.");
 static_assert(tunnel_lanes, "tunnel directions cannot be 0. 1 => Unidirectional. 2 => Bidirectional");
 
@@ -101,17 +100,6 @@ constexpr uint32_t remote_receiver_queue_size_words[MAX_TUNNEL_LANES] =
         get_compile_time_arg_val(31),
         get_compile_time_arg_val(33)
     };
-
-static_assert(is_power_of_2(remote_receiver_queue_size_words[0]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[1]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[2]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[3]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[4]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[5]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[6]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[7]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[8]), "remote_receiver_queue_size_words must be a power of 2");
-static_assert(is_power_of_2(remote_receiver_queue_size_words[9]), "remote_receiver_queue_size_words must be a power of 2");
 
 constexpr uint32_t remote_sender_x[MAX_TUNNEL_LANES] =
     {

--- a/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
@@ -11,8 +11,6 @@ constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
 constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
 constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
 
-static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
-
 constexpr uint32_t router_lanes = get_compile_time_arg_val(3);
 
 // FIXME imatosevic - is there a way to do this without explicit indexes?
@@ -68,11 +66,6 @@ constexpr uint32_t remote_tx_queue_size_words[MAX_SWITCH_FAN_OUT] =
         get_compile_time_arg_val(13),
         get_compile_time_arg_val(15)
     };
-
-static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((router_lanes < 2) || is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((router_lanes < 3) || is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
-static_assert((router_lanes < 4) || is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
 
 constexpr uint8_t remote_rx_x[MAX_SWITCH_FAN_OUT] =
     {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14427)

- PR Relation Chain

(replace registers with scratch buffers in packet_queue) https://github.com/tenstorrent/tt-metal/pull/15463
(enable routing microperfbenchmark tests) https://github.com/tenstorrent/tt-metal/pull/15468
(This one) (remove pow2 assertions in packet queue) https://github.com/tenstorrent/tt-metal/pull/15504

### Problem description
Support non-power of 2 queue sizes.

### What's changed
Removes the power of 2 assertions from the packet queue kernels and test.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
