### PR TITLE
Docker Release Images v2

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -8,7 +8,7 @@ inputs:
   docker_os_arch:
     description: 'Docker image architecture'
     required: false
-    default: ubuntu-20.04-amd64
+    default: tt-metalium/ubuntu-20.04-amd64
   docker_username:
     description: docker login username
     required: true

--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -89,7 +89,7 @@ runs:
           set -eu
 
           install_wheel=${{ inputs.install_wheel }}
-          if [[ "${install_wheel,,}" == "true" ]]; then
+          if [ "${install_wheel,,}" == "true" ]; then
             WHEEL_FILENAME=$(ls -1 *.whl)
             pip3 install "$WHEEL_FILENAME"
           fi

--- a/.github/actions/generate-docker-tag/action.yml
+++ b/.github/actions/generate-docker-tag/action.yml
@@ -24,8 +24,8 @@ runs:
     - name: Determine Full Docker Image Tag
       shell: bash
       run: |
-        echo "TT_METAL_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/tt-metalium/${{ inputs.image }}:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
-        echo "TT_METAL_REF_IMAGE_TAG=ghcr.io/${{ github.repository }}/tt-metalium/${{ inputs.image }}:latest" >> $GITHUB_ENV
+        echo "TT_METAL_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
+        echo "TT_METAL_REF_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest" >> $GITHUB_ENV
     - name: Output Docker Image Tag
       shell: bash
       run: |

--- a/.github/actions/generate-docker-tag/action.yml
+++ b/.github/actions/generate-docker-tag/action.yml
@@ -24,6 +24,8 @@ runs:
     - name: Determine Full Docker Image Tag
       shell: bash
       run: |
+        echo ${{ github.repository }}
+        echo ${{ inputs.image }}
         echo "TT_METAL_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
         echo "TT_METAL_REF_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest" >> $GITHUB_ENV
     - name: Output Docker Image Tag

--- a/.github/actions/generate-docker-tag/action.yml
+++ b/.github/actions/generate-docker-tag/action.yml
@@ -24,8 +24,6 @@ runs:
     - name: Determine Full Docker Image Tag
       shell: bash
       run: |
-        echo ${{ github.repository }}
-        echo ${{ inputs.image }}
         echo "TT_METAL_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
         echo "TT_METAL_REF_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest" >> $GITHUB_ENV
     - name: Output Docker Image Tag

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -99,7 +99,7 @@ jobs:
         id: generate-docker-tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: ${{ inputs.os }}
+          image: tt-metalium/${{ inputs.os }}
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Determine docker image tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: ${{ inputs.os }}
+          image: tt-metalium/${{ inputs.os }}
       - name: Build Docker image and push to GHCR
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,14 +50,13 @@ jobs:
         with:
           docker_username: ${{ github.actor }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_image_arch: ${{ inputs.arch }}
           docker_opts: |
             -e ARCH_NAME=${{ matrix.arch }}
             --group-add 1457
             -v /home/ubuntu/.ccache-ci:/home/ubuntu/.ccache
             -e CCACHE_DIR=/home/ubuntu/.ccache
             -v /mnt/MLPerf/ccache:/mnt/MLPerf/ccache
-          docker_os_arch: ${{ matrix.build.os }}-amd64
+          docker_os_arch: tt-metalium/${{ matrix.build.os }}-amd64
           run_args: |
             set -eu # basic shell hygiene
             set -x

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -54,7 +54,7 @@ jobs:
         id: generate-docker-tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: ${{ inputs.os }}
+          image: tt-metalium/${{ inputs.os }}
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/cpp-ttnn-project.yaml
+++ b/.github/workflows/cpp-ttnn-project.yaml
@@ -27,7 +27,7 @@ jobs:
         id: generate-docker-tag
         uses: ./.github/actions/generate-docker-tag
         with:
-          image: ubuntu-22.04-amd64
+          image: tt-metalium/ubuntu-22.04-amd64
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -180,7 +180,7 @@ jobs:
             infra/machine_setup/scripts/setup_hugepages.py
             metal_libs-*+*.whl
           fail_on_unmatched_files: true
-  create-docker-image:
+  create-docker-release-image:
     needs: [
       create-tag,
       create-and-upload-draft-release
@@ -189,7 +189,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
+      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}  
   release-docs:
     needs: [
       get-params,

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -189,7 +189,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}  
+      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
   release-docs:
     needs: [
       get-params,

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -185,27 +185,11 @@ jobs:
       create-tag,
       create-and-upload-draft-release
     ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: https://ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        env:
-          TT_METAL_DOCKER_IMAGE: tt-metalium/ubuntu-20.04-amd64
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: ghcr.io/${{ github.repository }}/tt-metalium/ubuntu-20.04-amd64:${{ needs.create-tag.outputs.version }}-dev
-          context: .
-          file: dockerfile/ubuntu-20.04-amd64.Dockerfile
+    uses: ./.github/workflows/publish-release-image.yaml
+    secrets: inherit
+    with:
+      version: ${{ needs.create-tag.outputs.version }}
+      is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
   release-docs:
     needs: [
       get-params,

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -3,11 +3,7 @@ name: "Create and Publish Release Docker Image"
 on:
   workflow_dispatch:
 jobs:
-  static-checks:
-    uses: ./.github/workflows/all-static-checks.yaml
-    secrets: inherit
   build-artifact:
-    needs: static-checks
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
   build-wheels:

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -5,8 +5,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  to_be_filled_out:
-    steps:
-      - name: This workflow will be filled out in https://github.com/tenstorrent/tt-metal/pull/15013
-        run: |
-          echo "NOOP"
+  static-checks:
+    uses: ./.github/workflows/all-static-checks.yaml
+    secrets: inherit
+  build-artifact:
+    needs: static-checks
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+  publish-release-image:
+    needs: build-artifact
+    uses: ./.github/workflows/publish-release-image.yaml
+    secrets: inherit
+    with:
+      version: test
+      is_major_version: false

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -28,5 +28,5 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      version: test
+      version: dev-${GITHUB_REF_NAME//\//-}
       is_major_version: false

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -1,9 +1,7 @@
 name: "Create and Publish Release Docker Image"
 
 on:
-  workflow_call:
   workflow_dispatch:
-
 jobs:
   static-checks:
     uses: ./.github/workflows/all-static-checks.yaml
@@ -12,8 +10,21 @@ jobs:
     needs: static-checks
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-  publish-release-image:
+  build-wheels:
     needs: build-artifact
+    strategy:
+      matrix:
+        # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
+        # The full 22.04 flow can be tested without precompiled
+        os: [ubuntu-20.04]
+        arch: [grayskull, wormhole_b0]
+    uses: ./.github/workflows/_build-wheels-impl.yaml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      from-precompiled: true
+  publish-release-image:
+    needs: build-wheels
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -49,7 +49,14 @@ jobs:
           tags: ${{ env.TAG_NAME }}
           context: .
           file: dockerfile/release.Dockerfile
-
+      - name: Run smoke test on the image
+        timeout-minutes: ${{ inputs.timeout }}
+        uses: ./.github/actions/docker-run
+        with:
+          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          run_args: |
+            pytest tests/end_to_end_tests
       - name: Tag latest if this is a major version release
         if: ${{ is_major_version }}
         run: |

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Get the name of the wheel and set up env variables
         run: |
           echo "WHEEL_FILENAME=$(ls -1 *.whl)" >> $GITHUB_ENV
-          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
+          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
           echo "REPO_IMAGE_NAME=$REPO_IMAGE_NAME" >> $GITHUB_ENV
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
@@ -53,12 +53,12 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
+          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           run_args: |
             pytest tests/end_to_end_tests
       - name: Tag latest if this is a major version release
-        if: ${{ is_major_version }}
+        if: ${{ inputs.is_major_version }}
         run: |
           docker pull $TAG_NAME
           docker tag $TAG_NAME $REPO_IMAGE_NAME:latest

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -105,7 +105,6 @@ jobs:
       - in-service
     steps:
       - name: Tag latest if this is a major version release
-        if: ${{ inputs.is_major_version }}
         run: |
           set -eu # basic shell hygiene
           LATEST_TAG=latest

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -42,7 +42,7 @@ jobs:
         id: generate-tag-name
         run: |
           echo "WHEEL_FILENAME=$(ls -1 *.whl)" >> $GITHUB_ENV
-          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
+          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
           echo "REPO_IMAGE_NAME=$REPO_IMAGE_NAME" >> $GITHUB_ENV
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -87,7 +87,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.test_group.arch }}
+          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.test_group.arch }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           run_args: |
             ${{ matrix.test_group.cmd }}
@@ -104,7 +104,7 @@ jobs:
       - name: Tag latest if this is a major version release
         if: ${{ inputs.is_major_version }}
         run: |
-          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
+          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           docker pull $TAG_NAME
           docker tag $TAG_NAME $REPO_IMAGE_NAME:latest

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -10,6 +10,10 @@ on:
         required: true
         type: boolean
         default: false
+      timeout:
+        required: false
+        type: number
+        default: 35
 jobs:
   create-docker-image:
     strategy:

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -110,7 +110,7 @@ jobs:
           LATEST_TAG=latest
           if [ "${{  inputs.is_major_version }}" = "true" ]; then
             LATEST_TAG=latest
-          else then
+          else
             LATEST_TAG=latest-rc
           fi
           REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -13,9 +13,9 @@ on:
       timeout:
         required: false
         type: number
-        default: 35
+        default: 10
 jobs:
-  create-docker-image:
+  create-docker-release-image:
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -72,13 +72,16 @@ jobs:
                 arch: wormhole_b0,
                 runs-on: ["cloud-virtual-machine", "N150", "in-service"],
                 cmd: pytest tests/end_to_end_tests,
-              }
+              },
+              {
+                arch: wormhole_b0,
+                runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+                cmd: pytest tests/end_to_end_tests,
+              },
           ]
     env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.test_group.arch }}
       LOGURU_LEVEL: INFO
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on: ${{ matrix.test_group.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -108,8 +108,14 @@ jobs:
         if: ${{ inputs.is_major_version }}
         run: |
           set -eu # basic shell hygiene
+          LATEST_TAG=latest
+          if [ "${{  inputs.is_major_version }}" = "true" ]; then
+            LATEST_TAG=latest
+          else then
+            LATEST_TAG=latest-rc
+          fi
           REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           docker pull $TAG_NAME
-          docker tag $TAG_NAME $REPO_IMAGE_NAME:latest
-          docker push $REPO_IMAGE_NAME:latest
+          docker tag $TAG_NAME $REPO_IMAGE_NAME:$LATEST_TAG
+          docker push $REPO_IMAGE_NAME:$LATEST_TAG

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -104,6 +104,12 @@ jobs:
       - build-docker
       - in-service
     steps:
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag latest if this is a major version release
         run: |
           set -eu # basic shell hygiene
@@ -113,8 +119,11 @@ jobs:
           else
             LATEST_TAG=latest-rc
           fi
+          echo "Determined that the current tag is " $LATEST_TAG
           REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           docker pull $TAG_NAME
+          echo "Tagging the image as " $REPO_IMAGE_NAME:$LATEST_TAG
           docker tag $TAG_NAME $REPO_IMAGE_NAME:$LATEST_TAG
+          echo "Pushing image with tag " $REPO_IMAGE_NAME:$LATEST_TAG
           docker push $REPO_IMAGE_NAME:$LATEST_TAG

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -57,7 +57,7 @@ jobs:
           context: .
           file: dockerfile/release.Dockerfile
   smoke-test-docker-image:
-    needs: create-docker-image
+    needs: create-docker-release-image
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -95,7 +95,7 @@ jobs:
           run_args: |
             ${{ matrix.test_group.cmd }}
   tag-docker-image-as-latest:
-    needs: [smoke-test-docker-image, create-docker-image]
+    needs: [smoke-test-docker-image, create-docker-release-image]
     strategy:
       matrix:
         os: [ubuntu-20.04]

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -20,7 +20,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         arch: [grayskull, wormhole_b0]
-    runs-on: ubuntu-latest
+    runs-on:
+      - build-docker
+      - in-service
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,6 +39,7 @@ jobs:
         with:
           name: eager-dist-${{ matrix.os }}-${{ matrix.arch }}
       - name: Get the name of the wheel and set up env variables
+        id: generate-tag-name
         run: |
           echo "WHEEL_FILENAME=$(ls -1 *.whl)" >> $GITHUB_ENV
           REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
@@ -53,17 +56,51 @@ jobs:
           tags: ${{ env.TAG_NAME }}
           context: .
           file: dockerfile/release.Dockerfile
+  smoke-test-docker-image:
+    needs: create-docker-image
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        test_group:
+          [
+              {
+                arch: grayskull,
+                runs-on: ["cloud-virtual-machine", "E150", "in-service"],
+                cmd: pytest tests/end_to_end_tests,
+              },
+              {
+                arch: wormhole_b0,
+                runs-on: ["cloud-virtual-machine", "N150", "in-service"],
+                cmd: pytest tests/end_to_end_tests,
+              }
+          ]
+    runs-on: ${{ matrix.test_group.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Run smoke test on the image
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
+          docker_os_arch: tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.test_group.arch }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           run_args: |
-            pytest tests/end_to_end_tests
+            ${{ matrix.test_group.cmd }}
+  tag-docker-image-as-latest:
+    needs: [smoke-test-docker-image, create-docker-image]
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        arch: [grayskull, wormhole_b0]
+    runs-on:
+      - build-docker
+      - in-service
+    steps:
       - name: Tag latest if this is a major version release
         if: ${{ inputs.is_major_version }}
         run: |
+          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-dev/${{ matrix.arch }}
+          TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           docker pull $TAG_NAME
           docker tag $TAG_NAME $REPO_IMAGE_NAME:latest
           docker push $REPO_IMAGE_NAME:latest

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -104,6 +104,7 @@ jobs:
       - name: Tag latest if this is a major version release
         if: ${{ inputs.is_major_version }}
         run: |
+          set -eu # basic shell hygiene
           REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
           TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
           docker pull $TAG_NAME

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -104,6 +104,8 @@ jobs:
       - build-docker
       - in-service
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -74,6 +74,11 @@ jobs:
                 cmd: pytest tests/end_to_end_tests,
               }
           ]
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ matrix.test_group.arch }}
+      LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on: ${{ matrix.test_group.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -1,0 +1,58 @@
+name: "[internal] Create and Publish Release Docker Image"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      is_major_version:
+        required: true
+        type: boolean
+        default: false
+jobs:
+  create-docker-image:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        arch: [grayskull, wormhole_b0]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: eager-dist-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Get the name of the wheel and set up env variables
+        run: |
+          echo "WHEEL_FILENAME=$(ls -1 *.whl)" >> $GITHUB_ENV
+          REPO_IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-metalium-${{ matrix.os }}-amd64-release/${{ matrix.arch }}
+          echo "REPO_IMAGE_NAME=$REPO_IMAGE_NAME" >> $GITHUB_ENV
+          TAG_NAME=$REPO_IMAGE_NAME:${{ inputs.version }}
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          build-args: |
+            WHEEL_FILENAME=${{ env.WHEEL_FILENAME }}
+            BASE_IMAGE_NAME=tt-metalium/${{ matrix.os }}-amd64
+          tags: ${{ env.TAG_NAME }}
+          context: .
+          file: dockerfile/release.Dockerfile
+
+      - name: Tag latest if this is a major version release
+        if: ${{ is_major_version }}
+        run: |
+          docker pull $TAG_NAME
+          docker tag $TAG_NAME $REPO_IMAGE_NAME:latest
+          docker push $REPO_IMAGE_NAME:latest

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -164,8 +164,8 @@ the particular Tenstorrent card architecture that you have installed on your
 system. (ie. Grayskull, Wormhole, etc)
 
 ```sh
-docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest
-docker run --it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest bash
+docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest-rc
+docker run --it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest-rc bash
 ```
 where `arch_name` is one of `grayskull`, `wormhole_b0`, or `blackhole`,
 depending on your Tenstorrent card type.

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -66,14 +66,14 @@ sudo -E python3 setup_hugepages.py enable && sudo -E python3 setup_hugepages.py 
 
 > [!NOTE]
 >
-> You may choose to install from either source or a Python wheel.
+> You may choose to install from either source, a Python wheel, or Docker release image.
 >
 > However, no matter your method, in order to use our pre-built models or to
 > follow along with the documentation and tutorials to get started, you will
 > still need the source code.
 >
 > If you do not want to use the models or follow the tutorials and want to
-> immediately start using the API, you may install just the wheel.
+> immediately start using the API, you may install just the wheel or get the release Docker container.
 
 1. Install git and git-lfs.
 
@@ -155,6 +155,25 @@ export PYTHONPATH=$(pwd)
 pip install -r tt_metal/python_env/requirements-dev.txt
 sudo apt-get install cpufrequtils
 sudo cpupower frequency-set -g performance
+```
+
+#### Option 3: From Docker Release Image
+
+Download the latest Docker release from our
+[releases](https://github.com/tenstorrent/tt-metal/releases/latest) page for
+the particular Tenstorrent card architecture that you have installed on your
+system. (ie. Grayskull, Wormhole, etc)
+
+```sh
+docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64-release/<arch_name>:latest
+docker run --it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64-release/<arch_name>:latest bash
+```
+where `arch_name` is one of `grayskull`, `wormhole_b0`, or `blackhole`,
+depending on your Tenstorrent card type.
+
+When inside of the container,
+```sh
+python3 -c "import ttnn"
 ```
 
 2. Start coding

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -165,8 +165,8 @@ the particular Tenstorrent card architecture that you have installed on your
 system. (ie. Grayskull, Wormhole, etc)
 
 ```sh
-docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64-release/<arch_name>:latest
-docker run --it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64-release/<arch_name>:latest bash
+docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest
+docker run --it --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-20.04-amd64-release/<arch_name>:latest bash
 ```
 where `arch_name` is one of `grayskull`, `wormhole_b0`, or `blackhole`,
 depending on your Tenstorrent card type.

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -159,8 +159,7 @@ sudo cpupower frequency-set -g performance
 
 #### Option 3: From Docker Release Image
 
-Download the latest Docker release from our
-[releases](https://github.com/tenstorrent/tt-metal/releases/latest) page for
+Download the latest Docker release from our [Docker registry](https://github.com/orgs/tenstorrent/packages?q=tt-metalium-ubuntu&tab=packages&q=tt-metalium-ubuntu-20.04-amd64-dev) page for
 the particular Tenstorrent card architecture that you have installed on your
 system. (ie. Grayskull, Wormhole, etc)
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -159,7 +159,7 @@ sudo cpupower frequency-set -g performance
 
 #### Option 3: From Docker Release Image
 
-Download the latest Docker release from our [Docker registry](https://github.com/orgs/tenstorrent/packages?q=tt-metalium-ubuntu&tab=packages&q=tt-metalium-ubuntu-20.04-amd64-dev) page for
+Download the latest Docker release from our [Docker registry](https://github.com/orgs/tenstorrent/packages?q=tt-metalium-ubuntu&tab=packages&q=tt-metalium-ubuntu-20.04-amd64-release) page for
 the particular Tenstorrent card architecture that you have installed on your
 system. (ie. Grayskull, Wormhole, etc)
 

--- a/dockerfile/release.Dockerfile
+++ b/dockerfile/release.Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE_NAME=tt-metalium/ubuntu-20.04-amd64
+#
+# Currently the release image uses the base image which is also the build image.
+# However, in the future, we could point a true base image that is a base for both releases and builds.
+# This work is described in https://github.com/tenstorrent/tt-metal/issues/11974
+FROM ghcr.io/tenstorrent/tt-metal/$BASE_IMAGE_NAME
+
+ARG WHEEL_FILENAME
+ADD $WHEEL_FILENAME $WHEEL_FILENAME
+RUN pip3 install $WHEEL_FILENAME


### PR DESCRIPTION
### Ticket

#12496
#12495 (describes agreed upon naming scheme)

### Problem description

Allow users to get started with TT-Metal stack within two command lines.

```
docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64-release/wormhole_b0:latest
docker run --rm -it -t ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64-release/wormhole_b0:latest python3 -c "import ttnn"
```

### What's changed
Add a job for the package release to also build/push a release image.

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12127666954
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
