### PR TITLE
#0: Fix recursive bug in hash function of global sem, cb

### DIFF
--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -164,7 +164,7 @@ namespace std {
 
 std::size_t hash<tt::tt_metal::v1::experimental::GlobalCircularBuffer>::operator()(
     const tt::tt_metal::v1::experimental::GlobalCircularBuffer& global_circular_buffer) const {
-    return tt::stl::hash::hash_objects_with_default_seed(global_circular_buffer);
+    return tt::stl::hash::hash_objects_with_default_seed(global_circular_buffer.attribute_values());
 }
 
 }  // namespace std

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -82,7 +82,7 @@ namespace std {
 
 std::size_t hash<tt::tt_metal::GlobalSemaphore>::operator()(
     const tt::tt_metal::GlobalSemaphore& global_semaphore) const {
-    return tt::stl::hash::hash_objects_with_default_seed(global_semaphore);
+    return tt::stl::hash::hash_objects_with_default_seed(global_semaphore.attribute_values());
 }
 
 }  // namespace std


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Recursive issue in hash function where std::hash would call hash_objects, which would call std::hash.

### What's changed
Update the std::hash function to hash the attributes, instead of hashing the object itself.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12258088304
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
