### PR TITLE
#14974: Clean up creation functions in the ttnn numpy package

### DIFF
--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -3,15 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/host_api.hpp"
+#include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include "common/constants.hpp"
 #include <magic_enum.hpp>
 #include <ttnn/operations/numpy/functions.hpp>
-
-#include <algorithm>
-#include <functional>
-#include <random>
 
 using namespace tt;
 using namespace tt_metal;
@@ -53,9 +50,8 @@ int main(int argc, char** argv) {
                     }
 
                     Tensor a = ttnn::numpy::random::random(input_shape_a).to(Layout::TILE).to(device);
-                    Tensor b = ttnn::numpy::zeros({1, 1, TILE_HEIGHT, TILE_WIDTH}, DataType::BFLOAT16)
-                                   .to(Layout::TILE)
-                                   .to(device);
+                    Tensor b = ttnn::zeros(
+                        ttnn::Shape({1, 1, TILE_HEIGHT, TILE_WIDTH}), DataType::BFLOAT16, Layout::TILE, *device);
 
                     for (auto bcast_math : magic_enum::enum_values<ttnn::BcastOpMath>()) {
                         Tensor c = ttnn::bcast(0, a, b, bcast_math, bcast_dim);
@@ -72,28 +68,28 @@ int main(int argc, char** argv) {
 
             {
                 Tensor a = ttnn::numpy::random::random({1, 1, 32, 4544}).to(Layout::TILE).to(device);
-                Tensor b = ttnn::numpy::zeros({1, 1, 32, 4544}, DataType::BFLOAT16).to(Layout::TILE).to(device);
+                Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 4544}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::H);
                 Tensor d = c.cpu();
             }
 
             {
                 Tensor a = ttnn::numpy::random::random({1, 1, 32, 4544}).to(Layout::TILE).to(device);
-                Tensor b = ttnn::numpy::zeros({1, 1, 32, 4544}, DataType::BFLOAT16).to(Layout::TILE).to(device);
+                Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 4544}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::ADD, ttnn::BcastOpDim::H);
                 Tensor d = c.cpu();
             }
 
             {
                 Tensor a = ttnn::numpy::random::random({1, 71, 32, 32}).to(Layout::TILE).to(device);
-                Tensor b = ttnn::numpy::zeros({1, 1, 32, 32}, DataType::BFLOAT16).to(Layout::TILE).to(device);
+                Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 32}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
                 Tensor d = c.cpu();
             }
 
             {
                 Tensor a = ttnn::numpy::random::random({1, 71, 32, 64}).to(Layout::TILE).to(device);
-                Tensor b = ttnn::numpy::zeros({1, 1, 32, 32}, DataType::BFLOAT16).to(Layout::TILE).to(device);
+                Tensor b = ttnn::zeros(ttnn::Shape({1, 1, 32, 32}), DataType::BFLOAT16, Layout::TILE, *device);
                 Tensor c = ttnn::bcast(0, a, b, ttnn::BcastOpMath::MUL, ttnn::BcastOpDim::HW);
                 Tensor d = c.cpu();
             }

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/host_api.hpp"
+#include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/matmul/device/matmul_op.hpp"
 #include "common/constants.hpp"
 #include "ttnn/operations/numpy/functions.hpp"
-
-#include <algorithm>
-#include <functional>
-#include <random>
 
 using namespace tt;
 using namespace tt_metal;
@@ -37,14 +35,14 @@ int main(int argc, char** argv) {
         uint32_t Kt = 2;
         uint32_t Nt = 4;
         uint32_t B = 5;
-        tt::tt_metal::LegacyShape shapea = {B, 1, Mt * TILE_HEIGHT, Kt * TILE_WIDTH};
-        tt::tt_metal::LegacyShape shapeb = {B, 1, Kt * TILE_HEIGHT, Nt * TILE_WIDTH};
-        tt::tt_metal::LegacyShape shapeb1 = {1, 1, Kt * TILE_HEIGHT, Nt * TILE_WIDTH};
+        ttnn::Shape shapea({B, 1, Mt * TILE_HEIGHT, Kt * TILE_WIDTH});
+        ttnn::Shape shapeb({B, 1, Kt * TILE_HEIGHT, Nt * TILE_WIDTH});
+        ttnn::Shape shapeb1({1, 1, Kt * TILE_HEIGHT, Nt * TILE_WIDTH});
 
         // Allocates a DRAM buffer on device populated with values specified by initialize
-        Tensor a = ttnn::numpy::random::random(shapea).to(Layout::TILE).to(device);
-        Tensor b = ttnn::numpy::zeros(shapeb, DataType::BFLOAT16).to(Layout::TILE).to(device);
-        Tensor b1 = ttnn::numpy::zeros(shapeb1, DataType::BFLOAT16).to(Layout::TILE).to(device);
+        Tensor a = ttnn::numpy::random::random(shapea.value).to(Layout::TILE).to(device);
+        Tensor b = ttnn::zeros(shapeb, DataType::BFLOAT16, Layout::TILE, *device);
+        Tensor b1 = ttnn::zeros(shapeb1, DataType::BFLOAT16, Layout::TILE, *device);
 
         Tensor mm = ttnn::operations::matmul::matmul(
                         a,

--- a/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
@@ -7,12 +7,12 @@
 #include <random>
 
 #include "common/constants.hpp"
+#include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/host_buffer/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
 #include "tt_metal/host_api.hpp"
-#include "ttnn/operations/numpy/functions.hpp"
 
 using namespace tt;
 using namespace tt_metal;
@@ -37,7 +37,8 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         ttnn::SimpleShape shape{1, 32, 61, 32};
         // Allocates a DRAM buffer on device populated with values specified by initialize
-        Tensor a = ttnn::numpy::arange<bfloat16>(0, shape.volume(), 1).reshape(shape).to(device);
+        Tensor a = ttnn::arange(/*start=*/0, /*stop=*/shape.volume(), /*step=*/1, DataType::BFLOAT16, std::ref(*device))
+                       .reshape(shape);
         Tensor b = ttnn::tilize_with_zero_padding(a);
         Tensor c = b.cpu();
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -14,7 +14,6 @@
 #include "ttnn/tensor/types.hpp"
 #include "tests/tt_metal/tt_metal/common/dispatch_fixture.hpp"
 #include "tt_metal/host_api.hpp"
-#include "ttnn/operations/numpy/functions.hpp"
 
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
@@ -37,7 +36,7 @@ TEST_F(DispatchFixture, TestTensorOwnershipSanity) {
     // Sanity test tensor read, write and update paths with synchronous
     // Ensure that tensor data is copied and owned as expected
     Device* device = this->devices_[0];
-    Tensor host_tensor = ttnn::numpy::arange<float>(0, 32 * 32 * 4, 1);
+    Tensor host_tensor = ttnn::arange(/*start=*/0, /*stop=*/32 * 32 * 4, /*step=*/1, DataType::FLOAT32);
     Tensor readback_tensor(1);
 
     auto func = [device, host_tensor, readback_tensor]() mutable {
@@ -259,7 +258,7 @@ TEST_F(DispatchFixture, TestTensorAsyncDataMovement) {
 
     {
         // host_tensor only lives in this scope
-        Tensor host_tensor = ttnn::numpy::arange<float>(tensor_start, tensor_stop, 1);
+        Tensor host_tensor = ttnn::arange(tensor_start, tensor_stop, /*step=*/1, DataType::FLOAT32);
         log_info(LogTest, "Spawning worker thread");
         worker = std::thread([tensor_stop, host_tensor, readback_tensor, device]() mutable {
             // Sleep for 3 seconds to ensure that main thread deallocates host_tensor

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -2,12 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <functional>
-#include <random>
-
 #include "common/bfloat16.hpp"
 #include "common/constants.hpp"
+#include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/host_buffer/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -58,7 +55,7 @@ bool test_tensor_copy_semantics(Device* device) {
     pass &= dev_a_data == host_d_copy_data;
 
     // dev tensor updated with host tensor copy assignment
-    Tensor host_e = ttnn::numpy::ones(single_tile_shape).to(Layout::TILE);
+    Tensor host_e = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE);
     Tensor dev_e_copy = ttnn::numpy::random::random(single_tile_shape).to(Layout::TILE).to(device);
     dev_e_copy = host_e;
     pass &= (dev_e_copy.storage_type() == StorageType::OWNED);
@@ -67,8 +64,8 @@ bool test_tensor_copy_semantics(Device* device) {
     pass &= host_e_data == dev_e_copy_data;
 
     // dev tensor updated with dev tensor copy assignment
-    Tensor dev_b = ttnn::numpy::ones(single_tile_shape).to(Layout::TILE).to(device);
-    Tensor dev_b_copy = ttnn::numpy::zeros(single_tile_shape).to(Layout::TILE).to(device);
+    Tensor dev_b = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE, *device);
+    Tensor dev_b_copy = ttnn::zeros(single_tile_shape, DataType::BFLOAT16, Layout::TILE, *device);
     dev_b_copy = dev_b;
     pass &= (dev_b_copy.storage_type() == StorageType::DEVICE);
     auto dev_b_on_host = dev_b.cpu();

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -37,7 +37,7 @@ bool test_tensor_copy_semantics(Device* device) {
     pass &= dev_a_data == dev_a_copy_data;
 
     // host tensor updated with host tensor copy assignment
-    Tensor host_c = ttnn::numpy::arange<bfloat16>(0, tt_metal::compute_volume(single_tile_shape), 1)
+    Tensor host_c = ttnn::arange(/*start=*/0, /*stop=*/tt_metal::compute_volume(single_tile_shape), /*step=*/1)
                         .reshape(single_tile_shape)
                         .to(Layout::TILE);
     Tensor host_c_copy = ttnn::numpy::random::random(single_tile_shape).to(Layout::TILE);

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -46,7 +46,7 @@ public:
     }
     void ReadBuffer(
         tt::tt_metal::Device* device,
-        std::shared_ptr<tt::tt_metal::Buffer> out_buffer,
+        const std::shared_ptr<tt::tt_metal::Buffer>& out_buffer,
         std::vector<uint32_t>& dst_vec) {
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::ReadFromBuffer(out_buffer, dst_vec);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -170,6 +170,25 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
     EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
 }
 
+TEST_P(MultiDeviceTensorCreationTest, Arange) {
+    MeshDevice* mesh_device = this->mesh_device_.get();
+    mesh_device->enable_async(GetParam());
+
+    Tensor tensor = ttnn::arange(
+        /*start=*/0,
+        /*end=*/1024,
+        /*step=*/1,
+        ttnn::DataType::BFLOAT16,
+        std::ref(*mesh_device));
+
+    EXPECT_EQ(tensor.storage_type(), StorageType::MULTI_DEVICE);
+    EXPECT_EQ(tensor.get_workers().size(), mesh_device->num_devices());
+    EXPECT_EQ(tensor.shape(), ttnn::SimpleShape({1, 1, 1, 1024}));
+
+    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(tensor);
+    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+}
+
 INSTANTIATE_TEST_SUITE_P(AllTests, MultiDeviceTensorCreationTest, ::testing::Bool());
 
 }  // namespace

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/cpp/ttnn/operations/creation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn_multi_command_queue_fixture.hpp"
@@ -10,14 +11,13 @@
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
 #include "common/bfloat16.hpp"
 #include "ttnn/async_runtime.hpp"
-#include "ttnn/operations/numpy/functions.hpp"
 #include "tt_metal/impl/event/event.hpp"
 #include <cmath>
 
-using namespace tt;
-using namespace tt_metal;
-using MultiCommandQueueSingleDeviceFixture = ttnn::MultiCommandQueueSingleDeviceFixture;
-using namespace constants;
+namespace tt::tt_metal {
+namespace {
+
+using MultiCommandQueueSingleDeviceFixture = ::ttnn::MultiCommandQueueSingleDeviceFixture;
 
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     Device* device = this->device_;
@@ -40,16 +40,14 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
         host_data[i] = bfloat16(static_cast<float>(1));
     }
     // Create golden data using tt_eager APIs
-    Tensor np_tensor = ttnn::numpy::full<float>(input_shape.value, static_cast<float>(1), DataType::BFLOAT16)
-                           .to(Layout::TILE)
-                           .to(device);
+    Tensor np_tensor = ttnn::full(input_shape, static_cast<float>(1), DataType::BFLOAT16, Layout::TILE, *device_);
     ttnn::SmallVector<int64_t> reduce_dims = {3};
     Tensor np_out = ttnn::moreh_sum(np_tensor, reduce_dims, false, std::nullopt, std::nullopt, std::nullopt);
     Tensor np_out_host = np_out.cpu();
     const bfloat16* golden_output =
         std::get<owned_buffer::Buffer<bfloat16>>(std::get<OwnedStorage>(np_out_host.get_storage()).buffer).begin();
     // Enable Asynchronous Execution and test ttnn runtime APIs
-    device->enable_async(true);
+    device_->enable_async(true);
     // Events for host - device synchronization
     auto write_event = std::make_shared<Event>();
     auto workload_event = std::make_shared<Event>();
@@ -63,9 +61,9 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
         output_buf_size_datums * datum_size_bytes,
         tensor_layout.compute_packed_buffer_size_bytes(np_out.get_padded_shape()));
     auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(
-        device, TensorSpec(input_shape.padded_shape(), tensor_layout));
+        device_, TensorSpec(input_shape.padded_shape(), tensor_layout));
     auto output_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(
-        device, TensorSpec(np_out.get_padded_shape(), tensor_layout));
+        device_, TensorSpec(np_out.get_padded_shape(), tensor_layout));
     auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
     auto output_storage = tt::tt_metal::DeviceStorage{output_buffer};
     Tensor input_tensor = Tensor(input_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
@@ -73,13 +71,13 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     // Populate input_tensor with data
     ttnn::write_buffer(io_cq, input_tensor, {host_data});
     // Record the completion of the write event
-    ttnn::record_event(device->command_queue(io_cq), write_event);
+    ttnn::record_event(device_->command_queue(io_cq), write_event);
     // Host stalls until write is completed, before sending workload
     ttnn::event_synchronize(write_event);
     // Dispatch workload. Preallocated output_tensor is populated by op/
     ttnn::moreh_sum(input_tensor, /*dim*/ 3, false, output_tensor, std::nullopt, std::nullopt);
     // Record completion of workload
-    ttnn::record_event(device->command_queue(workload_dispatch_cq), workload_event);
+    ttnn::record_event(device_->command_queue(workload_dispatch_cq), workload_event);
     ttnn::event_synchronize(workload_event);
     // Read output back, once workload is complete
     ttnn::read_buffer(io_cq, output_tensor, {readback_data});
@@ -93,7 +91,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     // Deallocate tensors (tensor gives up buffer). Done asynchronously, so sync on queue after.
     input_tensor.deallocate();
     output_tensor.deallocate();
-    ttnn::queue_synchronize(device->command_queue(io_cq));
+    ttnn::queue_synchronize(device_->command_queue(io_cq));
     // Buffer only has 2 owners in main thread.
     EXPECT_EQ(input_buffer.use_count(), 2);
     EXPECT_EQ(output_buffer.use_count(), 2);
@@ -103,8 +101,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
 }
 
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
-    Device* device = this->device_;
-    device->enable_async(true);
+    device_->enable_async(true);
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -131,26 +128,26 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
             TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
             ASSERT_EQ(buf_size_datums * datum_size_bytes, tensor_layout.compute_packed_buffer_size_bytes(shape));
             auto input_buffer =
-                tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, TensorSpec(shape, tensor_layout));
+                tt::tt_metal::tensor_impl::allocate_buffer_on_device(device_, TensorSpec(shape, tensor_layout));
             auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
             Tensor input_tensor = Tensor(input_storage, shape, DataType::BFLOAT16, Layout::TILE);
-            ttnn::write_buffer(io_cq, input_tensor, {host_data});           // Write using cq 1
-            ttnn::record_event(device->command_queue(io_cq), write_event);  // Record write on cq 1
+            ttnn::write_buffer(io_cq, input_tensor, {host_data});            // Write using cq 1
+            ttnn::record_event(device_->command_queue(io_cq), write_event);  // Record write on cq 1
             // Wait until cq 1 write is complete
-            ttnn::wait_for_event(device->command_queue(workload_dispatch_cq), write_event);
+            ttnn::wait_for_event(device_->command_queue(workload_dispatch_cq), write_event);
 
             // Run operation on cq 0
             Tensor output_tensor = ttnn::sqrt(workload_dispatch_cq, input_tensor);
             auto dummy_buffer_0 =
-                tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, TensorSpec(shape, tensor_layout));
+                tt::tt_metal::tensor_impl::allocate_buffer_on_device(device_, TensorSpec(shape, tensor_layout));
             output_tensor = ttnn::neg(workload_dispatch_cq, output_tensor);
             // Allocate this buffer to stress test async allocation across op execution and explicit allocation
             auto dummy_buffer_1 =
-                tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, TensorSpec(shape, tensor_layout));
+                tt::tt_metal::tensor_impl::allocate_buffer_on_device(device_, TensorSpec(shape, tensor_layout));
             // Record cq 0 prog execution
-            ttnn::record_event(device->command_queue(workload_dispatch_cq), workload_event);
+            ttnn::record_event(device_->command_queue(workload_dispatch_cq), workload_event);
             // Wait until cq 0 prog execution is done
-            ttnn::wait_for_event(device->command_queue(io_cq), workload_event);
+            ttnn::wait_for_event(device_->command_queue(io_cq), workload_event);
             // Read using cq 1
             ttnn::read_buffer(io_cq, output_tensor, {readback_data});
             for (int i = 0; i < buf_size_datums; i++) {
@@ -166,8 +163,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeBufferDestructor) {
     // Test functionality for the buffer destructor, which will call deallocate asynchronously
     // We must ensure that the deallocate step, which can run after the buffer has been destroyed
     // does not rely on stale buffer state, after the buffer has been destroyed on host
-    Device* device = this->device_;
-    device->enable_async(true);
+    device_->enable_async(true);
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -182,9 +178,9 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeBufferDestructor) {
     TensorLayout tensor_layout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg);
     TensorSpec tensor_spec(shape, tensor_layout);
     for (int loop = 0; loop < 100000; loop++) {
-        {
-            auto input_buffer_dummy = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
-            device->synchronize();
-        }
+        auto input_buffer_dummy = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device_, tensor_spec);
+        device_->synchronize();
     }
 }
+}  // namespace
+}  // namespace tt::tt_metal

--- a/ttnn/cpp/pybind11/operations/creation.hpp
+++ b/ttnn/cpp/pybind11/operations/creation.hpp
@@ -138,7 +138,7 @@ auto create_pybind_empty_like_overload() {
            const ttnn::Tensor& reference,
            const std::optional<DataType>& dtype,
            const std::optional<Layout>& layout,
-           const std::optional<std::reference_wrapper<Device>> device,
+           const std::optional<std::reference_wrapper<device_t>> device,
            const std::optional<MemoryConfig>& memory_config) -> ttnn::Tensor {
             return self(reference, dtype, layout, device, memory_config);
         },
@@ -146,6 +146,26 @@ auto create_pybind_empty_like_overload() {
         py::kw_only(),
         py::arg("dtype") = DataType::BFLOAT16,
         py::arg("layout") = Layout::ROW_MAJOR,
+        py::arg("device") = std::nullopt,
+        py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG};
+}
+
+template <typename creation_operation_t, typename device_t>
+auto create_pybind_arange_overload() {
+    return ttnn::pybind_overload_t{
+        [](const creation_operation_t& self,
+           const int64_t start,
+           const int64_t end,
+           const int64_t step,
+           const DataType dtype,
+           const std::optional<std::reference_wrapper<device_t>> device,
+           const MemoryConfig& memory_config) -> ttnn::Tensor {
+            return self(start, end, step, dtype, device, memory_config);
+        },
+        py::arg("start") = 0,
+        py::arg("end"),
+        py::arg("step") = 1,
+        py::arg("dtype") = DataType::BFLOAT16,
         py::arg("device") = std::nullopt,
         py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG};
 }
@@ -350,22 +370,8 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
         module,
         operation,
         doc,
-        ttnn::pybind_overload_t{
-            [](const creation_operation_t& self,
-               const int64_t start,
-               const int64_t end,
-               const int64_t step,
-               const DataType dtype,
-               const std::optional<std::reference_wrapper<Device>>& device,
-               const MemoryConfig& memory_config) -> ttnn::Tensor {
-                return self(start, end, step, dtype, device, memory_config);
-            },
-            py::arg("start") = 0,
-            py::arg("end"),
-            py::arg("step") = 1,
-            py::arg("dtype") = DataType::BFLOAT16,
-            py::arg("device") = std::nullopt,
-            py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG});
+        create_pybind_arange_overload<creation_operation_t, Device>(),
+        create_pybind_arange_overload<creation_operation_t, MeshDevice>());
 }
 
 template <typename creation_operation_t>

--- a/ttnn/cpp/ttnn/operations/numpy/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/numpy/functions.hpp
@@ -134,49 +134,6 @@ static Tensor full_impl(
     }
 }
 
-// TODO: #14974 - Can this be deleted, as it is only used in tests?
-template <typename T>
-static Tensor full(
-    const tt::tt_metal::LegacyShape& shape,
-    const T value,
-    const DataType data_type,
-    const Layout layout = Layout::ROW_MAJOR,
-    Device* device = nullptr,
-    const MemoryConfig& output_mem_config = MemoryConfig{
-        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
-    return full_impl(
-        ttnn::DefaultQueueId,
-        shape,
-        value,
-        data_type,
-        layout,
-        device ? std::vector<Device*>{device} : std::vector<Device*>{},
-        output_mem_config,
-        std::nullopt);
-}
-
-// TODO: #14974 - Can this be deleted, as it is only used in tests?
-static Tensor zeros(
-    const tt::tt_metal::LegacyShape& shape,
-    const DataType data_type = DataType::BFLOAT16,
-    const Layout layout = Layout::ROW_MAJOR,
-    Device* device = nullptr,
-    const MemoryConfig& output_mem_config = MemoryConfig{
-        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
-    return full(shape, 0.0f, data_type, layout, device, output_mem_config);
-}
-
-// TODO: #14974 - Can this be deleted, as it is only used in tests?
-static Tensor ones(
-    const tt::tt_metal::LegacyShape& shape,
-    const DataType data_type = DataType::BFLOAT16,
-    const Layout layout = Layout::ROW_MAJOR,
-    Device* device = nullptr,
-    const MemoryConfig& output_mem_config = MemoryConfig{
-        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
-    return full(shape, 1.0f, data_type, layout, device, output_mem_config);
-}
-
 template <typename T>
 static Tensor arange(
     const int64_t start,

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -41,6 +41,25 @@ enum class DataType {
     INVALID = 8,
 };
 
+template <typename T>
+consteval inline DataType convert_to_data_type() {
+    if constexpr (std::is_same_v<T, uint8_t>) {
+        return DataType::UINT8;
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return DataType::UINT16;
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return DataType::INT32;
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return DataType::UINT32;
+    } else if constexpr (std::is_same_v<T, float>) {
+        return DataType::FLOAT32;
+    } else if constexpr (std::is_same_v<T, ::bfloat16>) {
+        return DataType::BFLOAT16;
+    } else {
+        static_assert(false, "Unsupported DataType!");
+    }
+}
+
 inline bool is_floating_point(DataType dtype) {
     switch (dtype) {
         case DataType::BFLOAT16:

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -56,7 +56,7 @@ consteval inline DataType convert_to_data_type() {
     } else if constexpr (std::is_same_v<T, ::bfloat16>) {
         return DataType::BFLOAT16;
     } else {
-        static_assert(false, "Unsupported DataType!");
+        static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported DataType!");
     }
 }
 


### PR DESCRIPTION
### Ticket
#14974 

### Problem description
Creation functions like `zeros`, `ones`, `full` have a dedicated place `creation.hpp`. Currently, several unit tests rely on the redundant interfaces defined in `functions.hpp` in the numpy package.

### What's changed
* Migrated the use of `numpy` versions of `zeros`, `ones`, `full`, `arange` in tests to `ttnn::{zeros,ones,full}`.
* Moved the base implementation of `full` and `arange` into `creation.hpp` - the only place where they are used.
* Minor simplification / refactor changes to deduplicate code.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12152247431)
- [X] [T3K unit + frequent tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/12152254447)
- [X] New/Existing tests provide coverage for changes
