### PR TITLE
[Llama3-70b] Separate vllm generator class and add prompt length validation in input processor

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Union
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGeneration
+from models.demos.t3000.llama2_70b.tt.llama_common import (
+    load_llama_state_dict,
+    setup_llama_env,
+    check_mesh_device,
+)
+from models.demos.t3000.llama2_70b.reference.llama.llama.model import ModelArgs as ReferenceModelArgs
+
+from vllm.inputs import INPUT_REGISTRY, DecoderOnlyInputs, EncoderDecoderInputs, InputContext
+
+
+def input_processor_for_llama70b(ctx: InputContext, inputs: Union[DecoderOnlyInputs, EncoderDecoderInputs]):
+    prompt_len = len(inputs.get("prompt_token_ids"))
+    if prompt_len >= 32768:
+        raise ValueError(
+            f"TT LLama70b does not yet support prompts longer than 32768 tokens (received prompt with {prompt_len} tokens)"
+        )
+
+    return inputs
+
+
+@INPUT_REGISTRY.register_input_processor(input_processor_for_llama70b)
+class TtLlamaForCausalLM(TtLlamaModelForGeneration):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def initialize_vllm_model(cls, hf_config, t3k_mesh_device, max_batch_size):
+        # TODO: pass in model args and tt args as parameters from vllm
+        @dataclass
+        class ModelArgs:
+            llama_version: str = None
+            ckpt_dir: str = None
+            max_batch_size: int = 32  # overwritten by max_num_seqs from vllm
+            num_layers: int = 80
+            max_kv_context_len: int = 131072
+
+        @dataclass
+        class TTArgs:
+            mesh_device: object = None
+            cache_path: str = None
+
+        # setup configs
+        llama_version = "llama3"
+        model_config, ckpt_dir, _, cache_path = setup_llama_env(
+            llama_version=llama_version,
+        )
+        check_mesh_device(t3k_mesh_device, model_config)
+
+        # initialize arg classes
+        model_args = ModelArgs(llama_version=llama_version, ckpt_dir=ckpt_dir, max_batch_size=max_batch_size)
+        tt_args = TTArgs(mesh_device=t3k_mesh_device, cache_path=cache_path)
+
+        # load state dict
+        state_dict = load_llama_state_dict(model_args.ckpt_dir, n_layers=model_args.num_layers)
+
+        # TODO: delete this configuration setup once llama can directly accept hf_config
+
+        with open(Path(ckpt_dir) / "params.json", "r") as f:
+            params = json.loads(f.read())
+        configuration = ReferenceModelArgs(
+            max_seq_len=model_args.max_kv_context_len,
+            max_batch_size=model_args.max_batch_size,
+            **params,
+        )
+
+        return cls(
+            configuration=configuration, state_dict=state_dict, model_args=model_args, tt_args=tt_args, vllm=True
+        )
+
+    @property
+    def cache_path(self):
+        return self.tt_model.cache_path

--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -7,17 +7,11 @@ import torch
 import ttnn
 from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 
-from dataclasses import dataclass
 from loguru import logger
 
 import copy
 from models.demos.t3000.llama2_70b.tt.llama_model_optimized import TtLlamaModel_optimized as TtLlamaModel
-from models.demos.t3000.llama2_70b.tt.llama_common import (
-    BASE_URL,
-    load_llama_state_dict,
-    setup_llama_env,
-    check_mesh_device,
-)
+from models.demos.t3000.llama2_70b.tt.llama_common import BASE_URL
 from models.demos.t3000.llama2_70b.tt.model_config import (
     get_model_config,
 )
@@ -60,57 +54,6 @@ class TtLlamaModelForGeneration:
         )
 
         del state_dict
-
-    @classmethod
-    def initialize_vllm_model(cls, hf_config, t3k_mesh_device, max_batch_size):
-        # TODO: pass in model args and tt args as parameters from vllm
-        @dataclass
-        class ModelArgs:
-            llama_version: str = None
-            ckpt_dir: str = None
-            max_batch_size: int = 32  # overwritten by max_num_seqs from vllm
-            num_layers: int = 80
-            max_kv_context_len: int = 131072
-
-        @dataclass
-        class TTArgs:
-            mesh_device: object = None
-            cache_path: str = None
-
-        # setup configs
-        llama_version = "llama3"
-        model_config, ckpt_dir, _, cache_path = setup_llama_env(
-            llama_version=llama_version,
-        )
-        check_mesh_device(t3k_mesh_device, model_config)
-
-        # initialize arg classes
-        model_args = ModelArgs(llama_version=llama_version, ckpt_dir=ckpt_dir, max_batch_size=max_batch_size)
-        tt_args = TTArgs(mesh_device=t3k_mesh_device, cache_path=cache_path)
-
-        # load state dict
-        state_dict = load_llama_state_dict(model_args.ckpt_dir, n_layers=model_args.num_layers)
-
-        # TODO: delete this configuration setup once llama can directly accept hf_config
-        from models.demos.t3000.llama2_70b.reference.llama.llama.model import ModelArgs as ReferenceModelArgs
-        from pathlib import Path
-        import json
-
-        with open(Path(ckpt_dir) / "params.json", "r") as f:
-            params = json.loads(f.read())
-        configuration = ReferenceModelArgs(
-            max_seq_len=model_args.max_kv_context_len,
-            max_batch_size=model_args.max_batch_size,
-            **params,
-        )
-
-        return cls(
-            configuration=configuration, state_dict=state_dict, model_args=model_args, tt_args=tt_args, vllm=True
-        )
-
-    @property
-    def cache_path(self):
-        return self.tt_model.cache_path
 
     def forward(self, tokens: torch.Tensor, start_pos: int, page_table=None, kv_cache=None, prompt_lens=None):
         _, seq_len = tokens.shape


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/vllm/issues/39

### Problem description
- There was no way to validate prompt lengths from vLLM requests prior to model execution so the assert for prefill_len < 32k (during model execution) was causing server instances to crash

### What's changed
- Separated the vLLM generator class for llama70b into `generator_vllm.py`
- Added a custom input processor `input_processor_for_llama70b` which raises ValueErrors on the prompt length

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
