### PR TITLE
Run T3K Unit Tests in all-post-commit on push to main

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -195,6 +195,7 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
+    if: github.event_name == 'push'
   # We used to use this for post-commit, but we didn't have enough runners
   # to support the number of developers running this workflow
   # build-and-test-measure-perf:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -191,6 +191,10 @@ jobs:
     needs: [build-artifact, build-docker-image-2204]
     uses: ./.github/workflows/build.yaml
     secrets: inherit
+  t3000-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/t3000-unit-tests-impl.yaml
   # We used to use this for post-commit, but we didn't have enough runners
   # to support the number of developers running this workflow
   # build-and-test-measure-perf:

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -2,8 +2,6 @@ name: "(T3K) T3000 unit tests"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */3 * * *" # This cron schedule runs the workflow every 3 hours
 
 jobs:
   build-artifact:


### PR DESCRIPTION
### Problem description
T3K unit tests get broken, and we may not notice for several days, then we need to bisect.

### What's changed
Instead of running the t3k unit tests on cron schedule, run on every push to main.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
