### PR TITLE
Add performance and accuracy configurations to Llama 3

### DIFF
--- a/models/demos/llama3/PERF.md
+++ b/models/demos/llama3/PERF.md
@@ -20,6 +20,7 @@ This configuration uses bfp4 MLP FF1+FF3 for all models.
 | 8b | N300 | 84 | 98 | 38.6 |
 | 8b | T3K | 84 | 98 | 52.6 |
 | 11b | N300 | 86 | 97 | 38.6 |
+| 11b | T3K | 84 | 98 | 52.6 |
 | 70b | T3K | 95 | 100 | 14.3 |
 
 ## LlamaOptimizations.accuracy
@@ -38,4 +39,5 @@ This configuration uses bfp4 MLP FF1+FF3 only for the 3.1-70B model.
 | 8b | N300 | 90 | 98 | 34.1 |
 | 8b | T3K | 88 | 97 | 49.9 |
 | 11b | N300 | 90 | 97 | 33.8 |
+| 11b | T3K | 88 | 97 | 52.6 |
 | 70b | T3K | 95 | 100 | 14.5 |

--- a/models/demos/llama3/PERF.md
+++ b/models/demos/llama3/PERF.md
@@ -1,0 +1,35 @@
+# Llama 3 model performance and accuracy
+
+Performance collected from [demo/demo.py](demo/demo.py) and accuracy collected from [tests/test_llama_accuracy.py](tests/test_llama_accuracy.py). You can generate this table by running these tests with the `lt` tool (tell it to run `accuracy,demo`) and pressing `m` whilst in the results section to export to markdown.
+
+4-bit MLP:
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b | N150 | 79 | 98 | 90.5 |
+| 1b | N300 | 81 | 98 | 101.7 |
+| 1b | T3K | 81 | 98 | 97.5 |
+| 3b | N150 | 85 | 96 | 49.0 |
+| 3b | N300 | 88 | 97 | 56.9 |
+| 3b | T3K | 88 | 97 | 54.5 |
+| 8b | N150 | 86 | 98 | 28.4 |
+| 8b | N300 | 84 | 98 | 38.6 |
+| 8b | T3K | 84 | 98 | 52.6 |
+| 11b | N300 | 86 | 97 | 38.6 |
+| 70b | T3K | 95 | 100 | 14.3 |
+
+Mixed-bit MLP (main):
+
+| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
+|-------|--------|-----------|-----------|---------------|
+| 1b | N150 | 77 | 96 | 85.8 |
+| 1b | N300 | 80 | 98 | 98.6 |
+| 1b | T3K | 78 | 98 | 97.2 |
+| 3b | N150 | 88 | 98 | 44.1 |
+| 3b | N300 | 88 | 98 | 53.9 |
+| 3b | T3K | 88 | 98 | 54.8 |
+| 8b | N150 | 89 | 98 | 23.5 |
+| 8b | N300 | 90 | 98 | 34.1 |
+| 8b | T3K | 88 | 97 | 49.9 |
+| 11b | N300 | 90 | 97 | 33.8 |
+| 70b | T3K | 95 | 100 | 14.5 |

--- a/models/demos/llama3/PERF.md
+++ b/models/demos/llama3/PERF.md
@@ -2,7 +2,11 @@
 
 Performance collected from [demo/demo.py](demo/demo.py) and accuracy collected from [tests/test_llama_accuracy.py](tests/test_llama_accuracy.py). You can generate this table by running these tests with the `lt` tool (tell it to run `accuracy,demo`) and pressing `m` whilst in the results section to export to markdown.
 
-4-bit MLP:
+Note that `test_llama_accuracy.py` parses the below to determine expected values.
+
+## LlamaOptimizations.performance
+
+This configuration uses bfp4 MLP FF1+FF3 for all models.
 
 | Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
 |-------|--------|-----------|-----------|---------------|
@@ -18,7 +22,9 @@ Performance collected from [demo/demo.py](demo/demo.py) and accuracy collected f
 | 11b | N300 | 86 | 97 | 38.6 |
 | 70b | T3K | 95 | 100 | 14.3 |
 
-Mixed-bit MLP (main):
+## LlamaOptimizations.accuracy
+
+This configuration uses bfp4 MLP FF1+FF3 only for the 3.1-70B model.
 
 | Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |
 |-------|--------|-----------|-----------|---------------|

--- a/models/demos/llama3/README.md
+++ b/models/demos/llama3/README.md
@@ -85,6 +85,13 @@ pytest models/demos/llama3/demo/demo.py -k 'instruct and 1_batch'
 pytest models/demos/llama3/demo/demo.py -k 'general and 2_batch'
 ```
 
+By default we run the models in `LlamaOptimizations.performance` mode. You can override this by setting the `optimizations` argument in the demo. To compare the two on a long prompt, you can run:
+
+```
+pytest models/demos/llama3/demo/demo.py -k 'long-performance'
+pytest models/demos/llama3/demo/demo.py -k 'long-accuracy'
+```
+
 ### Expected performance and accuracy
 
-See [PERF.md](PERF.md) for expected performance and accuracy.
+See [PERF.md](PERF.md) for expected performance and accuracy across different configurations.

--- a/models/demos/llama3/README.md
+++ b/models/demos/llama3/README.md
@@ -84,3 +84,7 @@ pytest models/demos/llama3/demo/demo.py -k 'instruct and 1_batch'
 # Run 2 continuous batches with general weights
 pytest models/demos/llama3/demo/demo.py -k 'general and 2_batch'
 ```
+
+### Expected performance and accuracy
+
+See [PERF.md](PERF.md) for expected performance and accuracy.

--- a/models/demos/llama3/demo/demo.py
+++ b/models/demos/llama3/demo/demo.py
@@ -28,6 +28,7 @@ from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import T
 
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
+from models.demos.llama3.tt.model_config import LlamaOptimizations
 
 
 def load_and_cache_context(context_url, cache_dir):
@@ -152,7 +153,15 @@ def preprocess_inputs_prefill(
 
 
 def run_llama3_demo(
-    user_input, batch_size, single_layer, mesh_device, instruct_mode, is_ci_env, num_batches, print_to_file
+    user_input,
+    batch_size,
+    single_layer,
+    mesh_device,
+    instruct_mode,
+    is_ci_env,
+    num_batches,
+    print_to_file,
+    optimizations,
 ):
     # Creat batch output file
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -189,7 +198,7 @@ def run_llama3_demo(
         batch_prompts.append([input_prompts[(j + i) % len(input_prompts)] for j in range(len(input_prompts))])
 
     # Load model args, weights, and tokenizer
-    model_args = TtModelArgs(mesh_device, instruct=instruct_mode)
+    model_args = TtModelArgs(mesh_device, instruct=instruct_mode, optimizations=optimizations)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
     if single_layer:
@@ -700,21 +709,41 @@ def run_llama3_demo(
 
 
 @pytest.mark.parametrize(
-    "input_prompts, instruct_weights, num_batches, single_layer",
+    "input_prompts, instruct_weights, num_batches, single_layer, optimizations",
     [
-        ("models/demos/llama3/demo/input_data_prefill_128.json", False, 1, False),
-        ("models/demos/llama3/demo/input_data_prefill_128.json", False, 2, False),
-        ("models/demos/llama3/demo/input_data_questions_prefill_128.json", True, 1, False),
-        ("models/demos/llama3/demo/input_data_questions_prefill_128.json", True, 2, False),
-        ("models/demos/llama3/demo/input_data_long.json", True, 1, False),
-        ("models/demos/llama3/demo/input_data_questions_prefill_128.json", True, 1, True),
+        ("models/demos/llama3/demo/input_data_prefill_128.json", False, 1, False, LlamaOptimizations.performance),
+        ("models/demos/llama3/demo/input_data_prefill_128.json", False, 2, False, LlamaOptimizations.performance),
+        (
+            "models/demos/llama3/demo/input_data_questions_prefill_128.json",
+            True,
+            1,
+            False,
+            LlamaOptimizations.performance,
+        ),
+        (
+            "models/demos/llama3/demo/input_data_questions_prefill_128.json",
+            True,
+            2,
+            False,
+            LlamaOptimizations.performance,
+        ),
+        ("models/demos/llama3/demo/input_data_long.json", True, 1, False, LlamaOptimizations.performance),
+        ("models/demos/llama3/demo/input_data_long.json", True, 1, False, LlamaOptimizations.accuracy),
+        (
+            "models/demos/llama3/demo/input_data_questions_prefill_128.json",
+            True,
+            1,
+            True,
+            LlamaOptimizations.performance,
+        ),
     ],
     ids=[
         "general_weights-1_batch",
         "general_weights-2_batch",
         "instruct_weights-1_batch",
         "instruct_weights-2_batch",
-        "instruct_weights-long",
+        "instruct_weights-long-performance",
+        "instruct_weights-long-accuracy",
         "single_layer",
     ],
 )
@@ -729,7 +758,15 @@ def run_llama3_demo(
     indirect=True,
 )
 def test_llama_demo(
-    mesh_device, use_program_cache, input_prompts, instruct_weights, is_ci_env, num_batches, single_layer, reset_seeds
+    mesh_device,
+    use_program_cache,
+    input_prompts,
+    instruct_weights,
+    is_ci_env,
+    num_batches,
+    single_layer,
+    optimizations,
+    reset_seeds,
 ):
     if is_ci_env and (instruct_weights == False or "long" in input_prompts or single_layer == True):
         pytest.skip("CI demo test only runs instruct weights to reduce CI pipeline load (both are supported)")
@@ -745,4 +782,5 @@ def test_llama_demo(
         is_ci_env=is_ci_env,
         num_batches=num_batches,
         print_to_file=False,
+        optimizations=optimizations,
     )

--- a/models/demos/llama3/lt
+++ b/models/demos/llama3/lt
@@ -733,9 +733,9 @@ def run_entry_command(entry, screen_lock, output_entries, screen_needs_update):
         "decoder": "pytest models/demos/llama3/tests/test_llama_decoder.py",
         "decoder-prefill": "pytest models/demos/llama3/tests/test_llama_decoder_prefill.py",
         "lm-head": "pytest models/demos/llama3/tests/test_lm_head.py",
-        "model": "pytest models/demos/llama3/tests/test_llama_model.py -k full",
-        "model-quick": "pytest models/demos/llama3/tests/test_llama_model.py -k quick",
-        "model-prefill": "pytest models/demos/llama3/tests/test_llama_model_prefill.py",
+        "model": "pytest models/demos/llama3/tests/test_llama_model.py -k performance-full",
+        "model-quick": "pytest models/demos/llama3/tests/test_llama_model.py -k performance-quick",
+        "model-prefill": "pytest models/demos/llama3/tests/test_llama_model_prefill.py -k performance",
         "vision-mlp": "pytest models/demos/llama3/tests/multimodal/test_llama_image_mlp.py",
         "vision-attn": "pytest models/demos/llama3/tests/multimodal/test_llama_image_attention.py",
         "vision-block": "pytest models/demos/llama3/tests/multimodal/test_llama_image_block.py",
@@ -750,7 +750,7 @@ def run_entry_command(entry, screen_lock, output_entries, screen_needs_update):
         "vision-text-xfmr": "pytest models/demos/llama3/tests/multimodal/test_llama_cross_attention_transformer_text.py",
         "vision-vision-xfmr": "pytest models/demos/llama3/tests/multimodal/test_llama_cross_attention_transformer_vision.py",
         "perf": "pytest models/demos/llama3/tests/test_llama_perf.py -k 1024",
-        "accuracy": "pytest models/demos/llama3/tests/test_llama_accuracy.py",
+        "accuracy": "pytest models/demos/llama3/tests/test_llama_accuracy.py -k performance",
     }
 
     # Check if the command is a shortcut and replace it if necessary

--- a/models/demos/llama3/lt
+++ b/models/demos/llama3/lt
@@ -477,6 +477,10 @@ def main(stdscr):
                         entry["log_file"] = None
                         entry["stop_event"].clear()
                         screen_needs_update.set()
+        elif c == ord("m") and current_line >= len(input_fields):
+            # Export results to markdown
+            export_results_to_markdown(output_entries, stdscr)
+            screen_needs_update.set()
         else:
             if current_line < len(input_fields) and not exiting:
                 current_field = current_line
@@ -1031,6 +1035,49 @@ def cancel_entry(entry):
             return True
     # Entry is running/resetting, so don't remove it
     return False
+
+
+def export_results_to_markdown(output_entries, stdscr):
+    demo_results = {}
+    accuracy_results = {}
+
+    # Collect results from entries
+    for entry in output_entries:
+        if entry.command_name == "demo" and entry.status == "Finished":
+            demo_results[(entry.model, entry.device)] = entry.speed
+        elif entry.command_name == "accuracy" and entry.status == "Finished":
+            # Parse Top-1 and Top-5 from output
+            top1 = "N/A"
+            top5 = "N/A"
+            if entry.output:
+                match = re.search(r"Top-1: (\d+)% \| Top-5: (\d+)%", entry.output)
+                if match:
+                    top1, top5 = match.groups()
+            accuracy_results[(entry.model, entry.device)] = (top1, top5)
+
+    # Create markdown table
+    markdown_lines = [
+        "| Model | Device | Top-1 (%) | Top-5 (%) | Speed (t/s/u) |",
+        "|-------|--------|-----------|-----------|---------------|",
+    ]
+
+    for key in demo_results.keys():
+        model, device = key
+        speed = demo_results.get(key, "N/A")
+        top1, top5 = accuracy_results.get(key, ("N/A", "N/A"))
+        markdown_lines.append(f"| {model} | {device} | {top1} | {top5} | {speed} |")
+
+    # Write to PERF.md
+    with open("PERF.md", "w") as f:
+        f.write("\n".join(markdown_lines) + "\n")
+
+    # Clear screen and show message
+    stdscr.clear()
+    stdscr.addstr(0, 0, "\n".join(markdown_lines))
+    stdscr.addstr(len(markdown_lines) + 1, 0, f"Table written to {os.path.abspath('PERF.md')}")
+    stdscr.addstr(len(markdown_lines) + 2, 0, "Press any key to return...")
+    stdscr.refresh()
+    stdscr.getch()  # Wait for a key press
 
 
 if __name__ == "__main__":

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -14,9 +14,48 @@ from models.demos.llama3.tt.llama_common import (
     HostEmbedding,
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
-from models.demos.llama3.tt.model_config import TtModelArgs
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.demos.llama3.demo.demo import preprocess_inputs_prefill
+from pathlib import Path
+
+
+def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: LlamaOptimizations):
+    """Parse accuracy thresholds from PERF.md for the given model, optimization mode, and device."""
+    # Get model size (e.g., "1b", "3b", etc.)
+    model_size = model_name.split("-")[1].lower()
+
+    # Read PERF.md
+    perf_file = Path(__file__).parent.parent / "PERF.md"
+    with open(perf_file, "r") as f:
+        content = f.read()
+
+    # Split into sections based on optimization mode
+    sections = content.split("## ")
+    target_section = next(s for s in sections if s.startswith(f"LlamaOptimizations.{optimizations.__name__}\n"))
+
+    print(target_section)
+
+    # Parse the table and find the row for our model and device
+    rows = [
+        line.split("|")[1:]  # Each row starts with a separator
+        for line in target_section.split("\n")
+        if f"| {model_size} | {device_name} |" in line
+    ]
+    if not rows:
+        raise ValueError(
+            f"Could not find accuracy data for {model_size} on {device_name} in {optimizations.__name__} mode"
+        )
+
+    assert (
+        len(rows) == 1
+    ), f"Found multiple rows for {model_size} on {device_name} in {optimizations.__name__} mode in PERF.md"
+    row = rows[0]
+    top1_acc = float(row[2].strip())
+    top5_acc = float(row[3].strip())
+
+    # Allow for rounding
+    return top1_acc - 0.5, top5_acc - 0.5
 
 
 @torch.no_grad()
@@ -32,16 +71,28 @@ from models.demos.llama3.demo.demo import preprocess_inputs_prefill
     ],
     indirect=True,
 )
-def test_tt_model_accuracy(mesh_device, prefill_len, decode_len, use_program_cache, reset_seeds):
+@pytest.mark.parametrize(
+    "optimizations",
+    [
+        pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
+        pytest.param(LlamaOptimizations.performance, id="performance"),
+    ],
+)
+def test_tt_model_accuracy(mesh_device, prefill_len, decode_len, use_program_cache, reset_seeds, optimizations):
     dtype = ttnn.bfloat8_b
-    min_top1_acc = 75
-    min_top5_acc = 96
 
     mesh_device.enable_async(True)
 
     # Load model args and tokenizer
-    model_args = TtModelArgs(mesh_device)
+    model_args = TtModelArgs(mesh_device, optimizations=optimizations)
     tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    # Get accuracy thresholds from PERF.md
+    min_top1_acc, min_top5_acc = get_accuracy_thresholds(
+        model_args.model_name,
+        model_args.device_name,
+        optimizations,
+    )
 
     # Load state_dict for TT model
     logger.info("Loading weights...")

--- a/models/demos/llama3/tests/test_llama_accuracy.py
+++ b/models/demos/llama3/tests/test_llama_accuracy.py
@@ -34,8 +34,6 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
     sections = content.split("## ")
     target_section = next(s for s in sections if s.startswith(f"LlamaOptimizations.{optimizations.__name__}\n"))
 
-    print(target_section)
-
     # Parse the table and find the row for our model and device
     rows = [
         line.split("|")[1:]  # Each row starts with a separator
@@ -86,13 +84,6 @@ def test_tt_model_accuracy(mesh_device, prefill_len, decode_len, use_program_cac
     # Load model args and tokenizer
     model_args = TtModelArgs(mesh_device, optimizations=optimizations)
     tokenizer = Tokenizer(model_args.tokenizer_path)
-
-    # Get accuracy thresholds from PERF.md
-    min_top1_acc, min_top5_acc = get_accuracy_thresholds(
-        model_args.model_name,
-        model_args.device_name,
-        optimizations,
-    )
 
     # Load state_dict for TT model
     logger.info("Loading weights...")
@@ -319,6 +310,13 @@ def test_tt_model_accuracy(mesh_device, prefill_len, decode_len, use_program_cac
             expected = " | ".join(sanitize(t) for t in error["expected"])
             true_word = sanitize(tokenizer.decode([true_token]))
             logger.info(f"{error['position']}: {context}[{incorrect}] != [{expected}], true: [{true_word}]")
+
+    # Get accuracy thresholds from PERF.md
+    min_top1_acc, min_top5_acc = get_accuracy_thresholds(
+        model_args.model_name,
+        model_args.device_name,
+        optimizations,
+    )
 
     logger.info(f"Top-1: {total_top1_acc:.0f}% | Top-5: {total_top5_acc:.0f}%")
     assert total_top1_acc > min_top1_acc, f"Top-1 accuracy {total_top1_acc:.1f}% is too low (expected >{min_top1_acc}%)"

--- a/models/demos/llama3/tests/test_llama_model.py
+++ b/models/demos/llama3/tests/test_llama_model.py
@@ -14,7 +14,7 @@ from models.demos.llama3.tt.llama_common import (
     HostEmbedding,
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
-from models.demos.llama3.tt.model_config import TtModelArgs
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Transformer
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.utility_functions import (
@@ -37,6 +37,13 @@ from models.utility_functions import skip_for_grayskull
     ids=["quick", "full"],
 )
 @pytest.mark.parametrize(
+    "optimizations",
+    [
+        pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
+        pytest.param(LlamaOptimizations.performance, id="performance"),
+    ],
+)
+@pytest.mark.parametrize(
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
@@ -45,20 +52,16 @@ from models.utility_functions import skip_for_grayskull
     ],
     indirect=True,
 )
-def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, reset_seeds, ensure_gc):
-    run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
-    cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
-
-    dtype = ttnn.bfloat8_b
-
+def test_llama_model_inference(mesh_device, weights, layers, optimizations, use_program_cache, reset_seeds, ensure_gc):
     mesh_device.enable_async(True)
 
-    # This sets the minimum PCC for each iteration
-    pcc = 0.88 if layers == 1 else 0.94  # TODO For model test quick (1 layer) one iteration might get a worse PCC
-
+    run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
+    cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
+    dtype = ttnn.bfloat8_b
+    mode_accuracy = optimizations == LlamaOptimizations.accuracy
     instruct = True if weights == "instruct" else False
     dummy_weights = True if weights == "random" else False
-    model_args = TtModelArgs(mesh_device, instruct=instruct, dummy_weights=dummy_weights)
+    model_args = TtModelArgs(mesh_device, instruct=instruct, dummy_weights=dummy_weights, optimizations=optimizations)
 
     model_name = {
         (16, False): "llama32_1b",
@@ -68,12 +71,19 @@ def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, 
         (80, False): "llama31_70b",
     }[(model_args.n_layers, model_args.is_vision())]
 
+    # Define minimum PCC for each iteration
+    if layers == 1:
+        pcc = 0.88 if mode_accuracy else 0.86
+    else:
+        pcc = 0.94 if mode_accuracy else 0.94
+
+    # Define tight final PCC thresholds for quick mode
     final_model_pcc = {
-        "llama32_1b": 0.9991,
-        "llama32_3b": 0.9989,
-        "llama31_8b": 0.9987,
-        "llama32_11b": 0.9987,
-        "llama31_70b": 0.9843,
+        "llama32_1b": 0.9991 if mode_accuracy else 0.9864,
+        "llama32_3b": 0.9989 if mode_accuracy else 0.9837,
+        "llama31_8b": 0.9987 if mode_accuracy else 0.9850,
+        "llama32_11b": 0.9987 if mode_accuracy else 0.9850,
+        "llama31_70b": 0.9843 if mode_accuracy else 0.9843,
     }[model_name]
 
     final_k_cache_pcc = {
@@ -90,6 +100,7 @@ def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, 
         "llama32_11b": 0.9996,
         "llama31_70b": 0.9998,
     }[model_name]
+
     quick_iterations = {"llama32_1b": 2, "llama32_3b": 4, "llama31_8b": 6, "llama32_11b": 6, "llama31_70b": 6}[
         model_name
     ]
@@ -156,6 +167,8 @@ def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, 
 
     if run_ref_pt:
         all_tests_pass = True
+        final_tests_pass = True
+        kv_cache_tests_pass = True
 
     seqlen = 1  # Generating one token per user at a time
     batch = model_args.max_batch_size
@@ -230,6 +243,8 @@ def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, 
         if run_ref_pt:
             if layers == 1 and i == iterations - 1:  # On last iteration in the quick test, set a tighter PCC
                 passing, pcc_message = comp_pcc(ref_output, tt_output_torch, final_model_pcc)
+                if not passing:
+                    final_tests_pass = False
             else:
                 passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc)
 
@@ -282,9 +297,9 @@ def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, 
                             logger.info(f"V cache output: {output_pcc}")
 
                         if does_pass:
-                            logger.info(f"V Cache Passed!")
+                            logger.info(f"KV Cache Passed!")
                         else:
-                            logger.warning(f"V Cache Failed! PCC value is lower than {pcc}")
+                            logger.warning(f"KV Cache Failed! PCC value is lower than {pcc}")
                             all_tests_pass = False
 
         if not dummy_weights:
@@ -297,4 +312,6 @@ def test_llama_model_inference(mesh_device, weights, layers, use_program_cache, 
             logger.info(f"All {generation_length} Llama decode iterations Passed!")
         else:
             logger.warning("One or more iterations of Llama decode had bad PCC")
+            assert final_tests_pass, f"PCC value is lower than {final_model_pcc} for final output. Check Warnings!"
+            assert kv_cache_tests_pass, f"KV Cache PCC value is lower expected for some of the outputs. Check Warnings!"
             assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"

--- a/models/demos/llama3/tests/test_llama_model.py
+++ b/models/demos/llama3/tests/test_llama_model.py
@@ -75,7 +75,7 @@ def test_llama_model_inference(mesh_device, weights, layers, optimizations, use_
     if layers == 1:
         pcc = 0.88 if mode_accuracy else 0.86
     else:
-        pcc = 0.94 if mode_accuracy else 0.94
+        pcc = 0.94 if mode_accuracy else 0.86
 
     # Define tight final PCC thresholds for quick mode
     final_model_pcc = {

--- a/models/demos/llama3/tests/test_llama_model_prefill.py
+++ b/models/demos/llama3/tests/test_llama_model_prefill.py
@@ -15,7 +15,7 @@ from models.demos.llama3.tt.llama_common import (
     encode_prompt_llama_instruct,
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
-from models.demos.llama3.tt.model_config import TtModelArgs
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Transformer, precompute_freqs_cis
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.utility_functions import (
@@ -46,19 +46,31 @@ from models.utility_functions import skip_for_grayskull
     ],
     indirect=True,
 )
-def test_llama_model_inference(mesh_device, seq_len, use_program_cache, reset_seeds, ensure_gc):
+@pytest.mark.parametrize(
+    "optimizations",
+    [
+        pytest.param(LlamaOptimizations.accuracy, id="accuracy"),
+        pytest.param(LlamaOptimizations.performance, id="performance"),
+    ],
+)
+def test_llama_model_inference(mesh_device, seq_len, optimizations, use_program_cache, reset_seeds, ensure_gc):
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = False  # Flag to measure KV cache PCC for all layers
 
     dtype = ttnn.bfloat8_b
-    pcc = 0.91  # TODO Look on improving PCC
+    # This sets the minimum PCC for each iteration based on optimization mode
+    if optimizations == LlamaOptimizations.accuracy:
+        pcc = 0.91  # TODO Look on improving PCC
+    else:  # performance mode
+        assert optimizations == LlamaOptimizations.performance
+        pcc = 0.91
 
     mesh_device.enable_async(True)
 
     # Use instruct weights instead of general weights
     instruct = True
 
-    model_args = TtModelArgs(mesh_device, instruct=instruct, max_batch_size=1)
+    model_args = TtModelArgs(mesh_device, instruct=instruct, max_batch_size=1, optimizations=optimizations)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
     logger.info("Loading weights...")

--- a/models/demos/llama3/tests/test_llama_model_prefill.py
+++ b/models/demos/llama3/tests/test_llama_model_prefill.py
@@ -53,7 +53,12 @@ from models.utility_functions import skip_for_grayskull
         pytest.param(LlamaOptimizations.performance, id="performance"),
     ],
 )
-def test_llama_model_inference(mesh_device, seq_len, optimizations, use_program_cache, reset_seeds, ensure_gc):
+def test_llama_model_inference(
+    mesh_device, seq_len, optimizations, use_program_cache, reset_seeds, ensure_gc, is_ci_env
+):
+    if is_ci_env and optimizations == LlamaOptimizations.accuracy:
+        pytest.skip("CI test only runs performance mode to reduce CI pipeline load")
+
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = False  # Flag to measure KV cache PCC for all layers
 

--- a/models/demos/llama3/tests/test_llama_perf.py
+++ b/models/demos/llama3/tests/test_llama_perf.py
@@ -15,7 +15,7 @@ from models.demos.llama3.tt.llama_common import (
 )
 from models.demos.llama3.tt.llama_model import TtTransformer
 from models.demos.llama3.tt.llama_embedding import TtLlamaEmbedding
-from models.demos.llama3.tt.model_config import TtModelArgs
+from models.demos.llama3.tt.model_config import TtModelArgs, LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 
 from models.perf.perf_utils import prep_perf_report
@@ -50,7 +50,7 @@ def test_llama_model_perf(mesh_device, kv_cache_len, expected_compile_time, use_
 
     mesh_device.enable_async(True)
 
-    model_args = TtModelArgs(mesh_device)
+    model_args = TtModelArgs(mesh_device, optimizations=LlamaOptimizations.performance)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
     if "3.2-1B" in model_args.DEFAULT_CACHE_PATH:

--- a/models/demos/llama3/tt/llama_mlp.py
+++ b/models/demos/llama3/tt/llama_mlp.py
@@ -39,7 +39,8 @@ class TtLlamaMLP(LightweightModule):
             cache_file_name=cache_name(name),
         )
 
-        self.four_bit_mlp = self.args.is_large_model
+        # Set to "self.args.is_large_model" for mixed-mode MLP which is slightly more accurate
+        self.four_bit_mlp = True
 
         # Sharded weights
         self.w1 = as_sharded_tensor(

--- a/models/demos/llama3/tt/llama_mlp.py
+++ b/models/demos/llama3/tt/llama_mlp.py
@@ -39,8 +39,7 @@ class TtLlamaMLP(LightweightModule):
             cache_file_name=cache_name(name),
         )
 
-        # Set to "self.args.is_large_model" for mixed-mode MLP which is slightly more accurate
-        self.four_bit_mlp = True
+        self.four_bit_mlp = args.optimizations.bfp4_mlp
 
         # Sharded weights
         self.w1 = as_sharded_tensor(


### PR DESCRIPTION
### Problem description
We have some optimizations that hurt accuracy a little but we believe it to be a good tradeoff for performance. However, we expect different end users to have their own ideal perf/acc tradeoff points based on their application.

This PR improves perf by 5 t/s/u on 8b N150 and paves the way for including more tradeoff optimizations in a scalable, testable and well-documented manner.

### What's changed
* Add `LlamaOptimizations` to collect these in one place. For now only bfp4_mlp is supported (use bfp4 for FF1+FF3).
* Add `LlamaOptimizations.performance` and `LlamaOptimizations.accuracy` as two defaults; users can still create a custom `LlamaOptimizations` if they want to.
* TtModelArgs defaults to `accuracy` if nothing is specified
* `demo.py` uses `performance` for all tests, except a new test option that specifically uses `accuracy`
* Added `llama3/PERF.md` which records expected performance and accuracy
* Add support in `llama3/lt` to auto-generate these markdown tables by pressing `m` in the results section
* `test_llama_accuracy` and `test_llama_model` use both variants and have updated expected values
* `test_llama_perf` uses performance variant
* All other unit tests use accuracy variant
* 3.1 8B N150 performance increased from **23 t/s/u** to **28 t/s/u**, top-5 accuracy vs reference unchanged at 98% but top-1 falls from 89% to 86%.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12070408010)
- [x] [Single-card demo and perf](https://github.com/tenstorrent/tt-metal/actions/runs/12070752713)
- [x] [T3K model tests](https://github.com/tenstorrent/tt-metal/actions/runs/12070767208), rerun [frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/12083730743)
