### PR TITLE
Get Taskflow from CPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "third_party/lfs"]
 	path = tt_metal/third_party/lfs
 	url = https://github.com/tenstorrent-metal/lfs.git
-[submodule "tt_metal/third_party/taskflow"]
-	path = tt_metal/third_party/taskflow
-	url = https://github.com/taskflow/taskflow
 [submodule "tt_metal/third_party/tracy"]
 	path = tt_metal/third_party/tracy
 	url = https://github.com/tenstorrent-metal/tracy.git

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -91,3 +91,9 @@ CPMAddPackage(NAME range-v3 GITHUB_REPOSITORY ericniebler/range-v3 GIT_TAG 0.12.
 ############################################################################################################################
 
 CPMAddPackage(NAME pybind11 GITHUB_REPOSITORY pybind/pybind11 GIT_TAG b8f28551cc3a98ea9fbfc15c05b513c8f2d23e84)
+
+############################################################################################################################
+# taskflow : https://github.com/taskflow/taskflow
+############################################################################################################################
+
+CPMAddPackage(NAME taskflow GITHUB_REPOSITORY taskflow/taskflow GIT_TAG v3.7.0)

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
         span
         Metalium::Metal::STL
         Metalium::Metal::LLRT
+        Taskflow
         umd::Firmware
 )
 

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "third_party/taskflow/taskflow/taskflow.hpp"
+#include <taskflow/taskflow.hpp>
 #include <thread>
 #include <stdexcept>
 


### PR DESCRIPTION
### Problem description
- Submodules stink
- taskflow is a large submodule
- taskflow sources currently end up in our wheel

### What's changed
Bring in Taskflow via CPM instead of git submodule.

## Warning
Taskflow's CMakeLists.txt requires CMake 3.18 as minimum

Some may argue this breaks our Ubuntu 20.04 support, because the default CMake is 3.16 there.

I disagree with that argument, because CMake is not a runtime dependency. It takes 10 seconds to install later CMake on that platform.

However, some discussion on this topic will be needed before this is merged:
@tenstorrent/metalium-developers-infra 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12294363143)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
