### PR TITLE
#15246: Add sweep tests for addcdiv, addcmul, rdiv, rsub, ceil

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -45,13 +45,16 @@ on:
           - eltwise.unary.clip.clip
           - eltwise.unary.cbrt.cbrt
           - eltwise.unary.rsub.rsub
+          - eltwise.unary.rsub.rsub_sharded
           - eltwise.unary.rsub.rsub_pytorch2
           - eltwise.unary.rsqrt.rsqrt_pytorch2
           - eltwise.unary.rsqrt.rsqrt_forge
           - eltwise.unary.rdiv.rdiv
+          - eltwise.unary.rdiv.rdiv_sharded
           - eltwise.unary.frac.frac
           - eltwise.unary.frac.frac_sharded
           - eltwise.unary.ceil.ceil
+          - eltwise.unary.ceil.ceil_sharded
           - eltwise.unary.ceil.ceil_pytorch2
           - eltwise.unary.trunc.trunc
           - eltwise.unary.trunc.trunc_sharded
@@ -333,7 +336,9 @@ on:
           - eltwise.composite.binary.pow.pow_scalar_pytorch2
           - eltwise.composite.binary.pow.pow_tensor_pytorch2
           - eltwise.ternary.addcmul.addcmul
+          - eltwise.ternary.addcmul.addcmul_sharded
           - eltwise.ternary.addcdiv.addcdiv
+          - eltwise.ternary.addcdiv.addcdiv_sharded
           - eltwise.ternary.mac.mac
           - eltwise.ternary.lerp.lerp
           - eltwise.ternary.where.where

--- a/tests/sweep_framework/sweeps/eltwise/ternary/addcdiv/addcdiv_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/ternary/addcdiv/addcdiv_sharded.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import json
+import torch
+import random
+import ttnn
+import math
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 120
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_spec": gen_sharded_spec_unary(16, max_tensor_size_per_core=20 * 1024, layouts=["TILE_LAYOUT"]),
+        "input_dtype": [ttnn.bfloat16],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_dtype,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    torch_input_tensor_c = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    factor = random.randrange(-100, 100)
+    torch_op = ttnn.get_golden_function(ttnn.addcdiv)
+    torch_output_tensor = torch_op(torch_input_tensor_a, torch_input_tensor_b, torch_input_tensor_c, value=factor)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_c = ttnn.from_torch(
+        torch_input_tensor_c,
+        dtype=input_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.addcdiv(
+        input_tensor_a, input_tensor_b, input_tensor_c, value=factor, memory_config=sharded_config
+    )
+    e2e_perf = stop_measuring_time(start_time)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/ternary/addcmul/addcmul_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/ternary/addcmul/addcmul_sharded.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import json
+import torch
+import random
+import ttnn
+import math
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 120
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_spec": gen_sharded_spec_unary(16, max_tensor_size_per_core=20 * 1024, layouts=["TILE_LAYOUT"]),
+        "input_dtype": [ttnn.bfloat16],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_dtype,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    torch_input_tensor_c = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape)
+
+    factor = random.randrange(-100, 100)
+    torch_op = ttnn.get_golden_function(ttnn.addcmul)
+    torch_output_tensor = torch_op(torch_input_tensor_a, torch_input_tensor_b, torch_input_tensor_c, value=factor)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_c = ttnn.from_torch(
+        torch_input_tensor_c,
+        dtype=input_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.addcmul(
+        input_tensor_a, input_tensor_b, input_tensor_c, value=factor, memory_config=sharded_config
+    )
+    e2e_perf = stop_measuring_time(start_time)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/ceil/ceil_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/ceil/ceil_sharded.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import json
+import torch
+import random
+import ttnn
+import math
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 120
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_spec": gen_sharded_spec_unary(16, layouts=["TILE_LAYOUT"]),
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_a_dtype,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    torch_op = ttnn.get_golden_function(ttnn.ceil)
+    torch_output_tensor = torch_op(torch_input_tensor_a)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.ceil(input_tensor_a, memory_config=sharded_config)
+    e2e_perf = stop_measuring_time(start_time)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/rdiv/rdiv_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/rdiv/rdiv_sharded.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import json
+import torch
+import random
+import ttnn
+import math
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 120
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_spec": gen_sharded_spec_unary(16, layouts=["TILE_LAYOUT"]),
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_a_dtype,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    factor = random.randrange(1, 100)
+    torch_op = ttnn.get_golden_function(ttnn.rdiv)
+    torch_output_tensor = torch_op(torch_input_tensor_a, factor)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.rdiv(input_tensor_a, factor, memory_config=sharded_config)
+    e2e_perf = stop_measuring_time(start_time)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/rsub/rsub_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/rsub/rsub_sharded.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import json
+import torch
+import random
+import ttnn
+import math
+from tests.sweep_framework.sweep_utils.utils import gen_shapes, sanitize_shape_rm
+from tests.sweep_framework.sweep_utils.sharding_utils import gen_sharded_spec_unary, parse_sharding_spec
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 120
+
+random.seed(0)
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+parameters = {
+    "nightly": {
+        "input_spec": gen_sharded_spec_unary(16, layouts=["TILE_LAYOUT"]),
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    input_shape, X, Y, sharding_strategy, _, _, input_layout = test_vector["input_spec"].values()
+    pre_sharded_height = math.prod(input_shape[:-1])
+    pre_sharded_width = input_shape[-1]
+
+    if input_layout == "ROW_MAJOR_LAYOUT":
+        return True, "Input to eltwise binary must be tilized"
+
+    if input_layout == "ROW_MAJOR_LAYOUT" and test_vector["input_a_dtype"] == ttnn.bfloat8_b:
+        return True, "bfloat8_b is only supported on tiled layout"
+
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_a_dtype,
+    *,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    (
+        input_shape,
+        core_grid,
+        sharding_strategy,
+        shard_orientation,
+        tensor_hw_as_shard_shape,
+        input_layout,
+    ) = parse_sharding_spec(input_spec)
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        input_shape = sanitize_shape_rm(input_shape)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    factor = random.randrange(-100, 100)
+    torch_op = ttnn.get_golden_function(ttnn.rsub)
+    torch_output_tensor = torch_op(torch_input_tensor_a, factor)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape,
+        core_grid=core_grid,
+        strategy=sharding_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    output_tensor = ttnn.rsub(input_tensor_a, factor, memory_config=sharded_config)
+    e2e_perf = stop_measuring_time(start_time)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return [pcc, e2e_perf]

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_usehw_sharded.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_eltwise_usehw_sharded.py
@@ -17,6 +17,7 @@ Y, X = (8, 8)
 
 def run_tests(
     input_shape,
+    core_grid,
     dtype,
     dlayout,
     sharding_strategy,
@@ -40,7 +41,7 @@ def run_tests(
 
     sharded_config = ttnn.create_sharded_memory_config(
         shape=input_shape,
-        core_grid=ttnn.CoreGrid(y=Y, x=X),
+        core_grid=core_grid,
         strategy=sharding_strategy,
         orientation=shard_orientation,
         use_height_and_width_as_shard_shape=tensor_hw_as_shard_shape,
@@ -64,6 +65,7 @@ def run_tests(
 test_sweep_args = [
     (
         (1, 25, 160, 32),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat16,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
@@ -72,6 +74,7 @@ test_sweep_args = [
     ),
     (
         (1, 25, 160, 32),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat8_b,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
@@ -80,6 +83,7 @@ test_sweep_args = [
     ),
     (
         (1, 2, 1248, 32),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat16,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
@@ -88,6 +92,7 @@ test_sweep_args = [
     ),
     (
         (1, 2, 1248, 32),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat8_b,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
@@ -96,6 +101,7 @@ test_sweep_args = [
     ),
     (
         (1, 2, 1472, 32),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat16,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
@@ -104,6 +110,7 @@ test_sweep_args = [
     ),
     (
         (1, 2, 1472, 32),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat8_b,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
@@ -112,7 +119,26 @@ test_sweep_args = [
     ),
     (
         (2, 1, 224, 128),
+        ttnn.CoreGrid(y=8, x=8),
         ttnn.bfloat8_b,
+        ttnn.TILE_LAYOUT,
+        ttnn.ShardStrategy.BLOCK,
+        ttnn.ShardOrientation.COL_MAJOR,
+        True,
+    ),
+    (
+        (10, 1, 64, 32),
+        ttnn.CoreGrid(y=8, x=8),
+        ttnn.bfloat8_b,
+        ttnn.TILE_LAYOUT,
+        ttnn.ShardStrategy.BLOCK,
+        ttnn.ShardOrientation.COL_MAJOR,
+        True,
+    ),
+    (
+        (1, 1, 32, 96),
+        ttnn.CoreGrid(y=1, x=1),
+        ttnn.bfloat16,
         ttnn.TILE_LAYOUT,
         ttnn.ShardStrategy.BLOCK,
         ttnn.ShardOrientation.COL_MAJOR,
@@ -122,12 +148,15 @@ test_sweep_args = [
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_isfinite(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_isfinite(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -141,12 +170,15 @@ def test_eltwise_isfinite(input_shape, dtype, dlayout, sharding_strategy, shard_
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_isinf(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_isinf(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -160,12 +192,15 @@ def test_eltwise_isinf(input_shape, dtype, dlayout, sharding_strategy, shard_ori
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_isnan(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_isnan(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -179,12 +214,15 @@ def test_eltwise_isnan(input_shape, dtype, dlayout, sharding_strategy, shard_ori
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_isneginf(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_isneginf(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -198,12 +236,15 @@ def test_eltwise_isneginf(input_shape, dtype, dlayout, sharding_strategy, shard_
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_exp(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_exp(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -217,12 +258,15 @@ def test_eltwise_exp(input_shape, dtype, dlayout, sharding_strategy, shard_orien
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_sin(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_sin(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -236,12 +280,15 @@ def test_eltwise_sin(input_shape, dtype, dlayout, sharding_strategy, shard_orien
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_cos(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_cos(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -255,12 +302,15 @@ def test_eltwise_cos(input_shape, dtype, dlayout, sharding_strategy, shard_orien
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_abs(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_abs(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -335,12 +385,15 @@ def nop(x, memory_config=None):
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
     (test_sweep_args),
 )
-def test_eltwise_nop(input_shape, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device):
+def test_eltwise_nop(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
     run_tests(
         input_shape,
+        core_grid,
         dtype,
         dlayout,
         sharding_strategy,
@@ -348,6 +401,133 @@ def test_eltwise_nop(input_shape, dtype, dlayout, sharding_strategy, shard_orien
         hw_as_shard_shape,
         nop,
         nop,
+        False,
+        device,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_eltwise_frac(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_tests(
+        input_shape,
+        core_grid,
+        dtype,
+        dlayout,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        torch.frac,
+        ttnn.frac,
+        False,
+        device,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_eltwise_trunc(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_tests(
+        input_shape,
+        core_grid,
+        dtype,
+        dlayout,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        torch.trunc,
+        ttnn.trunc,
+        False,
+        device,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_eltwise_ceil(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_tests(
+        input_shape,
+        core_grid,
+        dtype,
+        dlayout,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        torch.ceil,
+        ttnn.ceil,
+        False,
+        device,
+    )
+
+
+def pt_rsub(x, memory_config=None):
+    torch_op = ttnn.get_golden_function(ttnn.rsub)
+    return torch_op(x, 10)
+
+
+def tt_rsub(x, memory_config=None):
+    return ttnn.rsub(x, 10, memory_config=memory_config)
+
+
+@pytest.mark.parametrize(
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_eltwise_rsub(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_tests(
+        input_shape,
+        core_grid,
+        dtype,
+        dlayout,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        pt_rsub,
+        tt_rsub,
+        False,
+        device,
+    )
+
+
+def pt_rdiv(x, memory_config=None):
+    return torch.div(x, 10)
+
+
+def tt_rdiv(x, memory_config=None):
+    return ttnn.rdiv(x, value=10, memory_config=memory_config)
+
+
+@pytest.mark.parametrize(
+    "input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape",
+    (test_sweep_args),
+)
+def test_eltwise_rdiv(
+    input_shape, core_grid, dtype, dlayout, sharding_strategy, shard_orientation, hw_as_shard_shape, device
+):
+    run_tests(
+        input_shape,
+        core_grid,
+        dtype,
+        dlayout,
+        sharding_strategy,
+        shard_orientation,
+        hw_as_shard_shape,
+        pt_rdiv,
+        tt_rdiv,
         False,
         device,
     )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11512)

### Problem description
We need sweep tests testing how ops behave when input is sharded.

### What's changed
Added sweep tests for multiple ops when input is sharded:

addcdiv
addcmul
rdiv
rsub
ceil

Also updated unit tests with failing situations.

### Pass rates for new sweeps:
sweeps/eltwise/ternary/addcdiv/addcdiv_sharded.py: 62 fail, 320 pass (84%)
sweeps/eltwise/ternary/addcmul/addcmul_sharded.py: 65 fail, 317 pass (83%)
sweeps/eltwise/unary/rdiv/rdiv_sharded.py: 467 fail, 301 pass (39%)
sweeps/eltwise/unary/rsub/rsub_sharded.py: 174 fail, 594 pass (77%)
sweeps/eltwise/unary/ceil/ceil_sharded.py: 174 fail, 594 pass (77%)

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12352463715
- [X] Sweep tests pass


