### PR TITLE
Re-enable device test for N300

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -67,11 +67,6 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
         GTEST_SKIP();
     }
 
-    // see issue #9594
-    if (arch == tt::ARCH::WORMHOLE_B0 && num_devices > 1) {
-        GTEST_SKIP();
-    }
-
     ASSERT_TRUE(num_devices > 0);
     vector<chip_id_t> ids;
     for (unsigned int id = 0; id < num_devices; id++) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9594#issuecomment-2518800582)

### Problem description
Test previously disabled for stability.

### What's changed
Tried test locally for thousands or iterations, could not repro old failure. Likely misc runtime bug fixes resolved this. Re-enabling test for main.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
