### PR TITLE
#0: Update global cb, sem apis to take in sub_device_ids to know what…

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -21,7 +21,7 @@ TEST_F(DispatchFixture, InitializeGlobalSemaphores) {
             uint32_t initial_value = 1;
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
             auto address = global_semaphore->address();
-
+            Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
@@ -33,7 +33,7 @@ TEST_F(DispatchFixture, InitializeGlobalSemaphores) {
             uint32_t initial_value = 2;
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
             auto address = global_semaphore->address();
-
+            Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
@@ -61,6 +61,7 @@ TEST_F(DispatchFixture, CreateMultipleGlobalSemaphoresOnSameCore) {
                 global_semaphores.push_back(tt::tt_metal::CreateGlobalSemaphore(device, cores[i], initial_values[i]));
                 addresses.push_back(global_semaphores[i]->address());
             }
+            Synchronize(device);
             for (size_t i = 0; i < cores.size(); i++) {
                 const auto& address = addresses[i];
                 const auto& initial_value = initial_values[i];
@@ -85,7 +86,7 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
             std::vector<uint32_t> overwrite_value = {2};
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
             auto address = global_semaphore->address();
-
+            Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
@@ -101,6 +102,7 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
                 EXPECT_EQ(sem_vals[0], overwrite_value[0]);
             }
             global_semaphore->reset_semaphore_value();
+            Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -299,16 +299,21 @@ uint32_t CreateSemaphore(
  *
  * Return value: std::shared_ptr<GlobalSemaphore>
  *
- * | Argument      | Description                                          | Type                                                      | Valid Range  | Required |
- * |---------------|------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
- * | device        | The device to create the semaphore on                | Device *                                                  |              | Yes      |
- * | cores         | Range of the Tensix co-ordinates using the semaphore | const CoreRangeSet &                                      |              | Yes      |
- * | initial_value | Initial value of the semaphore                       | uint32_t                                                  |              | Yes      |
- * | buffer_type   | Buffer type to store the semaphore                   | BufferType                                                | L1 types     | No       |
+ * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
+ * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
+ * | device         | The device to create the semaphore on                  | Device *                                                  |              | Yes      |
+ * | cores          | Range of the Tensix co-ordinates using the semaphore   | const CoreRangeSet &                                      |              | Yes      |
+ * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
+ * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
+ * | sub_device_ids | Sub-device ids to wait on before writing the semaphore | tt::stl::Span<const SubDeviceId>                          |              | No       |
  */
 // clang-format on
 std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
-    Device* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+    Device* device,
+    const CoreRangeSet& cores,
+    uint32_t initial_value,
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 // clang-format off
 /**
@@ -317,16 +322,21 @@ std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
  *
  * Return value: std::shared_ptr<GlobalSemaphore>
  *
- * | Argument      | Description                                          | Type                                                      | Valid Range  | Required |
- * |---------------|------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
- * | device        | The device to create the semaphore on                | Device *                                                  |              | Yes      |
- * | cores         | Range of the Tensix co-ordinates using the semaphore | CoreRangeSet &&                                           |              | Yes      |
- * | initial_value | Initial value of the semaphore                       | uint32_t                                                  |              | Yes      |
- * | buffer_type   | Buffer type to store the semaphore                   | BufferType                                                | L1 types     | No       |
+ * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
+ * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
+ * | device         | The device to create the semaphore on                  | Device *                                                  |              | Yes      |
+ * | cores          | Range of the Tensix co-ordinates using the semaphore   | CoreRangeSet &&                                           |              | Yes      |
+ * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
+ * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
+ * | sub_device_ids | Sub-device ids to wait on before writing the semaphore | tt::stl::Span<const SubDeviceId>                          |              | No       |
  */
 // clang-format on
 std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
-    Device* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+    Device* device,
+    CoreRangeSet&& cores,
+    uint32_t initial_value,
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 // clang-format off
 /**

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -27,7 +27,8 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type) :
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) :
     device_(device), sender_receiver_core_mapping_(sender_receiver_core_mapping), size_(size) {
     TT_FATAL(this->device_ != nullptr, "Device cannot be null");
     uint32_t num_sender_cores = sender_receiver_core_mapping.size();
@@ -46,10 +47,11 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     TT_FATAL(num_receiver_cores == this->receiver_cores_.num_cores(), "Duplicate receiver cores found");
     this->all_cores_ = this->sender_cores_.merge(this->receiver_cores_);
     TT_FATAL(this->all_cores_.num_cores() == num_sender_cores + num_receiver_cores, "Duplicate cores found");
-    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender, sub_device_ids);
 }
 
-void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender) {
+void GlobalCircularBuffer::setup_cb_buffers(
+    BufferType buffer_type, uint32_t max_num_receivers_per_sender, tt::stl::Span<const SubDeviceId> sub_device_ids) {
     TT_FATAL(
         buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
         "Global circular buffer can only be created for L1 buffer types");
@@ -123,12 +125,18 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         }
     }
 
-    // Blocking write of cb config to buffer
+    // Write the config buffer to the device
+    // Only block for the slow dispatch case
     if (this->device_->using_slow_dispatch()) {
         detail::WriteToBuffer(*this->cb_config_buffer_, cb_config_host_buffer);
         tt::Cluster::instance().l1_barrier(this->device_->id());
     } else {
-        EnqueueWriteBuffer(this->device_->command_queue(), this->cb_config_buffer_, cb_config_host_buffer.data(), true);
+        EnqueueWriteBuffer(
+            this->device_->command_queue(),
+            this->cb_config_buffer_,
+            cb_config_host_buffer.data(),
+            false,
+            sub_device_ids);
     }
 }
 
@@ -136,8 +144,10 @@ std::shared_ptr<GlobalCircularBuffer> GlobalCircularBuffer::create(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type) {
-    return std::make_unique<GlobalCircularBuffer>(device, sender_receiver_core_mapping, size, buffer_type);
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    return std::make_shared<GlobalCircularBuffer>(
+        device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
 }
 
 const Buffer& GlobalCircularBuffer::cb_buffer() const { return *this->cb_buffer_; }

--- a/tt_metal/impl/buffers/global_circular_buffer.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.hpp
@@ -9,6 +9,7 @@
 
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/llrt/hal.hpp"
 
 namespace tt::tt_metal {
@@ -30,7 +31,8 @@ public:
         Device* device,
         const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
         uint32_t size,
-        BufferType buffer_type);
+        BufferType buffer_type,
+        tt::stl::Span<const SubDeviceId> sub_device_ids);
 
     GlobalCircularBuffer(const GlobalCircularBuffer&) = default;
     GlobalCircularBuffer& operator=(const GlobalCircularBuffer&) = default;
@@ -42,7 +44,8 @@ public:
         Device* device,
         const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
         uint32_t size,
-        BufferType buffer_type = BufferType::L1);
+        BufferType buffer_type = BufferType::L1,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     const Buffer& cb_buffer() const;
 
@@ -57,7 +60,8 @@ public:
     const auto attribute_values() const { return std::make_tuple(this->sender_receiver_core_mapping_, this->size_); }
 
 private:
-    void setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender);
+    void setup_cb_buffers(
+        BufferType buffer_type, uint32_t max_num_receivers_per_sender, tt::stl::Span<const SubDeviceId> sub_device_ids);
 
     // GlobalCircularBuffer is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions

--- a/tt_metal/impl/buffers/global_semaphore.hpp
+++ b/tt_metal/impl/buffers/global_semaphore.hpp
@@ -9,6 +9,7 @@
 
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
+#include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/llrt/hal.hpp"
 
 namespace tt::tt_metal {
@@ -21,10 +22,18 @@ class Device;
 class GlobalSemaphore {
 public:
     GlobalSemaphore(
-        Device* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+        Device* device,
+        const CoreRangeSet& cores,
+        uint32_t initial_value,
+        BufferType buffer_type = BufferType::L1,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     GlobalSemaphore(
-        Device* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+        Device* device,
+        CoreRangeSet&& cores,
+        uint32_t initial_value,
+        BufferType buffer_type = BufferType::L1,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     GlobalSemaphore(const GlobalSemaphore&) = default;
     GlobalSemaphore& operator=(const GlobalSemaphore&) = default;
@@ -33,22 +42,30 @@ public:
     GlobalSemaphore& operator=(GlobalSemaphore&&) noexcept = default;
 
     static std::shared_ptr<GlobalSemaphore> create(
-        Device* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+        Device* device,
+        const CoreRangeSet& cores,
+        uint32_t initial_value,
+        BufferType buffer_type = BufferType::L1,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     static std::shared_ptr<GlobalSemaphore> create(
-        Device* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+        Device* device,
+        CoreRangeSet&& cores,
+        uint32_t initial_value,
+        BufferType buffer_type = BufferType::L1,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     Device* device() const;
 
     DeviceAddr address() const;
 
-    void reset_semaphore_value();
+    void reset_semaphore_value(tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
     static constexpr auto attribute_names = std::forward_as_tuple("cores", "initial_value");
     const auto attribute_values() const { return std::make_tuple(this->cores_, this->initial_value_); }
 
 private:
-    void setup_buffer(BufferType buffer_type);
+    void setup_buffer(BufferType buffer_type, tt::stl::Span<const SubDeviceId> sub_device_ids);
 
     // GlobalSemaphore is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions

--- a/tt_metal/include/tt_metal/global_circular_buffer.hpp
+++ b/tt_metal/include/tt_metal/global_circular_buffer.hpp
@@ -22,13 +22,16 @@ namespace experimental {
  * @param sender_receiver_core_mapping The mapping of remote sender to remote receiver cores for the circular buffer.
  * @param size Size of the global circular buffer per core in bytes.
  * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.
+ * @param sub_device_ids Sub-device IDs to wait on before writing the global circular buffer config to device. Defaults
+ * to waiting on all sub-devices.
  * @return Handle to the allocated global circular buffer.
  */
 std::shared_ptr<GlobalCircularBuffer> CreateGlobalCircularBuffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1);
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 }  // namespace experimental
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1153,13 +1153,21 @@ uint32_t CreateSemaphore(
 }
 
 std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
-    Device* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
-    return GlobalSemaphore::create(device, cores, initial_value, buffer_type);
+    Device* device,
+    const CoreRangeSet& cores,
+    uint32_t initial_value,
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    return GlobalSemaphore::create(device, cores, initial_value, buffer_type, sub_device_ids);
 }
 
 std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
-    Device* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) {
-    return GlobalSemaphore::create(device, std::move(cores), initial_value, buffer_type);
+    Device* device,
+    CoreRangeSet&& cores,
+    uint32_t initial_value,
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    return GlobalSemaphore::create(device, std::move(cores), initial_value, buffer_type, sub_device_ids);
 }
 
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
@@ -1362,8 +1370,9 @@ std::shared_ptr<GlobalCircularBuffer> CreateGlobalCircularBuffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type) {
-    return GlobalCircularBuffer::create(device, sender_receiver_core_mapping, size, buffer_type);
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    return GlobalCircularBuffer::create(device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
 }
 
 CBHandle CreateCircularBuffer(

--- a/ttnn/cpp/pybind11/global_circular_buffer.cpp
+++ b/ttnn/cpp/pybind11/global_circular_buffer.cpp
@@ -19,12 +19,19 @@ void py_module(py::module& module) {
     // Single Device APIs
     module.def(
         "create_global_circular_buffer",
-        py::overload_cast<Device*, const std::unordered_map<CoreCoord, CoreRangeSet>&, uint32_t, BufferType>(
-            &create_global_circular_buffer),
+        [](Device* device,
+           const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
+           uint32_t size,
+           BufferType buffer_type,
+           const std::vector<SubDeviceId>& sub_device_ids) {
+            return ttnn::global_circular_buffer::create_global_circular_buffer(
+                device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
+        },
         py::arg("device"),
         py::arg("sender_receiver_core_mapping"),
         py::arg("size"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Create a GlobalCircularBuffer Object on a single device.
 
@@ -33,17 +40,26 @@ void py_module(py::module& module) {
                 sender_receiver_core_mapping (dict): The mapping of remote sender to remote receiver cores for the circular buffer.
                 size (int): Size of the global circular buffer per core in bytes.
                 buffer_type (BufferType): The type of buffer to use for the global circular buffer.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global circular buffer config to device.
+                Defaults to waiting on all sub-devices.
             )doc");
 
     // Multi Device APIs
     module.def(
         "create_global_circular_buffer",
-        py::overload_cast<MeshDevice*, const std::unordered_map<CoreCoord, CoreRangeSet>&, uint32_t, BufferType>(
-            &create_global_circular_buffer),
+        [](MeshDevice* mesh_device,
+           const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
+           uint32_t size,
+           BufferType buffer_type,
+           const std::vector<SubDeviceId>& sub_device_ids) {
+            return ttnn::global_circular_buffer::create_global_circular_buffer(
+                mesh_device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
+        },
         py::arg("mesh_device"),
         py::arg("sender_receiver_core_mapping"),
         py::arg("size"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Create a GlobalCircularBuffer Object on a single device.
 
@@ -52,6 +68,8 @@ void py_module(py::module& module) {
                 sender_receiver_core_mapping (dict): The mapping of remote sender to remote receiver cores for the circular buffer.
                 size (int): Size of the global circular buffer per core in bytes.
                 buffer_type (BufferType): The type of buffer to use for the global circular buffer.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global circular buffer config to device.
+                Defaults to waiting on all sub-devices.
             )doc");
 }
 

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -19,11 +19,19 @@ void py_module(py::module& module) {
     // Single Device APIs
     module.def(
         "create_global_semaphore",
-        py::overload_cast<Device*, const CoreRangeSet&, uint32_t, BufferType>(&create_global_semaphore),
+        [](Device* device,
+           const CoreRangeSet& cores,
+           uint32_t initial_value,
+           BufferType buffer_type,
+           const std::vector<SubDeviceId>& sub_device_ids) {
+            return ttnn::global_semaphore::create_global_semaphore(
+                device, cores, initial_value, buffer_type, sub_device_ids);
+        },
         py::arg("device"),
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Create a GlobalSemaphore Object on a single device.
 
@@ -32,6 +40,8 @@ void py_module(py::module& module) {
                 cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
                 initial_value (int): The initial value of the global semaphore.
                 buffer_type (BufferType): The type of buffer to use for the global semaphore.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
+                Defaults to waiting on all sub-devices.
             )doc");
 
     module.def(
@@ -47,23 +57,35 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        py::overload_cast<const std::shared_ptr<GlobalSemaphore>&>(&reset_global_semaphore_value),
+        py::overload_cast<const std::shared_ptr<GlobalSemaphore>&, const std::vector<SubDeviceId>&>(
+            &reset_global_semaphore_value),
         py::arg("global_semaphore"),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Reset the value of the global semaphore.
 
             Args:
                 global_semaphore (GlobalSemaphore): The global semaphore object.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
+                Defaults to waiting on all sub-devices.
             )doc");
 
     // Multi Device APIs
     module.def(
         "create_global_semaphore",
-        py::overload_cast<MeshDevice*, const CoreRangeSet&, uint32_t, BufferType>(&create_global_semaphore),
+        [](MeshDevice* mesh_device,
+           const CoreRangeSet& cores,
+           uint32_t initial_value,
+           BufferType buffer_type,
+           const std::vector<SubDeviceId>& sub_device_ids) {
+            return ttnn::global_semaphore::create_global_semaphore(
+                mesh_device, cores, initial_value, buffer_type, sub_device_ids);
+        },
         py::arg("mesh_device"),
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Create a GlobalSemaphore Object on a single device.
 
@@ -72,6 +94,8 @@ void py_module(py::module& module) {
                 cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
                 initial_value (int): The initial value of the global semaphore.
                 buffer_type (BufferType): The type of buffer to use for the global semaphore.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
+                Defaults to waiting on all sub-devices.
             )doc");
 
     module.def(
@@ -87,13 +111,16 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        py::overload_cast<const MultiDeviceGlobalSemaphore&>(&reset_global_semaphore_value),
+        py::overload_cast<const MultiDeviceGlobalSemaphore&, const std::vector<SubDeviceId>&>(
+            &reset_global_semaphore_value),
         py::arg("global_semaphore"),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Reset the value of the global semaphore.
 
             Args:
                 global_semaphore (GlobalSemaphore): The global semaphore object.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
             )doc");
 }
 

--- a/ttnn/cpp/ttnn/global_circular_buffer.hpp
+++ b/ttnn/cpp/ttnn/global_circular_buffer.hpp
@@ -20,13 +20,15 @@ std::shared_ptr<GlobalCircularBuffer> create_global_circular_buffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1);
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 // Multi Device APIs
 MultiDeviceGlobalCircularBuffer create_global_circular_buffer(
     MeshDevice* mesh_device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1);
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/cpp/ttnn/global_semaphore.hpp
+++ b/ttnn/cpp/ttnn/global_semaphore.hpp
@@ -17,17 +17,24 @@ struct MultiDeviceGlobalSemaphore {
 
 // Single Device APIs
 std::shared_ptr<GlobalSemaphore> create_global_semaphore(
-    Device* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+    Device* device,
+    const CoreRangeSet& cores,
+    uint32_t initial_value,
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 DeviceAddr get_global_semaphore_address(const std::shared_ptr<GlobalSemaphore>& global_semaphore);
-void reset_global_semaphore_value(const std::shared_ptr<GlobalSemaphore>& global_semaphore);
+void reset_global_semaphore_value(
+    const std::shared_ptr<GlobalSemaphore>& global_semaphore, const std::vector<SubDeviceId>& sub_device_ids = {});
 
 // Multi Device APIs
 MultiDeviceGlobalSemaphore create_global_semaphore(
     MeshDevice* mesh_device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
-    BufferType buffer_type = BufferType::L1);
+    BufferType buffer_type = BufferType::L1,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 std::vector<DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSemaphore& global_semaphore);
-void reset_global_semaphore_value(const MultiDeviceGlobalSemaphore& global_semaphore);
+void reset_global_semaphore_value(
+    const MultiDeviceGlobalSemaphore& global_semaphore, const std::vector<SubDeviceId>& sub_device_ids = {});
 
 }  // namespace ttnn::global_semaphore


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Global sems/cbs need to support stalling only on a subset of sub-device ids when they need to write to device.

### What's changed
Add sub_device_ids arg to indicate what sub-devices to stall on.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12262918267
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
