### PR TITLE
Don't use tensix_types.h in ttnn

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -8,8 +8,9 @@
 
 #define DATUMS_PER_ROW 16
 
-// FIXME: ARCH_NAME specific include
-#include "tensix_types.h"  // DEST_REGISTER_FULL_SIZE
+// This parameter is the same for all supported architectures
+// Check this invariant when adding new architectures
+#define DEST_REGISTER_FULL_SIZE 64 * 16
 
 namespace ttnn {
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -7,9 +7,6 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 
-// FIXME: ARCH_NAME specific include
-#include "tensix_types.h"  // L1_SIZE
-
 using namespace tt::constants;
 using namespace tt;
 
@@ -92,14 +89,15 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
         block_ht * TILE_HEIGHT);
     uint32_t per_core_tiles = block_ht * block_wt;
 
+    const uint32_t l1_size = input_tensor.device()->l1_size_per_core();
     auto data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
     uint32_t single_tile_size = tile_size(data_format);
     TT_FATAL(
-        L1_SIZE >= 2 * per_core_tiles * single_tile_size,
+        l1_size >= 2 * per_core_tiles * single_tile_size,
         "Workload of Tiles {} at Tile Size {} (times 2 for output) exceeds L1 capacity {}",
         per_core_tiles,
         single_tile_size,
-        L1_SIZE);
+        l1_size);
 
     std::vector<uint32_t> num_tiles_per_group;
     num_tiles_per_group.reserve(output.size());

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -7,9 +7,6 @@
 
 #include "tt_metal/host_api.hpp"
 
-// FIXME: ARCH_NAME specific include
-#include "tensix_types.h"  // L1_SIZE
-
 namespace ttnn::operations::experimental::transformer {
 
 void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
@@ -122,10 +119,11 @@ void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Te
     uint32_t per_core_q_tiles = q_shard_ht * q_shard_wt;
     uint32_t per_core_k_tiles = k_shard_ht * k_shard_wt;
 
+    const uint32_t l1_size = q_input_tensor.device()->l1_size_per_core();
     const uint32_t single_tile_size =
         tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(q_input_tensor.get_dtype()));
     TT_FATAL(
-        L1_SIZE >= 2 * (per_core_q_tiles + 2 * per_core_k_tiles) * single_tile_size, "Workload exceeds L1 capacity");
+        l1_size >= 2 * (per_core_q_tiles + 2 * per_core_k_tiles) * single_tile_size, "Workload exceeds L1 capacity");
 
     // TODO: Add this back when output is HEIGHT sharded only!
     // TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -8,9 +8,6 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_log.h"
 
-// FIXME: ARCH_NAME specific include
-#include "tensix_types.h"  // L1_SIZE
-
 namespace ttnn::operations::reduction::detail {
 
 operation::ProgramWithCallbacks topk_single_core_interleaved(
@@ -179,6 +176,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
     uint16_t max_dim,
     CoreCoord grid,
     uint16_t k,
+    const uint32_t l1_size,
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
     const auto max_cores = grid.y - 1;  // reserve one core for the gather - switch to grid.x as it allows for more
@@ -193,7 +191,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
             (split_size / tt::constants::TILE_WIDTH) *
             (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
                                                   // as a matching set of indices, is processed by a core
-        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < L1_SIZE && num_cores > 1) {
+        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < l1_size && num_cores > 1) {
             return {num_cores + 1, split_size, rem, num_cores * k};
         }
     }
@@ -237,6 +235,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         input_shape[dim] / 2,
         device->compute_with_storage_grid_size(),
         k,
+        device->l1_size_per_core(),
         value_tile_size,
         index_tile_size);
 


### PR DESCRIPTION
### Ticket
Closes #14622 

### Problem description
We can't directly include architecture specific firmware include files in host code, if we want to have a single build for all architectures.

### What's changed
- Get L1_SIZE from existing device API.
- Just define DEST_REGISTER_FULL_SIZE since it is the same for all ARCH.

### Note for reviewers
- This is an alternate approach to solve the issue. It is less invasive, and uses existing APIs.
- Previous approach: https://github.com/tenstorrent/tt-metal/pull/15785
- The approach here may be preferred.
- Something that troubles me is that in `tt_metal` we actually have two methods of getting the size of the L1 SRAM. The older method is to use the api l1_size_per_core, which gets the parameter from an soc descriptor yaml file. The newer approach that I tried to leverage in the other PR uses the hardware abstraction layer, which pulls from firmware header files. To me ... using an API that depends on reading a file on disk is less preferable (what if that file got corrupted, what if it wasn't packaged?). Also, we don't have a single source of truth. Anyways, we can leave that refinement for future iterations. I just wanted to document my feelings here.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12211473316)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12211478100)
- [x] New/Existing tests provide coverage for changes
