### PR TITLE
Updated install_dependencies.sh to skip installing additional recommended packages and skip prompting for user input for certain package installations

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -22,6 +22,7 @@ FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 MAJOR=${VERSION%.*}
 ARCH=`uname -m`
+DEBIAN_FRONTEND="noninteractive"
 
 usage()
 {
@@ -121,7 +122,7 @@ install()
         prep_ubuntu
 
         echo "Installing packages..."
-        apt-get install -y "${UB_LIST[@]}"
+        DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get install -y --no-install-recommends "${UB_LIST[@]}"
     fi
 }
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -122,7 +122,7 @@ install()
         prep_ubuntu
 
         echo "Installing packages..."
-        DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get install -y --no-install-recommends "${UB_LIST[@]}"
+        apt-get install -y --no-install-recommends "${UB_LIST[@]}"
     fi
 }
 


### PR DESCRIPTION
On Ubuntu 22.04, one of the packages has tzdata as a dependency and tzdata pops up a GUI screen prompting users to select their timezone. This PR updates the script so that this prompt is skipped and also so that no additional recommended packages are installed.