### PR TITLE
Improve memory usage in test_bert_batch_dram.py

### DIFF
--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -221,6 +221,13 @@ def run_bert_question_and_answering_inference(
     profiler.end("processing_output_to_string")
 
     del tt_out
+    del tt_embedding
+    del tt_attention_mask
+    del tt_embedding_inputs
+    del bert_input
+    del pytorch_out
+    if "single_inputs" in locals():
+        del single_inputs
 
     profiler.print()
 


### PR DESCRIPTION
### Ticket
#15821 

### Problem description
When system memory is more constrained, we observed out of memory errors with this test suite.
It starts consuming more than 18G of RAM.
I turned on forced garbage collection in between tests, and that did not fix the problem.
Explicit deletion of these large objects does resolve the issue.

This is an issue because each test is ran in the same process by default in pytest, and clearly memory is not freed as soon as we would like.

### What's changed
Delete objects at the end of a function, once they are no longer needed.

### Checklist
- [x] [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12272437146)
