### PR TITLE
Add sweeps for unary, unary_sharded and binary_sharded versions of ops: fmod, remainder, maximum, minimum.

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -350,11 +350,13 @@ on:
           - eltwise.composite.binary.addalpha.addalpha
           - eltwise.composite.binary.subalpha.subalpha
           - eltwise.composite.binary.minimum.minimum
+          - eltwise.composite.binary.minimum.minimum_sharded
           - eltwise.composite.binary.minimum.minimum_unary
           - eltwise.composite.binary.minimum.minimum_unary_sharded
           - eltwise.composite.binary.minimum.minimum_pytorch2
           - eltwise.composite.binary.minimum.minimum_forge
           - eltwise.composite.binary.maximum.maximum
+          - eltwise.composite.binary.maximum.maximum_sharded
           - eltwise.composite.binary.maximum.maximum_unary
           - eltwise.composite.binary.maximum.maximum_unary_sharded
           - eltwise.composite.binary.maximum.maximum_pytorch2

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -305,6 +305,8 @@ on:
           - eltwise.binary.remainder.remainder
           - eltwise.binary.remainder.remainder_scalar_pytorch2
           - eltwise.binary.remainder.remainder_forge
+          - eltwise.binary.remainder.remainder_unary
+          - eltwise.binary.remainder.remainder_unary_sharded
           - eltwise.binary.squared_difference.squared_difference
           - eltwise.binary.squared_difference_output.squared_difference_output
           - eltwise.binary.scatter.scatter_forge
@@ -317,6 +319,8 @@ on:
           - eltwise.binary.gt.gt_forge
           - eltwise.binary.le.le_tensor_pytorch2
           - eltwise.binary.fmod.fmod
+          - eltwise.binary.fmod.fmod.unary
+          - eltwise.binary.fmod.fmod.unary_sharded
           - eltwise.binary.floor_divide.floor_divide_pytorch2
           - eltwise.binary.logaddexp.logaddexp
           - eltwise.binary.logaddexp2.logaddexp2
@@ -346,9 +350,13 @@ on:
           - eltwise.composite.binary.addalpha.addalpha
           - eltwise.composite.binary.subalpha.subalpha
           - eltwise.composite.binary.minimum.minimum
+          - eltwise.composite.binary.minimum.minimum_unary
+          - eltwise.composite.binary.minimum.minimum_unary_sharded
           - eltwise.composite.binary.minimum.minimum_pytorch2
           - eltwise.composite.binary.minimum.minimum_forge
           - eltwise.composite.binary.maximum.maximum
+          - eltwise.composite.binary.maximum.maximum_unary
+          - eltwise.composite.binary.maximum.maximum_unary_sharded
           - eltwise.composite.binary.maximum.maximum_pytorch2
           - eltwise.composite.binary.maximum.maximum_forge
           - eltwise.composite.binary.pow.pow_pytorch2

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -319,8 +319,8 @@ on:
           - eltwise.binary.gt.gt_forge
           - eltwise.binary.le.le_tensor_pytorch2
           - eltwise.binary.fmod.fmod
-          - eltwise.binary.fmod.fmod.unary
-          - eltwise.binary.fmod.fmod.unary_sharded
+          - eltwise.binary.fmod.fmod_unary
+          - eltwise.binary.fmod.fmod_unary_sharded
           - eltwise.binary.floor_divide.floor_divide_pytorch2
           - eltwise.binary.logaddexp.logaddexp
           - eltwise.binary.logaddexp2.logaddexp2

--- a/tests/sweep_framework/sweep_utils/sharding_utils.py
+++ b/tests/sweep_framework/sweep_utils/sharding_utils.py
@@ -10,7 +10,7 @@ import math
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import _gen_reshape_args_from_volume
 
 
-def gen_sharded_spec_unary(num_shapes, max_tensor_size_per_core=32 * 1024, layouts=["TILE_LAYOUT", "ROW_MAJOR_LAYOUT"]):
+def gen_sharded_spec_unary(num_shapes, max_tensor_size_per_core=62 * 1024, layouts=["TILE_LAYOUT", "ROW_MAJOR_LAYOUT"]):
     # device.compute_with_storage_grid_size()
     Y = 8
     X = 8
@@ -35,25 +35,28 @@ def gen_sharded_spec_unary(num_shapes, max_tensor_size_per_core=32 * 1024, layou
             max_tensor_size = max_tensor_size_per_core * x * y
 
             if tensor_hw_as_shard_shape:
-                if layout == "TILE_LAYOUT":
-                    min_tensor_height = 32
-                    min_tensor_width = 32
-                    max_tensor_height = int(math.sqrt(max_tensor_size_per_core))
-                    max_tensor_width = int(math.sqrt(max_tensor_size_per_core))
-                    tensor_height = random.randrange(min_tensor_height, max_tensor_height + 1, 32)
-                    tensor_width = random.randrange(min_tensor_width, max_tensor_width + 1, 32)
-                    input_shape = [tensor_height, tensor_width]
-                else:
-                    shard_size = random.randrange(1024, max_tensor_size_per_core + 1, 1024)
-                    tensor_width = random.randrange(16, shard_size // 2 + 1, 16)
-                    tensor_height = shard_size // tensor_width
-                    input_shape = [tensor_height, tensor_width]
+                # Gets stuck:
+                # X 8 Y 8 input_shape [1, 17792, 8] DataType.BFLOAT8_B Layout.TILE ShardStrategy.BLOCK ShardOrientation.COL_MAJOR tensor_hw_as_shard_shape True
 
-                if rank != 2:
-                    rest_volume = random.randint(1, max_tensor_size // math.prod(input_shape))
-                    rest_dims = random.choice(_gen_reshape_args_from_volume(rest_volume, step=1, out_dims=rank - 2))
-                    rest_dims = list(rest_dims["reshape_dims"])
-                    input_shape = rest_dims + input_shape
+                if layout == "TILE_LAYOUT":
+                    # In shard mode ShardMode::PHYSICAL, physical shard shape {12, 13312} is not compatible with alignment Alignment([32, 32])!
+                    min_shard_size_x = 32
+                    min_shard_size_y = 32
+                else:  # if layout == "ROW_MAJOR_LAYOUT":
+                    # Shard Size must be multiple of input_tile_size (width * height is multiple of 1024)
+                    min_shard_size_x = random.choice([1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024])
+                    min_shard_size_y = 1024 // min_shard_size_x
+
+                rest_volume = random.randint(1, max_tensor_size // (min_shard_size_x * min_shard_size_y * x * y))
+                input_shape = random.choice(_gen_reshape_args_from_volume(rest_volume, step=1, out_dims=rank))
+                input_shape = list(input_shape["reshape_dims"])
+                input_shape[-2] = input_shape[-2] * min_shard_size_x
+                input_shape[-1] = input_shape[-1] * min_shard_size_y
+
+                # Shard width should be multiple of 16 to satisfy L1 alignment (width = multiple 8 for bfloat16)
+                while input_shape[-1] % 16 != 0:
+                    input_shape[-1] *= 2
+                    input_shape[-2] //= 2
 
             elif sharding_strategy == "BLOCK":
                 min_shard_size_y = 32 * y

--- a/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_unary_sharded.py
@@ -11,9 +11,12 @@ import random
 import ttnn
 import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
-from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.sweep_framework.sweep_utils.sharding_utils import (
+    gen_sharded_spec_unary,
+    parse_sharding_spec,
+    invalidate_vector_sharding,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
@@ -48,18 +51,15 @@ def mesh_device_fixture():
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
-    pre_sharded_height = math.prod(input_shape[:-1])
-    pre_sharded_width = input_shape[-1]
-
-    if input_layout == "ROW_MAJOR_LAYOUT" and (input_shape[-1] % input_shape[-2] != 0):
-        return True, "Physical size <width, height> must be a multuple of page size <1, width>"
+    input_layout = test_vector["input_spec"]["input_layout"]
+    sharding_invalidated, output_str = invalidate_vector_sharding(test_vector["input_spec"])
 
     if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "Input_tensor_a doesn't support bfloat8_b"
-
     if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
+    if sharding_invalidated:
+        return sharding_invalidated, output_str
 
     return False, None
 
@@ -85,6 +85,7 @@ def run(
         shard_orientation,
         tensor_hw_as_shard_shape,
         input_layout,
+        shard_height_mul_of_32,
     ) = parse_sharding_spec(input_spec)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
@@ -108,6 +109,7 @@ def run(
         strategy=sharding_strategy,
         orientation=shard_orientation,
         use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+        tile_layout=shard_height_mul_of_32,
     )
 
     input_tensor_a = ttnn.from_torch(

--- a/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_unary_sharded.py
@@ -5,17 +5,20 @@
 from typing import Optional, Tuple
 from functools import partial
 
+import json
 import torch
 import random
 import ttnn
+import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
+TIMEOUT = 120
 
 random.seed(0)
 
@@ -26,29 +29,37 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
-        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
-        + gen_shapes([1, 1], [256, 256], [1, 1], 8),
+        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+def mesh_device_fixture():
+    device = ttnn.open_device(device_id=0)
+    assert ttnn.device.is_wormhole_b0(device), "This op is available for Wormhole_B0 only"
+    yield (device, "Wormhole_B0")
+    ttnn.close_device(device)
+    del device
 
 
 # Invalidate vector is called during the generation phase where each vector will be passed in.
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
-    ):
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and (input_shape[-1] % input_shape[-2] != 0):
+        return True, "Physical size <width, height> must be a multuple of page size <1, width>"
+
+    if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "Input_tensor_a doesn't support bfloat8_b"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
+
     return False, None
 
 
@@ -57,18 +68,22 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
-    input_shape,
+    input_spec,
     input_a_dtype,
-    input_b_dtype,
-    input_layout,
-    input_a_memory_config,
-    input_b_memory_config,
-    output_memory_config,
     *,
     device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
@@ -76,34 +91,31 @@ def run(
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
+    scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
 
-    torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-    )(input_shape)
+    golden_function = ttnn.get_golden_function(ttnn.fmod)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
 
-    golden_function = ttnn.get_golden_function(ttnn.minimum)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_a_dtype,
         layout=input_layout,
         device=device,
-        memory_config=input_a_memory_config,
-    )
-
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=input_b_dtype,
-        layout=input_layout,
-        device=device,
-        memory_config=input_b_memory_config,
+        memory_config=sharded_config,
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.fmod(input_tensor_a, scalar, memory_config=sharded_config)
     e2e_perf = stop_measuring_time(start_time)
-
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/fmod/fmod_unary_sharded.py
@@ -54,6 +54,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     input_layout = test_vector["input_spec"]["input_layout"]
     sharding_invalidated, output_str = invalidate_vector_sharding(test_vector["input_spec"])
 
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Row major layout is not supported"
     if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "Input_tensor_a doesn't support bfloat8_b"
     if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder.py
@@ -8,7 +8,7 @@ from functools import partial
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
@@ -25,26 +25,13 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
-        "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 128, 128], [1, 1, 32, 32], 16)
-        + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 16)
-        + gen_shapes([32, 32], [256, 256], [32, 32], 16),
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-    },
     "xfail": {
-        "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 128, 128], [1, 1, 32, 32], 16)
-        + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 16)
-        + gen_shapes([32, 32], [256, 256], [32, 32], 16),
+        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 128, 128], [1, 1, 1, 1], 16)
+        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 16)
+        + gen_shapes([1, 1], [256, 256], [1, 1], 16),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -60,8 +47,12 @@ def mesh_device_fixture():
     del device
 
 
-# TO-DO: Create an issue on this, since these constrictions are not mentioned in the documentation
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
     if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "Input_tensor_a doesn't support bfloat8_b"
     return False, None
@@ -75,8 +66,7 @@ def run(
     input_shape,
     input_a_dtype,
     input_b_dtype,
-    input_a_layout,
-    input_b_layout,
+    input_layout,
     input_a_memory_config,
     input_b_memory_config,
     output_memory_config,
@@ -85,20 +75,25 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
     torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    torch_output_tensor = torch.remainder(torch_input_tensor_a, torch_input_tensor_b)
+    golden_function = ttnn.get_golden_function(ttnn.remainder)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_a_dtype,
-        layout=input_a_layout,
+        layout=input_layout,
         device=device,
         memory_config=input_a_memory_config,
     )
@@ -106,14 +101,15 @@ def run(
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
         dtype=input_b_dtype,
-        layout=input_b_layout,
+        layout=input_layout,
         device=device,
         memory_config=input_b_memory_config,
     )
 
     start_time = start_measuring_time()
     output_tensor = ttnn.remainder(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
+
+    output_tensor = ttnn.to_torch(output_tensor)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary.py
@@ -12,7 +12,7 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_r
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
-from models.utility_functions import torch_random
+from models.utility_functions import torch_random, is_wormhole_b0
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -26,17 +26,34 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
-        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
-        + gen_shapes([1, 1], [256, 256], [1, 1], 8),
+        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 128, 128], [1, 1, 1, 1], 16)
+        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 16)
+        + gen_shapes([1, 1], [256, 256], [1, 1], 16),
+        "unsafe_range": [[-0.004, 0.004]],
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+    "xfail": {
+        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 128, 128], [1, 1, 1, 1], 16)
+        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 16)
+        + gen_shapes([1, 1], [256, 256], [1, 1], 16),
+        "unsafe_range": [None],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+def mesh_device_fixture():
+    device = ttnn.open_device(device_id=0)
+    assert ttnn.device.is_wormhole_b0(device), "This op is available for Wormhole_B0 only"
+    yield (device, "Wormhole_B0")
+    ttnn.close_device(device)
+    del device
 
 
 # Invalidate vector is called during the generation phase where each vector will be passed in.
@@ -45,10 +62,8 @@ parameters = {
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
         return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
-    ):
-        return True, "bfloat8_b is only supported on tiled layout"
+    if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "Input_tensor_a doesn't support bfloat8_b"
     return False, None
 
 
@@ -58,11 +73,10 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_shape,
+    unsafe_range,
     input_a_dtype,
-    input_b_dtype,
     input_layout,
     input_a_memory_config,
-    input_b_memory_config,
     output_memory_config,
     *,
     device,
@@ -77,12 +91,13 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-    )(input_shape)
+    scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
+    if unsafe_range:
+        while unsafe_range[0] <= scalar <= unsafe_range[1]:
+            scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
 
-    golden_function = ttnn.get_golden_function(ttnn.minimum)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+    golden_function = ttnn.get_golden_function(ttnn.remainder)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -92,16 +107,8 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=input_b_dtype,
-        layout=input_layout,
-        device=device,
-        memory_config=input_b_memory_config,
-    )
-
     start_time = start_measuring_time()
-    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.remainder(input_tensor_a, scalar, memory_config=output_memory_config)
     e2e_perf = stop_measuring_time(start_time)
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary_sharded.py
@@ -29,13 +29,8 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
+        "input_spec": gen_sharded_spec_unary(16, layouts=["TILE_LAYOUT"]),
         "use_unsafe_range": [False],
-        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-    },
-    "xfail": {
-        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
-        "use_unsafe_range": [True],
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     },
 }
@@ -75,6 +70,7 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     input_spec,
+    use_unsafe_range,
     input_a_dtype,
     *,
     device,
@@ -99,8 +95,9 @@ def run(
     )(input_shape)
 
     scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
-    while -0.004 <= scalar <= 0.004:
-        scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
+    if not use_unsafe_range:
+        while -0.004 <= scalar <= 0.004:
+            scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
 
     golden_function = ttnn.get_golden_function(ttnn.remainder)
     torch_output_tensor = golden_function(torch_input_tensor_a, scalar)

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary_sharded.py
@@ -5,17 +5,20 @@
 from typing import Optional, Tuple
 from functools import partial
 
+import json
 import torch
 import random
 import ttnn
+import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
+TIMEOUT = 120
 
 random.seed(0)
 
@@ -26,29 +29,43 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
-        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
-        + gen_shapes([1, 1], [256, 256], [1, 1], 8),
+        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
+        "use_unsafe_range": [False],
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+    "xfail": {
+        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
+        "use_unsafe_range": [True],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     },
 }
+
+
+def mesh_device_fixture():
+    device = ttnn.open_device(device_id=0)
+    assert ttnn.device.is_wormhole_b0(device), "This op is available for Wormhole_B0 only"
+    yield (device, "Wormhole_B0")
+    ttnn.close_device(device)
+    del device
 
 
 # Invalidate vector is called during the generation phase where each vector will be passed in.
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
-    ):
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "Input_tensor_a doesn't support bfloat8_b"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and (input_shape[-1] % input_shape[-2] != 0):
+        return True, "Physical size <width, height> must be a multuple of page size <1, width>"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
+
     return False, None
 
 
@@ -57,18 +74,22 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
-    input_shape,
+    input_spec,
     input_a_dtype,
-    input_b_dtype,
-    input_layout,
-    input_a_memory_config,
-    input_b_memory_config,
-    output_memory_config,
     *,
     device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
@@ -77,33 +98,33 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-    )(input_shape)
+    scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
+    while -0.004 <= scalar <= 0.004:
+        scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100).item()
 
-    golden_function = ttnn.get_golden_function(ttnn.minimum)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+    golden_function = ttnn.get_golden_function(ttnn.remainder)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_a_dtype,
         layout=input_layout,
         device=device,
-        memory_config=input_a_memory_config,
-    )
-
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=input_b_dtype,
-        layout=input_layout,
-        device=device,
-        memory_config=input_b_memory_config,
+        memory_config=sharded_config,
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.remainder(input_tensor_a, scalar, memory_config=sharded_config)
     e2e_perf = stop_measuring_time(start_time)
-
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/remainder/remainder_unary_sharded.py
@@ -54,6 +54,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     input_layout = test_vector["input_spec"]["input_layout"]
     sharding_invalidated, output_str = invalidate_vector_sharding(test_vector["input_spec"])
 
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Row major layout is not supported"
     if test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "Input_tensor_a doesn't support bfloat8_b"
     if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/maximum/maximum.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/maximum/maximum.py
@@ -8,7 +8,7 @@ from functools import partial
 import torch
 import random
 import ttnn
-from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
@@ -26,18 +26,30 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 8)
-        + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 8)
-        + gen_shapes([32, 32], [256, 256], [32, 32], 8),
+        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
+        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
+        + gen_shapes([1, 1], [256, 256], [1, 1], 8),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_a_layout": [ttnn.TILE_LAYOUT],
-        "input_b_layout": [ttnn.TILE_LAYOUT],
+        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
+        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
+    ):
+        return True, "bfloat8_b is only supported on tiled layout"
+    return False, None
 
 
 # This is the run instructions for the test, defined by the developer.
@@ -48,8 +60,7 @@ def run(
     input_shape,
     input_a_dtype,
     input_b_dtype,
-    input_a_layout,
-    input_b_layout,
+    input_layout,
     input_a_memory_config,
     input_b_memory_config,
     output_memory_config,
@@ -58,6 +69,10 @@ def run(
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
@@ -66,12 +81,13 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
     )(input_shape)
 
-    torch_output_tensor = torch.max(torch_input_tensor_a, torch_input_tensor_b)
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_a_dtype,
-        layout=input_a_layout,
+        layout=input_layout,
         device=device,
         memory_config=input_a_memory_config,
     )
@@ -79,14 +95,15 @@ def run(
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
         dtype=input_b_dtype,
-        layout=input_b_layout,
+        layout=input_layout,
         device=device,
         memory_config=input_b_memory_config,
     )
 
     start_time = start_measuring_time()
     output_tensor = ttnn.maximum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(output_tensor)
     e2e_perf = stop_measuring_time(start_time)
+
+    output_tensor = ttnn.to_torch(output_tensor)
 
     return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/maximum/maximum_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/maximum/maximum_unary_sharded.py
@@ -5,17 +5,20 @@
 from typing import Optional, Tuple
 from functools import partial
 
+import json
 import torch
 import random
 import ttnn
+import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
+TIMEOUT = 120
 
 random.seed(0)
 
@@ -26,15 +29,8 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
-        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
-        + gen_shapes([1, 1], [256, 256], [1, 1], 8),
+        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
 
@@ -43,12 +39,16 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
-    ):
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and (input_shape[-1] % input_shape[-2] != 0):
+        return True, "Physical size <width, height> must be a multuple of page size <1, width>"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
+
     return False, None
 
 
@@ -57,18 +57,22 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
-    input_shape,
+    input_spec,
     input_a_dtype,
-    input_b_dtype,
-    input_layout,
-    input_a_memory_config,
-    input_b_memory_config,
-    output_memory_config,
     *,
     device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
@@ -76,34 +80,31 @@ def run(
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
+    scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100)
 
-    torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-    )(input_shape)
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
 
-    golden_function = ttnn.get_golden_function(ttnn.minimum)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_a_dtype,
         layout=input_layout,
         device=device,
-        memory_config=input_a_memory_config,
-    )
-
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=input_b_dtype,
-        layout=input_layout,
-        device=device,
-        memory_config=input_b_memory_config,
+        memory_config=sharded_config,
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.maximum(input_tensor_a, scalar.item(), memory_config=sharded_config)
     e2e_perf = stop_measuring_time(start_time)
-
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/maximum/maximum_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/maximum/maximum_unary_sharded.py
@@ -29,7 +29,7 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
+        "input_spec": gen_sharded_spec_unary(16, layouts=["TILE_LAYOUT"]),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     },
 }

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary.py
@@ -25,15 +25,13 @@ random.seed(0)
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
-    "nightly": {
+    "xfail": {
         "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
         + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
         + gen_shapes([1, 1], [256, 256], [1, 1], 8),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
@@ -45,9 +43,7 @@ parameters = {
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
         return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
-    ):
+    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
     return False, None
 
@@ -59,10 +55,8 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 def run(
     input_shape,
     input_a_dtype,
-    input_b_dtype,
     input_layout,
     input_a_memory_config,
-    input_b_memory_config,
     output_memory_config,
     *,
     device,
@@ -77,12 +71,10 @@ def run(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
 
-    torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-    )(input_shape)
+    scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100)
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -92,16 +84,8 @@ def run(
         memory_config=input_a_memory_config,
     )
 
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=input_b_dtype,
-        layout=input_layout,
-        device=device,
-        memory_config=input_b_memory_config,
-    )
-
     start_time = start_measuring_time()
-    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.minimum(input_tensor_a, scalar.item(), memory_config=output_memory_config)
     e2e_perf = stop_measuring_time(start_time)
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py
@@ -5,17 +5,20 @@
 from typing import Optional, Tuple
 from functools import partial
 
+import json
 import torch
 import random
 import ttnn
+import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 30
+TIMEOUT = 120
 
 random.seed(0)
 
@@ -26,15 +29,8 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_shape": gen_shapes([1, 1, 1, 1], [6, 12, 256, 256], [1, 1, 1, 1], 8)
-        + gen_shapes([1, 1, 1], [12, 256, 256], [1, 1, 1], 8)
-        + gen_shapes([1, 1], [256, 256], [1, 1], 8),
+        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_b_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
-        "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
-        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
-        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     },
 }
 
@@ -43,12 +39,16 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor"
-    if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT and (
-        test_vector["input_a_dtype"] == ttnn.bfloat8_b or test_vector["input_b_dtype"] == ttnn.bfloat8_b
-    ):
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and (input_shape[-1] % input_shape[-2] != 0):
+        return True, "Physical size <width, height> must be a multuple of page size <1, width>"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
+
     return False, None
 
 
@@ -57,18 +57,22 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
 # If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
-    input_shape,
+    input_spec,
     input_a_dtype,
-    input_b_dtype,
-    input_layout,
-    input_a_memory_config,
-    input_b_memory_config,
-    output_memory_config,
     *,
     device,
 ) -> list:
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
         input_shape = sanitize_shape_rm(input_shape)
@@ -76,34 +80,31 @@ def run(
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
-
-    torch_input_tensor_b = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_b_dtype
-    )(input_shape)
+    scalar = torch.tensor(1, dtype=torch.bfloat16).uniform_(-100, 100)
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
-    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
         dtype=input_a_dtype,
         layout=input_layout,
         device=device,
-        memory_config=input_a_memory_config,
-    )
-
-    input_tensor_b = ttnn.from_torch(
-        torch_input_tensor_b,
-        dtype=input_b_dtype,
-        layout=input_layout,
-        device=device,
-        memory_config=input_b_memory_config,
+        memory_config=sharded_config,
     )
 
     start_time = start_measuring_time()
-    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.minimum(input_tensor_a, scalar.item(), memory_config=sharded_config)
     e2e_perf = stop_measuring_time(start_time)
-
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py
@@ -11,9 +11,12 @@ import random
 import ttnn
 import math
 from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
-from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.sweep_framework.sweep_utils.sharding_utils import (
+    gen_sharded_spec_unary,
+    parse_sharding_spec,
+    invalidate_vector_sharding,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
@@ -39,15 +42,15 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
-    pre_sharded_height = math.prod(input_shape[:-1])
-    pre_sharded_width = input_shape[-1]
+    input_layout = test_vector["input_spec"]["input_layout"]
+    sharding_invalidated, output_str = invalidate_vector_sharding(test_vector["input_spec"])
 
-    if input_layout == "ROW_MAJOR_LAYOUT" and (input_shape[-1] % input_shape[-2] != 0):
-        return True, "Physical size <width, height> must be a multuple of page size <1, width>"
-
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
     if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
         return True, "bfloat8_b is only supported on tiled layout"
+    if sharding_invalidated:
+        return sharding_invalidated, output_str
 
     return False, None
 
@@ -72,6 +75,7 @@ def run(
         shard_orientation,
         tensor_hw_as_shard_shape,
         input_layout,
+        shard_height_mul_of_32,
     ) = parse_sharding_spec(input_spec)
 
     if input_layout == ttnn.ROW_MAJOR_LAYOUT:
@@ -91,6 +95,7 @@ def run(
         strategy=sharding_strategy,
         orientation=shard_orientation,
         use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+        tile_layout=shard_height_mul_of_32,
     )
 
     input_tensor_a = ttnn.from_torch(

--- a/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py
@@ -29,7 +29,7 @@ random.seed(0)
 # Developers can create their own generator functions and pass them to the parameters as inputs.
 parameters = {
     "nightly": {
-        "input_spec": gen_sharded_spec_unary(12, layouts=["TILE_LAYOUT"]),
+        "input_spec": gen_sharded_spec_unary(16, layouts=["TILE_LAYOUT"]),
         "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     },
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11512)


### Problem description
1) Missing sweeps for unary sharded versions of ops sweeps for ops:
- fmod
- remainder
- maximum
- minimum
2) Missing sweeps for unary non-sharded versions of ops sweeps for ops:
- fmod
- remainder
- maximum
- minimum
3) Missing sweeps for unary non-sharded versions of ops sweeps for ops:
- maximum
- minimum
4) Non-sharded binary versions of ops sweeps need some minor factoring


### What's changed
1. Refactored non-sharded binary sweeps of aforementioned ops so that they include vector invalidation for row major layout tensors and modified their shape generation function to also use shapes with last two dims not divisible by 32. 
2. Added unary-sharded versions of sweeps for aforementioned ops
3. Added unary versions of sweeps for aforementioned ops
4. Added binary-sharded versions of sweeps for aforementioned ops


### Pass rates for all unary sharded sweeps:
`sweeps/eltwise/binary/fmod/fmod_unary_sharded.py `(nightly suite): 105 fail, 279 pass (72.66%).
`sweeps/eltwise/binary/remainder/remainder_unary_sharded.py` (nightly suite): 105 fail, 279 pass (72.66%).
`sweeps/eltwise/composite/binary/maximum/maximum_unary_sharded.py` (nightly suite): 221 fail, 547 pass (71.22%).
`sweeps/eltwise/composite/binary/minimum/minimum_unary_sharded.py` (nightly suite): 217 fail, 551 pass (71.74%).


### Pass rates for all unary non-sharded sweeps:
`sweeps/eltwise/binary/fmod/fmod_unary.py `(nightly suite): 0 fail, 192 pass (100%).
`sweeps/eltwise/binary/fmod/fmod_unary.py `(xfail suite): 1 fail, 191 pass (99.48%).
`sweeps/eltwise/binary/remainder/remainder_unary.py` (nightly suite): 0 fail, 192 pass (100%).
`sweeps/eltwise/binary/remainder/remainder_unary.py` (xfail suite): 1 fail, 191 pass (99.48%).
`sweeps/eltwise/composite/binary/maximum/maximum_unary.py` (nightly suite): 0 fail, 192 pass (100%).
`sweeps/eltwise/composite/binary/minimum/minimum_unary.py` (nightly suite): 3 fail, 189 pass (98.44%).


### Pass rates for all binary sharded sweeps:
`sweeps/eltwise/binary/maximum/maximum_sharded.py `(nightly suite): 420 fail, 1116 pass (72.66%).
`sweeps/eltwise/binary/minimum/minimum_sharded.py` (nightly suite): 420 fail, 1116 pass (72.66%).


### Checklist
- [X] [Post commit CI passes] (https://github.com/tenstorrent/tt-metal/actions/runs/12706891597)
- [X] Sweep tests pass