### PR TITLE
Adjust perf test targets for Falcon7b-t3k-decode-noasync to account for CI instability

### DIFF
--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -249,8 +249,8 @@ class TestParametrized:
             ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.142, False),
             ("prefill", 4, 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.42, False),
             ("prefill", 4, 32, 1, 2048, 0, "BFLOAT16-DRAM", 1.02, False),
-            ("decode", 4, 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.063, False),
-            ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.067, False),
+            ("decode", 4, 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.067, False),
+            ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.069, False),
             ("decode", 4, 32, 32, 1, 2047, "BFLOAT16-L1_SHARDED", 0.073, False),
             ("prefill", 4, 32, 1, 128, 0, "BFLOAT16-DRAM", 0.070, True),  # Issue 9422
             ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.142, True),


### PR DESCRIPTION
### Ticket
None

### Problem description
- The Falcon T3K perf tests for decode-128/1024-noasync are failing ND due to variability in CI perf. No real regression was observed when locally testing the commits of older passing runs vs recent failing runs. 

### What's changed
- Slightly increased decode-128/1024-noasync perf targets

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
