### PR TITLE
Re-enable multicore untilize on blackhole

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -87,9 +87,8 @@ MassagedConcat build_unsqueeze_concat(int input_rank, const MemoryConfig& output
         }});
 }
 
-MassagedConcat build_untilize_rm_retilize_concat(uint8_t queue_id,
-                                                 const MemoryConfig& output_memory_config,
-                                                 ttnn::SimpleShape logical_output_shape) {
+MassagedConcat build_untilize_rm_retilize_concat(
+    uint8_t queue_id, const MemoryConfig& output_memory_config, ttnn::SimpleShape& logical_output_shape) {
     return MassagedConcat(MassagedConcatParams{
         .predicate = [](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> bool {
             // untilize_rm_retilize if the concat dim is padded for tilized tensors

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -111,10 +111,7 @@ operation::ProgramWithCallbacks Untilize::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    auto device_is_blackhole = input_tensor_a.device()->arch() == tt::ARCH::BLACKHOLE;
-    auto in_or_out_sharded = input_tensor_a.memory_config().is_sharded() || output_tensor.memory_config().is_sharded();
-    // FIXME: Remove this restriction once multicore untilize is supported on blackhole
-    if (this->use_multicore && (in_or_out_sharded || !device_is_blackhole)) {
+    if (this->use_multicore) {
         return detail::untilize_multi_core(
             input_tensor_a, output_tensor, this->use_pack_untilize, this->fp32_dest_acc_en);
     } else {


### PR DESCRIPTION
### Ticket
#14061, #14594 

### Problem description
The multicore untilize kernel was previously broken and disabled on blackhole due to a bug in the pack_untilize LLK.

### What's changed
A fix to the LLK landed in main; this PR re-enables multicore untilize on blackhole.

### Checklist
- [x] [Post commit CI ~passes](https://github.com/tenstorrent/tt-metal/actions/runs/12130425579) (one job failing due to issue with runner. I'm not worried.)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12130426323)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12130427150)
- [x] [Blackhole post-commit passes](https://github.com/tenstorrent/tt-metal/actions/runs/12130436190)