### PR TITLE
#12253: Support for Batch normalization

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -29,6 +29,19 @@ def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is
     return pt_tensor, tt_tensor
 
 
+def data_gen_with_range_batch_norm(input_shapes, low, high, device, required_grad=False, is_row_major=False):
+    assert high > low, "Incorrect range provided"
+    torch.manual_seed(213919)
+    channels = input_shapes[1]
+    pt_tensor = torch.rand(channels, requires_grad=required_grad).bfloat16() * (high - low) + low
+    reshaped_tensor = pt_tensor.view(1, channels, 1, 1).expand(input_shapes)
+    if is_row_major:
+        tt_tensor = ttnn.Tensor(reshaped_tensor, ttnn.bfloat16).to(ttnn.ROW_MAJOR_LAYOUT).to(device)
+    else:
+        tt_tensor = ttnn.Tensor(reshaped_tensor, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    return pt_tensor, tt_tensor
+
+
 def data_gen_with_range_dtype(
     input_shapes, low, high, device, required_grad=False, is_row_major=False, ttnn_dtype=ttnn.bfloat16
 ):

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -143,6 +143,18 @@ struct ExecuteUnaryCompositeThreshold {
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
+struct ExecuteUnaryCompositeBatchNorm {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const float eps = 1e-05,
+        const float momentum = 0.1,
+        std::optional<Tensor> running_mean = std::nullopt,
+        std::optional<Tensor> running_var = std::nullopt,
+        const std::optional<Tensor>& weight = std::nullopt,
+        const std::optional<Tensor>& bias = std::nullopt,
+        const bool training = false,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+};
 struct ExecuteUnaryCompositeClip {
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -296,6 +308,8 @@ constexpr auto hardsigmoid = ttnn::register_operation_with_auto_launch_op<
 constexpr auto hardtanh = ttnn::register_operation_with_auto_launch_op<
     "ttnn::hardtanh",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::HARDTANH>>();
+constexpr auto batch_norm = ttnn::
+    register_operation_with_auto_launch_op<"ttnn::batch_norm", operations::unary::ExecuteUnaryCompositeBatchNorm>();
 constexpr auto clip =
     ttnn::register_operation_with_auto_launch_op<"ttnn::clip", operations::unary::ExecuteUnaryCompositeClip>();
 constexpr auto clamp =

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -175,6 +175,37 @@ for unary_function in TTNN_ELTWISE_UNARY_CPP_FUNCTIONS:
     register_ttnn_cpp_unary_function(unary_function)
 
 
+def _golden_function_batch_norm(
+    input_tensor,
+    *args,
+    eps=1e-05,
+    momentum=0.1,
+    running_mean=None,
+    running_var=None,
+    weight=None,
+    bias=None,
+    training=False,
+    **kwargs,
+):
+    import torch
+
+    output = torch.nn.functional.batch_norm(
+        input_tensor,
+        running_mean,
+        running_var,
+        weight,
+        bias,
+        training=training,
+        momentum=momentum,
+        eps=eps,
+    )
+
+    return output
+
+
+ttnn.attach_golden_function(ttnn.batch_norm, golden_function=_golden_function_batch_norm)
+
+
 def _golden_function_asin(input_tensor_a, *args, device, **kwargs):
     import torch
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12253
https://github.com/tenstorrent/tt-metal/issues/15372

### Problem description
Provide support for batch normalization 
https://pytorch.org/docs/stable/generated/torch.nn.functional.batch_norm.html

### What's changed

- Provided support for batch normalization 
- `data_gen_with_range_batch_norm ` to generate shape as in pytorch and pad the inputs to pass to `ttnn::batch_norm`
- In Progress task : 
  - Return running stats when in training
  - Adding sweep test
  - Move from eltwise to normalization folder

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12121027313) passes
