### PR TITLE
#13643: New binary op with full broadcasting support

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import random
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 1, 1]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 1, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
+    ),
+)
+def test_binary_scalar_ops(input_shapes, device):
+    a_shape, b_shape = input_shapes
+    a_pt = torch.rand(a_shape).bfloat16()
+    b_pt = torch.rand(b_shape).bfloat16()
+
+    a_tt = ttnn.from_torch(a_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    b_tt = ttnn.from_torch(b_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    cq_id = 0
+    out_tt = ttnn.experimental.add(a_tt, b_tt, queue_id=cq_id)
+    out_pt = a_pt + b_pt
+
+    comp_pass = compare_pcc([out_tt], [out_pt])
+    assert comp_pass

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -139,6 +139,10 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/binary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -17,6 +17,7 @@
 #include "ttnn/operations/conv/conv_pybind.hpp"
 #include "ttnn/operations/data_movement/data_movement_pybind.hpp"
 #include "ttnn/operations/eltwise/binary/binary_pybind.hpp"
+#include "ttnn/operations/eltwise/binary_ng/binary_ng_pybind.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp"
 #include "ttnn/operations/eltwise/complex/complex_pybind.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary_pybind.hpp"
@@ -66,6 +67,9 @@ void py_module(py::module& module) {
 
     auto m_binary = module.def_submodule("binary", "binary operations");
     binary::py_module(m_binary);
+
+    auto m_binary_ng = module.def_submodule("binary_ng", "binary_ng operations");
+    binary_ng::py_module(m_binary_ng);
 
     auto m_ternary = module.def_submodule("ternary", "ternary operations");
     ternary::py_module(m_ternary);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -1,0 +1,56 @@
+
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng.hpp"
+#include "device/binary_ng_device_operation.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryNg<binary_op_type>::invoke(
+    uint8_t queue_id,
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    const std::optional<const DataType> &output_dtype,
+    const std::optional<MemoryConfig> &memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    return ttnn::prim::binary_ng(
+        queue_id, input_tensor_a, input_tensor_b, binary_op_type, output_dtype, memory_config, optional_output_tensor);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryNg<binary_op_type>::invoke(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    const std::optional<const DataType> &output_dtype,
+    const std::optional<MemoryConfig> &memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    return invoke(DefaultQueueId, input_tensor_a, input_tensor_b, output_dtype, memory_config, optional_output_tensor);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryNg<binary_op_type>::invoke(
+    uint8_t queue_id,
+    const Tensor &input_tensor_a,
+    float scalar,
+    const std::optional<const DataType> &output_dtype,
+    const std::optional<MemoryConfig> &memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    return ttnn::prim::binary_ng(queue_id, input_tensor_a, scalar, binary_op_type, output_dtype, memory_config, optional_output_tensor);
+}
+
+template <BinaryOpType binary_op_type>
+Tensor BinaryNg<binary_op_type>::invoke(
+    const Tensor &input_tensor_a,
+    float scalar,
+    const std::optional<const DataType> &output_dtype,
+    const std::optional<MemoryConfig> &memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    return invoke(DefaultQueueId, input_tensor_a, scalar, output_dtype, memory_config, optional_output_tensor);
+}
+
+template struct BinaryNg<BinaryOpType::ADD>;
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -1,0 +1,52 @@
+
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/eltwise/binary_ng/types.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+template <BinaryOpType binary_op_type>
+struct BinaryNg {
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor &input_tensor_a,
+        const Tensor &input_tensor_b,
+        const std::optional<const DataType> &output_dtype = std::nullopt,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor &input_tensor_a,
+        const Tensor &input_tensor_b,
+        const std::optional<const DataType> &output_dtype = std::nullopt,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor &input_tensor_a,
+        float scalar,
+        const std::optional<const DataType> &output_dtype = std::nullopt,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor &input_tensor_a,
+        float scalar,
+        const std::optional<const DataType> &output_dtype = std::nullopt,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+};
+
+}  // namespace ttnn::operations::binary_ng
+
+namespace ttnn::experimental {
+constexpr auto add = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::add",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::ADD>>();
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_pybind.hpp"
+
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/eltwise/binary_ng/binary_ng.hpp"
+
+namespace ttnn::operations::binary_ng {
+namespace detail {
+void bind_binary_ng_operation(py::module& module) {
+    using OperationType = decltype(ttnn::experimental::add);
+
+    bind_registered_operation(
+        module,
+        ttnn::experimental::add,
+        "Binary Add Ng Operation",
+
+        // tensor and scalar
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor_a,
+               const float scalar,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               const uint8_t& queue_id) -> ttnn::Tensor {
+                return self(queue_id, input_tensor_a, scalar, dtype, memory_config, output_tensor);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("scalar"),
+            py::kw_only(),
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = 0},
+
+        // tensor and tensor
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const std::optional<const DataType>& dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::Tensor>& output_tensor,
+               uint8_t queue_id) -> ttnn::Tensor {
+                return self(queue_id, input_tensor_a, input_tensor_b, dtype, memory_config, output_tensor);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("dtype") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+}  // namespace detail
+
+void py_module(py::module& module) { detail::bind_binary_ng_operation(module); }
+}  // namespace ttnn::operations::eltwise::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::binary_ng {
+namespace detail {
+void bind_binary_ng_operation(py::module& module);
+}
+
+void py_module(py::module& module);
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_device_operation.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w) {
+    if (a_h == b_h && a_w == b_w) {
+        return SubtileBroadcastType::NONE;
+    }
+    if (a_h == 1 && a_w == 1) {
+        return SubtileBroadcastType::SCALAR_A;
+    }
+    if (b_h == 1 && b_w == 1) {
+        return SubtileBroadcastType::SCALAR_B;
+    }
+    if (a_h == 1 /* && a_w != 1 */ && b_w == 1 /* && b_h != 1 */) {
+        return SubtileBroadcastType::ROW_A_COL_B;
+    }
+    if (a_w == 1 /* && a_h != 1 */ && b_h == 1 /* && b_w != 1 */) {
+        return SubtileBroadcastType::ROW_B_COL_A;
+    }
+    if (a_h == 1) {
+        return SubtileBroadcastType::ROW_A;
+    }
+    if (a_w == 1) {
+        return SubtileBroadcastType::COL_A;
+    }
+    if (b_h == 1) {
+        return SubtileBroadcastType::ROW_B;
+    }
+    if (b_w == 1) {
+        return SubtileBroadcastType::COL_B;
+    }
+
+    TT_THROW("Invalid subtile broadcast type");
+}
+
+tt::stl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        binary_op_type, memory_config, get_dtype(), compute_kernel_config, subtile_broadcast_type);
+}
+
+DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
+    return this->dtype.value_or(this->input_dtype);
+}
+
+void BinaryNgDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    // We don't support sharding for now
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    TT_FATAL(
+        input_tensor_b.has_value() != attributes.scalar.has_value(), "Either the tensor b or scalar should be set");
+
+    BinaryNgDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
+
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "First operand to eltwise binary must be tilized");
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "First operand to eltwise binary must be interleaved");
+    TT_FATAL(
+        attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Output tensor to eltwise binary must be interleaved");
+
+    if (input_tensor_b.has_value()) {
+        TT_FATAL(input_tensor_b->get_layout() == Layout::TILE, "Second operand to eltwise binary must be tilized");
+        TT_FATAL(
+            input_tensor_b->memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Second operand to eltwise binary must be interleaved");
+    }
+
+    if (attributes.dtype.has_value() && output_tensor.has_value()) {
+        TT_FATAL(
+            *attributes.dtype == output_tensor->get_dtype(),
+            "If both output dtype and output tensor provided dtype should match");
+    }
+}
+
+void BinaryNgDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& output_tensor = tensor_args.output_tensor;
+
+    const auto& input_shape_a = input_tensor_a.get_logical_shape();
+    const auto input_shape_b =
+        tensor_args.input_tensor_b.has_value() ? tensor_args.input_tensor_b->get_logical_shape() : ttnn::Shape{1, 1};
+
+    constexpr int max_rank = 4;
+    for (int i = 0; i < max_rank; i++) {
+        auto a_dim = i < input_shape_a.rank() ? input_shape_a[-i] : 1;
+        auto b_dim = i < input_shape_b.rank() ? input_shape_b[-i] : 1;
+        TT_FATAL(
+            a_dim == b_dim || a_dim == 1 || b_dim == 1,
+            "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
+            i,
+            a_dim,
+            b_dim);
+    }
+}
+
+BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    if (output_tensor.has_value()) {
+        return output_tensor->get_tensor_spec();
+    }
+
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto input_shape_a = input_tensor_a.logical_shape();
+    const auto& tensor_b = tensor_args.input_tensor_b;
+    const auto input_shape_b = tensor_b.has_value() ? tensor_b->logical_shape() : ttnn::SimpleShape{};
+
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+
+    // Broadcasting Rules Overview:
+    // - If the two tensors have different ranks, we virtually pad the smaller-rank tensor's shape
+    //   with ones on the left (i.e., higher-order dimensions) until both shapes have the same length.
+    // - For each dimension (starting from the rightmost), the sizes are compatible if:
+    //     - They are equal, or
+    //     - One of them is 1 (the dimension can be broadcast to match the other size).
+    auto compute_broadcasted_output = [rank_a, rank_b, larger_rank](const auto& shape_a, const auto& shape_b) {
+        SmallVector<uint32_t> output_shape(larger_rank, 1);
+        for (int i = -1; i >= -larger_rank; --i) {
+            auto dim_a = (i >= -rank_a) ? shape_a[i] : 1;
+            auto dim_b = (i >= -rank_b) ? shape_b[i] : 1;
+            if (dim_a != 1 && dim_b != 1) {
+                output_shape[i + larger_rank] = dim_a;
+            } else {
+                output_shape[i + larger_rank] = dim_a + dim_b - 1;
+            }
+        }
+        return ttnn::SimpleShape(output_shape);
+    };
+
+    auto output_shape = compute_broadcasted_output(input_shape_a, input_shape_b);
+    return TensorSpec(
+        output_shape, TensorLayout(attributes.get_dtype(), PageConfig(Layout::TILE), attributes.memory_config));
+}
+
+BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return ProgramFactory{};
+}
+
+BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output_tensor;
+    if (output_tensor.has_value()) {
+        return output_tensor.value();
+    }
+
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
+}
+
+tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+
+    TT_ASSERT(
+        std::holds_alternative<DeviceStorage>(input_tensor_a.get_storage()),
+        "Unexpected type {}",
+        tt::stl::get_active_type_name_in_variant(input_tensor_a.get_storage()));
+
+    if (input_tensor_b.has_value()) {
+        TT_ASSERT(
+            std::holds_alternative<DeviceStorage>(input_tensor_b->get_storage()),
+            "Unexpected type {}",
+            tt::stl::get_active_type_name_in_variant(input_tensor_b->get_storage()));
+
+        return operation::hash_operation<BinaryNgDeviceOperation>(
+            attributes,
+            input_tensor_a.dtype(),
+            std::get<DeviceStorage>(input_tensor_a.storage()).memory_config(),
+            input_tensor_b->dtype(),
+            std::get<DeviceStorage>(input_tensor_b->storage()).memory_config());
+    }
+
+    return operation::hash_operation<BinaryNgDeviceOperation>(
+        attributes, input_tensor_a.dtype(), std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
+}
+
+std::tuple<BinaryNgDeviceOperation::operation_attributes_t, BinaryNgDeviceOperation::tensor_args_t>
+BinaryNgDeviceOperation::invoke(
+    const Tensor& input_tensor_a_arg,
+    const Tensor& input_tensor_b_arg,
+    BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    auto subtile_broadcast_type = get_subtile_broadcast_type(
+        input_tensor_a_arg.get_logical_shape()[-2],
+        input_tensor_a_arg.get_logical_shape()[-1],
+        input_tensor_b_arg.get_logical_shape()[-2],
+        input_tensor_b_arg.get_logical_shape()[-1]);
+
+    return {
+        operation_attributes_t{
+            binary_op_type,
+            std::nullopt,
+            memory_config.value_or(input_tensor_a_arg.memory_config()),
+            input_tensor_a_arg.get_dtype(),
+            output_dtype,
+            std::nullopt,
+            subtile_broadcast_type},
+        tensor_args_t{input_tensor_a_arg, input_tensor_b_arg, std::move(optional_output_tensor)}};
+}
+
+std::tuple<BinaryNgDeviceOperation::operation_attributes_t, BinaryNgDeviceOperation::tensor_args_t>
+BinaryNgDeviceOperation::invoke(
+    const Tensor& input_tensor_a_arg,
+    float scalar,
+    BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    return {
+        operation_attributes_t{
+            binary_op_type,
+            scalar,
+            memory_config.value_or(input_tensor_a_arg.memory_config()),
+            input_tensor_a_arg.get_dtype(),
+            output_dtype,
+            std::nullopt},
+        tensor_args_t{input_tensor_a_arg, std::nullopt, std::move(optional_output_tensor)}};
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/eltwise/binary_ng/types.hpp"
+
+namespace ttnn::operations::binary_ng {
+
+enum class SubtileBroadcastType {
+    NONE,         // both tensors have equal tile dimensions (H & W)
+    SCALAR_A,     // a is a scalar (H = 1, W = 1)
+    SCALAR_B,     // b is a scalar (H = 1, W = 1)
+    ROW_A_COL_B,  // a has a single tile row, b has a single tile column
+    ROW_B_COL_A,  // b has a single tile row, a has a single tile column
+    ROW_A,        // a has a single tile row, b is full
+    ROW_B,        // b has a single tile row, a is full
+    COL_A,        // a has a single tile column, b is full
+    COL_B,        // b has a single tile column, a is full
+};
+
+SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w);
+
+struct BinaryNgDeviceOperation {
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct operation_attributes_t {
+        BinaryOpType binary_op_type;
+        std::optional<float> scalar;
+        MemoryConfig memory_config;
+        DataType input_dtype;
+        std::optional<DataType> dtype;
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        SubtileBroadcastType subtile_broadcast_type = SubtileBroadcastType::NONE;
+
+        tt::stl::hash::hash_t to_hash() const;
+        DataType get_dtype() const;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input_tensor_a;
+        std::optional<Tensor> input_tensor_b;
+        std::optional<Tensor> output_tensor;
+    };
+
+    struct ProgramFactory {
+        struct shared_variables_t {
+            KernelHandle reader_kernel_id;
+            KernelHandle writer_kernel_id;
+            KernelHandle compute_kernel_id;
+            CoreCoord compute_with_storage_grid_size;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // tensor-tensor invocation
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor_a_arg,
+        const Tensor& input_tensor_b_arg,
+        BinaryOpType binary_op_type,
+        const std::optional<const DataType>& output_dtype,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<Tensor> optional_output_tensor);
+
+    // tensor-scalar invocation
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor_a_arg,
+        float scalar,
+        BinaryOpType binary_op_type,
+        const std::optional<const DataType>& output_dtype,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<Tensor> optional_output_tensor);
+};
+
+}  // namespace ttnn::operations::binary_ng
+
+namespace ttnn::prim {
+constexpr auto binary_ng =
+    ttnn::register_operation<"ttnn::prim::binary_ng", ttnn::operations::binary_ng::BinaryNgDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace ttnn::operations::binary_ng;
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};
+}
+
+enum class KernelName {
+    ReaderNoBcast,
+    ReaderRowBcast,
+    ReaderColBcast,
+    ReaderScalarBcast,
+    WriterNoBcast,
+    WriterRowBcast,
+    WriterColBcast,
+    WriterScalarBcast,
+    WriterScalar,
+    ComputeNoBcast,
+    ComputeBcast,
+    ComputeScalar
+};
+
+struct BinaryNgKernelConfig {
+    BinaryNgKernelConfig(SubtileBroadcastType subtile_broadcast_type) {
+        switch (subtile_broadcast_type) {
+            case SubtileBroadcastType::NONE:
+                reader_kernel = KernelName::ReaderNoBcast;
+                compute_kernel = KernelName::ComputeNoBcast;
+                writer_kernel = KernelName::WriterNoBcast;
+                bcast_input = std::nullopt;
+                break;
+
+            case SubtileBroadcastType::SCALAR_A:
+                reader_kernel = KernelName::ReaderScalarBcast;
+                compute_kernel = KernelName::ComputeBcast;
+                writer_kernel = KernelName::WriterNoBcast;
+                bcast_input = 0;
+                break;
+
+            case SubtileBroadcastType::SCALAR_B:
+                reader_kernel = KernelName::ReaderNoBcast;
+                compute_kernel = KernelName::ComputeBcast;
+                writer_kernel = KernelName::WriterScalarBcast;
+                bcast_input = 1;
+                break;
+
+            case SubtileBroadcastType::ROW_A:
+                reader_kernel = KernelName::ReaderRowBcast;
+                compute_kernel = KernelName::ComputeNoBcast;
+                writer_kernel = KernelName::WriterNoBcast;
+                bcast_input = std::nullopt;
+                break;
+
+            case SubtileBroadcastType::ROW_B:
+                reader_kernel = KernelName::ReaderNoBcast;
+                compute_kernel = KernelName::ComputeNoBcast;
+                writer_kernel = KernelName::WriterRowBcast;
+                bcast_input = std::nullopt;
+                break;
+
+            case SubtileBroadcastType::COL_A:
+                reader_kernel = KernelName::ReaderColBcast;
+                compute_kernel = KernelName::ComputeBcast;
+                writer_kernel = KernelName::WriterNoBcast;
+                bcast_input = 0;
+                break;
+
+            case SubtileBroadcastType::COL_B:
+                reader_kernel = KernelName::ReaderNoBcast;
+                compute_kernel = KernelName::ComputeBcast;
+                writer_kernel = KernelName::WriterColBcast;
+                bcast_input = 1;
+                break;
+
+            case SubtileBroadcastType::ROW_A_COL_B:
+                reader_kernel = KernelName::ReaderRowBcast;
+                compute_kernel = KernelName::ComputeBcast;
+                writer_kernel = KernelName::WriterColBcast;
+                bcast_input = 1;
+                break;
+
+            case SubtileBroadcastType::ROW_B_COL_A:
+                reader_kernel = KernelName::ReaderColBcast;
+                compute_kernel = KernelName::ComputeBcast;
+                writer_kernel = KernelName::WriterRowBcast;
+                bcast_input = 0;
+                break;
+        }
+    }
+
+    std::string bcast_input_str() const {
+        if (bcast_input.has_value()) {
+            return std::to_string(*bcast_input);
+        }
+        return "";
+    }
+
+    KernelName reader_kernel;
+    KernelName compute_kernel;
+    KernelName writer_kernel;
+    std::optional<uint32_t> bcast_input;
+};
+
+std::string get_kernel_file_path(KernelName kernel_name) {
+    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels";
+    constexpr std::string_view dataflow = "{}/dataflow/{}";
+    constexpr std::string_view compute = "{}/compute/{}";
+
+    switch (kernel_name) {
+        case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
+        case KernelName::ReaderRowBcast: return fmt::format(dataflow, root, "reader_interleaved_row_bcast.cpp");
+        case KernelName::ReaderColBcast: return fmt::format(dataflow, root, "reader_interleaved_col_bcast.cpp");
+        case KernelName::ReaderScalarBcast: return fmt::format(dataflow, root, "reader_interleaved_scalar_bcast.cpp");
+        case KernelName::WriterNoBcast: return fmt::format(dataflow, root, "writer_interleaved_no_bcast.cpp");
+        case KernelName::WriterRowBcast: return fmt::format(dataflow, root, "writer_interleaved_row_bcast.cpp");
+        case KernelName::WriterColBcast: return fmt::format(dataflow, root, "writer_interleaved_col_bcast.cpp");
+        case KernelName::WriterScalarBcast: return fmt::format(dataflow, root, "writer_interleaved_scalar_bcast.cpp");
+        case KernelName::WriterScalar: return fmt::format(dataflow, root, "writer_interleaved_scalar.cpp");
+        case KernelName::ComputeNoBcast: return fmt::format(compute, root, "eltwise_binary_no_bcast.cpp");
+        case KernelName::ComputeBcast: return fmt::format(compute, root, "eltwise_binary.cpp");
+        case KernelName::ComputeScalar: return fmt::format(compute, root, "eltwise_binary_scalar.cpp");
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
+    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t HtWt, uint32_t Wt) {
+    uint32_t start_t = start_tile_id % HtWt;
+    uint32_t start_tw = start_t % Wt;
+
+    switch (broadcast_type) {
+        case SubtileBroadcastType::NONE:
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::ROW_B: return {1, 0};
+        case SubtileBroadcastType::SCALAR_A:
+        case SubtileBroadcastType::SCALAR_B: return {HtWt, start_t};
+        case SubtileBroadcastType::COL_A:
+        case SubtileBroadcastType::ROW_B_COL_A:
+        case SubtileBroadcastType::COL_B:
+        case SubtileBroadcastType::ROW_A_COL_B: return {Wt, start_tw};
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+template <typename F>
+void set_or_update_runtime_arguments(
+    Program& program,
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    KernelHandle compute_kernel_id,
+    CoreCoord compute_with_storage_grid_size,
+    const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
+    const BinaryNgDeviceOperation::tensor_args_t& tensor_args,
+    BinaryNgDeviceOperation::tensor_return_value_t& c,
+    F handle_args) {
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+
+    const auto ashape = a.get_padded_shape();
+    const auto bshape = b.has_value() ? b->get_padded_shape() : SimpleShape{1, 1};
+    const auto cshape = c.get_padded_shape();
+
+    const auto [aN, aC, aHt, aWt] = extract_shape_dims(a);
+    const auto [bN, bC, bHt, bWt] = b.has_value() ? extract_shape_dims(*b) : std::tuple{1u, 1u, 1u, 1u};
+    const auto [cN, cC, cHt, cWt] = extract_shape_dims(c);
+
+    uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
+
+    constexpr bool row_major = true;
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
+
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        const auto& core = cores[i];
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 10>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 11>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
+            continue;
+        }
+
+        uint32_t cHtWt = cHt * cWt;
+        std::array reader_runtime_args = {
+            a.buffer()->address(),
+            start_tile_id,
+            num_tiles_per_core,
+            cHtWt,
+            aHt * aWt * aC * (aN > 1),
+            aHt * aWt * (aC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt};
+        handle_args(program, reader_kernel_id, core, reader_runtime_args);
+
+        if (b.has_value()) {
+            std::array writer_runtime_args = {
+                b->buffer()->address(),
+                c.buffer()->address(),
+                start_tile_id,
+                num_tiles_per_core,
+                cHtWt,
+                bHt * bWt * bC * (bN > 1),
+                bHt * bWt * (bC > 1),
+                cN,
+                cC,
+                cHt,
+                cWt};
+            handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+            auto [freq, counter] =
+                calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, start_tile_id, cHtWt, cWt);
+            std::array compute_runtime_args = {num_tiles_per_core, freq, counter};
+            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+        } else {
+            class bfloat16 bfloat_scalar(*operation_attributes.scalar);
+            uint32_t packed_scalar = pack_two_bfloat16_into_uint32({bfloat_scalar, bfloat_scalar});
+            std::array writer_runtime_args = {
+                packed_scalar,
+                c.buffer()->address(),
+                start_tile_id,
+                num_tiles_per_core,
+                cHtWt,
+                cN,
+                cC,
+                cHt,
+                cWt,
+                0u,
+                0u};
+            handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+            std::array compute_runtime_args = {num_tiles_per_core, 0u, 0u};
+            handle_args(program, compute_kernel_id, core, compute_runtime_args);
+        }
+
+        start_tile_id += num_tiles_per_core;
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::binary_ng {
+
+// Implements c = a op b
+BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperation::ProgramFactory::create(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+
+    auto program = CreateProgram();
+
+    auto* device = a.device();
+
+    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    auto b_data_format = b.has_value() ? datatype_to_dataformat_converter(b->get_dtype()) : DataFormat::Float16_b;
+    auto c_data_format = datatype_to_dataformat_converter(c.get_dtype());
+
+    uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
+    uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
+    uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
+
+    uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
+
+    // we parallelize the computation across the output tiles
+    constexpr bool row_major = true;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    Buffer* a_buffer = a.buffer();
+    Buffer* b_buffer = nullptr;
+    Buffer* c_buffer = c.buffer();
+
+    // How many tiles to store per input CB (double buffer)
+    constexpr uint32_t num_tiles_per_cb = 2;
+    auto [a_cb, a_cb_handle] =
+        create_cb(tt::CB::c_in0, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
+    auto [c_cb, c_cb_handle] =
+        create_cb(tt::CB::c_out0, program, all_device_cores, c_single_tile_size, num_tiles_per_cb, c_data_format);
+
+    // If b is a scalar, we only need one tile in the CB
+    uint32_t b_num_tiles_per_cb = b_buffer != nullptr ? num_tiles_per_cb : 1;
+    auto [b_cb, b_cb_handle] =
+        create_cb(tt::CB::c_in1, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+
+    auto a_is_dram = static_cast<uint32_t>(a_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    bool b_is_dram = false;
+    auto c_is_dram = static_cast<uint32_t>(c_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+
+    auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
+
+    // READER KERNEL
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(kernel_config.reader_kernel),
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram}));
+
+    // WRITER KERNEL
+    auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
+    auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
+    if (b.has_value()) {
+        b_buffer = b->buffer();
+        b_is_dram = static_cast<uint32_t>(b_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+        writer_kernel = kernel_config.writer_kernel;
+        compute_kernel = kernel_config.compute_kernel;
+    }
+
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(writer_kernel),
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram}));
+
+    // COMPUTE KERNEL
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32;
+
+    // Compute kernel needs to know which op it's going to perform
+    // This has to be passed as a compile-time argument
+    // For now we're just going to do addition
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_kernel_file_path(compute_kernel),
+        all_device_cores,
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en, .defines = {{"BCAST_INPUT", kernel_config.bcast_input_str()}}});
+
+    auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        compute_kernel_id,
+        compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        c,
+        set_runtime_args);
+
+    return {
+        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+}
+
+void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& c) {
+    auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        auto& all_args = GetRuntimeArgs(program, kernel_id);
+        auto& core_args = all_args.at(core.x).at(core.y);
+        std::copy(args.begin(), args.end(), core_args.data());
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
+        cached_program.shared_variables.compute_kernel_id,
+        cached_program.shared_variables.compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        c,
+        update_args);
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_binary.h"
+
+#include <cstdint>
+
+
+namespace NAMESPACE {
+
+ALWI void process_tile(uint32_t cb_bcast, uint32_t cb_other, uint32_t cb_out, uint32_t freq, uint32_t tile_start) {
+    constexpr uint32_t onetile = 1;
+
+    cb_wait_front(cb_bcast, onetile);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        cb_wait_front(cb_other, onetile);
+        cb_reserve_back(cb_out, onetile);
+
+        tile_regs_acquire();
+        add_tiles(cb_bcast, cb_other, 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_other, onetile);
+    }
+    cb_pop_front(cb_bcast, onetile);
+}
+
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+
+#if BCAST_INPUT
+    auto cb_bcast = cb_in1;
+    auto cb_other = cb_in0;
+#else
+    auto cb_bcast = cb_in0;
+    auto cb_other = cb_in1;
+#endif
+
+    binary_op_init_common(cb_bcast, cb_other, cb_out0);
+    add_tiles_init();
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(cb_bcast, cb_other, cb_out0, tile_freq, tile_start);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(cb_bcast, cb_other, cb_out0, remaining_iterations, tile_start);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_binary.h"
+#include "dprint.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init();
+
+    constexpr uint32_t onetile = 1;
+
+    for(uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        cb_wait_front(cb_in0, onetile);
+        cb_wait_front(cb_in1, onetile);
+        cb_reserve_back(cb_out0, onetile);
+
+        tile_regs_acquire();
+        add_tiles(cb_in0, cb_in1, 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out0);
+        tile_regs_release();
+
+        cb_push_back(cb_out0, onetile);
+        cb_pop_front(cb_in0, onetile);
+        cb_pop_front(cb_in1, onetile);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_binary.h"
+#include "dprint.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init();
+
+    constexpr uint32_t onetile = 1;
+
+    cb_wait_front(cb_in1, onetile);
+
+    for(uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        cb_wait_front(cb_in0, onetile);
+        cb_reserve_back(cb_out0, onetile);
+
+        tile_regs_acquire();
+        add_tiles(cb_in0, cb_in1, 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out0);
+        tile_regs_release();
+
+        cb_pop_front(cb_in0, onetile);
+        cb_push_back(cb_out0, onetile);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dataflow_api.h"
+
+// Fills one full tile of bfloat16 with a scalar value
+// Scalar is assumed to be a 16-bit value double packed into a u32
+FORCE_INLINE void fill_with_val_bfloat16(uint32_t cb_id, uint32_t packed_scalar) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    // 1024 is the number of elements in a full tile, but since the scalar is packed into a u32,
+    // each iteration writes 2 elements, hence the division by 2
+    for (uint32_t i = 0; i < 512; ++i) {
+        ptr[i] = packed_scalar;
+    }
+}
+
+// Reads the very first element of the CB and fills the entire tile with that value.
+// Tile is assumed to have 16-bit elements
+FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t cb_id) {
+    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    const uint16_t first_elem = read_ptr[0];
+    const uint32_t packed_first_elem = first_elem << 16 | first_elem;
+
+    // Since all elements in the tile are the same, we can ignore the faces and assume the entire
+    // tile is contiguous in memory.
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    // TODO: should I fill one face like this and then use noc to fill the rest?
+    for (uint32_t i = 0; i < 512; ++i) {
+        write_ptr[i] = packed_first_elem;
+    }
+}
+
+// Reads the very first row of the CB and fills the entire tile with the same row.
+// Tile is assumed to have 16-bit elements.
+FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t cb_id) {
+    // Here we have to account for the fact that a tile consists of 4 16x16 faces.
+    // So we have to fill faces 0 and 2 with the first row of face 0, and faces 1 and 3
+    // with the first row of face 1.
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+
+    uint32_t row_offset = 8;  // start at second row since first row is source
+    uint32_t num_rows = 15;
+
+    // iterate over face pairs (0,1) and (2,3)
+    for(uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 256) {
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            uint32_t dst_offset = face_offset + row_offset;
+            for (uint32_t col = 0; col < 8; ++col) {
+                ptr[dst_offset + col] = ptr[col];             // left face
+                ptr[dst_offset + col + 128] = ptr[col + 128]; // right face
+            }
+            row_offset += 8;
+        }
+        row_offset = 0;
+        num_rows = 16;
+    }
+}
+
+// Reads the very first column of the CB and fills the entire tile with the same column.
+// Tile is assumed to have 16-bit elements.
+FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t cb_id) {
+    // Here we have to account for the fact that a tile consists of 4 16x16 faces.
+    // So we have to fill faces 0 and 1 with the first column of face 0, and faces 2 and 3
+    // with the first column of face 2.
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+
+    constexpr uint32_t num_rows = 16;
+
+    // iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 512) {
+        for (uint32_t row = 0, row_offset = 0; row < num_rows; ++row, row_offset += 16) {
+            uint32_t dst_offset = face_offset + row_offset;
+            auto src_val = ptr[dst_offset];
+
+            ptr[dst_offset + 256] = src_val; // first column of right face
+            for (uint32_t col = 1; col < 16; ++col) {
+                ptr[dst_offset + col] = src_val;       // left face
+                ptr[dst_offset + col + 256] = src_val; // right face
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t HtWt = get_arg_val<uint32_t>(3);
+    uint32_t n_stride = get_arg_val<uint32_t>(4);
+    uint32_t c_stride = get_arg_val<uint32_t>(5);
+    uint32_t N = get_arg_val<uint32_t>(6);
+    uint32_t C = get_arg_val<uint32_t>(7);
+    uint32_t Ht = get_arg_val<uint32_t>(8);
+    uint32_t Wt = get_arg_val<uint32_t>(9);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in0;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+    uint32_t start_th = start_t / Wt;
+    uint32_t start_tw = start_t % Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_th = 0) {
+            for (uint32_t th = start_th; th < Ht && num_tiles_read < num_tiles; ++th, start_tw = 0) {
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset + th, src, l1_write_addr);
+                noc_async_read_barrier();
+                fill_tile_with_first_column_bfloat16(cb_id_src);
+                cb_push_back(cb_id_src, onetile);
+
+                num_tiles_read += Wt - start_tw;
+            }
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t HtWt = get_arg_val<uint32_t>(3);
+    uint32_t n_stride = get_arg_val<uint32_t>(4);
+    uint32_t c_stride = get_arg_val<uint32_t>(5);
+    uint32_t N = get_arg_val<uint32_t>(6);
+    uint32_t C = get_arg_val<uint32_t>(7);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in0;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
+
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
+            for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_src, onetile);
+            }
+            tile_offset += next_channel_shift;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t HtWt = get_arg_val<uint32_t>(3);
+    uint32_t n_stride = get_arg_val<uint32_t>(4);
+    uint32_t c_stride = get_arg_val<uint32_t>(5);
+    uint32_t N = get_arg_val<uint32_t>(6);
+    uint32_t C = get_arg_val<uint32_t>(7);
+    uint32_t Ht = get_arg_val<uint32_t>(8);
+    uint32_t Wt = get_arg_val<uint32_t>(9);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in0;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+    uint32_t start_th = start_t / Wt;
+    uint32_t start_tw = start_t % Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_th = 0) {
+            for (uint32_t th = start_th; th < Ht && num_tiles_read < num_tiles; ++th, start_tw = 0) {
+                for (uint32_t tw = start_tw; tw < Wt && num_tiles_read < num_tiles; ++tw, ++num_tiles_read) {
+                    cb_reserve_back(cb_id_src, onetile);
+                    uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                    noc_async_read_barrier();
+                    fill_tile_with_first_row_bfloat16(cb_id_src);
+                    cb_push_back(cb_id_src, onetile);
+                }
+            }
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t HtWt = get_arg_val<uint32_t>(3);
+    uint32_t n_stride = get_arg_val<uint32_t>(4);
+    uint32_t c_stride = get_arg_val<uint32_t>(5);
+    uint32_t N = get_arg_val<uint32_t>(6);
+    uint32_t C = get_arg_val<uint32_t>(7);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in0;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
+            cb_reserve_back(cb_id_src, onetile);
+            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+            noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+            noc_async_read_barrier();
+            fill_tile_with_first_element_bfloat16(cb_id_src);
+            cb_push_back(cb_id_src, onetile);
+
+            num_tiles_read += HtWt - start_t;
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
+    uint32_t Ht = get_arg_val<uint32_t>(9);
+    uint32_t Wt = get_arg_val<uint32_t>(10);
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    constexpr auto cb_id_dst = tt::CB::c_out0;
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+    uint32_t start_th = start_t / Wt;
+    uint32_t start_tw = start_t % Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_th = 0) {
+            for (uint32_t th = start_th; th < Ht && num_tiles_written < num_tiles; ++th, start_tw = 0) {
+                // read a tile from src
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset + th, src, l1_write_addr);
+                noc_async_read_barrier();
+                fill_tile_with_first_column_bfloat16(cb_id_src);
+                cb_push_back(cb_id_src, onetile);
+
+                for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < num_tiles; ++tw, ++num_tiles_written) {
+                    // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                    cb_wait_front(cb_id_dst, onetile);
+                    uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_dst, onetile);
+                }
+            }
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    constexpr auto cb_id_dst = tt::CB::c_out0;
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
+            for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
+                // read a tile from src
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset, src, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_src, onetile);
+                ++tile_offset;
+
+                // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                cb_wait_front(cb_id_dst, onetile);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_dst, onetile);
+            }
+            tile_offset += next_channel_shift;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
+    uint32_t Ht = get_arg_val<uint32_t>(9);
+    uint32_t Wt = get_arg_val<uint32_t>(10);
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    constexpr auto cb_id_dst = tt::CB::c_out0;
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+    uint32_t start_th = start_t / Wt;
+    uint32_t start_tw = start_t % Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_th = 0) {
+            for (uint32_t th = start_th; th < Ht && num_tiles_written < num_tiles; ++th, start_tw = 0) {
+                for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < num_tiles; ++tw, ++num_tiles_written) {
+                    // read a tile from src
+                    cb_reserve_back(cb_id_src, onetile);
+                    uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+                    noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
+                    noc_async_read_barrier();
+                    fill_tile_with_first_row_bfloat16(cb_id_src);
+                    cb_push_back(cb_id_src, onetile);
+
+                    // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                    cb_wait_front(cb_id_dst, onetile);
+                    uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_dst, onetile);
+                }
+            }
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+
+void kernel_main() {
+    uint32_t packed_scalar = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t N = get_arg_val<uint32_t>(5);
+    uint32_t C = get_arg_val<uint32_t>(6);
+    uint32_t H = get_arg_val<uint32_t>(7);
+    uint32_t W = get_arg_val<uint32_t>(8);
+
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in1;
+    constexpr auto cb_id_dst = tt::CB::c_out0;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // we only need to fill a tile with the scalar value once
+    cb_reserve_back(cb_id_src, onetile);
+    fill_with_val_bfloat16(cb_id_src, packed_scalar);
+    cb_push_back(cb_id_src, onetile);
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
+            for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
+                // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                cb_wait_front(cb_id_dst, onetile);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_dst, onetile);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
+
+    constexpr uint32_t onetile = 1;
+
+    constexpr auto cb_id_src = tt::CB::c_in1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    constexpr auto cb_id_dst = tt::CB::c_out0;
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
+            // read a tile from src
+            cb_reserve_back(cb_id_src, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+            noc_async_read_tile(tile_offset, src, l1_write_addr);
+            noc_async_read_barrier();
+            fill_tile_with_first_element_bfloat16(cb_id_src);
+            cb_push_back(cb_id_src, onetile);
+
+            for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
+                // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                cb_wait_front(cb_id_dst, onetile);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_dst, onetile);
+            }
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace ttnn::operations::binary_ng {
+
+enum class BinaryOpType {
+    ADD,
+    SUB,
+    MUL,
+    GT,
+    LT,
+    LTE,
+    GTE,
+    EQ,
+    NE,
+    SQUARED_DIFFERENCE,
+    BIAS_GELU,
+    LOGADDEXP,
+    LOGICAL_AND,
+    LOGICAL_OR,
+    LOGICAL_XOR,
+    LDEXP,
+    LOGADDEXP2,
+    DIV_FAST
+};
+
+}


### PR DESCRIPTION
### Ticket
#13643 

### Problem description
Current binary operations do not support full broadcasting along all dimensions ala numpy or torch.

### What's changed
This PR adds a new addition op that implements full broadcasting for up to 4D tensors. Subsequent PRs will deal with extending the math support. The focus here is on the broadcasting algorithm itself.

### Checklist
- [ ] Post commit CI passes
- [x] New/Existing tests provide coverage for changes
