### PR TITLE
Don't Run clang-tidy in all-post-commit when launched via workflow dispatch

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -159,6 +159,7 @@ jobs:
     secrets: inherit
     with:
       os: ubuntu-22.04-amd64
+    if: github.event_name == 'push'
   tt-train-cpp-unit-tests:
     needs: build-artifact
     secrets: inherit


### PR DESCRIPTION
### Problem description
When we run a full clang-tidy sweep on every all-post-commit we bog down a builder machine for 30-40 minutes.

As this is the longest workload for a builder machine it has become new CI bottleneck.

### What's changed
Restrict clang-tidy sweep to run only on pushes to main.
Lets see if we get better throughput.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
