### PR TITLE
Detecting arch through cluster descriptor

### DIFF
--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -6,6 +6,7 @@
 #include "common/utils.hpp"
 
 #include "umd/device/device_api_metal.h"
+#include "umd/device/tt_cluster_descriptor.h"
 
 #include <string>
 
@@ -43,11 +44,11 @@ inline std::string get_umd_arch_name() {
         return get_env_arch_name();
     }
 
-    std::vector<chip_id_t> physical_mmio_device_ids = tt::umd::Cluster::detect_available_device_ids();
-    tt::ARCH arch = detect_arch(physical_mmio_device_ids.at(0));
-    for (int dev_index = 1; dev_index < physical_mmio_device_ids.size(); dev_index++) {
-        chip_id_t device_id = physical_mmio_device_ids.at(dev_index);
-        tt::ARCH detected_arch = detect_arch(device_id);
+    auto cluster_desc = tt_ClusterDescriptor::create();
+    const std::unordered_set<chip_id_t> &device_ids = cluster_desc->get_all_chips();
+    tt::ARCH arch = cluster_desc->get_arch(*device_ids.begin());
+    for (auto device_id : device_ids) {
+        tt::ARCH detected_arch = cluster_desc->get_arch(device_id);
         TT_FATAL(
             arch == detected_arch,
             "Expected all devices to be {} but device {} is {}",

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -357,7 +357,7 @@ void metal_SocDescriptor::update_pcie_cores(const BoardType& board_type) {
         return;
     }
     switch (board_type) {
-        case DEFAULT: {  // Workaround for BHs running FW that does not return board type in the cluster yaml
+        case UNKNOWN: {  // Workaround for BHs running FW that does not return board type in the cluster yaml
             this->pcie_cores = {CoreCoord(11, 0)};
         } break;
         case P150A: {

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -48,8 +48,7 @@ namespace tt::tt_metal {
  * @endcode
  *
  * @see tt::get_arch_from_string
- * @see tt_ClusterDescriptor::detect_arch
- * @see tt_ClusterDescriptor::get_arch
+ * @see PCIDevice::enumerate_devices_info
  */
 inline tt::ARCH get_platform_architecture() {
     auto arch = tt::ARCH::Invalid;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks Prod_op::create_program(
 Tensor prod_all(const Tensor& input, const MemoryConfig& output_mem_config) {
     Tensor result = ttnn::tiled_prod(
         operation::run(Prod_op{.output_mem_config = output_mem_config}, {input}).at(0), output_mem_config);
-    auto arch_env = detect_arch();
+    auto arch_env = tt_ClusterDescriptor::detect_arch((chip_id_t)0);
     if (arch_env == tt::ARCH::WORMHOLE_B0) {
         return ttnn::numpy::prod_result_computation_WH_B0<bfloat16>(
             result, result.get_dtype(), result.get_layout(), result.device(), output_mem_config);


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/13948

### Problem description
detect_arch was in the global namespace. 
Now putting this functionality in the right place. It also now works with logical ids, as opposed to pci device enumeration id.
Related UMD change https://github.com/tenstorrent/tt-umd/pull/345

### What's changed
Changed detect_arch to tt_ClusterDescriptor::get_arch()
BoardType::DEFAULT changed to UNKNOWN
Also changed detect_arch to PCIDevice::enumerate_devices_info(), due to ClusterDescriptor::create() not working.

### Checklist
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139731818
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139733483
- [ ] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139735518
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/12139737448
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139739342
- [x] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139741041
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139742806
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139744773
- [ ] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139746353
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12139748257
- [x] All post-commit tests on last commit: https://github.com/tenstorrent/tt-metal/actions/runs/12178722655
