### PR TITLE
[skip ci] Disable clang-format in pre-commit and move version ahead

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
   rev: v1.35.1
   hooks:
     - id: yamllint
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.4
-  hooks:
-    - id: clang-format
-      types_or: [c++, c]
+#- repo: https://github.com/pre-commit/mirrors-clang-format
+#  rev: v19.1.4
+#  hooks:
+#    - id: clang-format
+#      types_or: [c++, c]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   hooks:
     - id: yamllint
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v18.1.5
+  rev: v19.1.4
   hooks:
     - id: clang-format
       types_or: [c++, c]


### PR DESCRIPTION
### Problem description
Move to modern clang-format
This matches the version I used to manually format many files.

### What's changed
clang-format version used in pre-commit

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
