### PR TITLE
[tt-train] Implement composite LayerNorm 

### DIFF
--- a/tt-train/configs/training_shakespear_nanogpt.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt.yaml
@@ -15,3 +15,5 @@ training_config:
     num_blocks: 6
     vocab_size: 96
     max_sequence_length: 256
+    experimental:
+      use_composite_layernorm: true

--- a/tt-train/configs/training_shakespear_nanogpt.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt.yaml
@@ -16,4 +16,4 @@ training_config:
     vocab_size: 96
     max_sequence_length: 256
     experimental:
-      use_composite_layernorm: true
+      use_composite_layernorm: false

--- a/tt-train/sources/ttml/models/gpt2.hpp
+++ b/tt-train/sources/ttml/models/gpt2.hpp
@@ -19,6 +19,11 @@ struct TransformerConfig {
     uint32_t num_blocks = 6;
     uint32_t vocab_size = 256;
     uint32_t max_sequence_length = 256;
+
+    struct Experimental {
+        bool use_composite_layernorm = false;
+    };
+    Experimental experimental;
 };
 
 class Transformer : public ttml::autograd::ModuleBase {

--- a/tt-train/sources/ttml/modules/gpt_block.cpp
+++ b/tt-train/sources/ttml/modules/gpt_block.cpp
@@ -29,10 +29,10 @@ autograd::TensorPtr GPTMLP::operator()(const autograd::TensorPtr& input) {
     return x;
 }
 
-GPTBlock::GPTBlock(uint32_t embedding_size, uint32_t num_heads, float dropout_prob) {
+GPTBlock::GPTBlock(uint32_t embedding_size, uint32_t num_heads, float dropout_prob, bool use_composite_layernorm) {
     mlp = std::make_shared<GPTMLP>(embedding_size, dropout_prob);
-    ln1 = std::make_shared<LayerNormLayer>(embedding_size);
-    ln2 = std::make_shared<LayerNormLayer>(embedding_size);
+    ln1 = std::make_shared<LayerNormLayer>(embedding_size, use_composite_layernorm);
+    ln2 = std::make_shared<LayerNormLayer>(embedding_size, use_composite_layernorm);
     attention = std::make_shared<MultiHeadAttention>(embedding_size, num_heads, dropout_prob);
 
     create_name("gpt_block");

--- a/tt-train/sources/ttml/modules/gpt_block.hpp
+++ b/tt-train/sources/ttml/modules/gpt_block.hpp
@@ -31,7 +31,8 @@ class GPTBlock : public autograd::ModuleBase {
     std::shared_ptr<MultiHeadAttention> attention;
 
 public:
-    explicit GPTBlock(uint32_t embedding_size, uint32_t num_heads, float dropout_prob);
+    explicit GPTBlock(
+        uint32_t embedding_size, uint32_t num_heads, float dropout_prob, bool use_composite_layernorm = false);
 
     autograd::TensorPtr operator()(const autograd::TensorPtr& input, const autograd::TensorPtr& mask);
 };

--- a/tt-train/sources/ttml/modules/layer_norm_module.cpp
+++ b/tt-train/sources/ttml/modules/layer_norm_module.cpp
@@ -15,7 +15,7 @@ void LayerNormLayer::initialize_tensors(uint32_t features) {
         autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
 }
 
-LayerNormLayer::LayerNormLayer(uint32_t features) {
+LayerNormLayer::LayerNormLayer(uint32_t features, bool use_composite_op) : m_use_composite_op(use_composite_op) {
     initialize_tensors(features);
 
     create_name("layernorm");
@@ -24,6 +24,9 @@ LayerNormLayer::LayerNormLayer(uint32_t features) {
 }
 
 autograd::TensorPtr LayerNormLayer::operator()(const autograd::TensorPtr& tensor) {
+    if (m_use_composite_op) {
+        return ops::composite_layernorm(tensor, m_gamma, m_beta);
+    }
     return ops::layernorm(tensor, m_gamma, m_beta);
 }
 

--- a/tt-train/sources/ttml/modules/layer_norm_module.hpp
+++ b/tt-train/sources/ttml/modules/layer_norm_module.hpp
@@ -14,12 +14,13 @@ namespace ttml::modules {
 
 class LayerNormLayer : public autograd::ModuleBase {
 private:
+    bool m_use_composite_op = false;
     autograd::TensorPtr m_gamma;
     autograd::TensorPtr m_beta;
 
 public:
     void initialize_tensors(uint32_t features);
-    explicit LayerNormLayer(uint32_t features);
+    explicit LayerNormLayer(uint32_t features, bool use_composite_op = false);
 
     [[nodiscard]] autograd::TensorPtr operator()(const autograd::TensorPtr& tensor);
 };

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -12,61 +12,185 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/graph.hpp"
 #include "autograd/graph_utils.hpp"
+#include "autograd/tensor.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
 
 namespace ttml::ops {
 
-// simplified version of layernorm
-// it works only for 4D tensors and for the last dimension
+// // simplified version of layernorm
+// // it works only for 4D tensors and for the last dimension
+// autograd::TensorPtr custom_layernorm(
+//     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
+//     auto tensor_shape = tensor->get_value().get_shape();
+//     auto mean = core::empty(
+//         core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1}),
+//         &autograd::ctx().get_device(),
+//         tensor->get_value().memory_config());
+//     auto rstd = ttnn::empty_like(mean);
+//     auto output = ttnn::empty_like(tensor->get_value());
+
+//     auto out_tensors = ttnn::moreh_layer_norm(
+//         tensor->get_value(),
+//         1,
+//         1e-6F,
+//         /* gamma */ gamma->get_value(),
+//         /* beta */ beta->get_value(),
+//         output,
+//         mean,
+//         rstd,
+//         /* memory_config */ std::nullopt,
+//         /* compute_kernel_config */ std::nullopt);
+
+//     auto out = autograd::create_tensor();
+//     out->set_value(out_tensors[0].value());
+//     mean = out_tensors[1].value();
+//     rstd = out_tensors[2].value();
+
+//     autograd::GradFunction grad = [tensor, out, mean, rstd, gamma, beta]() {
+//         auto input_grad = ttnn::empty_like(tensor->get_value());
+//         auto gamma_grad = ttnn::empty_like(gamma->get_value());
+//         auto beta_grad = ttnn::empty_like(beta->get_value());
+
+//         auto res = ttnn::moreh_layer_norm_backward(
+//             out->get_grad(),
+//             tensor->get_value(),
+//             mean,
+//             rstd,
+//             1,
+//             gamma->get_value(),
+//             input_grad,
+//             gamma_grad,
+//             beta_grad,
+//             /* memory_config */ std::nullopt,
+//             /* compute_kernel_config */ std::nullopt);
+
+//         tensor->add_grad(res[0].value());
+//         gamma->add_grad(res[1].value());
+//         beta->add_grad(res[2].value());
+//     };
+
+//     auto links = autograd::get_links(tensor);
+//     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
+
+//     return out;
+// }
+
 autograd::TensorPtr layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
     auto tensor_shape = tensor->get_value().get_shape();
-    auto mean = core::empty(
-        core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1}),
-        &autograd::ctx().get_device(),
-        tensor->get_value().memory_config());
-    auto rstd = ttnn::empty_like(mean);
-    auto output = ttnn::empty_like(tensor->get_value());
 
-    auto out_tensors = ttnn::moreh_layer_norm(
+    auto shape = core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1});
+    auto mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
+    ttnn::moreh_mean(
         tensor->get_value(),
-        1,
-        1e-6F,
-        /* gamma */ gamma->get_value(),
-        /* beta */ beta->get_value(),
-        output,
+        3,  // last dimension
+        true,
+        std::nullopt,
         mean,
-        rstd,
-        /* memory_config */ std::nullopt,
-        /* compute_kernel_config */ std::nullopt);
+        std::nullopt,
+        /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
 
-    auto out = autograd::create_tensor();
-    out->set_value(out_tensors[0].value());
-    mean = out_tensors[1].value();
-    rstd = out_tensors[2].value();
+    auto tensor_squared = ttnn::square(tensor->get_value());
+    auto mean_squared = core::zeros_like(mean);
+    ttnn::moreh_mean(
+        tensor_squared,
+        3,  // last dimension
+        true,
+        std::nullopt,
+        mean_squared,
+        std::nullopt,
+        /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
+    auto variance = ttnn::subtract(mean_squared, ttnn::square(mean));
 
-    autograd::GradFunction grad = [tensor, out, mean, rstd, gamma, beta]() {
-        auto input_grad = ttnn::empty_like(tensor->get_value());
-        auto gamma_grad = ttnn::empty_like(gamma->get_value());
-        auto beta_grad = ttnn::empty_like(beta->get_value());
+    const float eps = 1e-6F;
+    auto rstd = ttnn::rsqrt(ttnn::add(variance, eps));
 
-        auto res = ttnn::moreh_layer_norm_backward(
-            out->get_grad(),
+    auto normalized_tensor = ttnn::multiply(ttnn::subtract(tensor->get_value(), mean), rstd);
+    auto output = ttnn::add(ttnn::multiply(normalized_tensor, gamma->get_value()), beta->get_value());
+    auto out = autograd::create_tensor(output);
+
+    autograd::GradFunction grad = [tensor, out, mean, rstd, normalized_tensor, variance, gamma, beta, eps]() {
+        auto dout = out->get_grad();
+        auto dbeta = ttnn::moreh_sum(
+            dout,
+            /* dim */ ttnn::SmallVector<int64_t>{0, 1, 2},
+            /* keep_dim */ true,
+            /* output */ std::nullopt,
+            /* output_mem_config */ std::nullopt,
+            /*compute_kernel_config */ core::ComputeKernelConfig::precise());
+
+        auto dgamma = ttnn::moreh_sum(
+            ttnn::multiply(dout, normalized_tensor),
+            /* dim */ ttnn::SmallVector<int64_t>{0, 1, 2},
+            /* keep_dim */ true,
+            /* output */ std::nullopt,
+            /* output_mem_config */ std::nullopt,
+            /*compute_kernel_config */ core::ComputeKernelConfig::precise());
+
+        auto dtensor_normalized = ttnn::multiply(dout, gamma->get_value());
+
+        // dvariance = np.sum(dx_norm * (x - mean) * -0.5 * (variance + epsilon) ** (-1.5), axis=-1, keepdims=True)
+        // dx_norm * (x - mean) * -0.5 * (variance + epsilon) ** (-1.5)
+        auto x_sub_mean = ttnn::subtract(tensor->get_value(), mean);
+        auto x_sub_mean_half = ttnn::multiply(x_sub_mean, -0.5F);
+        auto x_variance_1_5 = ttnn::power(ttnn::add(variance, eps), -1.5F);
+        auto dvariance_before_reduce =
+            ttnn::multiply(dtensor_normalized, ttnn::multiply(x_sub_mean_half, x_variance_1_5));
+
+        auto dvariance = ttnn::moreh_sum(
+            dvariance_before_reduce,
+            /* dim */ ttnn::SmallVector<int64_t>{0, 1, 2},
+            /* keep_dim */ true,
+            /* output */ std::nullopt,
+            /* output_mem_config */ std::nullopt,
+            /*compute_kernel_config */ core::ComputeKernelConfig::precise());
+
+        // dmean =
+        //      np.sum(dx_norm * -1 / np.sqrt(variance + epsilon), axis=1, keepdims=True) +
+        //      dvariance * np.mean(-2 * (x - mean), axis=1, keepdims=True)
+
+        // np.sum(dx_norm * -1 / np.sqrt(variance + epsilon), axis=1, keepdims=True)
+        auto dmean_p0 = ttnn::multiply(ttnn::neg(dtensor_normalized), ttnn::rsqrt(ttnn::add(variance, eps)));
+        dmean_p0 = ttnn::moreh_sum(
+            dmean_p0,
+            /* dim */ 3,
+            /* keep_dim */ true,
+            /* output */ std::nullopt,
+            /* output_mem_config */ std::nullopt,
+            /*compute_kernel_config */ core::ComputeKernelConfig::precise());
+
+        // dvariance * np.mean(-2 * (x - mean), axis=1, keepdims=True)
+        auto x_sub_mean_mult_neg2 = ttnn::multiply(x_sub_mean, -2);
+        auto before_reduction_shape = x_sub_mean_mult_neg2.get_shape();
+        auto shape =
+            core::create_shape({before_reduction_shape[0], before_reduction_shape[1], before_reduction_shape[2], 1});
+        auto x_sub_mean_mult_neg2_reduced =
+            core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
+        ttnn::moreh_mean(
             tensor->get_value(),
-            mean,
-            rstd,
-            1,
-            gamma->get_value(),
-            input_grad,
-            gamma_grad,
-            beta_grad,
-            /* memory_config */ std::nullopt,
-            /* compute_kernel_config */ std::nullopt);
+            3,  // last dimension
+            true,
+            std::nullopt,
+            x_sub_mean_mult_neg2_reduced,
+            std::nullopt,
+            /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
 
-        tensor->add_grad(res[0].value());
-        gamma->add_grad(res[1].value());
-        beta->add_grad(res[2].value());
+        auto dmean_p1 = ttnn::multiply(dvariance, x_sub_mean_mult_neg2_reduced);
+        auto dmean = ttnn::add(dmean_p0, dmean_p1);
+
+        // dx = dx_norm / np.sqrt(variance + epsilon) + dvariance * 2 * (x - mean) / H + dmean / H
+        auto dtensor_p0 = ttnn::multiply(dtensor_normalized, ttnn::rsqrt(ttnn::add(variance, eps)));
+        auto dtensor_p1 = ttnn::multiply(dvariance, ttnn::multiply(x_sub_mean, 2));
+        dtensor_p1 = ttnn::add(dtensor_p1, dmean);
+
+        auto tensor_shape = tensor->get_value().get_shape();
+        dtensor_p1 = ttnn::multiply(dtensor_p1, 1.F / static_cast<float>(tensor_shape[3]));
+        auto dtensor = ttnn::add(dtensor_p0, dtensor_p1);
+
+        tensor->add_grad(dtensor);
+        gamma->add_grad(dgamma);
+        beta->add_grad(dbeta);
     };
 
     auto links = autograd::get_links(tensor);
@@ -74,4 +198,5 @@ autograd::TensorPtr layernorm(
 
     return out;
 }
+
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/layernorm_op.hpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.hpp
@@ -10,4 +10,7 @@ namespace ttml::ops {
 autograd::TensorPtr layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta);
 
+autograd::TensorPtr composite_layernorm(
+    const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta);
+
 }  // namespace ttml::ops

--- a/tt-train/tests/ops/layer_norm_op_test.cpp
+++ b/tt-train/tests/ops/layer_norm_op_test.cpp
@@ -100,3 +100,91 @@ TEST(LayerNormOpTest, LayerNormOp_backward) {
         EXPECT_NEAR(tensor_grad[i], expected_tensor_grad[i], 6e-2);
     }
 }
+
+TEST(LayerNormOpTest, CompositeLayerNormOp_0) {
+    using namespace ttml;
+
+    uint32_t batch_size = 6;
+    uint32_t seq_len = 13;
+    uint32_t heads = 16;
+    uint32_t features = 333;
+
+    uint32_t size = batch_size * seq_len * heads;
+
+    std::vector<float> test_data;
+    test_data.reserve((size_t)batch_size * seq_len * heads * features);
+    for (uint32_t i = 0; i < batch_size * seq_len * heads; i++) {
+        float mean = (float)i / (float)size;
+        float stddev = 1.F + (float)i / (float)(size * 2);
+        std::mt19937 gen(i);
+        std::normal_distribution<float> dist(mean, stddev);
+        for (uint32_t j = 0; j < features; j++) {
+            test_data.push_back(dist(gen));
+        }
+    }
+
+    auto tensor = autograd::create_tensor(core::from_vector(
+        test_data, core::create_shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
+
+    auto gamma =
+        autograd::create_tensor(core::ones(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta =
+        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+
+    auto result = ops::composite_layernorm(tensor, gamma, beta);
+
+    auto result_tensor = result->get_value();
+    auto result_data = core::to_vector(result_tensor);
+    for (uint32_t i = 0; i < batch_size * seq_len * heads; i++) {
+        uint32_t idx = i * features;
+
+        float exp_mean = 0.F;
+        float exp_var = 0.F;
+        for (uint32_t j = 0; j < features; ++j) {
+            exp_mean += result_data[idx + j];
+            exp_var += result_data[idx + j] * result_data[idx + j];
+        }
+
+        exp_mean /= (float)features;
+        exp_var /= (float)features;
+        exp_var = exp_var - exp_mean * exp_mean;
+
+        EXPECT_NEAR(exp_mean, 0.F, 3e-2);
+        EXPECT_NEAR(exp_var, 1.F, 3e-2);
+    }
+}
+
+TEST(LayerNormOpTest, CompositeLayerNormOp_backward) {
+    using namespace ttml;
+
+    uint32_t batch_size = 1;
+    uint32_t seq_len = 1;
+    uint32_t heads = 1;
+    uint32_t features = 3;
+
+    std::vector<float> test_data{0.0, 1.0, 2.0};
+    auto tensor = autograd::create_tensor(core::from_vector(
+        test_data, core::create_shape({batch_size, seq_len, heads, features}), &autograd::ctx().get_device()));
+
+    auto gamma = autograd::create_tensor(
+        core::from_vector({1, 2, 3}, core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+    auto beta =
+        autograd::create_tensor(core::zeros(core::create_shape({1, 1, 1, features}), &autograd::ctx().get_device()));
+
+    auto result = ops::composite_layernorm(tensor, gamma, beta);
+    auto target = autograd::create_tensor(core::zeros_like(tensor->get_value()));
+    result = ops::mse_loss(result, target);
+    result->backward();
+
+    auto tensor_grad = core::to_vector(tensor->get_grad());
+    auto gamma_grad = core::to_vector(gamma->get_grad());
+    auto beta_grad = core::to_vector(beta->get_grad());
+    std::vector<float> expected_tensor_grad{1.3333, -2.6667, 1.3333};
+    std::vector<float> expected_gamma_grad{1.0000, 0.0000, 3.0000};
+    std::vector<float> expected_beta_grad{-0.8165, 0.0000, 2.4495};
+    for (uint32_t i = 0; i < features; ++i) {
+        EXPECT_NEAR(beta_grad[i], expected_beta_grad[i], 3e-2);
+        EXPECT_NEAR(gamma_grad[i], expected_gamma_grad[i], 3e-2);
+        EXPECT_NEAR(tensor_grad[i], expected_tensor_grad[i], 6e-2);
+    }
+}


### PR DESCRIPTION
### Problem description
During training GPT2-S we see huge variance in LayerNorm gradients. We assume that there might be a problems in current implementation of `moreh_layer_norm` and `moreh_layer_norm_backward`. 

### What's changed
Implement composite LayerNorm operation. Add option to switch between moreh and composite operation in LayerNorm module. Accuracy of gamma/beta gradient and forward pass is improved from 5e-2 vs 3e-2. 

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12056216819
- [x] New/Existing tests provide coverage for changes
