### PR TITLE
#0: Fix llama3 embedding aftr recent changes

### DIFF
--- a/models/demos/llama3/tests/test_llama_embedding.py
+++ b/models/demos/llama3/tests/test_llama_embedding.py
@@ -74,7 +74,7 @@ def test_llama_embedding(max_seq_len, batch_size, mesh_device, use_program_cache
         layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     tt_output = tt_emb(tt_input)
-    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1))[0].view(
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1)).view(
         reference_output.shape
     )
     logger.info(f"tt_output_torch: {tt_output_torch.shape}")

--- a/models/demos/llama3/tt/llama_embedding.py
+++ b/models/demos/llama3/tt/llama_embedding.py
@@ -36,5 +36,4 @@ class TtLlamaEmbedding(LightweightModule):
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = ttnn.embedding(x, self.weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        x = ttnn.reshape(x, [x.shape[0], 1, x.shape[1], x.shape[2]])
         return x

--- a/models/demos/qwen/tests/test_qwen_embedding.py
+++ b/models/demos/qwen/tests/test_qwen_embedding.py
@@ -66,7 +66,7 @@ def test_qwen_embedding(mesh_device, use_program_cache, reset_seeds, ensure_gc):
         layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     tt_output = tt_emb(tt_input)
-    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1))[0].view(
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1)).view(
         reference_output.shape
     )
     logger.info(f"tt_output_torch: {tt_output_torch.shape}")

--- a/models/demos/qwen/tt/qwen_embedding.py
+++ b/models/demos/qwen/tt/qwen_embedding.py
@@ -36,5 +36,4 @@ class TtQwenEmbedding(LightweightModule):
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = ttnn.embedding(x, self.weights, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        x = ttnn.reshape(x, [x.shape[0], 1, x.shape[1], x.shape[2]])
         return x


### PR DESCRIPTION
A recent commit https://github.com/tenstorrent/tt-metal/commit/aee56acccd56dc577f95da9d49dd50ce036d8b8e added support for 1D embedding.

This PR fixes the embedding on Llama3.

Running the tests before pushing, just in case it's failing somewhere else I haven't tested (demo and embedding).

- [x] [Single tests](https://github.com/tenstorrent/tt-metal/actions/runs/12197549560)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/12197543823)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12197550392)