### PR TITLE
#15503: Fix didt testing framework targeting specific board in T3K

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -240,7 +240,7 @@ def board_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devi
     mesh_device_ids = [device_ids[pcie_id], device_ids[pcie_id + 4]]
     mesh_shape = ttnn.MeshShape(1, 2)
     mesh_device = ttnn.open_mesh_device(
-        mesh_shape, mesh_device_ids, dispatch_core_type=get_dispatch_core_type(), **device_params
+        mesh_shape, physical_device_ids=mesh_device_ids, dispatch_core_type=get_dispatch_core_type(), **device_params
     )
 
     logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15503

### Problem description
Support for targeting specific T3K board in didt testing framework was broken because of changes in `ttnn.open_mesh_device` function definition. Code is updated for correct passing of arguments.

### What's changed
`mesh_device_ids` is now passed as keyword argument

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
