### PR TITLE
Add bfloat exponent section 16B alignment for tiny tiles on host side

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -35,7 +35,7 @@ def find_max_subblock(out_block_h, out_block_w):
 @pytest.mark.parametrize("c", [5])
 @pytest.mark.parametrize("h", [384])
 @pytest.mark.parametrize("w", [768])
-@pytest.mark.parametrize("tile_h", [4, 8, 16, 32])
+@pytest.mark.parametrize("tile_h", [1, 2, 4, 8, 16, 32])
 @pytest.mark.parametrize("tile_w", [16, 32])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
 @pytest.mark.parametrize("transpose_tile", [True, False])

--- a/tt_metal/common/bfloat4.hpp
+++ b/tt_metal/common/bfloat4.hpp
@@ -60,6 +60,7 @@ inline std::vector<float> unpack_bfp4_tiles_into_float_vec(
     int data_dwords_per_exp_dword_log2 = log2(data_dwords_per_exp * num_exps_in_dword);
     int data_dwords_per_exp_log2 = log2(data_dwords_per_exp);
 
+    // the exponent index will always be 0 when tile_HW == 16, between 0-1 when tile_HW == 32, and between 0-3 otherwise
     uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
 
     uint32_t size_bytes = bfp_tiles.size() * 4;

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -113,6 +113,8 @@ inline std::vector<float> unpack_bfp8_tiles_into_float_vec(
     const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {
     ZoneScoped;
 
+    uint32_t l1_alignment = tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::L1);
+
     auto tile_H = tile.has_value() ? tile->get_tile_shape()[0] : tt::constants::TILE_HEIGHT;
     auto tile_W = tile.has_value() ? tile->get_tile_shape()[1] : tt::constants::TILE_WIDTH;
     auto face_H = tile.has_value() ? tile->get_face_shape()[0] : tt::constants::FACE_HEIGHT;
@@ -124,9 +126,11 @@ inline std::vector<float> unpack_bfp8_tiles_into_float_vec(
     auto subtiles_in_tile_col = tile_W / face_W;
     auto subtile_rows = face_H;
     auto subtile_cols = face_W;
-    uint32_t num_exp_words = num_faces * face_H / 4;
+    uint32_t num_exp_words = tt::round_up(num_faces * face_H, l1_alignment) / 4;
     uint32_t num_tile_words = tile_HW / 4;
     uint32_t num_bfp8_in_tile = num_tile_words + num_exp_words;
+
+    uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
 
     int num_elements_in_dword = 4;
     uint32_t size_bytes = bfp8_tiles.size() * num_elements_in_dword;  // each uint32_t contains 4 BFP8 values
@@ -172,8 +176,8 @@ inline std::vector<float> unpack_bfp8_tiles_into_float_vec(
 
                         int num_exponent_words_skip = tile_index * num_exp_words;
                         sub_word_index = ((tile_and_data_index - num_exponent_words_skip) >> 2) &
-                                         0x3;  // Extract the byte in which the shared exponent is stored. Each byte is
-                                               // shared amongst 16 datums.
+                                         exp_bit_mask;  // Extract the byte in which the shared exponent is stored. Each
+                                                        // byte is shared amongst 16 datums.
                         __m256i exp_vector =
                             _mm256_set1_epi32(get_byte(exp_word, sub_word_index));  // Replicate exp scalar in a vector
                         // Take 2 uint32_t values. These are 8 BFP8 values

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -130,7 +130,7 @@ inline std::vector<float> unpack_bfp8_tiles_into_float_vec(
     uint32_t num_tile_words = tile_HW / 4;
     uint32_t num_bfp8_in_tile = num_tile_words + num_exp_words;
 
-    // mask out all the extra bits when calculating the exponent index in the exponent dword
+    // the exponent index will always be 0 when tile_HW == 16, between 0-1 when tile_HW == 32, and between 0-3 otherwise
     uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
 
     int num_elements_in_dword = 4;

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -130,6 +130,7 @@ inline std::vector<float> unpack_bfp8_tiles_into_float_vec(
     uint32_t num_tile_words = tile_HW / 4;
     uint32_t num_bfp8_in_tile = num_tile_words + num_exp_words;
 
+    // mask out all the extra bits when calculating the exponent index in the exponent dword
     uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
 
     int num_elements_in_dword = 4;

--- a/tt_metal/common/blockfloat_common.hpp
+++ b/tt_metal/common/blockfloat_common.hpp
@@ -55,9 +55,12 @@ inline uint32_t get_exp_dword(const std::vector<uint8_t>& vec) {
 
 inline std::vector<uint32_t> pack_exponents(const std::vector<uint8_t>& exponents, size_t num_elements_in_dword) {
     TT_FATAL(
-        exponents.size() % num_elements_in_dword == 0, "Input vector size {} must be divisible by 4", exponents.size());
+        exponents.size() % num_elements_in_dword == 0,
+        "Input vector size {} must be divisible by num_elements_in_dword",
+        exponents.size());
 
     std::vector<uint32_t> packed_result;
+    packed_result.reserve(exponents.size() / num_elements_in_dword);
 
     for (size_t i = 0; i < exponents.size(); i += num_elements_in_dword) {
         uint32_t packed_value = 0;
@@ -327,6 +330,7 @@ inline std::vector<uint32_t> pack_fp32_vec_as_bfp_tiles(
     for (int tile_index = 0; tile_index < num_tiles; ++tile_index) {
         std::vector<uint32_t> packed_data;
         std::vector<uint8_t> exponents_with_padding;
+        exponents_with_padding.reserve(l1_alignment * subtiles_in_tile_row * subtiles_in_tile_col);
         for (int tr = 0; tr < subtiles_in_tile_row; ++tr) {
             for (int tc = 0; tc < subtiles_in_tile_col; ++tc) {
                 for (int i = 0; i < subtile_rows; ++i) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -251,14 +251,16 @@ FORCE_INLINE constexpr static std::uint32_t MUL_WITH_TILE_SIZE(uint format, uint
                                     : (tile_hw == 128) ? 7
                                     : (tile_hw == 64)  ? 6
                                     : (tile_hw == 32)  ? 5
+                                    : (tile_hw == 16)  ? 4
                                                        : 10;
 
     constexpr uint8_t exp_shift = (tile_hw == 1024)  ? 6
                                   : (tile_hw == 512) ? 5
                                   : (tile_hw == 256) ? 4
-                                  : (tile_hw == 128) ? 3
-                                  : (tile_hw == 64)  ? 2
-                                  : (tile_hw == 32)  ? 1
+                                  : (tile_hw == 128) ? 4
+                                  : (tile_hw == 64)  ? 4
+                                  : (tile_hw == 32)  ? 4
+                                  : (tile_hw == 16)  ? 4
                                                      : 6;
     switch (format & 0x1F) {
         case ((uint8_t)DataFormat::UInt8): return (index << datum_shift);

--- a/tt_metal/impl/tile/tile.hpp
+++ b/tt_metal/impl/tile/tile.hpp
@@ -10,6 +10,7 @@
 #include "common/tt_backend_api_types.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/common/math.hpp"
+#include "tt_metal/llrt/hal.hpp"
 
 namespace tt {
 
@@ -94,13 +95,15 @@ struct Tile {
     const bool get_transpose_of_faces() const { return transpose_of_faces; }
 
     const uint32_t get_tile_size(const DataFormat& format) const {
+        uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+        uint32_t aligned_exp_size = tt::round_up(face_shape[0] * num_faces, l1_alignment);
         switch (format) {
             case DataFormat::Bfp2:
-            case DataFormat::Bfp2_b: return (tile_hw / 4) + (face_shape[0] * num_faces);
+            case DataFormat::Bfp2_b: return (tile_hw / 4) + aligned_exp_size;
             case DataFormat::Bfp4:
-            case DataFormat::Bfp4_b: return (tile_hw / 2) + (face_shape[0] * num_faces);
+            case DataFormat::Bfp4_b: return (tile_hw / 2) + aligned_exp_size;
             case DataFormat::Bfp8:
-            case DataFormat::Bfp8_b: return tile_hw + (face_shape[0] * num_faces);
+            case DataFormat::Bfp8_b: return tile_hw + aligned_exp_size;
             case DataFormat::Float16:
             case DataFormat::Float16_b: return (tile_hw * 2);
             case DataFormat::Float32: return (tile_hw * 4);


### PR DESCRIPTION
### Problem description
Previously, some tiny tile shapes like 1x32 2x32 tiles doesn't have exponents section aligned to 16B, with this change, it will align to 16B so that LLk functions can read the correct data format.


### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12144242329
- [x] Blackhole Post commit  https://github.com/tenstorrent/tt-metal/actions/runs/12144247862
- [x] Model regression CI https://github.com/tenstorrent/tt-metal/actions/runs/12145753223
