### PR TITLE
[skip ci] Use @tenstorrent/metalium-developers-infra in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,74 +1,67 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-.clang-format @tt-rkim @afuller-TT @blozano-tt @tt-aho
+.pre-commit-config.yaml @tenstorrent/metalium-developers-infra
+.clang-format @tenstorrent/metalium-developers-infra
+.clang-tidy @tenstorrent/metalium-developers-infra
 
-.clang-tidy @tt-rkim @afuller-TT @blozano-tt @tt-aho
-
-.github/ @tt-rkim @ttmchiou @TT-billteng @blozano-tt @afuller-TT
+.github/ @tenstorrent/metalium-developers-infra
 .github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT
 
-/infra/ @tt-rkim
+/infra/ @tenstorrent/metalium-developers-infra
 
-CONTRIBUTING.md @tt-rkim
+CONTRIBUTING.md @tenstorrent/metalium-developers-infra
 
-CODEOWNERS @tt-rkim
+CODEOWNERS @tenstorrent/metalium-developers-infra
 
-INSTALLING.md @tt-rkim @TT-billteng
+INSTALLING.md @tenstorrent/metalium-developers-infra
 METALIUM_GUIDE.md @davorchap
-
-# Dependencies
-
-third_party/ @tt-rkim @TT-billteng
 
 # Build stuff
 
-MANIFEST.in @tt-rkim
-setup.py @tt-rkim
-pyproject.toml @tt-rkim @TT-billteng
-requirements*.txt @tt-rkim @TT-billteng @ttmchiou
-setup_hugepages.py @tt-rkim
+MANIFEST.in @tenstorrent/metalium-developers-infra
+setup.py @tenstorrent/metalium-developers-infra
+pyproject.toml @tenstorrent/metalium-developers-infra
+requirements*.txt @tenstorrent/metalium-developers-infra
+setup_hugepages.py @tenstorrent/metalium-developers-infra
 
-scripts/build_scripts/ @tt-rkim @vtangTT
-cmake/ @tt-rkim @vtangTT @afuller-TT
-build_metal.sh @tt-rkim @vtangTT
+scripts/build_scripts/ @tenstorrent/metalium-developers-infra
+cmake/ @tenstorrent/metalium-developers-infra
+build_metal.sh @tenstorrent/metalium-developers-infra
 
-Makefile @tt-rkim
-/CMakeLists.txt @tt-rkim @vtangTT @blozano-tt @afuller-TT
-tests/CMakeLists.txt @tt-rkim @vtangTT @blozano-tt @afuller-TT
+/CMakeLists.txt @tenstorrent/metalium-developers-infra
+tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
 
 # Testing scripts and infra
 
-conftest.py @tt-rkim
+conftest.py @tenstorrent/metalium-developers-infra
 /conftest.py @tt-rkim @cfjchu @SeanNijjar
 
-tests/scripts/run_pre_post_commit_regressions.sh @tt-rkim
-tests/scripts/run_tests.sh @tt-rkim
+tests/scripts/run_pre_post_commit_regressions.sh @tenstorrent/metalium-developers-infra
+tests/scripts/run_tests.sh @tenstorrent/metalium-developers-infra
 tests/scripts/run_pre_post_commit_regressions_multi_device.sh @tt-rkim @aliuTT @tt-aho @TT-BrianLiu
-tests/scripts/run_pre_post_commit_regressions_fast_dispatch.sh @tt-rkim @TT-billteng @ttmchiou
-tests/scripts/run_models.sh @tt-rkim
-tests/scripts/single_card/ @tt-rkim
-tests/scripts/single_card/nightly/ @tt-rkim @vtangTT
-tests/scripts/t3000/ @blozano-tt @ttmchiou
-tests/scripts/tg/ @afuller-TT @ttmchiou
-tests/scripts/tgg/ @afuller-TT @ttmchiou
+tests/scripts/run_pre_post_commit_regressions_fast_dispatch.sh @tenstorrent/metalium-developers-infra
+tests/scripts/run_models.sh @tenstorrent/metalium-developers-infra
+tests/scripts/single_card/ @tenstorrent/metalium-developers-infra
+tests/scripts/single_card/nightly/ @tenstorrent/metalium-developers-infra
+tests/scripts/t3000/ @tenstorrent/metalium-developers-infra
+tests/scripts/tg/ @tenstorrent/metalium-developers-infra
+tests/scripts/tgg/ @tenstorrent/metalium-developers-infra
 
 # metal - base
 tt_metal/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema
 tt_metal/host_api.hpp @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @davorchap
 tt_metal/impl/device/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu
 tt_metal/distributed/ @cfjchu @aliuTT @tt-asaigal @omilyutin-tt
-tt_metal/**/requirements*.txt @tt-rkim @TT-billteng @ttmchiou
+tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
 
 # metal - dispatch
 tt_metal/impl/dispatch/kernels/packet_* @ubcheema @aliuTT
 tt_metal/impl/dispatch/kernels/eth_* @ubcheema @aliuTT
-# docs/source/tt_metal/apis/host_apis/ @TT-billteng
 tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @ubcheema
 
 # metal - fw, llks, risc-v
 tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @ttmtrajkovic
-tt_metal/hw/firmware/**/Makefile @tt-rkim
 tt_metal/include/compute_kernel_api.h @davorchap @mywoodstock
 tt_metal/include/compute_kernel_api/ @rtawfik01 @rdjogoTT @ttmtrajkovic
 tt_metal/include/dataflow_kernel_api.h @davorchap @mywoodstock @ntarafdar
@@ -91,7 +84,7 @@ tt-metal/tt_metal/programming_examples/profiler @mo-tenstorrent
 
 # test scripts
 tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tt-rkim
-tests/scripts/run_performance.sh @tt-rkim
+tests/scripts/run_performance.sh @tenstorrent/metalium-developers-infra
 
 # TTNN
 ttnn/ @ayerofieiev-tt @dmakoviichuk-tt @cfjchu @TT-BrianLiu
@@ -164,12 +157,9 @@ models/perf/perf_report.py @yieldthought @uaydonat @tt-rkim
 models/perf/benchmarking_utils.py @skhorasganiTT @tt-rkim
 
 # docs
+docs/Makefile @tenstorrent/metalium-developers-infra
 docs/source/ttnn/dependencies/tt_lib.rst @eyonland @patrickroberts @yan-zaretskiy @ayerofieiev-tt
 docs/source/ttnn/ @eyonland @patrickroberts @yan-zaretskiy @ayerofieiev-tt @razorback3 @dongjin-na
-# docs/source/apis/host_apis/ @abhullar-tt @TT-billteng @davorchap @tt-rkim
-# docs/source/apis/host_apis2.rst @abhullar-tt @TT-billteng @davorchap @tt-rkim
-# docs/source/apis/kernel_apis/ @davorchap @pgkeller @tt-rkim
-# docs/source/apis/kernel_apis.rst @davorchap @pgkeller @tt-rkim
 
 # misc
 tests/**/dtx/ @mywoodstock @sankarmanoj-tt
@@ -181,11 +171,10 @@ tests/device_perf_tests/stable_diffusion/test_perf_stable_diffusion.py @esmalTT 
 tests/ttnn/integration_tests/unet @esmalTT @uaydonat @mywoodstock
 tests/nightly/wh_b0_only_eth/experimental/functional_unet @esmalTT @uaydonat @mywoodstock
 scripts/profiler/ @mo-tenstorrent
-scripts/docker @ttmchiou @tt-rkim
+scripts/docker @tenstorrent/metalium-developers-infra
 
-dockerfile @ttmchiou @tt-rkim
+dockerfile @tenstorrent/metalium-developers-infra
 
-tt_metal/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @blozano-tt
 ttnn/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @yan-zaretskiy
 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,11 +35,11 @@ tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
 # Testing scripts and infra
 
 conftest.py @tenstorrent/metalium-developers-infra
-/conftest.py @tt-rkim @cfjchu @SeanNijjar
+/conftest.py @cfjchu @SeanNijjar @tenstorrent/metalium-developers-infra
 
 tests/scripts/run_pre_post_commit_regressions.sh @tenstorrent/metalium-developers-infra
 tests/scripts/run_tests.sh @tenstorrent/metalium-developers-infra
-tests/scripts/run_pre_post_commit_regressions_multi_device.sh @tt-rkim @aliuTT @tt-aho @TT-BrianLiu
+tests/scripts/run_pre_post_commit_regressions_multi_device.sh @aliuTT @tt-aho @TT-BrianLiu @tenstorrent/metalium-developers-infra
 tests/scripts/run_pre_post_commit_regressions_fast_dispatch.sh @tenstorrent/metalium-developers-infra
 tests/scripts/run_models.sh @tenstorrent/metalium-developers-infra
 tests/scripts/single_card/ @tenstorrent/metalium-developers-infra
@@ -76,7 +76,7 @@ sfpi/ @pgkeller
 
 # metal - profiler
 tt_metal/**/profiler/ @mo-tenstorrent
-tt_metal/**/profiler/**/CMakeLists.txt @tt-rkim @mo-tenstorrent
+tt_metal/**/profiler/**/CMakeLists.txt @mo-tenstorrent @tenstorrent/metalium-developers-infra
 tests/tt_metal/tools/profiler/ @mo-tenstorrent
 tt_metal/hostdevcommon/profiler_common.h @mo-tenstorrent
 docs/source/performance_measurement_tools/profiler.rst @mo-tenstorrent

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,13 +127,13 @@ ttnn/ttnn/distributed/ @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @omilyutin-tt
 tests/ttnn/distributed/ @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @omilyutin-tt
 
 # models
-/models/ @tt-rkim @uaydonat
+/models/ @uaydonat
 /models/*/**
 models/conv_on_device_utils*.py @mywoodstock @shwetankTT @sankarmanoj-tt
 functional_*/ @uaydonat @esmalTT
-models/demos @uaydonat @tt-rkim
+models/demos @uaydonat
 models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu
-models/demos/wormhole @uaydonat @tt-rkim
+models/demos/wormhole @uaydonat
 models/demos/t3000 @uaydonat
 models/demos/llama3 @cglagovichTT @yieldthought @mtairum @uaydonat
 models/demos/qwen @sraizada-tt @mtairum @uaydonat @yieldthought
@@ -149,12 +149,12 @@ models/demos/t3000/llama3_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-
 models/demos/t3000/mixtral8x7b @yieldthought @mtairum @uaydonat
 models/demos/tg/llama3_70b @cglagovichTT @uaydonat @johanna-rock-tt @djordje-tt @kpaigwar
 models/demos/tg/falcon7b @skhorasganiTT @djordje-tt @uaydonat
-models/demos/grayskull @uaydonat @tt-rkim
+models/demos/grayskull @uaydonat
 models/demos/**/*resnet* @mywoodstock @shwetankTT @tt-aho
 models/experimental/functional_unet @esmalTT @uaydonat @mywoodstock
-models/perf/ @uaydonat @tt-rkim
-models/perf/perf_report.py @yieldthought @uaydonat @tt-rkim
-models/perf/benchmarking_utils.py @skhorasganiTT @tt-rkim
+models/perf/ @uaydonat
+models/perf/perf_report.py @yieldthought @uaydonat
+models/perf/benchmarking_utils.py @skhorasganiTT
 
 # docs
 docs/Makefile @tenstorrent/metalium-developers-infra

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,12 +83,12 @@ docs/source/performance_measurement_tools/profiler.rst @mo-tenstorrent
 tt-metal/tt_metal/programming_examples/profiler @mo-tenstorrent
 
 # test scripts
-tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tt-rkim
+tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
 tests/scripts/run_performance.sh @tenstorrent/metalium-developers-infra
 
 # TTNN
 ttnn/ @ayerofieiev-tt @dmakoviichuk-tt @cfjchu @TT-BrianLiu
-ttnn/ttnn/library_tweaks.py @ayerofieiev-tt @tt-rkim
+ttnn/ttnn/library_tweaks.py @ayerofieiev-tt @tenstorrent/metalium-developers-infra
 ttnn/ttnn/operations/moreh.py @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt
 ttnn/**/kernels/ # Removes the owners above from owning kernels unless specified afterwards
 ttnn/**/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @yan-zaretskiy


### PR DESCRIPTION
### Problem description
@tt-rkim was frequently the only code owner on several PRs. This means he can never take vacation.

### What's changed
Use the infra team as codeowners for shared ownership of PR review.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
