### PR TITLE
#15342: Add mirror_kernels option to conv_transpose2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.hpp
@@ -36,7 +36,8 @@ struct ConvTranpose2dOperation{
         std::optional<const ttnn::Tensor> bias_tensor = std::nullopt,
         const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
-        const std::optional<const MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+        bool mirror_kernel = true);
 
     static Result invoke(
         uint8_t queue_id,
@@ -57,7 +58,8 @@ struct ConvTranpose2dOperation{
         std::optional<const ttnn::Tensor> bias_tensor = std::nullopt,
         const std::optional<const Conv2dConfig>& conv_config_ = std::nullopt,
         const std::optional<const DeviceComputeKernelConfig>& compute_config_ = std::nullopt,
-        const std::optional<const MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+        bool mirror_kernel = true);
 };
 
 }  // namespace conv_transpose2d

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
@@ -108,8 +108,9 @@ void py_bind_conv_transpose2d(py::module& module) {
                 const std::optional<const Conv2dConfig>& conv_config,
                 const std::optional<const DeviceComputeKernelConfig>& compute_config,
                 const std::optional<const MemoryConfig>& memory_config,
+                bool mirror_kernel,
                 const uint8_t& queue_id) -> Result {
-                return self(queue_id, input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, output_padding, dilation, groups, bias_tensor, conv_config, compute_config, memory_config);
+                return self(queue_id, input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, output_padding, dilation, groups, bias_tensor, conv_config, compute_config, memory_config, mirror_kernel);
 
             },
             py::kw_only(),
@@ -131,6 +132,7 @@ void py_bind_conv_transpose2d(py::module& module) {
             py::arg("conv_config") = std::nullopt,
             py::arg("compute_config") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
+            py::arg("mirror_kernel") = true,
             py::arg("queue_id") = 0},
 
         ttnn::pybind_overload_t{
@@ -152,8 +154,9 @@ void py_bind_conv_transpose2d(py::module& module) {
                 const std::optional<const Conv2dConfig>& conv_config,
                 const std::optional<const DeviceComputeKernelConfig>& compute_config,
                 const std::optional<const MemoryConfig>& memory_config,
+                bool mirror_kernel,
                 const uint8_t& queue_id) -> Result {
-                return self(queue_id, input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, output_padding, dilation, groups, bias_tensor, conv_config, compute_config, memory_config);
+                return self(queue_id, input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, output_padding, dilation, groups, bias_tensor, conv_config, compute_config, memory_config, mirror_kernel);
 
             },
             py::kw_only(),
@@ -175,6 +178,7 @@ void py_bind_conv_transpose2d(py::module& module) {
             py::arg("conv_config") = std::nullopt,
             py::arg("compute_config") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
+            py::arg("mirror_kernel") = true,
             py::arg("queue_id") = 0}
     );
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d_pybind.cpp
@@ -63,6 +63,8 @@ void py_bind_conv_transpose2d(py::module& module) {
             bias_tensor    (ttnn.Tensor, optional): the bias tensor. Defaults to `None`.
             conv_config    (ttnn.Conv2dConfig, optional): the configuration for the convolution operation. Defaults to `None`.
             compute_config (ttnn.DeviceComputeKernelConfig, optional): the configuration for the compute kernel. Defaults to `None`.
+            memory_config  (ttnn.MemoryConfig, optional): the memory configuration of the output.
+            mirror_kernel  (bool): Set to true if the op should mirror the kernels along the height & width axes.
             queue_id       (int): the queue id to use for the operation. Defaults to `0`.
 
         Returns:

--- a/ttnn/ttnn/operations/transpose_conv2d.py
+++ b/ttnn/ttnn/operations/transpose_conv2d.py
@@ -37,6 +37,7 @@ def conv_transpose2d(
     conv_config: Conv2dConfig = None,  # config overrides by user
     compute_config=None,  # compute config overrides by user
     groups: int = 1,
+    mirror_kernel=True,
     return_output_dim=False,
     return_weights_and_bias=False,
 ) -> Tuple[ttnn.Tensor, int, int, ttnn.Tensor, ttnn.Tensor]:
@@ -64,6 +65,7 @@ def conv_transpose2d(
         conv_config=conv_config,
         compute_config=compute_config,
         groups=groups,
+        mirror_kernel=mirror_kernel,
     )
 
     if return_output_dim and return_weights_and_bias:


### PR DESCRIPTION
### Ticket
#15342 

### Problem description
conv_transpose2d always mirrors the kernels. This may not always be needed. 

### What's changed
Add a flag to control if conv_transpose2d should mirror the kernels. 

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/12348386611)
- [x] New/Existing tests provide coverage for changes
