### PR TITLE
#13127: Make TensorLayout::compute_physical_shard_shape public

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
@@ -7,7 +7,7 @@
 #include "tt_metal/common/logger.hpp"
 #include "tt_metal/common/work_split.hpp"
 #include "ttnn/async_runtime.hpp"
-#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn_test_fixtures.hpp"
@@ -81,33 +81,6 @@ void pretty_print_data_as_shards(
     std::cout << std::endl;
 }
 
-Size get_physical_shape(
-    const ttnn::SimpleShape& shape, const Size& logical_shard_shape, const Size& physical_shard_shape) {
-    const int rank = static_cast<int>(shape.rank());
-
-    size_t width = 1;
-    size_t height = 1;
-
-    // Iterate dims in reverse order
-    // Even tensor of rank 0 or 1
-    for (int i = -1; i >= -rank; --i) {
-        auto& dim = i == -1 ? width : height;
-        dim *= shape[i];
-    }
-
-    auto get_physical_size = [](auto original_size, auto logical_shard_size, auto physical_shard_size) {
-        auto num_shards = tt::div_up(original_size, logical_shard_size);
-
-        return physical_shard_size * num_shards;
-    };
-
-    auto physical_height = get_physical_size(height, logical_shard_shape.height(), physical_shard_shape.height());
-    auto physical_width = get_physical_size(width, logical_shard_shape.width(), physical_shard_shape.width());
-    Size size{physical_height, physical_width};
-
-    return size;
-}
-
 using LogicalPhysicalIdxPairs = std::vector<std::array<size_t, 2>>;
 using LogicalPhysicalMapping = std::pair<LogicalPhysicalIdxPairs, size_t>;
 std::vector<LogicalPhysicalMapping> compute_logical_to_physical_shards_mapping(
@@ -145,21 +118,22 @@ std::vector<LogicalPhysicalMapping> compute_logical_to_physical_shards_mapping(
 };
 
 std::vector<float> convert_fp32_logical_data_to_physical_data(
-    const std::vector<float>& data,
-    const ttnn::SimpleShape& shape,
-    const Size& logical_shard_shape,
-    const Size& physical_shard_shape) {
+    const std::vector<float>& logical_data, const TensorSpec& tensor_spec) {
+    const auto& logical_shape = tensor_spec.logical_shape();
     TT_FATAL(
-        data.size() == shape.volume(),
-        "Data size {} should be same as volume indicated by shape {}",
-        data.size(),
-        shape);
-    auto physical_size = get_physical_shape(shape, logical_shard_shape, physical_shard_shape);
+        logical_data.size() == logical_shape.volume(),
+        "Logical data size {} should be same as volume indicated by logical shape {}",
+        logical_data.size(),
+        logical_shape);
 
-    std::vector<float> physical_data(physical_size.height() * physical_size.width(), 0);
+    const auto& logical_shard_shape = tensor_spec.tensor_layout().get_logical_shard_shape();
+    const auto& physical_shard_shape = tensor_spec.tensor_layout().get_physical_shard_shape();
+    const auto& physical_shape = tensor_spec.physical_shape();
 
-    auto logical_2D_shape = flatten_to_2D(shape);
-    size_t physical_stride = physical_size.width();
+    std::vector<float> physical_data(physical_shape.height() * physical_shape.width(), 0);
+
+    auto logical_2D_shape = flatten_to_2D(logical_shape);
+    size_t physical_stride = physical_shape.width();
 
     const auto logical_physical_mapping = compute_logical_to_physical_shards_mapping(
         logical_2D_shape, logical_shard_shape, physical_shard_shape, physical_stride);
@@ -170,36 +144,37 @@ std::vector<float> convert_fp32_logical_data_to_physical_data(
             auto physical_idx_start = idx_pair[1];
 
             for (size_t col = 0; col < cols; col++) {
-                physical_data[physical_idx_start + col] = data[logical_idx_start + col];
+                physical_data[physical_idx_start + col] = logical_data[logical_idx_start + col];
             }
         }
     }
 
     TT_FATAL(
-        physical_data.size() == physical_size.height() * physical_size.width(),
-        "Physical data size {} should be same as calculated physical size {}",
+        physical_data.size() == physical_shape.height() * physical_shape.width(),
+        "Physical data size {} should be same as volume indicated by physical shape {}",
         physical_data.size(),
-        physical_size);
+        physical_shape);
 
     return physical_data;
 };
 
 std::vector<float> convert_fp32_physical_data_to_logical_data(
-    const std::vector<float>& physical_data,
-    const ttnn::SimpleShape& shape,
-    const Size& logical_shard_shape,
-    const Size& physical_shard_shape) {
-    auto physical_size = get_physical_shape(shape, logical_shard_shape, physical_shard_shape);
+    const std::vector<float>& physical_data, const TensorSpec& tensor_spec) {
+    auto physical_shape = tensor_spec.physical_shape();
     TT_FATAL(
-        physical_data.size() == physical_size.height() * physical_size.width(),
-        "Physical data size {} should be same as calculated physical size {}",
+        physical_data.size() == physical_shape.height() * physical_shape.width(),
+        "Physical data size {} should be same as volume indicated by physical shape {}",
         physical_data.size(),
-        physical_size);
+        physical_shape);
 
-    auto logical_2D_shape = flatten_to_2D(shape);
-    std::vector<float> data(logical_2D_shape.height() * logical_2D_shape.width(), 0);
+    const auto& logical_shape = tensor_spec.logical_shape();
+    const auto& logical_shard_shape = tensor_spec.tensor_layout().get_logical_shard_shape();
+    const auto& physical_shard_shape = tensor_spec.tensor_layout().get_physical_shard_shape();
 
-    size_t physical_stride = physical_size.width();
+    auto logical_2D_shape = flatten_to_2D(logical_shape);
+    std::vector<float> logical_data(logical_2D_shape.height() * logical_2D_shape.width(), 0);
+
+    size_t physical_stride = physical_shape.width();
 
     const auto logical_physical_mapping = compute_logical_to_physical_shards_mapping(
         logical_2D_shape, logical_shard_shape, physical_shard_shape, physical_stride);
@@ -210,18 +185,18 @@ std::vector<float> convert_fp32_physical_data_to_logical_data(
             auto physical_idx_start = idx_pair[1];
 
             for (size_t col = 0; col < cols; col++) {
-                data[logical_idx_start + col] = physical_data[physical_idx_start + col];
+                logical_data[logical_idx_start + col] = physical_data[physical_idx_start + col];
             }
         }
     }
 
     TT_FATAL(
-        data.size() == shape.volume(),
-        "Data size {} should be same as volume indicated by shape {}",
-        data.size(),
-        shape);
+        logical_data.size() == logical_shape.volume(),
+        "Logical data size {} should be same as volume indicated by logical shape {}",
+        logical_data.size(),
+        logical_shape);
 
-    return data;
+    return logical_data;
 };
 
 }  // namespace
@@ -229,14 +204,15 @@ std::vector<float> convert_fp32_physical_data_to_logical_data(
 namespace {
 struct ShardWithAlignmentInputs {
     SimpleShape shape;
-    Size shard_shape;
-    Alignment shard_alignment;
-    std::vector<float> data;
+    Size logical_shard_shape;
+    std::optional<Size> physical_shard_shape;
+    PageConfig page_config;
+    std::vector<float> logical_data;
 };
 
 struct ShardWithAlignmentExpected {
     Size physical_shard_shape;
-    Size physical_size;
+    Size physical_shape;
     std::vector<float> physical_data;
 };
 
@@ -252,23 +228,41 @@ class ShardWithAlignmentTests : public ::testing::TestWithParam<ShardWithAlignme
 TEST_P(ShardWithAlignmentTests, LogicalToPhysical) {
     const auto& params = GetParam();
 
-    auto physical_shard_height = tt::round_up(params.inputs.shard_shape.height(), params.inputs.shard_alignment[0]);
-    auto physical_shard_width = tt::round_up(params.inputs.shard_shape.width(), params.inputs.shard_alignment[1]);
-    Size physical_shard_shape{physical_shard_height, physical_shard_width};
+    // Only shard shapes and shard mode matters for this test
+    auto shard_spec = params.inputs.physical_shard_shape.has_value() ? ShardSpec(
+                                                                           CoreRangeSet{},
+                                                                           params.inputs.logical_shard_shape,
+                                                                           params.inputs.physical_shard_shape.value(),
+                                                                           ShardOrientation::ROW_MAJOR,
+                                                                           false)
+                                                                     : ShardSpec(
+                                                                           CoreRangeSet{},
+                                                                           params.inputs.logical_shard_shape,
+                                                                           ShardOrientation::ROW_MAJOR,
+                                                                           false,
+                                                                           ShardMode::LOGICAL);
+    MemoryConfig memory_config{
+        .memory_layout = TensorMemoryLayout::HEIGHT_SHARDED, .buffer_type = BufferType::L1, .shard_spec = shard_spec};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, params.inputs.page_config, memory_config);
+    auto tensor_spec = TensorSpec(params.inputs.shape, tensor_layout);
+
+    auto logical_shard_shape = tensor_layout.get_logical_shard_shape();
+    ASSERT_EQ(logical_shard_shape, params.inputs.logical_shard_shape);
+
+    auto physical_shard_shape = tensor_layout.get_physical_shard_shape();
     ASSERT_EQ(physical_shard_shape, params.expected.physical_shard_shape);
 
-    auto physical_size = get_physical_shape(params.inputs.shape, params.inputs.shard_shape, physical_shard_shape);
-    ASSERT_EQ(physical_size, params.expected.physical_size);
+    auto physical_shape = tensor_spec.physical_shape();
+    ASSERT_EQ(physical_shape, params.expected.physical_shape);
 
-    const auto& data = params.inputs.data;
+    const auto& logical_data = params.inputs.logical_data;
     const auto& expected_physical_data = params.expected.physical_data;
 
-    auto physical_data = convert_fp32_logical_data_to_physical_data(
-        data, params.inputs.shape, params.inputs.shard_shape, physical_shard_shape);
+    auto physical_data = convert_fp32_logical_data_to_physical_data(logical_data, tensor_spec);
 
-    // auto shape_2D = flatten_to_2D(params.inputs.shape);
-    // pretty_print_data_as_shards(data, shape_2D, params.inputs.shard_shape);
-    // pretty_print_data_as_shards(physical_data, physical_size, physical_shard_shape);
+    // auto shape_2D = flatten_to_2D(tensor_spec.logical_shape());
+    // pretty_print_data_as_shards(logical_data, shape_2D, logical_shard_shape);
+    // pretty_print_data_as_shards(physical_data, physical_shape, physical_shard_shape);
 
     ASSERT_EQ(physical_data.size(), expected_physical_data.size());
     for (size_t i = 0; i < physical_data.size(); i++) {
@@ -279,28 +273,46 @@ TEST_P(ShardWithAlignmentTests, LogicalToPhysical) {
 TEST_P(ShardWithAlignmentTests, PhysicalToLogical) {
     const auto& params = GetParam();
 
-    auto physical_shard_height = tt::round_up(params.inputs.shard_shape.height(), params.inputs.shard_alignment[0]);
-    auto physical_shard_width = tt::round_up(params.inputs.shard_shape.width(), params.inputs.shard_alignment[1]);
-    Size physical_shard_shape{physical_shard_height, physical_shard_width};
+    // Only shard shapes and shard mode matters for this test
+    auto shard_spec = params.inputs.physical_shard_shape.has_value() ? ShardSpec(
+                                                                           CoreRangeSet{},
+                                                                           params.inputs.logical_shard_shape,
+                                                                           params.inputs.physical_shard_shape.value(),
+                                                                           ShardOrientation::ROW_MAJOR,
+                                                                           false)
+                                                                     : ShardSpec(
+                                                                           CoreRangeSet{},
+                                                                           params.inputs.logical_shard_shape,
+                                                                           ShardOrientation::ROW_MAJOR,
+                                                                           false,
+                                                                           ShardMode::LOGICAL);
+    MemoryConfig memory_config{
+        .memory_layout = TensorMemoryLayout::HEIGHT_SHARDED, .buffer_type = BufferType::L1, .shard_spec = shard_spec};
+    auto tensor_layout = TensorLayout(DataType::BFLOAT16, params.inputs.page_config, memory_config);
+    auto tensor_spec = TensorSpec(params.inputs.shape, tensor_layout);
+
+    auto logical_shard_shape = tensor_layout.get_logical_shard_shape();
+    ASSERT_EQ(logical_shard_shape, params.inputs.logical_shard_shape);
+
+    auto physical_shard_shape = tensor_layout.get_physical_shard_shape();
     ASSERT_EQ(physical_shard_shape, params.expected.physical_shard_shape);
 
-    auto physical_size = get_physical_shape(params.inputs.shape, params.inputs.shard_shape, physical_shard_shape);
-    ASSERT_EQ(physical_size, params.expected.physical_size);
+    auto physical_shape = tensor_spec.physical_shape();
+    ASSERT_EQ(physical_shape, params.expected.physical_shape);
 
     // Use expected value as input physical data
     const auto& physical_data = params.expected.physical_data;
-    const auto& expected_data = params.inputs.data;
+    const auto& expected_data = params.inputs.logical_data;
 
-    auto data = convert_fp32_physical_data_to_logical_data(
-        physical_data, params.inputs.shape, params.inputs.shard_shape, physical_shard_shape);
+    auto logical_data = convert_fp32_physical_data_to_logical_data(physical_data, tensor_spec);
 
-    // auto shape_2D = flatten_to_2D(params.inputs.shape);
-    // pretty_print_data_as_shards(physical_data, physical_size, physical_shard_shape);
-    // pretty_print_data_as_shards(data, shape_2D, params.inputs.shard_shape);
+    // auto shape_2D = flatten_to_2D(tensor_spec.logical_shape());
+    // pretty_print_data_as_shards(physical_data, physical_shape, physical_shard_shape);
+    // pretty_print_data_as_shards(logical_data, shape_2D, logical_shard_shape);
 
-    ASSERT_EQ(data.size(), expected_data.size());
-    for (size_t i = 0; i < data.size(); i++) {
-        EXPECT_EQ(data[i], expected_data[i]);
+    ASSERT_EQ(logical_data.size(), expected_data.size());
+    for (size_t i = 0; i < logical_data.size(); i++) {
+        EXPECT_EQ(logical_data[i], expected_data[i]);
     }
 }
 
@@ -314,9 +326,10 @@ INSTANTIATE_TEST_SUITE_P(
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 15, 20},
-                .shard_shape = {15, 20},
-                .shard_alignment = Alignment({16, 16}),
-                .data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
+                .logical_shard_shape = Size{15, 20},
+                .physical_shard_shape = std::nullopt,
+                .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
+                .logical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
                           20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
                           40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
                           60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
@@ -349,8 +362,8 @@ INSTANTIATE_TEST_SUITE_P(
                          580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597, 598, 599}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {16, 32},
-                .physical_size = {32, 32},
+                .physical_shard_shape = Size{16, 32},
+                .physical_shape = Size{32, 32},
                 .physical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
                                    20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
                                    40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
@@ -391,9 +404,10 @@ INSTANTIATE_TEST_SUITE_P(
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 1, 15, 15},
-                .shard_shape = {5, 15},
-                .shard_alignment = Alignment({16, 16}),
-                .data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
+                .logical_shard_shape = Size{5, 15},
+                .physical_shard_shape = std::nullopt,
+                .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
+                .logical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
                           15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
                           30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
                           45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
@@ -412,8 +426,8 @@ INSTANTIATE_TEST_SUITE_P(
                          210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {16, 16},
-                .physical_size = {48, 16},
+                .physical_shard_shape = Size{16, 16},
+                .physical_shape = Size{48, 16},
                 .physical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,   0,
                                    15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,   0,
                                    30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,   0,
@@ -470,9 +484,10 @@ INSTANTIATE_TEST_SUITE_P(
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 5, 20},
-                .shard_shape = {10, 10},
-                .shard_alignment = Alignment({16, 16}),
-                .data = { 0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  /**/  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
+                .logical_shard_shape = Size{10, 10},
+                .physical_shard_shape = std::nullopt,
+                .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
+                .logical_data = { 0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  /**/  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
                          20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  /**/  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
                          40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
                          60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  /**/  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
@@ -484,8 +499,8 @@ INSTANTIATE_TEST_SUITE_P(
                         180, 181, 182, 183, 184, 185, 186, 187, 188, 189,  /**/ 190, 191, 192, 193, 194, 195, 196, 197, 198, 199}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {16, 16},
-                .physical_size = {16, 32},
+                .physical_shard_shape = Size{16, 16},
+                .physical_shape = Size{16, 32},
                 .physical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   0,   0,   0,   0,   0,  /**/  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,   0,   0,   0,   0,   0,   0,
                                    20,  21,  22,  23,  24,  25,  26,  27,  28,  29,   0,   0,   0,   0,   0,   0,  /**/  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,   0,   0,   0,   0,   0,   0,
                                    40,  41,  42,  43,  44,  45,  46,  47,  48,  49,   0,   0,   0,   0,   0,   0,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,   0,   0,   0,   0,   0,   0,
@@ -504,13 +519,107 @@ INSTANTIATE_TEST_SUITE_P(
                                     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0}
             }
         },
+        // TILE block sharded with alignment up to nearest page instead of physical shard shape in last row/col
+        ShardWithAlignmentParams{
+            ShardWithAlignmentInputs{
+                .shape = SimpleShape{1, 1, 30, 30},
+                .logical_shard_shape = Size{18, 20},
+                .physical_shard_shape = std::nullopt,
+                .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
+                .logical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  /**/  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+                          30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+                          60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  /**/  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
+                          90,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,  /**/ 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+                         120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,  /**/ 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+                         150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169,  /**/ 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+                         180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,  /**/ 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
+                         210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229,  /**/ 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+                         240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259,  /**/ 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
+                         270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289,  /**/ 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,
+                         300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319,  /**/ 320, 321, 322, 323, 324, 325, 326, 327, 328, 329,
+                         330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349,  /**/ 350, 351, 352, 353, 354, 355, 356, 357, 358, 359,
+                         360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379,  /**/ 380, 381, 382, 383, 384, 385, 386, 387, 388, 389,
+                         390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409,  /**/ 410, 411, 412, 413, 414, 415, 416, 417, 418, 419,
+                         420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439,  /**/ 440, 441, 442, 443, 444, 445, 446, 447, 448, 449,
+                         450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469,  /**/ 470, 471, 472, 473, 474, 475, 476, 477, 478, 479,
+                         480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499,  /**/ 500, 501, 502, 503, 504, 505, 506, 507, 508, 509,
+                         510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529,  /**/ 530, 531, 532, 533, 534, 535, 536, 537, 538, 539,
+
+                         540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559,  /**/ 560, 561, 562, 563, 564, 565, 566, 567, 568, 569,
+                         570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589,  /**/ 590, 591, 592, 593, 594, 595, 596, 597, 598, 599,
+                         600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619,  /**/ 620, 621, 622, 623, 624, 625, 626, 627, 628, 629,
+                         630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649,  /**/ 650, 651, 652, 653, 654, 655, 656, 657, 658, 659,
+                         660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679,  /**/ 680, 681, 682, 683, 684, 685, 686, 687, 688, 689,
+                         690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709,  /**/ 710, 711, 712, 713, 714, 715, 716, 717, 718, 719,
+                         720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739,  /**/ 740, 741, 742, 743, 744, 745, 746, 747, 748, 749,
+                         750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769,  /**/ 770, 771, 772, 773, 774, 775, 776, 777, 778, 779,
+                         780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799,  /**/ 800, 801, 802, 803, 804, 805, 806, 807, 808, 809,
+                         810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829,  /**/ 830, 831, 832, 833, 834, 835, 836, 837, 838, 839,
+                         840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859,  /**/ 860, 861, 862, 863, 864, 865, 866, 867, 868, 869,
+                         870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 889,  /**/ 890, 891, 892, 893, 894, 895, 896, 897, 898, 899}
+            },
+            ShardWithAlignmentExpected{
+                .physical_shard_shape = Size{32, 32},
+                .physical_shape = Size{48, 48},
+                .physical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,   0,   0,   0,   0,   0,   0,
+                                   30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,   0,   0,   0,   0,   0,   0,
+                                   60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,   0,   0,   0,   0,   0,   0,
+                                   90,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,   0,   0,   0,   0,   0,   0,
+                                  120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,   0,   0,   0,   0,   0,   0,
+                                  150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,   0,   0,   0,   0,   0,   0,
+                                  180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,   0,   0,   0,   0,   0,   0,
+                                  210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,   0,   0,   0,   0,   0,   0,
+                                  240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,   0,   0,   0,   0,   0,   0,
+                                  270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,   0,   0,   0,   0,   0,   0,
+                                  300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 320, 321, 322, 323, 324, 325, 326, 327, 328, 329,   0,   0,   0,   0,   0,   0,
+                                  330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 350, 351, 352, 353, 354, 355, 356, 357, 358, 359,   0,   0,   0,   0,   0,   0,
+                                  360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 380, 381, 382, 383, 384, 385, 386, 387, 388, 389,   0,   0,   0,   0,   0,   0,
+                                  390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 410, 411, 412, 413, 414, 415, 416, 417, 418, 419,   0,   0,   0,   0,   0,   0,
+                                  420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 440, 441, 442, 443, 444, 445, 446, 447, 448, 449,   0,   0,   0,   0,   0,   0,
+                                  450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 470, 471, 472, 473, 474, 475, 476, 477, 478, 479,   0,   0,   0,   0,   0,   0,
+                                  480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 500, 501, 502, 503, 504, 505, 506, 507, 508, 509,   0,   0,   0,   0,   0,   0,
+                                  510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 530, 531, 532, 533, 534, 535, 536, 537, 538, 539,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+
+                                  540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 560, 561, 562, 563, 564, 565, 566, 567, 568, 569,   0,   0,   0,   0,   0,   0,
+                                  570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 590, 591, 592, 593, 594, 595, 596, 597, 598, 599,   0,   0,   0,   0,   0,   0,
+                                  600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 620, 621, 622, 623, 624, 625, 626, 627, 628, 629,   0,   0,   0,   0,   0,   0,
+                                  630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 650, 651, 652, 653, 654, 655, 656, 657, 658, 659,   0,   0,   0,   0,   0,   0,
+                                  660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 680, 681, 682, 683, 684, 685, 686, 687, 688, 689,   0,   0,   0,   0,   0,   0,
+                                  690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 710, 711, 712, 713, 714, 715, 716, 717, 718, 719,   0,   0,   0,   0,   0,   0,
+                                  720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 740, 741, 742, 743, 744, 745, 746, 747, 748, 749,   0,   0,   0,   0,   0,   0,
+                                  750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 770, 771, 772, 773, 774, 775, 776, 777, 778, 779,   0,   0,   0,   0,   0,   0,
+                                  780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 800, 801, 802, 803, 804, 805, 806, 807, 808, 809,   0,   0,   0,   0,   0,   0,
+                                  810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 830, 831, 832, 833, 834, 835, 836, 837, 838, 839,   0,   0,   0,   0,   0,   0,
+                                  840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 860, 861, 862, 863, 864, 865, 866, 867, 868, 869,   0,   0,   0,   0,   0,   0,
+                                  870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 889,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/ 890, 891, 892, 893, 894, 895, 896, 897, 898, 899,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+                                    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  /**/   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0}
+            }
+        },
         // RM interleaved is equivalent to setting logical shard size to 1 by 1
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 5, 1},
-                .shard_shape = {1, 1},
-                .shard_alignment = Alignment({1, 4}),
-                .data = {  0,
+                .logical_shard_shape = Size{1, 1},
+                .physical_shard_shape = std::nullopt,
+                .page_config = PageConfig(Layout::ROW_MAJOR),
+                .logical_data = {  0,
 
                            1,
 
@@ -531,36 +640,37 @@ INSTANTIATE_TEST_SUITE_P(
                            9}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {1, 4},
-                .physical_size = {10, 4},
-                .physical_data = {  0,   0,   0,   0,
+                .physical_shard_shape = Size{1, 1},
+                .physical_shape = Size{10, 1},
+                .physical_data = {  0,
 
-                                    1,   0,   0,   0,
+                                    1,
 
-                                    2,   0,   0,   0,
+                                    2,
 
-                                    3,   0,   0,   0,
+                                    3,
 
-                                    4,   0,   0,   0,
+                                    4,
 
-                                    5,   0,   0,   0,
+                                    5,
 
-                                    6,   0,   0,   0,
+                                    6,
 
-                                    7,   0,   0,   0,
+                                    7,
 
-                                    8,   0,   0,   0,
+                                    8,
 
-                                    9,   0,   0,   0}
+                                    9}
             }
         },
-        // RM height sharded with padding along width to align shards
+        // RM height sharded with padding along width to arbitrary shard width
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 5, 1},
-                .shard_shape = {3, 1},
-                .shard_alignment = Alignment({1, 4}),
-                .data = {  0,
+                .logical_shard_shape = Size{3, 1},
+                .physical_shard_shape = Size{3, 4},
+                .page_config = PageConfig(Layout::ROW_MAJOR),
+                .logical_data = {  0,
                            1,
                            2,
 
@@ -575,8 +685,8 @@ INSTANTIATE_TEST_SUITE_P(
                            9}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {3, 4},
-                .physical_size = {12, 4},
+                .physical_shard_shape = Size{3, 4},
+                .physical_shape = Size{12, 4},
                 .physical_data = {  0,   0,   0,   0,
                                     1,   0,   0,   0,
                                     2,   0,   0,   0,
@@ -594,13 +704,14 @@ INSTANTIATE_TEST_SUITE_P(
                                     0,   0,   0,   0}
             }
         },
-        // RM width sharded with padding along width to align shards
+        // RM width sharded with padding along width to arbitrary shard width
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 5, 10},
-                .shard_shape = {10, 3},
-                .shard_alignment = Alignment({1, 4}),
-                .data = {  0,   1,   2,  /**/   3,   4,   5,  /**/   6,   7,   8,  /**/   9,
+                .logical_shard_shape = Size{10, 3},
+                .physical_shard_shape = Size{10, 4},
+                .page_config = PageConfig(Layout::ROW_MAJOR),
+                .logical_data = {  0,   1,   2,  /**/   3,   4,   5,  /**/   6,   7,   8,  /**/   9,
                           10,  11,  12,  /**/  13,  14,  15,  /**/  16,  17,  18,  /**/  19,
                           20,  21,  22,  /**/  23,  24,  25,  /**/  26,  27,  28,  /**/  29,
                           30,  31,  32,  /**/  33,  34,  35,  /**/  36,  37,  38,  /**/  39,
@@ -612,8 +723,8 @@ INSTANTIATE_TEST_SUITE_P(
                           90,  91,  92,  /**/  93,  94,  95,  /**/  96,  97,  98,  /**/  99}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {10, 4},
-                .physical_size = {10, 16},
+                .physical_shard_shape = Size{10, 4},
+                .physical_shape = Size{10, 16},
                 .physical_data = {  0,   1,   2,   0,  /**/   3,   4,   5,   0,  /**/   6,   7,   8,   0,  /**/   9,   0,   0,   0,
                                    10,  11,  12,   0,  /**/  13,  14,  15,   0,  /**/  16,  17,  18,   0,  /**/  19,   0,   0,   0,
                                    20,  21,  22,   0,  /**/  23,  24,  25,   0,  /**/  26,  27,  28,   0,  /**/  29,   0,   0,   0,
@@ -630,9 +741,10 @@ INSTANTIATE_TEST_SUITE_P(
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
                 .shape = SimpleShape{1, 2, 10, 10},
-                .shard_shape = {3, 4},
-                .shard_alignment = Alignment({5, 7}),
-                .data = {  0,   1,   2,   3,  /**/   4,   5,   6,   7,  /**/   8,   9,
+                .logical_shard_shape = Size{3, 4},
+                .physical_shard_shape = Size{5, 7},
+                .page_config = PageConfig(Layout::ROW_MAJOR),
+                .logical_data = {  0,   1,   2,   3,  /**/   4,   5,   6,   7,  /**/   8,   9,
                           10,  11,  12,  13,  /**/  14,  15,  16,  17,  /**/  18,  19,
                           20,  21,  22,  23,  /**/  24,  25,  26,  27,  /**/  28,  29,
 
@@ -660,8 +772,8 @@ INSTANTIATE_TEST_SUITE_P(
                          190, 191, 192, 193,  /**/ 194, 195, 196, 197,  /**/ 198, 199}
             },
             ShardWithAlignmentExpected{
-                .physical_shard_shape = {5, 7},
-                .physical_size = {35, 21},
+                .physical_shard_shape = Size{5, 7},
+                .physical_shape = Size{35, 21},
                 .physical_data = { 0,   1,   2,   3,   0,   0,   0,  /**/   4,   5,   6,   7,   0,   0,   0,  /**/   8,   9,   0,   0,   0,   0,   0,
                                   10,  11,  12,  13,   0,   0,   0,  /**/  14,  15,  16,  17,   0,   0,   0,  /**/  18,  19,   0,   0,   0,   0,   0,
                                   20,  21,  22,  23,   0,   0,   0,  /**/  24,  25,  26,  27,   0,   0,   0,  /**/  28,  29,   0,   0,   0,   0,   0,
@@ -720,7 +832,7 @@ struct CreateShardedTensorWithAlignmentInputs {
 };
 
 struct CreateShardedTensorWithAlignmentExpected {
-    Size physical_size;
+    Size physical_shape;
 };
 
 struct CreateShardedTensorWithAlignmentParams {
@@ -741,7 +853,7 @@ TEST_P(CreateShardedTensorWithAlignmentTests, AllocateTensor) {
 
     test_utils::test_tensor_on_device(input_shape, layout, device_);
 
-    EXPECT_EQ(layout.compute_physical_shape(input_shape), params.expected.physical_size);
+    EXPECT_EQ(layout.compute_physical_shape(input_shape), params.expected.physical_shape);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -772,7 +884,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{3584, 32}
+                .physical_shape = Size{3584, 32}
             }
         },
         // Example 1b: Logical shard shape that is already aligned
@@ -796,7 +908,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{2688, 32}
+                .physical_shape = Size{2688, 32}
             }
         },
         // Example 1c: For interleaved, we treat entire height/width as "logical shard shape" for calculations
@@ -814,7 +926,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{3072, 32}
+                .physical_shape = Size{3072, 32}
             }
         },
         /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -842,7 +954,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{20, 5}
+                .physical_shape = Size{20, 5}
             }
         },
         // Example 2b: Logical shard shape that is already aligned
@@ -866,7 +978,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{20, 8}
+                .physical_shape = Size{20, 8}
             }
         },
         // Example 2c: For interleaved, we treat entire height/width as "logical shard shape" for calculations
@@ -884,7 +996,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{20, 5}
+                .physical_shape = Size{20, 5}
             }
         },
         ////////////////////////////////////////////////////////////////////
@@ -911,7 +1023,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{384, 192}
+                .physical_shape = Size{384, 192}
             }
         },
         // Example 3b: ROW_MAJOR block sharded tensor with 2 and 1 extra rows and col per shard, respectively
@@ -935,7 +1047,7 @@ INSTANTIATE_TEST_SUITE_P(
                     }
             },
             CreateShardedTensorWithAlignmentExpected{
-                .physical_size = Size{28, 9}
+                .physical_shape = Size{28, 9}
             }
         }
     )  // Values

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.cpp
@@ -149,7 +149,7 @@ std::optional<ShardSpecBuffer> TensorLayout::compute_shard_spec_buffer(const ttn
     switch (shard_spec.mode) {
         case ShardMode::PHYSICAL: break;
         case ShardMode::LOGICAL: {
-            const auto& physical_shard_shape = compute_physical_shard_shape(shard_spec.shape);
+            const auto& physical_shard_shape = get_physical_shard_shape();
             shard_spec.shape = physical_shard_shape;
             break;
         }
@@ -190,29 +190,48 @@ size_t TensorLayout::compute_page_size_bytes(const Size& page_size) const {
     return page_config_.get_page_size_bytes(page_size, dtype_);
 }
 
-Size TensorLayout::compute_physical_shard_shape(const Size& logical_shard_shape) const {
+Size TensorLayout::get_logical_shard_shape() const {
     TT_FATAL(
-        memory_config_.shard_spec.has_value() and memory_config_.shard_spec.value().mode == ShardMode::LOGICAL,
-        "TensorLayout must be logically sharded for compute_physical_shard_shape!");
-    const auto& shard_spec = memory_config_.shard_spec.value();
-    // TODO: If physical_shard_shape is provided, alignment_ == physical_shard_shape is guaranteed (should we store
-    // physical_shard_shape instead?)
-    if (shard_spec.physical_shard_shape.has_value()) {
-        const auto& physical_shard_shape = shard_spec.physical_shard_shape.value();
-        TT_FATAL(
-            physical_shard_shape[0] == alignment_[-2] and physical_shard_shape[1] == alignment_[-1],
-            "Alignment {} must be same as physical shard shape {} provided in shard spec!",
-            alignment_,
-            physical_shard_shape);
-        return physical_shard_shape;
-    }
+        memory_config_.shard_spec.has_value(), "Shard spec must have value for TensorLayout::get_logical_shard_shape!");
 
-    // TODO: Alignment is guaranteed to be rank 2 or less if tensor is sharded (remove validate?)
-    const int alignment_rank = static_cast<int>(alignment_.size());
-    TT_FATAL(alignment_rank <= 2, "Alignment {} must be rank 2 or less to compute physical shard shape", alignment_);
-    auto physical_shard_height = CMAKE_UNIQUE_NAMESPACE::round_up(logical_shard_shape.height(), alignment_[-2]);
-    auto physical_shard_width = CMAKE_UNIQUE_NAMESPACE::round_up(logical_shard_shape.width(), alignment_[-1]);
-    return Size{physical_shard_height, physical_shard_width};
+    // Shape in shard spec will always represent logical shard shape in either mode
+    return Size(memory_config_.shard_spec.value().shape);
+}
+
+Size TensorLayout::get_physical_shard_shape() const {
+    TT_FATAL(
+        memory_config_.shard_spec.has_value(),
+        "Shard spec must have value for TensorLayout::get_physical_shard_shape!");
+    const auto& shard_spec = memory_config_.shard_spec.value();
+
+    auto compute_physical_shard_shape_for_logical_mode = [&]() -> Size {
+        // TODO: If physical_shard_shape is provided, alignment_ == physical_shard_shape is guaranteed (should we store
+        // physical_shard_shape instead?)
+        if (shard_spec.physical_shard_shape.has_value()) {
+            const auto& physical_shard_shape = shard_spec.physical_shard_shape.value();
+            TT_FATAL(
+                physical_shard_shape[0] == alignment_[-2] and physical_shard_shape[1] == alignment_[-1],
+                "Alignment {} must be same as physical shard shape {} provided in shard spec!",
+                alignment_,
+                physical_shard_shape);
+            return physical_shard_shape;
+        }
+
+        const auto& logical_shard_shape = Size(shard_spec.shape);
+        // TODO: Alignment is guaranteed to be rank 2 or less if tensor is sharded (remove validate?)
+        const int alignment_rank = static_cast<int>(alignment_.size());
+        TT_FATAL(
+            alignment_rank <= 2, "Alignment {} must be rank 2 or less to compute physical shard shape", alignment_);
+        auto physical_shard_height = CMAKE_UNIQUE_NAMESPACE::round_up(logical_shard_shape.height(), alignment_[-2]);
+        auto physical_shard_width = CMAKE_UNIQUE_NAMESPACE::round_up(logical_shard_shape.width(), alignment_[-1]);
+        return Size{physical_shard_height, physical_shard_width};
+    };
+
+    switch (shard_spec.mode) {
+        case ShardMode::PHYSICAL: return shard_spec.shape; break;
+        case ShardMode::LOGICAL: return compute_physical_shard_shape_for_logical_mode(); break;
+        default: TT_THROW("Unsupported shard mode {} in get_physical_shard_shape!", shard_spec.mode);
+    }
 }
 
 Size TensorLayout::compute_physical_shape(const ttnn::SimpleShape& shape) const {
@@ -230,8 +249,8 @@ Size TensorLayout::compute_physical_shape(const ttnn::SimpleShape& shape) const 
             dim *= shape[i];
         }
 
-        const auto& logical_shard_shape = Size(memory_config_.shard_spec.value().shape);
-        const auto& physical_shard_shape = compute_physical_shard_shape(logical_shard_shape);
+        const auto& logical_shard_shape = get_logical_shard_shape();
+        const auto& physical_shard_shape = get_physical_shard_shape();
 
         auto get_physical_size =
             [](auto original_size, auto logical_shard_size, auto physical_shard_size, auto alignment) -> uint32_t {
@@ -284,12 +303,7 @@ Size TensorLayout::compute_physical_shape(const ttnn::SimpleShape& shape) const 
 Size TensorLayout::compute_page_shape(const Size& physical_size) const {
     std::optional<Size> physical_shard_shape = std::nullopt;
     if (memory_config_.shard_spec.has_value()) {
-        const auto& shard_spec = memory_config_.shard_spec.value();
-        switch (shard_spec.mode) {
-            case ShardMode::PHYSICAL: physical_shard_shape = shard_spec.shape; break;
-            case ShardMode::LOGICAL: physical_shard_shape = compute_physical_shard_shape(shard_spec.shape); break;
-            default: TT_THROW("Unsupported shard mode {} in compute_shard_spec_buffer!", shard_spec.mode);
-        }
+        physical_shard_shape = get_physical_shard_shape();
     }
 
     return page_config_.get_page_shape(physical_size, dtype_, memory_config_, physical_shard_shape);

--- a/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/cpp/ttnn/tensor/layout/tensor_layout.hpp
@@ -55,6 +55,12 @@ public:
     //  H is all dimensions except W multiplied and aligned to tile and shard height
     Size compute_physical_shape(const ttnn::SimpleShape& shape) const;
 
+    // Returns logical shard shape from shard spec shape
+    Size get_logical_shard_shape() const;
+
+    // Returns physical shard shape based on ShardMode, shard shape, and alignment
+    Size get_physical_shard_shape() const;
+
     TensorLayout with_memory_config(MemoryConfig memory_config) const {
         TensorLayout result = *this;
         result.memory_config_ = std::move(memory_config);
@@ -79,7 +85,6 @@ private:
 
     Size compute_page_shape(const Size& physical_size) const;
     size_t compute_page_size_bytes(const Size& page_size) const;
-    Size compute_physical_shard_shape(const Size& logical_shard_shape) const;
 
     DataType dtype_ = DataType::BFLOAT16;
     PageConfig page_config_;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Physical shard shape is something that should be exposed by tensor layout.

### What's changed
- Add support for ShardMode::PHYSICAL
- Remove input logical_shard_shape arg
- Refactor tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp to use tensor spec
  * Remove get_physical_shape and use implementation in tensor spec
  * Switch shard alignment to PageConfig or optional physical shard shape
  * Update RM examples since there is no longer a page alignment for width
  * Add example to test alignment to nearest page (and not full shard) for shards in last row/col

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12323136719
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
