### PR TITLE
don't run UMD tests in post commit anymore

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -73,21 +73,6 @@ jobs:
       build-docker: false
       build-type: ${{ inputs.build-type || 'Release' }}
     secrets: inherit
-  # UMD Unit Tests
-  umd-unit-tests:
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: grayskull, runner-label: E150 },
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-        ]
-    uses: ./.github/workflows/umd-unit-tests.yaml
-    with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
   # Slow Dispatch Unit Tests
   sd-unit-tests:
     needs: build-artifact


### PR DESCRIPTION
### Ticket
None

### What's changed
UMD CI is up and running now, we don't need to run UMD unit tests in metal CI anymore

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
