### PR TITLE
#0: Fix Squeezebert

### DIFF
--- a/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
+++ b/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
@@ -71,9 +71,6 @@ def ttnn_conv1d(
     conv_config = ttnn.Conv1dConfig(
         dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat8_b,
-        math_approx_mode_enabled=math_approx,
-        fp32_dest_acc_enabled=fp32_accum,
-        packer_l1_accum_enabled=packer_l1_acc,
         activation=activation,
         input_channels_alignment=(16 if use_shallow_conv_variant else 32),
         deallocate_activation=deallocate_activation,
@@ -85,6 +82,13 @@ def ttnn_conv1d(
         ),
         core_grid=get_shard_grid_from_num_cores(56, device),
         math_fidelity=math_fidelity,
+    )
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=math_fidelity,
+        math_approx_mode=math_approx,
+        fp32_dest_acc_en=fp32_accum,
+        packer_l1_acc=packer_l1_acc,
     )
 
     [tt_output_tensor_on_device, out_length, weights_device, bias_device] = ttnn.Conv1d(
@@ -100,6 +104,7 @@ def ttnn_conv1d(
         batch_size=tt_input_tensor.shape[0],
         input_length=tt_input_tensor.shape[1],
         conv_config=conv_config,
+        compute_config=compute_config,
         conv_op_cache={},
         debug=debug,
         groups=groups,

--- a/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
+++ b/models/demos/squeezebert/tt/ttnn_functional_squeezebert.py
@@ -81,7 +81,6 @@ def ttnn_conv1d(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
         ),
         core_grid=get_shard_grid_from_num_cores(56, device),
-        math_fidelity=math_fidelity,
     )
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),


### PR DESCRIPTION
### Problem description
Squeezebert fails after changes to Conv1DConfig.

### What's changed
Removed compute kernel args from Conv1dConfig.

### Checklist
- [x] Model regression CI testing passes (https://github.com/tenstorrent/tt-metal/actions/runs/12234614018)
