### PR TITLE
Sub-Device fabric api updates, and make global sem/cb thread safe in metal

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -86,6 +86,7 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
     for (auto device : devices_) {
         {
             uint32_t initial_value = 1;
+            uint32_t reset_value = 2;
             std::vector<uint32_t> overwrite_value = {2};
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
             auto address = global_semaphore->address();
@@ -104,14 +105,14 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
 
                 EXPECT_EQ(sem_vals[0], overwrite_value[0]);
             }
-            global_semaphore->reset_semaphore_value();
+            global_semaphore->reset_semaphore_value(reset_value);
             Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));
                 tt::llrt::write_hex_vec_to_core(
                     device->id(), device->worker_core_from_logical_core(core), overwrite_value, address);
-                EXPECT_EQ(sem_vals[0], initial_value);
+                EXPECT_EQ(sem_vals[0], reset_value);
             }
         }
     }

--- a/tests/ttnn/unit_tests/test_global_semaphore.py
+++ b/tests/ttnn/unit_tests/test_global_semaphore.py
@@ -29,7 +29,7 @@ def run_global_semaphore(device):
 
     assert ttnn.get_global_semaphore_address(global_sem0) != ttnn.get_global_semaphore_address(global_sem1)
 
-    ttnn.reset_global_semaphore_value(global_sem0)
+    ttnn.reset_global_semaphore_value(global_sem0, 3)
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)

--- a/tests/ttnn/unit_tests/test_sub_device.py
+++ b/tests/ttnn/unit_tests/test_sub_device.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 
-def run_sub_devices(device, replicate_sub_devices=False):
+def run_sub_devices(device, create_fabric_sub_device=False):
     tensix_cores0 = ttnn.CoreRangeSet(
         {
             ttnn.CoreRange(
@@ -28,12 +28,12 @@ def run_sub_devices(device, replicate_sub_devices=False):
     sub_device_2 = ttnn.SubDevice([tensix_cores1])
     sub_devices_1 = [sub_device_1, sub_device_2]
     sub_devices_2 = [sub_device_2]
-    if replicate_sub_devices:
-        num_devices = 1 if isinstance(device, ttnn.Device) else device.get_num_devices()
-        sub_devices_1 = [sub_devices_1] * num_devices
-        sub_devices_2 = [sub_devices_2] * num_devices
-    sub_device_manager1 = device.create_sub_device_manager(sub_devices_1, 3200)
-    sub_device_manager2 = device.create_sub_device_manager(sub_devices_2, 3200)
+    if create_fabric_sub_device:
+        sub_device_manager1 = device.create_sub_device_manager_with_fabric(sub_devices_1, 3200)
+        sub_device_manager2 = device.create_sub_device_manager_with_fabric(sub_devices_2, 3200)
+    else:
+        sub_device_manager1 = device.create_sub_device_manager(sub_devices_1, 3200)
+        sub_device_manager2 = device.create_sub_device_manager(sub_devices_2, 3200)
     device.load_sub_device_manager(sub_device_manager1)
     ttnn.synchronize_devices(device, sub_device_ids=[ttnn.SubDeviceId(1)])
     ttnn.synchronize_devices(device, sub_device_ids=[ttnn.SubDeviceId(0), ttnn.SubDeviceId(1)])
@@ -45,7 +45,7 @@ def run_sub_devices(device, replicate_sub_devices=False):
     device.remove_sub_device_manager(sub_device_manager2)
 
 
-def run_sub_devices_program(device, replicate_sub_devices=False):
+def run_sub_devices_program(device, create_fabric_sub_device=False):
     is_mesh_device = isinstance(device, ttnn.MeshDevice)
     if is_mesh_device:
         inputs_mesh_mapper = ttnn.ShardTensorToMesh(device, dim=0)
@@ -74,10 +74,10 @@ def run_sub_devices_program(device, replicate_sub_devices=False):
     sub_device_1 = ttnn.SubDevice([tensix_cores0])
     sub_device_2 = ttnn.SubDevice([tensix_cores1])
     sub_devices = [sub_device_1, sub_device_2]
-    if replicate_sub_devices:
-        num_devices = 1 if isinstance(device, ttnn.Device) else device.get_num_devices()
-        sub_devices = [sub_devices] * num_devices
-    sub_device_manager = device.create_sub_device_manager(sub_devices, 3200)
+    if create_fabric_sub_device:
+        sub_device_manager = device.create_sub_device_manager_with_fabric(sub_devices, 3200)
+    else:
+        sub_device_manager = device.create_sub_device_manager(sub_devices, 3200)
     device.load_sub_device_manager(sub_device_manager)
 
     x = torch.randn(num_devices, 1, 64, 64, dtype=torch.bfloat16)
@@ -140,9 +140,9 @@ def test_sub_devices(device, enable_async_mode):
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-@pytest.mark.parametrize("replicate_sub_devices", (False, True))
-def test_sub_devices_mesh(mesh_device, replicate_sub_devices, enable_async_mode):
-    run_sub_devices(mesh_device, replicate_sub_devices)
+@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
+def test_sub_devices_mesh(mesh_device, create_fabric_sub_device, enable_async_mode):
+    run_sub_devices(mesh_device, create_fabric_sub_device)
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
@@ -151,6 +151,6 @@ def test_sub_device_program(device, enable_async_mode):
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-@pytest.mark.parametrize("replicate_sub_devices", (False, True))
-def test_sub_device_program_mesh(mesh_device, replicate_sub_devices, enable_async_mode):
-    run_sub_devices_program(mesh_device, replicate_sub_devices)
+@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
+def test_sub_device_program_mesh(mesh_device, create_fabric_sub_device, enable_async_mode):
+    run_sub_devices_program(mesh_device, create_fabric_sub_device)

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -137,8 +137,9 @@ public:
 
     MeshSubDeviceManagerId create_sub_device_manager(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
-    MeshSubDeviceManagerId create_sub_device_manager(
-        const std::vector<std::vector<SubDevice>>& mesh_sub_devices, DeviceAddr local_l1_size);
+    // TODO #15944: Temporary api until migration to actual fabric is complete
+    std::tuple<MeshSubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
+        tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
     void load_sub_device_manager(MeshSubDeviceManagerId mesh_sub_device_manager_id);
     void clear_loaded_sub_device_manager();
     void remove_sub_device_manager(MeshSubDeviceManagerId mesh_sub_device_manager_id);

--- a/tt_metal/impl/buffers/global_circular_buffer.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.hpp
@@ -26,26 +26,23 @@ namespace v1 {
 namespace experimental {
 
 class GlobalCircularBuffer {
+    struct Private {
+        explicit Private() = default;
+    };
+
 public:
-    GlobalCircularBuffer(
-        Device* device,
-        const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
-        uint32_t size,
-        BufferType buffer_type,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
-
-    GlobalCircularBuffer(const GlobalCircularBuffer&) = default;
-    GlobalCircularBuffer& operator=(const GlobalCircularBuffer&) = default;
-
-    GlobalCircularBuffer(GlobalCircularBuffer&&) noexcept = default;
-    GlobalCircularBuffer& operator=(GlobalCircularBuffer&&) noexcept = default;
-
     static std::shared_ptr<GlobalCircularBuffer> create(
         Device* device,
         const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
         uint32_t size,
         BufferType buffer_type = BufferType::L1,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
+    GlobalCircularBuffer(const GlobalCircularBuffer&) = delete;
+    GlobalCircularBuffer& operator=(const GlobalCircularBuffer&) = delete;
+
+    GlobalCircularBuffer(GlobalCircularBuffer&&) noexcept = delete;
+    GlobalCircularBuffer& operator=(GlobalCircularBuffer&&) noexcept = delete;
 
     const Buffer& cb_buffer() const;
 
@@ -58,6 +55,16 @@ public:
 
     static constexpr auto attribute_names = std::forward_as_tuple("sender_receiver_core_mapping", "size");
     const auto attribute_values() const { return std::make_tuple(this->sender_receiver_core_mapping_, this->size_); }
+
+    // "Private" constructor to prevent direct instantiation
+    // Use GlobalCircularBuffer::create instead
+    GlobalCircularBuffer(
+        Device* device,
+        const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
+        uint32_t size,
+        BufferType buffer_type,
+        tt::stl::Span<const SubDeviceId> sub_device_ids,
+        Private);
 
 private:
     void setup_cb_buffers(

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -3724,6 +3724,20 @@ SubDeviceManagerId Device::create_sub_device_manager(tt::stl::Span<const SubDevi
     return sub_device_manager->first;
 }
 
+std::tuple<SubDeviceManagerId, SubDeviceId> Device::create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
+    auto fabric_sub_device = SubDevice(std::array{CoreRangeSet(), this->default_sub_device_manager_->sub_device(SubDeviceId{0}).cores(HalProgrammableCoreType::ACTIVE_ETH)});
+    auto new_sub_devices = std::vector<SubDevice>(sub_devices.begin(), sub_devices.end());
+    new_sub_devices.push_back(fabric_sub_device);
+    auto fabric_sub_device_id = SubDeviceId{static_cast<uint32_t>(new_sub_devices.size() - 1)};
+    auto sub_device_manager_id = this->create_sub_device_manager(new_sub_devices, local_l1_size);
+    this->sub_device_managers_[sub_device_manager_id]->set_fabric_sub_device_id(fabric_sub_device_id);
+    return {sub_device_manager_id, fabric_sub_device_id};
+}
+
+std::optional<SubDeviceId> Device::get_fabric_sub_device_id() const {
+    return this->active_sub_device_manager_->fabric_sub_device_id();
+}
+
 void Device::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     TT_FATAL(!this->using_slow_dispatch(), "Using sub device managers is unsupported with slow dispatch");
     if (this->active_sub_device_manager_id_ == sub_device_manager_id) {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -389,6 +389,11 @@ class Device {
     void clear_loaded_sub_device_manager();
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
     const std::vector<SubDeviceId> &get_sub_device_ids() const;
+
+    // TODO #15944: Temporary api until migration to actual fabric is complete
+    std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
+    std::optional<SubDeviceId> get_fabric_sub_device_id() const;
+
    private:
     void initialize_default_sub_device_state(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap);
     SubDeviceManagerId get_next_sub_device_manager_id();

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -38,16 +38,16 @@ SubDeviceManager::SubDeviceManager(
 
 SubDeviceManager::SubDeviceManager(Device* device, std::unique_ptr<Allocator>&& global_allocator) : device_(device) {
     TT_ASSERT(device != nullptr, "Device must not be null");
-    this->local_l1_size_ = 0;
-    const auto& compute_grid_size = this->device_->compute_with_storage_grid_size();
-    const auto& active_eth_cores = this->device_->get_active_ethernet_cores(true);
+    local_l1_size_ = 0;
+    const auto& compute_grid_size = device_->compute_with_storage_grid_size();
+    const auto& active_eth_cores = device_->get_active_ethernet_cores(true);
     std::vector<CoreRange> active_eth_core_ranges;
     active_eth_core_ranges.reserve(active_eth_cores.size());
     for (const auto& core : active_eth_cores) {
         active_eth_core_ranges.emplace_back(core, core);
     }
 
-    this->sub_devices_ = {SubDevice(std::array{
+    sub_devices_ = {SubDevice(std::array{
         CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1})),
         CoreRangeSet(std::move(active_eth_core_ranges))})};
     this->populate_sub_device_ids();
@@ -59,7 +59,7 @@ SubDeviceManager::SubDeviceManager(Device* device, std::unique_ptr<Allocator>&& 
 }
 
 SubDeviceManager::~SubDeviceManager() {
-    for (const auto& allocator : this->sub_device_allocators_) {
+    for (const auto& allocator : sub_device_allocators_) {
         if (allocator) {
             // Clear the bank managers, this makes subsequent buffer deallocations fast
             allocator::clear(*allocator);
@@ -73,9 +73,9 @@ SubDeviceManager::~SubDeviceManager() {
     }
 }
 
-uint8_t SubDeviceManager::num_sub_devices() const { return this->sub_devices_.size(); }
+uint8_t SubDeviceManager::num_sub_devices() const { return sub_devices_.size(); }
 
-const std::vector<SubDeviceId>& SubDeviceManager::get_sub_device_ids() const { return this->sub_device_ids_; }
+const std::vector<SubDeviceId>& SubDeviceManager::get_sub_device_ids() const { return sub_device_ids_; }
 
 const SubDevice& SubDeviceManager::sub_device(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
@@ -88,46 +88,46 @@ const vector_memcpy_aligned<uint32_t>& SubDeviceManager::noc_mcast_unicast_data(
 
 uint8_t SubDeviceManager::num_noc_mcast_txns(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return this->num_noc_mcast_txns_[sub_device_index];
+    return num_noc_mcast_txns_[sub_device_index];
 }
 
 uint8_t SubDeviceManager::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return this->num_noc_unicast_txns_[sub_device_index];
+    return num_noc_unicast_txns_[sub_device_index];
 }
 
 uint8_t SubDeviceManager::noc_mcast_data_start_index(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return this->noc_mcast_data_start_index_[sub_device_index];
+    return noc_mcast_data_start_index_[sub_device_index];
 }
 
 uint8_t SubDeviceManager::noc_unicast_data_start_index(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return this->noc_unicast_data_start_index_[sub_device_index];
+    return noc_unicast_data_start_index_[sub_device_index];
 }
 
 const std::unique_ptr<Allocator>& SubDeviceManager::get_initialized_allocator(SubDeviceId sub_device_id) const {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    TT_FATAL(this->sub_device_allocators_[sub_device_index], "SubDevice allocator not initialized");
-    return this->sub_device_allocators_[sub_device_index];
+    TT_FATAL(sub_device_allocators_[sub_device_index], "SubDevice allocator not initialized");
+    return sub_device_allocators_[sub_device_index];
 }
 
 std::unique_ptr<Allocator>& SubDeviceManager::sub_device_allocator(SubDeviceId sub_device_id) {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return this->sub_device_allocators_[sub_device_index];
+    return sub_device_allocators_[sub_device_index];
 }
 
 std::shared_ptr<TraceBuffer>& SubDeviceManager::create_trace(uint32_t tid) {
-    auto [trace, emplaced] = this->trace_buffer_pool_.emplace(tid, Trace::create_empty_trace_buffer());
+    auto [trace, emplaced] = trace_buffer_pool_.emplace(tid, Trace::create_empty_trace_buffer());
     TT_ASSERT(emplaced, "Trace buffer with tid {} already exists", tid);
     return trace->second;
 }
 
-void SubDeviceManager::release_trace(uint32_t tid) { this->trace_buffer_pool_.erase(tid); }
+void SubDeviceManager::release_trace(uint32_t tid) { trace_buffer_pool_.erase(tid); }
 
 std::shared_ptr<TraceBuffer> SubDeviceManager::get_trace(uint32_t tid) {
-    auto trace = this->trace_buffer_pool_.find(tid);
-    if (trace != this->trace_buffer_pool_.end()) {
+    auto trace = trace_buffer_pool_.find(tid);
+    if (trace != trace_buffer_pool_.end()) {
         return trace->second;
     }
     return nullptr;
@@ -135,18 +135,18 @@ std::shared_ptr<TraceBuffer> SubDeviceManager::get_trace(uint32_t tid) {
 
 void SubDeviceManager::reset_worker_launch_message_buffer_state() {
     std::for_each(
-        this->worker_launch_message_buffer_state_.begin(),
-        this->worker_launch_message_buffer_state_.end(),
+        worker_launch_message_buffer_state_.begin(),
+        worker_launch_message_buffer_state_.end(),
         std::mem_fn(&LaunchMessageRingBufferState::reset));
 }
 
 LaunchMessageRingBufferState& SubDeviceManager::get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) {
     auto sub_device_index = this->get_sub_device_index(sub_device_id);
-    return this->worker_launch_message_buffer_state_[sub_device_index];
+    return worker_launch_message_buffer_state_[sub_device_index];
 }
 
 bool SubDeviceManager::has_allocations() const {
-    for (const auto& allocator : this->sub_device_allocators_) {
+    for (const auto& allocator : sub_device_allocators_) {
         if (allocator && allocator->allocated_buffers.size() > 0) {
             return true;
         }
@@ -154,25 +154,35 @@ bool SubDeviceManager::has_allocations() const {
     return false;
 }
 
-DeviceAddr SubDeviceManager::local_l1_size() const { return this->local_l1_size_; }
+DeviceAddr SubDeviceManager::local_l1_size() const { return local_l1_size_; }
+
+void SubDeviceManager::set_fabric_sub_device_id(SubDeviceId fabric_sub_device_id) {
+    const auto& fabric_sub_device = this->sub_device(fabric_sub_device_id);
+    TT_FATAL(
+        fabric_sub_device.cores(HalProgrammableCoreType::TENSIX).num_cores() == 0,
+        "Fabric sub device must not have Tensix cores");
+    fabric_sub_device_id_ = fabric_sub_device_id;
+}
+
+std::optional<SubDeviceId> SubDeviceManager::fabric_sub_device_id() const { return fabric_sub_device_id_; }
 
 uint8_t SubDeviceManager::get_sub_device_index(SubDeviceId sub_device_id) const {
     auto sub_device_index = sub_device_id.to_index();
     TT_FATAL(
-        sub_device_index < this->sub_devices_.size(),
+        sub_device_index < sub_devices_.size(),
         "SubDevice index {} out of bounds {}",
         sub_device_index,
-        this->sub_devices_.size());
+        sub_devices_.size());
     return sub_device_index;
 }
 
 void SubDeviceManager::validate_sub_devices() const {
-    TT_FATAL(this->sub_devices_.size() <= SubDeviceManager::MAX_NUM_SUB_DEVICES, "Too many sub devices specified");
+    TT_FATAL(sub_devices_.size() <= SubDeviceManager::MAX_NUM_SUB_DEVICES, "Too many sub devices specified");
     // Validate sub device cores fit inside the device grid
-    const auto& compute_grid_size = this->device_->compute_with_storage_grid_size();
+    const auto& compute_grid_size = device_->compute_with_storage_grid_size();
     CoreRange device_worker_cores = CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1});
-    const auto& device_eth_cores = this->device_->get_active_ethernet_cores(true);
-    for (const auto& sub_device : this->sub_devices_) {
+    const auto& device_eth_cores = device_->get_active_ethernet_cores(true);
+    for (const auto& sub_device : sub_devices_) {
         const auto& worker_cores = sub_device.cores(HalProgrammableCoreType::TENSIX);
         TT_FATAL(
             device_worker_cores.contains(worker_cores),
@@ -191,15 +201,15 @@ void SubDeviceManager::validate_sub_devices() const {
             "Ethernet cores {} specified in sub device must be within device grid",
             eth_cores);
     }
-    if (this->sub_devices_.size() < 2) {
+    if (sub_devices_.size() < 2) {
         return;
     }
     // Validate no overlap of sub devices
-    for (uint32_t i = 0; i < this->sub_devices_.size(); ++i) {
-        for (uint32_t j = i + 1; j < this->sub_devices_.size(); ++j) {
+    for (uint32_t i = 0; i < sub_devices_.size(); ++i) {
+        for (uint32_t j = i + 1; j < sub_devices_.size(); ++j) {
             for (uint32_t k = 0; k < NumHalProgrammableCoreTypes; ++k) {
                 TT_FATAL(
-                    !(this->sub_devices_[i].cores()[k].intersects(this->sub_devices_[j].cores()[k])),
+                    !(sub_devices_[i].cores()[k].intersects(sub_devices_[j].cores()[k])),
                     "SubDevices specified for SubDeviceManager intersect");
             }
         }
@@ -207,33 +217,33 @@ void SubDeviceManager::validate_sub_devices() const {
 }
 
 void SubDeviceManager::populate_sub_device_ids() {
-    this->sub_device_ids_.resize(this->num_sub_devices());
+    sub_device_ids_.resize(this->num_sub_devices());
     for (uint8_t i = 0; i < this->num_sub_devices(); ++i) {
-        this->sub_device_ids_[i] = SubDeviceId{i};
+        sub_device_ids_[i] = SubDeviceId{i};
     }
 }
 
 void SubDeviceManager::populate_num_cores() {
-    for (const auto& sub_device : this->sub_devices_) {
+    for (const auto& sub_device : sub_devices_) {
         for (uint32_t i = 0; i < NumHalProgrammableCoreTypes; ++i) {
-            this->num_cores_[i] += sub_device.num_cores(static_cast<HalProgrammableCoreType>(i));
+            num_cores_[i] += sub_device.num_cores(static_cast<HalProgrammableCoreType>(i));
         }
     }
 }
 
 void SubDeviceManager::populate_sub_allocators() {
-    this->sub_device_allocators_.resize(this->num_sub_devices());
-    if (this->local_l1_size_ == 0) {
+    sub_device_allocators_.resize(this->num_sub_devices());
+    if (local_l1_size_ == 0) {
         return;
     }
-    const auto& global_allocator_config = this->device_->get_initialized_allocator()->config;
+    const auto& global_allocator_config = device_->get_initialized_allocator()->config;
     // Construct allocator config from soc_desc
     // Take max alignment to satisfy NoC rd/wr constraints
     // Tensix/Eth -> PCIe/DRAM src and dst addrs must be L1_ALIGNMENT aligned
     // PCIe/DRAM -> Tensix/Eth src and dst addrs must be DRAM_ALIGNMENT aligned
     // Tensix/Eth <-> Tensix/Eth src and dst addrs must be L1_ALIGNMENT aligned
     for (uint32_t i = 0; i < this->num_sub_devices(); ++i) {
-        const auto& compute_cores = this->sub_devices_[i].cores(HalProgrammableCoreType::TENSIX);
+        const auto& compute_cores = sub_devices_[i].cores(HalProgrammableCoreType::TENSIX);
         if (compute_cores.empty()) {
             continue;
         }
@@ -243,7 +253,7 @@ void SubDeviceManager::populate_sub_allocators() {
         l1_bank_remap.reserve(compute_cores_vec.size());
         for (const auto& core : compute_cores_vec) {
             // These are compute cores, so they should have a single bank
-            l1_bank_remap.push_back(this->device_->bank_ids_from_logical_core(BufferType::L1, core)[0]);
+            l1_bank_remap.push_back(device_->bank_ids_from_logical_core(BufferType::L1, core)[0]);
         }
         AllocatorConfig config(
             {.num_dram_channels = global_allocator_config.num_dram_channels,
@@ -252,7 +262,7 @@ void SubDeviceManager::populate_sub_allocators() {
              .dram_unreserved_base = global_allocator_config.dram_unreserved_base,
              .l1_unreserved_base = global_allocator_config.l1_unreserved_base,
              .worker_grid = compute_cores,
-             .worker_l1_size = global_allocator_config.l1_unreserved_base + this->local_l1_size_,
+             .worker_l1_size = global_allocator_config.l1_unreserved_base + local_l1_size_,
              .storage_core_bank_size = std::nullopt,
              .l1_small_size = 0,
              .trace_region_size = 0,
@@ -275,53 +285,51 @@ void SubDeviceManager::populate_sub_allocators() {
 
         // sub_devices only have compute cores for allocation
         for (const CoreCoord& core : corerange_to_cores(compute_cores)) {
-            const auto noc_coord = this->device_->worker_core_from_logical_core(core);
+            const auto noc_coord = device_->worker_core_from_logical_core(core);
             config.core_type_from_noc_coord_table.insert({noc_coord, AllocCoreType::ComputeAndStore});
         }
 
         // L1_BANKING scheme creates 1 bank per DRAM core and splits up L1 such that there are power 2 num L1 banks
         // This is the only allocator scheme supported because kernel APIs assume num L1 banks are power of 2
-        TT_ASSERT(this->device_->allocator_scheme_ == MemoryAllocator::L1_BANKING);
-        this->sub_device_allocators_[i] = std::make_unique<L1BankingAllocator>(config);
+        TT_ASSERT(device_->allocator_scheme_ == MemoryAllocator::L1_BANKING);
+        sub_device_allocators_[i] = std::make_unique<L1BankingAllocator>(config);
     }
 }
 
 void SubDeviceManager::populate_noc_data() {
     uint32_t num_sub_devices = this->num_sub_devices();
-    this->num_noc_mcast_txns_.resize(num_sub_devices);
-    this->num_noc_unicast_txns_.resize(num_sub_devices);
-    this->noc_mcast_data_start_index_.resize(num_sub_devices);
-    this->noc_unicast_data_start_index_.resize(num_sub_devices);
+    num_noc_mcast_txns_.resize(num_sub_devices);
+    num_noc_unicast_txns_.resize(num_sub_devices);
+    noc_mcast_data_start_index_.resize(num_sub_devices);
+    noc_unicast_data_start_index_.resize(num_sub_devices);
 
-    NOC noc_index = this->device_->dispatch_go_signal_noc();
+    NOC noc_index = device_->dispatch_go_signal_noc();
     uint32_t idx = 0;
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
-        const auto& tensix_cores = this->sub_devices_[i].cores(HalProgrammableCoreType::TENSIX);
-        const auto& eth_cores = this->sub_devices_[i].cores(HalProgrammableCoreType::ACTIVE_ETH);
+        const auto& tensix_cores = sub_devices_[i].cores(HalProgrammableCoreType::TENSIX);
+        const auto& eth_cores = sub_devices_[i].cores(HalProgrammableCoreType::ACTIVE_ETH);
 
-        this->noc_mcast_data_start_index_[i] = idx;
-        this->num_noc_mcast_txns_[i] = tensix_cores.size();
-        this->noc_mcast_unicast_data_.resize(idx + this->num_noc_mcast_txns_[i] * 2);
+        noc_mcast_data_start_index_[i] = idx;
+        num_noc_mcast_txns_[i] = tensix_cores.size();
+        noc_mcast_unicast_data_.resize(idx + num_noc_mcast_txns_[i] * 2);
         for (const auto& core_range : tensix_cores.ranges()) {
-            auto virtual_start =
-                this->device_->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
-            auto virtual_end = this->device_->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
+            auto virtual_start = device_->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
+            auto virtual_end = device_->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);
             auto virtual_core_range = CoreRange(virtual_start, virtual_end);
-            this->noc_mcast_unicast_data_[idx++] =
-                this->device_->get_noc_multicast_encoding(noc_index, virtual_core_range);
-            this->noc_mcast_unicast_data_[idx++] = core_range.size();
+            noc_mcast_unicast_data_[idx++] = device_->get_noc_multicast_encoding(noc_index, virtual_core_range);
+            noc_mcast_unicast_data_[idx++] = core_range.size();
         }
-        this->noc_unicast_data_start_index_[i] = idx;
+        noc_unicast_data_start_index_[i] = idx;
 
         // TODO: Precompute number of eth cores and resize once
         for (const auto& core_range : eth_cores.ranges()) {
-            this->noc_mcast_unicast_data_.resize(idx + core_range.size());
+            noc_mcast_unicast_data_.resize(idx + core_range.size());
             for (const auto& core : core_range) {
-                auto virtual_core = this->device_->virtual_core_from_logical_core(core, CoreType::ETH);
-                this->noc_mcast_unicast_data_[idx++] = this->device_->get_noc_unicast_encoding(noc_index, virtual_core);
+                auto virtual_core = device_->virtual_core_from_logical_core(core, CoreType::ETH);
+                noc_mcast_unicast_data_[idx++] = device_->get_noc_unicast_encoding(noc_index, virtual_core);
             }
         }
-        this->num_noc_unicast_txns_[i] = idx - this->noc_unicast_data_start_index_[i];
+        num_noc_unicast_txns_[i] = idx - noc_unicast_data_start_index_[i];
 
         TT_FATAL(
             idx <= dispatch_constants::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES,
@@ -332,7 +340,7 @@ void SubDeviceManager::populate_noc_data() {
 }
 
 void SubDeviceManager::populate_worker_launch_message_buffer_state() {
-    this->worker_launch_message_buffer_state_.resize(this->num_sub_devices());
+    worker_launch_message_buffer_state_.resize(this->num_sub_devices());
     this->reset_worker_launch_message_buffer_state();
 }
 

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -68,6 +68,10 @@ public:
     bool has_allocations() const;
     DeviceAddr local_l1_size() const;
 
+    // #TODO #15944: Temporary until migration to actual fabric is complete
+    void set_fabric_sub_device_id(SubDeviceId sub_device_id);
+    std::optional<SubDeviceId> fabric_sub_device_id() const;
+
 private:
     void validate_sub_devices() const;
     uint8_t get_sub_device_index(SubDeviceId sub_device_id) const;
@@ -97,6 +101,9 @@ private:
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
 
     std::vector<LaunchMessageRingBufferState> worker_launch_message_buffer_state_;
+
+    // TODO #15944: Temporary until migration to actual fabric is complete
+    std::optional<SubDeviceId> fabric_sub_device_id_ = std::nullopt;
 };
 
 }  // namespace detail

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -57,15 +57,20 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        py::overload_cast<const std::shared_ptr<GlobalSemaphore>&, const std::vector<SubDeviceId>&>(
-            &reset_global_semaphore_value),
+        [](const std::shared_ptr<GlobalSemaphore>& global_semaphore,
+           uint32_t reset_value,
+           const std::vector<SubDeviceId>& sub_device_ids) {
+            ttnn::global_semaphore::reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);
+        },
         py::arg("global_semaphore"),
+        py::arg("reset_value"),
         py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Reset the value of the global semaphore.
 
             Args:
                 global_semaphore (GlobalSemaphore): The global semaphore object.
+                reset_value (int): The value to reset the global semaphore to.
                 sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
                 Defaults to waiting on all sub-devices.
             )doc");
@@ -111,15 +116,20 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        py::overload_cast<const MultiDeviceGlobalSemaphore&, const std::vector<SubDeviceId>&>(
-            &reset_global_semaphore_value),
+        [](const MultiDeviceGlobalSemaphore& global_semaphore,
+           uint32_t reset_value,
+           const std::vector<SubDeviceId>& sub_device_ids) {
+            ttnn::global_semaphore::reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);
+        },
         py::arg("global_semaphore"),
+        py::arg("reset_value"),
         py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         R"doc(
             Reset the value of the global semaphore.
 
             Args:
                 global_semaphore (GlobalSemaphore): The global semaphore object.
+                reset_value (int): The value to reset the global semaphore to.
                 sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
             )doc");
 }

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -197,23 +197,24 @@ void py_module(py::module& module) {
                     MeshSubDeviceManagerId: The ID of the created sub-device manager.
             )doc")
         .def(
-            "create_sub_device_manager",
-            [](MeshDevice& self,
-               const std::vector<std::vector<SubDevice>>& mesh_sub_devices,
-               DeviceAddr local_l1_size) { return self.create_sub_device_manager(mesh_sub_devices, local_l1_size); },
+            "create_sub_device_manager_with_fabric",
+            [](MeshDevice& self, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {
+                return self.create_sub_device_manager(sub_devices, local_l1_size);
+            },
             py::arg("sub_devices"),
             py::arg("local_l1_size"),
             R"doc(
-                Creates a sub-device manager for the given mesh device.
+                Creates a sub-device manager for the given mesh device. This will automatically create a sub-device of ethernet cores for use with fabric.
+                Note that this is a temporary API until migration to actual fabric is complete.
 
                 Args:
-                    mesh_sub_devices (List[List[ttnn.SubDevice]]): The sub-devices to include in the sub-device manager.
-                    Each element of the outer list will be used to configure the corresponding device in the MeshDevice.
-                    This means that the individual devices in the MeshDevice may have different configurations.
+                    sub_devices (List[ttnn.SubDevice]): The sub-devices to include in the sub-device manager. No ethernet cores should be included in this list.
+                    This configuration will be used for each device in the MeshDevice.
                     local_l1_size (int): The size of the local allocators of each sub-device. The global allocator will be shrunk by this amount.
 
                 Returns:
                     MeshSubDeviceManagerId: The ID of the created sub-device manager.
+                    SubDeviceId: The ID of the sub-device that will be used for fabric.
             )doc")
         .def(
             "load_sub_device_manager",

--- a/ttnn/cpp/ttnn/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn/global_semaphore.cpp
@@ -41,9 +41,13 @@ DeviceAddr get_global_semaphore_address(const std::shared_ptr<GlobalSemaphore>& 
 }
 
 void reset_global_semaphore_value(
-    const std::shared_ptr<GlobalSemaphore>& global_semaphore, const std::vector<SubDeviceId>& sub_device_ids) {
+    const std::shared_ptr<GlobalSemaphore>& global_semaphore,
+    uint32_t reset_value,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
     auto* device = global_semaphore->device();
-    device->push_work([global_semaphore, sub_device_ids] { global_semaphore->reset_semaphore_value(sub_device_ids); });
+    device->push_work([global_semaphore, reset_value, sub_device_ids] {
+        global_semaphore->reset_semaphore_value(reset_value, sub_device_ids);
+    });
 }
 
 MultiDeviceGlobalSemaphore create_global_semaphore(
@@ -82,9 +86,11 @@ std::vector<DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSema
 }
 
 void reset_global_semaphore_value(
-    const MultiDeviceGlobalSemaphore& global_semaphore, const std::vector<SubDeviceId>& sub_device_ids) {
+    const MultiDeviceGlobalSemaphore& global_semaphore,
+    uint32_t reset_value,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
     for (const auto& global_semaphore : global_semaphore.global_semaphores) {
-        reset_global_semaphore_value(global_semaphore, sub_device_ids);
+        reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);
     }
 }
 

--- a/ttnn/cpp/ttnn/global_semaphore.hpp
+++ b/ttnn/cpp/ttnn/global_semaphore.hpp
@@ -24,7 +24,9 @@ std::shared_ptr<GlobalSemaphore> create_global_semaphore(
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 DeviceAddr get_global_semaphore_address(const std::shared_ptr<GlobalSemaphore>& global_semaphore);
 void reset_global_semaphore_value(
-    const std::shared_ptr<GlobalSemaphore>& global_semaphore, const std::vector<SubDeviceId>& sub_device_ids = {});
+    const std::shared_ptr<GlobalSemaphore>& global_semaphore,
+    uint32_t reset_value,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 // Multi Device APIs
 MultiDeviceGlobalSemaphore create_global_semaphore(
@@ -35,6 +37,8 @@ MultiDeviceGlobalSemaphore create_global_semaphore(
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 std::vector<DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSemaphore& global_semaphore);
 void reset_global_semaphore_value(
-    const MultiDeviceGlobalSemaphore& global_semaphore, const std::vector<SubDeviceId>& sub_device_ids = {});
+    const MultiDeviceGlobalSemaphore& global_semaphore,
+    uint32_t reset_value,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
 }  // namespace ttnn::global_semaphore


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15944

### Problem description
Want to clean up the api regarding how to instantiate the ethernet cores as its own sub-device by adding a new temporary api that adds it automatically when creating the sub-device manager. This will be removed when actual fabric is implemented.

Global CBs + global sems were not thread-safe with the metal api Normally thread safety was handled in ttnn apis by pushing from the top level to workers, but some of the use cases of these apis were calling the metal api on the main thread, so we need to make them internally thread-safe.

### What's changed
Add a new api `create_sub_device_manager_with_fabric` which has the same signature as `create_sub_device_manager`, but will automatically instantiate the ethernet cores as a separate sub-device. This also allows us to remove the MeshDevice `create_sub_device_manager` overload that allowed users to specify a different sub-device configuration per device that was added due to eth cores being different per device. This api is temporary until we have proper fabric, where eth cores will no longer be user programmable and won't be a sub-device anymore.

Make global cbs + sems metal apis thread safe by pushing the relevant code (writing the config/initial value) to the worker thread.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12300333118
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12300336248/job/34329022263
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
