### PR TITLE
Improve VGG device perf

### DIFF
--- a/models/demos/vgg/tests/test_perf_vgg.py
+++ b/models/demos/vgg/tests/test_perf_vgg.py
@@ -137,10 +137,10 @@ def test_perf_device_bare_metal_vgg(batch_size, model_name):
     margin = 0.03
 
     if model_name == "ttnn_vgg11":
-        expected_perf = 168 if is_grayskull() else 283.289
+        expected_perf = 183 if is_grayskull() else 356
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg11.py"
     else:
-        expected_perf = 144 if is_grayskull() else 194.84
+        expected_perf = 165 if is_grayskull() else 276
         command = f"pytest tests/ttnn/integration_tests/vgg/test_ttnn_vgg16.py"
 
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/demos/vgg/tt/ttnn_vgg.py
+++ b/models/demos/vgg/tt/ttnn_vgg.py
@@ -50,7 +50,7 @@ conv_ttnn_params = [
 ]
 conv_feature_ids = [0, 2, 5, 7, 10, 12, 14, 17, 19, 21, 24, 26, 28]
 classifier_ids = [0, 3, 6]
-h_override = [128, 128, 128, 64, 32, 32, 32, 32, 32, 32, 32, 32, 32]
+h_override = [None, None, None, None, None, 256, 256, None, None, None, None, None, None]
 
 
 def ttnn_vgg16(
@@ -98,7 +98,6 @@ def ttnn_vgg16(
                 deallocate_activation=False,
                 input_channels_alignment=32,
                 reallocate_halo_output=False,
-                act_block_h_override=h_override[iter_conv_id],
                 transpose_shards=True,
                 shard_layout=(
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if h_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
@@ -106,6 +105,8 @@ def ttnn_vgg16(
                 reshard_if_not_optimal=True,
                 enable_weights_double_buffer=True,
             )
+            if h_override[iter_conv_id] is not None:
+                conv_config.act_block_h_override = h_override[iter_conv_id]
 
             tt_weight = parameters.features[conv_feature_ids[iter_conv_id]].weight
             tt_weight = ttnn.to_layout(ttnn.from_device(tt_weight), layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -173,7 +174,7 @@ conv_ttnn_params_2 = [
     [512, 512, 14, 14],
     [512, 512, 14, 14],
 ]
-height_override_11 = [128, 128, 32, 32, 32, 32, 32, 32]
+height_override_11 = [None, None, None, 256, None, None, None, None]
 
 
 def ttnn_vgg11(
@@ -220,13 +221,14 @@ def ttnn_vgg11(
                 deallocate_activation=False,
                 input_channels_alignment=32,
                 reallocate_halo_output=False,
-                act_block_h_override=height_override_11[iter_conv_id],
                 transpose_shards=True,
                 shard_layout=(
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if h_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
                 ),
                 enable_weights_double_buffer=True,
             )
+            if height_override_11[iter_conv_id] is not None:
+                conv_config.act_block_h_override = height_override_11[iter_conv_id]
 
             tt_weight = parameters.features[conv_feature_ids_2[iter_conv_id]].weight
             tt_weight = ttnn.to_layout(ttnn.from_device(tt_weight), layout=ttnn.ROW_MAJOR_LAYOUT)


### PR DESCRIPTION
After change to improve conv2d parallelisation 236622e7b17ca0d2fd8baf7ae39773503251c637,
we get more L1 memory perf core as we are using
more cores for the same op.
This change is using this L1 by reducing the usage of act_block_h_override and in turn improving the
device perf.

### Checklist
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12129016664
- [x] Device performance regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12124059633

