### PR TITLE
Move pybind11 to CPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third_party/pybind11"]
-	path = tt_metal/third_party/pybind11
-	url = https://github.com/pybind/pybind11.git
 [submodule "third_party/lfs"]
 	path = tt_metal/third_party/lfs
 	url = https://github.com/tenstorrent-metal/lfs.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,18 +259,6 @@ if(ENABLE_TRACY)
     add_link_options(-rdynamic)
 endif()
 
-if(WITH_PYTHON_BINDINGS)
-    # Can't use the `REUSE_FROM` option bc tt_lib and ttnn have different build flags :(
-    add_library(pch_pybinds INTERFACE)
-    target_precompile_headers(
-        pch_pybinds
-        INTERFACE
-            ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/operators.h
-            ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/pybind11.h
-            ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
-    )
-endif()
-
 ############################################################################################################################
 # Build subdirectories
 ############################################################################################################################

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -85,3 +85,9 @@ CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.0.1)
 ############################################################################################################################
 
 CPMAddPackage(NAME range-v3 GITHUB_REPOSITORY ericniebler/range-v3 GIT_TAG 0.12.0)
+
+############################################################################################################################
+# pybind11 : https://github.com/pybind/pybind11
+############################################################################################################################
+
+CPMAddPackage(NAME pybind11 GITHUB_REPOSITORY pybind/pybind11 GIT_TAG b8f28551cc3a98ea9fbfc15c05b513c8f2d23e84)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -671,7 +671,7 @@ if(WITH_PYTHON_BINDINGS)
     list(
         APPEND
         TTNN_PUBLIC_LINK_LIBRARIES
-        pch_pybinds
+        pybind11::module
         ${Python3_LIBRARIES}
     )
 endif()


### PR DESCRIPTION
### Problem description
pybind11 is brought in as a git submodule.
This means everytime we clone the repo recursively the entire source code of pybind11 is brought down.
pybind11 sources are also showing up in our wheel.

### What's changed
Use CPM to bring down the repo as needed, into `.cpmcache`.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12231484903)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
