### PR TITLE
[tt-train] Gradient accumulation steps

### DIFF
--- a/tt-train/configs/training_shakespear_gpt2s.yaml
+++ b/tt-train/configs/training_shakespear_gpt2s.yaml
@@ -1,0 +1,21 @@
+training_config:
+  project_name: "tt_train_nano_gpt"
+  seed: 5489
+  model_save_interval: 500
+  batch_size: 4
+  num_epochs: 1
+  max_steps: 5000
+  learning_rate: 0.0003
+  weight_decay: 0.01
+  use_kahan_summation: true
+  gradient_accumulation_steps: 16
+
+  transformer_config:
+    num_heads: 12
+    embedding_dim: 768
+    dropout_prob: 0.2
+    num_blocks: 12
+    vocab_size: 96
+    max_sequence_length: 1024
+    experimental:
+      use_composite_layernorm: true

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -371,6 +371,8 @@ int main(int argc, char **argv) {
                 if (global_step >= config.max_steps) {
                     break;
                 }
+
+                gradient_accumulator_helper.reset();
             }
             auto end_timer = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -143,6 +143,8 @@ struct TrainingConfig {
     float weight_decay = 1e-2F;
     // works only for AdamW
     bool use_kahan_summation = false;
+    // accumulate batches for gradient update
+    uint32_t gradient_accumulation_steps = 1;
     std::string model_path;
     std::string data_path;
     ttml::models::gpt2::TransformerConfig transformer_config;
@@ -160,6 +162,8 @@ TrainingConfig parse_config(const YAML::Node &yaml_config) {
     config.learning_rate = training_config["learning_rate"].as<float>();
     config.weight_decay = training_config["weight_decay"].as<float>();
     config.use_kahan_summation = training_config["use_kahan_summation"].as<bool>(config.use_kahan_summation);
+    config.gradient_accumulation_steps =
+        training_config["gradient_accumulation_steps"].as<uint32_t>(config.gradient_accumulation_steps);
     config.model_path = training_config["model_path"].as<std::string>("");
     config.data_path = training_config["data_path"].as<std::string>(std::string(DATA_FOLDER) + "/shakespeare.txt");
     config.transformer_config = ttml::models::gpt2::read_config(training_config["transformer_config"]);
@@ -198,6 +202,9 @@ int main(int argc, char **argv) {
         {"batch_size", static_cast<int>(config.batch_size)},
         {"sequence_length", static_cast<int>(config.transformer_config.max_sequence_length)},
         {"max_steps", static_cast<int>(config.max_steps)},
+        {"seed", static_cast<int>(config.seed)},
+        {"use_kahan_summation", config.use_kahan_summation},
+        {"gradient_accumulation_steps", static_cast<int>(config.gradient_accumulation_steps)},
     });
 
     // set seed
@@ -213,6 +220,8 @@ int main(int argc, char **argv) {
 
     fmt::print("Max steps {}\n", config.max_steps);
     fmt::print("Batch size {}\n", config.batch_size);
+    fmt::print("Gradient accumulation steps {}\n", config.gradient_accumulation_steps);
+    fmt::print("Total batch size {}\n", config.batch_size * config.gradient_accumulation_steps);
     fmt::print("Seed {}\n", ttml::autograd::ctx().get_seed());
     auto sequence_length = config.transformer_config.max_sequence_length;
 
@@ -320,30 +329,48 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    auto get_samples_count = [&config](uint32_t global_step) {
+        return global_step * config.batch_size * config.gradient_accumulation_steps;
+    };
+
     const uint32_t num_epochs = config.num_epochs;
+    auto gradient_accumulator_helper = GradientAccumulator(config.gradient_accumulation_steps);
     for (uint32_t epoch = 0; epoch < num_epochs; ++epoch) {
         for (auto [features, target, masks, positions] : train_dataloader) {
             auto start_timer = std::chrono::high_resolution_clock::now();
-            optimizer.zero_grad();
+            if (gradient_accumulator_helper.should_zero_grad()) {
+                optimizer.zero_grad();
+            }
             auto output = (*model)(features, positions, masks);
             auto loss = ttml::ops::nll_loss(output, target);
+            loss = gradient_accumulator_helper.scale(loss);
             auto loss_float = ttml::core::to_vector(loss->get_value())[0];
             loss_meter.update(loss_float, features->get_value().get_shape()[0]);
+
             loss->backward();
-            optimizer.step();
             ttml::autograd::ctx().reset_graph();
-            auto global_step = optimizer.get_steps();
-            fmt::print("Step: {}, Loss: {}\n", global_step, loss_float);
 
-            if (global_step % 10 == 0) {
-                wandbcpp::log({{"Step", (int)global_step}, {"Loss", loss_float}});
-            }
-            if (!config.model_path.empty() && global_step % config.model_save_interval == 0) {
-                save_model_and_optimizer(config.model_path, model, optimizer, "transformer", "adamw");
-            }
+            auto samples = features->get_value().get_shape()[0];
+            gradient_accumulator_helper.update(loss_float, samples);
 
-            if (global_step >= config.max_steps) {
-                break;
+            if (gradient_accumulator_helper.should_step()) {
+                optimizer.step();
+                auto global_step = optimizer.get_steps();
+                fmt::print("Step: {}, Loss: {}\n", global_step, gradient_accumulator_helper.average_loss());
+
+                if (global_step % 10 == 0) {
+                    wandbcpp::log(
+                        {{"Step", (int)global_step},
+                         {"Samples", (int)get_samples_count(global_step)},
+                         {"Loss", gradient_accumulator_helper.average_loss()}});
+                }
+                if (!config.model_path.empty() && global_step % config.model_save_interval == 0) {
+                    save_model_and_optimizer(config.model_path, model, optimizer, "transformer", "adamw");
+                }
+
+                if (global_step >= config.max_steps) {
+                    break;
+                }
             }
             auto end_timer = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();

--- a/tt-train/sources/examples/nano_gpt/utils.cpp
+++ b/tt-train/sources/examples/nano_gpt/utils.cpp
@@ -4,6 +4,9 @@
 
 #include "utils.hpp"
 
+#include "autograd/tensor.hpp"
+#include "ops/binary_ops.hpp"
+
 void LossAverageMeter::update(float loss, size_t count) {
     m_sum += loss * static_cast<float>(count);
     m_count += count;
@@ -21,7 +24,7 @@ void LossAverageMeter::reset() {
     m_count = 0;
 }
 
-std::string read_file_to_str(const std::string& file_path) {
+std::string read_file_to_str(const std::string &file_path) {
     std::ifstream file(file_path);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open file: " + file_path);
@@ -34,4 +37,39 @@ std::string read_file_to_str(const std::string& file_path) {
 
 uint32_t round_up_to_tile(uint32_t value, uint32_t tile_size) {
     return (value + tile_size - 1) / tile_size * tile_size;
+}
+
+GradientAccumulator::GradientAccumulator(uint32_t accumulation_steps) : m_accumulation_steps(accumulation_steps) {
+}
+
+bool GradientAccumulator::should_zero_grad() const {
+    return m_steps % m_accumulation_steps == 0;
+}
+
+bool GradientAccumulator::should_step() const {
+    return m_steps % m_accumulation_steps == 0;
+}
+
+ttml::autograd::TensorPtr GradientAccumulator::scale(ttml::autograd::TensorPtr &tensor) {
+    if (m_accumulation_steps > 1) {
+        return ttml::ops::mul(tensor, 1.0F / static_cast<float>(m_accumulation_steps));
+    }
+
+    return tensor;
+}
+
+void GradientAccumulator::update(float loss, size_t samples) {
+    m_total_loss += loss * samples * static_cast<float>(m_accumulation_steps);
+    m_total_samples += samples;
+    ++m_steps;
+}
+
+void GradientAccumulator::reset() {
+    m_total_loss = 0.0F;
+    m_total_samples = 0;
+    m_steps = 0;
+}
+
+float GradientAccumulator::average_loss() const {
+    return m_total_loss / static_cast<float>(m_total_samples);
 }

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 
+#include "autograd/tensor.hpp"
 #include "serialization/msgpack_file.hpp"
 #include "serialization/serialization.hpp"
 
@@ -52,3 +54,23 @@ void load_model_and_optimizer(
 }
 
 uint32_t round_up_to_tile(uint32_t value, uint32_t tile_size = 32);
+
+class GradientAccumulator {
+public:
+    explicit GradientAccumulator(uint32_t accumulation_steps);
+
+    [[nodiscard]] bool should_zero_grad() const;
+    [[nodiscard]] bool should_step() const;
+    ttml::autograd::TensorPtr scale(ttml::autograd::TensorPtr &tensor_ptr);
+    void update(float loss, size_t samples = 1);
+    void reset();
+
+    [[nodiscard]] float average_loss() const;
+
+private:
+    uint32_t m_accumulation_steps = 1;
+    uint32_t m_steps = 0;
+
+    float m_total_loss = 0.0F;
+    size_t m_total_samples = 0;
+};

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -70,6 +70,19 @@ autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::Tens
     return out;
 }
 
+autograd::TensorPtr operator*(const autograd::TensorPtr& a, float b) {
+    auto out = autograd::create_tensor(ttnn::multiply(a->get_value(), b));
+    autograd::GradFunction grad = [a, b, out]() {
+        auto a_grad = ttnn::multiply(out->get_grad(), b);
+
+        a->add_grad(a_grad);
+    };
+    auto links = autograd::get_links(a);
+    out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
+
+    return out;
+}
+
 autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
     auto out = autograd::create_tensor();
 
@@ -99,6 +112,10 @@ autograd::TensorPtr mul(const autograd::TensorPtr& a, const autograd::TensorPtr&
 
 autograd::TensorPtr div(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
     return a / b;
+}
+
+autograd::TensorPtr mul(const autograd::TensorPtr& a, float b) {
+    return a * b;
 }
 
 }  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/binary_ops.hpp
+++ b/tt-train/sources/ttml/ops/binary_ops.hpp
@@ -9,12 +9,14 @@ namespace ttml::ops {
 
 autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
+autograd::TensorPtr operator*(const autograd::TensorPtr& a, float b);
 autograd::TensorPtr operator-(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 
 autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr sub(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr mul(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
+autograd::TensorPtr mul(const autograd::TensorPtr& a, float b);
 autograd::TensorPtr div(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 
 }  // namespace ttml::ops


### PR DESCRIPTION
### Problem description
Batch for GPT2-S is too small (4) for training. Small batch causes instability during training. 

### What's changed
Add gradient accumulation steps. 
Add multiplication op between tensor and float. 
Add GPT2-S config

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12145087673
- [x] New/Existing tests provide coverage for changes
