### PR TITLE
Mo/10234 eth dispatch profiling

### DIFF
--- a/scripts/tools_setup_common.sh
+++ b/scripts/tools_setup_common.sh
@@ -42,8 +42,9 @@ verify_perf_line_count_floor(){
 verify_perf_line_count(){
     csvLog=$1
     LINE_COUNT=$2
+    FILTER=$3
 
-    lineCount=$(cat $csvLog | wc | awk  'NR == 1 { print $1 }')
+    lineCount=$(cat $csvLog | grep $FILTER | wc | awk  'NR == 1 { print $1 }')
 
     if [[ ! $lineCount =~ ^[0-9]+$ ]]; then
         echo "Value for line count was $lineCount, not a number !" 1>&2

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -70,8 +70,8 @@ run_additional_T3000_test(){
     else
         echo "Verifying test results"
         runDate=$(ls $PROFILER_OUTPUT_DIR/)
-        LINE_COUNT=9 #1 header + 8 devices
-        res=$(verify_perf_line_count "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
+        LINE_COUNT=8 #8 devices
+        res=$(verify_perf_line_count "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT" "AllGather")
         echo $res
 
         run_tracing_async_mode_T3000_test

--- a/tests/ttnn/tracy/test_dispatch_profiler.py
+++ b/tests/ttnn/tracy/test_dispatch_profiler.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+
+def test_with_ops(device):
+    torch.manual_seed(0)
+
+    ttnn.enable_program_cache(device)
+    m = 1024
+    k = 1024
+    n = 1024
+    torch_a = torch.randn((m, k), dtype=torch.bfloat16)
+    torch_b = torch.randn((k, n), dtype=torch.bfloat16)
+    a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = a @ b
+    output = a @ b
+
+    output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+    a = ttnn.from_torch(torch_a)
+    b = ttnn.from_torch(torch_b)
+
+    a = ttnn.to_device(a, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    b = ttnn.to_device(b, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    a = ttnn.to_layout(a, ttnn.TILE_LAYOUT)
+    b = ttnn.to_layout(b, ttnn.TILE_LAYOUT)
+
+    for i in range(1000):
+        output = ttnn.matmul(a, b, memory_config=ttnn.L1_MEMORY_CONFIG, core_grid=ttnn.CoreGrid(y=8, x=8))
+
+
+@pytest.mark.parametrize("num_devices", [(8)])
+def test_all_devices(
+    all_devices,
+    num_devices,
+):
+    logger.debug("Testing All Devices")

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -117,6 +117,9 @@ int main() {
     //device_setup();
 
     noc_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);
+    for (uint32_t n = 0; n < NUM_NOCS; n++) {
+        noc_local_state_init(n);
+    }
 
     deassert_all_reset(); // Bring all riscs on eth cores out of reset
     mailboxes->go_message.signal = RUN_MSG_DONE;
@@ -188,13 +191,12 @@ int main() {
                     true /*posted*/);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
-
-#ifndef ARCH_BLACKHOLE
-            while (1) {
-                RISC_POST_HEARTBEAT(heartbeat);
-            }
-#endif
         }
+#ifndef ARCH_BLACKHOLE
+        while (1) {
+            RISC_POST_HEARTBEAT(heartbeat);
+        }
+#endif
     }
 
     return 0;

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -22,8 +22,6 @@
 #include <kernel_includes.hpp>
 
 void kernel_launch(uint32_t kernel_base_addr) {
-    DeviceZoneScopedMainChildN("ERISC-KERNEL");
-
     extern uint32_t __kernel_init_local_l1_base[];
     extern uint32_t __fw_export_end_text[];
     do_crt1((uint32_t tt_l1_ptr
@@ -31,16 +29,19 @@ void kernel_launch(uint32_t kernel_base_addr) {
 
     noc_local_state_init(NOC_INDEX);
 
-    kernel_main();
-    if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
-        WAYPOINT("NKFW");
-        // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC
-        // interface is in a known idle state for the next kernel.
-        ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
-        ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
-        ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
-        ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
-        ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
-        WAYPOINT("NKFD");
+    {
+        DeviceZoneScopedMainChildN("IDLE-ERISC-KERNEL");
+        kernel_main();
+        if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
+            WAYPOINT("NKFW");
+            // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC
+            // interface is in a known idle state for the next kernel.
+            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
+            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+            WAYPOINT("NKFD");
+        }
     }
 }

--- a/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
@@ -116,6 +116,7 @@ void kernel_main() {
     uint64_t start_timestamp = get_timestamp();
     uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
     while (!all_outputs_finished && !timeout) {
+        DeviceZoneScopedN("ETH-TUNNELER");
         iter++;
         if (timeout_cycles > 0) {
             uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -222,6 +222,7 @@ void kernel_main() {
     uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
     uint32_t heartbeat = 0;
     while (!all_outputs_finished && !timeout) {
+        DeviceZoneScopedN("PACKET-DEMUX");
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
         iter++;
         if (timeout_cycles > 0) {

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -176,6 +176,7 @@ void kernel_main() {
     uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
     uint32_t heartbeat = 0;
     while (!dest_finished && !timeout) {
+        DeviceZoneScopedN("PACKET-MUX");
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
         iter++;
         if (timeout_cycles > 0) {

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -227,6 +227,12 @@ class test_dispatch_cores(default_setup):
             "start": {"risc": "NCRISC", "zone_name": "KERNEL-MAIN-HD"},
             "end": {"risc": "NCRISC", "zone_name": "KERNEL-MAIN-HD"},
         },
+    }
+    detectOps = False
+
+
+class test_ethernet_dispatch_cores(default_setup):
+    timerAnalysis = {
         "Ethernet CQ Dispatch": {
             "across": "core",
             "type": "adjacent",

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -32,9 +32,10 @@
     DO_PRAGMA(message(PROFILER_MSG_NAME(name))); \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
 
-#if defined(PROFILE_KERNEL) &&    \
-    (!defined(DISPATCH_KERNEL) || \
-     (defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)))
+#if defined(PROFILE_KERNEL) &&                                                                     \
+    (!defined(DISPATCH_KERNEL) ||                                                                  \
+     (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)) &&           \
+     (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)))
 namespace kernel_profiler {
 
 extern uint32_t wIndex;
@@ -78,6 +79,8 @@ constexpr uint32_t Hash16_CT(const char (&s)[N]) {
     return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
 }
 
+enum class DoingDispatch { DISPATCH, NOT_DISPATCH };
+
 __attribute__((noinline)) void init_profiler(
     uint16_t briscKernelID = 0, uint16_t ncriscKernelID = 0, uint16_t triscsKernelID = 0) {
     wIndex = CUSTOM_MARKERS;
@@ -120,10 +123,10 @@ inline __attribute__((always_inline)) uint32_t get_id(uint32_t id, PacketTypes t
     return ((id & 0xFFFF) | ((type << 16) & 0x7FFFF));
 }
 
-template <bool dispatch = false>
+template <DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
 inline __attribute__((always_inline)) bool bufferHasRoom() {
     bool bufferHasRoom = false;
-    if constexpr (dispatch) {
+    if constexpr (dispatch == DoingDispatch::DISPATCH) {
         bufferHasRoom =
             wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE));
     } else {
@@ -244,8 +247,10 @@ __attribute__((noinline)) void finish_profiler() {
 #endif
 }
 
-inline __attribute__((always_inline)) void quick_push() {
-#if defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)
+__attribute__((noinline)) void quick_push() {
+#if defined(DISPATCH_KERNEL) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES) && \
+    (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+
     SrcLocNameToHash("PROFILER-NOC-QUICK-SEND");
     mark_time_at_index_inlined(wIndex, hash);
     wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
@@ -270,6 +275,9 @@ inline __attribute__((always_inline)) void quick_push() {
     mark_time_at_index_inlined(wIndex, get_const_id(hash, ZONE_END));
     wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
 
+    for (uint32_t i = 0; i < (wIndex % NOC_ALIGNMENT_FACTOR); i++) {
+        mark_padding();
+    }
     uint32_t currEndIndex = profiler_control_buffer[HOST_BUFFER_END_INDEX_BR_ER + myRiscID] + wIndex;
 
     if (currEndIndex <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
@@ -278,6 +286,7 @@ inline __attribute__((always_inline)) void quick_push() {
             dram_bank_dst_noc_addr,
             wIndex * sizeof(uint32_t));
 
+        noc_async_write_barrier();
         profiler_control_buffer[HOST_BUFFER_END_INDEX_BR_ER + myRiscID] = currEndIndex;
 
     } else {
@@ -289,7 +298,7 @@ inline __attribute__((always_inline)) void quick_push() {
 #endif
 }
 
-template <uint32_t timer_id, bool dispatch = false>
+template <uint32_t timer_id, DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
 struct profileScope {
     bool start_marked = false;
     inline __attribute__((always_inline)) profileScope() {
@@ -309,7 +318,7 @@ struct profileScope {
             stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
         }
 
-        if constexpr (dispatch) {
+        if constexpr (dispatch == DoingDispatch::DISPATCH) {
             if (wIndex >= (PROFILER_L1_VECTOR_SIZE - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE))) {
                 quick_push();
             }
@@ -352,7 +361,7 @@ struct profileScopeAccumulate {
     }
 };
 
-template <uint32_t data_id, bool dispatch = false>
+template <uint32_t data_id, DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
 inline __attribute__((always_inline)) void timeStampedData(uint64_t data) {
     if (bufferHasRoom<dispatch>()) {
         mark_time_at_index_inlined(wIndex, get_const_id(data_id, TS_DATA));
@@ -362,7 +371,7 @@ inline __attribute__((always_inline)) void timeStampedData(uint64_t data) {
     }
 }
 
-template <bool dispatch = false>
+template <DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
 inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
     if (bufferHasRoom<dispatch>()) {
         mark_time_at_index_inlined(wIndex, get_id(event_id, TS_EVENT));
@@ -372,7 +381,9 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 }  // namespace kernel_profiler
 
 // Not dispatch
-#if (!defined(DISPATCH_KERNEL) || !defined(COMPILE_FOR_NCRISC))
+#if (                            \
+    !defined(DISPATCH_KERNEL) || \
+    !(defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)))
 
 #define DeviceZoneScopedN(name)                                                \
     DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
@@ -384,12 +395,16 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
 #define DeviceRecordEvent(event_id) kernel_profiler::recordEvent(event_id);
 
 // Dispatch and enabled
-#elif (defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
+#elif (                                                                                                 \
+    defined(DISPATCH_KERNEL) &&                                                                       \
+    (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_ERISC)) && \
+    (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
 
-#define DeviceZoneScopedN(name)                                                \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
-    kernel_profiler::profileScope<hash, true> zone = kernel_profiler::profileScope<hash, true>();
+#define DeviceZoneScopedN(name)                                                         \
+    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                         \
+    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));           \
+    kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
+        kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH>();
 
 #define DeviceTimestampedData(data_id, data) kernel_profiler::timeStampedData<data_id, true>(data);
 

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -76,7 +76,7 @@ private:
 
     // Helper function for reading risc profile results
     void readRiscProfilerResults(
-        int device_id, const std::vector<std::uint32_t>& profile_buffer, const CoreCoord& worker_core);
+        IDevice* device, const std::vector<std::uint32_t>& profile_buffer, CoreCoord& worker_core);
 
     // Push device results to tracy
     void pushTracyDeviceResults();


### PR DESCRIPTION
### Ticket
[10234
](https://github.com/tenstorrent/tt-metal/issues/10234)
### Problem description
Eth dispatch is not working with TRACY

### What's changed
Bring in device profiler support for idle-eth cores, enabling eth dispatch profiling in the process. 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12716060795)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/12694985656)
- [x] [Microbenchmark](https://github.com/tenstorrent/tt-metal/actions/runs/12672947150)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/12672683240)
