### PR TITLE
#0: Prevent slice from padding up a 0 volume tensor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -135,7 +135,7 @@ ttnn::Tensor SliceOperation::invoke(
             input_tensor.storage_type() == StorageType::DEVICE,
             "Host tensor slice cannot return a scalar or empty tensor");
         return ttnn::empty(
-            output_shape,
+            ttnn::Shape(actual_shape, actual_shape),
             input_tensor.dtype(),
             input_tensor.layout(),
             input_tensor.device(),


### PR DESCRIPTION
### Ticket
None

### Problem description
Old infra did not allow to create a 0 volume tensor so some of the existing code makes a 0 volume tensor non-zero.
This is the case for slice. Makes a tensor on device, at times a large tensor, which should never be allocated anywhere
For example, [0, 1, 768, 16] gets padded to [1, 1, 768, 32] and created on device.

### What's changed
The proper fix is to change ttnn::empty api to accept SimpleShape.
This is a quick fix to avoid passing padding into a call to empty.
If tests pass, I am okay with this change for now.
And the function API will mature in the next couple months and the team eliminates usage of ttnn::Shape and LegacyShape, replacing everything with SimpleShape.

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12309857749)