### PR TITLE
Remove redundant function determine_parallel_config_non_tile_mul_width.

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -293,7 +293,8 @@ void py_bind_conv2d(py::module& module) {
                 compute_grid_size,
                 block_shard_orientation,
                 enable_channels_padding,
-                is_out_tiled);
+                is_out_tiled,
+                false);
         },
         py::arg("shard_layout"),
         py::arg("batch_size"),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -108,7 +108,8 @@ sliding_window::ParallelConfig determine_parallel_config(
     const CoreCoord& compute_grid_size,
     ShardOrientation block_shard_orientation,
     bool enable_channels_padding,
-    bool is_out_tiled = true);
+    bool is_out_tiled=true,
+    bool is_non_tile_mul_shard_width=false);
 
 sliding_window::ParallelConfig determine_output_parallel_config(
     const sliding_window::ParallelConfig& input_parallel_config,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10109

### Problem description
determine_paralle_config_non_tile_mul_width is not needed. determine_parallel_config should be enough.

### What's changed
Remove redundant code.

### Checklist
- [X] Post commit CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/12298294291) [Latest](https://github.com/tenstorrent/tt-metal/actions/runs/12629017067)
- [X] Nightly fast dispatch [Link1](https://github.com/tenstorrent/tt-metal/actions/runs/12298282651) [Latest](https://github.com/tenstorrent/tt-metal/actions/runs/12629018601)
- [X] Model regression CI testing passes (if applicable) [Link1](https://github.com/tenstorrent/tt-metal/actions/runs/12629020615) same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/12630420739)
- [X] Device performance regression CI testing passes (if applicable) [Link](https://github.com/tenstorrent/tt-metal/actions/runs/12629022707).
- [X] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests [Link](https://github.com/tenstorrent/tt-metal/actions/runs/12629024332) same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/12610198962)

