### PR TITLE
Fix to concat support for tensors with tile padding

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -11,6 +11,31 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+@pytest.mark.parametrize(
+    "concat_spec",
+    (([[1, 1, 12, 50], [1, 1, 12, 50]], -1),),
+)
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
+def test_tiled_concat(device, concat_spec, async_mode):
+    shapes, dim = concat_spec
+    device.enable_async(async_mode)
+    torch_input_tensors = [torch.rand(shape, dtype=torch.bfloat16) for shape in shapes]
+    torch_output_tensor = torch.concat(torch_input_tensors, dim=dim)
+
+    input_tensors = [
+        ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+        for torch_input_tensor in torch_input_tensors
+    ]
+
+    # if ttnn.has_tile_padding(input_tensor_a, dim=dim) or ttnn.has_tile_padding(input_tensor_b, dim=dim):
+    #     pytest.skip("Cannot concat tensors with tile padding")
+
+    output = ttnn.concat(input_tensors, dim=dim)
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_output_tensor, output, 0.9999)
+
+
 @pytest.mark.parametrize("height", [20, 32])
 @pytest.mark.parametrize("width", [4, 32])
 @pytest.mark.parametrize("dim", [0, 1])
@@ -23,9 +48,6 @@ def test_concat(device, height, width, dim, async_mode):
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
-
-    if ttnn.has_tile_padding(input_tensor_a, dim=dim) or ttnn.has_tile_padding(input_tensor_b, dim=dim):
-        pytest.skip("Cannot concat tensors with tile padding")
 
     output = ttnn.concat([input_tensor_a, input_tensor_b], dim=dim)
     output = ttnn.to_torch(output)

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -27,9 +27,6 @@ def test_tiled_concat(device, concat_spec, async_mode):
         for torch_input_tensor in torch_input_tensors
     ]
 
-    # if ttnn.has_tile_padding(input_tensor_a, dim=dim) or ttnn.has_tile_padding(input_tensor_b, dim=dim):
-    #     pytest.skip("Cannot concat tensors with tile padding")
-
     output = ttnn.concat(input_tensors, dim=dim)
     output = ttnn.to_torch(output)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -102,7 +102,7 @@ MassagedConcat build_untilize_rm_retilize_concat(uint8_t queue_id,
             return res;
         },
         .pre_transform =
-            [](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> OwnedConcatArgs {
+            [queue_id, output_memory_config](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> OwnedConcatArgs {
             std::vector<ttnn::Tensor> itensors;
             itensors.reserve(tensors.size());
             std::transform(
@@ -141,7 +141,8 @@ MassagedConcat build_untilize_rm_retilize_concat(uint8_t queue_id,
                 });
             return std::make_tuple(itensors, dim, groups);
         },
-        .post_transform = [&logical_output_shape, queue_id](const ttnn::Tensor& output) -> ttnn::Tensor {
+        .post_transform = [&logical_output_shape,
+                           queue_id](const ttnn::Tensor& output) -> ttnn::Tensor {
             // now we have a rm tensor, so we need ensure its's padded to tile size and re-tilize it
             if (output.get_layout() != ttnn::TILE_LAYOUT) {
                 auto padded = pad_to_tile_vol(queue_id, output, 0.0f, true, output.memory_config());

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -317,7 +317,7 @@ ttnn::Tensor ConcatOperation::invoke(
         return shape_out;
     };
 
-    ttnn::SimpleShape logical_output_shape = compute_output_shape(input_tensors);
+    ttnn::SimpleShape logical_output_shape = compute_output_shape(input_tensors, dim);
 
     auto untilize_rm_retilize_concat = build_untilize_rm_retilize_concat(queue_id, mem_config, logical_output_shape);
     auto non_aligned_last_dim_concat = build_non_aligned_last_dim_concat(input_tensors, queue_id, mem_config);

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -152,7 +152,7 @@ MassagedConcat build_untilize_rm_retilize_concat(uint8_t queue_id,
                 concat_db_print(true, "[DEBUG] tilized");
                 // need to reshape tilized result to logical concat output shape
                 auto reshaped = ttnn::reshape(
-                    tilized, ttnn::Shape{logical_output_shape->view(), tilized.get_padded_shape().view()});
+                    tilized, ttnn::Shape{logical_output_shape.view(), tilized.get_padded_shape().view()});
                 return reshaped;
             }
             concat_db_print(true, "[DEBUG] already tilized");


### PR DESCRIPTION
### Ticket
#13667 

### Problem description
The previous fix for concat adding support for tile padding didn't actually strip the padding from the input/output tensors. This resulted in tensors with the wrong logical shape and junk values.

### What's changed
This PR adds the requisite slices on the inputs/reshape on the outputs so that we only concat meaningful non-padding values and obtain a tiled tensor of the expected logical shape.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12073835822)
- [ ] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12073836804)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12073837999)
- [x] New/Existing tests provide coverage for changes
