### PR TITLE
#0: Fix conv_transpose2d_pybind.cpp for clang-tidy

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
@@ -103,8 +103,8 @@ void py_bind_conv_transpose2d(py::module& module) {
                 std::array<uint32_t, 2> dilation,
                 uint32_t groups,
                 std::optional<const ttnn::Tensor> bias_tensor,
-                std::optional<const Conv2dConfig> conv_config,
-                const std::optional<const MemoryConfig> memory_config,
+                const std::optional<const Conv2dConfig>& conv_config,
+                const std::optional<const MemoryConfig>& memory_config,
                 const uint8_t& queue_id) -> Result {
                 return self(queue_id, input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, output_padding, dilation, groups, bias_tensor, conv_config, memory_config);
             },
@@ -144,8 +144,8 @@ void py_bind_conv_transpose2d(py::module& module) {
                 std::array<uint32_t, 2> dilation,
                 uint32_t groups,
                 std::optional<const ttnn::Tensor> bias_tensor,
-                std::optional<const Conv2dConfig> conv_config,
-                const std::optional<const MemoryConfig> memory_config,
+                const std::optional<const Conv2dConfig>& conv_config,
+                const std::optional<const MemoryConfig>& memory_config,
                 const uint8_t& queue_id) -> Result {
                 return self(queue_id, input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, output_padding, dilation, groups, bias_tensor, conv_config, memory_config);
             },


### PR DESCRIPTION
### Problem description
Fix clang-tidy

### What's changed
clang-tidy fails in conv_transpose2d_pybind.cpp

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
