### PR TITLE
#15374: Fix golden string in watcher unit test

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -145,11 +145,15 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
                     k_id_s = "";
                 }
                 expected = fmt::format(
-                    "Device {} ethnet core(x={:2},y={:2}) phys(x={:2},y={:2}): {},   X,   X,   X,   X  rmsg:* k_id:{}",
-                    device->id(), logical_core.x, logical_core.y, phys_core.x, phys_core.y,
+                    "Device {} ethnet core(x={:2},y={:2}) phys(x={:2},y={:2}): {},   X,   X,   X,   X  rmsg:* h_id:0 "
+                    "k_id:{}",
+                    device->id(),
+                    logical_core.x,
+                    logical_core.y,
+                    phys_core.x,
+                    phys_core.y,
                     waypoint,
-                    k_id_s
-                );
+                    k_id_s);
             } else {
                 // Each different config has a different calculation for k_id, let's just do one. Fast Dispatch, one device.
                 string k_id_s;
@@ -161,11 +165,19 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
                     k_id_s = "";
                 }
                 expected = fmt::format(
-                    "Device {} worker core(x={:2},y={:2}) phys(x={:2},y={:2}): {},{},{},{},{}  rmsg:***|*** smsg:**** k_ids:{}",
-                    device->id(), logical_core.x, logical_core.y, phys_core.x, phys_core.y,
-                    waypoint, waypoint, waypoint, waypoint, waypoint,
-                    k_id_s
-                );
+                    "Device {} worker core(x={:2},y={:2}) phys(x={:2},y={:2}): {},{},{},{},{}  rmsg:***|*** h_id:0 "
+                    "smsg:**** k_ids:{}",
+                    device->id(),
+                    logical_core.x,
+                    logical_core.y,
+                    phys_core.x,
+                    phys_core.y,
+                    waypoint,
+                    waypoint,
+                    waypoint,
+                    waypoint,
+                    waypoint,
+                    k_id_s);
             }
             expected_waypoints.push_back(expected);
         }


### PR DESCRIPTION

### Ticket
#15374

### Problem description
Watcher unit tests are failing.

### What's changed
Update the string in the unit test to match the one now emitted by watcher.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
