### PR TITLE
Fix group norm L1 OOM error in Stable Diffusion

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -416,6 +416,8 @@ class resnetBlock2D:
         hidden_states = ttnn.reshape(
             hidden_states, (self.batch_size, 1, self.conv2_input_height * self.conv2_input_width, in_channels)
         )
+        hidden_states = ttnn.reallocate(hidden_states)
+
         hidden_states = ttnn.group_norm(
             hidden_states,
             num_groups=groups,


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/15436

### What's changed
- Added `ttnn.reallocate` to reduce L1 fragmentation.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
