### PR TITLE
Add support for rank-n tensors to tilize and untilize

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_test.py
@@ -10,14 +10,14 @@ from models.utility_functions import tilize
 
 
 @pytest.mark.parametrize(
-    "nb, nc, nh, nw",
+    "shape",
     (
-        (5, 2, 4, 8),
-        (5, 2, 4, 7),
+        [5, 2, 4, 8],
+        [5, 2, 4, 7],
         ## resnet shapes
-        (1, 1, 784, 2),
-        (8, 1, 2, 64),
-        (1, 1, 1, 64),
+        [1, 1, 784, 2],
+        [8, 1, 2, 64],
+        [1, 1, 1, 64],
     ),
 )
 @pytest.mark.parametrize(
@@ -27,9 +27,9 @@ from models.utility_functions import tilize
         True,
     ),
 )
-def test_run_tilize_test(nb, nc, nh, nw, multicore, device):
-    nt = nb * nc * nh * nw
-    shape = [nb, nc, 32 * nh, 32 * nw]
+def test_run_tilize_test(shape, multicore, device):
+    shape[-1] *= 32
+    shape[-2] *= 32
 
     inp = torch.rand(*shape).bfloat16()
 
@@ -43,3 +43,37 @@ def test_run_tilize_test(nb, nc, nh, nw, multicore, device):
     tilized_inp = tilize(inp)
     passing = torch.equal(tilized_inp, c)
     assert passing
+
+
+@pytest.mark.parametrize(
+    "shape",
+    (
+        [1, 1, 1, 5, 1],
+        [1, 1, 1, 4, 2],
+        [1, 1, 1, 3, 3],
+        [1, 1, 1, 2, 4],
+        [1, 1, 1, 1, 5],
+        [1, 2, 3, 2, 1],
+    ),
+)
+@pytest.mark.parametrize(
+    "multicore",
+    (
+        False,
+        True,
+    ),
+)
+def test_tilize_5d(shape, multicore, device):
+    # tests that host -> device -> tilize -> untilize -> host is a no-op
+    shape[-1] *= 32
+    shape[-2] *= 32
+
+    inp = torch.rand(*shape).bfloat16()
+    a = ttnn.Tensor(
+        inp,
+        ttnn.bfloat16,
+    ).to(device)
+    b = ttnn.tilize(a, use_multicore=multicore)
+    c = ttnn.untilize(b)
+    d = c.cpu().to_torch()
+    assert torch.equal(inp, d)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_test.py
@@ -10,14 +10,14 @@ from models.utility_functions import tilize
 
 
 @pytest.mark.parametrize(
-    "shape",
+    "nb, nc, nh, nw",
     (
-        [5, 2, 4, 8],
-        [5, 2, 4, 7],
+        (5, 2, 4, 8),
+        (5, 2, 4, 7),
         ## resnet shapes
-        [1, 1, 784, 2],
-        [8, 1, 2, 64],
-        [1, 1, 1, 64],
+        (1, 1, 784, 2),
+        (8, 1, 2, 64),
+        (1, 1, 1, 64),
     ),
 )
 @pytest.mark.parametrize(
@@ -27,9 +27,8 @@ from models.utility_functions import tilize
         True,
     ),
 )
-def test_run_tilize_test(shape, multicore, device):
-    shape[-1] *= 32
-    shape[-2] *= 32
+def test_run_tilize_test(nb, nc, nh, nw, multicore, device):
+    shape = [nb, nc, nh * 32, nw * 32]
 
     inp = torch.rand(*shape).bfloat16()
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -33,7 +33,6 @@ inline void concat_db_print(bool condition, const std::string& msg) {
 namespace ttnn {
 namespace operations {
 namespace data_movement {
-using ConcatArgs = std::tuple<const std::vector<ttnn::Tensor>&, int, unsigned int>;
 using OwnedConcatArgs = std::tuple<std::vector<ttnn::Tensor>, int, unsigned int>;
 
 using MassagedConcat = MassagedOperation<ttnn::Tensor, const std::vector<ttnn::Tensor>&, int, unsigned int>;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -7,10 +7,33 @@
 #include "device/tilize_op.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/run_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
+using OwnedTilizeArgs = std::tuple<ttnn::Tensor>;
+using BaseTilizeType = std::function<ttnn::Tensor(const ttnn::Tensor&)>;
+
+using MassagedTilize = MassagedOperation<ttnn::Tensor, const ttnn::Tensor&>;
+using MassagedTilizeParams = MassagedOperationParams<ttnn::Tensor, const ttnn::Tensor&>;
+
+MassagedTilize build_ndiml_tilize(BaseTilizeType base_tilize) {
+    auto original_shape = std::make_shared<ttnn::Shape>(ttnn::Shape{});
+    return MassagedTilize(MassagedTilizeParams{
+        .predicate = [](const ttnn::Tensor& input_tensor) -> bool { return input_tensor.get_shape().rank() > 4; },
+        .pre_transform = [=](const ttnn::Tensor& input_tensor) -> OwnedTilizeArgs {
+            *original_shape = input_tensor.get_shape();
+            ttnn::Tensor squeezed_tensor = squeeze_to_le_4D(input_tensor);
+            return std::make_tuple(squeezed_tensor);
+        },
+        .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
+            auto unsqueezed_tensor = ttnn::reshape(output, *original_shape);
+            return unsqueezed_tensor;
+        },
+        .operation = base_tilize});
+}
 
 ttnn::Tensor ExecuteTilize::invoke(
     uint8_t queue_id,
@@ -18,16 +41,19 @@ ttnn::Tensor ExecuteTilize::invoke(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore) {
-    return operation::run(
-               Tilize{
-                   memory_config.value_or(input_tensor.memory_config()),
-                   output_dtype.value_or(input_tensor.get_dtype()),
-                   use_multicore},
-               {input_tensor},
-               {},
-               {},
-               queue_id)
-        .at(0);
+    auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
+        return operation::run(
+            Tilize{
+                memory_config.value_or(input_tensor.memory_config()),
+                output_dtype.value_or(input_tensor.get_dtype()),
+                use_multicore},
+            {input_tensor},
+            {},
+            {},
+            queue_id)[0];
+    };
+
+    return build_ndiml_tilize(base_tilize)(input_tensor);
 }
 
 ttnn::Tensor ExecuteTilize::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -32,7 +32,7 @@ MassagedTilize build_ndiml_tilize(BaseTilizeType base_tilize) {
             auto unsqueezed_tensor = ttnn::reshape(output, *original_shape);
             return unsqueezed_tensor;
         },
-        .operation = base_tilize});
+        .operation = std::move(base_tilize)});
 }
 
 ttnn::Tensor ExecuteTilize::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -7,10 +7,33 @@
 #include "device/untilize_op.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/run_operation.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
+using OwnedUntilizeArgs = std::tuple<ttnn::Tensor>;
+using BaseUntilizeType = std::function<ttnn::Tensor(const ttnn::Tensor&)>;
+
+using MassagedUntilize = MassagedOperation<ttnn::Tensor, const ttnn::Tensor&>;
+using MassagedUntilizeParams = MassagedOperationParams<ttnn::Tensor, const ttnn::Tensor&>;
+
+MassagedUntilize build_ndiml_untilize(BaseUntilizeType base_untilize) {
+    auto original_shape = std::make_shared<ttnn::Shape>(ttnn::Shape{});
+    return MassagedUntilize(MassagedUntilizeParams{
+        .predicate = [](const ttnn::Tensor& input_tensor) -> bool { return input_tensor.get_shape().rank() > 4; },
+        .pre_transform = [=](const ttnn::Tensor& input_tensor) -> OwnedUntilizeArgs {
+            *original_shape = input_tensor.get_shape();
+            ttnn::Tensor squeezed_tensor = squeeze_to_le_4D(input_tensor);
+            return std::make_tuple(squeezed_tensor);
+        },
+        .post_transform = [=](const ttnn::Tensor& output) -> ttnn::Tensor {
+            auto unsqueezed_tensor = ttnn::reshape(output, *original_shape);
+            return unsqueezed_tensor;
+        },
+        .operation = base_untilize});
+}
 
 ttnn::Tensor ExecuteUntilize::invoke(
     uint8_t queue_id,
@@ -22,17 +45,20 @@ ttnn::Tensor ExecuteUntilize::invoke(
         input_tensor.get_dtype() ==
         DataType::UINT32;  // MT: Currently only uint32 is moved to DST directly, fp32 is converted to fp16b
 
-    return operation::run(
-               Untilize{
-                   memory_config.value_or(input_tensor.memory_config()),
-                   use_multicore,
-                   use_pack_untilize,
-                   fp32_dest_acc_en},
-               {input_tensor},
-               {},
-               {},
-               queue_id)
-        .at(0);
+    auto base_untilize = [=](const ttnn::Tensor& input_tensor) {
+        return operation::run(
+            Untilize{
+                memory_config.value_or(input_tensor.memory_config()),
+                use_multicore,
+                use_pack_untilize,
+                fp32_dest_acc_en},
+            {input_tensor},
+            {},
+            {},
+            queue_id)[0];
+    };
+
+    return build_ndiml_untilize(base_untilize)(input_tensor);
 }
 
 ttnn::Tensor ExecuteUntilize::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
@@ -32,7 +32,7 @@ MassagedUntilize build_ndiml_untilize(BaseUntilizeType base_untilize) {
             auto unsqueezed_tensor = ttnn::reshape(output, *original_shape);
             return unsqueezed_tensor;
         },
-        .operation = base_untilize});
+        .operation = std::move(base_untilize)});
 }
 
 ttnn::Tensor ExecuteUntilize::invoke(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15165

### What's changed
- Adds support for rank-n tensors to the tilize and untilize ops. In particular this introduces support for 5D tensors.
- We support rank-n tensors by first squeezing to a supported rank <= 4, then performing the tilize/untilize, then unsqueezing back to the original shape/rank.
- Adds tests for a handful of 5D cases to both the untilize and tilize unit test suites.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12063111681)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12059576026)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12059576677)
- [x] New/Existing tests provide coverage for changes
