### PR TITLE
Speed up linking for incremental builds. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     endif()
 endif()
 
+option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up incremental builds" OFF)
 CHECK_COMPILERS()
 
 if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE IN_LIST CMAKE_CONFIGURATION_TYPES)
@@ -124,6 +125,8 @@ message(STATUS "Build Programming Examples: ${BUILD_PROGRAMMING_EXAMPLES}")
 message(STATUS "Build TT METAL Tests: ${TT_METAL_BUILD_TESTS}")
 message(STATUS "Build TTNN Tests: ${TTNN_BUILD_TESTS}")
 message(STATUS "Build with Unity builds: ${TT_UNITY_BUILDS}")
+message(STATUS "Build with Shared TTNN Sublibraries: ${ENABLE_TTNN_SHARED_SUBLIBS}")
+
 ############################################################################################################################
 
 if(ENABLE_BUILD_TIME_TRACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     endif()
 endif()
 
-option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up incremental builds" OFF)
 CHECK_COMPILERS()
 
 if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE IN_LIST CMAKE_CONFIGURATION_TYPES)

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -31,6 +31,7 @@ show_help() {
     echo "  --disable-unity-builds           Disable Unity builds"
     echo "  --cxx-compiler-path              Set path to C++ compiler."
     echo "  --c-compiler-path                Set path to C++ compiler."
+    echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
 }
 
 clean() {
@@ -59,11 +60,12 @@ unity_builds="ON"
 build_all="OFF"
 cxx_compiler_path=""
 c_compiler_path=""
+ttnn_shared_sub_libs="OFF"
 
 declare -a cmake_args
 
 OPTIONS=h,e,c,t,a,m,s,u,b:,p
-LONGOPTIONS=help,build-all,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,build-tt-train,build-static-libs,disable-unity-builds,release,development,debug,clean,cxx-compiler-path:,c-compiler-path:
+LONGOPTIONS=help,build-all,export-compile-commands,enable-ccache,enable-time-trace,enable-asan,enable-msan,enable-tsan,enable-ubsan,build-type:,enable-profiler,install-prefix:,build-tests,build-ttnn-tests,build-metal-tests,build-umd-tests,build-programming-examples,build-tt-train,build-static-libs,disable-unity-builds,release,development,debug,clean,cxx-compiler-path:,c-compiler-path:,ttnn-shared-sub-libs
 
 # Parse the options
 PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTIONS --name "$0" -- "$@")
@@ -115,6 +117,8 @@ while true; do
             build_static_libs="ON";;
         --build-all)
             build_all="ON";;
+        --ttnn-shared-sub-libs)
+            ttnn_shared_sub_libs="ON";;
         --disable-unity-builds)
 	    unity_builds="OFF";;
         --cxx-compiler-path)
@@ -177,6 +181,7 @@ echo "INFO: Build directory: $build_dir"
 echo "INFO: Install Prefix: $cmake_install_prefix"
 echo "INFO: Build tests: $build_tests"
 echo "INFO: Enable Unity builds: $unity_builds"
+echo "INFO: TTNN Shared sub libs : $ttnn_shared_sub_libs"
 
 # Prepare cmake arguments
 cmake_args+=("-B" "$build_dir")
@@ -226,6 +231,10 @@ if [ "$export_compile_commands" = "ON" ]; then
     cmake_args+=("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
 else
     cmake_args+=("-DCMAKE_EXPORT_COMPILE_COMMANDS=OFF")
+fi
+
+if [ "$ttnn_shared_sub_libs" = "ON" ]; then
+    cmake_args+=("-DENABLE_TTNN_SHARED_SUBLIBS=ON")
 fi
 
 if [ "$build_tests" = "ON" ]; then

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -18,6 +18,8 @@ option(TTNN_BUILD_TESTS "Enables build of ttnn tests" OFF)
 option(ENABLE_CCACHE "Build with compiler cache" FALSE)
 option(TT_UNITY_BUILDS "Build with Unity builds" ON)
 option(BUILD_TT_TRAIN "Enables build of tt-train" OFF)
+option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up incremental builds" OFF)
+
 ###########################################################################################
 
 if(CMAKE_CXX_CLANG_TIDY AND TT_UNITY_BUILDS)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -715,7 +715,24 @@ endfunction()
 set(PRECOMPILED_HEADER_TARGET "")
 
 function(add_ttnn_sublibrary SUBLIBRARY_NAME)
-    add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        message(
+            "Debug build for "
+            ${SUBLIBRARY_NAME}
+        )
+        add_library(${SUBLIBRARY_NAME} SHARED ${ARGN})
+        install(
+            TARGETS
+                ${SUBLIBRARY_NAME}
+            LIBRARY
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT tt_build_artifacts
+        )
+    else()
+        add_library(${SUBLIBRARY_NAME} STATIC ${ARGN})
+    endif()
     if(WITH_PYTHON_BINDINGS)
         target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=1)
     else()

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -715,27 +715,14 @@ endfunction()
 set(PRECOMPILED_HEADER_TARGET "")
 
 function(add_ttnn_sublibrary SUBLIBRARY_NAME)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_library(${SUBLIBRARY_NAME} SHARED ${ARGN})
-        install(
-            TARGETS
-                ${SUBLIBRARY_NAME}
-            LIBRARY
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT tt_build_artifacts
-        )
-    else()
-        add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
-    endif()
+    add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
     if(WITH_PYTHON_BINDINGS)
         target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=1)
     else()
         target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=0)
     endif()
-    target_include_directories(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_INCLUDE_DIRS})
-    target_link_libraries(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_LINK_LIBRARIES})
+    target_include_directories(${SUBLIBRARY_NAME} PUBLIC ${TTNN_PUBLIC_INCLUDE_DIRS})
+    target_link_libraries(${SUBLIBRARY_NAME} PUBLIC ${TTNN_PUBLIC_LINK_LIBRARIES})
     target_link_directories(${SUBLIBRARY_NAME} PUBLIC ${TTNN_PUBLIC_LINK_DIRS})
     use_precompiled_header(${SUBLIBRARY_NAME})
     set(PRECOMPILED_HEADER_TARGET "${PRECOMPILED_HEADER_TARGET}" PARENT_SCOPE)
@@ -779,7 +766,6 @@ endforeach(
 )
 
 add_ttnn_sublibrary(ttnn_tensor ${TENSOR_SRCS})
-# add_ttnn_sublibrary(tt_dnn ${TT_DNN_SRCS})
 add_ttnn_sublibrary(ttnn_ccl ${CCL_TTNN_SRCS})
 add_ttnn_sublibrary(ttnn_ccl_exp ${CCL_EXPERIMENTAL_TTNN_SRCS})
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -683,6 +683,7 @@ if(WITH_PYTHON_BINDINGS)
         TTNN_BASE_SRCS
         ${PROJECT_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp
         ${TT_LIB_SRCS}
+        ${PYBIND_SRC}
     ) # TT_LIB_SRCS from tt_eager/tt_lib/CMakeLists.txt for python bindigns
 
     list(
@@ -715,24 +716,7 @@ endfunction()
 set(PRECOMPILED_HEADER_TARGET "")
 
 function(add_ttnn_sublibrary SUBLIBRARY_NAME)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        message(
-            "Debug build for "
-            ${SUBLIBRARY_NAME}
-        )
-        add_library(${SUBLIBRARY_NAME} SHARED ${ARGN})
-        install(
-            TARGETS
-                ${SUBLIBRARY_NAME}
-            LIBRARY
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT tt_build_artifacts
-        )
-    else()
-        add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
-    endif()
+    add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
     target_include_directories(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_INCLUDE_DIRS})
     target_link_libraries(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_LINK_LIBRARIES})
     target_link_directories(${SUBLIBRARY_NAME} PUBLIC ${TTNN_PUBLIC_LINK_DIRS})

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -631,7 +631,9 @@ set(PYBIND_SRC
 
 foreach(FILE ${TTNN_OP_SRCS})
     if(FILE MATCHES "_pybind.cpp$")
-        list(APPEND PYBIND_SRC ${FILE})
+        if(WITH_PYTHON_BINDINGS)
+            list(APPEND TTNN_SRC ${FILE})
+        endif()
     else()
         list(APPEND TTNN_SRC ${FILE})
     endif()
@@ -680,7 +682,6 @@ if(WITH_PYTHON_BINDINGS)
         APPEND
         TTNN_BASE_SRCS
         ${PROJECT_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp
-        ${PYBIND_SRC}
         ${TT_LIB_SRCS}
     ) # TT_LIB_SRCS from tt_eager/tt_lib/CMakeLists.txt for python bindigns
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -716,6 +716,11 @@ set(PRECOMPILED_HEADER_TARGET "")
 
 function(add_ttnn_sublibrary SUBLIBRARY_NAME)
     add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
+    if(WITH_PYTHON_BINDINGS)
+        target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=1)
+    else()
+        target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=0)
+    endif()
     target_include_directories(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_INCLUDE_DIRS})
     target_link_libraries(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_LINK_LIBRARIES})
     target_link_directories(${SUBLIBRARY_NAME} PUBLIC ${TTNN_PUBLIC_LINK_DIRS})
@@ -809,7 +814,7 @@ set_target_properties(
             ""
 )
 
-TT_ENABLE_UNITY_BUILD(ttnn)
+# TT_ENABLE_UNITY_BUILD(ttnn)
 
 #We move the library binaries to a different path rather than PROJECT_BINARY_DIR
 #in the Python wheel

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -731,7 +731,7 @@ function(add_ttnn_sublibrary SUBLIBRARY_NAME)
                 COMPONENT tt_build_artifacts
         )
     else()
-        add_library(${SUBLIBRARY_NAME} STATIC ${ARGN})
+        add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
     endif()
     if(WITH_PYTHON_BINDINGS)
         target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=1)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -690,7 +690,6 @@ if(WITH_PYTHON_BINDINGS)
         APPEND
         TTNN_PUBLIC_INCLUDE_DIRS
         ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/experimental/tt_lib
-        ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include
         ${Python3_INCLUDE_DIRS}
     )
 
@@ -794,7 +793,7 @@ endif()
 target_include_directories(ttnn PUBLIC ${TTNN_PUBLIC_INCLUDE_DIRS})
 target_link_libraries(
     ttnn
-    PRIVATE
+    PUBLIC
         ${TTNN_PUBLIC_LINK_LIBRARIES}
         ${ALL_TTNN_SUBLIBRARIES}
         ttnn_tensor

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -716,10 +716,6 @@ set(PRECOMPILED_HEADER_TARGET "")
 
 function(add_ttnn_sublibrary SUBLIBRARY_NAME)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        message(
-            "Debug build for "
-            ${SUBLIBRARY_NAME}
-        )
         add_library(${SUBLIBRARY_NAME} SHARED ${ARGN})
         install(
             TARGETS

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(ALL_TTNN_SRCS
+set(TTNN_BASE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/core.cpp
@@ -15,6 +15,10 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_processor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_trace_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/graph/graph_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/creation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sharding_utilities.cpp
+)
+set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -385,8 +389,6 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/clone/clone_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/creation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sharding_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/uniform/uniform.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/uniform/uniform_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -568,6 +570,51 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/expand/device/expand_device_operation.cpp
 )
 
+set(TTNN_SUBLIBRARIES
+    ttnn/operations/ccl/
+    ttnn/operations/conv
+    ttnn/operations/core
+    ttnn/operations/data_movement
+    ttnn/operations/eltwise/binary
+    ttnn/operations/eltwise/binary_backward
+    ttnn/operations/bernoulli
+    ttnn/operations/eltwise/complex
+    ttnn/operations/eltwise/complex_binary
+    ttnn/operations/eltwise/complex_unary
+    ttnn/operations/eltwise/complex_unary_backward
+    ttnn/operations/eltwise/ternary
+    ttnn/operations/eltwise/ternary_backward
+    ttnn/operations/eltwise/unary
+    ttnn/operations/eltwise/unary_backward
+    ttnn/operations/embedding_backward
+    ttnn/operations/embedding
+    ttnn/operations/examples
+    ttnn/operations/experimental/auto_format
+    ttnn/operations/experimental/ccl
+    ttnn/operations/experimental/cnn
+    ttnn/operations/experimental/copy
+    ttnn/operations/experimental/experimental_pybind
+    ttnn/operations/experimental/matmul
+    ttnn/operations/experimental/paged_cache
+    ttnn/operations/experimental/plusone
+    ttnn/operations/experimental/reduction
+    ttnn/operations/experimental/ssm
+    ttnn/operations/experimental/transformer
+    ttnn/operations/full_like
+    ttnn/operations/full
+    ttnn/operations/index_fill
+    ttnn/operations/kv_cache
+    ttnn/operations/loss
+    ttnn/operations/matmul
+    ttnn/operations/moreh
+    ttnn/operations/normalization
+    ttnn/operations/pool
+    ttnn/operations/reduction
+    ttnn/operations/sliding_window
+    ttnn/operations/transformer
+    ttnn/operations/uniform
+)
+
 #Split src and python bindings
 #We only build python bindings optionally
 set(TTNN_SRC)
@@ -582,7 +629,7 @@ set(PYBIND_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/pybind11/pytensor.cpp
 )
 
-foreach(FILE ${ALL_TTNN_SRCS})
+foreach(FILE ${TTNN_OP_SRCS})
     if(FILE MATCHES "_pybind.cpp$")
         list(APPEND PYBIND_SRC ${FILE})
     else()
@@ -593,16 +640,8 @@ endforeach()
 ### Setup TTNN as a shared library with optional Python bindings
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations//experimental/ccl)
-add_subdirectory(cpp/ttnn/deprecated)
-set(TTNN_FINAL_SRC
-    ${TTNN_SRC}
-    ${QUEUE_SRCS}
-    ${TENSOR_SRCS}
-    ${CCL_TTNN_SRCS}
-    ${CCL_EXPERIMENTAL_TTNN_SRCS}
-    ${TT_DNN_SRCS}
-)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated)
 
 set(TTNN_PUBLIC_INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}
@@ -639,7 +678,7 @@ if(WITH_PYTHON_BINDINGS)
     #pybinds will always be built as a shared library
     list(
         APPEND
-        TTNN_FINAL_SRC
+        TTNN_BASE_SRCS
         ${PROJECT_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp
         ${PYBIND_SRC}
         ${TT_LIB_SRCS}
@@ -663,7 +702,91 @@ if(WITH_PYTHON_BINDINGS)
     )
 endif()
 
-add_library(ttnn SHARED ${TTNN_FINAL_SRC})
+function(use_precompiled_header TARGET)
+    if("${PRECOMPILED_HEADER_TARGET}" STREQUAL "")
+        set(PRECOMPILED_HEADER_TARGET "${TARGET}" PARENT_SCOPE)
+        target_precompile_headers(${TARGET} PUBLIC ${TTNN_PRECOMPILED_HEADERS})
+    else()
+        target_precompile_headers(${TARGET} REUSE_FROM ${PRECOMPILED_HEADER_TARGET})
+    endif()
+endfunction()
+
+set(PRECOMPILED_HEADER_TARGET "")
+
+function(add_ttnn_sublibrary SUBLIBRARY_NAME)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        message(
+            "Debug build for "
+            ${SUBLIBRARY_NAME}
+        )
+        add_library(${SUBLIBRARY_NAME} SHARED ${ARGN})
+        install(
+            TARGETS
+                ${SUBLIBRARY_NAME}
+            LIBRARY
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT tt_build_artifacts
+        )
+    else()
+        add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
+    endif()
+    target_include_directories(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_INCLUDE_DIRS})
+    target_link_libraries(${SUBLIBRARY_NAME} PRIVATE ${TTNN_PUBLIC_LINK_LIBRARIES})
+    target_link_directories(${SUBLIBRARY_NAME} PUBLIC ${TTNN_PUBLIC_LINK_DIRS})
+    use_precompiled_header(${SUBLIBRARY_NAME})
+    set(PRECOMPILED_HEADER_TARGET "${PRECOMPILED_HEADER_TARGET}" PARENT_SCOPE)
+    target_compile_options(
+        ${SUBLIBRARY_NAME}
+        PRIVATE
+            -MP
+            -Wno-int-to-pointer-cast
+            -fno-var-tracking
+            -ffunction-sections
+    )
+    set_target_properties(
+        ${SUBLIBRARY_NAME}
+        PROPERTIES
+            DEFINE_SYMBOL
+                ""
+    )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_definitions(${SUBLIBRARY_NAME} PRIVATE DISABLE_NAMESPACE_STATIC_ASSERT)
+        target_link_options(
+            ${SUBLIBRARY_NAME}
+            PRIVATE
+                "-Wl,--gc-sections"
+                "-Wl,--no-as-needed"
+        )
+    endif()
+endfunction()
+
+foreach(SUBLIBRARY_PATH ${TTNN_SUBLIBRARIES})
+    set(SUBLIBRARY_SRCS ${TTNN_SRC})
+    list(FILTER SUBLIBRARY_SRCS INCLUDE REGEX "${SUBLIBRARY_PATH}")
+    list(FILTER TTNN_SRC EXCLUDE REGEX "${SUBLIBRARY_PATH}")
+    if(SUBLIBRARY_SRCS)
+        string(REPLACE "/" "_" SUBLIBRARY_NAME ${SUBLIBRARY_PATH})
+        add_ttnn_sublibrary(${SUBLIBRARY_NAME} ${SUBLIBRARY_SRCS})
+        list(APPEND ALL_TTNN_SUBLIBRARIES ${SUBLIBRARY_NAME})
+    endif()
+endforeach(
+    SUBLIBRARY_PATH
+    ${TTNN_SUBLIBRARIES}
+)
+
+add_ttnn_sublibrary(ttnn_tensor ${TENSOR_SRCS})
+# add_ttnn_sublibrary(tt_dnn ${TT_DNN_SRCS})
+add_ttnn_sublibrary(ttnn_ccl ${CCL_TTNN_SRCS})
+add_ttnn_sublibrary(ttnn_ccl_exp ${CCL_EXPERIMENTAL_TTNN_SRCS})
+
+add_library(
+    ttnn
+    SHARED
+    ${TTNN_BASE_SRCS}
+    ${QUEUE_SRCS}
+)
 add_library(Metalium::TTNN ALIAS ttnn)
 target_compile_options(
     ttnn
@@ -684,9 +807,24 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 target_include_directories(ttnn PUBLIC ${TTNN_PUBLIC_INCLUDE_DIRS})
-target_link_libraries(ttnn PUBLIC ${TTNN_PUBLIC_LINK_LIBRARIES})
+target_link_libraries(
+    ttnn
+    PRIVATE
+        ${TTNN_PUBLIC_LINK_LIBRARIES}
+        ${ALL_TTNN_SUBLIBRARIES}
+        ttnn_tensor
+        ttnn_ccl
+        ttnn_ccl_exp
+)
 target_link_directories(ttnn PUBLIC ${TTNN_PUBLIC_LINK_DIRS})
-target_precompile_headers(ttnn PRIVATE ${TTNN_PRECOMPILED_HEADERS})
+target_precompile_headers(ttnn REUSE_FROM ${PRECOMPILED_HEADER_TARGET})
+set_target_properties(
+    ttnn
+    PROPERTIES
+        DEFINE_SYMBOL
+            ""
+)
+
 TT_ENABLE_UNITY_BUILD(ttnn)
 
 #We move the library binaries to a different path rather than PROJECT_BINARY_DIR

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -715,7 +715,20 @@ endfunction()
 set(PRECOMPILED_HEADER_TARGET "")
 
 function(add_ttnn_sublibrary SUBLIBRARY_NAME)
-    add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
+    if(ENABLE_TTNN_SHARED_SUBLIBS)
+        add_library(${SUBLIBRARY_NAME} SHARED ${ARGN})
+        install(
+            TARGETS
+                ${SUBLIBRARY_NAME}
+            LIBRARY
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT tt_build_artifacts
+        )
+    else()
+        add_library(${SUBLIBRARY_NAME} OBJECT ${ARGN})
+    endif()
     if(WITH_PYTHON_BINDINGS)
         target_compile_definitions(${SUBLIBRARY_NAME} PUBLIC TTNN_WITH_PYTHON_BINDINGS=1)
     else()

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -826,7 +826,7 @@ set_target_properties(
             ""
 )
 
-# TT_ENABLE_UNITY_BUILD(ttnn)
+TT_ENABLE_UNITY_BUILD(ttnn)
 
 #We move the library binaries to a different path rather than PROJECT_BINARY_DIR
 #in the Python wheel

--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -6,6 +6,7 @@
 
 #include "tt_metal/impl/event/event.hpp"
 #include "pybind11/pybind11.h"
+#include <pybind11/stl.h>
 
 using namespace tt::tt_metal;
 


### PR DESCRIPTION
### Problem description
Incremental builds take a very long time due to the time taken to link `_ttnn.so`. 

### What's changed
Split ttnn into multiple sub libraries, were each sub library is built and linked into shared libraries independently. These sub libraries are then linked together to form `_ttnn.so` 

Reduced incremental build time from **150s** to **21s** for Debug builds  .

This speed up was achieved by using shared libraries for all the sub libraries in Debug build. For Release build, there is only one libraries so that there are not a lot of installation artifacts. 

### New Flag for build_metal.sh
There is a new flag added to the build script called `--ttnn-shared-sub-libs` that can be used to enable this feature. It is off by default. It is best used to speed up Debug builds. 

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/12351388706)

