### PR TITLE
#15780: div ops debug

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div.py
@@ -51,7 +51,6 @@ class TestDiv:
             if round_mode in ["trunc", "floor"]:
                 pytest.skip("does not work for Grayskull -skipping")
         if accurate_mode == False:  # If input_b is non-zero tensor
-            pytest.skip("will be enabled after #15780 is resolved")
             datagen_func = [
                 generation_funcs.gen_func_with_cast(
                     partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_fmod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_fmod.py
@@ -24,7 +24,6 @@ mem_configs = [
 ]
 
 
-@pytest.mark.skip(reason="This test will be enabled after #15780 is resolved")
 @pytest.mark.parametrize(
     "input_shapes",
     [
@@ -45,14 +44,12 @@ class TestFmod:
         dst_mem_config,
         device,
     ):
-        # The ranges need to be retested and updated for respective dtypes in issue #15780
+        # For FMOD on inputs with > 2 decimals, use float32 for precision: issue #15780
         datagen_func = [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
-        ] + [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
-        ]
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+        ] + [generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
-        test_args.update({"output_mem_config": dst_mem_config})
+        test_args.update({"dtype": [ttnn.float32, ttnn.float32], "output_mem_config": dst_mem_config})
         comparison_func = comparison_funcs.comp_pcc
 
         run_single_pytorch_test(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -119,7 +119,6 @@ def test_mul_fp32(device, ttnn_function):
     assert status
 
 
-@pytest.mark.skip(reason="This test will be enabled after #15780 is resolved")
 @skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
@@ -130,8 +129,12 @@ def test_mul_fp32(device, ttnn_function):
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
 def test_div_fp32(device, ttnn_function):
-    x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1]], dtype=torch.float32)
-    y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0]], dtype=torch.float32)
+    x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
+    y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
+    # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
+    #            1.500000000000000]])
+    # tt out in torch TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
+    #            1.499999880790710]])
     golden_fn = ttnn.get_golden_function(ttnn_function)
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -152,7 +155,8 @@ def test_div_fp32(device, ttnn_function):
     ],
 )
 # Torch: num/ 0 = inf and 0/0  nan;
-# TT: num/ 0 = inf but 0/0= 0 not nan and 1/0 is not inf; input_b must be non-zero
+# TT: num/ 0 = inf but 0/0= 0 not nan and 1/0 is 170141183460469231731687303715884105728.000000000000000 not inf;
+# input_b must be non-zero
 def test_div_bf16(device, ttnn_function):
     x_torch = torch.tensor(
         [
@@ -165,6 +169,7 @@ def test_div_bf16(device, ttnn_function):
                 -12,
                 0,
                 0,
+                15,
             ]
         ],
         dtype=torch.bfloat16,
@@ -180,10 +185,15 @@ def test_div_bf16(device, ttnn_function):
                 0,
                 0,
                 1,
+                10,
             ]
         ],
         dtype=torch.bfloat16,
     )
+    # torch out in ttnn TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,  1.500000000000000]],
+    #         dtype=torch.bfloat16)
+    # tt out in torch TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,  0.000000000000000,  0.000000000000000,  1.500000000000000]],
+    #         dtype=torch.bfloat16)
     golden_fn = ttnn.get_golden_function(ttnn_function)
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+import pytest
+from models.utility_functions import skip_for_grayskull
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.remainder,
+    ],
+)
+def test_remainder_fp32(device, ttnn_function):
+    torch.manual_seed(213919)
+    x_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
+    y_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    z_torch = golden_fn(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_div = ttnn.remainder(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt_div)
+
+    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
+    assert status
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.div_no_nan,
+    ],
+)
+def test_div_no_nan_fp32(device, ttnn_function):
+    x_torch = torch.tensor(
+        [
+            [
+                15,
+                0,
+                2,
+                0,
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    y_torch = torch.tensor(
+        [
+            [
+                10,
+                0,
+                0,
+                2,
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    # direct div sfpu result before where: tt out in torch TorchTensor([[1.5000,    nan,    inf, 0.0000]])
+    # predicate b==0 tt out in torch TorchTensor([[0., 1., 1., 0.]])
+    # t1 false tt out in torch TorchTensor([[1.5000,    nan,    nan, 0.0000]]) 0 * nan = nan, 0 * inf = nan ?
+    # t2 true  tt out in torch TorchTensor([[0., 0., 0., 0.]])
+    # t1 + t2 tt out in torch TorchTensor([[1.5000,    nan,    nan, 0.0000]]) 0 + nan = nan
+    # final div_result = tt out in torch TorchTensor([[1.5000,    nan,    nan, 0.0000]])
+
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    z_torch = golden_fn(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt = ttnn.from_torch(z_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_div = ttnn.div_no_nan(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt_div)
+
+    status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
+    assert status
+
+
+@skip_for_grayskull("Unsupported dtype for Grayskull")
+@pytest.mark.parametrize(
+    "ttnn_function",
+    [
+        ttnn.remainder,
+    ],
+)
+def test_remainder_forge(device, ttnn_function):
+    torch.manual_seed(213919)
+    input1 = torch.randn(2, 32, 32)
+    input2 = torch.randn(2, 32, 32)
+
+    golden_fn = ttnn.get_golden_function(ttnn_function)
+    torch_output = golden_fn(input1, input2)
+
+    input1 = ttnn.from_torch(input1, dtype=ttnn.float32)
+    input2 = ttnn.from_torch(input2, dtype=ttnn.float32)
+
+    input1 = ttnn.to_device(input1, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    input2 = ttnn.to_device(input2, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    input1 = ttnn.to_layout(input1, ttnn.TILE_LAYOUT)
+    input2 = ttnn.to_layout(input2, ttnn.TILE_LAYOUT)
+
+    output = ttnn.remainder(input1, input2)
+
+    output = ttnn.to_torch(output)
+
+    status = ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.999
+    assert status
+
+
+def generate_torch_tensor(shape, low, high, step=0.0025, dtype=torch.float32):
+    num_elements = torch.prod(torch.tensor(shape))
+    values = torch.arange(low, high + step, step, dtype=dtype)
+
+    if values.numel() < num_elements:
+        values = values.repeat((num_elements // values.numel()) + 1)
+    values = values[:num_elements]
+    return values.reshape(shape)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "input_shapes",
+    [[64, 640], [2, 32, 320], [2, 1, 1024, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 64]],
+)
+def test_binary_fmod_bf16(
+    device,
+    input_shapes,
+):
+    torch_input_tensor_a = generate_torch_tensor(input_shapes, -100, 100, step=0.22, dtype=torch.bfloat16)
+    torch_input_tensor_b = generate_torch_tensor(input_shapes, -80, 120, step=0.11, dtype=torch.bfloat16)
+    torch_output_tensor = torch.fmod(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.fmod(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+
+    pcc = ttnn.pearson_correlation_coefficient(torch_output_tensor, output)
+    assert pcc >= 0.99

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -1655,8 +1655,8 @@ void py_module(py::module& module) {
         )doc",
         R"doc(INT32)doc",
         R"doc(2, 3, 4)doc",
-        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device))doc",
-        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device))doc");
+        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device))doc",
+        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device))doc");
 
     detail::bind_binary_composite(
         module,
@@ -1667,8 +1667,8 @@ void py_module(py::module& module) {
         )doc",
         R"doc(INT32)doc",
         R"doc(2, 3, 4)doc",
-        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device))doc",
-        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), layout=ttnn.TILE_LAYOUT, device=device))doc");
+        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device))doc",
+        R"doc(ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device))doc");
 
     detail::bind_binary_composite_with_alpha(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -223,16 +223,31 @@ Tensor ExecuteDiv::invoke(
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
     output_tensor = output_tensor.value_or(ttnn::empty_like(input_a));
     auto arch = input_a.device()->arch();
-    if (arch == tt::ARCH::WORMHOLE_B0) {
+    if (arch != tt::ARCH::GRAYSKULL) {
         DataType input_dtype = input_a.get_dtype();
+
+        // No accurate_mode for FP32 div as inf/nan are handled at kernel level
+        if (input_dtype == DataType::FLOAT32 && input_b.get_dtype() == DataType::FLOAT32) {
+            Tensor result = ttnn::divide(queue_id, input_a, input_b, std::nullopt, output_mem_config, output_tensor);
+            if (round_mode == "trunc") {
+                result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);
+            } else if (round_mode == "floor") {
+                result = ttnn::floor(queue_id, result, output_mem_config, output_tensor);
+            }
+            return result;
+        }
+
         Tensor a = typecast(queue_id, input_a, DataType::FLOAT32);
         Tensor b = typecast(queue_id, input_b, DataType::FLOAT32);
-        Tensor result = ttnn::divide(queue_id, a, b);
+
+        // Div operation without inf/nan handling as reciprocal(0) = 1.7014118346046923e+38 not inf/nan
+        Tensor result =
+            ttnn::multiply(queue_id, a, ttnn::reciprocal(b), std::nullopt, output_mem_config, output_tensor);
 
         if (round_mode == "trunc") {
-            result = ttnn::trunc(queue_id, result);
+            result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);
         } else if (round_mode == "floor") {
-            result = ttnn::floor(queue_id, result);
+            result = ttnn::floor(queue_id, result, output_mem_config, output_tensor);
         }
 
         if (accurate_mode == false) {  // If input_b is non-zero tensor
@@ -311,8 +326,14 @@ Tensor _div_no_nan_overload(const Tensor& input_a, float value, const std::optio
 }
 
 Tensor _div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor div_result = ttnn::div(input_a, input_b, false, std::nullopt, output_mem_config);
-    return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0, div_result);
+    if (input_a.get_dtype() == DataType::FLOAT32 && input_b.get_dtype() == DataType::FLOAT32) {
+        // Not using SFPU div op here since inf/nan handling is not required
+        Tensor div_result = ttnn::multiply(input_a, ttnn::reciprocal(input_b), std::nullopt, output_mem_config);
+        return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
+    } else {
+        Tensor div_result = ttnn::divide(input_a, input_b, std::nullopt, output_mem_config);
+        return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
+    }
 }
 
 Tensor ExecutePrelu::invoke(const Tensor& input, float weight, const std::optional<MemoryConfig>& output_mem_config) {
@@ -349,14 +370,30 @@ Tensor ExecutePrelu::invoke(
 Tensor ExecuteBinaryRemainder::invoke(
     const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     auto arch = input_a.device()->arch();
-    TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is supported on Wormhole or Blackhole");
     DataType input_dtype = input_a.get_dtype();
+    // No typecast for FP32 input
+    if (input_dtype == DataType::FLOAT32 && input_b.get_dtype() == DataType::FLOAT32) {
+        Tensor result = ttnn::subtract(
+            input_a,
+            ttnn::multiply(
+                input_b,
+                ttnn::div(input_a, input_b, true, "floor", output_mem_config),
+                std::nullopt,
+                output_mem_config),
+            std::nullopt,
+            output_mem_config);
+        result = ttnn::where(ttnn::ge(result, input_b), ttnn::subtract(result, input_b), result);
+        result = ttnn::where(ttnn::ltz(input_b), ttnn::add(result, input_b), result);
+        result = ttnn::where(ttnn::eq(input_a, input_b, std::nullopt, output_mem_config), 0.0f, result);
+        return result;
+    }
     Tensor a = typecast(input_a, DataType::FLOAT32);
     Tensor b = typecast(input_b, DataType::FLOAT32);
     Tensor result = ttnn::subtract(
         a,
         ttnn::multiply(
-            b, ttnn::div(input_a, input_b, true, "floor", output_mem_config), std::nullopt, output_mem_config),
+            b, ttnn::div(input_a, input_b, false, "floor", output_mem_config), std::nullopt, output_mem_config),
         std::nullopt,
         output_mem_config);
     result = ttnn::where(ttnn::ge(result, b), ttnn::subtract(result, b), result);
@@ -370,15 +407,31 @@ Tensor ExecuteBinaryRemainder::invoke(
     return ttnn::unary_remainder(input, scalar);
 }
 
+// FMOD result = input − (other * trunc(input/other))
 // Binary FMOD will be overloaded by unary FMOD in another PR
 Tensor ExecuteBinaryFmod::invoke(
     const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     auto arch = input_a.device()->arch();
     TT_FATAL(
         arch == tt::ARCH::WORMHOLE_B0 or arch == tt::ARCH::BLACKHOLE, "Op is only supported on Wormhole or Blackhole");
+
     DataType input_dtype = input_a.get_dtype();
+    // No typecast for FP32 input
+    if (input_dtype == DataType::FLOAT32 && input_b.get_dtype() == DataType::FLOAT32) {
+        Tensor div_res = ttnn::divide(input_a, input_b, std::nullopt, output_mem_config);
+        div_res = ttnn::trunc(div_res, output_mem_config);
+        Tensor result = ttnn::subtract(
+            input_a,
+            ttnn::multiply(div_res, input_b, std::nullopt, output_mem_config),
+            std::nullopt,
+            output_mem_config);
+        result = ttnn::where(ttnn::eq(input_a, input_b, std::nullopt, output_mem_config), 0.0f, result);
+        return result;
+    }
+    // For bfloat16 with decimal values, need to typecast to FP32 to improve precision
     Tensor a = typecast(input_a, DataType::FLOAT32);
     Tensor b = typecast(input_b, DataType::FLOAT32);
+
     Tensor div_res = typecast(ttnn::div(input_a, input_b, true, "trunc", output_mem_config), DataType::FLOAT32);
     Tensor result =
         ttnn::subtract(a, ttnn::multiply(div_res, b, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
@@ -393,7 +446,7 @@ Tensor ExecuteBinaryFmod::invoke(
 
 Tensor _floor_div_overload(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
     auto arch = input_a.device()->arch();
-    TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is supported on Wormhole");
     if (value == 0) {
         float t_inf = std::numeric_limits<float>::infinity();
         float t_nan = std::nanf("");
@@ -408,7 +461,7 @@ Tensor _floor_div_overload(const Tensor& input_a, float value, const std::option
 
 Tensor _floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     auto arch = input_a.device()->arch();
-    TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is supported on Wormhole");
     Tensor temp = ttnn::div(input_a, input_b, true, std::nullopt, output_mem_config);
     Tensor result = ttnn::div(input_a, input_b, true, "floor", output_mem_config);
     // floor(nan, inf, -inf) = nan, inf, -inf
@@ -511,6 +564,7 @@ Tensor ExecuteGCD::invoke(
     constexpr std::size_t max_iterations = 14;
     for (std::size_t iteration = 0; iteration < max_iterations; ++iteration) {
         Tensor isz = ttnn::eqz(min);
+        //  0's in min are replaced with 1
         Tensor rem = ttnn::remainder(max, ttnn::where(isz, isz, min));
         max = ttnn::where(isz, max, min);
         min = rem;
@@ -522,8 +576,9 @@ Tensor ExecuteLCM::invoke(
     const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor val = ttnn::multiply(input_a, input_b, std::nullopt, output_mem_config);
     Tensor tmp_result = ttnn::gcd(input_a, input_b);
-    Tensor result = ttnn::div(val, tmp_result, false, std::nullopt, output_mem_config);
-    return ttnn::abs(result);
+    Tensor result = ttnn::divide(val, tmp_result, std::nullopt, output_mem_config);
+    result = ttnn::abs(result);
+    return result;
 }
 
 // power - floating point exponent

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -19,7 +19,7 @@ namespace utils {
         case BinaryOpType::ADD: return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32));
         case BinaryOpType::SUB:
         case BinaryOpType::MUL:
-        // case BinaryOpType::DIV_FAST: will be enabled after #15780 is resolved
+        case BinaryOpType::DIV_FAST:
         case BinaryOpType::RSUB:
         case BinaryOpType::LOGADDEXP:
         case BinaryOpType::LOGADDEXP2:


### PR DESCRIPTION
### Ticket
Link to Github Issue #15780 #16011

### Problem description
div ops debug

### What's changed

- [x] Enabled sfpu div tile
- [x] Modified `ttnn.div`
- `accurate_mode` does not apply for Float32 div as inf/nan are handled at kernel level
-  for other dtypes, use chained (mul * recip) div to avoid `nan` values
- retains typecasting other dtype inputs to Float32 to avoid precision loss on decimals
- [x] Modified `ttnn.div_no_nan`
- for other dtypes, use chained (mul * recip) div to avoid `nan` values
- [x] Modified `ttnn.remainder`
- removed typecasting for Float32 inputs
- [x] Modified `ttnn.fmod`
- retains typecasting inputs to Float32 to avoid precision loss on decimals
- [x] added tests for LCM with non-zero inputs
- [x] added tests for Forge and other edge cases

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12348897592
- [ ] Blackhole Post commit (if applicable)
- [x] SC demo https://github.com/tenstorrent/tt-metal/actions/runs/12347029855
- [ ] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12347030936
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes https://github.com/tenstorrent/tt-metal/actions/runs/12339863753
- [x] New/Existing tests provide coverage for changes
