### PR TITLE
#15542: Add dtype to `to_torch`

### DIFF
--- a/tests/ttnn/unit_tests/test_to_dtype.py
+++ b/tests/ttnn/unit_tests/test_to_dtype.py
@@ -34,6 +34,5 @@ def test_to_dtype(height, width, from_dtype, to_dtype):
         assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
     assert tuple(output_tensor.shape) == (height, width)
 
-    output_tensor = ttnn.to_torch(output_tensor).to(torch_input_tensor.dtype)
-
+    output_tensor = ttnn.to_torch(output_tensor, dtype=torch_input_tensor.dtype)
     assert_with_pcc(torch_input_tensor, output_tensor)

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -316,10 +316,12 @@ def to_torch(
                 raise RuntimeError("ttnn: Unable to squeeze to desired rank!")
             tensor = tensor.squeeze(0)
 
-    if dtype is not None:
-        tensor = tensor.to(dtype=dtype)
+    torch_tensor = TorchTensor(tensor)
 
-    return TorchTensor(tensor)
+    if dtype is not None:
+        torch_tensor = torch_tensor.to(dtype=dtype)
+
+    return torch_tensor
 
 
 def _golden_function(tensor, *args, **kwargs):

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -257,7 +257,7 @@ class TorchTensor(torch.Tensor):
 @ttnn.register_python_operation(name="ttnn.to_torch", golden_function=_golden_function)
 def to_torch(
     tensor: ttnn.Tensor,
-    dtype: Optional[ttnn.DataType] = None,
+    dtype: Optional[torch.dtype] = None,
     *,
     torch_rank: Optional[int] = None,
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
@@ -270,7 +270,7 @@ def to_torch(
 
     Args:
         tensor (ttnn.Tensor): the input tensor.
-        dtype (ttnn.DataType, optional): the desired `ttnn` data type. Defaults to `None`.
+        dtype (torch.dtype, optional): the desired `torch` data type of returned tensor. Defaults to `None`.
 
     Keyword Args:
         torch_rank (int, optional): Desired rank of the `torch.Tensor`. Defaults to `None`.

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -257,6 +257,7 @@ class TorchTensor(torch.Tensor):
 @ttnn.register_python_operation(name="ttnn.to_torch", golden_function=_golden_function)
 def to_torch(
     tensor: ttnn.Tensor,
+    dtype: Optional[ttnn.DataType] = None,
     *,
     torch_rank: Optional[int] = None,
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
@@ -269,6 +270,7 @@ def to_torch(
 
     Args:
         tensor (ttnn.Tensor): the input tensor.
+        dtype (ttnn.DataType, optional): the desired `ttnn` data type. Defaults to `None`.
 
     Keyword Args:
         torch_rank (int, optional): Desired rank of the `torch.Tensor`. Defaults to `None`.
@@ -313,6 +315,9 @@ def to_torch(
             if tensor.shape[0] != 1:
                 raise RuntimeError("ttnn: Unable to squeeze to desired rank!")
             tensor = tensor.squeeze(0)
+
+    if dtype is not None:
+        tensor = tensor.to(dtype=dtype)
 
     return TorchTensor(tensor)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15542

### Problem description
```Python
import pytest
import torch
import ttnn

torch.set_printoptions(threshold=1000000, linewidth=100000000, sci_mode=False)

@pytest.mark.parametrize("ttnn_dtype, torch_dtype", [
    [ttnn.DataType.FLOAT32, torch.float32],
    [ttnn.DataType.BFLOAT16, torch.bfloat16],
    [ttnn.DataType.BFLOAT8_B, torch.bfloat16],
],)
def test_support_1d(device, ttnn_dtype, torch_dtype):
    torch_x = torch.rand(20, dtype=torch_dtype)

    ttnn_x_bf16 = ttnn.from_torch(torch_x, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.TILE_LAYOUT)
    ttnn_x = ttnn.from_torch(torch_x, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT)
    torch_y = ttnn.to_torch(ttnn_x)

    print("ttnn_dtype", ttnn_dtype)
    print("torch_dtype", torch_dtype)
    print("torch_x\n", torch_x)
    print("ttnn_x_bf16\n", ttnn_x_bf16)
    print("ttnn_x\n", ttnn_x)
    print("torch_y\n", torch_y, type(torch_y))
```
In the unit test, the `to_torch` function is used to convert `ttnn` tensors to `torch` tensors. 
However, the dtype conversion in `to_torch` is as follows:
ttnn -> torch
BFLOAT16-> bfloat16
FLOAT32-> float32
BFLOAT8_B -> float32

Since PyTorch does not have a `bfloat8_b` type, it is not an issue that it converts to `float`. 
However, the problem with `from_torch` is that it has a `dtype` parameter, while `to_torch` requires an additional conversion using `to(dtype=torch_dtype)`, which makes it a bit cumbersome.


### What's changed
Add dtype to `to_torch`
Add test.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
