### PR TITLE
Optimize bfloat16 construction

### DIFF
--- a/tt_metal/common/bfloat16.hpp
+++ b/tt_metal/common/bfloat16.hpp
@@ -18,6 +18,7 @@ private:
     uint16_t uint16_data;
 
 public:
+    static constexpr size_t SIZEOF = 2;
     bfloat16() = default;
 
     // create from float: no rounding, just truncate
@@ -37,8 +38,10 @@ public:
 
     float to_float() const {
         // move lower 16 to upper 16 (of 32) and convert to float
-        uint32_t uint32_data = ((uint32_t)uint16_data) << 16;
-        return *reinterpret_cast<float*>(&uint32_data);
+        uint32_t uint32_data = (uint32_t)uint16_data << 16;
+        float f;
+        std::memcpy(&f, &uint32_data, sizeof(f));
+        return f;
     }
     uint16_t to_packed() const { return uint16_data; }
     uint16_t to_uint16() const { return uint16_data; }

--- a/tt_metal/common/bfloat16.hpp
+++ b/tt_metal/common/bfloat16.hpp
@@ -18,20 +18,13 @@ private:
     uint16_t uint16_data;
 
 public:
-    static const size_t SIZEOF = 2;
-    bfloat16() {}
+    bfloat16() = default;
 
     // create from float: no rounding, just truncate
     bfloat16(float float_num) {
-        uint32_t uint32_data;
-        TT_ASSERT(sizeof float_num == sizeof uint32_data);
+        static_assert(sizeof float_num == 4, "float must have size 4");
 
-        uint32_data = *reinterpret_cast<uint32_t*>(&float_num);
-        // just move upper 16 to lower 16 (truncate)
-        uint32_data = (uint32_data >> 16);
-
-        // store lower 16 as 16-bit uint
-        uint16_data = (uint16_t)uint32_data;
+        uint16_data = (*reinterpret_cast<uint32_t*>(&float_num)) >> 16;
     }
 
     // store lower 16 as 16-bit uint
@@ -44,10 +37,8 @@ public:
 
     float to_float() const {
         // move lower 16 to upper 16 (of 32) and convert to float
-        uint32_t uint32_data = (uint32_t)uint16_data << 16;
-        float f;
-        std::memcpy(&f, &uint32_data, sizeof(f));
-        return f;
+        uint32_t uint32_data = ((uint32_t)uint16_data) << 16;
+        return *reinterpret_cast<float*>(&uint32_data);
     }
     uint16_t to_packed() const { return uint16_data; }
     uint16_t to_uint16() const { return uint16_data; }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15822)

### Problem description
bfloat16 construction speed is the current bottleneck during model loading in GGML.

### What's changed
Removes unnecessary runtime checks, casts and functions calls. As a result, time loading Tiny LLaMA 1.1B on GGML reduces from 15.2s to 13.4s. I believe this patch would also benefit TT.

```plaintext
Before:
bin/llama-cli -ngl 30 -m tinyllama-1.1b-chat-v1.0.Q4_0.gguf -p "" -n 0 -nkvo   16.85s user 1.01s system 117% cpu 15.234 total

After:
bin/llama-cli -ngl 30 -m tinyllama-1.1b-chat-v1.0.Q4_0.gguf -p "" -n 0 -nkvo   15.17s user 0.86s system 119% cpu 13.437 total
```

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12252764125)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
