### PR TITLE
[Llama70b] Fix minor bug with assertion for valid prompt lengths

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -20,7 +20,7 @@ from vllm.inputs import INPUT_REGISTRY, DecoderOnlyInputs, EncoderDecoderInputs,
 
 def input_processor_for_llama70b(ctx: InputContext, inputs: Union[DecoderOnlyInputs, EncoderDecoderInputs]):
     prompt_len = len(inputs.get("prompt_token_ids"))
-    if prompt_len >= 32768:
+    if prompt_len > 32768:
         raise ValueError(
             f"TT LLama70b does not yet support prompts longer than 32768 tokens (received prompt with {prompt_len} tokens)"
         )

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -178,8 +178,8 @@ class TtLlamaModel_optimized:
 
         if mode == "prefill":
             assert (
-                seq_len < self.model_config["MAX_PREFILL_SEQ_LEN"]
-            ), f"Prefill only supports seq_len < {self.model_config['MAX_PREFILL_SEQ_LEN']}"
+                seq_len <= self.model_config["MAX_PREFILL_SEQ_LEN"]
+            ), f"Prefill only supports seq_len <= {self.model_config['MAX_PREFILL_SEQ_LEN']}"
 
     def prepare_inputs(self, inp_ids, start_pos, valid_seq_len=None, mode="decode", page_table=None):
         """


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/vllm/issues/40

### Problem description
- The assertion for prompt length < 32k was disallowing prompts that are padded up to 32k as the nearest 1024.

### What's changed
- Changed the assertion to <= 32k
- Modified the vLLM input processing to raise bad request errors on prompt len > 32k instead of >=

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
