### PR TITLE
#15106: add missing tile_c_dim to packer config call

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1845,7 +1845,6 @@ def test_sharded_tilize_with_val_padding(input_shape, sharding_config, output_dt
     assert passing
 
 
-@skip_for_blackhole("GH #15234")
 @pytest.mark.parametrize("N", [8, 16])
 @pytest.mark.parametrize("in_sharded", [True], ids=["in0_sharded"])
 @pytest.mark.parametrize("out_sharded", [True], ids=["out_sharded"])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -343,6 +343,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
     if constexpr (at_kernel_start) {
         const std::uint32_t output_id = get_output_id(icb_out);
         const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
+        const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
         const std::uint32_t num_faces = get_output_num_faces(output_id);
         const bool partial_face = get_output_partial_face(output_id);
         const bool narrow_tile = get_output_narrow_tile(output_id);
@@ -358,6 +359,7 @@ inline void llk_pack_reduce_config_v2(uint32_t icb_out) {
             pack_dst_format[output_id],
             tile_size,
             face_r_dim,
+            tile_c_dim,
             num_faces,
             partial_face,
             narrow_tile,


### PR DESCRIPTION
### Ticket
Link to Github Issue #15106

### Problem description
- a parameter was not passed on when setting the config

### What's changed
- pass on the parameter
- remove skip for now passing test

### Checklist
- [ ] Post commit CI passes N/A BH only changes
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12282755287
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes N/A
- [x] New/Existing tests provide coverage for changes
