### PR TITLE
Integrate chunked prefill into t3k Llama3-70B

### DIFF
--- a/models/demos/t3000/llama2_70b/tests/test_chunked_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_chunked_generation.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+import torch
+import ttnn
+from ttnn import ReplicateTensorToMesh
+
+from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
+from models.demos.t3000.llama2_70b.tt.llama_generation import (
+    TtLlamaModelForGeneration,
+    get_block_size,
+    num_blocks_in_seq,
+)
+from models.demos.t3000.llama2_70b.tt.llama_common import (
+    setup_llama_env,
+    check_mesh_device,
+    comp_pcc,
+    load_llama_state_dict,
+)
+from models.demos.t3000.llama2_70b.demo.demo_continuous_batching_paged_attention import (
+    PagedAttentionConfig,
+    ModelArgs,
+    TTArgs,
+)
+
+
+def run_chunked_prefill_single_user(model_args, tt_args, chunk_size):
+    # Set up paged attention config
+    paged_attention_config = PagedAttentionConfig()
+    bsz = model_args.max_batch_size
+
+    # Create static page table (same as in demo)
+    permutation = torch.randperm(paged_attention_config.max_num_blocks)
+    reverse_permutation = torch.argsort(permutation)
+    static_page_table = reverse_permutation.reshape(bsz, paged_attention_config.max_num_blocks // bsz)
+
+    # Build reference generator
+    ref_generator = Llama.build(
+        ckpt_dir=model_args.ckpt_dir,
+        tokenizer_path=model_args.tokenizer_path,
+        max_seq_len=model_args.max_seq_len,
+        max_batch_size=model_args.max_batch_size,
+        skip_model_load=model_args.skip_model_load,
+        n_layers=model_args.num_layers,
+    )
+
+    # Load state dict for TT model
+    state_dict = load_llama_state_dict(model_args.ckpt_dir, n_layers=model_args.num_layers)
+
+    # Build TT generator with paged attention
+    tt_model = TtLlamaModelForGeneration(
+        configuration=ref_generator.model.params,
+        state_dict=state_dict,
+        model_args=model_args,
+        tt_args=tt_args,
+        paged_attention_config=paged_attention_config,
+    )
+
+    # For testing, override the max prefill length
+    tt_model.model_config["MAX_PREFILL_SEQ_LEN"] = chunk_size
+
+    # Extract the model's KV cache such that we can pass it in to the forward function
+    kv_cache = [l.attention.layer_past for l in tt_model.tt_model.layers]
+
+    # Create random input
+    seq_len = model_args.max_seq_len
+    input_tokens = torch.randint(0, 32000, (1, seq_len), dtype=torch.long)
+
+    # Slice out relevant part of page table
+    block_size = get_block_size(kv_cache)
+    num_blocks = num_blocks_in_seq(seq_len, block_size)
+    static_page_table = static_page_table[:, :num_blocks]
+
+    # Run both models
+    with torch.no_grad():
+        tt_logits = tt_model.prefill_forward_single_user(
+            input_tokens,
+            start_pos=0,
+            user_id=0,
+            page_table=static_page_table,
+            kv_cache=kv_cache,
+        )
+        ref_logits = ref_generator.model.forward(input_tokens, start_pos=0)
+
+    # Compare outputs
+    does_pass, pcc = comp_pcc(ref_logits, tt_logits, pcc=0.99)
+    logger.info(f"PCC between reference and TT model logits: {pcc}")
+    assert does_pass, f"Logits PCC {pcc} below threshold of 0.99"
+
+    ref_kv_cache = [[l.attention.cache_k, l.attention.cache_v] for l in ref_generator.model.layers]
+    # Compare KV caches
+    for layer_idx in range(len(kv_cache)):
+        tt_cache = kv_cache[layer_idx]
+        ref_cache = ref_kv_cache[layer_idx]
+
+        # Unshuffle paged cache and review it as unpaged cache (similar to paged_update_cache test)
+        tt_got_back_shuffled = [
+            ttnn.to_torch(kv, mesh_composer=ttnn.ConcatMeshToTensor(tt_args.mesh_device, dim=1)) for kv in tt_cache
+        ]
+        tt_got_back_unshuffled = [shuffled[reverse_permutation] for shuffled in tt_got_back_shuffled]
+
+        # Reshape to match reference cache dimensions
+        max_num_blocks = tt_got_back_shuffled[0].shape[0]
+        block_size = tt_got_back_shuffled[0].shape[2]
+        num_heads = tt_got_back_shuffled[0].shape[1]
+        head_dim = tt_got_back_shuffled[0].shape[3]
+        tt_got_back = [
+            unshuffled.reshape(1, max_num_blocks, num_heads, block_size, head_dim)
+            .transpose(1, 2)
+            .reshape(1, num_heads, -1, head_dim)
+            for unshuffled in tt_got_back_unshuffled
+        ]
+
+        for i in range(len(tt_got_back)):
+            ref_cache_slice = ref_cache[i][:1, :seq_len, :, :].permute(0, 2, 1, 3)
+            # Compare caches
+            does_pass_cache, pcc_cache = comp_pcc(ref_cache_slice, tt_got_back[i][:, :, :seq_len, :])
+            logger.info(f"PCC between reference and TT model KV cache at layer {layer_idx}: {pcc_cache}")
+        assert does_pass_cache, f"KV cache PCC {pcc_cache} below threshold at layer {layer_idx}"
+
+    return does_pass, pcc
+
+
+@torch.no_grad()
+@pytest.mark.timeout(240000)
+@pytest.mark.parametrize(
+    "llama_version",
+    ["llama3"],
+)
+@pytest.mark.parametrize(
+    "num_layers",
+    [
+        1,
+    ],
+    ids=[
+        "1L",
+    ],
+)
+@pytest.mark.parametrize(
+    "max_batch_size, max_context_len, chunk_size",
+    [(1, 128 * 1024, 32 * 1024), (16, 8 * 1024, 2 * 1024), (32, 2 * 1024, 1 * 1024)],
+    ids=["1BSZ", "16BSZ", "32BSZ"],
+)
+def test_chunked_prefill_single_user(
+    t3k_mesh_device, llama_version, num_layers, max_batch_size, max_context_len, chunk_size
+):
+    """
+    This test ensures that chunked prefill, when used by calling `prefill_forward_single_user`,
+    matches the reference implementation.
+    """
+    if max_context_len == 128 * 1024:
+        pytest.skip("Skipping test for max_context_len = 128*1024 since reference runs OOM")
+    # Set up environment
+    model_config, ckpt_dir, tokenizer_path, cache_path = setup_llama_env(
+        llama_version=llama_version,
+    )
+
+    # Check device compatibility
+    check_mesh_device(t3k_mesh_device, model_config)
+    t3k_mesh_device.enable_async(True)
+
+    # Create args
+    model_args = ModelArgs(
+        implementation="tt",
+        llama_version=llama_version,
+        ckpt_dir=ckpt_dir,
+        tokenizer_path=tokenizer_path,
+        max_batch_size=max_batch_size,
+        num_layers=num_layers,
+        max_seq_len=max_context_len,
+        max_kv_context_len=max_context_len,
+    )
+
+    tt_args = TTArgs(
+        mesh_device=t3k_mesh_device,
+        n_devices=8,
+        cache_path=cache_path,
+    )
+
+    # Run test
+    does_pass, pcc = run_chunked_prefill_single_user(model_args, tt_args, chunk_size)
+    assert does_pass, f"Test failed with PCC {pcc}"
+
+
+def run_batch_prefill_test(model_args, tt_args, chunk_size, batch):
+    # Set up paged attention config
+    paged_attention_config = PagedAttentionConfig()
+    # Create static page table (same as in demo)
+    permutation = torch.randperm(paged_attention_config.max_num_blocks)
+    reverse_permutation = torch.argsort(permutation)
+    static_page_table = reverse_permutation.reshape(
+        model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+    )
+    # Build reference generator
+    ref_generator = Llama.build(
+        ckpt_dir=model_args.ckpt_dir,
+        tokenizer_path=model_args.tokenizer_path,
+        max_seq_len=model_args.max_seq_len,
+        max_batch_size=model_args.max_batch_size,
+        skip_model_load=model_args.skip_model_load,
+        n_layers=model_args.num_layers,
+    )
+
+    # Load state dict for TT model
+    state_dict = load_llama_state_dict(model_args.ckpt_dir, n_layers=model_args.num_layers)
+
+    # Build TT generator with paged attention
+    tt_model = TtLlamaModelForGeneration(
+        configuration=ref_generator.model.params,
+        state_dict=state_dict,
+        model_args=model_args,
+        tt_args=tt_args,
+        paged_attention_config=paged_attention_config,
+    )
+
+    # For testing, override the max prefill length
+    tt_model.model_config["MAX_PREFILL_SEQ_LEN"] = chunk_size
+
+    # Extract the model's KV cache such that we can pass it in to the forward function
+    kv_cache = [l.attention.layer_past for l in tt_model.tt_model.layers]
+
+    # Create random input with varying sequence lengths
+    max_seq_len = model_args.max_seq_len
+    prompt_lens = torch.randint(
+        chunk_size, max_seq_len + 1, (batch,)
+    )  # Random lengths between chunk_size and max_seq_len
+    input_tokens = torch.randint(0, 32000, (batch, max_seq_len), dtype=torch.long)
+    logger.info(f"Prompt lengths: {prompt_lens}")
+    batch_page_table = static_page_table[:batch]
+    # Run both models
+    with torch.no_grad():
+        tt_logits = tt_model.prefill_forward(
+            input_tokens,
+            start_pos=0,
+            page_table=batch_page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+        )
+        logger.info(f"TT logits shape: {tt_logits.shape}")
+
+        # Run reference model
+        batch_logits = ref_generator.model.forward(input_tokens, start_pos=0)
+        ref_logits = batch_logits[torch.arange(batch), prompt_lens - 1, :].unsqueeze(1)  # Only keep last token's logits
+        ref_kv_cache = [[l.attention.cache_k, l.attention.cache_v] for l in ref_generator.model.layers]
+
+    # Compare outputs
+    does_pass, pcc = comp_pcc(ref_logits, tt_logits, pcc=0.99)
+    logger.info(f"PCC between reference and TT model: {pcc}")
+    assert does_pass, f"PCC {pcc} below threshold of 0.99"
+
+    # Compare KV caches
+    for layer_idx in range(len(kv_cache)):
+        tt_cache = kv_cache[layer_idx]
+        ref_cache = ref_kv_cache[layer_idx]
+
+        # Unshuffle paged cache and review it as unpaged cache (similar to paged_update_cache test)
+        tt_got_back_shuffled = [
+            ttnn.to_torch(kv, mesh_composer=ttnn.ConcatMeshToTensor(tt_args.mesh_device, dim=1)) for kv in tt_cache
+        ]
+        tt_got_back_unshuffled = [shuffled[reverse_permutation] for shuffled in tt_got_back_shuffled]
+
+        # Reshape to match reference cache dimensions
+        max_num_blocks = tt_got_back_shuffled[0].shape[0]
+        block_size = tt_got_back_shuffled[0].shape[2]
+        num_heads = tt_got_back_shuffled[0].shape[1]
+        head_dim = tt_got_back_shuffled[0].shape[3]
+        tt_got_back = [
+            unshuffled.reshape(
+                model_args.max_batch_size, max_num_blocks // model_args.max_batch_size, num_heads, block_size, head_dim
+            )
+            .transpose(1, 2)
+            .reshape(model_args.max_batch_size, num_heads, -1, head_dim)
+            for unshuffled in tt_got_back_unshuffled
+        ]
+
+        for b in range(batch):
+            valid_seq_len = prompt_lens[b]
+            logger.info(f"valid seq len: {valid_seq_len}")
+            for i in range(len(tt_got_back)):
+                logger.info(f"layer {i}, batch {b}")
+                logger.info(f"ref cache shape: {ref_cache[i].shape}")
+                logger.info(f"tt cache shape: {tt_got_back[i].shape}")
+                ref_cache_slice = ref_cache[i][b : b + 1, :valid_seq_len, :, :].permute(0, 2, 1, 3)
+                tt_cache_slice = tt_got_back[i][b : b + 1, :, :valid_seq_len, :]
+                # Compare caches
+                does_pass_cache, pcc_cache = comp_pcc(ref_cache_slice, tt_cache_slice)
+                logger.info(f"PCC between reference and TT model KV cache at layer {layer_idx}: {pcc_cache}")
+                assert does_pass_cache, f"KV cache PCC {pcc_cache} below threshold at layer {layer_idx}"
+
+    return does_pass, pcc
+
+
+@torch.no_grad()
+@pytest.mark.timeout(240000)
+@pytest.mark.parametrize(
+    "llama_version",
+    ["llama3"],
+)
+@pytest.mark.parametrize(
+    "num_layers",
+    [
+        1,
+    ],
+    ids=[
+        "1L",
+    ],
+)
+@pytest.mark.parametrize(
+    "max_batch_size, max_context_len, chunk_size, batch",
+    [(1, 128 * 1024, 32 * 1024, 1), (16, 8 * 1024, 2 * 1024, 4), (32, 2 * 1024, 1 * 1024, 4)],
+    ids=["1BSZ", "16BSZ", "32BSZ"],
+)
+def test_batch_prefill(t3k_mesh_device, llama_version, num_layers, max_batch_size, max_context_len, chunk_size, batch):
+    """
+    This test ensures that batch prefill matches the reference implementation
+    when processing multiple sequences of different lengths.
+    """
+    if max_context_len == 128 * 1024:
+        pytest.skip("Skipping test for max_context_len = 128*1024 since reference runs OOM")
+    # Set up environment
+    model_config, ckpt_dir, tokenizer_path, cache_path = setup_llama_env(
+        llama_version=llama_version,
+    )
+
+    # Check device compatibility
+    check_mesh_device(t3k_mesh_device, model_config)
+    t3k_mesh_device.enable_async(True)
+
+    # Create args
+    model_args = ModelArgs(
+        implementation="tt",
+        llama_version=llama_version,
+        ckpt_dir=ckpt_dir,
+        tokenizer_path=tokenizer_path,
+        max_batch_size=max_batch_size,
+        num_layers=num_layers,
+        max_seq_len=max_context_len,
+        max_kv_context_len=max_context_len,
+    )
+
+    tt_args = TTArgs(
+        mesh_device=t3k_mesh_device,
+        n_devices=8,
+        cache_path=cache_path,
+    )
+
+    # Run test
+    does_pass, pcc = run_batch_prefill_test(model_args, tt_args, chunk_size, batch)
+    assert does_pass, f"Test failed with PCC {pcc}"

--- a/models/demos/t3000/llama2_70b/tests/test_llama_attention.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_attention.py
@@ -146,7 +146,7 @@ def tt_llama_attention_prepare_inputs(
             cos_gathered,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            cache_file_name=cache_name(f"cos_gathered_prefill_{seq_len}"),
+            cache_file_name=cache_name(f"cos_gathered_prefill_{start_pos}_to_{start_pos + seq_len}"),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             device=llama_attention_model.mesh_device,
             mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
@@ -155,7 +155,7 @@ def tt_llama_attention_prepare_inputs(
             sin_gathered,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            cache_file_name=cache_name(f"sin_gathered_prefill_{seq_len}"),
+            cache_file_name=cache_name(f"sin_gathered_prefill_{start_pos}_to_{start_pos + seq_len}"),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             device=llama_attention_model.mesh_device,
             mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
@@ -219,6 +219,8 @@ def run_test_LlamaAttention_inference(
     tokenizer_path,
     cache_path,
     paged_attention,
+    is_chunked_prefill=False,
+    chunk_size=None,
 ):
     # Prepare paths and devices
     skip_model_load = should_skip_model_load()
@@ -315,15 +317,9 @@ def run_test_LlamaAttention_inference(
         start_pos = generation_start_pos + i
 
         # PyTorch output --------------------------------------------------------------------
-        if mode == "prefill":
-            attention_input, start_pos, freqs_cis, attn_mask = pytorch_LlamaAttention_model.prepare_inputs_prefill(
-                pt_inp_normed, start_pos
-            )
-        else:
-            attention_input, start_pos, freqs_cis, attn_mask = pytorch_LlamaAttention_model.prepare_inputs(
-                pt_inp_normed, start_pos
-            )
-
+        attention_input, start_pos, freqs_cis, attn_mask = pytorch_LlamaAttention_model.prepare_inputs_prefill(
+            pt_inp_normed, start_pos
+        )
         pytorch_out = pytorch_LlamaAttention_model(
             attention_input,
             start_pos,
@@ -331,36 +327,138 @@ def run_test_LlamaAttention_inference(
             attn_mask,
         )
 
-        # TT hardware execution -------------------------------------------------------------
-        attention_input, start_pos, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
-            tt_LlamaAttention_model,
-            tt_input,
-            start_pos,
-            mode,
-            configuration.rope_theta,
-            rope_setup=rope_setup if mode == "decode" else None,
-            use_scaled_rope=configuration.use_scaled_rope,
-        )
+        if mode == "prefill":
+            assert start_pos == 0, "Start pos should be 0 for chunked prefill"
+            assert batch == 1, "Batch should be 1 for chunked prefill"
+            if is_chunked_prefill:
+                """
+                In chunked prefill mode, we need to split the prefill input into chunks.
+                Each chunk will be processed sequentially. Each chunk must be given the appropriate
+                sin/cos values. Also, each chunk must be given a partial page table for paged_fill_cache
+                so that paged_fill_cache fills the current chunk properly.
+                Be vary careful that we don't pick up cached sin/cos values since they will be incorrect.
+                """
+                for chunk_start in range(0, seq_len, chunk_size):
+                    chunk_end = chunk_start + chunk_size
+                    assert chunk_end <= seq_len, "Chunk end should be less than seq_len"
+                    chunk_page_table = page_table[
+                        :,
+                        chunk_start
+                        // paged_attention_config.block_size : chunk_end
+                        // paged_attention_config.block_size,
+                    ]
+                    chunk_page_table_tt = ttnn.as_tensor(
+                        chunk_page_table,
+                        dtype=ttnn.int32,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        device=t3k_mesh_device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
+                    )
+                    # SDPA requires that the page table batch dim matches the input batch dim, which must be 1 in prefill
+                    prefill_page_table = page_table[0:1, :]
+                    prefill_page_table_tt = ttnn.as_tensor(
+                        prefill_page_table,
+                        dtype=ttnn.int32,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        device=t3k_mesh_device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
+                    )
 
-        tt_out = tt_LlamaAttention_model(
-            attention_input,
-            rot_mat,
-            start_pos,
-            cache_idxs=cache_idxs if mode == "decode" else None,
-            page_table=page_table_tt,
-            mode=mode,
-        )
+                    chunk_tt_input = tt_input[:, chunk_start:chunk_end]
+                    # TT hardware execution -------------------------------------------------------------
+                    attention_input, _, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
+                        tt_LlamaAttention_model,
+                        chunk_tt_input,
+                        chunk_start,
+                        mode,
+                        configuration.rope_theta,
+                        rope_setup=None,
+                        use_scaled_rope=configuration.use_scaled_rope,
+                    )
+                    tt_chunk_out = tt_LlamaAttention_model(
+                        attention_input,
+                        rot_mat,
+                        None,
+                        cache_idxs=None,
+                        page_table=prefill_page_table_tt,
+                        mode=mode,
+                        chunk_page_table=chunk_page_table_tt,
+                        chunk_start_idx=chunk_start,
+                    )
 
-        tt_out = ttnn.from_device(tt_out)
-        tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
-        tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
-        if mode == "decode":
+                    tt_chunk_out = ttnn.from_device(tt_chunk_out)
+                    tt_chunk_out = ttnn.to_torch(tt_chunk_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+                    tt_chunk_out = tt_chunk_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
+
+                    # check outputs ----------------------------------------------------------------------
+                    pytorch_chunk_out = pytorch_out[:, chunk_start:chunk_end]
+                    does_pass, output_pcc = comp_pcc(pytorch_chunk_out, tt_chunk_out, pcc)
+                    logger.info(f"Chunk {chunk_start} output: {output_pcc}")
+                    all_pccs.append(extract_pcc_from_log(output_pcc))
+
+            else:
+                # TT hardware execution -------------------------------------------------------------
+                attention_input, start_pos, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
+                    tt_LlamaAttention_model,
+                    tt_input,
+                    start_pos,
+                    mode,
+                    configuration.rope_theta,
+                    rope_setup=None,
+                    use_scaled_rope=configuration.use_scaled_rope,
+                )
+
+                tt_out = tt_LlamaAttention_model(
+                    attention_input,
+                    rot_mat,
+                    start_pos,
+                    cache_idxs=None,
+                    page_table=page_table_tt,
+                    mode=mode,
+                )
+
+                tt_out = ttnn.from_device(tt_out)
+                tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+                tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
+
+                # check outputs ----------------------------------------------------------------------
+                does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
+                logger.info(f"Output: {output_pcc}")
+                all_pccs.append(extract_pcc_from_log(output_pcc))
+
+        else:
+            # TT hardware execution -------------------------------------------------------------
+            attention_input, start_pos, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
+                tt_LlamaAttention_model,
+                tt_input,
+                start_pos,
+                mode,
+                configuration.rope_theta,
+                rope_setup=rope_setup,
+                use_scaled_rope=configuration.use_scaled_rope,
+            )
+
+            tt_out = tt_LlamaAttention_model(
+                attention_input,
+                rot_mat,
+                start_pos,
+                cache_idxs=cache_idxs,
+                page_table=page_table_tt,
+                mode=mode,
+            )
+
+            tt_out = ttnn.from_device(tt_out)
+            tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+            tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
+
             tt_out = tt_out[:batch]
 
-        # check outputs ----------------------------------------------------------------------
-        does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
-        logger.info(f"Output: {output_pcc}")
-        all_pccs.append(extract_pcc_from_log(output_pcc))
+            # check outputs ----------------------------------------------------------------------
+            does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
+            logger.info(f"Output: {output_pcc}")
+            all_pccs.append(extract_pcc_from_log(output_pcc))
 
         if does_pass:
             logger.info(f"[start_pos={start_pos}] {llama_version} Attention output Passed!")
@@ -451,9 +549,13 @@ def run_test_LlamaAttention_inference(
     ),
 )
 @pytest.mark.parametrize(
-    "paged_attention",
-    (True, False),
-    ids=("paged_attention", "non_paged_attention"),
+    "paged_attention, is_chunked_prefill, chunk_size",
+    (
+        (True, True, 128),
+        (True, False, None),
+        (False, False, None),
+    ),
+    ids=("chunked_paged_attention", "standard_paged_attention", "non_paged_attention"),
 )
 def test_LlamaAttention_inference(
     batch,
@@ -464,6 +566,8 @@ def test_LlamaAttention_inference(
     max_context_len,
     llama_version,
     paged_attention,
+    is_chunked_prefill,
+    chunk_size,
     use_program_cache,
 ):
     if seq_len == 1 and batch != max_batch_size:
@@ -474,6 +578,15 @@ def test_LlamaAttention_inference(
 
     if llama_version == "llama2" and seq_len > 2048:
         pytest.skip(f"Llama2 with seq_len={seq_len} is not supported (max 2048)")
+
+    if is_chunked_prefill and seq_len == 1:
+        pytest.skip("Chunked prefill is not valid for decode mode tests")
+
+    if is_chunked_prefill:
+        assert paged_attention, "Chunked prefill is only valid for paged attention"
+        assert chunk_size is not None, "Chunk size must be provided for chunked prefill"
+        assert chunk_size > 0, "Chunk size must be greater than 0"
+        assert seq_len % chunk_size == 0, "Sequence length must be divisible by chunk size"
 
     model_config, ckpt_dir, tokenizer_path, cache_path = setup_llama_env(
         llama_version=llama_version,
@@ -494,4 +607,6 @@ def test_LlamaAttention_inference(
         tokenizer_path,
         cache_path,
         paged_attention,
+        is_chunked_prefill,
+        chunk_size,
     )

--- a/models/demos/t3000/llama2_70b/tests/test_llama_attention.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_attention.py
@@ -327,105 +327,74 @@ def run_test_LlamaAttention_inference(
             attn_mask,
         )
 
-        if mode == "prefill":
+        if is_chunked_prefill:
+            assert mode == "prefill", "Chunked prefill should only be run in prefill mode"
             assert start_pos == 0, "Start pos should be 0 for chunked prefill"
             assert batch == 1, "Batch should be 1 for chunked prefill"
-            if is_chunked_prefill:
-                """
-                In chunked prefill mode, we need to split the prefill input into chunks.
-                Each chunk will be processed sequentially. Each chunk must be given the appropriate
-                sin/cos values. Also, each chunk must be given a partial page table for paged_fill_cache
-                so that paged_fill_cache fills the current chunk properly.
-                Be vary careful that we don't pick up cached sin/cos values since they will be incorrect.
-                """
-                for chunk_start in range(0, seq_len, chunk_size):
-                    chunk_end = chunk_start + chunk_size
-                    assert chunk_end <= seq_len, "Chunk end should be less than seq_len"
-                    chunk_page_table = page_table[
-                        :,
-                        chunk_start
-                        // paged_attention_config.block_size : chunk_end
-                        // paged_attention_config.block_size,
-                    ]
-                    chunk_page_table_tt = ttnn.as_tensor(
-                        chunk_page_table,
-                        dtype=ttnn.int32,
-                        layout=ttnn.ROW_MAJOR_LAYOUT,
-                        device=t3k_mesh_device,
-                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
-                    )
-                    # SDPA requires that the page table batch dim matches the input batch dim, which must be 1 in prefill
-                    prefill_page_table = page_table[0:1, :]
-                    prefill_page_table_tt = ttnn.as_tensor(
-                        prefill_page_table,
-                        dtype=ttnn.int32,
-                        layout=ttnn.ROW_MAJOR_LAYOUT,
-                        device=t3k_mesh_device,
-                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
-                    )
 
-                    chunk_tt_input = tt_input[:, chunk_start:chunk_end]
-                    # TT hardware execution -------------------------------------------------------------
-                    attention_input, _, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
-                        tt_LlamaAttention_model,
-                        chunk_tt_input,
-                        chunk_start,
-                        mode,
-                        configuration.rope_theta,
-                        rope_setup=None,
-                        use_scaled_rope=configuration.use_scaled_rope,
-                    )
-                    tt_chunk_out = tt_LlamaAttention_model(
-                        attention_input,
-                        rot_mat,
-                        None,
-                        cache_idxs=None,
-                        page_table=prefill_page_table_tt,
-                        mode=mode,
-                        chunk_page_table=chunk_page_table_tt,
-                        chunk_start_idx=chunk_start,
-                    )
+            """
+            In chunked prefill mode, we need to split the prefill input into chunks.
+            Each chunk will be processed sequentially. Each chunk must be given the appropriate
+            sin/cos values. Also, each chunk must be given a partial page table for paged_fill_cache
+            so that paged_fill_cache fills the current chunk properly.
+            Be vary careful that we don't pick up cached sin/cos values since they will be incorrect.
+            """
+            for chunk_start in range(0, seq_len, chunk_size):
+                chunk_end = chunk_start + chunk_size
+                assert chunk_end <= seq_len, "Chunk end should be less than seq_len"
+                chunk_page_table = page_table[
+                    :,
+                    chunk_start // paged_attention_config.block_size : chunk_end // paged_attention_config.block_size,
+                ]
+                chunk_page_table_tt = ttnn.as_tensor(
+                    chunk_page_table,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    device=t3k_mesh_device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
+                )
+                # SDPA requires that the page table batch dim matches the input batch dim, which must be 1 in prefill
+                prefill_page_table = page_table[0:1, :]
+                prefill_page_table_tt = ttnn.as_tensor(
+                    prefill_page_table,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    device=t3k_mesh_device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
+                )
 
-                    tt_chunk_out = ttnn.from_device(tt_chunk_out)
-                    tt_chunk_out = ttnn.to_torch(tt_chunk_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
-                    tt_chunk_out = tt_chunk_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
-
-                    # check outputs ----------------------------------------------------------------------
-                    pytorch_chunk_out = pytorch_out[:, chunk_start:chunk_end]
-                    does_pass, output_pcc = comp_pcc(pytorch_chunk_out, tt_chunk_out, pcc)
-                    logger.info(f"Chunk {chunk_start} output: {output_pcc}")
-                    all_pccs.append(extract_pcc_from_log(output_pcc))
-
-            else:
+                chunk_tt_input = tt_input[:, chunk_start:chunk_end]
                 # TT hardware execution -------------------------------------------------------------
-                attention_input, start_pos, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
+                attention_input, _, rot_mat, cache_idxs = tt_llama_attention_prepare_inputs(
                     tt_LlamaAttention_model,
-                    tt_input,
-                    start_pos,
+                    chunk_tt_input,
+                    chunk_start,
                     mode,
                     configuration.rope_theta,
                     rope_setup=None,
                     use_scaled_rope=configuration.use_scaled_rope,
                 )
-
-                tt_out = tt_LlamaAttention_model(
+                tt_chunk_out = tt_LlamaAttention_model(
                     attention_input,
                     rot_mat,
-                    start_pos,
+                    None,
                     cache_idxs=None,
-                    page_table=page_table_tt,
+                    page_table=prefill_page_table_tt,
                     mode=mode,
+                    chunk_page_table=chunk_page_table_tt,
+                    chunk_start_idx=chunk_start,
                 )
 
-                tt_out = ttnn.from_device(tt_out)
-                tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
-                tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
+                tt_chunk_out = ttnn.from_device(tt_chunk_out)
+                tt_chunk_out = ttnn.to_torch(tt_chunk_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+                tt_chunk_out = tt_chunk_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
 
                 # check outputs ----------------------------------------------------------------------
-                does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
-                logger.info(f"Output: {output_pcc}")
+                pytorch_chunk_out = pytorch_out[:, chunk_start:chunk_end]
+                does_pass, output_pcc = comp_pcc(pytorch_chunk_out, tt_chunk_out, pcc)
+                logger.info(f"Chunk {chunk_start} output: {output_pcc}")
                 all_pccs.append(extract_pcc_from_log(output_pcc))
 
         else:
@@ -436,7 +405,7 @@ def run_test_LlamaAttention_inference(
                 start_pos,
                 mode,
                 configuration.rope_theta,
-                rope_setup=rope_setup,
+                rope_setup=rope_setup if mode == "decode" else None,
                 use_scaled_rope=configuration.use_scaled_rope,
             )
 
@@ -453,7 +422,8 @@ def run_test_LlamaAttention_inference(
             tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
             tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
 
-            tt_out = tt_out[:batch]
+            if mode == "decode":
+                tt_out = tt_out[:batch]
 
             # check outputs ----------------------------------------------------------------------
             does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
@@ -485,7 +455,6 @@ def run_test_LlamaAttention_inference(
     # concat the pasts by heads
     tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaAttention_model.layer_past]
     if paged_attention:
-        tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaAttention_model.layer_past]
         tt_layer_present_all = [
             (
                 ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=1))[reverse_permutation]

--- a/models/demos/t3000/llama2_70b/tests/test_llama_device_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_device_perf.py
@@ -76,6 +76,7 @@ def test_run_device_perf_llama(
         t3k_mesh_device,
         batch,
         seq_len,
+        max_batch_size,
         max_context_len,
         N_LAYERS_TO_PCC[n_layers],
         model_config,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_model.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_model.py
@@ -6,7 +6,7 @@ import pytest
 from loguru import logger
 import torch
 import ttnn
-from ttnn import ConcatMeshToTensor
+from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 import os
 
 import scipy
@@ -31,6 +31,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
     check_kv_cache,
 )
 
+from models.demos.t3000.llama2_70b.tests.test_llama_attention import PagedAttentionConfig
 
 DEVICE_PERF_START_SIGNPOST = "START_PERF_RUN"
 DEVICE_PERF_END_SIGNPOST = "END_PERF_RUN"
@@ -64,6 +65,7 @@ def run_test_LlamaModel_inference(
     t3k_mesh_device,
     batch,
     seq_len,
+    max_batch_size,
     max_context_len,
     pcc,
     model_config,
@@ -75,6 +77,8 @@ def run_test_LlamaModel_inference(
     prompt_file=None,
     generation_start_pos=0,
     device_perf=False,  # set to True when measuring device perf
+    paged_attention=False,
+    chunk_size=None,
 ):
     if device_perf:  # Enable tracy signpost support in device perf runs only
         from tracy import signpost
@@ -108,6 +112,20 @@ def run_test_LlamaModel_inference(
     # PyTorch model --------------------------------------------------------------------
     pytorch_model = PytorchLlamaModel(hugging_face_reference_model)
     # TT model -------------------------------------------------------------------------
+
+    page_table = None
+    paged_attention_config = None
+    if paged_attention:
+        paged_attention_config = PagedAttentionConfig()
+
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtua blocks to physical
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            max_batch_size, paged_attention_config.max_num_blocks // max_batch_size
+        )
+
     tt_model = TtLlamaModel_optimized(
         t3k_mesh_device,
         state_dict,
@@ -116,6 +134,7 @@ def run_test_LlamaModel_inference(
         model_config,
         configuration,
         cache_path=cache_path,
+        paged_attention_config=paged_attention_config,
     )
 
     mode = "prefill" if seq_len > 1 else "decode"
@@ -155,36 +174,96 @@ def run_test_LlamaModel_inference(
             pt_inp_ids,
             start_pos,
         )
-
-        if device_perf:
-            signpost(DEVICE_PERF_START_SIGNPOST)  # start for device perf measurement
-        # TT hardware execution -------------------------------------------------------------
-        tt_inp_emb, start_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs(tt_inp_ids, start_pos, mode=mode)
-
-        tt_out = tt_model(
-            tt_inp_emb,
-            rot_mat,
-            start_pos,
-            cache_idxs=cache_idxs,
-            mode=mode,
-        )
-        del tt_inp_emb, rot_mat
-
-        tt_out = ttnn.from_device(tt_out)
-        tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
-
-        if device_perf:
-            signpost(DEVICE_PERF_END_SIGNPOST)  # end for device perf measurement
-
-        tt_out = tt_out[..., : configuration.vocab_size]
-        tt_out = tt_out.permute(2, 1, 0, 3).squeeze()  # [batch, hidden_dim]
-        if mode == "decode":
-            tt_out = tt_out[:batch]
-        tt_out = tt_out.float()
         if mode == "decode":
             pytorch_out = pytorch_out.squeeze().reshape(batch, -1)  # [batch, hidden_dim]
         else:
             pytorch_out = pytorch_out.squeeze().reshape(seq_len, -1)  # [seq, hidden_dim]
+
+        if device_perf:
+            signpost(DEVICE_PERF_START_SIGNPOST)  # start for device perf measurement
+        # TT hardware execution -------------------------------------------------------------
+        if chunk_size is not None:
+            tt_out = []
+            assert mode == "prefill"
+            for chunk_start in range(0, seq_len, chunk_size):
+                logger.info(f"Chunk start: {chunk_start}")
+                chunk_end = chunk_start + chunk_size
+                assert chunk_end <= seq_len, "Chunk end should be less than seq_len"
+                chunk_page_table = page_table[
+                    :,
+                    chunk_start // paged_attention_config.block_size : chunk_end // paged_attention_config.block_size,
+                ]
+                # SDPA requires that the page table batch dim matches the input batch dim, which must be 1 in prefill
+                prefill_page_table = page_table[0:1, :]
+
+                chunk_tt_input = tt_inp_ids[:, chunk_start:chunk_end]
+                # TT hardware execution -------------------------------------------------------------
+                (
+                    tt_inp_emb,
+                    start_pos,
+                    rot_mat,
+                    rot_idxs_tt,
+                    cache_idxs,
+                    page_table_tt,
+                    chunk_page_table_tt,
+                ) = tt_model.prepare_inputs(
+                    chunk_tt_input,
+                    chunk_start,
+                    mode=mode,
+                    page_table=prefill_page_table,
+                    chunk_page_table=chunk_page_table,
+                )
+
+                tt_chunk_out = tt_model(
+                    tt_inp_emb,
+                    rot_mat,
+                    start_pos,
+                    cache_idxs=cache_idxs,
+                    mode=mode,
+                    page_table=page_table_tt,
+                    chunk_page_table=chunk_page_table_tt,
+                    chunk_start_idx=chunk_start,
+                )
+
+                tt_chunk_out = ttnn.from_device(tt_chunk_out)
+                tt_chunk_out = ttnn.to_torch(tt_chunk_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+                tt_chunk_out = tt_chunk_out[..., : configuration.vocab_size]
+                tt_chunk_out = tt_chunk_out.permute(2, 1, 0, 3).squeeze()  # [batch, seq_len, hidden_dim]
+
+                tt_out.append(tt_chunk_out)
+
+            tt_out = torch.cat(tt_out, dim=0).float()
+
+        else:
+            if mode == "decode":
+                tt_inp_emb, start_pos, rot_mat, cache_idxs, *_ = tt_model.prepare_device_inputs_decode(
+                    tt_inp_ids, start_pos, mode=mode
+                )
+            else:
+                tt_inp_emb, start_pos, rot_mat, cache_idxs, *_ = tt_model.prepare_inputs(
+                    tt_inp_ids, start_pos, mode=mode
+                )
+
+            tt_out = tt_model(
+                tt_inp_emb,
+                rot_mat,
+                start_pos,
+                cache_idxs=cache_idxs,
+                mode=mode,
+            )
+            del tt_inp_emb, rot_mat
+
+            tt_out = ttnn.from_device(tt_out)
+            tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
+
+            if device_perf:
+                signpost(DEVICE_PERF_END_SIGNPOST)  # end for device perf measurement
+
+            tt_out = tt_out[..., : configuration.vocab_size]
+            tt_out = tt_out.permute(2, 1, 0, 3).squeeze()  # [batch, hidden_dim]
+            if mode == "decode":
+                tt_out = tt_out[:batch]
+            tt_out = tt_out.float()
 
         # check outputs ----------------------------------------------------------------------
         does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
@@ -219,33 +298,34 @@ def run_test_LlamaModel_inference(
     logger.info(f"Average Top-5 over {len(all_top5)} tokens: {sum(all_top5) / len(all_top5)}")
     # Check kv cache
     # PyTorch output --------------------------------------------------------------------
-    pytorch_layer_present = [
-        pytorch_model.model.layers[0]
-        .attention.cache_k.clone()
-        .permute(0, 2, 1, 3)[:batch, ...],  # [batch, n_kv_heads, seq, head_dim]
-        pytorch_model.model.layers[0]
-        .attention.cache_v.clone()
-        .permute(0, 2, 1, 3)[:batch, ...],  # [batch, n_kv_heads, seq, head_dim]
-    ]
+    if chunk_size is None:
+        pytorch_layer_present = [
+            pytorch_model.model.layers[0]
+            .attention.cache_k.clone()
+            .permute(0, 2, 1, 3)[:batch, ...],  # [batch, n_kv_heads, seq, head_dim]
+            pytorch_model.model.layers[0]
+            .attention.cache_v.clone()
+            .permute(0, 2, 1, 3)[:batch, ...],  # [batch, n_kv_heads, seq, head_dim]
+        ]
 
-    tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_model.layers[0].attention.layer_past]
-    tt_layer_present_all = [
-        ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=1))[:batch, ...]
-        for lp in tt_layer_present_all
-    ]
+        tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_model.layers[0].attention.layer_past]
+        tt_layer_present_all = [
+            ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=1))[:batch, ...]
+            for lp in tt_layer_present_all
+        ]
 
-    cache_test_pass = check_kv_cache(
-        pytorch_layer_present,
-        tt_layer_present_all,
-        generation_start_pos,
-        generation_length,
-        seq_len,
-        mode == "prefill",
-        pcc,
-    )
-    all_tests_pass = all_tests_pass and cache_test_pass
-    if all_tests_pass:
-        logger.info(f"{llama_version} output Passed!")
+        cache_test_pass = check_kv_cache(
+            pytorch_layer_present,
+            tt_layer_present_all,
+            generation_start_pos,
+            generation_length,
+            seq_len,
+            mode == "prefill",
+            pcc,
+        )
+        all_tests_pass = all_tests_pass and cache_test_pass
+        if all_tests_pass:
+            logger.info(f"{llama_version} output Passed!")
 
     assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"
 
@@ -298,6 +378,14 @@ def run_test_LlamaModel_inference(
     ("models/demos/t3000/llama2_70b/demo/data/a_tale_of_two_cities.txt", None),
     ids=("prompt_input", "rand_input"),
 )
+@pytest.mark.parametrize(
+    "paged_attention, chunk_size",
+    (
+        (True, 128),
+        (False, None),
+    ),
+    ids=("chunked_paged_attention", "unpaged_attention"),
+)
 def test_LlamaModel_inference(
     batch,
     seq_len,
@@ -308,8 +396,18 @@ def test_LlamaModel_inference(
     max_context_len,
     llama_version,
     prompt_file,
+    paged_attention,
+    chunk_size,
     use_program_cache,
 ):
+    if chunk_size is not None and seq_len == 1:
+        pytest.skip("Chunked prefill is not valid for decode mode tests")
+
+    if chunk_size is not None:
+        assert paged_attention, "Chunked prefill is only valid for paged attention"
+        assert chunk_size > 0, "Chunk size must be greater than 0"
+        assert seq_len % chunk_size == 0, "Sequence length must be divisible by chunk size"
+
     is_decode = seq_len == 1
     if is_decode and batch != max_batch_size:
         pytest.skip(f"Input batch size should match max_batch_size")
@@ -332,6 +430,7 @@ def test_LlamaModel_inference(
         t3k_mesh_device,
         batch,
         seq_len,
+        max_batch_size,
         max_context_len,
         pcc,
         model_config,
@@ -341,4 +440,6 @@ def test_LlamaModel_inference(
         tokenizer_path,
         cache_path,
         prompt_file=prompt_file,
+        paged_attention=paged_attention,
+        chunk_size=chunk_size,
     )

--- a/models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
@@ -71,6 +71,7 @@ def test_LlamaModel_inference(
         t3k_mesh_device,
         batch,
         seq_len,
+        max_batch_size,
         max_context_len,
         N_LAYERS_TO_PCC[n_layers],
         model_config,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
@@ -154,7 +154,7 @@ def run_test_LlamaModel_end_to_end(
         if user_id == 0 or user_id == 25:
             profiler.start(f"processing_of_prefill_input_{user_id}")
 
-        tt_inp_emb, start_pos, rot_mat, _, _ = tt_model.prepare_device_inputs(
+        tt_inp_emb, start_pos, rot_mat, *_ = tt_model.prepare_inputs(
             prefill_ids[user_id : user_id + 1], start_pos=0, mode="prefill"
         )
         if user_id == 0 or user_id == 25:
@@ -204,7 +204,7 @@ def run_test_LlamaModel_end_to_end(
         if cur_pos == 0 or cur_pos == 35:  # Skip the first few iterations to warm up
             profiler.start(f"processing_of_decode_input_{cur_pos}")
 
-        tt_inp_emb, start_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs(
+        tt_inp_emb, start_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs_decode(
             decode_ids, start_pos, mode="decode"
         )
 

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -129,7 +129,7 @@ def run_test_LlamaModel_end_to_end(
 
     ##### Prepare Inputs #####
     prev_pos = total_len - 1
-    tt_inp_emb, prev_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs(tokens, prev_pos)
+    tt_inp_emb, prev_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs_decode(tokens, prev_pos)
 
     ##### Compile Model #####
     logger.info("Compiling model")
@@ -320,7 +320,9 @@ def run_test_LlamaModel_end_to_end_hybrid_data_tensor_parallel(
 
         ##### Prepare Inputs #####
         prev_pos = total_len - 1
-        tt_inp_emb, prev_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs(tokens, prev_pos, mode="decode")
+        tt_inp_emb, prev_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs_decode(
+            tokens, prev_pos, mode="decode"
+        )
 
         ##### Compile Model #####
         logger.info("Compiling model")

--- a/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_stress_test.py
@@ -98,7 +98,7 @@ def run_test_LlamaModel_stress_test(
         start_pos = 0
         prev_pos = start_pos
         for cur_pos in tqdm(range(start_pos + 1, total_len), desc="Decode to 2k Progress", leave=False, colour="green"):
-            tt_inp_emb, prev_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs(
+            tt_inp_emb, prev_pos, rot_mat, cache_idxs, _ = tt_model.prepare_device_inputs_decode(
                 tokens[:, prev_pos:cur_pos], prev_pos
             )
 

--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -15,20 +15,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 )
 from models.demos.t3000.llama2_70b.reference.llama.llama.model import ModelArgs as ReferenceModelArgs
 
-from vllm.inputs import INPUT_REGISTRY, DecoderOnlyInputs, EncoderDecoderInputs, InputContext
 
-
-def input_processor_for_llama70b(ctx: InputContext, inputs: Union[DecoderOnlyInputs, EncoderDecoderInputs]):
-    prompt_len = len(inputs.get("prompt_token_ids"))
-    if prompt_len > 32768:
-        raise ValueError(
-            f"TT LLama70b does not yet support prompts longer than 32768 tokens (received prompt with {prompt_len} tokens)"
-        )
-
-    return inputs
-
-
-@INPUT_REGISTRY.register_input_processor(input_processor_for_llama70b)
 class TtLlamaForCausalLM(TtLlamaModelForGeneration):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -206,6 +206,8 @@ class TtLlamaAttention_optimized:
         page_table=None,
         kv_cache=None,
         mode="decode",
+        chunk_page_table=None,
+        chunk_start_idx=None,
     ):
         # Decode should have input tensor of shape (seqlen=1, 1, batch, hidden_size)
         if mode == "decode":
@@ -219,7 +221,15 @@ class TtLlamaAttention_optimized:
             )
         # Prefill should have input tensor of shape (1, batch=1, seqlen, hidden_size)
         elif mode == "prefill":
-            return self.prefill_forward(xs, rot_mats, user_id, page_table=page_table, kv_cache=kv_cache)
+            return self.prefill_forward(
+                xs,
+                rot_mats,
+                user_id,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+            )
         else:
             raise ValueError(f"Unknown llm_mode: {mode}")
 
@@ -350,10 +360,26 @@ class TtLlamaAttention_optimized:
 
         return tt_matmul_out_tensor
 
-    def prefill_forward(self, xs, rot_mats, user_id: int = 0, page_table=None, kv_cache=None):
+    def prefill_forward(
+        self,
+        xs,
+        rot_mats,
+        user_id: int = 0,
+        page_table=None,
+        kv_cache=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+    ):
         query_layer, key_layer, value_layer = self.prefill_attn_qkv(xs, rot_mats)
         attn_outputs = self.prefill_attn_mqa(
-            query_layer, key_layer, value_layer, user_id, page_table=page_table, kv_cache=kv_cache
+            query_layer,
+            key_layer,
+            value_layer,
+            user_id,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
         )
         return self.prefill_attn_selfout(attn_outputs)
 
@@ -429,7 +455,17 @@ class TtLlamaAttention_optimized:
 
         return query_layer_ret, key_layer_ret, value_layer
 
-    def prefill_attn_mqa(self, query_layer, key_layer, value_layer, user_id: int = 0, page_table=None, kv_cache=None):
+    def prefill_attn_mqa(
+        self,
+        query_layer,
+        key_layer,
+        value_layer,
+        user_id: int = 0,
+        page_table=None,
+        kv_cache=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+    ):
         if kv_cache:
             keys = kv_cache[self.layer_num][0]
             values = kv_cache[self.layer_num][1]
@@ -438,11 +474,14 @@ class TtLlamaAttention_optimized:
             values = self.layer_past[1]
 
         if page_table:
+            # If chunked prefill, use chunk_page_table if given, otherwise use page_table.
+            fill_page_table = chunk_page_table if chunk_page_table is not None else page_table
+
             ttnn.experimental.paged_fill_cache(
-                keys, ttnn.experimental.typecast(key_layer, self.kv_dtype), page_table, batch_idx=user_id
+                keys, ttnn.experimental.typecast(key_layer, self.kv_dtype), fill_page_table, batch_idx=user_id
             )
             ttnn.experimental.paged_fill_cache(
-                values, ttnn.experimental.typecast(value_layer, self.kv_dtype), page_table, batch_idx=user_id
+                values, ttnn.experimental.typecast(value_layer, self.kv_dtype), fill_page_table, batch_idx=user_id
             )
         else:
             ttnn.fill_cache(keys, ttnn.experimental.typecast(key_layer, self.kv_dtype), user_id)
@@ -456,15 +495,30 @@ class TtLlamaAttention_optimized:
             compute_with_storage_grid_size=[8, 7],
             q_chunk_size=q_chunk_size,
             k_chunk_size=k_chunk_size,
+            exp_approx_mode=False,
         )
-        attn_output = ttnn.transformer.scaled_dot_product_attention(
-            query_layer,
-            key_layer,
-            value_layer,
-            is_causal=True,
-            scale=self.scale,
-            program_config=pc_sdpa,
-        )
+        if chunk_start_idx is not None:
+            """
+            Chunked prefill mode uses the chunk_start_idx to offset Q into the filled paged K and V cache.
+            """
+            attn_output = ttnn.transformer.chunked_scaled_dot_product_attention(
+                query_layer,
+                keys,
+                values,
+                page_table,
+                chunk_start_idx,
+                program_config=pc_sdpa,
+                compute_kernel_config=self.model_config["SDPA_COMPUTE_KERNEL_CONFIG"],
+            )
+        else:
+            attn_output = ttnn.transformer.scaled_dot_product_attention(
+                query_layer,
+                key_layer,
+                value_layer,
+                is_causal=True,
+                scale=self.scale,
+                program_config=pc_sdpa,
+            )
 
         # deallocate keys and values
         query_layer.deallocate(True)

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -525,6 +525,7 @@ class TtLlamaAttention_optimized:
                 is_causal=True,
                 scale=self.scale,
                 program_config=pc_sdpa,
+                compute_kernel_config=self.model_config["SDPA_COMPUTE_KERNEL_CONFIG"],
             )
 
         # deallocate keys and values

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -496,7 +496,7 @@ class TtLlamaAttention_optimized:
 
         seq_len = query_layer.shape[2]
         q_chunk_size = 128 if seq_len % 128 == 0 else 32
-        k_chunk_size = q_chunk_size
+        k_chunk_size = 512 if seq_len % 512 == 0 else 128 if seq_len % 128 == 0 else 32
 
         pc_sdpa = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=[8, 7],

--- a/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
@@ -154,9 +154,20 @@ class TtLlamaDecoder_optimized:
         page_table=None,
         kv_cache=None,
         mode="decode",
+        chunk_page_table=None,
+        chunk_start_idx=None,
     ) -> ttnn.Tensor:
         if mode == "prefill":
-            return self.prefill_forward(xs, rot_mats, start_pos, user_id, page_table=page_table, kv_cache=kv_cache)
+            return self.prefill_forward(
+                xs,
+                rot_mats,
+                start_pos,
+                user_id,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+            )
         elif mode == "decode":
             return self.decode_forward(xs, rot_mats, start_pos, cache_idxs, page_table=page_table, kv_cache=kv_cache)
         else:
@@ -276,6 +287,8 @@ class TtLlamaDecoder_optimized:
         user_id: int = 0,
         page_table=None,
         kv_cache=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
     ) -> List[ttnn.Tensor]:
         attn_norm_interleaved = self.tt_distributed_rmsnorm(xs, self.norm_eps, self.attn_norm_sharded)
         attn_norm_interleaved = ttnn.all_gather(
@@ -294,6 +307,8 @@ class TtLlamaDecoder_optimized:
             page_table=page_table,
             kv_cache=kv_cache,
             mode="prefill",
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
         )
 
         attn_norm_interleaved.deallocate(True)

--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -267,7 +267,6 @@ class TtLlamaModelForGeneration:
                     chunk_page_table=chunk_page_table_tt,
                     chunk_start_idx=chunk_start,
                 )
-                logger.info(f"TT logits shape: {tt_logits.shape}")
 
                 logits = self._process_logits(tt_logits)
                 logits = logits.squeeze(1)

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -176,12 +176,9 @@ class TtLlamaModel_optimized:
             seq_len <= self.model_config["MAX_CONTEXT_LEN"]
         ), f"Sequence length {seq_len} exceeds MAX_CONTEXT_LEN {self.model_config['MAX_CONTEXT_LEN']}"
 
-        if mode == "prefill":
-            assert (
-                seq_len <= self.model_config["MAX_PREFILL_SEQ_LEN"]
-            ), f"Prefill only supports seq_len <= {self.model_config['MAX_PREFILL_SEQ_LEN']}"
-
-    def prepare_inputs(self, inp_ids, start_pos, valid_seq_len=None, mode="decode", page_table=None):
+    def prepare_inputs(
+        self, inp_ids, start_pos, valid_seq_len=None, mode="decode", page_table=None, chunk_page_table=None
+    ):
         """
         Prepare inputs for decode mode. Assume that current token is at
         start_pos, and KV cache has valid data up to start_pos.
@@ -235,7 +232,7 @@ class TtLlamaModel_optimized:
                 cos_gathered,
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
-                cache_file_name=cache_name(f"cos_gathered_prefill_{seq_len}"),
+                cache_file_name=cache_name(f"cos_gathered_prefill_{start_pos}_{start_pos+seq_len}"),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 device=self.mesh_device,
                 mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
@@ -244,7 +241,7 @@ class TtLlamaModel_optimized:
                 sin_gathered,
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
-                cache_file_name=cache_name(f"sin_gathered_prefill_{seq_len}"),
+                cache_file_name=cache_name(f"sin_gathered_prefill_{start_pos}_{start_pos+seq_len}"),
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 device=self.mesh_device,
                 mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
@@ -266,6 +263,17 @@ class TtLlamaModel_optimized:
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                 )
+            if chunk_page_table is not None:
+                chunk_page_table = ttnn.as_tensor(
+                    chunk_page_table,
+                    device=self.mesh_device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    dtype=ttnn.int32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
+                )
+
+            return (xs, start_pos, rot_mats, rot_idxs_tt, cache_idxs_tt, page_table, chunk_page_table)
 
         elif mode == "decode":
             assert seq_len == 1, "Decode mode only supports seq_len=1"
@@ -297,10 +305,9 @@ class TtLlamaModel_optimized:
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                 )
+            return (xs, start_pos, rot_mats, rot_idxs_tt, cache_idxs_tt, page_table)
 
-        return (xs, start_pos, rot_mats, rot_idxs_tt, cache_idxs_tt, page_table)
-
-    def prepare_device_inputs(
+    def prepare_device_inputs_decode(
         self,
         tokens: torch.Tensor,
         start_pos: int,
@@ -310,29 +317,27 @@ class TtLlamaModel_optimized:
         return_tokens=False,  # if true, return tokens for decode mode
         return_rot_idxs=False,  # if true, return rot_idxs for decode mode
     ):
+        assert mode == "decode"
         tt_inp, start_pos, rot_mat, rot_idxs_tt, cache_idxs_tt, tt_page_table = self.prepare_inputs(
             tokens, start_pos, valid_seq_len=valid_seq_len, mode=mode, page_table=page_table
         )
 
-        if mode == "decode":
-            tt_inp = ttnn.to_device(tt_inp, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-            tt_inp_emb = self.tt_embd(tt_inp)
-            tt_inp_emb = ttnn.interleaved_to_sharded(tt_inp_emb, self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"])
-            cache_idxs_tt = ttnn.to_device(cache_idxs_tt, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-            rot_mat, rot_idxs_tt = self.rope_setup_decode.get_rot_mats(
-                rot_idxs_tt, return_rot_idxs=True
-            )  # Sends rot_idxs to device internally
-            if tt_page_table is not None:
-                tt_page_table = ttnn.to_device(tt_page_table, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        else:
-            tt_inp_emb = tt_inp
+        tt_inp = ttnn.to_device(tt_inp, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_inp_emb = self.tt_embd(tt_inp)
+        tt_inp_emb = ttnn.interleaved_to_sharded(tt_inp_emb, self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"])
+        cache_idxs_tt = ttnn.to_device(cache_idxs_tt, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        rot_mat, rot_idxs_tt = self.rope_setup_decode.get_rot_mats(
+            rot_idxs_tt, return_rot_idxs=True
+        )  # Sends rot_idxs to device internally
+        if tt_page_table is not None:
+            tt_page_table = ttnn.to_device(tt_page_table, self.mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
         return_out = [tt_inp_emb, start_pos, rot_mat, cache_idxs_tt, tt_page_table]
-        if mode == "decode":
-            if return_tokens:
-                return_out.append(tt_inp)
-            if return_rot_idxs:
-                return_out.append(rot_idxs_tt)
+
+        if return_tokens:
+            return_out.append(tt_inp)
+        if return_rot_idxs:
+            return_out.append(rot_idxs_tt)
         return tuple(return_out)
 
     def __call__(
@@ -346,6 +351,8 @@ class TtLlamaModel_optimized:
         page_table=None,
         kv_cache=None,
         mode="decode",
+        chunk_page_table=None,
+        chunk_start_idx=None,
     ) -> ttnn.Tensor:
         if self.vllm:
             assert page_table is not None
@@ -359,6 +366,8 @@ class TtLlamaModel_optimized:
                 last_token_idx=last_token_idx,
                 page_table=page_table,
                 kv_cache=kv_cache,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
             )
         elif mode == "decode":
             return self.decode_forward(xs, rot_mats, start_pos, cache_idxs, page_table=page_table, kv_cache=kv_cache)
@@ -450,11 +459,21 @@ class TtLlamaModel_optimized:
         last_token_idx=None,
         page_table=None,
         kv_cache=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
     ) -> ttnn.Tensor:
         ### Run all layers
         for layer in self.layers:
             xs = layer(
-                xs, rot_mats, start_pos, user_id, page_table=page_table, kv_cache=kv_cache, mode="prefill"
+                xs,
+                rot_mats,
+                start_pos,
+                user_id,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                mode="prefill",
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
             )  # xs is sharded
 
         # Distributed rmsnorm

--- a/models/demos/t3000/llama2_70b/tt/model_config.py
+++ b/models/demos/t3000/llama2_70b/tt/model_config.py
@@ -388,7 +388,8 @@ def get_model_config(llama_version="llama3", max_batch_size=32, max_context_len=
     model_config["SDPA_DECODE_PROGRAM_CONFIG"] = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=[8, 4],  # Can be increased, but could result in di/dt?
         q_chunk_size=0,  # unused
-        k_chunk_size=0,  # unused
+        k_chunk_size=256,  # unused
+        exp_approx_mode=False,
     )
 
     model_config["SDPA_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -35,6 +35,9 @@ run_t3000_llama3_70b_tests() {
   # Output verification demo for old llama3-70b codebase, to be removed once old codebase is deleted
   env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama3_70b/demo/demo.py::test_LlamaModel_demo[wormhole_b0-True-device_params0-short_context-check_enabled-greedy-tt-70b-T3000-80L-decode_only-trace_mode_off-text_completion-llama3] --timeout=900 ; fail+=$?
 
+  # Test chunked prefill for llama2-70b
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama2_70b/tests/test_chunked_generation.py::test_batch_prefill --timeout=900 ; fail+=$?
+
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))


### PR DESCRIPTION
## Ticket
#15873 

## Problem description
Llama3-7-B on T3K supports up to 128k context length with batch=1. However, it is limited such that the maximum prompt length is 32k. That means that the full 128k context can be used by prefill len + decode len only if prefill len <= 32k.

This constraint is caused by the fact that prefill activations for long sequences become large, leading to OOM on device DRAM. For example, the activations are 128k * 8k * 2B = 2 GB for input len 128k.

## What's changed
The solution to this problem is to implement chunked prefill. Given some prompt_len and a chunk_size (<= 32k), the prompt is split into prompt_len / chunk_size chunks and iteratively prefilled. Chunked prefill will reduce the size of the activations which should solve the OOM error.

This PR uses the new `chunked_scaled_dot_product_attention` kernel in Llama to enable chunked prefill. It modifies the attention and model tests, and creates a new test in the T3K demo pipeline which tests chunked prefill as used by `llama_generation`, which is the entrypoint that vLLM will use.

*Note* that this functionality was added to the "old" Llama codebase since it was an urgent request. I expect we will be adding chunked prefill to the llama family folder sometime soon.

## Checklist
- [x] All post commit https://github.com/tenstorrent/tt-metal/actions/runs/12303936776
- [x] T3K pipelines https://github.com/tenstorrent/tt-metal/actions/runs/12303156746
  - ttnn test fails but this PR should not have affected it
  - Kicking T3K pipelines again after some changes https://github.com/tenstorrent/tt-metal/actions/runs/12354567605
  - Many T3K pipelines are failing but these changes only affect old-codebase llama3-70b, which are green.