### PR TITLE
[Llama3.2-11b] Add vLLM interface and support for external kv_cache and page_table

### DIFF
--- a/models/demos/llama3/tt/generator_vllm.py
+++ b/models/demos/llama3/tt/generator_vllm.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Union
+import torch
+import PIL
+from llama_models.llama3.api.chat_format import create_vision_mask
+
+from models.demos.llama3.tt.generator import LlamaGenerator
+from models.demos.llama3.demo.simple_vision_demo import create_multimodal_model
+
+from vllm.inputs import INPUT_REGISTRY, DecoderOnlyInputs, EncoderDecoderInputs, InputContext
+
+
+def input_processor_for_mllama(ctx: InputContext, inputs: Union[DecoderOnlyInputs, EncoderDecoderInputs]):
+    """
+    Based on vllm.model_executor.models.mllama.py::input_processor_for_mllama().
+    Note that vLLM's input_processor_for_mllama performs additional processing to handle chunking which we do not yet support.
+    """
+
+    # Move encoder_prompt to prompt. If the user does not explicitly provide separate
+    # encoder and decoder prompts, vLLM by default will treat the prompt as the encoder prompt.
+    # For the block manager to allocate enough blocks and add them to the block table, the decoder prompt
+    # must contain the full text prompt.
+    if inputs.get("prompt") is None:
+        inputs["prompt"] = inputs["encoder_prompt"]
+        inputs["prompt_token_ids"] = inputs["encoder_prompt_token_ids"]
+
+    return inputs
+
+
+@INPUT_REGISTRY.register_input_processor(input_processor_for_mllama)
+class TtMllamaForConditionalGeneration(LlamaGenerator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.MLLAMA_IMAGE_TOKEN_ID = 128256
+        self.max_gen_len = self.model_args.max_seq_len - 1  # TODO: double check what this should be
+
+    @classmethod
+    def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size):
+        max_seq_len = 512  # TODO: Increase to 131072 once it's verified to work
+        model_args, model = create_multimodal_model(mesh_device, max_batch_size, max_seq_len, use_paged_kv_cache=True)
+        return cls(model, model_args, mesh_device)
+
+    @property
+    def cache_path(self):
+        return self.model_args.model_cache_path
+
+    def prefill_forward(
+        self,
+        tokens: torch.Tensor,
+        images: List[PIL.Image.Image],
+        xattn_caches,
+        start_pos,
+        page_table: torch.Tensor = None,
+        kv_cache=None,
+        prompt_lens=None,
+    ):
+        """
+        Replaces prefill_forward from LlamaGenerator with a version that supports mask creation.
+        """
+        batch = tokens.shape[0]
+
+        vision_images = []
+        vision_masks = []
+        total_lens = []
+        for user_id in range(batch):
+            vision_images.append([images[user_id]])
+            prompt_tokens = [int(tokens[user_id, i]) for i in range(prompt_lens[user_id])]
+            vision_masks.append(create_vision_mask(prompt_tokens, self.MLLAMA_IMAGE_TOKEN_ID))
+            total_lens.append(prompt_lens[user_id] + self.max_gen_len)
+
+        return super().prefill_forward(
+            vision_images, vision_masks, tokens, xattn_caches, total_lens, prompt_lens, page_table, kv_cache
+        )

--- a/models/demos/llama3/tt/llama_attention.py
+++ b/models/demos/llama3/tt/llama_attention.py
@@ -23,6 +23,7 @@ class TtLlamaAttention(LightweightModule):
         transformation_mats,
         configuration,
         paged_attention_config=None,
+        use_paged_kv_cache=False,
     ):
         super().__init__()
 
@@ -56,6 +57,7 @@ class TtLlamaAttention(LightweightModule):
         self.ccl_topology = configuration.ccl_topology()
         self.is_multichip = configuration.is_multichip
 
+        self.layer_num = layer_num
         layer_name = configuration.get_state_dict_prefix(self.__class__.__name__, layer_num)
         if configuration.dummy_weights or (weight_cache_path is None):
             cache_name = lambda _: None
@@ -144,6 +146,17 @@ class TtLlamaAttention(LightweightModule):
                 cache_file_name=cache_name("wo_height_sharded"),
             )
 
+        if not use_paged_kv_cache:
+            # vLLM provides its own kv cache
+            self.init_kv_cache(configuration, weight_cache_path)
+
+        self.scale = self.head_dim**-0.5
+
+    def init_kv_cache(self, configuration, weight_cache_path):
+        """
+        Generates empty KV cache and pushed to device memory
+        """
+
         if self.paged_attention_config:
             cache_k = torch.zeros(
                 (
@@ -194,14 +207,13 @@ class TtLlamaAttention(LightweightModule):
             for k_or_v in [cache_k, cache_v]
         ]
 
-        self.scale = self.head_dim**-0.5
-
     def forward_decode(
         self,
         x: ttnn.Tensor,
         current_pos,
         rot_mats=None,
         page_table=None,
+        kv_cache=None,
     ) -> ttnn.Tensor:
         """
         x: (seq_len, 1, batch, dim)
@@ -263,8 +275,12 @@ class TtLlamaAttention(LightweightModule):
         ###
         # KV update
         ###
-        keys = self.layer_past[0]
-        values = self.layer_past[1]
+        if kv_cache:
+            keys = kv_cache[self.layer_num][0]
+            values = kv_cache[self.layer_num][1]
+        else:
+            keys = self.layer_past[0]
+            values = self.layer_past[1]
         # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
         # v_heads [seqlen, n_kv_heads, bsz, head_dim]
         # keys, [max_batch_size, n_kv_heads // configuration.num_devices, kv_seq_len, head_dim]
@@ -272,9 +288,6 @@ class TtLlamaAttention(LightweightModule):
         ttnn.experimental.paged_update_cache(
             values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
         )
-
-        self.layer_past[0] = keys
-        self.layer_past[1] = values
 
         # ttnn.deallocate(k_heads_1BKD)
         # ttnn.deallocate(v_heads_1BKD)
@@ -362,7 +375,7 @@ class TtLlamaAttention(LightweightModule):
             dense_out_sharded = ttnn.to_memory_config(dense_out_sharded, self.model_config["DECODE_RESIDUAL_MEMCFG"])
             return dense_out_sharded
 
-    def forward_prefill(self, x_11SH, rot_mats, transformation_mats, user_id: int = 0, page_table=None):
+    def forward_prefill(self, x_11SH, rot_mats, transformation_mats, user_id: int = 0, page_table=None, kv_cache=None):
         seq_len = x_11SH.shape[-2]
         assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
         ###
@@ -425,7 +438,10 @@ class TtLlamaAttention(LightweightModule):
         # ttnn.deallocate(k_heads_1KSD_pre_rot)
 
         # Fill KV-Cache
-        keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
+        if kv_cache:
+            keys_BKSD, values_BKSD = kv_cache[self.layer_num][0], kv_cache[self.layer_num][1]
+        else:
+            keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
 
         k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=ttnn.bfloat8_b)
         # ttnn.deallocate(k_heads_1KSD)
@@ -445,8 +461,12 @@ class TtLlamaAttention(LightweightModule):
             v_fill = v_heads_1VSD_8b
 
         if page_table:
-            ttnn.experimental.paged_fill_cache(keys_BKSD, k_fill, page_table, batch_idx=user_id)
-            ttnn.experimental.paged_fill_cache(values_BKSD, v_fill, page_table, batch_idx=user_id)
+            # In the case that the tokens have been padded along the seq len dimension, we need to fill the cache with the unpadded k/v values.
+            # Assume that the page table does not have padding, so we can use it to get the unpadded page len.
+            block_size = keys_BKSD.shape[2]
+            page_len = page_table.shape[1] * block_size
+            ttnn.experimental.paged_fill_cache(keys_BKSD, k_fill[:, :, :page_len, :], page_table, batch_idx=user_id)
+            ttnn.experimental.paged_fill_cache(values_BKSD, v_fill[:, :, :page_len, :], page_table, batch_idx=user_id)
         else:
             ttnn.fill_cache(
                 keys_BKSD,
@@ -462,8 +482,6 @@ class TtLlamaAttention(LightweightModule):
         # if seq_len >= self.min_kv_prefill_shard_seqlen:
         #     ttnn.deallocate(k_fill)
         #     ttnn.deallocate(v_fill)
-
-        self.layer_past = [keys_BKSD, values_BKSD]
 
         # SDPA
 
@@ -545,9 +563,19 @@ class TtLlamaAttention(LightweightModule):
 
     # TODO Miguel: Remove transformation_mats input (send at initialization instead)
     def forward(
-        self, x, current_pos, rot_mats=None, transformation_mats=None, user_id=0, mode="decode", page_table=None
+        self,
+        x,
+        current_pos,
+        rot_mats=None,
+        transformation_mats=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        kv_cache=None,
     ):
         if mode == "prefill":
-            return self.forward_prefill(x, rot_mats, transformation_mats, user_id, page_table)
+            return self.forward_prefill(
+                x, rot_mats, transformation_mats, user_id, page_table=page_table, kv_cache=kv_cache
+            )
         else:
-            return self.forward_decode(x, current_pos, rot_mats, page_table)
+            return self.forward_decode(x, current_pos, rot_mats, page_table=page_table, kv_cache=kv_cache)

--- a/models/demos/llama3/tt/llama_decoder.py
+++ b/models/demos/llama3/tt/llama_decoder.py
@@ -20,6 +20,7 @@ class TtTransformerBlock(LightweightModule):
         weight_cache_path,
         transformation_mats,
         paged_attention_config=None,
+        use_paged_kv_cache=False,
     ):
         super().__init__()
 
@@ -49,6 +50,7 @@ class TtTransformerBlock(LightweightModule):
             transformation_mats=transformation_mats,
             configuration=args,
             paged_attention_config=paged_attention_config,
+            use_paged_kv_cache=use_paged_kv_cache,
         )
         self.feed_forward = TtLlamaMLP(
             mesh_device=mesh_device,
@@ -99,6 +101,7 @@ class TtTransformerBlock(LightweightModule):
         user_id=0,
         mode="decode",
         page_table=None,
+        kv_cache=None,
     ) -> ttnn.Tensor:
         # x is fractured across devices and interleaved in DRAM (for prefill) and sharded in L1 (for decode)
         skip_mem_cfg = self.model_config["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
@@ -115,7 +118,8 @@ class TtTransformerBlock(LightweightModule):
             transformation_mats,
             user_id,
             mode,
-            page_table,
+            page_table=page_table,
+            kv_cache=kv_cache,
         )
         # Here x and attn_out are both fractured across devices
         h = ttnn.add(x, attn_out, memory_config=skip_mem_cfg)

--- a/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -5,6 +5,7 @@
 import math
 import ttnn
 import torch
+from tqdm import tqdm
 from models.demos.llama3.tt.llama_decoder import TtTransformerBlock
 from models.demos.llama3.tt.multimodal.llama_cross_block import TtLlamaCrossAttentionTransformerBlock
 from models.demos.llama3.tt.distributed_norm import DistributedNorm
@@ -43,6 +44,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         weight_cache_path,
         dtype,
         configuration,
+        use_paged_kv_cache=False,
     ):
         super().__init__()
         self.vocab_size = configuration.vocab_size
@@ -131,7 +133,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         # transformer blocks
         self.layers = []
         self.cross_attention_layers = []
-        for i in range(configuration.n_layers):
+        for i in tqdm(range(configuration.n_layers), desc="Loading text transformer layers"):
             layer_id = i
             block = TtTransformerBlock(
                 configuration,
@@ -141,6 +143,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
                 layer_id,
                 weight_cache_path,
                 transformation_mats=self.trans_mats_dict,
+                use_paged_kv_cache=use_paged_kv_cache,
             )
             self.layers.append(block)
             if layer_id in self.fusion_schedule:
@@ -272,6 +275,7 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         user_id=0,
         mode="decode",
         page_table=None,
+        kv_cache=None,
         # get_last_token=-1,
         text_only_inference=False,
         vision_tokens=None,
@@ -299,6 +303,8 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
                 transformation_mats=transformation_mats,
                 user_id=user_id,
                 mode=mode,
+                page_table=page_table,
+                kv_cache=kv_cache,
             )
 
         h = self.norm(h, mode=mode)

--- a/models/demos/llama3/tt/multimodal/llama_image_transformer.py
+++ b/models/demos/llama3/tt/multimodal/llama_image_transformer.py
@@ -2,10 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
-import torch
+from tqdm import tqdm
 
-import ttnn
 from models.utility_functions import (
     nearest_32,
 )
@@ -41,7 +39,7 @@ class TtLlamaImageTransformer(LightweightModule):
                 configuration=configuration,
                 gated=gated,
             )
-            for i in range(layers)
+            for i in tqdm(range(layers), desc=f"Loading vision transformer layers")
         ]
 
     def forward(self, x, return_intermediate=None, mask=None):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N/A

### What's changed
- Added vLLM interface for Llama3.2-11b in `generator_vllm.py` (inherits forward functions from `generator.py`)
- Added support for external (paged) kv_cache and page_table in Llama3.1/3.2
- Fixed bug where zero-padding of prefill page tables was overwriting valid block-0 entries by slicing the page table and k_fill/v_fill for each user to the proper page length

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
