### PR TITLE
#0: support unequal ranked inputs for broadcast in binary_ng

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -30,3 +30,62 @@ def test_binary_scalar_ops(input_shapes, device):
 
     comp_pass = compare_pcc([out_tt], [out_pt])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [[1, 71, 7, 7], [7, 7]],
+        [[920, 1, 256], [256]],
+        [[4, 12, 64, 64], [12, 1, 1]],
+        [[4, 16, 64, 64], [16, 1, 1]],
+        [[64, 3, 64, 64], [3, 1, 1]],
+        [[64, 4, 64, 64], [4, 1, 1]],
+        [[16, 6, 64, 64], [6, 1, 1]],
+        [[16, 8, 64, 64], [8, 1, 1]],
+        [[16, 1], [1, 1, 32]],
+    ],
+)
+def test_unequal_ranks(device, shapes):
+    torch.manual_seed(0)
+    torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    output_tensor = ttnn.experimental.add(input_tensor_a, input_tensor_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ([], [], []),
+        ([1], [2], [3]),
+        ([1], [], []),
+        ([], [1], []),
+        ([1, 2], [3], [4, 5]),
+        ([1], [2, 3], [3, 4]),
+        ([1, 2], [3, 4], [4, 6]),
+    ],
+)
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+def test_01_volume_tensors(device, data, memory_config):
+    (a, b, c_golden) = data
+    a = torch.BFloat16Tensor(a)
+    b = torch.BFloat16Tensor(b)
+    assert torch.add(a, b).tolist() == c_golden
+
+    ttnn_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config)
+    ttnn_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config)
+    ttnn_c = ttnn.experimental.add(ttnn_a, ttnn_b)
+    c = ttnn.to_torch(ttnn_c).reshape((-1))
+
+    assert c.tolist() == c_golden

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -1394,7 +1394,7 @@ void py_module(py::module& module) {
         R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i + \mathrm{{input\_tensor\_b}}_i)doc",
         R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
     detail::bind_binary_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -91,15 +91,17 @@ void BinaryNgDeviceOperation::validate_on_program_cache_hit(
         tensor_args.input_tensor_b.has_value() ? tensor_args.input_tensor_b->get_logical_shape() : ttnn::Shape{1, 1};
 
     constexpr int max_rank = 4;
-    for (int i = 0; i < max_rank; i++) {
-        auto a_dim = i < input_shape_a.rank() ? input_shape_a[-i] : 1;
-        auto b_dim = i < input_shape_b.rank() ? input_shape_b[-i] : 1;
-        TT_FATAL(
-            a_dim == b_dim || a_dim == 1 || b_dim == 1,
-            "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
-            i,
-            a_dim,
-            b_dim);
+    if (input_shape_a.rank() > 0 && input_shape_b.rank() > 0) {
+        for (int i = 1; i <= max_rank; i++) {
+            auto a_dim = i <= input_shape_a.rank() ? input_shape_a[-i] : 1;
+            auto b_dim = i <= input_shape_b.rank() ? input_shape_b[-i] : 1;
+            TT_FATAL(
+                a_dim == b_dim || a_dim == 1 || b_dim == 1,
+                "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
+                i,
+                a_dim,
+                b_dim);
+        }
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue 

### Problem description
Enable broadcast support for unequal ranked inputs in binary_ng

### What's changed
Enabled broadcast support for unequal ranked inputs in binary_ng
When eltwise binary is integrated with binary_ng, this should address the following issues #14730 #14731 

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12293370647
https://github.com/tenstorrent/tt-metal/actions/runs/12347015916
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
