### PR TITLE
#0: update batch_size for Bert-Tiny data parallel

### DIFF
--- a/models/demos/wormhole/bert_tiny/README.md
+++ b/models/demos/wormhole/bert_tiny/README.md
@@ -8,14 +8,15 @@ BERT stands for Bidirectional Encoder Representations from Transformers. Unlike 
 
 ## How to Run
 
-Use `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo[wormhole_b0-True-models/demos/wormhole/bert_tiny/demo/input_data.json-mrm8488/bert-tiny-finetuned-squadv2-128-device_params0]` to run the demo.
-
-If you wish to run the demo with a different input use `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo[wormhole_b0-True-<address_to_your_json_file.json>-mrm8488/bert-tiny-finetuned-squadv2-128-device_params0]`. This file is expected to have exactly 16 inputs.
+Use `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo[wormhole_b0-True-models/demos/wormhole/bert_tiny/demo/input_data.json-mrm8488/bert-tiny-finetuned-squadv2-8-128-device_params0]` to run the demo.
 
 
-Our second demo is designed to run SQuADV2 dataset, run this with `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo_squadv2[wormhole_b0-True-1-mrm8488/bert-tiny-finetuned-squadv2-384-device_params0]`.
+If you wish to run the demo with a different input use `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo[wormhole_b0-True-<address_to_your_json_file.json>-mrm8488/bert-tiny-finetuned-squadv2-8-128-device_params0]`. This file is expected to have exactly 16 inputs.
 
-If you wish to run for `n_iterations` samples, use `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo_squadv2[wormhole_b0-True-<n_iterations>-mrm8488/bert-tiny-finetuned-squadv2-384-device_params0]`
+
+Our second demo is designed to run SQuADV2 dataset, run this with `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo_squadv2[wormhole_b0-True-1-mrm8488/bert-tiny-finetuned-squadv2-384-8-device_params0]`.
+
+If you wish to run for `n_iterations` samples, use `pytest --disable-warnings models/demos/wormhole/bert_tiny/demo/demo.py::test_demo_squadv2[wormhole_b0-True-<n_iterations>-mrm8488/bert-tiny-finetuned-squadv2-384-8-device_params0]`
 
 
 # Inputs

--- a/models/demos/wormhole/bert_tiny/demo/demo.py
+++ b/models/demos/wormhole/bert_tiny/demo/demo.py
@@ -53,6 +53,7 @@ def run_bert_question_and_answering_inference(
     mesh_device,
     use_program_cache,
     model_name,
+    batch_size,
     sequence_size,
     model_location_generator,
     input_path,
@@ -69,7 +70,7 @@ def run_bert_question_and_answering_inference(
 
     profiler.start(f"preprocessing_parameter")
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
@@ -171,6 +172,7 @@ def run_bert_question_and_answering_inference_squad_v2(
     mesh_device,
     use_program_cache,
     model_name,
+    batch_size,
     sequence_size,
     model_location_generator,
     n_iterations,
@@ -187,7 +189,7 @@ def run_bert_question_and_answering_inference_squad_v2(
     config = hugging_face_reference_model.config
 
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
 
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
@@ -265,10 +267,12 @@ def run_bert_question_and_answering_inference_squad_v2(
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("sequence_size", [128])
+@pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("model_name", ["mrm8488/bert-tiny-finetuned-squadv2"])
 @pytest.mark.parametrize("input_loc", ["models/demos/wormhole/bert_tiny/demo/input_data.json"])
 def test_demo(
     input_loc,
+    batch_size,
     sequence_size,
     model_name,
     model_location_generator,
@@ -283,6 +287,7 @@ def test_demo(
         use_program_cache=use_program_cache,
         model_name=model_name,
         sequence_size=sequence_size,
+        batch_size=batch_size,
         model_location_generator=model_location_generator,
         input_path=input_loc,
     )
@@ -290,6 +295,7 @@ def test_demo(
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [384])
 @pytest.mark.parametrize("model_name", ["mrm8488/bert-tiny-finetuned-squadv2"])
 @pytest.mark.parametrize(
@@ -299,6 +305,7 @@ def test_demo(
 def test_demo_squadv2(
     model_name,
     sequence_size,
+    batch_size,
     n_iterations,
     model_location_generator,
     mesh_device,
@@ -311,6 +318,7 @@ def test_demo_squadv2(
         mesh_device=mesh_device,
         use_program_cache=use_program_cache,
         model_name=model_name,
+        batch_size=batch_size,
         sequence_size=sequence_size,
         model_location_generator=model_location_generator,
         n_iterations=n_iterations,

--- a/tests/ttnn/integration_tests/bert_tiny/test_bert_tiny_wh.py
+++ b/tests/ttnn/integration_tests/bert_tiny/test_bert_tiny_wh.py
@@ -20,10 +20,12 @@ from models.utility_functions import skip_for_grayskull, is_wormhole_b0
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("batch_size", [8])
 def test_bert_attention_inference(
     model_location_generator,
     mesh_device,
     reset_seeds,
+    batch_size,
 ):
     model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
     hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
@@ -32,7 +34,7 @@ def test_bert_attention_inference(
     pytorch_attention_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx].attention
     config = hugging_face_reference_model.config
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
@@ -77,9 +79,11 @@ def test_bert_attention_inference(
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("batch_size", [8])
 def test_bert_intermediate_inference(
     model_location_generator,
     mesh_device,
+    batch_size,
     reset_seeds,
 ):
     model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
@@ -89,7 +93,7 @@ def test_bert_intermediate_inference(
     pytorch_intermediate_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx].intermediate
 
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
@@ -123,9 +127,11 @@ def test_bert_intermediate_inference(
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("batch_size", [8])
 def test_bert_output_inference(
     model_location_generator,
     mesh_device,
+    batch_size,
     reset_seeds,
 ):
     model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
@@ -136,7 +142,7 @@ def test_bert_output_inference(
     pytorch_output_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx].attention.output
 
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
@@ -180,8 +186,10 @@ def test_bert_output_inference(
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("batch_size", [8])
 def test_bert_layer_inference(
     model_location_generator,
+    batch_size,
     mesh_device,
     reset_seeds,
 ):
@@ -193,7 +201,7 @@ def test_bert_layer_inference(
     pytorch_layer_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx]
 
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
@@ -231,7 +239,10 @@ def test_bert_layer_inference(
 @pytest.mark.parametrize("model_name", ["mrm8488/bert-tiny-finetuned-squadv2"])
 @pytest.mark.parametrize("sequence_size", [128])
 @pytest.mark.parametrize("num_hidden_layers", [1])
-def test_bert_for_question_answering(mesh_device, model_name, sequence_size, num_hidden_layers, reset_seeds):
+@pytest.mark.parametrize("batch_size", [8])
+def test_bert_for_question_answering(
+    mesh_device, model_name, batch_size, sequence_size, num_hidden_layers, reset_seeds
+):
     inputs_mesh_mapper = None
     output_mesh_composer = None
     parameters = None
@@ -243,7 +254,7 @@ def test_bert_for_question_answering(mesh_device, model_name, sequence_size, num
         config.num_hidden_layers = num_hidden_layers
 
     mesh_device_flag = is_wormhole_b0() and ttnn.GetNumAvailableDevices() == 2
-    batch_size = 16 if mesh_device_flag else 8
+    batch_size = 2 * batch_size if mesh_device_flag else batch_size
     inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
     output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add batch_size fixture in Bert-Tiny data parallel model.


### What's changed
Update the batch size fixture in Bert-Tiny model to support both n150 and n300 devices.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
