### PR TITLE
#0: Resolve Versim failure after Virtual Coordinates commit

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -425,7 +425,7 @@ tt_cxy_pair Cluster::get_virtual_coordinate_from_logical_coordinates(tt_cxy_pair
 }
 CoreCoord Cluster::get_virtual_coordinate_from_physical_coordinates(chip_id_t chip_id, CoreCoord physical_coord, const CoreType& core_type) const {
     auto& soc_desc = this->get_soc_desc(chip_id);
-    if (not (core_type == CoreType::WORKER or core_type == CoreType::ETH)) {
+    if ((not (core_type == CoreType::WORKER or core_type == CoreType::ETH)) or this->target_type_ == TargetDevice::Simulator) {
         return physical_coord;
     }
     tt_cxy_pair virtual_chip_coord = soc_desc.convert_to_umd_coordinates(tt_cxy_pair(chip_id, physical_coord.x, physical_coord.y));


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
Virtual Coordinates commit broke Versim runs. The Versim driver does not support querying Virtual/Translated coordinates.

### What's changed
Make Virtual Coordinates == Physical Coordinates for Versim.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
