### PR TITLE
Enable too-small-loop-variable check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,6 @@ Checks: >
   -bugprone-string-integer-assignment,
   -bugprone-suspicious-include,
   -bugprone-switch-missing-default-case,
-  -bugprone-too-small-loop-variable,
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-self-assignment,
   -bugprone-unused-raii,

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -526,7 +526,7 @@ DevicePool::~DevicePool() {
 }
 
 v1::DeviceHandle DevicePool::get_handle(Device* device) const {
-    for (v1::DeviceKey::value_type index = 0; index < this->devices.size(); ++index) {
+    for (size_t index = 0; index < this->devices.size(); ++index) {
         if (this->devices[index].get() == device) {
             return {{index, 0}};
         }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2046,7 +2046,7 @@ void HWCommandQueue::reset_worker_state(bool reset_launch_msg_state) {
     if (reset_launch_msg_state) {
         if (device->dispatch_s_enabled()) {
             uint16_t index_bitmask = 0;
-            for (uint8_t i = 0; i < num_sub_devices; ++i) {
+            for (uint32_t i = 0; i < num_sub_devices; ++i) {
                 index_bitmask |= 1 << i;
             }
             command_sequence.add_notify_dispatch_s_go_signal_cmd(false, index_bitmask);
@@ -2056,7 +2056,7 @@ void HWCommandQueue::reset_worker_state(bool reset_launch_msg_state) {
         reset_launch_message_read_ptr_go_signal.signal = RUN_MSG_RESET_READ_PTR;
         reset_launch_message_read_ptr_go_signal.master_x = (uint8_t)this->virtual_enqueue_program_dispatch_core.x;
         reset_launch_message_read_ptr_go_signal.master_y = (uint8_t)this->virtual_enqueue_program_dispatch_core.y;
-        for (uint8_t i = 0; i < num_sub_devices; ++i) {
+        for (uint32_t i = 0; i < num_sub_devices; ++i) {
             reset_launch_message_read_ptr_go_signal.dispatch_message_offset = (uint8_t)dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(i);
             uint32_t dispatch_message_addr = dispatch_message_base_addr + dispatch_constants::get(dispatch_core_type).get_dispatch_message_offset(i);
             // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1430,7 +1430,7 @@ const std::vector<SubDeviceId> &detail::Program_::determine_sub_device_ids(const
                 uint32_t num_intersections = 0;
                 uint32_t num_cores = 0;
                 for (const auto& kg : program_kgs) {
-                    for (uint8_t i = 0; i < device->num_sub_devices(); ++i) {
+                    for (size_t i = 0; i < device->num_sub_devices(); ++i) {
                         const auto& sub_device_cores = device->worker_cores(core_type, SubDeviceId{i});
                         auto intersection = sub_device_cores.intersection(kg.core_ranges);
                         if (intersection.size() > 0) {

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -72,7 +72,7 @@ HalCoreInfoType create_active_eth_mem_map() {
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumEthDispatchClasses - 1);
     std::vector<HalJitBuildConfig> processor_types(1);
-    for (std::uint8_t processor_class_idx = 0; processor_class_idx < processor_classes.size(); processor_class_idx++) {
+    for (std::size_t processor_class_idx = 0; processor_class_idx < processor_classes.size(); processor_class_idx++) {
         // BH active ethernet runs idle erisc FW on the second ethernet
         processor_types[0] = HalJitBuildConfig{
             .fw_base_addr = eth_l1_mem::address_map::FIRMWARE_BASE,

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -70,7 +70,7 @@ HalCoreInfoType create_tensix_mem_map() {
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
         uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        for (uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+        for (size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
             DeviceAddr fw_base, local_init;
             switch (processor_class_idx) {
                 case 0: {

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -85,7 +85,7 @@ void Hal::initialize_gs() {
     for (uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
         uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        for (uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+        for (size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
             DeviceAddr fw_base, local_init;
             switch (processor_class_idx) {
                 case 0: {

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -71,7 +71,7 @@ HalCoreInfoType create_tensix_mem_map() {
     for (std::uint8_t processor_class_idx = 0; processor_class_idx < NumTensixDispatchClasses; processor_class_idx++) {
         std::uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
-        for (std::uint8_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
+        for (std::size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
             DeviceAddr fw_base, local_init;
             switch (processor_class_idx) {
                 case 0: {


### PR DESCRIPTION
### Ticket
#15123

### Problem description
Loop variables should be capable of covering the range of values that are will be compared against.  More info: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/too-small-loop-variable.html

### What's changed
The issues fixed here should not have ever exhibited as bugs.  However now that we're clean we can enforce the check globally which can save us from future bugs.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12307379048
