### PR TITLE
Re-enable git-clang-format for pre-commit again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,11 @@ repos:
   rev: v1.35.1
   hooks:
     - id: yamllint
-# - repo: https://github.com/pre-commit/mirrors-clang-format
-#   rev: v19.1.4
-#   hooks:
-#     - id: clang-format
-#       entry: git-clang-format
-#       types_or: [c++, c]
-#       args: ["--style=file"]
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v19.1.4
+  hooks:
+    - id: clang-format
+      entry: git-clang-format
+      require_serial: true
+      types_or: [c++, c]
+      args: ["--style=file"]

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -8,7 +8,7 @@
 platformdirs<4.0.0
 pre-commit==3.0.4
 black==24.3.0
-clang-format==18.1.5
+clang-format==19.1.4
 build==0.10.0
 twine==4.0.2
 yamllint==1.32.0


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Some users were seeing errors regarding the lock file used by git-clang-format. This was due to precommit running git-clang-format in parallel. Only one should be run at a time.

### What's changed
Set requires_serial: true and update requirements-dev version of clang-format to match pre-commit version.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
