### PR TITLE
#0: fix.

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -822,10 +822,6 @@ void adjust_conv_op_config_for_auto_shard_if_necessary(
             // Currently data-movement ops have too many restrictions to support shallow convs with tiled input.
             conv_config.input_channels_alignment = constants::TILE_WIDTH / 2;
         }
-
-        // Set act_block_h_override to min value to
-        // be conservative with L1 memory usage.
-        conv_config.act_block_h_override = constants::TILE_HEIGHT;
     }
 
     if (conv_config.act_block_w_div == 1 && conv_config.shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {


### PR DESCRIPTION
### Ticket
#0

### Problem description
act_block_h_override  should be set from python side.

### What's changed
act_block_h_override is used in checking whether to use maximum cores or not. this value should be set from python side.

Will be helpful for this issue
[#14977](https://github.com/tenstorrent/tt-metal/issues/14977)

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
