### PR TITLE
#15879: supported subcoregrid for createqkv heads

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -224,7 +224,6 @@ def run_test_create_min_width_shard(
             {ttnn.CoreRange(grid_start_coord, ttnn.CoreCoord(device_core_grid_size.x - 1, device_core_grid_size.y - 1))}
         )
     else:
-        breakpoint()
         sub_core_grids_bounds = sub_core_grids.bounding_box()
         if (
             sub_core_grids_bounds.start.x < 0
@@ -330,9 +329,14 @@ def test_create_min_width_shard(
     assert device.num_program_cache_entries() == 1, "Only one Op program cache should exist"
 
 
+@pytest.fixture()
+def set_dispatch_col(device_params):
+    device_params["dispatch_core_axis"] = ttnn.DispatchCoreAxis.COL
+    return device_params
+
+
 @skip_for_blackhole("Requires eth connected devices to run, see #12349")
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 @pytest.mark.parametrize("batch", (1, 8, 16))
 @pytest.mark.parametrize(
     "n_local_heads, n_local_kv_heads, head_dim",
@@ -351,11 +355,12 @@ def test_create_min_width_shard(
     ),
 )
 def test_create_min_width_shard_subcoregrid(
+    set_dispatch_col,
+    device,
     batch,
     n_local_heads,
     n_local_kv_heads,
     head_dim,
-    device,
     overlap_coregrid,
     use_program_cache,
     sub_core_grids,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "tt_metal/common/constants.hpp"
+
+using namespace tt::constants;
+void kernel_main() {
+    uint32_t in_tile_offset_by_batch = get_arg_val<uint32_t>(0);
+    uint32_t q_start_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(0);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_k_out = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_v_out = get_compile_time_arg_val(4);
+    constexpr uint32_t head_size = get_compile_time_arg_val(5);
+    constexpr uint32_t num_q_heads = get_compile_time_arg_val(6);
+    constexpr uint32_t num_kv_heads = get_compile_time_arg_val(7);
+    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t PHASES_TO_READ =
+        get_compile_time_arg_val(9);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+    constexpr uint32_t in_num_cores = get_compile_time_arg_val(10);
+    constexpr uint32_t PROCESS_QV = get_compile_time_arg_val(11);
+    constexpr uint32_t PROCESS_K = get_compile_time_arg_val(12);
+
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + in_num_cores));
+
+    // Q
+    uint32_t qkv_x = 0;
+    uint32_t qkv_y = 0;
+    uint32_t total_input_cores = in_num_cores;
+    uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / total_input_cores;
+    uint32_t num_q_cores = num_tiles_per_core * num_q_heads * head_size_num_tiles;
+    uint32_t num_kv_cores = num_tiles_per_core * num_kv_heads * head_size_num_tiles;
+
+    uint64_t qkv_read_addr =
+        get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+    uint32_t num_tiles_read_cur_core = 0;
+    uint32_t q_write_addr = 0;
+    constexpr uint32_t tile_size = head_size / head_size_num_tiles;
+    constexpr uint32_t HALF_TILE_ELEMENTS = FACE_HEIGHT * TILE_WIDTH;
+    constexpr uint32_t SUBTILE_ROWS = FACE_HEIGHT;
+
+    // Skip Q section if PROCESS_QV is False
+    if constexpr (PROCESS_QV == 1) {
+        for (uint32_t q = 0; q < num_q_heads; ++q) {
+            uint32_t wptr_offset = q < SUBTILE_ROWS
+                                       ? q * SUBTILE_LINE_BYTES
+                                       : (q - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
+            for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+                // Read first phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                    noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+                }
+                // Read second phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                    noc_async_read(
+                        qkv_read_addr + FACE_HW * ELEMENT_SIZE,
+                        q_write_addr + FACE_HW * ELEMENT_SIZE,
+                        SUBTILE_LINE_BYTES);
+                }
+
+                qkv_read_addr += tile_size;
+                q_write_addr += tile_size;
+                num_tiles_read_cur_core++;
+
+                if (num_tiles_read_cur_core == num_tiles_per_core) {
+                    qkv_x++;
+                    qkv_y++;
+                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
+                                    in_tile_offset_by_batch;
+                    num_tiles_read_cur_core = 0;
+                }
+            }
+        }
+    } else {
+        qkv_x += num_q_cores;
+        qkv_y += num_q_cores;
+        qkv_read_addr =
+            get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+    }
+
+    if constexpr (PROCESS_K == 1) {
+        // K
+        uint32_t k_write_addr = 0;
+
+        // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+        for (uint32_t k = 0; k < num_kv_heads; ++k) {
+            uint32_t wptr_offset = k < SUBTILE_ROWS
+                                       ? k * SUBTILE_LINE_BYTES
+                                       : (k - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
+            for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+                // Read first phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                    noc_async_read(qkv_read_addr, k_write_addr, SUBTILE_LINE_BYTES);
+                }
+                // Read second phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                    noc_async_read(
+                        qkv_read_addr + FACE_HW * ELEMENT_SIZE,
+                        k_write_addr + FACE_HW * ELEMENT_SIZE,
+                        SUBTILE_LINE_BYTES);
+                }
+
+                qkv_read_addr += tile_size;
+                k_write_addr += tile_size;
+                num_tiles_read_cur_core++;
+
+                if (num_tiles_read_cur_core == num_tiles_per_core) {
+                    qkv_x++;
+                    qkv_y++;
+                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
+                                    in_tile_offset_by_batch;
+                    num_tiles_read_cur_core = 0;
+                }
+            }
+        }
+    } else {
+        qkv_x += num_kv_cores;
+        qkv_y += num_kv_cores;
+        qkv_read_addr =
+            get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+    }
+
+    if constexpr (PROCESS_QV == 1) {
+        // v
+        uint32_t v_write_addr = 0;
+
+        // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+        for (uint32_t v = 0; v < num_kv_heads; ++v) {
+            uint32_t wptr_offset = v < SUBTILE_ROWS
+                                       ? v * SUBTILE_LINE_BYTES
+                                       : (v - SUBTILE_ROWS) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+            uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
+            for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+                // Read first phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                    noc_async_read(qkv_read_addr, v_write_addr, SUBTILE_LINE_BYTES);
+                }
+                // Read second phase
+                if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                    noc_async_read(
+                        qkv_read_addr + FACE_HW * ELEMENT_SIZE,
+                        v_write_addr + FACE_HW * ELEMENT_SIZE,
+                        SUBTILE_LINE_BYTES);
+                }
+
+                qkv_read_addr += tile_size;
+                v_write_addr += tile_size;
+                num_tiles_read_cur_core++;
+
+                if (num_tiles_read_cur_core == num_tiles_per_core) {
+                    qkv_x++;
+                    qkv_y++;
+                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
+                                    in_tile_offset_by_batch;
+                    num_tiles_read_cur_core = 0;
+                }
+            }
+        }
+    }
+
+    noc_async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
@@ -30,15 +30,13 @@ void kernel_main() {
     tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + in_num_cores));
 
     // Q
-    uint32_t qkv_x = 0;
-    uint32_t qkv_y = 0;
-    uint32_t total_input_cores = in_num_cores;
-    uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / total_input_cores;
+    uint32_t cur_core_idx = 0;
+    uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / in_num_cores;
     uint32_t num_q_cores = num_tiles_per_core * num_q_heads * head_size_num_tiles;
     uint32_t num_kv_cores = num_tiles_per_core * num_kv_heads * head_size_num_tiles;
 
-    uint64_t qkv_read_addr =
-        get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+    uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                             in_tile_offset_by_batch;
     uint32_t num_tiles_read_cur_core = 0;
     uint32_t q_write_addr = 0;
     constexpr uint32_t tile_size = head_size / head_size_num_tiles;
@@ -70,19 +68,18 @@ void kernel_main() {
                 num_tiles_read_cur_core++;
 
                 if (num_tiles_read_cur_core == num_tiles_per_core) {
-                    qkv_x++;
-                    qkv_y++;
-                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
-                                    in_tile_offset_by_batch;
+                    cur_core_idx++;
+                    qkv_read_addr =
+                        get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                        in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }
             }
         }
     } else {
-        qkv_x += num_q_cores;
-        qkv_y += num_q_cores;
-        qkv_read_addr =
-            get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+        cur_core_idx += num_q_cores;
+        qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                        in_tile_offset_by_batch;
     }
 
     if constexpr (PROCESS_K == 1) {
@@ -113,19 +110,18 @@ void kernel_main() {
                 num_tiles_read_cur_core++;
 
                 if (num_tiles_read_cur_core == num_tiles_per_core) {
-                    qkv_x++;
-                    qkv_y++;
-                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
-                                    in_tile_offset_by_batch;
+                    cur_core_idx++;
+                    qkv_read_addr =
+                        get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                        in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }
             }
         }
     } else {
-        qkv_x += num_kv_cores;
-        qkv_y += num_kv_cores;
-        qkv_read_addr =
-            get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
+        cur_core_idx += num_kv_cores;
+        qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                        in_tile_offset_by_batch;
     }
 
     if constexpr (PROCESS_QV == 1) {
@@ -156,10 +152,10 @@ void kernel_main() {
                 num_tiles_read_cur_core++;
 
                 if (num_tiles_read_cur_core == num_tiles_per_core) {
-                    qkv_x++;
-                    qkv_y++;
-                    qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) +
-                                    in_tile_offset_by_batch;
+                    cur_core_idx++;
+                    qkv_read_addr =
+                        get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                        in_tile_offset_by_batch;
                     num_tiles_read_cur_core = 0;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
@@ -11,17 +11,46 @@
 
 namespace ttnn::operations::experimental::transformer {
 
-    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
-    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
-    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    const bool overlap_qk_coregrid,
+    const bool input_on_subcoregrids,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    const bool overlap_qk_coregrid,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input_subcoregrid(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    const bool overlap_qk_coregrid,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size);
 
-
-    struct NLPCreateHeadsDecodeDeviceOperation {
-        const uint32_t num_q_heads;
-        const uint32_t num_kv_heads;
-        const uint32_t head_dim;
-        const bool overlap_qk_coregrid;
-        MemoryConfig output_mem_config;
+struct NLPCreateHeadsDecodeDeviceOperation {
+    const uint32_t num_q_heads;
+    const uint32_t num_kv_heads;
+    const uint32_t head_dim;
+    const bool overlap_qk_coregrid;
+    const bool input_on_subcoregrids;
+    MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -13,14 +13,41 @@ using namespace tt;
 
 namespace ttnn::operations::experimental::transformer {
 
-    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
-        bool is_input_sharded = input_tensor.is_sharded();
-        if (is_input_sharded) {
-            return multi_core_nlp_create_qkv_heads_decode_sharded_input(input_tensor, num_q_heads, num_kv_heads, head_dim, overlap_qk_coregrid, output, compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    const bool overlap_qk_coregrid,
+    const bool input_on_subcoregrids,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size) {
+    bool is_input_sharded = input_tensor.is_sharded();
+    if (is_input_sharded) {
+        if (input_on_subcoregrids) {
+            return multi_core_nlp_create_qkv_heads_decode_sharded_input_subcoregrid(
+                input_tensor,
+                num_q_heads,
+                num_kv_heads,
+                head_dim,
+                overlap_qk_coregrid,
+                output,
+                compute_with_storage_grid_size);
         } else {
-            return multi_core_nlp_create_qkv_heads_decode_interleaved_input(input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
+            return multi_core_nlp_create_qkv_heads_decode_sharded_input(
+                input_tensor,
+                num_q_heads,
+                num_kv_heads,
+                head_dim,
+                overlap_qk_coregrid,
+                output,
+                compute_with_storage_grid_size);
         }
+    } else {
+        return multi_core_nlp_create_qkv_heads_decode_interleaved_input(
+            input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
     }
+}
 
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(
     const Tensor& input_tensor,
@@ -179,9 +206,15 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleav
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
-
-    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool overlap_qk_coregrid, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
-        tt_metal::Program program = tt_metal::CreateProgram();
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    const bool overlap_qk_coregrid,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size) {
+    tt_metal::Program program = tt_metal::CreateProgram();
 
     const auto& input_shape = input_tensor.get_legacy_shape();
 
@@ -427,7 +460,262 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleav
         };
 
         return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+
+}  // namespace ttnn::operations::experimental::transformer
+
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input_subcoregrid(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t head_dim,
+    const bool overlap_qk_coregrid,
+    std::vector<Tensor>& output,
+    CoreCoord compute_with_storage_grid_size) {
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    const auto& input_shape = input_tensor.get_legacy_shape();
+
+    tt_metal::Device* device = input_tensor.device();
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+
+    uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+
+    uint32_t head_tiles = head_dim / TILE_WIDTH;
+    uint32_t head_size = head_tiles * single_tile_size;
+
+    uint32_t element_size = input_tensor.element_size();
+    uint32_t sub_tile_line_bytes = 16 * element_size;
+    auto q_shard_spec = output[0].shard_spec().value();
+    auto q_cores = q_shard_spec.grid;
+    auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+    auto in_shard_spec = input_tensor.shard_spec().value();
+    auto in_cores = in_shard_spec.grid;
+    auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t q_output_cb_index = CBIndex::c_16;
+    tt_metal::CircularBufferConfig cb_q_output_config =
+        tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
+            .set_page_size(q_output_cb_index, single_tile_size)
+            .set_globally_allocated_address(*output[0].buffer());
+    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+    auto k_shard_spec = output[1].shard_spec().value();
+    auto k_cores = k_shard_spec.grid;
+    auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t k_output_cb_index = CBIndex::c_17;
+    tt_metal::CircularBufferConfig cb_k_output_config =
+        tt_metal::CircularBufferConfig(k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
+            .set_page_size(k_output_cb_index, single_tile_size)
+            .set_globally_allocated_address(*output[1].buffer());
+    auto cb_k_output = tt_metal::CreateCircularBuffer(program, k_cores, cb_k_output_config);
+
+    auto v_shard_spec = output[0].shard_spec().value();
+    auto v_cores = q_shard_spec.grid;
+    auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t v_output_cb_index = CBIndex::c_18;
+    tt_metal::CircularBufferConfig cb_v_output_config =
+        tt_metal::CircularBufferConfig(v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
+            .set_page_size(v_output_cb_index, single_tile_size)
+            .set_globally_allocated_address(*output[2].buffer());
+    auto cb_v_output = tt_metal::CreateCircularBuffer(program, v_cores, cb_v_output_config);
+
+    uint32_t q_base_addr = input_tensor.buffer()->address();
+
+    // cores for q
+    uint32_t q_num_cores = q_cores.num_cores();  // number of cores of the output
+    const auto& q_cores_vector = corerange_to_cores(q_cores, q_num_cores, true);
+
+    // cores for k
+    uint32_t k_num_cores = k_cores.num_cores();  // number of cores of the output
+    const auto& k_cores_vector = corerange_to_cores(k_cores, k_num_cores, true);
+
+    // cores for input
+    uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
+    auto in_cores_vec = corerange_to_cores(in_cores, in_num_cores, true);
+
+    std::vector<uint32_t> noc_x_coords, noc_y_coords;
+    noc_x_coords.reserve(in_num_cores);
+    noc_y_coords.reserve(in_num_cores);
+
+    for (uint32_t i = 0; i < in_num_cores; ++i) {
+        auto worker_core = device->worker_core_from_logical_core(in_cores_vec[i]);
+        noc_x_coords.push_back(worker_core.x);
+        noc_y_coords.push_back(worker_core.y);
+    }
+    uint32_t process_qv = 1, process_k = 1;
+    // In case of overlapping qk coregrid, we create a single set of kernels for q which also process k and v heads from
+    // the input and write to the respective output buffers while if q and k are not overlapped, we create two sets of
+    // kernels in different coregrids one set of kernels for q which also process v heads but skips k heads from the
+    // input and write to the respective output buffers another set of kernels for k which reads k heads from the input
+    // and write to the respective output buffers while skipping q and v heads
+    if (!overlap_qk_coregrid) {
+        process_qv = 1;
+        process_k = 0;
     }
 
+    // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a
+    // tile respectively)
+    std::vector<uint32_t> q_reader_compile_time_args = {
+        (std::uint32_t)element_size,
+        (std::uint32_t)sub_tile_line_bytes,
+        q_output_cb_index,
+        k_output_cb_index,
+        v_output_cb_index,
+        head_size,
+        num_q_heads,
+        num_kv_heads,
+        head_tiles,
+        1,  // read the first phase
+        in_num_cores,
+        process_qv,  // read and write q and v heads
+        process_k    // read and write k heads
+    };
 
+    auto q_reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
+        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
+        q_cores,
+        tt_metal::ReaderDataMovementConfig(q_reader_compile_time_args));
+    std::vector<uint32_t> q_writer_compile_time_args = q_reader_compile_time_args;
+    q_writer_compile_time_args[9] = 2;  // read the second phase
+    auto q_writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
+        "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
+        q_cores,
+        tt_metal::WriterDataMovementConfig(q_writer_compile_time_args));
+
+    KernelHandle k_reader_kernel_id = 0, k_writer_kernel_id = 0;
+    if (!overlap_qk_coregrid) {
+        // Switch process_qv and process_k for k kernels
+        process_qv = 0;
+        process_k = 1;
+        std::vector<uint32_t> k_reader_compile_time_args = q_reader_compile_time_args;
+        k_reader_compile_time_args[11] = process_qv;
+        k_reader_compile_time_args[12] = process_k;
+        k_reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
+            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
+            k_cores,
+            tt_metal::ReaderDataMovementConfig(k_reader_compile_time_args));
+
+        std::vector<uint32_t> k_writer_compile_time_args = k_reader_compile_time_args;
+        k_writer_compile_time_args[9] = 2;  // read the second phase
+        k_writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/"
+            "reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp",
+            k_cores,
+            tt_metal::WriterDataMovementConfig(k_writer_compile_time_args));
+    }
+
+    uint32_t q_start_addr = q_base_addr;
+
+    for (uint32_t i = 0; i < q_num_cores; ++i) {
+        uint32_t in_tile_offset_by_batch =
+            i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+
+        const auto& core = q_cores_vector[i];
+        std::vector<uint32_t> q_reader_runtime_args;
+        q_reader_runtime_args.reserve(2 + 2 * in_num_cores);
+        q_reader_runtime_args = {
+            in_tile_offset_by_batch,
+            q_start_addr,
+        };
+        q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+        q_reader_runtime_args.insert(q_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+        tt_metal::SetRuntimeArgs(program, q_reader_kernel_id, core, q_reader_runtime_args);
+        tt_metal::SetRuntimeArgs(program, q_writer_kernel_id, core, q_reader_runtime_args);
+    }
+
+    if (!overlap_qk_coregrid) {
+        for (uint32_t i = 0; i < k_num_cores; ++i) {
+            uint32_t in_tile_offset_by_batch =
+                i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+
+            const auto& core = k_cores_vector[i];
+            std::vector<uint32_t> k_reader_runtime_args;
+            k_reader_runtime_args.reserve(2 + 2 * in_num_cores);
+            k_reader_runtime_args = {
+                in_tile_offset_by_batch,
+                q_start_addr,
+            };
+            k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+            k_reader_runtime_args.insert(k_reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+            tt_metal::SetRuntimeArgs(program, k_reader_kernel_id, core, k_reader_runtime_args);
+            tt_metal::SetRuntimeArgs(program, k_writer_kernel_id, core, k_reader_runtime_args);
+        }
+    }
+
+    auto override_runtime_arguments_callback =
+        [q_reader_kernel_id,
+         q_writer_kernel_id,
+         k_reader_kernel_id,
+         k_writer_kernel_id,
+         q_num_cores,
+         k_num_cores,
+         cb_q_output,
+         cb_k_output,
+         cb_v_output,
+         q_cores_vector,
+         k_cores_vector,
+         element_size,
+         sub_tile_line_bytes,
+         overlap_qk_coregrid](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto src_buffer = input_tensors.at(0).buffer();
+
+            uint32_t src_kv_buffer_addr = 0;
+
+            auto dst_buffer_query = output_tensors.at(0).buffer();
+            auto dst_buffer_key = output_tensors.at(1).buffer();
+            auto dst_buffer_value = output_tensors.at(2).buffer();
+
+            UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
+            UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
+            UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
+
+            uint32_t q_base_addr = input_tensors[0].buffer()->address();
+            uint32_t q_start_addr = q_base_addr;
+
+            for (uint32_t i = 0; i < q_num_cores; ++i) {
+                uint32_t in_tile_offset_by_batch =
+                    i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+                const auto& core = q_cores_vector[i];
+                auto& runtime_args = GetRuntimeArgs(program, q_reader_kernel_id, core);
+                runtime_args[0] = in_tile_offset_by_batch;
+                runtime_args[1] = q_start_addr;
+
+                auto& runtime_args_writer = GetRuntimeArgs(program, q_writer_kernel_id, core);
+                runtime_args_writer[0] = in_tile_offset_by_batch;
+                runtime_args_writer[1] = q_start_addr;
+            }
+
+            if (!overlap_qk_coregrid) {
+                for (uint32_t i = 0; i < k_num_cores; ++i) {
+                    uint32_t in_tile_offset_by_batch =
+                        i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+                    const auto& core = k_cores_vector[i];
+                    auto& runtime_args = GetRuntimeArgs(program, k_reader_kernel_id, core);
+                    runtime_args[0] = in_tile_offset_by_batch;
+                    runtime_args[1] = q_start_addr;
+
+                    auto& runtime_args_writer = GetRuntimeArgs(program, k_writer_kernel_id, core);
+                    runtime_args_writer[0] = in_tile_offset_by_batch;
+                    runtime_args_writer[1] = q_start_addr;
+                }
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
 } // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -479,19 +479,19 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
 
-    uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+    const uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
 
-    uint32_t head_tiles = head_dim / TILE_WIDTH;
-    uint32_t head_size = head_tiles * single_tile_size;
+    const uint32_t head_tiles = head_dim / TILE_WIDTH;
+    const uint32_t head_size = head_tiles * single_tile_size;
 
-    uint32_t element_size = input_tensor.element_size();
-    uint32_t sub_tile_line_bytes = 16 * element_size;
-    auto q_shard_spec = output[0].shard_spec().value();
-    auto q_cores = q_shard_spec.grid;
-    auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
-    auto in_shard_spec = input_tensor.shard_spec().value();
-    auto in_cores = in_shard_spec.grid;
-    auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
+    const uint32_t element_size = input_tensor.element_size();
+    const uint32_t sub_tile_line_bytes = 16 * element_size;
+    const auto q_shard_spec = output[0].shard_spec().value();
+    const auto q_cores = q_shard_spec.grid;
+    const auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+    const auto in_shard_spec = input_tensor.shard_spec().value();
+    const auto in_cores = in_shard_spec.grid;
+    const auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
 
     uint32_t q_output_cb_index = CBIndex::c_16;
     tt_metal::CircularBufferConfig cb_q_output_config =
@@ -500,9 +500,9 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
             .set_globally_allocated_address(*output[0].buffer());
     auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
 
-    auto k_shard_spec = output[1].shard_spec().value();
-    auto k_cores = k_shard_spec.grid;
-    auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
+    const auto k_shard_spec = output[1].shard_spec().value();
+    const auto k_cores = k_shard_spec.grid;
+    const auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
 
     uint32_t k_output_cb_index = CBIndex::c_17;
     tt_metal::CircularBufferConfig cb_k_output_config =
@@ -511,9 +511,9 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
             .set_globally_allocated_address(*output[1].buffer());
     auto cb_k_output = tt_metal::CreateCircularBuffer(program, k_cores, cb_k_output_config);
 
-    auto v_shard_spec = output[0].shard_spec().value();
-    auto v_cores = q_shard_spec.grid;
-    auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
+    const auto v_shard_spec = output[0].shard_spec().value();
+    const auto v_cores = q_shard_spec.grid;
+    const auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
 
     uint32_t v_output_cb_index = CBIndex::c_18;
     tt_metal::CircularBufferConfig cb_v_output_config =
@@ -525,15 +525,15 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_i
     uint32_t q_base_addr = input_tensor.buffer()->address();
 
     // cores for q
-    uint32_t q_num_cores = q_cores.num_cores();  // number of cores of the output
+    const uint32_t q_num_cores = q_cores.num_cores();  // number of cores of the output
     const auto& q_cores_vector = corerange_to_cores(q_cores, q_num_cores, true);
 
     // cores for k
-    uint32_t k_num_cores = k_cores.num_cores();  // number of cores of the output
+    const uint32_t k_num_cores = k_cores.num_cores();  // number of cores of the output
     const auto& k_cores_vector = corerange_to_cores(k_cores, k_num_cores, true);
 
     // cores for input
-    uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
+    const uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
     auto in_cores_vec = corerange_to_cores(in_cores, in_num_cores, true);
 
     std::vector<uint32_t> noc_x_coords, noc_y_coords;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](#15879 )

### Problem description
This adds support to run and create qkv heads on given subcoregrid.

### What's changed
1. Based on if input is sharded on subcoregrids, the Op chooses the right program factory.
2. Added new program factory which handles input on sub_core_grid and generates (noc_x, noc_y) coords for each core
3. Added new reader kernel for respective program factory.
4. Shouldnot affect perf or accuracy of existing Op


### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12436698216
- [x] New/Existing tests provide coverage for changes
