### PR TITLE
Afuller/fix clang tidy scan

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -178,7 +178,7 @@ jobs:
             # Symlink tomfoolery here so that Ninja believes the build command has not changed from the previous run
             ln -sf $(which clang-tidy-17) ./clang-tidy-shim
 
-            cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY=$(pwd)/clang-tidy-shim -DCMAKE_C_CLANG_TIDY=$(pwd)/clang-tidy-shim
+            cmake --preset clang-tidy -DCMAKE_CXX_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
             nice -n 19 cmake --build --preset clang-tidy
             mkdir -p out
             ccache -s > out/ccache.stats

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -35,7 +35,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
                ScaledDotProductAttention{
                    .scale = scale,
                    .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
-                   .program_config = program_config,
+                   .program_config = std::move(program_config),
                    .is_causal = is_causal,
                    .chunk_start_idx = std::nullopt,
                    .compute_kernel_config = kernel_config_val},
@@ -65,7 +65,7 @@ ttnn::Tensor ExecuteScaledDotProductAttention::invoke(
         is_causal,
         scale,
         memory_config,
-        program_config,
+        std::move(program_config),
         compute_kernel_config);
 }
 
@@ -90,7 +90,7 @@ ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
                ScaledDotProductAttention{
                    .scale = scale,
                    .output_mem_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
-                   .program_config = program_config,
+                   .program_config = std::move(program_config),
                    .is_causal = true,  // Always causal for chunked version
                    .chunk_start_idx = chunk_start_idx,
                    .compute_kernel_config = kernel_config_val},
@@ -120,7 +120,7 @@ ttnn::Tensor ExecuteChunkedScaledDotProductAttention::invoke(
         chunk_start_idx,
         scale,
         memory_config,
-        program_config,
+        std::move(program_config),
         compute_kernel_config);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -4,6 +4,8 @@
 
 #include "sdpa_decode.hpp"
 
+#include <utility>
+
 #include "device/sdpa_decode_op.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/run_operation.hpp"
@@ -107,7 +109,7 @@ ttnn::Tensor ExecuteScaledDotProductAttentionDecode::invoke(
         cur_pos_tensor,
         scale,
         memory_config,
-        program_config,
+        std::move(program_config),
         compute_kernel_config);
 }
 
@@ -188,7 +190,7 @@ ttnn::Tensor ExecutePagedScaledDotProductAttentionDecode::invoke(
         cur_pos_tensor,
         scale,
         memory_config,
-        program_config,
+        std::move(program_config),
         compute_kernel_config);
 }
 


### PR DESCRIPTION
### Ticket
#15730

### Problem description
I goofed in #15888.  By overriding CMAKE_CXX_CLANG_TIDY I've bypassed setting `--warnings-as-errors=*` and now all detected issues are merely warnings and the whole thing exists with exit code 0.  Effectively voiding the entire run.

### What's changed
Reinstate --warnings-as-errors
Fix detected issues.

