### PR TITLE
Remove core_config.h from host code inclusion in dev_msgs.h

### DIFF
--- a/tt_metal/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/dprint_common.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include "core_config.h"
-
 // DataFormat comes from tt_backend_api_types.hpp for SW, and tensix_types.h for HW...
 // But wait there's more, SW also includes tensix_types.h so there's both tt::DataFormat and DataFormat there. Use a
 // different name here so that this header can be included in both.
@@ -19,6 +17,7 @@
 #include "common/tt_backend_api_types.hpp"
 typedef tt::DataFormat CommonDataFormat;
 #else  // HW already includes tensix_types.h
+#include "core_config.h"
 typedef DataFormat CommonDataFormat;
 #endif
 

--- a/tt_metal/hw/inc/blackhole/core_config.h
+++ b/tt_metal/hw/inc/blackhole/core_config.h
@@ -13,16 +13,6 @@ enum ProgrammableCoreType {
     COUNT = 3,
 };
 
-enum class AddressableCoreType : uint8_t {
-    TENSIX = 0,
-    ETH = 1,
-    PCIE = 2,
-    DRAM = 3,
-    HARVESTED = 4,
-    UNKNOWN = 5,
-    COUNT = 6,
-};
-
 enum class TensixProcessorTypes : uint8_t { DM0 = 0, DM1 = 1, MATH0 = 2, MATH1 = 3, MATH2 = 4, COUNT = 5 };
 
 enum class EthProcessorTypes : uint8_t { DM0 = 0, DM1 = 1, COUNT = 2 };

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "core_config.h"
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
 
@@ -21,6 +20,7 @@
 // We don't want to pollute host code with those
 // Including them here within the guard to make FW/KERNEL happy
 // The right thing to do, would be "include what you use" in the other header files
+#include "core_config.h"
 #include "noc/noc_parameters.h"
 #include "dev_mem_map.h"
 
@@ -97,16 +97,20 @@ struct rta_offset_t {
     volatile uint16_t crta_offset;
 };
 
+// Maximums across all archs
+constexpr auto NUM_PROGRAMMABLE_CORE_TYPES = 3u;
+constexpr auto NUM_PROCESSORS_PER_CORE_TYPE = 5u;
+
 struct kernel_config_msg_t {
     volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
     // Ring buffer of kernel configuration data
-    volatile uint32_t kernel_config_base[static_cast<int>(ProgrammableCoreType::COUNT)];
-    volatile uint16_t sem_offset[static_cast<int>(ProgrammableCoreType::COUNT)];
+    volatile uint32_t kernel_config_base[NUM_PROGRAMMABLE_CORE_TYPES];
+    volatile uint16_t sem_offset[NUM_PROGRAMMABLE_CORE_TYPES];
     volatile uint16_t cb_offset;
     rta_offset_t rta_offset[DISPATCH_CLASS_MAX];
-    volatile uint32_t kernel_text_offset[MaxProcessorsPerCoreType];
+    volatile uint32_t kernel_text_offset[NUM_PROCESSORS_PER_CORE_TYPE];
 
     volatile uint16_t host_assigned_id;
 
@@ -275,6 +279,16 @@ static constexpr uint32_t PROFILER_NOC_ALIGNMENT_PAD_COUNT = 2;
 struct profiler_msg_t {
     uint32_t control_vector[kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE];
     uint32_t buffer[PROFILER_RISC_COUNT][kernel_profiler::PROFILER_L1_VECTOR_SIZE];
+};
+
+enum class AddressableCoreType : uint8_t {
+    TENSIX = 0,
+    ETH = 1,
+    PCIE = 2,
+    DRAM = 3,
+    HARVESTED = 4,
+    UNKNOWN = 5,
+    COUNT = 6,
 };
 
 struct addressable_core_t {

--- a/tt_metal/hw/inc/grayskull/core_config.h
+++ b/tt_metal/hw/inc/grayskull/core_config.h
@@ -11,16 +11,6 @@ enum ProgrammableCoreType {
     COUNT = 3,  // for now, easier to keep structures shared across arches' the same size
 };
 
-enum class AddressableCoreType : uint8_t {
-    TENSIX = 0,
-    ETH = 1,  // TODO: Make this accessible through the HAL and remove non-GS entries
-    PCIE = 2,
-    DRAM = 3,
-    HARVESTED = 4,
-    UNKNOWN = 5,
-    COUNT = 6,
-};
-
 enum class TensixProcessorTypes : uint8_t { DM0 = 0, DM1 = 1, MATH0 = 2, MATH1 = 3, MATH2 = 4, COUNT = 5 };
 
 constexpr uint8_t MaxProcessorsPerCoreType = 5;

--- a/tt_metal/hw/inc/wormhole/core_config.h
+++ b/tt_metal/hw/inc/wormhole/core_config.h
@@ -13,16 +13,6 @@ enum ProgrammableCoreType {
     COUNT = 3,
 };
 
-enum class AddressableCoreType : uint8_t {
-    TENSIX = 0,
-    ETH = 1,
-    PCIE = 2,
-    DRAM = 3,
-    HARVESTED = 4,
-    UNKNOWN = 5,
-    COUNT = 6,
-};
-
 enum class TensixProcessorTypes : uint8_t { DM0 = 0, DM1 = 1, MATH0 = 2, MATH1 = 3, MATH2 = 4, COUNT = 5 };
 
 enum class EthProcessorTypes : uint8_t { DM0 = 0, COUNT = 1 };

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -408,7 +408,7 @@ KernelGroup::KernelGroup(
         }
     }
 
-    for (uint32_t index = 0; index < MaxProcessorsPerCoreType; index ++) {
+    for (uint32_t index = 0; index < NUM_PROCESSORS_PER_CORE_TYPE; index ++) {
         this->kernel_bin_sizes[index] = 0;
         this->kernel_text_offsets[index] = 0;
         this->launch_msg.kernel_config.kernel_text_offset[index] = 0;

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -54,8 +54,8 @@ struct KernelGroup {
     kernel_id_array_t kernel_ids;
     uint32_t rta_sizes[DISPATCH_CLASS_MAX];
     uint32_t total_rta_size;
-    uint32_t kernel_text_offsets[MaxProcessorsPerCoreType];
-    uint32_t kernel_bin_sizes[MaxProcessorsPerCoreType];
+    uint32_t kernel_text_offsets[NUM_PROCESSORS_PER_CORE_TYPE];
+    uint32_t kernel_bin_sizes[NUM_PROCESSORS_PER_CORE_TYPE];
     launch_msg_t launch_msg;
     go_msg_t go_msg;
 

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "core_config.h"
 #include "dev_msgs.h"
 #include "eth_l1_address_map.h"
 

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <vector>
 
-#include "core_config.h"  // ProgrammableCoreType
+#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "core_config.h"
 #include "dev_msgs.h"
 #include "eth_l1_address_map.h"
 

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <vector>
 
+#include "core_config.h"
 #include "dev_mem_map.h"
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"


### PR DESCRIPTION
### Ticket
Closes #14643 

### Problem description
Need to make dev_msgs.h agnostic to ARCH_NAME

### What's changed
dev_msgs..h becomes independent of ARCH_NAME via:
- Move AddressableCoreTypes enum to `dev_msgs.h` as it is common to all archs, and its values are used in host code.
- Use maximal constant for NUM_PROGRAMMABLE_CORE_TYPES and NUM_PROCESSORS_PER_CORE_TYPE

This solution does not move any structs or enums behind the Hal.

Moving these structs and/or enums behind the Hal is a far more invasive change, that would lead to the following complexities:
- How would firmware code access structs like launch_msg_t, bring hal into firmware?
- Would need APIs to create, modify, and/or serialize structs like kernel_config_msg_t, because their memory layout would not be constant.
- Could negatively impact performance

If it is still desired to move these structs / enums behind Hal later, we can do that as a second stage effort.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12111819016)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12111842983)
- [x] New/Existing tests provide coverage for changes
