### PR TITLE
#0: Remove warning log: "Specifying tile shape for a row major layout is deprecated"

### DIFF
--- a/ttnn/cpp/ttnn/tensor/layout/page_config.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/page_config.cpp
@@ -33,9 +33,7 @@ PageConfig::PageConfig(Layout layout) : PageConfig(layout, std::nullopt) {}
 
 PageConfig::PageConfig(Layout layout, const std::optional<Tile>& tile) {
     if (layout == Layout::ROW_MAJOR) {
-        if (tile.has_value()) {
-            tt::log_warning("Specifying tile shape for a row major layout is deprecated, and will be removed soon");
-        }
+        // TODO: add TT_FATAL(!tile.has_value(), "Specifying tile shape for a row major layout is not supported")
         config_ = RowMajorPageConfig(tile.value_or(Tile()));
     } else {
         config_ = TilePageConfig(tile.value_or(Tile()));


### PR DESCRIPTION
### Ticket

### Problem description
Currently there are lots of logs "Specifying tile shape for a row major layout is deprecated", which aren't helpful to users

### What's changed
Replaced the log with a comment

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
