### PR TITLE
#12979: place rodata in data segment

### DIFF
--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -42,11 +42,11 @@ SECTIONS
     ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections present");
   } > REGION_APP_CODE :text
 
-  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > REGION_APP_CODE :text
-  .rodata1        : { *(.rodata1) } > REGION_APP_CODE :text
-
   .data : ALIGN(4)
   {
+    *(.rodata .rodata.* .gnu.linkonce.r.*)
+    *(.rodata1)
+
     *(.dynamic)
     *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*)
 

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -46,10 +46,10 @@ SECTIONS
     ASSERT(SIZEOF(.init.fini) == 0, ".init/.fini sections present");
   } > REGION_APP_KERNEL_CODE :text
 
-  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*)  } > REGION_APP_KERNEL_CODE :text
-  .rodata1        : { *(.rodata1) } > REGION_APP_KERNEL_CODE :text
-
   .data : ALIGN(16) {
+    *(.rodata .rodata.* .gnu.linkonce.r.*)
+    *(.rodata1)
+
     *(.dynamic)
     *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12979

### Problem description
the erisc linker scripts place rodata in the text segment. While this works it:
a) is different to the other linker scripts
b) has a higher latency of access

### What's changed
Place rodata in the data segment.

### Checklist
- [YES] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
