### PR TITLE
#15877: added support for subcoregrid in sdpa decode

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
@@ -11,6 +11,7 @@ namespace ttnn::operations::transformer {
 
 struct SDPAProgramConfig {
     CoreCoord compute_with_storage_grid_size;
+    std::optional<CoreRangeSet> sub_core_grids;
     std::size_t q_chunk_size;
     std::size_t k_chunk_size;
     std::optional<bool> exp_approx_mode;

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_pybind.cpp
@@ -21,13 +21,15 @@ namespace py = pybind11;
 void py_module(py::module& module) {
     py::class_<SDPAProgramConfig>(module, "SDPAProgramConfig")
         .def(
-            py::init<CoreCoord, std::size_t, std::size_t, std::optional<bool>>(),
+            py::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>>(),
             py::kw_only(),
             py::arg("compute_with_storage_grid_size"),
+            py::arg("sub_core_grids") = std::nullopt,
             py::arg("q_chunk_size").noconvert(),
             py::arg("k_chunk_size").noconvert(),
             py::arg("exp_approx_mode") = std::nullopt)
         .def_readwrite("compute_with_storage_grid_size", &SDPAProgramConfig::compute_with_storage_grid_size)
+        .def_readwrite("sub_core_grids", &SDPAProgramConfig::sub_core_grids)
         .def_readwrite("q_chunk_size", &SDPAProgramConfig::q_chunk_size)
         .def_readwrite("k_chunk_size", &SDPAProgramConfig::k_chunk_size)
         .def_readwrite("exp_approx_mode", &SDPAProgramConfig::exp_approx_mode);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15877)

### Problem description
SDPA decode can now run on subcoregrids if sub_core_grids is passed in SDPA Program Config

### What shouldn't be affected
Regular sdpa decode shouldn't be affected in any aspects

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12284547374
- [x] New/Existing tests provide coverage for changes
