### PR TITLE
#0: Fix CI: Don't cache weights for quick Llama test

### DIFF
--- a/models/demos/llama3/tt/llama_embedding.py
+++ b/models/demos/llama3/tt/llama_embedding.py
@@ -23,7 +23,7 @@ class TtLlamaEmbedding(LightweightModule):
 
         base_name = args.get_state_dict_prefix("", None) + "tok_embeddings.weight"
         torch_weight = self.state_dict[base_name].unsqueeze(0).unsqueeze(0)
-        cache_name = weight_cache_path / base_name
+        cache_name = None if args.dummy_weights else weight_cache_path / base_name
         self.weights = ttnn.as_tensor(
             torch_weight,
             dtype=dtype,


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/actions/runs/12201739608/job/34041262001
Llama Feature PR #15706 broke post commit since embedding module in llama-model did not respect dummy weights. Post commit does not have weka mounted, so it failed with "file not found".

This PR fixes that by setting cache path to None if using dummy weights.

- [ ] AllPostCommit https://github.com/tenstorrent/tt-metal/actions/runs/12205253580
- [ ] T3K unit, frequent, demo https://github.com/tenstorrent/tt-metal/actions/runs/12205337737