### PR TITLE
#15833: Handle copying multi-device host storage to 1x1 mesh device

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
@@ -11,39 +11,76 @@ from models.utility_functions import comp_pcc
 from models.utility_functions import is_grayskull
 
 
+@pytest.mark.parametrize("shape", [(1, 10, 64, 96), (32, 1, 64, 64), (32, 3, 256, 256), (16, 1, 1024, 1024)])
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED])
 @pytest.mark.parametrize("memory_location", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 5), (False, 5)),
-)
+@pytest.mark.parametrize("enable_async", (False, True))
 def test_tensor_preallocation_and_write_apis(
-    num_loops, enable_async, in_dtype, mem_layout, memory_location, tensor_layout, device
+    enable_async, shape, in_dtype, mem_layout, memory_location, tensor_layout, device
 ):
     if in_dtype == ttnn.bfloat8_b and tensor_layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Row Major Layout not supported for Bfp8")
     torch.manual_seed(0)
     device.enable_async(enable_async)
+
+    # Preallocate tensor on device
+    preallocated_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape),
+        in_dtype,
+        tensor_layout,
+        device,
+        ttnn.MemoryConfig(memory_layout=mem_layout, buffer_type=memory_location),
+    )
+    for loop in range(5):
+        # Write to prreallocated tensor multiple times
+        input_tensor_a = torch.randn(shape).bfloat16()
+        tt_input_tensor_a = ttnn.Tensor(input_tensor_a, in_dtype).to(tensor_layout)
+        ttnn.copy_host_to_device_tensor(tt_input_tensor_a, preallocated_tensor)
+        readback = preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        allclose, output = comp_pcc(readback, input_tensor_a)
+        assert allclose, f"FAILED: {output}"
+
+
+@pytest.mark.parametrize("shape", [(1, 10, 64, 96), (32, 3, 256, 256)])
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED])
+@pytest.mark.parametrize("memory_location", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("enable_async", (False, True))
+@pytest.mark.parametrize("mesh_device", ((1, 1), 4), indirect=True)
+def test_tensor_preallocation_and_write_apis(
+    enable_async, shape, in_dtype, mem_layout, memory_location, tensor_layout, mesh_device
+):
+    if in_dtype == ttnn.bfloat8_b and tensor_layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("Row Major Layout not supported for Bfp8")
+    torch.manual_seed(0)
+    mesh_device.enable_async(enable_async)
     shapes = [(1, 10, 64, 96), (32, 1, 64, 64), (32, 3, 256, 256), (16, 1, 1024, 1024)]
 
-    for tensor_shape in shapes:
-        # Preallocate tensor on device
-        preallocated_tensor = ttnn.allocate_tensor_on_device(
-            ttnn.Shape(tensor_shape),
-            in_dtype,
-            tensor_layout,
-            device,
-            ttnn.MemoryConfig(memory_layout=mem_layout, buffer_type=memory_location),
+    # Preallocate tensor on device
+    preallocated_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape),
+        in_dtype,
+        tensor_layout,
+        mesh_device,
+        ttnn.MemoryConfig(memory_layout=mem_layout, buffer_type=memory_location),
+    )
+    for loop in range(5):
+        # Write to prreallocated tensor multiple times
+        input_tensor_a = torch.randn(shape).bfloat16()
+        tt_input_tensor_a = ttnn.from_torch(
+            input_tensor_a,
+            dtype=in_dtype,
+            layout=tensor_layout,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
-        for loop in range(num_loops):
-            # Write to prreallocated tensor multiple times
-            input_tensor_a = torch.randn(tensor_shape).bfloat16()
-            tt_input_tensor_a = ttnn.Tensor(input_tensor_a, in_dtype).to(tensor_layout)
-            ttnn.copy_host_to_device_tensor(tt_input_tensor_a, preallocated_tensor)
-            readback = preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-            allclose, output = comp_pcc(readback, input_tensor_a)
+        ttnn.copy_host_to_device_tensor(tt_input_tensor_a, preallocated_tensor)
+        readback_tensors = ttnn.to_torch(
+            preallocated_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT),
+            mesh_composer=ttnn.ListMeshToTensor(mesh_device),
+        )
+        for readback_tensor in readback_tensors:
+            allclose, output = comp_pcc(readback_tensor, input_tensor_a)
             assert allclose, f"FAILED: {output}"
-
-    device.enable_async(False)


### PR DESCRIPTION
### Ticket
#15833 

### Problem description
See #15833. There is a mismatch with how device tensor is handling 1x1 mesh, as opposed to host tensor for 1x1 mesh.

This is a temporary local fix! #15840 tracks a proper fix.

### What's changed
Handle copying tensors from 1x1 host storage to a single device.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12244129605)
- [X] [T3K unit + frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/12246012734)
- [X] New/Existing tests provide coverage for changes
