### PR TITLE
#0: Make sub-device bank ids for cores the same as global bank ids

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -59,68 +59,82 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceAllocations) {
     auto input_3 =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, interleaved_config.size / sizeof(uint32_t));
 
-    for (Device* device : devices_) {
-        auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1}, local_l1_size);
-        auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
-        DeviceAddr l1_unreserved_base = device->get_base_allocator_addr(HalMemType::L1);
-        DeviceAddr max_addr = l1_unreserved_base + local_l1_size;
+    auto device = devices_[0];
+    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1}, local_l1_size);
+    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
+    DeviceAddr l1_unreserved_base = device->get_base_allocator_addr(HalMemType::L1);
+    DeviceAddr max_addr = l1_unreserved_base + local_l1_size;
 
-        shard_config_1.device = device;
-        shard_config_2.device = device;
-        interleaved_config.device = device;
+    shard_config_1.device = device;
+    shard_config_2.device = device;
+    interleaved_config.device = device;
 
-        std::vector<CoreCoord> physical_cores_1;
-        physical_cores_1.reserve(sharded_cores_1_vec.size());
-        for (const auto& core : sharded_cores_1_vec) {
-            physical_cores_1.push_back(device->worker_core_from_logical_core(core));
-        }
+    std::vector<CoreCoord> physical_cores_1;
+    physical_cores_1.reserve(sharded_cores_1_vec.size());
+    for (const auto& core : sharded_cores_1_vec) {
+        physical_cores_1.push_back(device->worker_core_from_logical_core(core));
+    }
 
-        std::vector<CoreCoord> physical_cores_2;
-        physical_cores_2.reserve(sharded_cores_2_vec.size());
-        for (const auto& core : sharded_cores_2_vec) {
-            physical_cores_2.push_back(device->worker_core_from_logical_core(core));
-        }
+    std::vector<CoreCoord> physical_cores_2;
+    physical_cores_2.reserve(sharded_cores_2_vec.size());
+    for (const auto& core : sharded_cores_2_vec) {
+        physical_cores_2.push_back(device->worker_core_from_logical_core(core));
+    }
 
-        device->load_sub_device_manager(sub_device_manager_1);
+    device->load_sub_device_manager(sub_device_manager_1);
 
-        auto buffer_1 = CreateBuffer(shard_config_1, SubDeviceId{0});
-        EXPECT_EQ(buffer_1->address(), max_addr - buffer_1->aligned_page_size());
-        EnqueueWriteBuffer(device->command_queue(), buffer_1, input_1, false);
-        std::vector<uint32_t> output_1;
-        EnqueueReadBuffer(device->command_queue(), buffer_1, output_1, true);
-        EXPECT_EQ(input_1, output_1);
-        auto input_1_it = input_1.begin();
-        for (const auto& physical_core : physical_cores_1) {
-            auto readback =
-                tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer_1->address(), page_size_1);
-            EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
-            input_1_it += page_size_1 / sizeof(uint32_t);
-        }
+    auto buffer_1 = CreateBuffer(shard_config_1, SubDeviceId{0});
+    EXPECT_EQ(buffer_1->address(), max_addr - buffer_1->aligned_page_size());
+    EnqueueWriteBuffer(device->command_queue(), buffer_1, input_1, false);
+    std::vector<uint32_t> output_1;
+    EnqueueReadBuffer(device->command_queue(), buffer_1, output_1, true);
+    EXPECT_EQ(input_1, output_1);
+    auto input_1_it = input_1.begin();
+    for (const auto& physical_core : physical_cores_1) {
+        auto readback = tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer_1->address(), page_size_1);
+        EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
+        input_1_it += page_size_1 / sizeof(uint32_t);
+    }
 
-        auto buffer_2 = CreateBuffer(interleaved_config);
-        EXPECT_THROW(CreateBuffer(shard_config_1, SubDeviceId{1}), std::exception);
-        EXPECT_THROW(device->clear_loaded_sub_device_manager(), std::exception);
-        EXPECT_THROW(device->load_sub_device_manager(sub_device_manager_2), std::exception);
-        DeallocateBuffer(*buffer_1);
-        device->clear_loaded_sub_device_manager();
-        device->load_sub_device_manager(sub_device_manager_2);
+    auto buffer_2 = CreateBuffer(interleaved_config);
+    EXPECT_THROW(CreateBuffer(shard_config_1, SubDeviceId{1}), std::exception);
+    EXPECT_THROW(device->clear_loaded_sub_device_manager(), std::exception);
+    EXPECT_THROW(device->load_sub_device_manager(sub_device_manager_2), std::exception);
+    DeallocateBuffer(*buffer_1);
+    device->clear_loaded_sub_device_manager();
+    device->load_sub_device_manager(sub_device_manager_2);
 
-        auto buffer_3 = CreateBuffer(shard_config_2, SubDeviceId{1});
-        EXPECT_EQ(buffer_3->address(), max_addr - buffer_3->aligned_page_size());
-        EnqueueWriteBuffer(device->command_queue(), buffer_3, input_2, false);
-        std::vector<uint32_t> output_2;
-        EnqueueReadBuffer(device->command_queue(), buffer_3, output_2, true);
-        EXPECT_EQ(input_2, output_2);
-        auto input_2_it = input_2.begin();
-        for (const auto& physical_core : physical_cores_2) {
-            auto readback =
-                tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer_3->address(), page_size_2);
-            EXPECT_TRUE(std::equal(input_2_it, input_2_it + page_size_2 / sizeof(uint32_t), readback.begin()));
-            input_2_it += page_size_2 / sizeof(uint32_t);
-        }
+    auto buffer_3 = CreateBuffer(shard_config_2, SubDeviceId{1});
+    EXPECT_EQ(buffer_3->address(), max_addr - buffer_3->aligned_page_size());
+    EnqueueWriteBuffer(device->command_queue(), buffer_3, input_2, false);
+    std::vector<uint32_t> output_2;
+    EnqueueReadBuffer(device->command_queue(), buffer_3, output_2, true);
+    EXPECT_EQ(input_2, output_2);
+    auto input_2_it = input_2.begin();
+    for (const auto& physical_core : physical_cores_2) {
+        auto readback = tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer_3->address(), page_size_2);
+        EXPECT_TRUE(std::equal(input_2_it, input_2_it + page_size_2 / sizeof(uint32_t), readback.begin()));
+        input_2_it += page_size_2 / sizeof(uint32_t);
+    }
 
-        auto buffer_4 = CreateBuffer(shard_config_1, SubDeviceId{0});
-        EXPECT_EQ(buffer_4->address(), max_addr - buffer_4->aligned_page_size());
-        EXPECT_THROW(CreateBuffer(interleaved_config, SubDeviceId{0}), std::exception);
+    auto buffer_4 = CreateBuffer(shard_config_1, SubDeviceId{0});
+    EXPECT_EQ(buffer_4->address(), max_addr - buffer_4->aligned_page_size());
+    EXPECT_THROW(CreateBuffer(interleaved_config, SubDeviceId{0}), std::exception);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBankIds) {
+    uint32_t local_l1_size = 3200;
+    SubDevice sub_device(std::array{
+        CoreRangeSet(std::array{CoreRange({5, 4}, {5, 4}), CoreRange({3, 2}, {3, 3}), CoreRange({0, 0}, {2, 2})})});
+
+    auto device = devices_[0];
+    auto sub_device_manager = device->create_sub_device_manager({sub_device}, local_l1_size);
+    device->load_sub_device_manager(sub_device_manager);
+
+    auto cores_vec = corerange_to_cores(device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}));
+    for (const auto& core : cores_vec) {
+        auto global_bank_id = device->bank_ids_from_logical_core(BufferType::L1, core)[0];
+        auto sub_device_bank_id = device->bank_ids_from_logical_core(BufferType::L1, core, SubDeviceId{0})[0];
+        EXPECT_EQ(global_bank_id, sub_device_bank_id);
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Sub-device bank ids for cores did not match bank ids of the global allocator. This makes things more complicated on device if we are looking things up by bank id (ex virtual coords). Making them the same means we can reuse the existing bank to noc coord mappings.

### What's changed
Use l1_bank_remap when creating the sub-device allocator to remap to the global bank ids.

### Checklist
- [X] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12094589866)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
