### PR TITLE
Enforce 'const' left of the type, even via clang-tidy's FIX-ITs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -95,6 +95,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+QualifierAlignment: Left
 RawStringFormats:
   - Language:        Cpp
     Delimiters:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -195,3 +195,5 @@ Checks: >
 CheckOptions:
   - key: readability-function-cognitive-complexity.IgnoreMacros
     value: true
+
+FormatStyle: 'file'


### PR DESCRIPTION
### Ticket
None

### Problem description
Clang-tidy was trying to insert `const` right of the type.

### What's changed
* Told clang-format we want it on the left.
* Told clang-tidy to do what clang-format says.

