### PR TITLE
update all-reduce to enable basic n300 support

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
@@ -244,3 +244,69 @@ def test_ring_all_reduce_post_commit(
         num_iters=num_iters,
         enable_async=enable_async,
     )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (2, 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape",
+    [
+        ([2, 2, 64, 64]),
+        ([1, 1, 64, 64]),
+    ],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [
+        ttnn.TILE_LAYOUT,
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+    ],
+)
+@pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
+@pytest.mark.parametrize("enable_async", [True])
+def test_ring_all_reduce_post_commit_2chip(
+    pcie_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    num_iters=2,
+):
+    run_all_reduce_test(
+        pcie_mesh_device,
+        num_devices,
+        per_chip_output_shape,
+        num_links,
+        math_op,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        topology=ttnn.Topology.Linear,
+    )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp"
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/ccl/all_gather/device/all_gather_op.hpp"
@@ -66,18 +67,28 @@ namespace experimental {
 namespace ccl {
 
 static AllReduceStrategy choose_all_reduce_strategy(
-    const Tensor& input_tensor, uint32_t num_devices, uint32_t num_links) {
+    const Tensor& input_tensor, uint32_t num_devices, uint32_t num_links, ttnn::ccl::Topology topology) {
     auto shape = input_tensor.get_logical_shape();
     auto rank = shape.rank();
 
     uint32_t all_reduce_dim = -1;
     bool optimized_version = false;
 
+    if (num_devices == 2) {
+        // 2 devices == n300 == linear topology
+        topology = ttnn::ccl::Topology::Linear;
+    }
+
     for (uint32_t i = 0; i < rank; ++i) {
         if (shape[i] % num_devices == 0) {
             all_reduce_dim = i;
             optimized_version = true;
         }
+    }
+
+    if (topology == ttnn::ccl::Topology::Linear) {
+        // reduce scatter doesn't reliably support line topology yet
+        optimized_version = false;
     }
 
     if (optimized_version) {
@@ -110,7 +121,7 @@ static Tensor all_gather_local_reduce(
     const std::optional<size_t> user_defined_num_workers,
     const std::optional<size_t> user_defined_num_buffers_per_channel,
     const std::vector<Device*>& devices,
-    const ttnn::ccl::Topology& topology) {
+    ttnn::ccl::Topology topology) {
     auto shape = input_tensor.get_logical_shape();
     auto rank = shape.rank();
     log_warning(
@@ -118,6 +129,11 @@ static Tensor all_gather_local_reduce(
         "Falling back to unoptimized version (all_gather + local reduce) as the input tensor shape {} is not handled "
         "by optimized version",
         shape);
+
+    if (num_devices == 2) {
+        // 2 devices == n300 == linear topology
+        topology = ttnn::ccl::Topology::Linear;
+    }
 
     TT_FATAL(rank == 4, "Tensor rank must be 4, but has {} ", rank);
     uint32_t merged_dim_size = 1;
@@ -247,7 +263,6 @@ Tensor all_reduce(
     ttnn::operations::binary::BinaryOpType binary_op_type = convert_reduce_type_to_eltwise_type(math_op);
     TT_FATAL(
         std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr, "All Reduce op is only supported for Fast Dispatch");
-    TT_FATAL(topology == ttnn::ccl::Topology::Ring, "All Reduce op is currently supported only on Ring topology");
 
     auto devices = input_tensor.get_workers();
     uint32_t num_devices = devices.size();
@@ -272,7 +287,7 @@ Tensor all_reduce(
             const auto& input_tensor = input_tensors.at(0);
 
             // Choose the appropriate strategy
-            AllReduceStrategy strategy = choose_all_reduce_strategy(input_tensor, num_devices, num_links);
+            AllReduceStrategy strategy = choose_all_reduce_strategy(input_tensor, num_devices, num_links, topology);
 
             // Run the selected all-reduce operation
             Tensor result = run_all_reduce(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15789)

### Problem description
N300 support wasn't enabled with all-gather so there were some basic issues with it.

### What's changed
This commit resolves the basic issue which was that for n300, all-reduce was 
a) trying to invoke a ring on an n300 (which is really a line)
b) using the reduce-scatter + all-gather implementation (which is buggy on line topology due to buggy line reduce scatter implementation) -> all-reduce will invoke the naive all-gather + local reduce implementation in this case

Note this is old CCL code that will  be deprecated soon. I'm hoping to put as few man hours into it as possible.

### Checklist
- [x] Post commit CI:  https://github.com/tenstorrent/tt-metal/actions/runs/12207721173
- [x] T3k frequence, nightly, model perf: https://github.com/tenstorrent/tt-metal/actions/runs/12207718435
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
