### PR TITLE
#14977: conv config to use higher cores.

### DIFF
--- a/models/demos/segformer/tt/common.py
+++ b/models/demos/segformer/tt/common.py
@@ -19,6 +19,7 @@ class Conv:
         activation="",
         groups=1,
         dtype=ttnn.bfloat8_b,
+        output_layout=ttnn.TILE_LAYOUT,
     ) -> None:
         self.weights = parameters["weight"]
         self.bias = parameters["bias"]
@@ -35,6 +36,7 @@ class Conv:
         self.shard_layout = (
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
         )
+        self.output_layout = output_layout
 
     def __call__(self, device, input_tensor):
         conv_config = ttnn.Conv2dConfig(
@@ -49,6 +51,7 @@ class Conv:
             reallocate_halo_output=True,
             enable_act_double_buffer=True,
             enable_split_reader=False,
+            output_layout=self.output_layout,
         )
         compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/models/demos/segformer/tt/ttnn_segformer_efficient_selfattention.py
+++ b/models/demos/segformer/tt/ttnn_segformer_efficient_selfattention.py
@@ -83,7 +83,7 @@ class TtSegformerEfficientSelfAttention:
                 strategy=mm_a_x_strategy,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
             ),
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
         )
         query = ttnn.linear(
             hidden_states,
@@ -91,7 +91,7 @@ class TtSegformerEfficientSelfAttention:
             bias=parameters.query.bias,
             memory_config=mm_a_x_memory_config,
             core_grid=ttnn.CoreGrid(y=mm_a_y, x=mm_a_x),
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
         )
 
         query = ttnn.to_memory_config(query, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
@@ -110,15 +110,19 @@ class TtSegformerEfficientSelfAttention:
                 batch_size, __, seq_len, num_channels = hidden_states.shape
 
             # Need for RM input to reshape, then back to TILE after that
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
+            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat16)
             hidden_states = ttnn.to_layout(hidden_states, layout=ttnn.ROW_MAJOR_LAYOUT)
             hidden_states = ttnn.reshape(hidden_states, (batch_size, height, width, num_channels))
-            hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
+            if hidden_states.shape[3] == 160:
+                # conv config update
+                self.sr.output_layout = ttnn.TILE_LAYOUT
+                hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
+                hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
 
             hidden_states, __, __ = self.sr(device, hidden_states)
             hidden_states = ttnn.to_memory_config(hidden_states, memory_config=ttnn.L1_MEMORY_CONFIG)
 
+            hidden_states = ttnn.to_layout(hidden_states, ttnn.TILE_LAYOUT)
             hidden_states = ttnn.layer_norm(
                 hidden_states,
                 weight=parameters.layer_norm.weight,

--- a/tests/ttnn/integration_tests/segformer/test_segformer_encoder.py
+++ b/tests/ttnn/integration_tests/segformer/test_segformer_encoder.py
@@ -89,6 +89,7 @@ def move_to_device(object, device):
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 def test_segformer_encoder(batch_size, num_channels, height, width, device, reset_seeds, is_ci_env):
+    torch.manual_seed(0)
     if is_ci_env:
         pytest.skip("Skip in CI, model is WIP, issue# 13357")
 

--- a/tests/ttnn/integration_tests/segformer/test_segformer_encoder.py
+++ b/tests/ttnn/integration_tests/segformer/test_segformer_encoder.py
@@ -89,7 +89,6 @@ def move_to_device(object, device):
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 def test_segformer_encoder(batch_size, num_channels, height, width, device, reset_seeds, is_ci_env):
-    torch.manual_seed(0)
     if is_ci_env:
         pytest.skip("Skip in CI, model is WIP, issue# 13357")
 


### PR DESCRIPTION
### Ticket
#14977

### Problem description
The convolution in these layers were using 8 cores only. Changed the config to row major so that they can have use more cores.

This also improves performance as some of the tensor layout conversion are not required anymore.
if the output is in bfloat16 and output_layout is ROW_MAJOR it can take partial tile as shard shape and will use all 64 cores.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

CI: 
[all post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12359400016)
[single card test for new model](https://github.com/tenstorrent/tt-metal/actions/runs/12359401246)

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
