### PR TITLE
Optimize loading of falcon model checkpoints

### DIFF
--- a/models/demos/ttnn_falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_attention.py
@@ -33,7 +33,7 @@ def get_model_prefix(layer_index: int = 0):
 @pytest.fixture(scope="module")
 def torch_model():
     hugging_face_reference_model = transformers.FalconForCausalLM.from_pretrained(
-        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True
+        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True, device_map="auto"
     ).eval()
     state_dict = hugging_face_reference_model.state_dict()
     filtered_state_dict = strip_state_dict_prefix(state_dict, get_model_prefix())

--- a/models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
@@ -33,7 +33,7 @@ def get_model_prefix(layer_index: int = 0):
 @pytest.fixture(scope="module")
 def torch_model():
     hugging_face_reference_model = transformers.FalconForCausalLM.from_pretrained(
-        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True
+        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True, device_map="auto"
     ).eval()
     state_dict = hugging_face_reference_model.state_dict()
     mlp_state_dict = strip_state_dict_prefix(state_dict, get_model_prefix())

--- a/models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
@@ -25,7 +25,7 @@ def get_model_prefix(layer_index: int = 0):
 @pytest.fixture(scope="module")
 def torch_model():
     hugging_face_reference_model = transformers.FalconForCausalLM.from_pretrained(
-        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True
+        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True, device_map="auto"
     ).eval()
     state_dict = hugging_face_reference_model.state_dict()
     mlp_state_dict = strip_state_dict_prefix(state_dict, get_model_prefix())

--- a/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
@@ -29,7 +29,7 @@ def get_model_prefix(layer_index: int = 0):
 @pytest.fixture(scope="module")
 def torch_model():
     hugging_face_reference_model = transformers.FalconForCausalLM.from_pretrained(
-        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True
+        PRETRAINED_MODEL_NAME, low_cpu_mem_usage=True, device_map="auto"
     ).eval()
     state_dict = hugging_face_reference_model.state_dict()
     filtered_state_dict = strip_state_dict_prefix(state_dict, get_model_prefix())


### PR DESCRIPTION
### Ticket
#15821 

### Problem description
In an environment where system RAM is constrained (2G less than normal due to hugepages)...

Loading these models causes the process to be killed by the linux kernel due to out of memory issues.

A swapfile does not seem to help.

These models alone seem to be around 18GB.

### What's changed
Use `device_map="auto"` to automatically offload parts of the model to disk when system memory is not enough.

### Checklist
Custom Test Dispatched: `pytest tests/nightly/single_card/common_models`
- [x] [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12273319997)
