### PR TITLE
Add missing check in mul_tiles_bcast_cols

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm.py
@@ -171,7 +171,6 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
         assert passing, output
 
 
-@pytest.mark.skipif(is_blackhole(), reason="Mismatching on Blackhole, see #12349")
 @pytest.mark.parametrize(
     "out_mem_config",
     (ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),),

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax.py
@@ -20,7 +20,6 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_ze
 from models.utility_functions import is_grayskull, is_blackhole, skip_for_blackhole
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16, ttnn.float32),
@@ -28,7 +27,7 @@ from models.utility_functions import is_grayskull, is_blackhole, skip_for_blackh
 )
 @pytest.mark.parametrize("inplace", [True, False])
 def test_softmax(device, inplace, dtype):
-    if (is_grayskull() or is_blackhole()) and dtype == ttnn.float32:
+    if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull and Blackhole. For Blackhole see #12349")
 
     torch.manual_seed(0)
@@ -70,7 +69,6 @@ def test_softmax(device, inplace, dtype):
         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("inplace", [True, False])
 def test_softmax_with_program_cache(device, use_program_cache, inplace):
     torch.manual_seed(0)
@@ -94,7 +92,6 @@ def test_softmax_with_program_cache(device, use_program_cache, inplace):
         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "in_dtype",
     (ttnn.bfloat16, ttnn.bfloat8_b),
@@ -123,7 +120,6 @@ def test_softmax_mix_precision(device, inplace, in_dtype):
         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "seq_len",
     [64, 384],
@@ -230,7 +226,6 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, causal_mas
         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "in0_mem_config",
     (ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),),


### PR DESCRIPTION
### Ticket
#14352 #14349

### Problem description
Tests from ```misc/test_layernorm.py``` and ```misc/test_softmax.py``` are failing. They are calling mul_tiles_bcast_cols, which is incorrect for BH for two reasons:
1. There's a missing check when clearing faces 0 and 1. These faces shouldn't be cleared from DEST unconditionally, but only if DEST result is reused.
2. ZEROACC instructions in FP32 case are being incorrectly used for BH. That is why despite the first reason, the tests pass on WH, because there two ZEROACC instructions are needed, each of which clears half of face. Since this must be tested in more detail, it's moved to be fixed as a part of #15713. 

### What's changed
This PR does the following:
1. Adds the missing DEST reuse check.
2. Enables the tests from ```misc/test_layernorm.py``` and ```misc/test_softmax.py```.
3. Since it pulls the changes from `tt-llk-bh`, it removes the assert for reduce scalar in fp32 mode, thus enabling #15744 


### Checklist
- [ ] Post commit CI passes - [not necessary](https://github.com/tenstorrent/tt-metal/actions/runs/12185815043)
- [x] Blackhole Post commit (if applicable) - [#2127](https://github.com/tenstorrent/tt-metal/actions/runs/12185808879)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
