### PR TITLE
ScopedGraphCapture

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 class TestScopedGraphCapture : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
-    tt::tt_metal::Device* device = &(this->getDevice());
+    tt::tt_metal::IDevice* device = &(this->getDevice());
 
     auto operation = [&device](tt::tt_metal::DataType datatype) {
         const auto input_a = ttnn::TensorSpec(

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -8,6 +8,8 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_consts.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/normalization/softmax/softmax.hpp"
 
 #include <string>
 
@@ -121,3 +123,99 @@ INSTANTIATE_TEST_SUITE_P(
         return ss.str();
     });
 }  // namespace ttnn::graph::test
+
+class TestGraphCaptureScopeGuard : public ttnn::TTNNFixtureWithDevice {};
+TEST_F(TestGraphCaptureScopeGuard, GraphCaptureScopedGuard) {
+    tt::tt_metal::Device* device = &(this->getDevice());
+
+    auto operation = [&device](tt::tt_metal::DataType datatype) {
+        const auto input_a = ttnn::TensorSpec(
+            ttnn::SimpleShape(tt::tt_metal::Array4D{1, 4, 512, 512}),
+            tt::tt_metal::TensorLayout(
+                datatype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor_a = tt::tt_metal::create_device_tensor(input_a, device);
+        const auto output_tensor = ttnn::softmax(input_tensor_a, -1);
+    };
+
+    // build reference
+    std::vector<std::string> ref_calltrace;
+    nlohmann::json ref_json_trace;
+    {
+        auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+        operation(tt::tt_metal::DataType::BFLOAT16);
+        ref_json_trace = capture.end_graph_capture();
+        ref_calltrace = ttnn::graph::extract_calltrace(ref_json_trace);
+    }
+    for (const auto& call : ref_calltrace) {
+        std::cout << call << std::endl;
+    }
+
+    // with manual exception in the nested loop
+    {
+        auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+        try {
+            auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+            operation(tt::tt_metal::DataType::BFLOAT16);
+            throw std::runtime_error("Expected");
+        } catch (const std::exception& e) {
+            EXPECT_EQ(std::string(e.what()), "Expected");
+        }
+        auto json_trace = capture.end_graph_capture();
+        EXPECT_EQ(ttnn::graph::extract_calltrace(json_trace), ref_calltrace);
+    }
+
+    // with exception in the operation #1
+    {
+        auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+        try {
+            auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+            operation(tt::tt_metal::DataType::INVALID);  // fails at a first create_device_tensor (before softmax)
+        } catch (const std::exception& e) {
+            EXPECT_TRUE(std::string(e.what()).find("TT_ASSERT") != std::string::npos);
+        }
+        auto json_trace = capture.end_graph_capture();
+        EXPECT_EQ(
+            ttnn::graph::extract_calltrace(json_trace),
+            std::vector<std::string>({"tt::tt_metal::create_device_tensor"}));
+    }
+
+    // with exception in the operation #2
+    {
+        auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+        try {
+            auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+            operation(tt::tt_metal::DataType::UINT8);  // fails in the softmax::validate (not supported data type)
+        } catch (const std::exception& e) {
+            EXPECT_TRUE(std::string(e.what()).find("FATAL") != std::string::npos);
+        }
+        auto json_trace = capture.end_graph_capture();
+
+        EXPECT_EQ(
+            ttnn::graph::extract_calltrace(json_trace),
+            std::vector<std::string>(
+                {"tt::tt_metal::create_device_tensor",
+                 "ttnn::softmax",
+                 "ttnn::prim::old_infra_device_operation",
+                 "Softmax",
+                 "tt::tt_metal::create_device_tensor"}));
+    }
+
+    // check original again to ensure it's not affected by the thrown exceptions
+    {
+        auto capture = ttnn::graph::GraphCaptureScopeGuard(IGraphProcessor::RunMode::NO_DISPATCH);
+        operation(tt::tt_metal::DataType::BFLOAT16);
+        auto json_trace = capture.end_graph_capture();
+        // std::cout << json_trace.dump(4);
+        EXPECT_EQ(ttnn::graph::extract_calltrace(json_trace), ref_calltrace);
+
+        EXPECT_EQ(json_trace.size(), ref_json_trace.size());
+        // tensor ids can be different, therfore checking if general structure is the same
+        for (size_t i = 0; i < json_trace.size(); i++) {
+            const auto& v = json_trace[i];
+            const auto& ref_v = ref_json_trace[i];
+            EXPECT_EQ(v[ttnn::graph::kCounter], ref_v[ttnn::graph::kCounter]);
+            EXPECT_EQ(v[ttnn::graph::kConnections], ref_v[ttnn::graph::kConnections]);
+            EXPECT_EQ(v[ttnn::graph::kNodeType], ref_v[ttnn::graph::kNodeType]);
+        }
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -164,21 +164,6 @@ TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
         EXPECT_EQ(ttnn::graph::extract_calltrace(json_trace), ref_calltrace);
     }
 
-    // with exception in the operation #1
-    {
-        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
-        try {
-            auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
-            operation(tt::tt_metal::DataType::INVALID);  // fails at a first create_device_tensor (before softmax)
-        } catch (const std::exception& e) {
-            EXPECT_TRUE(std::string(e.what()).find("TT_ASSERT") != std::string::npos);
-        }
-        auto json_trace = capture.end_graph_capture();
-        EXPECT_EQ(
-            ttnn::graph::extract_calltrace(json_trace),
-            std::vector<std::string>({"tt::tt_metal::create_device_tensor"}));
-    }
-
     // with exception in the operation #2
     {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -20,12 +20,11 @@ using namespace tt::tt_metal;
 
 namespace {
 std::string demangle(const char* name) {
-
     int status = -4;
 
     char* res = abi::__cxa_demangle(name, NULL, NULL, &status);
 
-    const char* const demangled_name = (status==0)?res:name;
+    const char* const demangled_name = (status == 0) ? res : name;
 
     std::string ret_val(demangled_name);
 
@@ -36,24 +35,18 @@ std::string demangle(const char* name) {
 
 std::string tensorMemoryLayoutToString(TensorMemoryLayout layout) {
     switch (layout) {
-        case TensorMemoryLayout::INTERLEAVED:
-            return "INTERLEAVED";
-        case TensorMemoryLayout::SINGLE_BANK:
-            return "SINGLE_BANK";
-        case TensorMemoryLayout::HEIGHT_SHARDED:
-            return "HEIGHT_SHARDED";
-        case TensorMemoryLayout::WIDTH_SHARDED:
-            return "WIDTH_SHARDED";
-        case TensorMemoryLayout::BLOCK_SHARDED:
-            return "BLOCK_SHARDED";
-        default:
-            return "UNKNOWN"; // Handle unexpected values
+        case TensorMemoryLayout::INTERLEAVED: return "INTERLEAVED";
+        case TensorMemoryLayout::SINGLE_BANK: return "SINGLE_BANK";
+        case TensorMemoryLayout::HEIGHT_SHARDED: return "HEIGHT_SHARDED";
+        case TensorMemoryLayout::WIDTH_SHARDED: return "WIDTH_SHARDED";
+        case TensorMemoryLayout::BLOCK_SHARDED: return "BLOCK_SHARDED";
+        default: return "UNKNOWN";  // Handle unexpected values
     }
 }
 
-template<class Variant>
-std::type_info const& get_type_in_var(const Variant& v){
-    return std::visit( [](auto&&x)->decltype(auto){ return typeid(x); }, v );
+template <class Variant>
+const std::type_info& get_type_in_var(const Variant& v) {
+    return std::visit([](auto&& x) -> decltype(auto) { return typeid(x); }, v);
 }
 
 nlohmann::json to_json(const ttnn::graph::GraphProcessor::Vertex& data) {
@@ -73,26 +66,40 @@ nlohmann::json to_json(const std::vector<ttnn::graph::GraphProcessor::Vertex>& d
     return j;
 }
 
-}
+}  // namespace
 
 namespace ttnn::graph {
 
 GraphProcessor::GraphProcessor(RunMode mode) : run_mode(mode) {
     begin_capture(mode);
-    begin_function_any_map[typeid(std::reference_wrapper<std::vector<Tensor>>)] = [ptr = this]  (const std::any& val) mutable {ptr->begin_function_process_ref_vector(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<Tensor>>>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_vector_optional(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<const Tensor>>>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_vector_optional_const(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<Tensor>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_tensor(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<const Tensor>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_const_tensor(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<std::optional<Tensor>>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_optional_tensor(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<std::optional<Tensor> const>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_optional_tensor_const(val);};
-    begin_function_any_map[typeid(std::reference_wrapper<std::optional<const Tensor>>)] = [ptr = this] (const std::any& val) mutable {ptr->begin_function_process_ref_optional_const_tensor(val);};
+    begin_function_any_map[typeid(std::reference_wrapper<std::vector<Tensor>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->begin_function_process_ref_vector(val); };
+    begin_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<Tensor>>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->begin_function_process_ref_vector_optional(val); };
+    begin_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<const Tensor>>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->begin_function_process_ref_vector_optional_const(val); };
+    begin_function_any_map[typeid(std::reference_wrapper<Tensor>)] = [ptr = this](const std::any& val) mutable {
+        ptr->begin_function_process_ref_tensor(val);
+    };
+    begin_function_any_map[typeid(std::reference_wrapper<const Tensor>)] = [ptr = this](const std::any& val) mutable {
+        ptr->begin_function_process_ref_const_tensor(val);
+    };
+    begin_function_any_map[typeid(std::reference_wrapper<std::optional<Tensor>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->begin_function_process_ref_optional_tensor(val); };
+    begin_function_any_map[typeid(std::reference_wrapper<const std::optional<Tensor>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->begin_function_process_ref_optional_tensor_const(val); };
+    begin_function_any_map[typeid(std::reference_wrapper<std::optional<const Tensor>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->begin_function_process_ref_optional_const_tensor(val); };
 
-    end_function_any_map[typeid(std::reference_wrapper<std::vector<Tensor>>)] = [ptr = this] (const std::any& val) mutable {ptr->end_function_process_vector(val);};
-    end_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<Tensor>>>)] = [ptr = this] (const std::any& val) mutable {ptr->end_function_process_vector_optional(val);};
-    end_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<const Tensor>>>)] = [ptr = this] (const std::any& val) mutable {ptr->end_function_process_vector_optional_const(val);};
-    end_function_any_map[typeid(std::reference_wrapper<Tensor>)] = [ptr = this] (const std::any& val) mutable {ptr->end_function_process_tensor(val);};
-
+    end_function_any_map[typeid(std::reference_wrapper<std::vector<Tensor>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->end_function_process_vector(val); };
+    end_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<Tensor>>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->end_function_process_vector_optional(val); };
+    end_function_any_map[typeid(std::reference_wrapper<std::vector<std::optional<const Tensor>>>)] =
+        [ptr = this](const std::any& val) mutable { ptr->end_function_process_vector_optional_const(val); };
+    end_function_any_map[typeid(std::reference_wrapper<Tensor>)] = [ptr = this](const std::any& val) mutable {
+        ptr->end_function_process_tensor(val);
+    };
 }
 void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
     const std::lock_guard<std::mutex> lock(mutex);
@@ -101,21 +108,16 @@ void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
     auto counter = graph.size();
 
     std::unordered_map<std::string, std::string> params = {
-            {kSize, std::to_string(buffer->size())},
-            {kAddress, std::to_string(buffer->address())},
-            {kType, buffer->is_dram() ? "DRAM" : "L1"},
-            {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
-            {kPageSize, std::to_string(buffer->page_size())},
-            {kNumCores, std::to_string(buffer->num_cores().value_or(0))}, // use 0 for interleaved
-            {kDeviceId, std::to_string(buffer->device()->id())}
-    };
+        {kSize, std::to_string(buffer->size())},
+        {kAddress, std::to_string(buffer->address())},
+        {kType, buffer->is_dram() ? "DRAM" : "L1"},
+        {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
+        {kPageSize, std::to_string(buffer->page_size())},
+        {kNumCores, std::to_string(buffer->num_cores().value_or(0))},  // use 0 for interleaved
+        {kDeviceId, std::to_string(buffer->device()->id())}};
     {
-        graph.push_back(Vertex{
-            .counter = counter,
-            .node_type = kNodeBufferAllocate,
-            .params = params,
-            .connections = {buffer_id}
-        });
+        graph.push_back(
+            Vertex{.counter = counter, .node_type = kNodeBufferAllocate, .params = params, .connections = {buffer_id}});
         graph[current_op_id.top()].connections.push_back(counter);
     }
 }
@@ -125,26 +127,25 @@ void GraphProcessor::track_deallocate(tt::tt_metal::Buffer* buffer) {
     auto buffer_id = add_buffer(buffer);
     auto counter = graph.size();
     std::unordered_map<std::string, std::string> params = {
-            {kSize, std::to_string(buffer->size())},
-            {kType, buffer->is_dram() ? "DRAM" : "L1"},
-            {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
-            {kPageSize, std::to_string(buffer->page_size())},
-            {kNumCores, std::to_string(buffer->num_cores().value_or(0))}, // use 0 for interleaved
-            {kDeviceId, std::to_string(buffer->device()->id())}
-    };
+        {kSize, std::to_string(buffer->size())},
+        {kType, buffer->is_dram() ? "DRAM" : "L1"},
+        {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
+        {kPageSize, std::to_string(buffer->page_size())},
+        {kNumCores, std::to_string(buffer->num_cores().value_or(0))},  // use 0 for interleaved
+        {kDeviceId, std::to_string(buffer->device()->id())}};
     {
         graph.push_back(Vertex{
-            .counter = counter,
-            .node_type = kNodeBufferDeallocate,
-            .params = params,
-            .connections = {buffer_id}
-        });
+            .counter = counter, .node_type = kNodeBufferDeallocate, .params = params, .connections = {buffer_id}});
         graph[current_op_id.top()].connections.push_back(counter);
     }
-
 }
 
-void GraphProcessor::track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated, const tt::tt_metal::IDevice* device) {
+void GraphProcessor::track_allocate_cb(
+    const CoreRangeSet& core_range_set,
+    uint64_t addr,
+    uint64_t size,
+    bool is_globally_allocated,
+    const tt::tt_metal::IDevice* device) {
     TT_ASSERT(device);
     const std::lock_guard<std::mutex> lock(mutex);
     std::unordered_map<std::string, std::string> params = {
@@ -152,19 +153,12 @@ void GraphProcessor::track_allocate_cb(const CoreRangeSet &core_range_set, uint6
         {kAddress, std::to_string(addr)},
         {kCoreRangeSet, core_range_set.str()},
         {kGloballyAllocated, std::to_string(is_globally_allocated)},
-        {kDeviceId, std::to_string(device->id())}
-    };
+        {kDeviceId, std::to_string(device->id())}};
     auto counter = graph.size();
     {
-        graph.push_back({
-            .counter = counter,
-            .node_type = kNodeCBAllocate,
-            .params = params,
-            .connections = {}
-        });
+        graph.push_back({.counter = counter, .node_type = kNodeCBAllocate, .params = params, .connections = {}});
         graph[current_op_id.top()].connections.push_back(counter);
     }
-
 }
 
 void GraphProcessor::track_deallocate_cb(const tt::tt_metal::IDevice* device) {
@@ -175,11 +169,8 @@ void GraphProcessor::track_deallocate_cb(const tt::tt_metal::IDevice* device) {
         graph.push_back(Vertex{
             .counter = counter,
             .node_type = kNodeCBDeallocateAll,
-            .params = {
-                {kDeviceId, std::to_string(device->id())}
-            },
-            .connections = {current_op_id.top()}
-        });
+            .params = {{kDeviceId, std::to_string(device->id())}},
+            .connections = {current_op_id.top()}});
         graph[current_op_id.top()].connections.push_back(counter);
     }
 }
@@ -213,15 +204,13 @@ void GraphProcessor::track_function_start(std::string_view function_name, std::s
             .counter = counter,
             .node_type = kNodeFunctionStart,
             .params = params,
-            .connections = {/*current_op_id.top()*/}
-        });
-        if ( last_finished_op_id != -1 ) {
+            .connections = {/*current_op_id.top()*/}});
+        if (last_finished_op_id != -1) {
             graph[last_finished_op_id].connections.push_back(counter);
             last_finished_op_id = -1;
         }
         graph[current_op_id.top()].connections.push_back(counter);
         current_op_id.push(counter);
-
     }
 
     for (auto& any : input_parameters) {
@@ -242,12 +231,8 @@ void GraphProcessor::track_function_end_impl() {
 
     auto counter = graph.size();
     {
-        graph.push_back(Vertex{
-            .counter = counter,
-            .node_type = kNodeFunctionEnd,
-            .params = {{kName, name}},
-            .connections = {}
-        });
+        graph.push_back(
+            Vertex{.counter = counter, .node_type = kNodeFunctionEnd, .params = {{kName, name}}, .connections = {}});
         graph[current_op_id.top()].connections.push_back(counter);
     }
     last_finished_op_id = counter;
@@ -289,7 +274,9 @@ int GraphProcessor::add_tensor(const Tensor& t) {
         storage);
     std::int64_t tensor_id;
     if (not t.tensor_id.has_value()) {
-        tt::log_warning("Tensor doesn't have tensor_id, generating new one. Ideally this should not happen. Please set tensor_id for this tensor ahead of time.");
+        tt::log_warning(
+            "Tensor doesn't have tensor_id, generating new one. Ideally this should not happen. Please set tensor_id "
+            "for this tensor ahead of time.");
         tensor_id = ttnn::CoreIDs::instance().fetch_and_increment_tensor_id();
     } else {
         tensor_id = t.tensor_id.value();
@@ -303,12 +290,14 @@ int GraphProcessor::add_tensor(const Tensor& t) {
     };
 
     if (tensor_id_to_counter.count(tensor_id) == 0) {
-        graph.push_back(Vertex{.counter = tensor_counter, .node_type = kNodeTensor, .params = params, .connections = {}});
+        graph.push_back(
+            Vertex{.counter = tensor_counter, .node_type = kNodeTensor, .params = params, .connections = {}});
         tensor_id_to_counter[tensor_id] = tensor_counter;
     }
 
     if (buffers.empty()) {
-        tt::log_info("Tensor doesn't have buffer, but storage is {}", demangle(get_type_in_var(t.get_storage()).name()));
+        tt::log_info(
+            "Tensor doesn't have buffer, but storage is {}", demangle(get_type_in_var(t.get_storage()).name()));
     }
 
     for (auto& buffer : buffers) {
@@ -327,22 +316,15 @@ int GraphProcessor::add_buffer(const tt::tt_metal::Buffer* buffer) {
             {kSize, std::to_string(buffer->size())},
             {kType, buffer->is_dram() ? "DRAM" : "L1"},
             {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
-            {kDeviceId, std::to_string(buffer->device()->id())}
-        };
+            {kDeviceId, std::to_string(buffer->device()->id())}};
 
-        graph.push_back(Vertex{
-            .counter = counter,
-            .node_type = kNodeBuffer,
-            .params = params,
-            .connections = {}
-        });
+        graph.push_back(Vertex{.counter = counter, .node_type = kNodeBuffer, .params = params, .connections = {}});
         graph[current_op_id.top()].connections.push_back(counter);
         buffer_id_to_counter[buffer_id] = counter;
         return counter;
     }
     return buffer_id_to_counter[buffer_id];
 }
-
 
 void GraphProcessor::begin_function_process_ref_vector(const std::any& any_val) {
     const auto& tensor_vec = std::any_cast<std::reference_wrapper<std::vector<Tensor>>>(any_val).get();
@@ -361,7 +343,8 @@ void GraphProcessor::begin_function_process_ref_vector_optional(const std::any& 
     }
 }
 void GraphProcessor::begin_function_process_ref_vector_optional_const(const std::any& any_val) {
-    const auto& tensor_vec = std::any_cast<std::reference_wrapper<std::vector<std::optional<const Tensor>>>>(any_val).get();
+    const auto& tensor_vec =
+        std::any_cast<std::reference_wrapper<std::vector<std::optional<const Tensor>>>>(any_val).get();
     for (auto& it : tensor_vec) {
         if (it.has_value()) {
             int tensor_id = add_tensor(it.value());
@@ -387,7 +370,7 @@ void GraphProcessor::begin_function_process_ref_optional_tensor(const std::any& 
     }
 }
 void GraphProcessor::begin_function_process_ref_optional_tensor_const(const std::any& any_val) {
-    const auto& tensor = std::any_cast<std::reference_wrapper<std::optional<Tensor> const>>(any_val).get();
+    const auto& tensor = std::any_cast<std::reference_wrapper<const std::optional<Tensor>>>(any_val).get();
     if (tensor.has_value()) {
         int tensor_id = add_tensor(tensor.value());
         graph[tensor_id].connections.push_back(current_op_id.top());
@@ -417,7 +400,8 @@ void GraphProcessor::end_function_process_vector_optional(const std::any& any_va
     }
 }
 void GraphProcessor::end_function_process_vector_optional_const(const std::any& any_val) {
-    const auto& tensor_vec = std::any_cast<std::reference_wrapper<std::vector<std::optional<const Tensor>>>>(any_val).get();
+    const auto& tensor_vec =
+        std::any_cast<std::reference_wrapper<std::vector<std::optional<const Tensor>>>>(any_val).get();
     for (auto& it : tensor_vec) {
         if (it.has_value()) {
             int tensor_id = add_tensor(it.value());
@@ -443,12 +427,7 @@ void GraphProcessor::begin_capture(RunMode mode) {
     graph.clear();
     buffer_id_to_counter.clear();
     tensor_id_to_counter.clear();
-    graph.push_back(Vertex{
-        .counter = 0,
-        .node_type = kNodeCaptureStart,
-        .params = {},
-        .connections = {}
-    });
+    graph.push_back(Vertex{.counter = 0, .node_type = kNodeCaptureStart, .params = {}, .connections = {}});
 
     if (!tt::tt_metal::GraphTracker::instance().get_hook()) {
         hook = std::make_shared<ProcessorHooks>();
@@ -460,18 +439,15 @@ void GraphProcessor::begin_capture(RunMode mode) {
 nlohmann::json GraphProcessor::end_capture() {
     const std::lock_guard<std::mutex> lock(mutex);
     int counter = graph.size();
-    graph.push_back(Vertex{
-        .counter = counter,
-        .node_type = kNodeCaptureEnd,
-        .params = {},
-        .connections = {}
-    });
-    if ( last_finished_op_id != -1 ) {
+    graph.push_back(Vertex{.counter = counter, .node_type = kNodeCaptureEnd, .params = {}, .connections = {}});
+    if (last_finished_op_id != -1) {
         graph[last_finished_op_id].connections.push_back(counter);
     } else {
         // lets connect capture_start with capture_end
         // it means we didn't capture any functions
-        TT_ASSERT(current_op_id.size(), "Graph size cannot be 0. This means that track_function_end was called more than begin.");
+        TT_ASSERT(
+            current_op_id.size(),
+            "Graph size cannot be 0. This means that track_function_end was called more than begin.");
         graph[0].connections.push_back(counter);
     }
     clean_hook();
@@ -486,36 +462,38 @@ void GraphProcessor::clean_hook() {
     }
 }
 
-GraphProcessor::~GraphProcessor() {
-    clean_hook();
-}
+GraphProcessor::~GraphProcessor() { clean_hook(); }
 
 void GraphProcessor::begin_graph_capture(RunMode mode = RunMode::NORMAL) {
     tt::tt_metal::GraphTracker::instance().push_processor(std::make_shared<GraphProcessor>(mode));
-
 }
 nlohmann::json GraphProcessor::end_graph_capture() {
-        auto res = tt::tt_metal::GraphTracker::instance().get_processors().back()->end_capture();
-        tt::tt_metal::GraphTracker::instance().pop_processor();
-        return res;
+    auto res = tt::tt_metal::GraphTracker::instance().get_processors().back()->end_capture();
+    tt::tt_metal::GraphTracker::instance().pop_processor();
+    return res;
 }
 
-bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer) {
-    return do_block;
+bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* buffer) { return do_block; }
+
+bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) { return do_block; }
+
+bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
+
+void ProcessorHooks::set_block(bool block) { do_block = block; }
+bool ProcessorHooks::get_block() const { return do_block; }
+
+GraphCaptureScopeGuard::GraphCaptureScopeGuard(GraphProcessor::RunMode mode) {
+    GraphProcessor::begin_graph_capture(mode);
+    is_active = true;
+}
+GraphCaptureScopeGuard::~GraphCaptureScopeGuard() {
+    if (is_active) {
+        GraphProcessor::end_graph_capture();
+    }
+}
+nlohmann::json GraphCaptureScopeGuard::end_graph_capture() {
+    is_active = false;
+    return GraphProcessor::end_graph_capture();
 }
 
-bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* buffer) {
-    return do_block;
-}
-
-bool ProcessorHooks::hook_program(tt::tt_metal::Program*) {
-    return do_block;
-}
-
-void ProcessorHooks::set_block(bool block) {
-    do_block = block;
-}
-bool ProcessorHooks::get_block() const {
-    return do_block;
-}
-}
+}  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -482,16 +482,16 @@ bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
 void ProcessorHooks::set_block(bool block) { do_block = block; }
 bool ProcessorHooks::get_block() const { return do_block; }
 
-GraphCaptureScopeGuard::GraphCaptureScopeGuard(GraphProcessor::RunMode mode) {
+ScopedGraphCapture::ScopedGraphCapture(GraphProcessor::RunMode mode) {
     GraphProcessor::begin_graph_capture(mode);
     is_active = true;
 }
-GraphCaptureScopeGuard::~GraphCaptureScopeGuard() {
+ScopedGraphCapture::~ScopedGraphCapture() {
     if (is_active) {
         GraphProcessor::end_graph_capture();
     }
 }
-nlohmann::json GraphCaptureScopeGuard::end_graph_capture() {
+nlohmann::json ScopedGraphCapture::end_graph_capture() {
     is_active = false;
     return GraphProcessor::end_graph_capture();
 }

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -112,26 +112,26 @@ public:
 };
 
 /**
- * @class GraphCaptureScopeGuard
+ * @class ScopedGraphCapture
  * @brief A RAII wrapper around graph capture that ensures proper resource management.
  *
  * This class automatically calls begin_graph_capture upon construction and
  * end_graph_capture when it goes out of scope. It can be ended regularly
- * by calling GraphCaptureScopeGuard::end_graph_capture().
+ * by calling ScopedGraphCapture::end_graph_capture().
  *
  * @note Copy and move operations are deleted to prevent multiple instances
  * managing the same resource.
  */
-class GraphCaptureScopeGuard {
+class ScopedGraphCapture {
 public:
-    GraphCaptureScopeGuard(GraphProcessor::RunMode mode);
-    ~GraphCaptureScopeGuard();
+    ScopedGraphCapture(GraphProcessor::RunMode mode);
+    ~ScopedGraphCapture();
     nlohmann::json end_graph_capture();
 
-    GraphCaptureScopeGuard(const GraphCaptureScopeGuard&) = delete;
-    GraphCaptureScopeGuard(GraphCaptureScopeGuard&&) = delete;
-    GraphCaptureScopeGuard& operator=(const GraphCaptureScopeGuard&) = delete;
-    GraphCaptureScopeGuard& operator=(GraphCaptureScopeGuard&&) = delete;
+    ScopedGraphCapture(const ScopedGraphCapture&) = delete;
+    ScopedGraphCapture(ScopedGraphCapture&&) = delete;
+    ScopedGraphCapture& operator=(const ScopedGraphCapture&) = delete;
+    ScopedGraphCapture& operator=(ScopedGraphCapture&&) = delete;
 
 private:
     bool is_active = false;

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -111,6 +111,17 @@ public:
     static nlohmann::json end_graph_capture();
 };
 
+/**
+ * @class GraphCaptureScopeGuard
+ * @brief A RAII wrapper around graph capture that ensures proper resource management.
+ *
+ * This class automatically calls begin_graph_capture upon construction and
+ * end_graph_capture when it goes out of scope. It can be ended regularly
+ * by calling GraphCaptureScopeGuard::end_graph_capture().
+ *
+ * @note Copy and move operations are deleted to prevent multiple instances
+ * managing the same resource.
+ */
 class GraphCaptureScopeGuard {
 public:
     GraphCaptureScopeGuard(GraphProcessor::RunMode mode);

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -49,7 +49,7 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
         nlohmann::json op_trace;
         // outer graph capture is to avoid dispatching/allocating dummy input tensors
         {
-            auto capture_outer = GraphCaptureScopeGuard(GraphProcessor::RunMode::NO_DISPATCH);
+            auto capture_outer = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
 
             // helper lambda to transform TensorSpec to DeviceTensor
             auto transform_arg = [device](auto&& arg) {
@@ -63,7 +63,7 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
 
             // inner graph capture is to capture the actual op graph trace
             {
-                auto capture_inner = GraphCaptureScopeGuard(GraphProcessor::RunMode::NO_DISPATCH);
+                auto capture_inner = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
                 std::apply(op, transformed_args);
                 op_trace = capture_inner.end_graph_capture();
             }  // end of inner graph capture

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -46,28 +46,29 @@ template <typename Op, typename... Args>
 auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
     uint32_t num_of_active_graph_captures = 0;
     try {
+        nlohmann::json op_trace;
         // outer graph capture is to avoid dispatching/allocating dummy input tensors
-        GraphProcessor::begin_graph_capture(GraphProcessor::RunMode::NO_DISPATCH);
-        num_of_active_graph_captures++;
+        {
+            auto capture_outer = GraphCaptureScopeGuard(GraphProcessor::RunMode::NO_DISPATCH);
 
-        // helper lambda to transform TensorSpec to DeviceTensor
-        auto transform_arg = [device](auto&& arg) {
-            if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
-                return create_device_tensor(arg, device);
-            } else {
-                return std::forward<decltype(arg)>(arg);
-            }
-        };
-        auto transformed_args = std::make_tuple(transform_arg(std::forward<Args>(args))...);
+            // helper lambda to transform TensorSpec to DeviceTensor
+            auto transform_arg = [device](auto&& arg) {
+                if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
+                    return create_device_tensor(arg, device);
+                } else {
+                    return std::forward<decltype(arg)>(arg);
+                }
+            };
+            auto transformed_args = std::make_tuple(transform_arg(std::forward<Args>(args))...);
 
-        // inner graph capture is to capture the actual op graph trace
-        GraphProcessor::begin_graph_capture(GraphProcessor::RunMode::NO_DISPATCH);
-        num_of_active_graph_captures++;
-        std::apply(op, transformed_args);
-        const nlohmann::json op_trace = GraphProcessor::end_graph_capture();  // end of inner graph capture
-        num_of_active_graph_captures--;
-        GraphProcessor::end_graph_capture();  // end of outer graph capture
-        num_of_active_graph_captures--;
+            // inner graph capture is to capture the actual op graph trace
+            {
+                auto capture_inner = GraphCaptureScopeGuard(GraphProcessor::RunMode::NO_DISPATCH);
+                std::apply(op, transformed_args);
+                op_trace = capture_inner.end_graph_capture();
+            }  // end of inner graph capture
+
+        }  // end of outer graph capture
 
         // extract memory footprint from the trace
         auto interleaved_storage_cores = device->num_banks(tt::tt_metal::BufferType::L1);
@@ -81,10 +82,6 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
             ExecutionStatus::Success, {cb_peak_size_per_core, l1_buffers_peak_per_core, l1_output_buffer_per_core}};
 
     } catch (const std::exception& e) {
-        // end all active graph captures
-        for (uint32_t i = 0; i < num_of_active_graph_captures; i++) {
-            GraphProcessor::end_graph_capture();
-        }
         tt::log_debug(tt::LogOp, "op_constraints - error: {}", e.what());
         return QueryResponse{ExecutionStatus::Error, {0, 0, 0}, e.what()};
     }


### PR DESCRIPTION
### Problem description
If one wants to catch exception during graph capture thrown by op, they need to end graph capture if it was still active. Requires manual tracking.

### What's changed
Introduced ScopedGraphCapture, a wrapper class that begins capture on the creation, can be manually ended, or ends when goes out of scope. 

Utilized in the op_constraints 

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12757393308/job/35568824855