### PR TITLE
#15061: Refactor utilities related to Mesh infra

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -257,7 +257,7 @@ def pcie_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
         mesh_shape=ttnn.MeshShape(2, 2),
         dispatch_core_config=dispatch_core_config,
         **device_params,
-        offset=(0, 1),
+        offset=ttnn.MeshOffset(0, 1),
         mesh_type=ttnn.MeshType.Ring,
     )
 

--- a/tests/tt_metal/distributed/test_distributed.cpp
+++ b/tests/tt_metal/distributed/test_distributed.cpp
@@ -46,7 +46,7 @@ TEST(MeshDeviceSuite, Test1x1SystemMeshInitialize) {
     auto& sys = tt::tt_metal::distributed::SystemMesh::instance();
 
     auto config =
-        tt::tt_metal::distributed::MeshDeviceConfig({1, 1}, std::pair<size_t, size_t>(0, 0), {}, MeshType::RowMajor);
+        tt::tt_metal::distributed::MeshDeviceConfig(MeshShape(1, 1), MeshOffset(0, 0), {}, MeshType::RowMajor);
 
     EXPECT_NO_THROW({
         auto mesh = tt::tt_metal::distributed::MeshDevice::create(

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -216,7 +216,7 @@ TEST(GalaxyTests, TestReduceScatterDeadlock) {
     auto view = ttnn::MeshDeviceView(*mesh);
     std::vector<Device*> ring_devices = view.get_devices_on_row(0);  // Tunnel 0
     std::vector<Device*> ring_devices_1 =
-        view.get_devices_on_column(mesh_shape.second - 1);  // Orthogonal to tunnel .. no deadlocks
+        view.get_devices_on_column(mesh_shape.num_cols - 1);  // Orthogonal to tunnel .. no deadlocks
     ring_devices_1 = std::vector<Device*>(ring_devices_1.begin() + 1, ring_devices_1.end());
     std::vector<Device*> ring_devices_2 =
         view.get_devices_on_row(7);  // Tunnel 7 .. potential deadlocks with lack of buffering

--- a/tt-train/sources/ttml/core/distributed_mapping.hpp
+++ b/tt-train/sources/ttml/core/distributed_mapping.hpp
@@ -74,7 +74,7 @@ protected:
     tt::tt_metal::distributed::MeshShape m_mesh_shape;
 
     size_t get_num_devices() const {
-        return m_mesh_shape.first * m_mesh_shape.second;
+        return m_mesh_shape.num_rows * m_mesh_shape.num_cols;
     }
 };
 
@@ -130,8 +130,8 @@ public:
             throw std::invalid_argument("ShardTensor2dMesh requires at least one dimension to shard");
         }
 
-        int rows = Base::m_mesh_shape.first;
-        int cols = Base::m_mesh_shape.second;
+        int rows = Base::m_mesh_shape.num_rows;
+        int cols = Base::m_mesh_shape.num_cols;
         auto row_dim = m_dims.first;
         auto col_dim = m_dims.second;
 
@@ -178,8 +178,8 @@ public:
     std::unordered_map<std::string, std::string> config_impl() const {
         return {
             {"strategy", "shard_2d"},
-            {"mesh_shape_y", std::to_string(Base::m_mesh_shape.first)},
-            {"mesh_shape_x", std::to_string(Base::m_mesh_shape.second)}};
+            {"mesh_shape_y", std::to_string(Base::m_mesh_shape.num_rows)},
+            {"mesh_shape_x", std::to_string(Base::m_mesh_shape.num_cols)}};
     }
 
 private:
@@ -193,16 +193,16 @@ public:
     ConcatMesh2dToTensor(
         tt::tt_metal::distributed::MeshShape mesh_shape, const tt::tt_metal::distributed::MeshShape& dims) :
         Base(std::move(mesh_shape)), m_dims(dims) {
-        if (m_dims.first == m_dims.second) {
+        if (m_dims.num_rows == m_dims.num_cols) {
             throw std::invalid_argument("Dimensions in 'dims' must be different");
         }
     }
 
     std::vector<xt::xarray<T>> compose_impl(const std::vector<xt::xarray<T>>& tensors) const {
-        int rows = Base::m_mesh_shape.first;
-        int cols = Base::m_mesh_shape.second;
-        size_t row_dim = m_dims.first;
-        size_t col_dim = m_dims.second;
+        int rows = Base::m_mesh_shape.num_rows;
+        int cols = Base::m_mesh_shape.num_cols;
+        size_t row_dim = m_dims.num_rows;
+        size_t col_dim = m_dims.num_cols;
 
         std::vector<xt::xarray<T>> row_concatenated;
         row_concatenated.reserve(static_cast<size_t>(rows));

--- a/tt-train/tests/core/distributed_test.cpp
+++ b/tt-train/tests/core/distributed_test.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(MeshOpsTest, ShardTensor2dMeshTwoDimSharding) {
 
 TYPED_TEST(MeshOpsTest, ReplicateXTensorToMeshReplication) {
     tt::tt_metal::distributed::MeshShape mesh_shape = {2, 2};
-    int num_devices = mesh_shape.first * mesh_shape.second;  // 4
+    int num_devices = mesh_shape.num_rows * mesh_shape.num_cols;  // 4
 
     auto tensor = xt::arange<TypeParam>(4);  // [0,1,2,3]
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -105,7 +105,7 @@ MeshShape SystemMesh::Impl::get_system_mesh_shape(size_t system_num_devices) {
     TT_FATAL(
         system_mesh_to_shape.contains(system_num_devices), "Unsupported number of devices: {}", system_num_devices);
     auto shape = system_mesh_to_shape.at(system_num_devices);
-    log_debug(LogMetal, "Logical SystemMesh Shape: {}x{}", shape.first, shape.second);
+    log_debug(LogMetal, "Logical SystemMesh Shape: {}x{}", shape.num_rows, shape.num_cols);
     return shape;
 }
 
@@ -293,32 +293,32 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
 
 std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
     const MeshShape& submesh_shape, const MeshOffset& offset, MeshType type) {
-    if (submesh_shape.first <= 0 || submesh_shape.second <= 0) {
+    if (submesh_shape.num_rows <= 0 || submesh_shape.num_cols <= 0) {
         TT_THROW(
             "Invalid submesh shape: ({}, {}). Both dimensions must be positive.",
-            submesh_shape.first,
-            submesh_shape.second);
+            submesh_shape.num_rows,
+            submesh_shape.num_cols);
     }
 
-    if (offset.first < 0 || offset.second < 0) {
-        TT_THROW("Invalid offset: ({}, {}). Offset must be non-negative.", offset.first, offset.second);
+    if (offset.row < 0 || offset.col < 0) {
+        TT_THROW("Invalid offset: ({}, {}). Offset must be non-negative.", offset.row, offset.col);
     }
 
-    if (offset.first + submesh_shape.first > this->mesh_device_shape.first ||
-        offset.second + submesh_shape.second > this->mesh_device_shape.second) {
+    if (offset.row + submesh_shape.num_rows > this->mesh_device_shape.num_rows ||
+        offset.col + submesh_shape.num_cols > this->mesh_device_shape.num_cols) {
         TT_THROW(
             "Submesh ({}x{}) with offset ({}, {}) does not fit within parent mesh ({}x{}).",
-            submesh_shape.first,
-            submesh_shape.second,
-            offset.first,
-            offset.second,
-            this->mesh_device_shape.first,
-            this->mesh_device_shape.second);
+            submesh_shape.num_rows,
+            submesh_shape.num_cols,
+            offset.row,
+            offset.col,
+            this->mesh_device_shape.num_rows,
+            this->mesh_device_shape.num_cols);
     }
 
     auto submesh = std::make_shared<MeshDevice>(submesh_shape, type, shared_from_this());
-    auto start_coordinate = Coordinate{offset.first, offset.second};
-    auto end_coordinate = Coordinate{offset.first + submesh_shape.first - 1, offset.second + submesh_shape.second - 1};
+    auto start_coordinate = Coordinate{offset.row, offset.col};
+    auto end_coordinate = Coordinate{offset.row + submesh_shape.num_rows - 1, offset.col + submesh_shape.num_cols - 1};
     submesh->primary_view = std::make_shared<MeshDeviceView>(*this, start_coordinate, end_coordinate);
     submesh->devices = submesh->primary_view->get_devices();
     SystemMesh::instance().register_mesh_device(submesh, submesh->devices);
@@ -338,8 +338,8 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
 
 std::vector<std::shared_ptr<MeshDevice>> MeshDevice::create_submeshes(const MeshShape& submesh_shape, MeshType type) {
     std::vector<std::shared_ptr<MeshDevice>> submeshes;
-    for (int row = 0; row < this->num_rows(); row += submesh_shape.first) {
-        for (int col = 0; col < this->num_cols(); col += submesh_shape.second) {
+    for (int row = 0; row < this->num_rows(); row += submesh_shape.num_rows) {
+        for (int col = 0; col < this->num_cols(); col += submesh_shape.num_cols) {
             auto submesh = this->create_submesh(submesh_shape, MeshOffset{row, col}, type);
             submeshes.push_back(submesh);
         }
@@ -413,9 +413,9 @@ CoreCoord MeshDevice::dram_grid_size() const { return this->reference_device()->
 
 tt::ARCH MeshDevice::arch() const { return this->reference_device()->arch(); }
 
-size_t MeshDevice::num_rows() const { return this->mesh_device_shape.first; }
+size_t MeshDevice::num_rows() const { return this->mesh_device_shape.num_rows; }
 
-size_t MeshDevice::num_cols() const { return this->mesh_device_shape.second; }
+size_t MeshDevice::num_cols() const { return this->mesh_device_shape.num_cols; }
 
 MeshShape MeshDevice::shape() const { return this->mesh_device_shape; }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -327,10 +327,10 @@ std::shared_ptr<MeshDevice> MeshDevice::create_submesh(
         LogMetal,
         "Instantiating submesh {}: {}x{} with offset: {} {}",
         submesh->get_mesh_id(),
-        submesh_shape.first,
-        submesh_shape.second,
-        offset.first,
-        offset.second);
+        submesh_shape.num_rows,
+        submesh_shape.num_cols,
+        offset.row,
+        offset.col);
     log_trace(LogMetal, "Submesh {} instantiated with {} devices", submesh->get_mesh_id(), submesh->devices);
 
     return submesh;

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -18,7 +18,10 @@ namespace tt::tt_metal::distributed {
 
 using DeviceIds = std::vector<int>;
 using MeshDeviceID = size_t;
-using MeshOffset = std::pair<size_t, size_t>;
+struct MeshOffset {
+    size_t row = 0;
+    size_t col = 0;
+};
 class MeshDeviceView;
 
 struct MeshSubDeviceManagerId;

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -83,7 +83,7 @@ MeshDeviceView::DeviceView MeshDeviceView::get_devices(const Coordinate& start, 
 }
 
 MeshDeviceView::DeviceView MeshDeviceView::get_devices(const MeshShape& shape) {
-    return get_devices({0, 0}, {shape.first - 1, shape.second - 1});
+    return get_devices({0, 0}, {shape.num_rows - 1, shape.num_cols - 1});
 }
 
 std::vector<MeshDeviceView::device_pointer> MeshDeviceView::get_devices_on_row(size_t row) const {
@@ -128,7 +128,7 @@ bool MeshDeviceView::empty() const noexcept { return devices_.empty(); }
 
 size_t MeshDeviceView::size() const noexcept { return devices_.size(); }
 
-std::pair<size_t, size_t> MeshDeviceView::shape() const noexcept { return {num_rows(), num_cols()}; }
+MeshShape MeshDeviceView::shape() const noexcept { return {num_rows(), num_cols()}; }
 
 bool MeshDeviceView::contains(const Coordinate& coord) const noexcept {
     return coord.row >= top_left_.row && coord.row <= bottom_right_.row && coord.col >= top_left_.col &&

--- a/tt_metal/distributed/mesh_device_view.hpp
+++ b/tt_metal/distributed/mesh_device_view.hpp
@@ -17,7 +17,10 @@ namespace tt::tt_metal::distributed {
 
 // Forward declaration of MeshDevice
 class MeshDevice;
-using MeshShape = std::pair<size_t, size_t>;
+struct MeshShape {
+    size_t num_rows = 0;
+    size_t num_cols = 0;
+};
 
 struct Coordinate {
     size_t row;

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -8,6 +8,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/run_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/api.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_processor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_trace_utils.cpp

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -144,7 +144,7 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     return physical_device_ids;
 }
 
-std::vector<Device*> get_devices_for_tensor(const Tensor& tensor, MeshDevice& mesh_device) {
+std::vector<Device*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_device) {
     // For multi-device tensors, returns the number of workers capped by the number of buffers
     // Otherwise, returns all available workes from mesh_device.
     auto get_workers_for_tensor = [&tensor, &mesh_device]() {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -25,7 +25,14 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     MeshType mesh_type,
     const std::pair<size_t, size_t>& offset,
     const std::vector<int>& physical_device_ids) {
-    auto config = MeshDeviceConfig(mesh_shape, offset, physical_device_ids, mesh_type);
+    auto config = MeshDeviceConfig(
+        mesh_shape,
+        MeshOffset{
+            .row = offset.first,
+            .col = offset.second,
+        },
+        physical_device_ids,
+        mesh_type);
     return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
 }
 

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -131,7 +131,6 @@ Tensor aggregate_as_tensor(
             reference_shard.get_layout(),
             tile);
     }
-    return physical_device_ids;
 }
 
 std::vector<int> get_t3k_physical_device_ids_ring() {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -23,16 +23,9 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
     MeshType mesh_type,
-    const std::pair<size_t, size_t>& offset,
+    const MeshOffset& offset,
     const std::vector<int>& physical_device_ids) {
-    auto config = MeshDeviceConfig(
-        mesh_shape,
-        MeshOffset{
-            .row = offset.first,
-            .col = offset.second,
-        },
-        physical_device_ids,
-        mesh_type);
+    auto config = MeshDeviceConfig(mesh_shape, offset, physical_device_ids, mesh_type);
     return MeshDevice::create(config, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
 }
 

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -6,8 +6,10 @@
 
 #include <memory>
 
+#include "tt_metal/tt_stl/overloaded.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "tt_metal/distributed/mesh_device.hpp"
 
 using namespace tt::tt_metal;
@@ -58,18 +60,20 @@ std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor) {
     TT_THROW("Expected tensor to be on MultiDeviceHostStorage type!");
 }
 
-Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards) {
+Tensor aggregate_as_tensor(
+    const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config) {
     TT_ASSERT(tensor_shards.size() > 0, "At least one tensor shard must be provided");
+    const auto& reference_shard = tensor_shards.at(0);
     for (const auto& shard : tensor_shards) {
-        if (shard.storage_type() != tensor_shards.at(0).storage_type()) {
+        if (shard.storage_type() != reference_shard.storage_type()) {
             TT_THROW("All tensor shards must have the same storage type");
         }
     }
 
     // Based whether the first tensor shard has OwnedBuffer or Device buffer,
     // we want to use MultiDeviceHostStorage or MultiDeviceStorage
-    StorageType storage_type = tensor_shards.at(0).storage_type();
-    Tile tile = tensor_shards.at(0).get_tensor_spec().tile();
+    StorageType storage_type = reference_shard.storage_type();
+    Tile tile = reference_shard.get_tensor_spec().tile();
     if (storage_type == StorageType::OWNED) {
         std::vector<ttnn::Shape> shapes;
         std::vector<OwnedBuffer> host_owned_buffers;
@@ -81,7 +85,7 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards) {
                 TT_THROW(
                     "Error aggregating multichip tensors: Attempting to aggregate tensors with different tiling "
                     "configurations. Device {} has tiling ({}x{}) while device {} has tiling {}x{}.",
-                    tensor_shards.at(0).device()->id(),
+                    reference_shard.device()->id(),
                     tile.get_height(),
                     tile.get_width(),
                     shard.device()->id(),
@@ -89,12 +93,12 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards) {
                     shard_tile.get_width());
             }
         }
-        auto storage = MultiDeviceHostStorage{AllGatherTensor(), std::move(host_owned_buffers), shapes};
+        auto storage = MultiDeviceHostStorage{config, std::move(host_owned_buffers), shapes};
         return Tensor(
             std::move(storage),
-            tensor_shards.at(0).get_legacy_shape(),
-            tensor_shards.at(0).get_dtype(),
-            tensor_shards.at(0).get_layout(),
+            reference_shard.get_legacy_shape(),
+            reference_shard.get_dtype(),
+            reference_shard.get_layout(),
             tile);
     } else {
         std::vector<int> ordered_device_ids;
@@ -111,7 +115,7 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards) {
                 TT_THROW(
                     "Error aggregating multichip tensors: Attempting to aggregate tensors with different tiling "
                     "configurations. Device {} has tiling ({}x{}) while device {} has tiling {}x{}.",
-                    tensor_shards.at(0).device()->id(),
+                    reference_shard.device()->id(),
                     tile.get_height(),
                     tile.get_width(),
                     shard.device()->id(),
@@ -119,14 +123,15 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards) {
                     shard_tile.get_width());
             }
         }
-        auto storage = MultiDeviceStorage{AllGatherTensor(), ordered_device_ids, std::move(device_buffers), shapes};
+        auto storage = MultiDeviceStorage{config, ordered_device_ids, std::move(device_buffers), shapes};
         return Tensor(
             std::move(storage),
-            tensor_shards.at(0).get_legacy_shape(),
-            tensor_shards.at(0).get_dtype(),
-            tensor_shards.at(0).get_layout(),
+            reference_shard.get_legacy_shape(),
+            reference_shard.get_dtype(),
+            reference_shard.get_layout(),
             tile);
     }
+    return physical_device_ids;
 }
 
 std::vector<int> get_t3k_physical_device_ids_ring() {
@@ -140,7 +145,7 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
     return physical_device_ids;
 }
 
-std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, MeshDevice& mesh_device) {
+std::vector<Device*> get_devices_for_tensor(const Tensor& tensor, MeshDevice& mesh_device) {
     // For multi-device tensors, returns the number of workers capped by the number of buffers
     // Otherwise, returns all available workes from mesh_device.
     auto get_workers_for_tensor = [&tensor, &mesh_device]() {
@@ -151,19 +156,15 @@ std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, MeshDevice&
         }
         return workers;
     };
-
     if (mesh_device.get_view() != nullptr and std::holds_alternative<MultiDeviceHostStorage>(tensor.get_storage())) {
         const auto& host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());
 
         return std::visit(
-            [&](const auto& strategy) {
-                using StrategyType = std::decay_t<decltype(strategy)>;
-                if constexpr (std::is_same_v<StrategyType, ShardTensor2D>) {
-                    return mesh_device.get_view()->get_devices(strategy.shard_mesh);
-                } else {
-                    return get_workers_for_tensor();
-                }
-            },
+            tt::stl::overloaded{
+                [&](const ShardTensor2D& s) {
+                    return mesh_device.get_view()->get_devices(MeshShape{s.shard_mesh.y, s.shard_mesh.x});
+                },
+                [&](const auto&) { return get_workers_for_tensor(); }},
             host_storage.strategy);
     } else if (std::holds_alternative<MultiDeviceStorage>(tensor.get_storage())) {
         return tensor.workers;

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -34,7 +34,7 @@ Tensor aggregate_as_tensor(
 std::vector<int> get_t3k_physical_device_ids_ring();
 
 // Maps a tensor to the set of devices in the device-mesh that the shards will be distributed across.
-std::vector<Device*> get_devices_for_tensor(const Tensor& tensor, MeshDevice& mesh_device);
+std::vector<Device*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_device);
 
 // Get the distributed tensor config from a tensor.
 tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/distributed/types.hpp"
 
 namespace ttnn::distributed::api {
@@ -23,14 +24,17 @@ std::shared_ptr<MeshDevice> open_mesh_device(
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);
 
+// Given a multi-device tensor, returns a list of individual per-device tensors.
 std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);
 
-Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards);
+// Given a list of per-device shards, returns multi-device tensor.
+Tensor aggregate_as_tensor(
+    const std::vector<Tensor>& tensor_shards, const tt::tt_metal::DistributedTensorConfig& config);
 
 std::vector<int> get_t3k_physical_device_ids_ring();
 
 // Maps a tensor to the set of devices in the device-mesh that the shards will be distributed across.
-std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, MeshDevice& mesh_device);
+std::vector<Device*> get_devices_for_tensor(const Tensor& tensor, MeshDevice& mesh_device);
 
 // Get the distributed tensor config from a tensor.
 tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -19,7 +19,7 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t num_command_queues,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config,
     MeshType mesh_type = MeshType::RowMajor,
-    const std::pair<size_t, size_t>& offset = std::pair<size_t, size_t>(0, 0),
+    const MeshOffset& offset = MeshOffset(0, 0),
     const std::vector<int>& physical_device_ids = {});
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -40,7 +40,14 @@ void py_module(py::module& module) {
                         const std::vector<chip_id_t>& physical_device_ids,
                         MeshType mesh_type) {
                 return MeshDevice::create(
-                    MeshDeviceConfig(mesh_device_shape, offset, physical_device_ids, mesh_type),
+                    MeshDeviceConfig(
+                        mesh_device_shape,
+                        MeshOffset{
+                            .row = offset.first,
+                            .col = offset.second,
+                        },
+                        physical_device_ids,
+                        mesh_type),
                     l1_small_size,
                     trace_region_size,
                     num_command_queues,

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -40,10 +40,13 @@ void py_module(py::module& module) {
             py::arg("num_cols"))
         .def_readwrite("num_rows", &MeshShape::num_rows, "Number of rows in the mesh.")
         .def_readwrite("num_cols", &MeshShape::num_cols, "Number of columns in the mesh.")
-        .def("__repr__", [](const MeshShape& ms) {
-            return "<MeshShape num_rows=" + std::to_string(ms.num_rows) + " num_cols=" + std::to_string(ms.num_cols) +
-                   ">";
-        });
+        .def(
+            "__repr__",
+            [](const MeshShape& ms) {
+                return "<MeshShape num_rows=" + std::to_string(ms.num_rows) +
+                       " num_cols=" + std::to_string(ms.num_cols) + ">";
+            })
+        .def("__iter__", [](const MeshShape& ms) { return py::iter(py::make_tuple(ms.num_rows, ms.num_cols)); });
     static_cast<py::class_<MeshOffset>>(module.attr("MeshOffset"))
         .def(
             py::init([](size_t row, size_t col) { return MeshOffset(row, col); }),
@@ -52,9 +55,12 @@ void py_module(py::module& module) {
             py::arg("col"))
         .def_readwrite("row", &MeshOffset::row, "Row offset in the mesh.")
         .def_readwrite("col", &MeshOffset::col, "Column offset in the mesh.")
-        .def("__repr__", [](const MeshOffset& mo) {
-            return "<MeshOffset row=" + std::to_string(mo.row) + " col=" + std::to_string(mo.col) + ">";
-        });
+        .def(
+            "__repr__",
+            [](const MeshOffset& mo) {
+                return "<MeshOffset row=" + std::to_string(mo.row) + " col=" + std::to_string(mo.col) + ">";
+            })
+        .def("__iter__", [](const MeshOffset& mo) { return py::iter(py::make_tuple(mo.row, mo.col)); });
 
     auto py_mesh_device = static_cast<py::class_<MeshDevice, std::shared_ptr<MeshDevice>>>(module.attr("MeshDevice"));
     py_mesh_device

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -233,7 +233,11 @@ void py_module(py::module& module) {
             Tensor: The shard of the tensor corresponding to the device.
     )doc");
     module.def("get_device_tensors", &get_device_tensors, py::arg("tensor"), py::kw_only());
-    module.def("aggregate_as_tensor", &aggregate_as_tensor, py::arg("tensors"), py::kw_only());
+    module.def(
+        "aggregate_as_tensor",
+        [](const std::vector<Tensor>& tensors) -> Tensor { return aggregate_as_tensor(tensors, AllGatherTensor{}); },
+        py::arg("tensors"),
+        py::kw_only());
     module.def("get_t3k_physical_device_ids_ring", &get_t3k_physical_device_ids_ring);
 }
 

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <unordered_map>
+#include <string>
+
+#include "common/assert.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+DistributedTensorConfig create_shard_distributed_tensor_config(
+    const std::unordered_map<std::string, std::string>& metadata) {
+    return ShardTensor(std::stoi(metadata.at("shard_dim")));
+}
+DistributedTensorConfig create_shard_2d_distributed_tensor_config(
+    const std::unordered_map<std::string, std::string>& metadata) {
+    return ShardTensor2D(ShardMesh(std::stoi(metadata.at("mesh_shape_y")), std::stoi(metadata.at("mesh_shape_x"))));
+}
+DistributedTensorConfig create_replicate_distributed_tensor_config(
+    const std::unordered_map<std::string, std::string>& metadata) {
+    if (auto it = metadata.find("replication_factor"); it != metadata.end()) {
+        return ReplicateTensor(std::stoi(it->second));
+    }
+    TT_THROW("Unsupported Replication strategy:");
+}
+}  // namespace
+
+DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
+    if (auto it = metadata.find("strategy"); it != metadata.end()) {
+        const std::string& strategy = it->second;
+        if (strategy == "shard") {
+            return create_shard_distributed_tensor_config(metadata);
+        } else if (strategy == "shard_2d") {
+            return create_shard_2d_distributed_tensor_config(metadata);
+        } else if (strategy == "replicate") {
+            return create_replicate_distributed_tensor_config(metadata);
+        }
+    }
+    TT_THROW("Unsupported DistributedTensorConfig strategy:");
+}
+
+bool operator==(const ReplicateTensor& a, const ReplicateTensor& b) {
+    return a.replication_factor == b.replication_factor;
+}
+bool operator==(const AllGatherTensor&, const AllGatherTensor&) {
+    // All instances are considered equal because there are no data members.
+    return true;
+}
+bool operator==(const ShardTensor& lhs, const ShardTensor& rhs) { return lhs.shard_dimension == rhs.shard_dimension; }
+bool operator==(const ShardTensor2D& lhs, const ShardTensor2D& rhs) {
+    return lhs.shard_mesh.x == rhs.shard_mesh.x && lhs.shard_mesh.y == rhs.shard_mesh.y;
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <variant>
+
+namespace tt::tt_metal {
+
+struct ReplicateTensor {
+    int replication_factor = 1;
+    ReplicateTensor() = default;
+    ReplicateTensor(int replication_factor) : replication_factor(replication_factor) {}
+};
+bool operator==(const ReplicateTensor&, const ReplicateTensor&);
+struct ShardTensor {
+    int shard_dimension;
+    ShardTensor(int shard_dimension) : shard_dimension(shard_dimension) {}
+};
+bool operator==(const ShardTensor& lhs, const ShardTensor& rhs);
+
+struct ShardMesh {
+    std::uint16_t y = 0;
+    std::uint16_t x = 0;
+};
+
+struct ShardTensor2D {
+    ShardMesh shard_mesh;  // logic 2D grid that defines the mapping of shards to devices
+    ShardTensor2D(ShardMesh mesh) : shard_mesh(std::move(mesh)) {}
+};
+bool operator==(const ShardTensor2D& lhs, const ShardTensor2D& rhs);
+
+struct AllGatherTensor {};
+bool operator==(const AllGatherTensor&, const AllGatherTensor&);
+
+// DistributedTensorConfig is a variant of different ways in which a tensor can be distributed across devices.
+using DistributedTensorConfig = std::variant<ReplicateTensor, ShardTensor, ShardTensor2D, AllGatherTensor>;
+DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata);
+
+}  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -13,6 +13,7 @@
 namespace ttnn::distributed {
 
 using MeshShape = tt::tt_metal::distributed::MeshShape;
+using MeshOffset = tt::tt_metal::distributed::MeshOffset;
 using DeviceIds = tt::tt_metal::distributed::DeviceIds;
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using MeshDeviceView = tt::tt_metal::distributed::MeshDeviceView;
@@ -29,6 +30,7 @@ using ttnn::distributed::DeviceIds;
 using ttnn::distributed::MeshDevice;
 using ttnn::distributed::MeshDeviceConfig;
 using ttnn::distributed::MeshDeviceView;
+using ttnn::distributed::MeshOffset;
 using ttnn::distributed::MeshShape;
 using ttnn::distributed::MeshSubDeviceManagerId;
 using ttnn::distributed::MeshType;

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -568,7 +568,7 @@ Tensor Tensor::to(Device* target_device, const MemoryConfig& mem_config) const {
 }
 
 Tensor Tensor::to(distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config) const {
-    std::vector<Device*> workers_to_use = ttnn::distributed::get_devices_for_tensor(*this, *mesh_device);
+    std::vector<Device*> workers_to_use = ttnn::distributed::get_mapped_devices(*this, *mesh_device);
     return tensor_ops::tensor_to(*this, workers_to_use, mem_config);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -568,7 +568,7 @@ Tensor Tensor::to(Device* target_device, const MemoryConfig& mem_config) const {
 }
 
 Tensor Tensor::to(distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config) const {
-    std::vector<Device*> workers_to_use = ttnn::distributed::distribute_tensor_to_mesh(*this, *mesh_device);
+    std::vector<Device*> workers_to_use = ttnn::distributed::get_devices_for_tensor(*this, *mesh_device);
     return tensor_ops::tensor_to(*this, workers_to_use, mem_config);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -16,6 +16,7 @@
 #include "common/test_tiles.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -181,7 +181,7 @@ Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, distributed::
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_layout, mesh_device);
     if (mesh_device) {
-        auto workers = ttnn::distributed::get_devices_for_tensor(input_tensor, *mesh_device);
+        auto workers = ttnn::distributed::get_mapped_devices(input_tensor, *mesh_device);
         TT_FATAL(
             validate_worker_modes(workers),
             "All device threads/workers must be running in the same mode (ASYNC or SYNC)");

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -181,15 +181,15 @@ Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, distributed::
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_layout, mesh_device);
     if (mesh_device) {
-        auto workers = ttnn::distributed::distribute_tensor_to_mesh(input_tensor, *mesh_device);
+        auto workers = ttnn::distributed::get_devices_for_tensor(input_tensor, *mesh_device);
         TT_FATAL(
             validate_worker_modes(workers),
             "All device threads/workers must be running in the same mode (ASYNC or SYNC)");
 
         std::optional<DistributedTensorConfig> distributed_config = std::nullopt;
-        if (std::holds_alternative<MultiDeviceHostStorage>(input_tensor.get_storage())) {
-            auto& host_storage = std::get<MultiDeviceHostStorage>(input_tensor.get_storage());
-            distributed_config = host_storage.strategy;
+        if (auto* host_storage = std::get_if<MultiDeviceHostStorage>(&input_tensor.get_storage());
+            host_storage != nullptr) {
+            distributed_config = host_storage->strategy;
         }
         Tensor tensor_modified_layout = Tensor(workers.size(), distributed_config);
         for (int worker_index = 0; worker_index < workers.size(); ++worker_index) {

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -142,40 +142,6 @@ void insert_buffer_and_shape_for_device(
 
 Tensor copy_borrowed_tensor_in_async_mode(Device* worker, const Tensor& tensor);
 
-template <typename TensorContainer>
-auto get_device_tensors(Device* device, const TensorContainer& input_tensors) {
-    // Could be Tensor, const Tensor, std::optional<Tensor>, or std::optional<const Tensor>
-    using ValueType = typename TensorContainer::value_type;
-
-    // We need a way to extract the underlying Tensor type (const or non-const) from ValueType
-    // and to decide whether we are dealing with an optional type.
-    using IsOptional = std::conditional_t<
-        std::is_same_v<ValueType, std::optional<Tensor>> || std::is_same_v<ValueType, std::optional<const Tensor>>,
-        std::true_type,
-        std::false_type>;
-    using TensorType = std::conditional_t<
-        std::is_same_v<ValueType, std::optional<Tensor>> || std::is_same_v<ValueType, Tensor>,
-        Tensor,
-        const Tensor>;
-
-    // Result container type adjustment based on input type
-    using ResultType = std::conditional_t<IsOptional::value, std::optional<TensorType>, TensorType>;
-    std::vector<ResultType> transformed_tensors;
-
-    for (const auto& tensor : input_tensors) {
-        if constexpr (IsOptional::value) {
-            if (tensor.has_value()) {
-                transformed_tensors.emplace_back(get_device_tensor(tensor.value(), device));
-            } else {
-                transformed_tensors.emplace_back(std::nullopt);
-            }
-        } else {
-            transformed_tensors.emplace_back(get_device_tensor(tensor, device));
-        }
-    }
-    return transformed_tensors;
-}
-
 inline bool is_tensor_on_device(const ttnn::Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
 
 inline bool is_tensor_on_multi_device(const ttnn::Tensor& tensor) {
@@ -196,5 +162,4 @@ inline uint32_t get_batch_size(const T& shape) {
 }
 
 }  // namespace tt_metal
-
 }  // namespace tt

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -18,6 +18,7 @@
 #include "tt_metal/tt_stl/concepts.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
 #include "tt_metal/tt_stl/span.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/tensor/host_buffer/types.hpp"
 #include "ttnn/cpp/ttnn/tensor/enum_types.hpp"
 
@@ -77,31 +78,6 @@ enum class StorageType {
     MULTI_DEVICE,       // on-device storage for multi-device context
     MULTI_DEVICE_HOST,  // host storage for multi-device context
 };
-
-struct AllGatherTensor {};
-bool operator==(const AllGatherTensor &, const AllGatherTensor &);
-struct ReplicateTensor {
-    int replication_factor = 1;
-    ReplicateTensor() = default;
-    ReplicateTensor(int replication_factor) : replication_factor(replication_factor) {}
-};
-bool operator==(const ReplicateTensor &, const ReplicateTensor &);
-struct ShardTensor {
-    int shard_dimension;
-    ShardTensor(int shard_dimension) : shard_dimension(shard_dimension) {}
-};
-bool operator==(const ShardTensor &lhs, const ShardTensor &rhs);
-
-using ShardMesh = std::pair<std::uint16_t, std::uint16_t>;  // (y,x)
-struct ShardTensor2D {
-    ShardMesh shard_mesh;  // logic 2D grid that defines the mapping of shards to devices
-    ShardTensor2D(ShardMesh mesh) : shard_mesh(std::move(mesh)) {}
-};
-bool operator==(const ShardTensor2D &lhs, const ShardTensor2D &rhs);
-
-// DistributedTensorConfig is a variant of different ways in which a tensor can be distributed across devices.
-using DistributedTensorConfig = std::variant<ReplicateTensor, ShardTensor, ShardTensor2D, AllGatherTensor>;
-DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string> &metadata);
 
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -153,6 +153,7 @@ from ttnn.types import (
     WormholeComputeKernelConfig,
     GrayskullComputeKernelConfig,
     MeshShape,
+    MeshOffset,
     UnaryWithParam,
     UnaryOpType,
     BinaryOpType,

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -455,6 +455,8 @@ class ConcatMeshToTensor(MeshToTensor):
         return torch.cat(device_shards_converted_to_torch, dim=self.concat_dim)
 
 
+# TODO: #15061 - Remove this function, as it does not abide to the MeshToTensor interface.
+# Instead, lift this implementation to the caller.
 class ListMeshToTensor(MeshToTensor):
     def __init__(self, mesh_device: MeshDevice):
         self.mesh_device = mesh_device

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -139,7 +139,7 @@ def open_mesh_device(
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
     dispatch_core_config: ttnn.DispatchCoreConfig = ttnn.DispatchCoreConfig(),
-    offset: Tuple[int, int] = (0, 0),
+    offset: ttnn.MeshOffset = ttnn.MeshOffset(0, 0),
     physical_device_ids: List[int] = [],
     mesh_type: "MeshType" = MeshType.RowMajor,
 ):
@@ -152,7 +152,7 @@ def open_mesh_device(
         trace_region_size (int, optional): Size of the trace region. Defaults to ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE.
         num_command_queues (int, optional): Number of command queues. Defaults to 1.
         dispatch_core_type (int, optional): Type of dispatch core. Defaults to DispatchCoreType.WORKER.
-        offset (Tuple[int, int], optional): Offset in logical mesh coordinates for the mesh device. Defaults to (0, 0).
+        offset (ttnn.MeshOffset, optional): Offset in logical mesh coordinates for the mesh device. Defaults to (0, 0).
         mesh_type (MeshType, optional): Defines type of mesh requested. Type imposes connectivity constraints and defines device iteration order.
 
     Returns:
@@ -165,7 +165,7 @@ def open_mesh_device(
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
         dispatch_core_config=dispatch_core_config,
-        offset=offset,
+        offset=offset.as_tuple(),
         physical_device_ids=physical_device_ids,
         mesh_type=mesh_type,
     )

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -139,7 +139,7 @@ def open_mesh_device(
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
     dispatch_core_config: ttnn.DispatchCoreConfig = ttnn.DispatchCoreConfig(),
-    offset: ttnn.MeshOffset = ttnn.MeshOffset(0, 0),
+    offset: ttnn.MeshOffset = ttnn.MeshOffset(row=0, col=0),
     physical_device_ids: List[int] = [],
     mesh_type: "MeshType" = MeshType.RowMajor,
 ):
@@ -153,6 +153,7 @@ def open_mesh_device(
         num_command_queues (int, optional): Number of command queues. Defaults to 1.
         dispatch_core_type (int, optional): Type of dispatch core. Defaults to DispatchCoreType.WORKER.
         offset (ttnn.MeshOffset, optional): Offset in logical mesh coordinates for the mesh device. Defaults to (0, 0).
+        physical_device_ids (List[int], optional): List of physical device IDs to use. Defaults to [].
         mesh_type (MeshType, optional): Defines type of mesh requested. Type imposes connectivity constraints and defines device iteration order.
 
     Returns:
@@ -160,12 +161,12 @@ def open_mesh_device(
 
     """
     return ttnn._ttnn.multi_device.MeshDevice(
-        mesh_shape=mesh_shape.as_tuple(),
+        mesh_shape=mesh_shape,
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
         dispatch_core_config=dispatch_core_config,
-        offset=offset.as_tuple(),
+        offset=offset,
         physical_device_ids=physical_device_ids,
         mesh_type=mesh_type,
     )

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -58,34 +58,14 @@ class CoreRange:
     end: CoreGrid
 
 
-@dataclasses.dataclass
-class MeshShape:
-    y: int
-    x: int
-
-    @property
-    def num_devices(self):
-        return self.y * self.x
-
-    def as_tuple(self):
-        return (self.y, self.x)
-
-
-@dataclasses.dataclass
-class MeshOffset:
-    y: int
-    x: int
-
-    def as_tuple(self):
-        return (self.y, self.x)
-
-
 class ShardStrategy(Enum):
     HEIGHT = 1
     WIDTH = 2
     BLOCK = 3
 
 
+MeshShape = ttnn._ttnn.multi_device.MeshShape
+MeshOffset = ttnn._ttnn.multi_device.MeshOffset
 ShardOrientation = ttnn._ttnn.tensor.ShardOrientation
 ShardMode = ttnn._ttnn.tensor.ShardMode
 ShardSpec = ttnn._ttnn.tensor.ShardSpec

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -71,6 +71,15 @@ class MeshShape:
         return (self.y, self.x)
 
 
+@dataclasses.dataclass
+class MeshOffset:
+    y: int
+    x: int
+
+    def as_tuple(self):
+        return (self.y, self.x)
+
+
 class ShardStrategy(Enum):
     HEIGHT = 1
     WIDTH = 2


### PR DESCRIPTION
### Ticket
#15061 

### What's changed
* Refactor `DistributedTensorConfig` in it's own header
* Use typed `struct` to represent `MeshShape` and `MeshOffset`

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12210236362)
- [X] New/Existing tests provide coverage for changes
