### PR TITLE
Create new FD frequent pipeline to isolate unstable pgm benchmark tests

### DIFF
--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           arch: ${{ matrix.test-group.arch }}
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ inputs.timeout }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
         uses: ./.github/actions/docker-run
         with:
           docker_os_arch: tt-metalium/${{ inputs.os }}-amd64

--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] Fast dispatch frequent tests impl"
 
 on:
   workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: "ubuntu-20.04"
 
 jobs:
   fd-frequent:
@@ -37,7 +42,7 @@ jobs:
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
             -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=${{ inputs.arch }}
+            -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
           run_args: |
             ${{ matrix.test-group.cmd }}

--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -1,0 +1,54 @@
+name: "[internal] Fast dispatch frequent tests impl"
+
+on:
+  workflow_call:
+
+jobs:
+  fd-frequent:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group:
+          [
+            {
+              name: "WH N300 pgm dispatch nightly",
+              arch: wormhole_b0,
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+              cmd: ./tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/compare_pgm_dispatch_perf_ci.sh,
+              timeout: 10
+            },
+          ]
+    name: ${{ matrix.test-group.name }}
+    env:
+      LOGURU_LEVEL: INFO
+    runs-on: ${{ matrix.test-group.runs-on }}
+    steps:
+      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
+      - uses: ./.github/actions/prepare-metal-run
+        with:
+          arch: ${{ matrix.test-group.arch }}
+      - name: ${{ matrix.test-group.name }} tests
+        timeout-minutes: ${{ inputs.timeout }}
+        uses: ./.github/actions/docker-run
+        with:
+          docker_os_arch: tt-metalium/${{ inputs.os }}-amd64
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=${{ inputs.arch }}
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          run_args: |
+            ${{ matrix.test-group.cmd }}
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U01Q0T3J3D0 # Paul Keller
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"

--- a/.github/workflows/fast-dispatch-frequent-tests.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests.yaml
@@ -5,6 +5,9 @@ on:
   workflow_call:
   schedule:
     - cron: "0 */4 * * *"
+  push:
+    branches:
+      - "rkim/0-new-fd-frequent"
 
 jobs:
   build-artifact:

--- a/.github/workflows/fast-dispatch-frequent-tests.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests.yaml
@@ -1,0 +1,16 @@
+name: "(Single-card) Fast dispatch frequent tests"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: "0 */4 * * *"
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+  fd-nightly:
+    needs: build-artifact
+    uses: ./.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+    secrets: inherit


### PR DESCRIPTION
### Ticket

To stabilize nightly pipelines

### Problem description

pgm dispatch tests were unstable, causing loss of trust in pipeline

### What's changed

Isolate to separate pipeline and set @jbaumanTT as owner

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
