### PR TITLE
Moved UMD headers to types/ subfolder

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -8,7 +8,7 @@
 #include "dispatch_fixture.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "impl/device/device.hpp"
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -8,7 +8,7 @@
 
 #include "host_api.hpp"
 #include "dispatch_fixture.hpp"
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
@@ -11,7 +11,7 @@
 #include "impl/kernels/data_types.hpp"
 #include "impl/kernels/kernel_types.hpp"
 #include "impl/program/program.hpp"
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "program_with_kernel_created_from_string_fixture.hpp"
 
 TEST_F(ProgramWithKernelCreatedFromStringFixture, TensixDataMovementKernel) {

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -9,7 +9,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include "impl/device/device.hpp"
 #include "llrt/hal.hpp"
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"

--- a/tests/tt_metal/tt_metal/integration/test_autonomous_relay_streams.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_autonomous_relay_streams.cpp
@@ -11,7 +11,7 @@
 #include <tuple>
 
 #include "gtest/gtest.h"
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "command_queue_fixture.hpp"
 #include "tt_metal/common/logger.hpp"
 #include "impl/device/device.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -9,7 +9,7 @@
 #include <random>
 #include <tuple>
 
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "impl/device/device.hpp"
 #include "impl/kernels/kernel_types.hpp"
 #include "tt_backend_api_types.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -10,7 +10,7 @@
 
 #include "tt_metal/distributed/mesh_device_view.hpp"
 #include "tt_metal/common/logger.hpp"
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "impl/device/device.hpp"
 #include "impl/kernels/data_types.hpp"
 #include "impl/kernels/kernel_types.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <map>
 
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "impl/device/device.hpp"
 #include "impl/kernels/kernel_types.hpp"
 #include "tt_backend_api_types.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <random>
 
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "tt_backend_api_types.hpp"
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/common/math.hpp"

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -10,7 +10,7 @@
 
 #include "gtest/gtest.h"
 
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 // #include "tt_backend_api_types.hpp"
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/common/math.hpp"

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <random>
 
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "gtest/gtest.h"
 // #include "tt_backend_api_types.hpp"
 #include "tt_metal/common/core_coord.hpp"

--- a/tt_metal/common/tt_backend_api_types.hpp
+++ b/tt_metal/common/tt_backend_api_types.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "fmt/base.h"
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 
 namespace tt {
 

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <map>
 
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "umd/device/tt_soc_descriptor.h"
 #include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/common/core_coord.hpp"

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/common/logger.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/host_api.hpp"

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -18,7 +18,7 @@
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/core_coord.hpp"
-#include "umd/device/xy_pair.h"
+#include "umd/device/types/xy_pair.h"
 #include <fmt/base.h>
 
 #include "llrt/hal.hpp"

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -22,7 +22,7 @@
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
 #include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "umd/device/tt_soc_descriptor.h"
-#include "umd/device/xy_pair.h"
+#include "umd/device/types/xy_pair.h"
 #include "tt_metal/tt_stl/concepts.hpp"
 #include "tt_metal/common/assert.hpp"
 #include "third_party/json/json.hpp"

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -18,8 +18,8 @@
 #include "eth_l1_address_map.h"  // for address_map
 #include "hw/inc/dev_msgs.h"
 
-#include "umd/device/tt_arch_types.h"
-#include "umd/device/xy_pair.h"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/xy_pair.h"
 #include <fmt/base.h>
 #include "llrt/llrt.hpp"
 #include "llrt/tt_cluster.hpp"

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/host_api.hpp"
 #include "impl/debug/dprint_server.hpp"
 #include "tt_metal/impl/device/device.hpp"

--- a/tt_metal/jit_build/data_format.hpp
+++ b/tt_metal/jit_build/data_format.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <vector>
 #include "common/tt_backend_api_types.hpp"              // for DataFormat
-#include "umd/device/tt_arch_types.h"                       // for ARCH
+#include "umd/device/types/arch.h"                      // for ARCH
 #include "tt_metal/hw/inc/circular_buffer_constants.h"  // for NUM_CIRCULAR_BUFFERS
 
 enum class UnpackToDestMode : std::uint8_t;

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -43,7 +43,7 @@ namespace tt::tt_metal {
  * if (arch == tt::ARCH::Invalid) {
  *     std::cerr << "Failed to detect architecture!" << std::endl;
  * } else {
- *     std::cout << "Detected architecture: " << tt::get_arch_str(arch) << std::endl;
+ *     std::cout << "Detected architecture: " << tt::arch_to_str(arch) << std::endl;
  * }
  * @endcode
  *
@@ -68,9 +68,9 @@ inline tt::ARCH get_platform_architecture() {
                 TT_FATAL(
                     arch == detected_arch,
                     "Expected all devices to be {} but device {} is {}",
-                    get_arch_str(arch),
+                    tt::arch_to_str(arch),
                     device_id,
-                    get_arch_str(detected_arch));
+                    tt::arch_to_str(detected_arch));
             }
         }
     }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -26,13 +26,13 @@
 #include "tt_metal/common/metal_soc_descriptor.h"
 #include "tt_metal/common/test_common.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "umd/device/tt_cluster_descriptor.h"
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "umd/device/cluster.h"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
-#include "umd/device/xy_pair.h"
+#include "umd/device/types/xy_pair.h"
 #include "umd/device/hugepage.h"
 
 // TODO: ARCH_NAME specific, must remove

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "eth_l1_address_map.h"
-#include "umd/device/tt_cluster_descriptor_types.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 #include "ttnn/cpp/ttnn/operations/ccl/kernels/edm_fabric/fabric_edm_types.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -8,7 +8,7 @@
 #include <variant>
 #include <tuple>
 #include <optional>
-#include "umd/device/tt_arch_types.h"
+#include "umd/device/types/arch.h"
 #include "tt_metal/common/base_types.hpp"
 
 namespace ttnn {


### PR DESCRIPTION
### Ticket
All related to https://github.com/tenstorrent/tt-metal/issues/13948

### Problem description
Some api header files have been moved around in UMD repo.
UMD PR: https://github.com/tenstorrent/tt-umd/pull/357

### What's changed
- umd/device/tt_arch_type.h -> umd/device/types/arch.h
- umd/device/tt_cluster_descriptor_types.h -> umd/device/types/cluster_descriptor_types.h
- umd/device/xy_pair.h -> umd/device/types/xy_pair.h
- get_arch_str -> tt::arch_to_str

### Checklist
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224723517
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224723937
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224724459
- [ ] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/12224725026
- [x] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224725640
- [x] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224726199
- [x] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224726548
- [x] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224726936
- [x] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224727791
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12224728493
