### PR TITLE
[tt-train] Improve logging information 

### DIFF
--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -183,14 +183,16 @@ int main(int argc, char **argv) {
 
     std::string config_name = std::string(CONFIGS_FOLDER) + "/training_shakespear_nanogpt.yaml";
     bool is_eval = false;
+    bool add_time_to_name = true;
     app.add_option("-c,--config", config_name, "Yaml Config name")->default_val(config_name);
     app.add_option("-e,--eval", is_eval, "Is evaluation")->default_val(is_eval);
+    app.add_option("-t,--add_time_to_name", add_time_to_name, "Add time to run name")->default_val(add_time_to_name);
 
     CLI11_PARSE(app, argc, argv);
     auto yaml_config = YAML::LoadFile(config_name);
     TrainingConfig config = parse_config(yaml_config);
 
-    wandbcpp::init({.project = config.project_name});
+    wandbcpp::init({.project = config.project_name, .name = generate_run_name(config, add_time_to_name)});
     wandbcpp::update_config({
         {"model", "transformer"},
         {"num_heads", static_cast<int>(config.transformer_config.num_heads)},

--- a/tt-train/sources/examples/nano_gpt/utils.hpp
+++ b/tt-train/sources/examples/nano_gpt/utils.hpp
@@ -74,3 +74,47 @@ private:
     float m_total_loss = 0.0F;
     size_t m_total_samples = 0;
 };
+
+template <typename TrainingConfig>
+std::string generate_run_name(const TrainingConfig &config, bool add_time_to_run_name) {
+    std::stringstream ss;
+
+    auto &transformer_config = config.transformer_config;
+
+    auto is_nano_gpt_config = [&transformer_config]() {
+        return transformer_config.num_heads == 6 && transformer_config.embedding_dim == 384 &&
+               transformer_config.num_blocks == 6;
+    };
+
+    auto is_gpt2s_config = [&transformer_config]() {
+        return transformer_config.num_heads == 12 && transformer_config.embedding_dim == 768 &&
+               transformer_config.num_blocks == 12;
+    };
+
+    auto batch_size = config.batch_size * config.gradient_accumulation_steps;
+
+    if (is_nano_gpt_config()) {
+        ss << "nano_gpt";
+    } else if (is_gpt2s_config()) {
+        ss << "gpt2s";
+    } else {
+        ss << "transformer";
+    }
+    ss << "_bs_" << batch_size;
+    ss << "_lr_" << config.learning_rate;
+    ss << "_wd_" << config.weight_decay;
+    if (config.use_kahan_summation) {
+        ss << "_kahan";
+    }
+
+    if (config.gradient_accumulation_steps > 1) {
+        ss << "_grad_acc_" << config.gradient_accumulation_steps;
+    }
+
+    if (add_time_to_run_name) {
+        auto now = std::chrono::system_clock::now();
+        std::time_t current_time = std::chrono::system_clock::to_time_t(now);
+        ss << "_date_" << std::put_time(std::localtime(&current_time), "%Y-%m-%d_%H:%M:%S");
+    }
+    return ss.str();
+}

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -25,6 +25,7 @@ Transformer::Transformer(const TransformerConfig& config) {
     fmt::print("    Num heads: {}\n", num_heads);
     fmt::print("    Dropout probability: {}\n", dropout_prob);
     fmt::print("    Num blocks: {}\n", num_blocks);
+    fmt::print("    Composite layernorm: {}\n", use_composite_layernorm);
 
     uint32_t vocab_size_divisible_by_32 = (vocab_size + 31) / 32 * 32;
     if (max_sequence_length % 32 != 0) {


### PR DESCRIPTION
### Problem description
It's important to identify runs in wandb as well as parameters in terminal once job is running. 

### What's changed
Add print about usage of layernorm. 
Add wandb run name generation. 
<img width="567" alt="image" src="https://github.com/user-attachments/assets/8d7bb262-280d-4bba-a7b9-5f6f9ee96b3a">

### Checklist
- [x] New/Existing tests provide coverage for changes
