### PR TITLE
#0: Add overloaded helper to tt::stl

### DIFF
--- a/tt_metal/tt_stl/overloaded.hpp
+++ b/tt_metal/tt_stl/overloaded.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::stl {
+
+// `overloaded` allows to combine multiple lambdas into a single object with the overloaded `operator()`.
+// This is useful for creating visitor objects for using in `std::visit`, for example:
+//
+// void f(const std::variant<int, std::string>& v) {
+//   std::visit(overloaded {
+//     [](int i) { std::cout << "Got an int: " << i << std::endl; },
+//     [](const std::string& str) { std::cout << "Got a string: " << str << std::endl; },
+//   }, v);
+// }
+//
+//
+// Generic lambdas can also be used to simplify handling of variant types:
+//
+// void f(const std::variant<std::vector<int>, int, std::string>& v) {
+//   std::visit(overloaded {
+//     [](const std::vector<int>& vec) { std::cout << "Got a vector of size: " << vec.size() << std::endl; },
+//     [](const auto& other) { std::cout << "Got something else: " << other << std::endl; },
+//   }, v);
+// }
+//
+//
+//
+template <typename... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template <typename... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+}  // namespace tt::stl

--- a/tt_metal/tt_stl/overloaded.hpp
+++ b/tt_metal/tt_stl/overloaded.hpp
@@ -11,22 +11,18 @@ namespace tt::stl {
 // `overloaded` allows to combine multiple lambdas into a single object with the overloaded `operator()`.
 // This is useful for creating visitor objects for using in `std::visit`, for example:
 //
-// void f(const std::variant<int, std::string>& v) {
-//   std::visit(overloaded {
-//     [](int i) { std::cout << "Got an int: " << i << std::endl; },
-//     [](const std::string& str) { std::cout << "Got a string: " << str << std::endl; },
-//   }, v);
-// }
 //
+// class A, B, C;
+// std::variant<A, B, C> my_variant;
+// ...
 //
-// Generic lambdas can also be used to simplify handling of variant types:
-//
-// void f(const std::variant<std::vector<int>, int, std::string>& v) {
-//   std::visit(overloaded {
-//     [](const std::vector<int>& vec) { std::cout << "Got a vector of size: " << vec.size() << std::endl; },
-//     [](const auto& other) { std::cout << "Got something else: " << other << std::endl; },
-//   }, v);
-// }
+// std::visit(
+//     tt::stl::overloaded{
+//         [](const A&) { /*Process A...*/ },
+//         [](const B&) { /*Process B...*/ },
+//         [](const C&) { /*Process C...*/ },
+//     },
+//     my_variant);
 //
 //
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -10,6 +10,7 @@
 
 #include "common/bfloat16.hpp"
 #include "impl/buffers/buffer_constants.hpp"
+#include "overloaded.hpp"
 #include "tensor_ops.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/tensor/tensor_impl_wrapper.hpp"
@@ -735,31 +736,23 @@ namespace detail {
 template <typename DataType>
 void* get_raw_host_data_ptr(const Tensor& tensor) {
     return std::visit(
-        [](auto&& storage) -> void* {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (std::is_same_v<StorageType, OwnedStorage>) {
-                auto buffer = owned_buffer::get_as<DataType>(storage.buffer);
+        tt::stl::overloaded{
+            [](OwnedStorage& s) {
+                auto buffer = owned_buffer::get_as<DataType>(s.buffer);
                 return buffer.data();
-            } else if constexpr (std::is_same_v<StorageType, BorrowedStorage>) {
+            },
+            [](BorrowedStorage& s) {
                 if constexpr (
                     std::is_same_v<DataType, float> or std::is_same_v<DataType, bfloat16> or
                     std::is_same_v<DataType, std::uint32_t> or std::is_same_v<DataType, std::int32_t> or
                     std::is_same_v<DataType, std::uint8_t> or std::is_same_v<DataType, std::uint16_t>) {
-                    auto buffer = borrowed_buffer::get_as<DataType>(storage.buffer);
+                    auto buffer = borrowed_buffer::get_as<DataType>(s.buffer);
                     return buffer.data();
                 } else {
                     TT_THROW("Borrowed storage doesn't support this data type");
                 }
-            } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
-                TT_THROW("Device storage isn't supported");
-            } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {
-                TT_THROW("Device storage isn't supported");
-            } else if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
-                TT_THROW("Device storage isn't supported");
-            } else {
-                raise_unsupported_storage<StorageType>();
-            }
-        },
+            },
+            []<typename OtherStorage>(OtherStorage&) -> void* { TT_THROW("Device storage isn't supported"); }},
         tensor.get_storage());
 }
 }  // namespace detail

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -737,11 +737,11 @@ template <typename DataType>
 void* get_raw_host_data_ptr(const Tensor& tensor) {
     return std::visit(
         tt::stl::overloaded{
-            [](OwnedStorage& s) {
+            [](const OwnedStorage& s) {
                 auto buffer = owned_buffer::get_as<DataType>(s.buffer);
                 return buffer.data();
             },
-            [](BorrowedStorage& s) {
+            [](const BorrowedStorage& s) {
                 if constexpr (
                     std::is_same_v<DataType, float> or std::is_same_v<DataType, bfloat16> or
                     std::is_same_v<DataType, std::uint32_t> or std::is_same_v<DataType, std::int32_t> or
@@ -752,7 +752,8 @@ void* get_raw_host_data_ptr(const Tensor& tensor) {
                     TT_THROW("Borrowed storage doesn't support this data type");
                 }
             },
-            [](auto&&) -> void* { TT_THROW("Device storage doesn't support this data type"); }},
+            [](auto&&) -> void* { TT_THROW("Device storage doesn't support this data type"); },
+        },
         tensor.get_storage());
 }
 }  // namespace detail

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -735,25 +735,21 @@ Tensor create_device_tensor(
 namespace detail {
 template <typename DataType>
 void* get_raw_host_data_ptr(const Tensor& tensor) {
-    return std::visit(
-        tt::stl::overloaded{
-            [](OwnedStorage& s) {
-                auto buffer = owned_buffer::get_as<DataType>(s.buffer);
-                return buffer.data();
-            },
-            [](BorrowedStorage& s) {
-                return tt::stl::overloaded{
-                    [&s]()
-                        requires(std::is_same_v<DataType, float> or std::is_same_v<DataType, bfloat16> or
-                                 std::is_same_v<DataType, std::uint32_t> or std::is_same_v<DataType, std::int32_t> or
-                                 std::is_same_v<DataType, std::uint8_t> or std::is_same_v<DataType, std::uint16_t>)
-                    {
-                        auto buffer = borrowed_buffer::get_as<DataType>(s.buffer);
-                        return buffer.data();
-                    },
-                    []() -> void* { TT_THROW("Borrowed storage doesn't support this data type"); }}();
-            },
-            [](auto&&) -> void* { TT_THROW("Device storage doesn't support this data type"); }},
+    return std::visit(tt::stl::overloaded{
+        [](OwnedStorage& s) {
+            auto buffer = owned_buffer::get_as<DataType>(s.buffer);
+            return buffer.data();
+        },
+        [](BorrowedStorage& s)
+            requires(std::is_same_v<DataType, float> or std::is_same_v<DataType, bfloat16> or
+                     std::is_same_v<DataType, std::uint32_t> or std::is_same_v<DataType, std::int32_t> or
+                     std::is_same_v<DataType, std::uint8_t> or std::is_same_v<DataType, std::uint16_t>)
+        {
+            auto buffer = borrowed_buffer::get_as<DataType>(s.buffer);
+            return buffer.data();
+        },
+        [](BorrowedStorage&) -> void* { TT_THROW("Borrowed storage doesn't support this data type"); },
+        [](auto&&) -> void* { TT_THROW("Device storage doesn't support this data type"); }},
         tensor.get_storage());
 }
 }  // namespace detail


### PR DESCRIPTION
### Problem description
`overloaded` helper allows more clearly express processing logic for `std::variant`-based types, encapsulating logic in different physical overloads instead of relying on cascading `if constexpr`.

### What's changed
Added `overloaded.hpp` and used it in `tensor.cpp` as an illustration.

### Checklist
- [X] Post commit CI passes ([umd unit tests failure](https://github.com/tenstorrent/tt-metal/actions/runs/12132413898) + [re-run](https://github.com/tenstorrent/tt-metal/actions/runs/12143339634)).
