### PR TITLE
Create chunked-prefill mode in SDPA op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -297,3 +297,188 @@ def test_sdpa_noncausal_unequal_seqlen(device, b, nh, nkv, sq, sk, d, q_chunk_si
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     ttnn.device.DisablePersistentKernelCache()
     run_sdpa_noncausal(device, b, nh, nkv, sq, d, q_chunk_size, k_chunk_size, dtype, sk=sk)
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
+@skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
+# @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
+@pytest.mark.parametrize("q_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("k_dtype", [ttnn.bfloat16])
+# @pytest.mark.parametrize("q_chunk_size", [128, 256], ids=["q128", "q256"])
+# @pytest.mark.parametrize("k_chunk_size", [128, 256], ids=["k128", "k256"])
+@pytest.mark.parametrize("q_chunk_size", [32])
+@pytest.mark.parametrize("k_chunk_size", [32])
+@pytest.mark.parametrize("prefill_chunk_size", [32])
+@pytest.mark.parametrize("page_block_size", [32])
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d",
+    (
+        [1, 1, 1, 64, 32],  # Llama2-70B
+        # [1, 16, 1, 2048, 64],  # Falcon-40B
+        # [1, 71, 1, 2048, 64],  # Falcon-7B
+    ),
+)
+def test_sdpa_chunked(
+    device,
+    b,
+    nh,
+    nkv,
+    s,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    prefill_chunk_size,
+    page_block_size,
+    q_dtype,
+    k_dtype,
+    use_high_precision_compute=False,
+    use_program_cache=False,
+):
+    for _ in range(2):
+        run_test_chunked_sdpa(
+            device,
+            b,
+            nh,
+            nkv,
+            s,
+            d,
+            q_chunk_size,
+            k_chunk_size,
+            prefill_chunk_size,
+            page_block_size,
+            q_dtype,
+            k_dtype,
+            use_high_precision_compute,
+        )
+
+
+def run_test_chunked_sdpa(
+    device,
+    b,
+    nh,
+    nkv,
+    s,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    prefill_chunk_size,
+    page_block_size,
+    q_dtype,
+    k_dtype,
+    use_high_precision_compute,
+):
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=(1, 1),
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+
+    if use_high_precision_compute:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+    Q = fa_rand(b, nh, s, d)
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
+    K_repeated = torch.cat([K[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)  # b, nh, d, S
+    V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)  # b, nh, d, S
+    gt = torch.nn.functional.scaled_dot_product_attention(Q, K_repeated, V_repeated, is_causal=True)
+
+    # Print shapes of all inputs along with input names
+    logger.debug(f"Q: {Q.shape}")
+    logger.debug(f"K: {K.shape}")
+    logger.debug(f"V: {V.shape}")
+
+    assert s % prefill_chunk_size == 0, "s must be divisible by prefill_chunk_size"
+    assert prefill_chunk_size % page_block_size == 0, "prefill_chunk_size must be divisible by page_block_size"
+    num_prefill_chunks = s // prefill_chunk_size
+    # Prepare K, V paged for TT
+    max_num_blocks_per_seq = s // page_block_size
+    assert max_num_blocks_per_seq * page_block_size == s
+    max_num_blocks = b * max_num_blocks_per_seq
+    assert max_num_blocks * page_block_size == b * s
+
+    # Shuffle paged KV cache according to some random page_table
+    permutation = torch.randperm(max_num_blocks)
+    reverse_permutation = torch.argsort(permutation)
+    # page_table is the reverse permutation from shuffled -> unshuffled, and is used to map
+    # a virtual block to the physical block id.
+    page_table = reverse_permutation.reshape(b, max_num_blocks_per_seq)
+
+    def page_cache(cache):
+        paged_cache = (
+            cache.reshape(b, nkv, max_num_blocks_per_seq, page_block_size, d)
+            .transpose(1, 2)
+            .reshape(max_num_blocks, nkv, page_block_size, d)
+        )
+
+        shuffled_page_cache = paged_cache[permutation]
+        return shuffled_page_cache
+
+    def unpage_cache(cache):
+        unshuffled_page_cache = cache[reverse_permutation]
+        paged_cache_back = (
+            unshuffled_page_cache.reshape(b, nkv, max_num_blocks_per_seq, page_block_size, d)
+            .transpose(1, 2)
+            .reshape(b, nkv, s, d)
+        )
+        return paged_cache_back
+
+    # Check that we can convert from normal to paged to normal
+    assert torch.allclose(unpage_cache(page_cache(K)), K)
+    assert torch.allclose(unpage_cache(page_cache(V)), V)
+
+    tt_paged_K = ttnn.Tensor(page_cache(K), k_dtype).to(ttnn.TILE_LAYOUT).to(device)
+    tt_paged_V = ttnn.Tensor(page_cache(V), k_dtype).to(ttnn.TILE_LAYOUT).to(device)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # tt_K = ttnn.Tensor(K, k_dtype).to(ttnn.TILE_LAYOUT).to(device)
+    # tt_V = ttnn.Tensor(V, k_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    # # TODO: Chunk Q
+    # tt_Q = ttnn.Tensor(Q, q_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    # tt_back = ttnn.transformer.scaled_dot_product_attention(
+    #     tt_Q, tt_K, tt_V, is_causal=True, program_config=program_config, compute_kernel_config=compute_kernel_config
+    # )
+    # tt_back = tt_back.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+
+    for chunk_idx in range(num_prefill_chunks):
+        # Chunk Q
+        Q_chunk = Q[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+        tt_Q_chunk = ttnn.Tensor(Q_chunk, q_dtype).to(ttnn.TILE_LAYOUT).to(device)
+        chunk_start_idx = chunk_idx * prefill_chunk_size
+
+        tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
+            tt_Q_chunk,
+            tt_paged_K,
+            tt_paged_V,
+            page_table_tt,
+            chunk_start_idx,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+        tt_back = tt_back.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+
+        # tt_chunk = tt_back[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+        gt_chunk = gt[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+        out_pass, out_pcc = comp_pcc(gt_chunk, tt_back, 0.994)
+        logger.debug(f"python vs pytorch: {out_pcc}")
+        assert out_pass
+
+    # out_pass, out_pcc = comp_pcc(gt, tt_back, 0.994)
+    # logger.debug(f"python vs pytorch: {out_pcc}")
+    # assert out_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -304,17 +304,17 @@ def test_sdpa_noncausal_unequal_seqlen(device, b, nh, nkv, sq, sk, d, q_chunk_si
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
 # @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
 @pytest.mark.parametrize("q_dtype", [ttnn.bfloat16])
-@pytest.mark.parametrize("k_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("k_dtype", [ttnn.bfloat8_b])
 # @pytest.mark.parametrize("q_chunk_size", [128, 256], ids=["q128", "q256"])
 # @pytest.mark.parametrize("k_chunk_size", [128, 256], ids=["k128", "k256"])
-@pytest.mark.parametrize("q_chunk_size", [32])
-@pytest.mark.parametrize("k_chunk_size", [32])
-@pytest.mark.parametrize("prefill_chunk_size", [32])
-@pytest.mark.parametrize("page_block_size", [32])
+@pytest.mark.parametrize("q_chunk_size", [64, 128])
+@pytest.mark.parametrize("k_chunk_size", [64, 128])
+@pytest.mark.parametrize("prefill_chunk_size", [1024, 2048])
+@pytest.mark.parametrize("page_block_size", [64, 128])
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d",
     (
-        [1, 1, 1, 64, 32],  # Llama2-70B
+        [1, 1, 1, 16 * 1024, 32],  # Llama2-70B
         # [1, 16, 1, 2048, 64],  # Falcon-40B
         # [1, 71, 1, 2048, 64],  # Falcon-7B
     ),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -15,7 +15,6 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/matmul.h"
 #include "compute_kernel_api/reduce.h"
-#include "debug/dprint.h"
 
 namespace NAMESPACE {
 template <uint32_t in0, uint32_t in1, uint32_t num_tiles>
@@ -370,7 +369,7 @@ void MAIN {
     const uint32_t local_nh_end = get_arg_val<uint32_t>(4);
     const uint32_t local_q_start = get_arg_val<uint32_t>(5);
     const uint32_t local_q_end = get_arg_val<uint32_t>(6);
-    const uint32_t chunk_start_t = get_arg_val<uint32_t>(7);
+    const uint32_t chunked_q_chunk_offset = get_arg_val<uint32_t>(7);
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
 
@@ -416,6 +415,9 @@ void MAIN {
 #endif
 
                 // Get Q chunk
+                if constexpr (is_chunked) {
+                    q_chunk = chunked_q_chunk_offset + q_chunk;
+                }
                 uint32_t q_low_idx =
                     q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
                 uint32_t q_high_idx;
@@ -424,19 +426,12 @@ void MAIN {
                 } else {
                     q_high_idx = Skt;
                 }
-                if constexpr (is_chunked) {
-                    q_low_idx = chunk_start_t + q_low_idx;
-                    q_high_idx = chunk_start_t + q_high_idx;
-                }
-                // UNPACK(DPRINT << "UNPACK: q_low_idx: " << q_low_idx << ENDL();)
-                // UNPACK(DPRINT << "UNPACK: q_high_idx: " << q_high_idx << ENDL();)
                 cb_wait_front(cb_q_in, q_chunk_tiles);
 
                 // loop while k_low < q_high
                 for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
                     const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
                     const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
-                    // UNPACK(DPRINT << "UNPACK: k_chunk: " << k_chunk << ENDL();)
 
                     /* QK = Q_CHUNK @ K_CHUNK */
                     pack_reconfig_data_format(cb_qk_im);
@@ -455,8 +450,6 @@ void MAIN {
                         qk_subblock_w,
                         true /*transpose*/);
 
-                    // UNPACK(DPRINT << "UNPACK: done with qk_im" << ENDL();)
-
                     /* QK *= SCALE */
                     mul_block_bcast_scalar_inplace<cb_qk_im, cb_scale_in, qk_chunk_tiles>();
 
@@ -467,7 +460,6 @@ void MAIN {
                     // Due to loop bounds, we should never have k_low >= q_high. Can simplify this conditional check
                     if constexpr (is_causal) {
                         if (!(q_low_idx >= k_high_idx)) {
-                            // UNPACK(DPRINT << "UNPACK: adding mask" << ENDL();)
                             /* QK += MASK */
                             reconfig_data_format(cb_qk_im, cb_mask_in);
                             add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
@@ -479,7 +471,6 @@ void MAIN {
                             add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
                         }
                     }
-                    // UNPACK(DPRINT << "UNPACK: done with mask" << ENDL();)
 
                     reconfig_data_format(cb_qk_im, cb_identity_scale_in);
                     reduce_c<
@@ -524,7 +515,7 @@ void MAIN {
                         out_subblock_h,
                         out_subblock_w,
                         false /*transpose*/);
-                    // UNPACK(DPRINT << "UNPACK: done with out_im" << ENDL();)
+
                     reconfig_data_format_srca(cb_out_im);
                     cb_pop_front(cb_qk_im, qk_chunk_tiles);
 
@@ -570,8 +561,5 @@ void MAIN {
             }
         }
     }
-    // UNPACK(DPRINT << "UNPACK: done" << ENDL();)
-    // MATH(DPRINT << "MATH: done" << ENDL();)
-    // PACK(DPRINT << "PACK: done" << ENDL();)
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -4,10 +4,26 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#include "debug/dprint.h"
 
 template <uint32_t tile_bytes, uint32_t num_readers>
 constexpr uint32_t get_barrier_read_threshold() {
     return ((512 / num_readers) * (1024 + 128)) / tile_bytes;
+}
+
+template <uint32_t num_heads, uint32_t block_size_t, uint32_t Wt>
+uint32_t virtual_seq_tile_id_to_physical_tile_id(
+    uint32_t seq_tile_idx, uint32_t cur_head, volatile tt_l1_ptr const uint32_t* const page_table_ptr) {
+    // Given some index in the sequence tiles in range [0, max_seq_len_t]
+    // Return the physical tile id for that tile row
+    constexpr uint32_t block_stride = num_heads * block_size_t * Wt;
+    const uint32_t head_offset = cur_head * block_size_t * Wt;
+
+    const uint32_t virtual_block = seq_tile_idx / block_size_t;
+    const uint32_t physical_block = page_table_ptr[virtual_block];
+    const uint32_t block_row_offset = seq_tile_idx % block_size_t;
+    const uint32_t block_offset = block_row_offset * Wt;
+    return physical_block * block_stride + head_offset + block_offset;
 }
 
 void kernel_main() {
@@ -24,18 +40,25 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_compile_time_arg_val(10);
     constexpr uint32_t is_causal = get_compile_time_arg_val(11) == 1;
     constexpr uint32_t use_provided_mask = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t is_chunked = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(14) == 1;
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(15);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(16);
 
-    const uint32_t q_addr = get_arg_val<uint32_t>(0);
-    const uint32_t k_addr = get_arg_val<uint32_t>(1);
-    const uint32_t v_addr = get_arg_val<uint32_t>(2);
-    const uint32_t mask_addr = get_arg_val<uint32_t>(3);
-    const uint32_t core_id = get_arg_val<uint32_t>(4);
-    const uint32_t local_batch_start = get_arg_val<uint32_t>(5);
-    const uint32_t local_batch_end = get_arg_val<uint32_t>(6);
-    const uint32_t local_nh_start = get_arg_val<uint32_t>(7);
-    const uint32_t local_nh_end = get_arg_val<uint32_t>(8);
-    const uint32_t local_q_start = get_arg_val<uint32_t>(9);
-    const uint32_t local_q_end = get_arg_val<uint32_t>(10);
+    uint32_t argidx = 0;
+    const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t k_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t v_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t mask_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t page_table_addr = get_arg_val<uint32_t>(argidx++);
+    const uint32_t core_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t local_batch_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t local_batch_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t local_nh_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t local_nh_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t local_q_start = get_arg_val<uint32_t>(argidx++);
+    const uint32_t local_q_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t chunk_start_t = get_arg_val<uint32_t>(argidx++);
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
 
@@ -76,6 +99,8 @@ void kernel_main() {
     const InterleavedAddrGenFast<is_dram> mask_reader = {
         .bank_base_address = mask_addr, .page_size = mask_tile_bytes, .data_format = mask_data_format};
 
+    volatile tt_l1_ptr uint32_t* page_table_ptr;
+
     uint32_t q_tile_id = 0;
     uint32_t k_tile_id = 0;
     uint32_t v_tile_id = 0;
@@ -83,11 +108,25 @@ void kernel_main() {
     uint32_t barrier_count = 0;
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
+        if constexpr (is_chunked) {
+            // Chunked means that we have paged attention
+            constexpr uint32_t cb_id_page_table = tt::CBIndex::c_6;
+            const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                .bank_base_address = page_table_addr, .page_size = page_table_stick_size};
+            cb_reserve_back(cb_id_page_table, 1);
+            uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
+            uint64_t page_table_noc_addr = get_noc_addr(nb, page_table_gen);
+            noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_page_table, 1);
+            page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
+        }
         const uint32_t q_batch_offset = nb * NQH * Sqt * DHt;
         const uint32_t kv_batch_offset = nb * NKH * Skt * DHt;
         const uint32_t mask_batch_offset = nb * Sqt * Skt;
         for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
             for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
+                // DPRINT << "q_iter: " << q_iter << ENDL();
                 uint32_t q_chunk;
 #if defined BALANCED_Q_PARALLEL
                 uint32_t q_chunk_div_2 = q_chunks_per_core / 2;
@@ -124,7 +163,9 @@ void kernel_main() {
 
                 cb_push_back(cb_q_in, q_chunk_tiles);
 
-                const uint32_t q_low_idx =
+                // DPRINT << "q_chunk: " << q_chunk << "\n";
+
+                uint32_t q_low_idx =
                     q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
                 uint32_t q_high_idx;
                 if constexpr (is_causal) {
@@ -132,6 +173,14 @@ void kernel_main() {
                 } else {
                     q_high_idx = Skt;
                 }
+                if constexpr (is_chunked) {
+                    // Add the chunk offset to the low and high indices
+                    q_low_idx = chunk_start_t + q_low_idx;
+                    q_high_idx = chunk_start_t + q_high_idx;
+                }
+
+                // DPRINT << "q_low_idx: " << q_low_idx << ENDL();
+                // DPRINT << "q_high_idx: " << q_high_idx << ENDL();
 
                 const uint32_t kv_head = nq / q_heads_per_kv;
                 const uint32_t kv_head_offset = kv_head * Skt * DHt;
@@ -141,27 +190,57 @@ void kernel_main() {
                     const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
                     const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
                     const uint32_t k_start_tile_id = kv_batch_offset + kv_head_offset + k_chunk * Sk_chunk_t * DHt;
+                    // DPRINT << "READER: k_chunk: " << k_chunk << ENDL();
 
-                    // Read K chunk transposed
-                    cb_reserve_back(cb_k_in, k_chunk_tiles);
-                    uint32_t k_write_ptr = get_write_ptr(cb_k_in);
-                    barrier_count = 0;
-                    for (uint32_t col = 0; col < DHt; ++col) {
-                        k_tile_id = k_start_tile_id + col;
+                    if constexpr (is_chunked) {
+                        // Use page table to read K chunk
+                        const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                        cb_reserve_back(cb_k_in, k_chunk_tiles);
+                        uint32_t k_write_ptr = get_write_ptr(cb_k_in);
+                        barrier_count = 0;
                         for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
-                            noc_async_read_tile(k_tile_id, k_reader, k_write_ptr);
-                            k_tile_id += DHt;
-                            k_write_ptr += k_tile_bytes;
+                            uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
+                            uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
+                            uint32_t physical_k_tile_id =
+                                virtual_seq_tile_id_to_physical_tile_id<NKH, block_size_t, DHt>(
+                                    virtual_k_tile_row_num, kv_head, page_table_ptr);
+                            for (uint32_t col = 0; col < DHt; ++col) {
+                                noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                                physical_k_tile_id += 1;                       // Go to next tile in row
+                                k_write_ptr_col += Sk_chunk_t * k_tile_bytes;  // Go to next column in CB
 
-                            if (++barrier_count == barrier_threshold) {
-                                noc_async_read_barrier();
-                                barrier_count = 0;
+                                if (++barrier_count == barrier_threshold) {
+                                    noc_async_read_barrier();
+                                    barrier_count = 0;
+                                }
                             }
                         }
-                    }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_k_in, k_chunk_tiles);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_k_in, k_chunk_tiles);
 
+                    } else {
+                        // Read K chunk transposed
+                        cb_reserve_back(cb_k_in, k_chunk_tiles);
+                        uint32_t k_write_ptr = get_write_ptr(cb_k_in);
+                        barrier_count = 0;
+                        for (uint32_t col = 0; col < DHt; ++col) {
+                            k_tile_id = k_start_tile_id + col;
+                            for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
+                                noc_async_read_tile(k_tile_id, k_reader, k_write_ptr);
+                                k_tile_id += DHt;
+                                k_write_ptr += k_tile_bytes;
+
+                                if (++barrier_count == barrier_threshold) {
+                                    noc_async_read_barrier();
+                                    barrier_count = 0;
+                                }
+                            }
+                        }
+                        noc_async_read_barrier();
+                        cb_push_back(cb_k_in, k_chunk_tiles);
+                    }
+
+                    // DPRINT << "READER: done with k_chunk: " << k_chunk << ENDL();
                     if constexpr (use_provided_mask) {
                         // Finding the diagonal is harder now that q_chunk_size and k_chunk_size can differ
                         // Q-range = [q_low, q_high)
@@ -191,25 +270,55 @@ void kernel_main() {
                         cb_push_back(cb_mask_in, mask_chunk_tiles);
                     }
 
-                    v_tile_id = k_start_tile_id;
-                    // Read V chunk
-                    cb_reserve_back(cb_v_in, k_chunk_tiles);
-                    uint32_t v_write_ptr = get_write_ptr(cb_v_in);
-                    barrier_count = 0;
-                    for (uint32_t tile = 0; tile < k_chunk_tiles; ++tile) {
-                        noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
-                        v_tile_id += 1;
-                        v_write_ptr += v_tile_bytes;
+                    if constexpr (is_chunked) {
+                        // Use page table to read V chunk
+                        const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                        cb_reserve_back(cb_v_in, k_chunk_tiles);
+                        uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+                        barrier_count = 0;
 
-                        if (++barrier_count == barrier_threshold) {
-                            noc_async_read_barrier();
-                            barrier_count = 0;
+                        for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
+                            uint32_t virtual_v_tile_row_num = k_chunk_start_row_num + row;
+                            uint32_t physical_v_tile_id =
+                                virtual_seq_tile_id_to_physical_tile_id<NKH, block_size_t, DHt>(
+                                    virtual_v_tile_row_num, kv_head, page_table_ptr);
+                            for (uint32_t col = 0; col < DHt; ++col) {
+                                noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
+                                physical_v_tile_id += 1;
+                                v_write_ptr += v_tile_bytes;
+
+                                if (++barrier_count == barrier_threshold) {
+                                    noc_async_read_barrier();
+                                    barrier_count = 0;
+                                }
+                            }
                         }
+                        noc_async_read_barrier();
+                        cb_push_back(cb_v_in, k_chunk_tiles);
+                    } else {
+                        v_tile_id = k_start_tile_id;
+                        // Read V chunk
+                        cb_reserve_back(cb_v_in, k_chunk_tiles);
+                        uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+                        barrier_count = 0;
+                        for (uint32_t tile = 0; tile < k_chunk_tiles; ++tile) {
+                            noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
+                            v_tile_id += 1;
+                            v_write_ptr += v_tile_bytes;
+
+                            if (++barrier_count == barrier_threshold) {
+                                noc_async_read_barrier();
+                                barrier_count = 0;
+                            }
+                        }
+                        noc_async_read_barrier();
+                        cb_push_back(cb_v_in, k_chunk_tiles);
                     }
-                    noc_async_read_barrier();
-                    cb_push_back(cb_v_in, k_chunk_tiles);
+
+                    // DPRINT << "READER: done with v_chunk: " << k_chunk << ENDL();
                 }
             }
         }
     }
+    // DPRINT << "READER: done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -71,6 +71,7 @@ void kernel_main() {
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
     constexpr uint32_t cb_v_in = tt::CBIndex::c_2;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
+    constexpr uint32_t cb_id_page_table = tt::CBIndex::c_6;
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
@@ -109,7 +110,6 @@ void kernel_main() {
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
         if constexpr (is_chunked) {
             // Chunked means that we have paged attention
-            constexpr uint32_t cb_id_page_table = tt::CBIndex::c_6;
             const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
                 .bank_base_address = page_table_addr, .page_size = page_table_stick_size};
             cb_reserve_back(cb_id_page_table, 1);
@@ -305,6 +305,10 @@ void kernel_main() {
                     }
                 }
             }
+        }
+
+        if constexpr (is_chunked) {
+            cb_pop_front(cb_id_page_table, 1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -50,7 +50,6 @@ void fill_diagonal_tile(uint32_t cb_id, uint32_t tile_id, uint32_t partial_val) 
 
     fill_tile<tile_bytes>(cb_id, tile_id, 0);
 
-    // DPRINT << "Fill partial tile" << ENDL();
     const uint16_t datum_val = partial_val >> 16;
     volatile tt_l1_ptr uint16_t* uint16_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
@@ -215,12 +214,6 @@ void kernel_main() {
                         q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
                     uint32_t q_high_idx = q_low_idx + Sq_chunk_t;
 
-                    // if constexpr (is_chunked) {
-                    //     q_low_idx = chunk_start_t + q_low_idx;
-                    //     q_high_idx = chunk_start_t + q_high_idx;
-                    //     q_chunk = chunk_start_t_in_q_chunks + q_chunk;
-                    // }
-
                     for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
                         const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
                         const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
@@ -233,7 +226,6 @@ void kernel_main() {
                         if (!(q_low_idx >= k_high_idx)) {
                             generate_mask<cb_mask_in>(Sq_chunk_t, Sk_chunk_t, q_chunk, k_chunk);
                         }
-                        // DPRINT << "WRITER: done with k_chunk: " << k_chunk << ENDL();
                     }
                 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -5,7 +5,6 @@
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
-#include "debug/dprint.h"
 
 template <uint32_t tile_bytes, uint32_t num_readers>
 constexpr uint32_t get_barrier_read_threshold() {
@@ -158,7 +157,7 @@ void kernel_main() {
     const uint32_t local_nh_end = get_arg_val<uint32_t>(5);
     const uint32_t local_q_start = get_arg_val<uint32_t>(6);
     const uint32_t local_q_end = get_arg_val<uint32_t>(7);
-    const uint32_t chunk_start_t = get_arg_val<uint32_t>(8);
+    const uint32_t chunk_start_t_in_q_chunks = get_arg_val<uint32_t>(8);
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
 
@@ -208,14 +207,19 @@ void kernel_main() {
                 out_tile_id = q_batch_offset + q_head_offset + q_chunk_offset;
 
                 if constexpr (is_causal) {
+                    if constexpr (is_chunked) {
+                        // Bump it up to the chunk start
+                        q_chunk = chunk_start_t_in_q_chunks + q_chunk;
+                    }
                     uint32_t q_low_idx =
                         q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
                     uint32_t q_high_idx = q_low_idx + Sq_chunk_t;
 
-                    if constexpr (is_chunked) {
-                        q_low_idx = chunk_start_t + q_low_idx;
-                        q_high_idx = chunk_start_t + q_high_idx;
-                    }
+                    // if constexpr (is_chunked) {
+                    //     q_low_idx = chunk_start_t + q_low_idx;
+                    //     q_high_idx = chunk_start_t + q_high_idx;
+                    //     q_chunk = chunk_start_t_in_q_chunks + q_chunk;
+                    // }
 
                     for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
                         const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
@@ -227,11 +231,6 @@ void kernel_main() {
                         // Due to loop bounds, we should never have k_low >= q_high. Can simplify this conditional check
                         // Read mask chunk
                         if (!(q_low_idx >= k_high_idx)) {
-                            DPRINT << "WRITER: chunk_start_t: " << chunk_start_t << ENDL();
-                            DPRINT << "WRITER: q_low_idx: " << q_low_idx << ENDL();
-                            DPRINT << "WRITER: k_high_idx: " << k_high_idx << ENDL();
-                            DPRINT << "WRITER: masking for q_chunk: " << q_chunk << " and k_chunk: " << k_chunk
-                                   << ENDL();
                             generate_mask<cb_mask_in>(Sq_chunk_t, Sk_chunk_t, q_chunk, k_chunk);
                         }
                         // DPRINT << "WRITER: done with k_chunk: " << k_chunk << ENDL();
@@ -257,5 +256,4 @@ void kernel_main() {
             }
         }
     }
-    DPRINT << "WRITER: done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -14,9 +14,11 @@ namespace ttnn::operations::transformer {
 void ScaledDotProductAttention::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
+    // Common validations for both modes
+    TT_FATAL(input_tensors.size() == 3, "Must have 3 input tensors (Q, K, V)");
     TT_FATAL(
-        input_tensors.size() == 3 and optional_input_tensors.size() == 1,
-        "Must have 3 input tensors and optional mask");
+        optional_input_tensors.size() == 1 or optional_input_tensors.size() == 2,
+        "Must have 1 or 2 optional tensors (mask/page_table)");
 
     for (auto& input_tensor : input_tensors) {
         TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to SDPA need to be on device");
@@ -29,75 +31,188 @@ void ScaledDotProductAttention::validate(
             "Operands to SDPA need to be in DRAM");
     }
 
-    TT_FATAL(
-        !(this->is_causal && optional_input_tensors.at(0).has_value()),
-        "is_causal and attn_mask cannot both be present. Got is_causal: {}, attn_mask: {}",
-        this->is_causal,
-        optional_input_tensors.at(0).has_value());
-
-    const auto& mask_option = optional_input_tensors.at(0);
-    if (mask_option.has_value()) {
-        auto mask = optional_input_tensors.at(0).value();
+    auto validate_regular_mode = [&]() {
         TT_FATAL(
-            mask.storage_type() == StorageType::DEVICE, "When mask is provided to SDPA, the tensor must be on device");
-        TT_FATAL(
-            input_tensors.at(0).device() == mask.device(),
-            "When mask is provided to SDPA, it must be on the same device as the input tensors");
-        TT_FATAL(mask.get_layout() == Layout::TILE, "When mask is provided to SDPA, it must be tilized");
-        TT_FATAL(
-            mask.get_dtype() == DataType::BFLOAT16 || mask.get_dtype() == DataType::BFLOAT8_B ||
-                mask.get_dtype() == DataType::BFLOAT4_B,
-            "When mask is provided to SDPA, it must be in BF16, BFP8, or BFP4 dataformat");
+            !(this->is_causal && optional_input_tensors.at(0).has_value()),
+            "is_causal and attn_mask cannot both be present. Got is_causal: {}, attn_mask: {}",
+            this->is_causal,
+            optional_input_tensors.at(0).has_value());
+
+        const auto& mask_option = optional_input_tensors.at(0);
+        if (mask_option.has_value()) {
+            auto mask = mask_option.value();
+            TT_FATAL(
+                mask.storage_type() == StorageType::DEVICE,
+                "When mask is provided to SDPA, the tensor must be on device");
+            TT_FATAL(
+                input_tensors.at(0).device() == mask.device(),
+                "When mask is provided to SDPA, it must be on the same device as the input tensors");
+            TT_FATAL(mask.get_layout() == Layout::TILE, "When mask is provided to SDPA, it must be tilized");
+            TT_FATAL(
+                mask.get_dtype() == DataType::BFLOAT16 || mask.get_dtype() == DataType::BFLOAT8_B ||
+                    mask.get_dtype() == DataType::BFLOAT4_B,
+                "When mask is provided to SDPA, it must be in BF16, BFP8, or BFP4 dataformat");
+
+            TT_FATAL(
+                mask.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
+                "When mask is provided to SDPA, it must be in DRAM");
+
+            const auto mask_shape = mask.get_legacy_shape();
+            const auto q_shape = input_tensors.at(0).get_legacy_shape();
+            const auto k_shape = input_tensors.at(1).get_legacy_shape();
+
+            TT_FATAL(mask_shape[0] == q_shape[0], "Mask batch dim must match Q batch dim");
+            TT_FATAL(mask_shape[1] == 1, "Mask num_heads must be 1 to be broadcasted across all heads");
+            TT_FATAL(mask_shape[2] == q_shape[2], "Mask sequence length must match Q sequence length");
+            TT_FATAL(mask_shape[3] == k_shape[2], "Mask sequence length must match K sequence length");
+        }
+
+        // Shape checks
+        const auto q_shape = input_tensors.at(0).get_legacy_shape();
+        const auto k_shape = input_tensors.at(1).get_legacy_shape();
+        const auto v_shape = input_tensors.at(2).get_legacy_shape();
+        const auto B = q_shape[0];
+        const auto nqh = q_shape[1];
+        const auto nkv = k_shape[1];
+        const auto Sq = q_shape[2];
+        const auto DH = q_shape[3];
+        const auto Sk = k_shape[2];
+        if (this->is_causal) {
+            TT_FATAL(
+                Sq == Sk, "Causal SDPA requires Q and K to have the same sequence length. Got Q: {}, K: {}", Sq, Sk);
+        }
 
         TT_FATAL(
-            mask.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
-            "When mask is provided to SDPA, it must be in DRAM");
-    }
+            k_shape[0] == B && v_shape[0] == B, "K and V batch must match. Got K: {}, V: {}", k_shape[0], v_shape[0]);
+        TT_FATAL(v_shape[1] == nkv, "K and V num_heads must match. Got K: {}, V: {}", k_shape[1], v_shape[1]);
+        TT_FATAL(v_shape[2] == Sk, "K and V sequence length must match. Got K: {}, V: {}", k_shape[2], v_shape[2]);
+        TT_FATAL(
+            k_shape[3] == DH && v_shape[3] == DH,
+            "K and V hidden dim must match. Got K: {}, V: {}",
+            k_shape[3],
+            v_shape[3]);
+        TT_FATAL(
+            nqh >= nkv && nqh % nkv == 0,
+            "Q num_heads must be >= K num_heads and divisible by K num_heads. Got Q: {}, K: {}",
+            nqh,
+            nkv);
 
-    // assert all dataformats are the same
-    TT_FATAL(
-        input_tensors.at(0).get_dtype() == input_tensors.at(1).get_dtype() &&
-            input_tensors.at(0).get_dtype() == input_tensors.at(2).get_dtype(),
-        "All inputs to SDPA must have the same dataformat");
+        if (this->program_config.has_value()) {
+            auto q_chunk_size = program_config->q_chunk_size;
+            auto k_chunk_size = program_config->k_chunk_size;
 
-    TT_FATAL(this->output_mem_config.buffer_type == tt::tt_metal::BufferType::DRAM, "Output must be in DRAM");
+            TT_FATAL(
+                Sq % q_chunk_size == 0,
+                "q_chunk_size must divide q_shape[-2]. Got q_chunk_size: {}, q_shape[-2]: {}",
+                q_chunk_size,
+                q_shape[-2]);
+            TT_FATAL(
+                Sk % k_chunk_size == 0,
+                "k_chunk_size must divide k_shape[-2]. Got k_chunk_size: {}, k_shape[-2]: {}",
+                k_chunk_size,
+                k_shape[-2]);
+        }
+    };
 
-    // Check shapes
-    const auto q_shape = input_tensors.at(0).get_legacy_shape();
-    const auto k_shape = input_tensors.at(1).get_legacy_shape();
-    const auto v_shape = input_tensors.at(2).get_legacy_shape();
-    const auto B = q_shape[0];
-    const auto nqh = q_shape[1];
-    const auto nkv = k_shape[1];
-    const auto Sq = q_shape[2];
-    const auto DH = q_shape[3];
-    const auto Sk = k_shape[2];
-    if (this->is_causal) {
-        TT_FATAL(Sq == Sk, "Causal SDPA requires Q and K to have the same sequence length. Got Q: {}, K: {}", Sq, Sk);
-    }
+    auto validate_chunked_mode = [&]() {
+        TT_FATAL(chunk_start_idx.has_value(), "chunk_start_idx must be provided for chunked mode");
+        TT_FATAL(chunk_start_idx.value() >= 0, "chunk_start_idx must be non-negative");
 
-    TT_FATAL(k_shape[0] == B && v_shape[0] == B, "K and V batch must match. Got K: {}, V: {}", k_shape[0], v_shape[0]);
-    TT_FATAL(v_shape[1] == nkv, "K and V num_heads must match. Got K: {}, V: {}", k_shape[1], v_shape[1]);
-    TT_FATAL(v_shape[2] == Sk, "K and V sequence length must match. Got K: {}, V: {}", k_shape[2], v_shape[2]);
-    TT_FATAL(k_shape[3] == DH && v_shape[3] == DH, "K and V hidden dim must match. Got K: {}, V: {}", k_shape[3], v_shape[3]);
-    TT_FATAL(nqh >= nkv && nqh % nkv == 0, "Q num_heads must be >= K num_heads and divisible by K num_heads. Got Q: {}, K: {}", nqh, nkv);
+        // Validate page table tensor
+        const auto& page_table = optional_input_tensors[1].value();
+        TT_FATAL(page_table.storage_type() == StorageType::DEVICE, "Page table tensor must be on device");
+        TT_FATAL(
+            input_tensors.at(0).device() == page_table.device(),
+            "Page table must be on the same device as the input tensors");
+        TT_FATAL(page_table.get_layout() == Layout::ROW_MAJOR, "Page table must be row major");
+        // Check that page table is int32
+        TT_FATAL(page_table.get_dtype() == DataType::INT32, "Page table must be int32");
+        // Validate that first optional tensor (mask) is not provided
+        TT_FATAL(
+            !optional_input_tensors[0].has_value(),
+            "Attention mask should not be provided in chunked mode - masking is handled internally");
 
-    if (mask_option.has_value()) {
-        const auto mask_shape = mask_option.value().get_legacy_shape();
+        // Additional chunked-specific validations
+        const auto q_shape = input_tensors.at(0).get_legacy_shape();
+        const auto k_shape = input_tensors.at(1).get_legacy_shape();
+        const auto v_shape = input_tensors.at(2).get_legacy_shape();
+        const auto page_table_shape = page_table.get_legacy_shape();
+        const auto B = q_shape[0];
+        const auto nqh = q_shape[1];
+        const auto nkv = k_shape[1];
+        const auto Sq = q_shape[2];
+        const auto DH = q_shape[3];
+        const auto k_page_size = k_shape[2];
+        const uint32_t num_pages_per_user = page_table.get_legacy_shape()[1];
+        // Check that k page size matches v page size
+        TT_FATAL(
+            k_page_size == v_shape[2], "K page size must match V page size. Got K: {}, V: {}", k_page_size, v_shape[2]);
+        // Check that page table has same batch size as input tensors
+        TT_FATAL(
+            page_table_shape[0] == B,
+            "Page table batch size must match input batch size. Got Page table: {}, Input: {}",
+            page_table_shape[0],
+            B);
+        // Calculate K length based on number of pages per user
+        const uint32_t kv_length = num_pages_per_user * k_page_size;
 
-        TT_FATAL(mask_shape[0] == B, "Mask batch dim must match Q batch dim");
-        TT_FATAL(mask_shape[1] == 1, "Mask num_heads must be 1 to be broadcasted across all heads");
-        TT_FATAL(mask_shape[2] == Sq, "Mask sequence length must match Q sequence length");
-        TT_FATAL(mask_shape[3] == Sk, "Mask sequence length must match K sequence length");
-    }
+        TT_FATAL(v_shape[1] == nkv, "K and V num_heads must match. Got K: {}, V: {}", k_shape[1], v_shape[1]);
+        TT_FATAL(
+            k_shape[3] == DH && v_shape[3] == DH,
+            "K and V hidden dim must match. Got K: {}, V: {}",
+            k_shape[3],
+            v_shape[3]);
+        TT_FATAL(
+            nqh >= nkv && nqh % nkv == 0,
+            "Q num_heads must be >= K num_heads and divisible by K num_heads. Got Q: {}, K: {}",
+            nqh,
+            nkv);
 
-    if (this->program_config.has_value()) {
-        auto q_chunk_size = program_config->q_chunk_size;
-        auto k_chunk_size = program_config->k_chunk_size;
+        if (this->program_config.has_value()) {
+            auto q_chunk_size = program_config->q_chunk_size;
+            auto k_chunk_size = program_config->k_chunk_size;
 
-        TT_FATAL(Sq % q_chunk_size == 0, "q_chunk_size must divide q_shape[-2]. Got q_chunk_size: {}, q_shape[-2]: {}", q_chunk_size, q_shape[-2]);
-        TT_FATAL(Sk % k_chunk_size == 0, "k_chunk_size must divide k_shape[-2]. Got k_chunk_size: {}, k_shape[-2]: {}", k_chunk_size, k_shape[-2]);
+            TT_FATAL(
+                Sq % q_chunk_size == 0,
+                "q_chunk_size must divide q_shape[-2]. Got q_chunk_size: {}, q_shape[-2]: {}",
+                q_chunk_size,
+                q_shape[-2]);
+            TT_FATAL(
+                kv_length % k_chunk_size == 0,
+                "k_chunk_size must divide k_shape[-2]. Got k_chunk_size: {}, k_shape[-2]: {}",
+                k_chunk_size,
+                k_shape[-2]);
+        }
 
+        // In chunked mode, K's sequence dimension should be >= Q's sequence dimension + chunk_start_idx
+        TT_FATAL(
+            kv_length >= q_shape[2] + chunk_start_idx.value(),
+            "K's sequence length must be >= Q's sequence length + chunk_start_idx. Got K: {}, Q: {}, chunk_start_idx: "
+            "{}",
+            kv_length,
+            q_shape[2],
+            chunk_start_idx.value());
+    };
+
+    auto check_conditions = [&]() {
+        bool has_chunk_start = chunk_start_idx.has_value();
+        bool has_two_optional_inputs = optional_input_tensors.size() == 2;
+        bool has_page_table = optional_input_tensors.size() > 1 && optional_input_tensors.at(1).has_value();
+        TT_FATAL(
+            has_chunk_start == has_two_optional_inputs, "chunk_start_idx and number of optional inputs must match");
+        TT_FATAL(
+            has_two_optional_inputs == has_page_table,
+            "page_table must be provided if and only if there are two optional inputs");
+    };
+
+    check_conditions();
+    bool is_chunked_mode = chunk_start_idx.has_value();
+
+    // Check if we're in chunked mode and call appropriate validation
+    if (is_chunked_mode) {
+        validate_chunked_mode();
+    } else {
+        validate_regular_mode();
     }
 }
 
@@ -125,6 +240,8 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
 
     std::size_t q_chunk_size = this->program_config ? this->program_config->q_chunk_size : 32;
     std::size_t k_chunk_size = this->program_config ? this->program_config->k_chunk_size : 32;
+    // get page table if chunked
+    const auto page_table = this->chunk_start_idx.has_value() ? optional_input_tensors.at(1) : std::nullopt;
 
     return detail::sdpa_multi_core(
         input_tensor_q,
@@ -132,6 +249,8 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
         input_tensor_v,
         output_tensor,
         attn_mask,
+        page_table,
+        this->chunk_start_idx,
         scale,
         this->is_causal,
         q_chunk_size,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -259,4 +259,19 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
         this->program_config);
 }
 
+operation::Hash ScaledDotProductAttention::compute_program_hash(
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
+    bool is_chunked_prefill = this->chunk_start_idx.has_value();
+    return operation::hash_operation<ScaledDotProductAttention>(
+        this->scale,
+        this->output_mem_config,
+        this->program_config,
+        this->is_causal,
+        is_chunked_prefill,
+        this->compute_kernel_config,
+        input_tensors,
+        optional_input_tensors);
+}
+
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
@@ -18,6 +18,7 @@ struct ScaledDotProductAttention {
     const MemoryConfig output_mem_config;
     const std::optional<SDPAProgramConfig> program_config;
     const bool is_causal;
+    const std::optional<int64_t> chunk_start_idx;
     const DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.hpp
@@ -31,6 +31,10 @@ struct ScaledDotProductAttention {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
+
+    operation::Hash compute_program_hash(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
 };
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sdpa_program_factory.hpp"
+#include "sdpa_op.hpp"
 
 #include <optional>
 
@@ -26,6 +27,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     const Tensor& input_tensor_v,
     const Tensor& output_tensor,
     const std::optional<const Tensor>& attn_mask,
+    const std::optional<const Tensor>& page_table,
+    const std::optional<int64_t>& chunk_start_idx,
     std::optional<float> scale,
     bool is_causal,
     std::size_t q_chunk_size,
@@ -42,8 +45,49 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     const auto q_shape = input_tensor_q.get_legacy_shape();
     const auto k_shape = input_tensor_k.get_legacy_shape();
     const uint32_t B = q_shape[0], NQH = q_shape[1], Sq = q_shape[2], DH = q_shape[3];
-    const uint32_t Sk = k_shape[2];
     const uint32_t NKH = k_shape[1];
+
+    // Paged cache parameters when in chunked mode
+    bool is_chunked = chunk_start_idx.has_value();
+    uint32_t chunk_start_t = 0;
+    uint32_t block_size = 0;
+    uint32_t block_size_t = 0;
+    uint32_t max_blocks_per_seq = 0;
+    uint32_t page_table_stick_size = 0;
+    bool page_table_is_dram = true;
+    tt::DataFormat page_table_df = tt::DataFormat::Int32;
+
+    if (is_chunked) {
+        chunk_start_t = chunk_start_idx.value() / TILE_HEIGHT;  // Q offset in tiles
+        const auto& page_table_tensor = page_table.value();
+        block_size = k_shape[2];  // K's sequence dimension represents block size
+        block_size_t = block_size / TILE_HEIGHT;
+        max_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
+        page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
+        TT_FATAL(
+            page_table_stick_size % 32 == 0,
+            "page table page size in bytes must be a multiple of 32 due to address alignment");
+        page_table_is_dram = page_table_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+        TT_FATAL(
+            page_table_stick_size % 32 == 0,
+            "page table page size in bytes must be a multiple of 32 due to address alignment");
+    }
+    // Log page table info
+    tt::log_info("is_chunked: {}", is_chunked);
+    if (is_chunked) {
+        tt::log_info("chunk_start_t: {}", chunk_start_t);
+        tt::log_info("block_size: {}", block_size);
+        tt::log_info("block_size_t: {}", block_size_t);
+        tt::log_info("max_blocks_per_seq: {}", max_blocks_per_seq);
+        tt::log_info("page_table_stick_size: {}", page_table_stick_size);
+        tt::log_info("page_table_is_dram: {}", page_table_is_dram);
+        tt::log_info("page_table_df: {}", page_table_df);
+    }
+
+    // In chunked mode, we only need to process K/V up to chunk_start_idx + Sq
+    const uint32_t Sk = is_chunked ? (chunk_start_idx.value() + Sq) : k_shape[2];
+
     const uint32_t Sqt = Sq / TILE_HEIGHT;
     const uint32_t Skt = Sk / TILE_HEIGHT;
     const uint32_t DHt = DH / TILE_WIDTH;
@@ -220,22 +264,26 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     scale_union.f = scale.value_or(1.0f);
 
     std::vector<uint32_t> reader_compile_time_args = {// interleaved accessor args
-        B,
-        NQH,
-        NKH,
-        Sqt,
-        Skt,
-        DHt,
-        Sq_chunk_t,
-        q_num_chunks,
-        Sk_chunk_t,
-        k_num_chunks,
-        num_cores,
-        (std::uint32_t)is_causal,
-        (std::uint32_t)use_provided_mask
-    };
+                                                      B,
+                                                      NQH,
+                                                      NKH,
+                                                      Sqt,
+                                                      Skt,
+                                                      DHt,
+                                                      Sq_chunk_t,
+                                                      q_num_chunks,
+                                                      Sk_chunk_t,
+                                                      k_num_chunks,
+                                                      num_cores,
+                                                      (std::uint32_t)is_causal,
+                                                      (std::uint32_t)use_provided_mask,
+                                                      (uint32_t)is_chunked,
+                                                      (uint32_t)page_table_is_dram,
+                                                      block_size_t,
+                                                      page_table_stick_size};
 
-    std::vector<uint32_t> writer_compile_time_args = {// interleaved accessor args
+    std::vector<uint32_t> writer_compile_time_args = {
+        // interleaved accessor args
         B,
         NQH,
         NKH,
@@ -249,10 +297,12 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         scale_union.u,
         num_cores,
         (std::uint32_t)is_causal,
-        (std::uint32_t)use_provided_mask
+        (std::uint32_t)use_provided_mask,
+        (uint32_t)is_chunked,
     };
 
-    std::vector<uint32_t> compute_compile_time_args = {// matmul args
+    std::vector<uint32_t> compute_compile_time_args = {
+        // matmul args
         B,
         NQH,
         NKH,
@@ -276,7 +326,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
         out_num_blocks,
         num_cores,
         (std::uint32_t)is_causal,
-        (std::uint32_t)use_provided_mask
+        (std::uint32_t)use_provided_mask,
+        (uint32_t)is_chunked,
     };
 
     std::map<string, string> defines;
@@ -381,6 +432,12 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                             .set_page_size(tt::CBIndex::c_5, scalar_tile_size);
     auto cb_in5_id = CreateCircularBuffer(program, core_grid, c_in5_config);
 
+    if (is_chunked) {
+        auto c_in6_config = CircularBufferConfig(page_table_stick_size, {{tt::CBIndex::c_6, page_table_df}})
+                                .set_page_size(tt::CBIndex::c_6, page_table_stick_size);
+        auto cb_in6_id = CreateCircularBuffer(program, core_grid, c_in6_config);
+    }
+
     // cb_qk_im
     auto c_intermed0_config = CircularBufferConfig(qk_tiles * im_tile_size, {{tt::CBIndex::c_24, im_df}})
                                   .set_page_size(tt::CBIndex::c_24, im_tile_size);
@@ -471,13 +528,15 @@ operation::ProgramWithCallbacks sdpa_multi_core(
              k_addr,
              v_addr,
              mask_addr,
+             is_chunked ? page_table.value().buffer()->address() : 0,
              i,
              local_batch_start,
              local_batch_end,
              local_nh_start,
              local_nh_end,
              local_q_start,
-             local_q_end});
+             local_q_end,
+             chunk_start_t});
         SetRuntimeArgs(
             program,
             writer_kernels_id,
@@ -489,12 +548,20 @@ operation::ProgramWithCallbacks sdpa_multi_core(
              local_nh_start,
              local_nh_end,
              local_q_start,
-             local_q_end});
+             local_q_end,
+             chunk_start_t});
         SetRuntimeArgs(
             program,
             compute_kernels_id,
             core,
-            {i, local_batch_start, local_batch_end, local_nh_start, local_nh_end, local_q_start, local_q_end});
+            {i,
+             local_batch_start,
+             local_batch_end,
+             local_nh_start,
+             local_nh_end,
+             local_q_start,
+             local_q_end,
+             chunk_start_t});
     }
 
     auto override_runtime_arguments_callback =
@@ -513,7 +580,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
          q_num_chunks,
          is_causal,
          cb_in0_id,
-         cb_out0_id](
+         cb_out0_id,
+         is_chunked](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
@@ -532,9 +600,17 @@ operation::ProgramWithCallbacks sdpa_multi_core(
             uint32_t mask_addr = mask_buffer != nullptr ? mask_buffer->address() : 0;
             uint32_t out_addr = out0_buffer->address();
 
+            uint32_t page_table_addr = 0;
+            uint32_t chunk_start_t = 0;
+            if (is_chunked) {
+                page_table_addr = optional_input_tensors.at(1).value().buffer()->address();
+                chunk_start_t = static_cast<const ScaledDotProductAttention*>(operation)->chunk_start_idx.value() /
+                                TILE_HEIGHT;  // Q offset in tiles
+            }
+
             auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernels_id);
             auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernels_id);
-
+            auto& compute_args_by_core = GetRuntimeArgs(program, compute_kernels_id);
             // Set reader rt args
             for (uint32_t i = 0; i < num_cores; ++i) {
                 CoreCoord core = {i % grid_size.x, i / grid_size.x};
@@ -566,13 +642,18 @@ operation::ProgramWithCallbacks sdpa_multi_core(
 
                 auto& reader_args = reader_args_by_core[core.x][core.y];
                 auto& writer_args = writer_args_by_core[core.x][core.y];
-
+                auto& compute_args = compute_args_by_core[core.x][core.y];
                 reader_args[0] = q_addr;
                 reader_args[1] = k_addr;
                 reader_args[2] = v_addr;
                 reader_args[3] = mask_addr;
+                reader_args[4] = page_table_addr;
+                reader_args[12] = chunk_start_t;
 
                 writer_args[0] = out_addr;
+                writer_args[8] = chunk_start_t;
+
+                compute_args[7] = chunk_start_t;
             }
         };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp
@@ -16,6 +16,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     const Tensor& input_tensor_v,
     const Tensor& output_tensor,
     const std::optional<const Tensor>& attn_mask,
+    const std::optional<const Tensor>& page_table,
+    const std::optional<int64_t>& chunk_start_idx,
     std::optional<float> scale,
     bool is_causal,
     std::size_t q_chunk_size,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -37,6 +37,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
                    .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
                    .program_config = program_config,
                    .is_causal = is_causal,
+                   .chunk_start_idx = std::nullopt,
                    .compute_kernel_config = kernel_config_val},
                {input_tensor_q, input_tensor_k, input_tensor_v},
                {attn_mask},
@@ -62,6 +63,61 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
         input_tensor_v,
         std::move(attn_mask),
         is_causal,
+        scale,
+        memory_config,
+        program_config,
+        compute_kernel_config);
+}
+
+ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
+    uint8_t queue_id,
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const ttnn::Tensor& input_tensor_v,
+    const ttnn::Tensor& page_table_tensor,
+    int64_t chunk_start_idx,
+    std::optional<float> scale,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<SDPAProgramConfig> program_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
+                    ? input_tensor_q.device()->arch()
+                    : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto kernel_config_val = init_device_compute_kernel_config(
+        input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+
+    return operation::run(
+               ScaledDotProductAttention{
+                   .scale = scale,
+                   .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
+                   .program_config = program_config,
+                   .is_causal = true,  // Always causal for chunked version
+                   .chunk_start_idx = chunk_start_idx,
+                   .compute_kernel_config = kernel_config_val},
+               {input_tensor_q, input_tensor_k, input_tensor_v},
+               {std::nullopt, page_table_tensor},  // No attention mask - handled internally based on chunk_start_idx
+               {},
+               queue_id)
+        .at(0);
+}
+
+ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const ttnn::Tensor& input_tensor_v,
+    const ttnn::Tensor& page_table_tensor,
+    int64_t chunk_start_idx,
+    std::optional<float> scale,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<SDPAProgramConfig> program_config,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    return invoke(
+        DefaultQueueId,
+        input_tensor_q,
+        input_tensor_k,
+        input_tensor_v,
+        page_table_tensor,
+        chunk_start_idx,
         scale,
         memory_config,
         program_config,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -36,6 +36,31 @@ struct ExecuteScaledDotProductAttention {
         std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 
+struct ExecuteChunkedScaledDotProductAttention {
+    static ttnn::Tensor invoke(
+        uint8_t queue_id,
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        const ttnn::Tensor& input_tensor_v,
+        const ttnn::Tensor& page_table_tensor,
+        int64_t chunk_start_idx,
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        const ttnn::Tensor& input_tensor_v,
+        const ttnn::Tensor& page_table_tensor,
+        int64_t chunk_start_idx,
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+};
+
 }  // namespace operations::transformer
 
 namespace transformer {
@@ -43,6 +68,10 @@ namespace transformer {
 constexpr auto scaled_dot_product_attention = ttnn::register_operation_with_auto_launch_op<
     "ttnn::transformer::scaled_dot_product_attention",
     ttnn::operations::transformer::ExecuteScaledDotProductAttention>();
+
+constexpr auto chunked_scaled_dot_product_attention = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::transformer::chunked_scaled_dot_product_attention",
+    ttnn::operations::transformer::ExecuteChunkedScaledDotProductAttention>();
 
 }  // namespace transformer
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_pybind.cpp
@@ -81,5 +81,73 @@ void py_bind_sdpa(py::module& module) {
             py::arg("compute_kernel_config").noconvert() = std::nullopt,
             py::arg("queue_id") = 0,
         });
+
+    auto chunked_doc =
+        R"doc(
+        Chunked causal scaled dot product attention for processing long sequences in chunks.
+        This variant allows processing of sequences longer than the maximum supported length
+        by splitting the input into chunks and maintaining KV cache state.
+        The KV cache is page-based, and the page table tensor is used to map the page indices to the corresponding KV cache indices.
+
+        Args:
+            input_tensor_q (ttnn.Tensor): the input tensor.          [b x nqh x s x dh]
+            input_tensor_k (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
+            input_tensor_v (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
+            page_table_tensor (ttnn.Tensor): the page table tensor.  [b x num_pages]
+            chunk_start_idx (int): Absolute position in the sequence where this chunk starts.
+
+        Keyword args:
+            scale (float, optional): Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            program_config (SDPAProgramConfig, optional): Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
+            queue_id (int, optional): command queue id. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the output tensor [b x nqh x s x dh].
+
+        )doc";
+
+    using ChunkedOperationType = decltype(ttnn::transformer::chunked_scaled_dot_product_attention);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::transformer::chunked_scaled_dot_product_attention,
+        chunked_doc,
+        ttnn::pybind_overload_t{
+            [](const ChunkedOperationType& self,
+               const ttnn::Tensor& input_tensor_q,
+               const ttnn::Tensor& input_tensor_k,
+               const ttnn::Tensor& input_tensor_v,
+               const ttnn::Tensor& page_table_tensor,
+               int64_t chunk_start_idx,
+               std::optional<float> scale,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<SDPAProgramConfig> program_config,
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+               uint8_t queue_id) {
+                return self(
+                    queue_id,
+                    input_tensor_q,
+                    input_tensor_k,
+                    input_tensor_v,
+                    page_table_tensor,
+                    chunk_start_idx,
+                    scale,
+                    memory_config,
+                    program_config,
+                    compute_kernel_config);
+            },
+            py::arg("input_tensor_q").noconvert(),
+            py::arg("input_tensor_k").noconvert(),
+            py::arg("input_tensor_v").noconvert(),
+            py::arg("page_table_tensor").noconvert(),
+            py::arg("chunk_start_idx"),
+            py::kw_only(),
+            py::arg("scale").noconvert() = std::nullopt,
+            py::arg("memory_config").noconvert() = std::nullopt,
+            py::arg("program_config").noconvert() = std::nullopt,
+            py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("queue_id") = 0,
+        });
 }
 }  // namespace ttnn::operations::transformer


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15876

### Problem description
Long context length prefill can run OOM due to large activations. To solve that issue, we're implementing chunked prefill. This requires a modification to the SDPA op. 

### What's changed
There's a new binding into the SDPA op called `ttnn::transformer::chunked_scaled_dot_product_attention`.
It can be used in the following way:
```python
tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
            tt_Q_chunk,
            tt_paged_K,
            tt_paged_V,
            page_table_tt,
            chunk_start_idx,
            program_config=program_config,
            compute_kernel_config=compute_kernel_config,
        )
```

The assumption is that `tt_Q_chunk` has seqlen `chunk_size` and `tt_paged_K` and `tt_paged_V` are paged KV caches which have already been filled with the relevant new K and V, in addition to containing any previous chunks K and V. The `page_table_tt` provides the op with a mapping from KV blocks to physical blocks, and `chunk_start_idx` is the index at which this `tt_Q_chunk` lies in the original, unchunked sequence.
For example, if `seqlen = 128k` and `prefill_chunk_size = 32k`, then the second chunk would call `chunked_scaled_dot_product_attention` with `chunk_start_idx = 32k`.

Additional constraints:
- chunked SDPA is always causal, therefore you may never provide a mask

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12277488819
- [x] Model regression CI testing passes: T3K unit, frequent, demo https://github.com/tenstorrent/tt-metal/actions/runs/12277503729
  - Some AllGather tests are failing but that can't be related to this PR
- [x] New/Existing tests provide coverage for changes
