### PR TITLE
[tt-train] Add multiple options for positional embedding

### DIFF
--- a/tt-train/configs/training_shakespear_nanogpt.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt.yaml
@@ -15,5 +15,6 @@ training_config:
     num_blocks: 6
     vocab_size: 96
     max_sequence_length: 256
+    positional_embedding_type: trainable
     experimental:
       use_composite_layernorm: false

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -202,6 +202,10 @@ int main(int argc, char **argv) {
         {"seed", static_cast<int>(config.seed)},
         {"use_kahan_summation", config.use_kahan_summation},
         {"gradient_accumulation_steps", static_cast<int>(config.gradient_accumulation_steps)},
+        {"positional_embedding_type",
+         config.transformer_config.positional_embedding_type == ttml::models::gpt2::PositionalEmbeddingType::Trainable
+             ? "trainable"
+             : "fixed"},
     });
 
     // set seed

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -36,8 +36,8 @@ void signal_handler(int signum) {
 using ttml::autograd::TensorPtr;
 
 using DatasetSample = std::pair<std::span<const uint32_t>, std::span<const uint32_t>>;
-// tokens, targets, mask, positions
-using BatchType = std::tuple<TensorPtr, TensorPtr, TensorPtr, TensorPtr>;
+// tokens, targets, masks
+using BatchType = std::tuple<TensorPtr, TensorPtr, TensorPtr>;
 using DataLoader = ttml::datasets::DataLoader<
     ttml::datasets::InMemoryTokenDataset,
     std::function<BatchType(std::vector<DatasetSample> &&samples)>,
@@ -77,11 +77,6 @@ void generate(
 
     auto vocab_size = tokenizer.get_vocab_size();
 
-    auto positions_vector = std::vector<uint32_t>(max_sequence_length);
-    std::iota(positions_vector.begin(), positions_vector.end(), 0);
-    auto positions_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
-        positions_vector, ttml::core::create_shape({1, 1, 1, max_sequence_length}), device, Layout::ROW_MAJOR));
-
     std::vector<float> mask;
     mask.reserve(static_cast<size_t>(max_sequence_length * max_sequence_length * num_heads));
     for (int head = 0; head < num_heads; ++head) {
@@ -114,7 +109,7 @@ void generate(
             device,
             Layout::ROW_MAJOR));
 
-        auto output = (*model)(prompt_tensor, positions_tensor, mask_tensor);
+        auto output = (*model)(prompt_tensor, mask_tensor);
         auto output_vector = ttml::core::to_vector(output->get_value());
 
         uint32_t predicted_token_id = prompt_tokens.size() - 1U;
@@ -242,17 +237,9 @@ int main(int argc, char **argv) {
         std::vector<uint32_t> data;
         std::vector<int32_t> targets;
         ttml::autograd::TensorPtr masks_tensor;
-        ttml::autograd::TensorPtr positions_tensor;
     };
     CachedHostData cached_data;
-    std::vector<uint32_t> positions;
     std::vector<float> mask;
-    positions.reserve((size_t)config.batch_size * sequence_length);
-    for (int sample_idx = 0; sample_idx < config.batch_size; ++sample_idx) {
-        for (int i = 0; i < sequence_length; ++i) {
-            positions.push_back(i);
-        }
-    }
     auto num_heads = config.transformer_config.num_heads;
     mask.reserve((size_t)config.batch_size * sequence_length * sequence_length * num_heads);
     for (int sample_idx = 0; sample_idx < config.batch_size; ++sample_idx) {
@@ -266,8 +253,6 @@ int main(int argc, char **argv) {
     }
     cached_data.masks_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
         mask, ttml::core::create_shape({config.batch_size, num_heads, sequence_length, sequence_length}), device));
-    cached_data.positions_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
-        positions, ttml::core::create_shape({config.batch_size, 1, 1, sequence_length}), device, Layout::ROW_MAJOR));
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
         [sequence_length, num_heads, vocab_size = tokenizer.get_vocab_size(), device, &cached_data](
@@ -296,7 +281,7 @@ int main(int argc, char **argv) {
             end_timer = std::chrono::high_resolution_clock::now();
             duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();
             fmt::print("dataloader step time {} ms\n", (double)duration / 1000.);
-            return std::make_tuple(data_tensor, targets_tensor, cached_data.masks_tensor, cached_data.positions_tensor);
+            return std::make_tuple(data_tensor, targets_tensor, cached_data.masks_tensor);
         };
 
     LossAverageMeter loss_meter;
@@ -338,12 +323,12 @@ int main(int argc, char **argv) {
     const uint32_t num_epochs = config.num_epochs;
     auto gradient_accumulator_helper = GradientAccumulator(config.gradient_accumulation_steps);
     for (uint32_t epoch = 0; epoch < num_epochs; ++epoch) {
-        for (auto [features, target, masks, positions] : train_dataloader) {
+        for (auto [features, target, masks] : train_dataloader) {
             auto start_timer = std::chrono::high_resolution_clock::now();
             if (gradient_accumulator_helper.should_zero_grad()) {
                 optimizer.zero_grad();
             }
-            auto output = (*model)(features, positions, masks);
+            auto output = (*model)(features, masks);
             auto loss = ttml::ops::nll_loss(output, target);
             loss = gradient_accumulator_helper.scale(loss);
             auto loss_float = ttml::core::to_vector(loss->get_value())[0];

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -100,13 +100,15 @@ TransformerConfig read_config(const YAML::Node& config) {
     transformer_config.vocab_size = config["vocab_size"].as<uint32_t>();
     transformer_config.max_sequence_length = config["max_sequence_length"].as<uint32_t>();
 
-    auto positional_embedding_str = config["positional_embedding"].as<std::string>("trainable");
+    auto positional_embedding_str = config["positional_embedding_type"].as<std::string>("trainable");
     if (positional_embedding_str == "trainable") {
         transformer_config.positional_embedding_type = PositionalEmbeddingType::Trainable;
     } else if (positional_embedding_str == "fixed") {
         transformer_config.positional_embedding_type = PositionalEmbeddingType::Fixed;
     } else {
-        throw std::runtime_error(fmt::format("Unknown positional embedding type: {}", positional_embedding_str));
+        throw std::runtime_error(fmt::format(
+            "Unknown positional embedding type: {}. Supported positional embedding types [trainable, fixed]",
+            positional_embedding_str));
     }
 
     if (auto experimental_config = config["experimental"]) {

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -91,6 +91,19 @@ ttml::autograd::TensorPtr Transformer::operator()(
     return log_softmax;
 }
 
+PositionalEmbeddingType read_positional_embedding_type(const YAML::Node& config) {
+    auto positional_embedding_str = config["positional_embedding_type"].as<std::string>("trainable");
+    if (positional_embedding_str == "trainable") {
+        return PositionalEmbeddingType::Trainable;
+    } else if (positional_embedding_str == "fixed") {
+        return PositionalEmbeddingType::Fixed;
+    } else {
+        throw std::runtime_error(fmt::format(
+            "Unknown positional embedding type: {}. Supported positional embedding types [trainable, fixed]",
+            positional_embedding_str));
+    }
+}
+
 TransformerConfig read_config(const YAML::Node& config) {
     TransformerConfig transformer_config;
     transformer_config.num_heads = config["num_heads"].as<uint32_t>();
@@ -99,17 +112,7 @@ TransformerConfig read_config(const YAML::Node& config) {
     transformer_config.num_blocks = config["num_blocks"].as<uint32_t>();
     transformer_config.vocab_size = config["vocab_size"].as<uint32_t>();
     transformer_config.max_sequence_length = config["max_sequence_length"].as<uint32_t>();
-
-    auto positional_embedding_str = config["positional_embedding_type"].as<std::string>("trainable");
-    if (positional_embedding_str == "trainable") {
-        transformer_config.positional_embedding_type = PositionalEmbeddingType::Trainable;
-    } else if (positional_embedding_str == "fixed") {
-        transformer_config.positional_embedding_type = PositionalEmbeddingType::Fixed;
-    } else {
-        throw std::runtime_error(fmt::format(
-            "Unknown positional embedding type: {}. Supported positional embedding types [trainable, fixed]",
-            positional_embedding_str));
-    }
+    transformer_config.positional_embedding_type = read_positional_embedding_type(config);
 
     if (auto experimental_config = config["experimental"]) {
         transformer_config.experimental.use_composite_layernorm =

--- a/tt-train/sources/ttml/models/gpt2.cpp
+++ b/tt-train/sources/ttml/models/gpt2.cpp
@@ -4,6 +4,7 @@
 
 #include "gpt2.hpp"
 
+#include "modules/positional_embeddings.hpp"
 #include "ops/binary_ops.hpp"
 #include "ops/unary_ops.hpp"
 
@@ -16,6 +17,7 @@ Transformer::Transformer(const TransformerConfig& config) {
     uint32_t num_heads = config.num_heads;
     float dropout_prob = config.dropout_prob;
     uint32_t num_blocks = config.num_blocks;
+    auto position_embedding_type = config.positional_embedding_type;
     auto use_composite_layernorm = config.experimental.use_composite_layernorm;
 
     fmt::print("Transformer configuration:\n");
@@ -25,6 +27,9 @@ Transformer::Transformer(const TransformerConfig& config) {
     fmt::print("    Num heads: {}\n", num_heads);
     fmt::print("    Dropout probability: {}\n", dropout_prob);
     fmt::print("    Num blocks: {}\n", num_blocks);
+    fmt::print(
+        "    Positional embedding type: {}\n",
+        position_embedding_type == PositionalEmbeddingType::Trainable ? "Trainable" : "Fixed");
     fmt::print("    Composite layernorm: {}\n", use_composite_layernorm);
 
     uint32_t vocab_size_divisible_by_32 = (vocab_size + 31) / 32 * 32;
@@ -41,7 +46,20 @@ Transformer::Transformer(const TransformerConfig& config) {
             embedding_dim));
     }
     tok_emb = std::make_shared<ttml::modules::Embedding>(vocab_size_divisible_by_32, embedding_dim);
-    pos_emb = std::make_shared<ttml::modules::Embedding>(max_sequence_length, embedding_dim);
+
+    auto create_positional_embedding = [position_embedding_type,
+                                        max_sequence_length,
+                                        embedding_dim,
+                                        dropout_prob]() -> std::shared_ptr<modules::PositionalEmbeddingBase> {
+        if (position_embedding_type == PositionalEmbeddingType::Trainable) {
+            return std::make_shared<ttml::modules::TrainablePositionalEmbedding>(
+                embedding_dim, dropout_prob, max_sequence_length);
+        } else {
+            return std::make_shared<ttml::modules::PositionalEmbedding>(
+                embedding_dim, dropout_prob, max_sequence_length);
+        }
+    };
+    pos_emb = create_positional_embedding();
     blocks.reserve(num_blocks);
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
         blocks.push_back(
@@ -61,12 +79,9 @@ Transformer::Transformer(const TransformerConfig& config) {
 }
 
 ttml::autograd::TensorPtr Transformer::operator()(
-    const ttml::autograd::TensorPtr& x,
-    const ttml::autograd::TensorPtr& positions,
-    const ttml::autograd::TensorPtr& mask) {
+    const ttml::autograd::TensorPtr& x, const ttml::autograd::TensorPtr& mask) {
     auto tok_emb_out = (*tok_emb)(x);
-    auto pos_emb_out = (*pos_emb)(positions);
-    auto out = ttml::ops::add(tok_emb_out, pos_emb_out);
+    auto out = (*pos_emb)(tok_emb_out);
     for (auto& block : blocks) {
         out = (*block)(out, mask);
     }
@@ -84,6 +99,16 @@ TransformerConfig read_config(const YAML::Node& config) {
     transformer_config.num_blocks = config["num_blocks"].as<uint32_t>();
     transformer_config.vocab_size = config["vocab_size"].as<uint32_t>();
     transformer_config.max_sequence_length = config["max_sequence_length"].as<uint32_t>();
+
+    auto positional_embedding_str = config["positional_embedding"].as<std::string>("trainable");
+    if (positional_embedding_str == "trainable") {
+        transformer_config.positional_embedding_type = PositionalEmbeddingType::Trainable;
+    } else if (positional_embedding_str == "fixed") {
+        transformer_config.positional_embedding_type = PositionalEmbeddingType::Fixed;
+    } else {
+        throw std::runtime_error(fmt::format("Unknown positional embedding type: {}", positional_embedding_str));
+    }
+
     if (auto experimental_config = config["experimental"]) {
         transformer_config.experimental.use_composite_layernorm =
             experimental_config["use_composite_layernorm"].as<bool>();

--- a/tt-train/sources/ttml/models/gpt2.hpp
+++ b/tt-train/sources/ttml/models/gpt2.hpp
@@ -9,8 +9,14 @@
 #include "modules/embedding_module.hpp"
 #include "modules/gpt_block.hpp"
 #include "modules/layer_norm_module.hpp"
+#include "modules/positional_embeddings.hpp"
 
 namespace ttml::models::gpt2 {
+
+enum class PositionalEmbeddingType {
+    Trainable,
+    Fixed,
+};
 
 struct TransformerConfig {
     uint32_t num_heads = 6;
@@ -19,6 +25,7 @@ struct TransformerConfig {
     uint32_t num_blocks = 6;
     uint32_t vocab_size = 256;
     uint32_t max_sequence_length = 256;
+    PositionalEmbeddingType positional_embedding_type = PositionalEmbeddingType::Trainable;
 
     struct Experimental {
         bool use_composite_layernorm = false;
@@ -29,7 +36,7 @@ struct TransformerConfig {
 class Transformer : public ttml::autograd::ModuleBase {
 private:
     std::shared_ptr<ttml::modules::Embedding> tok_emb;
-    std::shared_ptr<ttml::modules::Embedding> pos_emb;
+    std::shared_ptr<ttml::modules::PositionalEmbeddingBase> pos_emb;
     std::vector<std::shared_ptr<ttml::modules::GPTBlock>> blocks;
     std::shared_ptr<ttml::modules::LayerNormLayer> ln_fc;
     std::shared_ptr<ttml::modules::LinearLayer> fc;
@@ -37,10 +44,7 @@ private:
 public:
     explicit Transformer(const TransformerConfig& config);
 
-    ttml::autograd::TensorPtr operator()(
-        const ttml::autograd::TensorPtr& x,
-        const ttml::autograd::TensorPtr& positions,
-        const ttml::autograd::TensorPtr& mask);
+    ttml::autograd::TensorPtr operator()(const ttml::autograd::TensorPtr& x, const ttml::autograd::TensorPtr& mask);
 };
 
 [[nodiscard]] TransformerConfig read_config(const YAML::Node& config);

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -1,0 +1,104 @@
+#include "modules/positional_embeddings.hpp"
+
+#include "autograd/autocast_tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "init/tensor_initializers.hpp"
+#include "modules/dropout_module.hpp"
+#include "ops/binary_ops.hpp"
+
+namespace ttml::modules {
+
+namespace {
+
+autograd::AutocastTensor generate_positional_embedding_tensor(uint32_t sequence_length, uint32_t embedding_dim) {
+    std::vector<float> positional_embedding_data;
+    positional_embedding_data.reserve(sequence_length * embedding_dim);
+
+    const float div_const = 10000.0f;
+    for (uint32_t pos = 0; pos < sequence_length; ++pos) {
+        for (uint32_t emb_idx = 0; emb_idx < embedding_dim; ++emb_idx) {
+            float value = (emb_idx & 1) ? std::cos(pos / std::powf(div_const, 2 * emb_idx / embedding_dim))
+                                        : std::sin(pos / std::powf(div_const, 2 * emb_idx / embedding_dim));
+            positional_embedding_data.push_back(value);
+        }
+    }
+
+    auto shape = core::create_shape({1, 1, sequence_length, embedding_dim});
+    auto* device = &autograd::ctx().get_device();
+    auto tensor = core::from_vector(positional_embedding_data, shape, device);
+    return autograd::AutocastTensor(tensor);
+}
+
+}  // namespace
+
+PositionalEmbedding::PositionalEmbedding(uint32_t embedding_dim, float dropout_prob, uint32_t sequence_length) :
+    m_sequence_length(sequence_length) {
+    m_dropout = std::make_shared<DropoutLayer>(dropout_prob);
+    m_positional_embedding = generate_positional_embedding_tensor(sequence_length, embedding_dim);
+
+    create_name("positional_embedding");
+    register_module(m_dropout, "dropout");
+}
+
+autograd::TensorPtr PositionalEmbedding::operator()(const autograd::TensorPtr& input) {
+    auto input_tensor = input->get_value();
+    auto input_shape = input_tensor.get_logical_shape();
+    if (input_shape.rank() != 4) {
+        throw std::runtime_error(
+            "PositionalEmbedding: input tensor must have 4 dimensions. Got rank " + std::to_string(input_shape.rank()));
+    }
+
+    const uint32_t sequence_index = 2U;
+    if (input_shape[sequence_index] != m_sequence_length) {
+        throw std::runtime_error(fmt::format(
+            "PositionalEmbedding: input tensor sequence length ({}) does not match the expected value ({})",
+            input_shape[sequence_index],
+            m_sequence_length));
+    }
+
+    auto x = ops::add(input, m_positional_embedding);
+    x = (*m_dropout)(x);
+    return x;
+}
+
+void TrainablePositionalEmbedding::initialize_tensors(uint32_t sequence_length, uint32_t embedding_dim) {
+    auto* device = &autograd::ctx().get_device();
+    m_weight = autograd::create_tensor();
+    init::normal_init(
+        m_weight, core::create_shape({1, 1, sequence_length, embedding_dim}), /* normal params */ {0.F, 1.F});
+}
+
+TrainablePositionalEmbedding::TrainablePositionalEmbedding(
+    uint32_t embedding_dim, float dropout_prob, uint32_t sequence_length) :
+    m_sequence_length(sequence_length) {
+    m_dropout = std::make_shared<DropoutLayer>(dropout_prob);
+    initialize_tensors(sequence_length, embedding_dim);
+
+    create_name("trainable_positional_embedding");
+    register_module(m_dropout, "dropout");
+    register_tensor(m_weight, "weight");
+}
+
+autograd::TensorPtr TrainablePositionalEmbedding::operator()(const autograd::TensorPtr& input) {
+    auto input_tensor = input->get_value();
+    auto input_shape = input_tensor.get_logical_shape();
+    if (input_shape.rank() != 4) {
+        throw std::runtime_error(
+            "TrainablePositionalEmbedding: input tensor must have 4 dimensions. Got rank " +
+            std::to_string(input_shape.rank()));
+    }
+
+    const uint32_t sequence_index = 2U;
+    if (input_shape[sequence_index] != m_sequence_length) {
+        throw std::runtime_error(fmt::format(
+            "TrainablePositionalEmbedding: input tensor sequence length ({}) does not match the expected value ({})",
+            input_shape[sequence_index],
+            m_sequence_length));
+    }
+
+    auto x = ops::add(input, m_weight);
+    x = (*m_dropout)(x);
+    return x;
+}
+
+}  // namespace ttml::modules

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -17,8 +17,9 @@ autograd::AutocastTensor create_positional_embedding_tensor(uint32_t sequence_le
     const float div_const = 10000.F;
     for (uint32_t pos = 0; pos < sequence_length; ++pos) {
         for (uint32_t emb_idx = 0; emb_idx < embedding_dim; ++emb_idx) {
-            float value = (emb_idx & 1) ? std::cos(pos / std::powf(div_const, 2.F * emb_idx / embedding_dim))
-                                        : std::sin(pos / std::powf(div_const, 2.F * emb_idx / embedding_dim));
+            float value = (emb_idx & 1)
+                              ? std::cosf(pos / std::powf(div_const, static_cast<float>(emb_idx - 1) / embedding_dim))
+                              : std::sinf(pos / std::powf(div_const, static_cast<float>(emb_idx) / embedding_dim));
             positional_embedding_data.push_back(value);
         }
     }

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "modules/positional_embeddings.hpp"
 
 #include "autograd/autocast_tensor.hpp"

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -10,15 +10,15 @@ namespace ttml::modules {
 
 namespace {
 
-autograd::AutocastTensor generate_positional_embedding_tensor(uint32_t sequence_length, uint32_t embedding_dim) {
+autograd::AutocastTensor create_positional_embedding_tensor(uint32_t sequence_length, uint32_t embedding_dim) {
     std::vector<float> positional_embedding_data;
     positional_embedding_data.reserve(sequence_length * embedding_dim);
 
-    const float div_const = 10000.0f;
+    const float div_const = 10000.F;
     for (uint32_t pos = 0; pos < sequence_length; ++pos) {
         for (uint32_t emb_idx = 0; emb_idx < embedding_dim; ++emb_idx) {
-            float value = (emb_idx & 1) ? std::cos(pos / std::powf(div_const, 2 * emb_idx / embedding_dim))
-                                        : std::sin(pos / std::powf(div_const, 2 * emb_idx / embedding_dim));
+            float value = (emb_idx & 1) ? std::cos(pos / std::powf(div_const, 2.F * emb_idx / embedding_dim))
+                                        : std::sin(pos / std::powf(div_const, 2.F * emb_idx / embedding_dim));
             positional_embedding_data.push_back(value);
         }
     }
@@ -34,7 +34,7 @@ autograd::AutocastTensor generate_positional_embedding_tensor(uint32_t sequence_
 PositionalEmbedding::PositionalEmbedding(uint32_t embedding_dim, float dropout_prob, uint32_t sequence_length) :
     m_sequence_length(sequence_length) {
     m_dropout = std::make_shared<DropoutLayer>(dropout_prob);
-    m_positional_embedding = generate_positional_embedding_tensor(sequence_length, embedding_dim);
+    m_positional_embedding = create_positional_embedding_tensor(sequence_length, embedding_dim);
 
     create_name("positional_embedding");
     register_module(m_dropout, "dropout");

--- a/tt-train/sources/ttml/modules/positional_embeddings.hpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.hpp
@@ -24,7 +24,7 @@ private:
     autograd::AutocastTensor m_positional_embedding;
 
 public:
-    PositionalEmbedding(uint32_t embedding_dim, float dropout_prob = 0.F, uint32_t sequence_length = 1024);
+    explicit PositionalEmbedding(uint32_t embedding_dim, float dropout_prob = 0.F, uint32_t sequence_length = 1024);
     [[nodiscard]] autograd::TensorPtr operator()(const autograd::TensorPtr& input) override;
 };
 
@@ -35,7 +35,8 @@ class TrainablePositionalEmbedding : public PositionalEmbeddingBase {
     void initialize_tensors(uint32_t sequence_length, uint32_t embedding_dim);
 
 public:
-    TrainablePositionalEmbedding(uint32_t embedding_dim, float dropout_prob = 0.F, uint32_t sequence_length = 1024);
+    explicit TrainablePositionalEmbedding(
+        uint32_t embedding_dim, float dropout_prob = 0.F, uint32_t sequence_length = 1024);
     [[nodiscard]] autograd::TensorPtr operator()(const autograd::TensorPtr& input) override;
 };
 

--- a/tt-train/sources/ttml/modules/positional_embeddings.hpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "autograd/auto_context.hpp"
+#include "autograd/autocast_tensor.hpp"
+#include "autograd/module_base.hpp"
+#include "autograd/tensor.hpp"
+#include "modules/dropout_module.hpp"
+
+namespace ttml::modules {
+
+class PositionalEmbeddingBase : public autograd::ModuleBase {
+public:
+    virtual autograd::TensorPtr operator()(const autograd::TensorPtr& input) = 0;
+};
+
+class PositionalEmbedding : public PositionalEmbeddingBase {
+private:
+    uint32_t m_sequence_length{};
+    std::shared_ptr<DropoutLayer> m_dropout;
+    autograd::AutocastTensor m_positional_embedding;
+
+public:
+    PositionalEmbedding(uint32_t embedding_dim, float dropout_prob = 0.F, uint32_t sequence_length = 1024);
+    [[nodiscard]] autograd::TensorPtr operator()(const autograd::TensorPtr& input) override;
+};
+
+class TrainablePositionalEmbedding : public PositionalEmbeddingBase {
+    uint32_t m_sequence_length{};
+    autograd::TensorPtr m_weight;
+    std::shared_ptr<DropoutLayer> m_dropout;
+    void initialize_tensors(uint32_t sequence_length, uint32_t embedding_dim);
+
+public:
+    TrainablePositionalEmbedding(uint32_t embedding_dim, float dropout_prob = 0.F, uint32_t sequence_length = 1024);
+    [[nodiscard]] autograd::TensorPtr operator()(const autograd::TensorPtr& input) override;
+};
+
+}  // namespace ttml::modules

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "autograd/auto_context.hpp"
+#include "autograd/autocast_tensor.hpp"
 #include "autograd/graph.hpp"
 #include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"
@@ -20,13 +21,53 @@
 
 namespace ttml::ops {
 
+namespace {
+
+bool is_batch_broadcasted(const autograd::TensorPtr& a, const ttnn::Tensor& grad) {
+    auto a_shape = a->get_value().get_logical_shape();
+    auto b_shape = grad.get_logical_shape();
+    if (a_shape.rank() != b_shape.rank()) {
+        return false;
+    }
+    for (size_t i = 1; i < a_shape.size(); ++i) {
+        if (a_shape[i] != b_shape[i]) {
+            return false;
+        }
+    }
+
+    if (a_shape[0] == 1 && b_shape[0] != 1) {
+        return true;
+    }
+
+    return false;
+}
+
+}  // namespace
+
+autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::AutocastTensor& b) {
+    auto out = autograd::create_tensor(ttnn::add(a->get_value(), b.get_tensor()));
+    autograd::GradFunction grad = [a, out]() { a->add_grad(out->get_grad()); };
+    auto links = autograd::get_links(a);
+    out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
+    return out;
+}
+
 autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {
     auto out = autograd::create_tensor();
 
     out->set_value(ttnn::add(a->get_value(), b->get_value()));
     autograd::GradFunction grad = [a, b, out]() {
-        a->add_grad(out->get_grad());
-        b->add_grad(out->get_grad());
+        if (is_batch_broadcasted(a, out->get_grad())) {
+            a->add_grad(ttnn_fixed::sum_over_dim(out->get_grad(), /* axis */ 0));
+        } else {
+            a->add_grad(out->get_grad());
+        }
+
+        if (is_batch_broadcasted(b, out->get_grad())) {
+            b->add_grad(ttnn_fixed::sum_over_dim(out->get_grad(), /* axis */ 0));
+        } else {
+            b->add_grad(out->get_grad());
+        }
     };
     auto links = autograd::get_links(a, b);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
@@ -96,6 +137,10 @@ autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::Tens
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
 
     return out;
+}
+
+autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::AutocastTensor& b) {
+    return a + b;
 }
 
 autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::TensorPtr& b) {

--- a/tt-train/sources/ttml/ops/binary_ops.hpp
+++ b/tt-train/sources/ttml/ops/binary_ops.hpp
@@ -4,15 +4,18 @@
 
 #pragma once
 
+#include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"
 namespace ttml::ops {
 
+autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::AutocastTensor& b);
 autograd::TensorPtr operator+(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator*(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator*(const autograd::TensorPtr& a, float b);
 autograd::TensorPtr operator-(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr operator/(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 
+autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::AutocastTensor& b);
 autograd::TensorPtr add(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr sub(const autograd::TensorPtr& a, const autograd::TensorPtr& b);
 autograd::TensorPtr mul(const autograd::TensorPtr& a, const autograd::TensorPtr& b);

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -21,8 +21,8 @@
 using ttml::autograd::TensorPtr;
 
 using DatasetSample = std::pair<std::span<const uint32_t>, std::span<const uint32_t>>;
-// tokens, targets, mask, positions
-using BatchType = std::tuple<TensorPtr, TensorPtr, TensorPtr, TensorPtr>;
+// tokens, targets, mask
+using BatchType = std::tuple<TensorPtr, TensorPtr, TensorPtr>;
 using DataLoader = ttml::datasets::DataLoader<
     ttml::datasets::InMemoryTokenDataset,
     std::function<BatchType(std::vector<DatasetSample> &&samples)>,
@@ -76,17 +76,10 @@ void train_test(bool use_moreh_adamw = false) {
         std::vector<uint32_t> data;
         std::vector<int32_t> targets;
         ttml::autograd::TensorPtr masks_tensor;
-        ttml::autograd::TensorPtr positions_tensor;
     };
     CachedHostData cached_data;
-    std::vector<uint32_t> positions;
+
     std::vector<float> mask;
-    positions.reserve((size_t)config.batch_size * sequence_length);
-    for (int sample_idx = 0; sample_idx < config.batch_size; ++sample_idx) {
-        for (int i = 0; i < sequence_length; ++i) {
-            positions.push_back(i);
-        }
-    }
     auto num_heads = config.transformer_config.num_heads;
     mask.reserve((size_t)config.batch_size * sequence_length * sequence_length * num_heads);
     for (int sample_idx = 0; sample_idx < config.batch_size; ++sample_idx) {
@@ -100,8 +93,6 @@ void train_test(bool use_moreh_adamw = false) {
     }
     cached_data.masks_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
         mask, ttml::core::create_shape({config.batch_size, num_heads, sequence_length, sequence_length}), device));
-    cached_data.positions_tensor = ttml::autograd::create_tensor(ttml::core::from_vector<uint32_t, DataType::UINT32>(
-        positions, ttml::core::create_shape({config.batch_size, 1, 1, sequence_length}), device, Layout::ROW_MAJOR));
 
     std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
         [sequence_length, num_heads, vocab_size = tokenizer.get_vocab_size(), device, &cached_data](
@@ -130,7 +121,7 @@ void train_test(bool use_moreh_adamw = false) {
             end_timer = std::chrono::high_resolution_clock::now();
             duration = std::chrono::duration_cast<std::chrono::microseconds>(end_timer - start_timer).count();
             fmt::print("dataloader step time {} ms\n", (double)duration / 1000.);
-            return std::make_tuple(data_tensor, targets_tensor, cached_data.masks_tensor, cached_data.positions_tensor);
+            return std::make_tuple(data_tensor, targets_tensor, cached_data.masks_tensor);
         };
     auto train_dataloader = DataLoader(dataset, /* batch_size */ config.batch_size, /* shuffle */ true, collate_fn);
 
@@ -155,10 +146,10 @@ void train_test(bool use_moreh_adamw = false) {
     std::vector<double> steps_time;
     std::vector<float> losses;
 
-    for (auto [features, target, masks, positions] : train_dataloader) {
+    for (auto [features, target, masks] : train_dataloader) {
         auto start_timer = std::chrono::high_resolution_clock::now();
         optimizer->zero_grad();
-        auto output = (*model)(features, positions, masks);
+        auto output = (*model)(features, masks);
         auto loss = ttml::ops::nll_loss(output, target);
         auto loss_float = ttml::core::to_vector(loss->get_value())[0];
         loss->backward();

--- a/tt-train/tests/ops/positional_embedding_test.cpp
+++ b/tt-train/tests/ops/positional_embedding_test.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <core/ttnn_all_includes.hpp>
+
+#include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "modules/positional_embeddings.hpp"
+
+TEST(PositionalEmbeddingTest, NonTrainableEmbedding) {
+    using namespace ttml;
+
+    auto* device = &autograd::ctx().get_device();
+
+    uint32_t batch_size = 2;
+    uint32_t sentence_size = 2;
+    uint32_t embedding_dim = 4;
+
+    auto x =
+        autograd::create_tensor(core::zeros(core::create_shape({batch_size, 1, sentence_size, embedding_dim}), device));
+    auto pos_emb = modules::PositionalEmbedding(embedding_dim, 0.F, sentence_size);
+    auto y = pos_emb(x);
+
+    auto y_vector = core::to_vector(y->get_value());
+    std::vector<float> target_vector{
+        0.0000F,
+        1.0000F,
+        0.0000F,
+        1.0000F,
+        0.8415F,
+        0.5403F,
+        0.0100F,
+        0.9999F,
+        0.0000F,
+        1.0000F,
+        0.0000F,
+        1.0000F,
+        0.8415F,
+        0.5403F,
+        0.0100F,
+        0.9999F,
+
+    };
+
+    EXPECT_EQ(y_vector.size(), target_vector.size());
+    const float eps = 4e-3F;
+    for (size_t i = 0; i < y_vector.size(); i++) {
+        EXPECT_NEAR(y_vector[i], target_vector[i], eps);
+    }
+}


### PR DESCRIPTION
### Problem description
We want to try out original positional non-trainable embedding. 

### What's changed
Add positional embedding modules. 
Add missing dropout after embedding composition. 
Add batch broadcast to plus operation. 
Add tests 

Main vs trainable + Dropout (previously missing)
![image](https://github.com/user-attachments/assets/f9b1d180-1bb7-4daf-9bd8-86334936c247)

Trainable vs non-trainable positional embedding (both include previously missing dropout)
![image](https://github.com/user-attachments/assets/9b06e63c-a723-49e8-921f-6aea39155c49)


### Checklist
- [x] Post commit CI passes
- [x] New/Existing tests provide coverage for changes
