### PR TITLE
Add reflection for std::unordered_map to support hashing global circular buffers

### DIFF
--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -159,3 +159,12 @@ uint32_t GlobalCircularBuffer::size() const { return this->size_; }
 }  // namespace v1
 
 }  // namespace tt::tt_metal
+
+namespace std {
+
+std::size_t hash<tt::tt_metal::v1::experimental::GlobalCircularBuffer>::operator()(
+    const tt::tt_metal::v1::experimental::GlobalCircularBuffer& global_circular_buffer) const {
+    return tt::stl::hash::hash_objects_with_default_seed(global_circular_buffer);
+}
+
+}  // namespace std

--- a/tt_metal/impl/buffers/global_circular_buffer.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.hpp
@@ -76,3 +76,12 @@ private:
 }  // namespace v1
 
 }  // namespace tt::tt_metal
+
+namespace std {
+
+template <>
+struct hash<tt::tt_metal::v1::experimental::GlobalCircularBuffer> {
+    std::size_t operator()(const tt::tt_metal::v1::experimental::GlobalCircularBuffer& global_circular_buffer) const;
+};
+
+}  // namespace std

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -77,3 +77,12 @@ void GlobalSemaphore::reset_semaphore_value() {
 }
 
 }  // namespace tt::tt_metal
+
+namespace std {
+
+std::size_t hash<tt::tt_metal::GlobalSemaphore>::operator()(
+    const tt::tt_metal::GlobalSemaphore& global_semaphore) const {
+    return tt::stl::hash::hash_objects_with_default_seed(global_semaphore);
+}
+
+}  // namespace std

--- a/tt_metal/impl/buffers/global_semaphore.hpp
+++ b/tt_metal/impl/buffers/global_semaphore.hpp
@@ -44,6 +44,9 @@ public:
 
     void reset_semaphore_value();
 
+    static constexpr auto attribute_names = std::forward_as_tuple("cores", "initial_value");
+    const auto attribute_values() const { return std::make_tuple(this->cores_, this->initial_value_); }
+
 private:
     void setup_buffer(BufferType buffer_type);
 
@@ -59,3 +62,12 @@ private:
 }  // namespace v0
 
 }  // namespace tt::tt_metal
+
+namespace std {
+
+template <>
+struct hash<tt::tt_metal::GlobalSemaphore> {
+    std::size_t operator()(const tt::tt_metal::GlobalSemaphore& global_semaphore) const;
+};
+
+}  // namespace std

--- a/tt_metal/tt_stl/reflection.hpp
+++ b/tt_metal/tt_stl/reflection.hpp
@@ -6,7 +6,10 @@
 
 #include <fmt/core.h>
 
+#include <algorithm>
+#include <array>
 #include <experimental/type_traits>
+#include <map>
 #include <optional>
 #include <ostream>
 #include <reflect>
@@ -14,6 +17,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 #include <filesystem>
@@ -443,6 +447,32 @@ std::ostream& operator<<(std::ostream& os, const std::set<T>& set) {
             os << ", ";
         }
         index++;
+    }
+    os << "}";
+    return os;
+}
+
+template <typename K, typename V>
+std::ostream& operator<<(std::ostream& os, const std::map<K, V>& map) {
+    os << "{";
+    for (auto it = map.begin(); it != map.end(); ++it) {
+        os << it->first << ": " << it->second;
+        if (it != map.end()) {
+            os << ", ";
+        }
+    }
+    os << "}";
+    return os;
+}
+
+template <typename K, typename V>
+std::ostream& operator<<(std::ostream& os, const std::unordered_map<K, V>& map) {
+    os << "{";
+    for (auto it = map.begin(); it != map.end(); ++it) {
+        os << it->first << ": " << it->second;
+        if (it != map.end()) {
+            os << ", ";
+        }
     }
     os << "}";
     return os;
@@ -978,6 +1008,30 @@ struct fmt::formatter<std::set<T>> {
     }
 };
 
+template <typename K, typename V>
+struct fmt::formatter<std::map<K, V>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::map<K, V>& map, format_context& ctx) const -> format_context::iterator {
+        using tt::stl::reflection::operator<<;
+        std::stringstream ss;
+        ss << map;
+        return fmt::format_to(ctx.out(), "{}", ss.str());
+    }
+};
+
+template <typename K, typename V>
+struct fmt::formatter<std::unordered_map<K, V>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const std::unordered_map<K, V>& map, format_context& ctx) const -> format_context::iterator {
+        using tt::stl::reflection::operator<<;
+        std::stringstream ss;
+        ss << map;
+        return fmt::format_to(ctx.out(), "{}", ss.str());
+    }
+};
+
 template <typename T>
     requires(
         tt::stl::concepts::Reflectable<T> and not(std::integral<T> or std::is_array<T>::value or
@@ -1063,7 +1117,7 @@ inline hash_t hash_object(const T& object) noexcept {
             fmt::print("Hashing struct {} using compile-time attributes: {}\n", get_type_name<T>(), object);
         }
         constexpr auto num_attributes = reflection::detail::get_num_attributes<T>();
-        std::size_t hash = 0;
+        hash_t hash = 0;
         const auto attribute_values = object.attribute_values();
         [&object, &hash, &attribute_values]<size_t... Ns>(std::index_sequence<Ns...>) {
             (
@@ -1074,11 +1128,26 @@ inline hash_t hash_object(const T& object) noexcept {
                 ...);
         }(std::make_index_sequence<num_attributes>{});
         return hash;
+    } else if constexpr (is_specialization_v<T, std::tuple>) {
+        if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
+            fmt::print("Hashing std::tuple of type {}: {}\n", get_type_name<T>(), object);
+        }
+        constexpr auto num_elements = std::tuple_size_v<T>;
+        hash_t hash = 0;
+        [&object, &hash]<size_t... Ns>(std::index_sequence<Ns...>) {
+            (
+                [&object, &hash] {
+                    const auto& element = std::get<Ns>(object);
+                    hash = hash_objects(hash, element);
+                }(),
+                ...);
+        }(std::make_index_sequence<num_elements>{});
+        return hash;
     } else if constexpr (is_specialization_v<T, std::vector>) {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::vector of type {}: {}\n", get_type_name<T>(), object);
         }
-        auto hash = 0;
+        hash_t hash = 0;
         for (const auto& element : object) {
             hash = hash_objects(hash, element);
         }
@@ -1087,9 +1156,35 @@ inline hash_t hash_object(const T& object) noexcept {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing std::set of type {}: {}\n", get_type_name<T>(), object);
         }
-        auto hash = 0;
+        hash_t hash = 0;
         for (const auto& element : object) {
             hash = hash_objects(hash, element);
+        }
+        return hash;
+    } else if constexpr (is_specialization_v<T, std::map>) {
+        if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
+            fmt::print("Hashing std::map of type {}: {}\n", get_type_name<T>(), object);
+        }
+        hash_t hash = 0;
+        for (const auto& [key, value] : object) {
+            hash = hash_objects(hash, key, value);
+        }
+        return hash;
+    } else if constexpr (is_specialization_v<T, std::unordered_map>) {
+        if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
+            fmt::print("Hashing std::unordered_map of type {}: {}\n", get_type_name<T>(), object);
+        }
+        // Sort the unordered map by key to make the hash order invariant
+        std::vector<typename T::const_iterator> iterators;
+        iterators.reserve(object.size());
+        for (auto it = object.begin(); it != object.end(); ++it) {
+            iterators.push_back(it);
+        }
+        std::sort(iterators.begin(), iterators.end(), [](const auto& a, const auto& b) { return a->first < b->first; });
+
+        hash_t hash = 0;
+        for (const auto& it : iterators) {
+            hash = hash_objects(hash, it->first, it->second);
         }
         return hash;
     } else if constexpr (is_specialization_v<T, std::optional>) {
@@ -1105,7 +1200,7 @@ inline hash_t hash_object(const T& object) noexcept {
         if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
             fmt::print("Hashing struct {} using reflect library: {}\n", get_type_name<T>(), object);
         }
-        std::size_t hash = 0;
+        hash_t hash = 0;
         reflect::for_each([&hash, &object](auto I) { hash = hash_objects(hash, reflect::get<I>(object)); }, object);
         return hash;
     } else {
@@ -1335,7 +1430,7 @@ struct to_json_t<std::map<K, V>> {
     nlohmann::json operator()(const std::map<K, V>& object) {
         nlohmann::json json_object = nlohmann::json::object();
         for (const auto& [key, value] : object) {
-            json_object[to_json(key)] = to_json(value);
+            json_object[to_json(key).dump()] = to_json(value);
         }
         return json_object;
     }
@@ -1346,7 +1441,29 @@ struct from_json_t<std::map<K, V>> {
     std::map<K, V> operator()(const nlohmann::json& json_object) {
         std::map<K, V> object;
         for (const auto& [key, value] : json_object.items()) {
-            object[from_json<K>(key)] = from_json<V>(value);
+            object[from_json<K>(nlohmann::json::parse(key))] = from_json<V>(value);
+        }
+        return object;
+    }
+};
+
+template <typename K, typename V>
+struct to_json_t<std::unordered_map<K, V>> {
+    nlohmann::json operator()(const std::unordered_map<K, V>& object) {
+        nlohmann::json json_object = nlohmann::json::object();
+        for (const auto& [key, value] : object) {
+            json_object[to_json(key).dump()] = to_json(value);
+        }
+        return json_object;
+    }
+};
+
+template <typename K, typename V>
+struct from_json_t<std::unordered_map<K, V>> {
+    std::map<K, V> operator()(const nlohmann::json& json_object) {
+        std::unordered_map<K, V> object;
+        for (const auto& [key, value] : json_object.items()) {
+            object[from_json<K>(nlohmann::json::parse(key))] = from_json<V>(value);
         }
         return object;
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to support hashing the GlobalCircularBuffer object in order to be consumed by ops, which has an unordered_map.

### What's changed
Add hashing support for std::map and std::unordered_map.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12245882594)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
