### PR TITLE
#15374: Log host_assigned_id in watcher

### DIFF
--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -381,7 +381,7 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     } else {
         fprintf(f, "rmsg:");
         DumpRunState(core, &mbox_data->launch[launch_msg_read_ptr], mbox_data->go_message.signal);
-        fprintf(f, " ");
+        fprintf(f, " h_id:%d ", mbox_data->launch[launch_msg_read_ptr].kernel_config.host_assigned_id);
     }
 
     // Eth core only reports erisc kernel id, uses the brisc field
@@ -685,7 +685,7 @@ void WatcherDeviceReader::DumpLaunchMessage(CoreDescriptor& core, const mailboxe
         fprintf(f, "t");
     }
 
-    fprintf(f, " ");
+    fprintf(f, " h_id:%d ", launch_msg->kernel_config.host_assigned_id);
 
     fprintf(f, "smsg:");
     DumpRunState(core, launch_msg, slave_sync->dm1);


### PR DESCRIPTION

### Ticket
#15374

### Problem description
As dispatch becomes more asynchronous, it can be difficult to tell if the kernel information on idle cores is from a previously-running kernel, or the next kernel to run.

### What's changed
 Watcher should output the kernel_config.host_assigned_id from each core to make it easier to disambiguate those.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
