### PR TITLE
#0: Re-order reshape and device upload in test_tilize_zero_padding_channels_last.cpp

### DIFF
--- a/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
@@ -37,8 +37,9 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         ttnn::SimpleShape shape{1, 32, 61, 32};
         // Allocates a DRAM buffer on device populated with values specified by initialize
-        Tensor a = ttnn::arange(/*start=*/0, /*stop=*/shape.volume(), /*step=*/1, DataType::BFLOAT16, std::ref(*device))
-                       .reshape(shape);
+        Tensor a = ttnn::arange(/*start=*/0, /*stop=*/shape.volume(), /*step=*/1, DataType::BFLOAT16)
+                       .reshape(shape)
+                       .to(device);
         Tensor b = ttnn::tilize_with_zero_padding(a);
         Tensor c = b.cpu();
         ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Problem description
[PR](https://github.com/tenstorrent/tt-metal/pull/15671/files#diff-4f512870412ccb31b911cf600798f5b502963f64bf93e04f39e13fe7eb9b8737) possibly introduced a failure in the test.

### What's changed
Re-shape now happens on the host, before uploading a tensor on device.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12279520776)
- [X] Manual test on a grayskull machine - reproduced the issue and confirmed the fix resolves it.
