### PR TITLE
#15540: support bfp8_b 1d tensor in ttnn

### DIFF
--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -189,8 +189,6 @@ def from_torch(
 
     shape_with_padding = None
     if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
-        if len(tensor.shape) < 2:
-            raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires at least 2 dimensions!")
         if layout != ttnn.TILE_LAYOUT:
             raise RuntimeError("ttnn.from_torch: bfloat8_b/bfloat4_b requires TILE_LAYOUT!")
         # Tilize tensor


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15540

### Problem description
Currently, when trying to create a bfp8_b type 1D tensor using from_torch in ttnn, a runtime error occurs.
However, it seems that removing the 1D runtime error doesn't cause any issues.

### What's changed
 I will remove the code that raises the runtime error.


```Python
# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.

# SPDX-License-Identifier: Apache-2.0

import pytest

import torch

import ttnn

torch.set_printoptions(threshold=1000000, linewidth=100000000, sci_mode=False)

@pytest.mark.parametrize("ttnn_dtype, torch_dtype", [
    [ttnn.DataType.BFLOAT16, torch.bfloat16],
    [ttnn.DataType.BFLOAT8_B, torch.bfloat16],
],)
def test_support_1d(device, ttnn_dtype, torch_dtype):
    torch_x = torch.rand(20, dtype=torch_dtype)

    ttnn_x_bf16 = ttnn.from_torch(torch_x, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT)
    ttnn_x = ttnn.from_torch(torch_x, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT)
    torch_y = ttnn.to_torch(ttnn_x).to(dtype=torch_dtype)

    print("ttnn_dtype", ttnn_dtype)
    print("torch_dtype", torch_dtype)
    print("torch_x\n", torch_x)
    print("ttnn_x_bf16\n", ttnn_x_bf16)
    print("ttnn_x\n", ttnn_x)
    print("torch_y\n", torch_y, type(torch_y))

```

I have confirmed that the 1D `bfp8_b` tensor is created without any issues, but I couldn't find an appropriate location to add this test.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
