### PR TITLE
#0: Update eltwise binary to support sharding on arbitrary cores on an arbitrary sub-device grid

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
@@ -7,9 +7,9 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.utility_functions import untilize, comp_pcc
-from models.utility_functions import is_grayskull
-from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
+from models.utility_functions import comp_pcc
+from models.utility_functions import is_grayskull, run_for_wormhole_b0
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
@@ -67,5 +67,116 @@ def test_run_elt_binary(dtype, test_func_name, torch_func_name, pre_in0_silu, de
         passing, output = comp_pcc(out, torch_func_name(torch_silu(in0), in1), 0.9999)
     else:
         passing, output = comp_pcc(out, torch_func_name(in0, in1), 0.9999)
+    logger.info(output)
+    assert passing
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
+def test_run_elt_binary_add_with_sub_devices(device):
+    unharvested_grid_size = (7, 10)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if unharvested_grid_size[0] > compute_grid_size.x or unharvested_grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {unharvested_grid_size} grid size to run this test but core grid is {compute_grid_size}")
+
+    shape = (1, 1, 32, 2048)
+    torch.manual_seed(10)
+
+    start_core = ttnn.CoreCoord(1, 0)
+    core_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+        ]
+    )
+    shard_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(start_core, 32, core_grid, row_wise=True)
+    shard_spec = ttnn.ShardSpec(shard_grid, (32, 64), ttnn.ShardOrientation.ROW_MAJOR, False)
+    output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    in0 = torch.randn(shape).bfloat16().float()
+    in1 = torch.randn(shape).bfloat16().float()
+    in0_t = ttnn.from_torch(
+        in0,
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    in1_t = ttnn.from_torch(
+        in0,
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=output_mem_config,
+    )
+    in1 = ttnn.to_torch(in1_t)
+
+    out_t = ttnn.add(in0_t, in1_t, dtype=ttnn.bfloat16, memory_config=output_mem_config)
+
+    out = ttnn.to_torch(out_t)
+
+    passing, output = comp_pcc(out, torch.add(in0, in1), 0.9999)
+    logger.info(output)
+    assert passing
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
+def test_run_elt_binary_mul_with_sub_devices(device):
+    unharvested_grid_size = (7, 10)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if unharvested_grid_size[0] > compute_grid_size.x or unharvested_grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {unharvested_grid_size} grid size to run this test but core grid is {compute_grid_size}")
+
+    shape = (1, 1, 32, 896)
+    torch.manual_seed(10)
+
+    start_core = ttnn.CoreCoord(1, 0)
+    core_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+        ]
+    )
+    shard_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(start_core, 28, core_grid, row_wise=True)
+    shard_spec = ttnn.ShardSpec(shard_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR, False)
+    output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+    in0 = torch.randn(shape).bfloat16().float()
+    in1 = torch.randn(shape).bfloat16().float()
+    in0_t = ttnn.from_torch(
+        in0,
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=output_mem_config,
+    )
+    in0 = ttnn.to_torch(in0_t)
+    in1_t = ttnn.from_torch(
+        in0,
+        device=device,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=output_mem_config,
+    )
+    in1 = ttnn.to_torch(in1_t)
+
+    out_t = ttnn.mul(
+        in0_t,
+        in1_t,
+        input_tensor_a_activation=ttnn.UnaryOpType.SILU,
+        dtype=ttnn.bfloat8_b,
+        memory_config=output_mem_config,
+    )
+
+    out = ttnn.to_torch(out_t)
+    torch_silu = torch.nn.SiLU()
+    passing, output = comp_pcc(out, torch.mul(torch_silu(in0), in1), 0.999)
     logger.info(output)
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -330,7 +330,7 @@ def run_test_sdpa_decode_single_iter(
             pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
     else:
         unharvested_grid_size = (7, 10)
-        if compute_grid_size.x > unharvested_grid_size[0] or compute_grid_size.y > unharvested_grid_size[1]:
+        if unharvested_grid_size[0] > compute_grid_size.x or unharvested_grid_size[1] > compute_grid_size.y:
             pytest.skip(f"Need {unharvested_grid_size} grid size to run this test but core grid is {compute_grid_size}")
         if grid_size[0] * grid_size[1] > sub_core_grids.num_cores():
             pytest.skip(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -515,3 +515,73 @@ def test_01_volume_tensors(device, data, memory_config):
     c = ttnn.to_torch(ttnn_c).reshape((-1))
 
     assert c.tolist() == c_golden
+
+
+@pytest.mark.parametrize("input_a_sharded", [True, False])
+@pytest.mark.parametrize("input_b_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_add_with_sub_devices(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    shape = (1, 1, 1024, 1024)
+    torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand(shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        shard_shape = (1024 // 8, 1024)
+    else:
+        shard_shape = (1024, 1024 // 8)
+
+    core_range_set = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(2, 2), ttnn.CoreCoord(3, 3)),
+            ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(1, 1)),
+            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(4, 2)),
+        ]
+    )
+
+    height_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=shard_shape,
+        core_grid=core_range_set,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output_tensor = torch_input_tensor_a + torch_input_tensor_b
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    if input_a_sharded:
+        input_tensor_a = ttnn.to_memory_config(input_tensor_a, height_sharded_mem_config)
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    if input_b_sharded:
+        input_tensor_b = ttnn.to_memory_config(input_tensor_b, height_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = height_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    sub_device = ttnn.SubDevice(
+        [
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(4, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(5, 0)),
+                ]
+            )
+        ]
+    )
+    sub_device_manager_id = device.create_sub_device_manager([sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager_id)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988
+    assert output_tensor.shape == shape

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -93,6 +93,7 @@ def test_pytorch_2_0_failed_cases(device, m, k, n):
     assert_with_pcc(z_t, z)
 
 
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [256])

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -522,6 +522,30 @@ std::vector<CoreCoord> grid_to_cores_with_noop(
     return cores;
 }
 
+// Noop cores are appended at the end with no guarantees on ordering
+std::vector<CoreCoord> grid_to_cores_with_noop(
+    const CoreRangeSet& used_cores, const CoreRangeSet& all_cores, const bool row_wise) {
+    ZoneScoped;
+    TT_ASSERT(all_cores.contains(used_cores));
+    // Most likely a lot of optimizations to do here
+    // Implemented this way for simplicity for now
+    std::vector<CoreCoord> cores;
+    cores.reserve(all_cores.num_cores());
+    cores = corerange_to_cores(used_cores, std::nullopt, row_wise);
+    std::vector<CoreCoord> all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_wise);
+    auto sorted_used_cores = cores;
+    std::sort(sorted_used_cores.begin(), sorted_used_cores.end());
+    std::sort(all_cores_vec.begin(), all_cores_vec.end());
+    std::set_difference(
+        all_cores_vec.begin(),
+        all_cores_vec.end(),
+        sorted_used_cores.begin(),
+        sorted_used_cores.end(),
+        std::back_inserter(cores));
+
+    return cores;
+}
+
 std::vector<CoreCoord> corerange_to_cores(const CoreRangeSet& crs, std::optional<uint32_t> max_cores, bool row_wise) {
     std::vector<CoreCoord> all_cores;
     auto num_cores = crs.num_cores();

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -191,6 +191,10 @@ std::vector<CoreCoord> grid_to_cores_with_noop(
     const uint32_t grid_size_y,
     const bool row_wise = false);
 
+// Noop cores are appended at the end with no guarantees on ordering
+std::vector<CoreCoord> grid_to_cores_with_noop(
+    const CoreRangeSet& used_cores, const CoreRangeSet& all_cores, const bool row_wise = false);
+
 std::vector<CoreCoord> corerange_to_cores(
     const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false);
 

--- a/tt_metal/common/core_descriptor.cpp
+++ b/tt_metal/common/core_descriptor.cpp
@@ -10,15 +10,13 @@ namespace tt {
 
 const core_descriptor_t& get_core_descriptor_config(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    // {arch : {product : {num hardware command queues : config}}}
-    static std::unordered_map<ARCH, std::unordered_map<std::string, std::unordered_map<uint8_t, core_descriptor_t>>>
+    // {arch : {product : {dispatch core axis: {num hardware command queues : config}}}}
+    static std::unordered_map<
+        ARCH,
+        std::unordered_map<
+            std::string,
+            std::unordered_map<tt_metal::DispatchCoreConfig, std::unordered_map<uint8_t, core_descriptor_t>>>>
         config_by_arch;
-    // TODO: is there a better way to do this?
-    static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
-        config_by_arch.clear();
-        previous_dispatch_core_type = dispatch_core_config.get_core_type();
-    }
 
     ARCH arch = tt::Cluster::instance().arch();
     uint32_t harvesting_mask = tt::Cluster::instance().get_harvested_rows(device_id);
@@ -45,14 +43,11 @@ const core_descriptor_t& get_core_descriptor_config(
         }
     }
 
-    if (config_by_arch.count(arch) and config_by_arch.at(arch).count(product_name) and
-        config_by_arch.at(arch).at(product_name).count(num_hw_cqs)) {
-        return config_by_arch.at(arch).at(product_name).at(num_hw_cqs);
+    std::unordered_map<uint8_t, core_descriptor_t>& config_by_num_cqs =
+        config_by_arch[arch][product_name][dispatch_core_config];
+    if (config_by_num_cqs.count(num_hw_cqs)) {
+        return config_by_num_cqs.at(num_hw_cqs);
     }
-
-    std::unordered_map<std::string, std::unordered_map<uint8_t, core_descriptor_t>>& config_by_product =
-        config_by_arch[arch];
-    std::unordered_map<uint8_t, core_descriptor_t>& config_by_num_cqs = config_by_product[product_name];
 
     YAML::Node core_descriptor_yaml = YAML::LoadFile(get_core_descriptor_file(arch, dispatch_core_config));
     YAML::Node desc_yaml =
@@ -123,30 +118,61 @@ const core_descriptor_t& get_core_descriptor_config(
     }
     TT_ASSERT(dispatch_cores.size() || std::getenv("TT_METAL_SIMULATOR_EN"), "Dispatch cores size must be positive");
 
-    config_by_num_cqs[num_hw_cqs] = core_descriptor_t{
-        .compute_grid_size = compute_grid_size,
-        .relative_compute_cores = compute_cores,
-        .relative_storage_cores = storage_cores,
-        .storage_core_bank_size = storage_core_bank_size,
-        .relative_dispatch_cores = dispatch_cores,
-    };
-    return config_by_arch.at(arch).at(product_name).at(num_hw_cqs);
+    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
+
+    std::vector<CoreCoord> logical_compute_cores;
+    logical_compute_cores.reserve(compute_cores.size());
+    std::transform(
+        compute_cores.cbegin(),
+        compute_cores.cend(),
+        std::back_inserter(logical_compute_cores),
+        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
+
+    std::vector<CoreCoord> logical_storage_cores;
+    logical_storage_cores.reserve(storage_cores.size());
+    std::transform(
+        storage_cores.cbegin(),
+        storage_cores.cend(),
+        std::back_inserter(logical_storage_cores),
+        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
+
+    std::vector<CoreCoord> logical_dispatch_cores;
+    logical_dispatch_cores.reserve(dispatch_cores.size());
+    std::transform(
+        dispatch_cores.cbegin(),
+        dispatch_cores.cend(),
+        std::back_inserter(logical_dispatch_cores),
+        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
+
+    auto [it, _] = config_by_num_cqs.emplace(std::make_pair(
+        num_hw_cqs,
+        core_descriptor_t{
+            .compute_grid_size = std::move(compute_grid_size),
+            .relative_compute_cores = std::move(compute_cores),
+            .relative_storage_cores = std::move(storage_cores),
+            .storage_core_bank_size = std::move(storage_core_bank_size),
+            .relative_dispatch_cores = std::move(dispatch_cores),
+            .logical_compute_cores = std::move(logical_compute_cores),
+            .logical_storage_cores = std::move(logical_storage_cores),
+            .logical_dispatch_cores = std::move(logical_dispatch_cores),
+        }));
+    return it->second;
 }
 
 const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
-    chip_id_t chip, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
+    chip_id_t device_id, uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     // Get logical compute grid dimensions and num workers
     static std::unordered_map<uint32_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
     // Unique hash generated based on the config that's being queried
     uint32_t config_hash = ((uint8_t)(dispatch_core_config.get_core_type())) |
                            ((uint8_t)(dispatch_core_config.get_dispatch_core_axis()) << 4) | (num_hw_cqs << 8) |
-                           (chip << 16);
+                           (device_id << 16);
     if (physical_grid_config_cache.find(config_hash) == physical_grid_config_cache.end()) {
-        auto worker_grid = tt::get_compute_grid_size(chip, num_hw_cqs, dispatch_core_config);
+        auto worker_grid = tt::get_compute_grid_size(device_id, num_hw_cqs, dispatch_core_config);
         std::size_t tensix_num_worker_cols = worker_grid.x;
         std::size_t tensix_num_worker_rows = worker_grid.y;
         uint32_t tensix_num_worker_cores = tensix_num_worker_cols * tensix_num_worker_rows;
-        const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(chip);
+        const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
         // Get physical compute grid range based on SOC Desc and Logical Coords
         CoreCoord tensix_worker_start_phys = soc_desc.get_physical_core_from_logical_core(
             CoreCoord(0, 0), CoreType::WORKER);  // Logical Worker Coords start at 0,0

--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -17,6 +17,9 @@ struct core_descriptor_t {
     std::vector<RelativeCoreCoord> relative_storage_cores;
     std::optional<uint32_t> storage_core_bank_size = std::nullopt;
     std::vector<RelativeCoreCoord> relative_dispatch_cores;
+    std::vector<CoreCoord> logical_compute_cores;
+    std::vector<CoreCoord> logical_storage_cores;
+    std::vector<CoreCoord> logical_dispatch_cores;
 };
 
 inline std::string get_core_descriptor_file(
@@ -64,7 +67,7 @@ inline std::string get_core_descriptor_file(
     return "";
 }
 
-inline const std::string get_product_name(tt::ARCH arch, uint32_t num_harvested_rows) {
+inline const std::string& get_product_name(tt::ARCH arch, uint32_t num_harvested_rows) {
     const static std::map<tt::ARCH, std::map<uint32_t, std::string>> product_name = {
         {tt::ARCH::GRAYSKULL, {{0, "E150"}, {2, "E75"}}},
         {tt::ARCH::WORMHOLE_B0, {{0, "galaxy"}, {1, "nebula_x1"}, {2, "nebula_x2"}}},
@@ -95,29 +98,11 @@ inline std::optional<uint32_t> get_storage_core_bank_size(
 
 inline const std::vector<CoreCoord>& get_logical_storage_cores(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
-        logical_storage_cores_by_device;
-    static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
-        logical_storage_cores_by_device.clear();
-        previous_dispatch_core_type = dispatch_core_config.get_core_type();
-    }
-    auto& logical_storage_cores_by_cq = logical_storage_cores_by_device[device_id];
-    if (auto it = logical_storage_cores_by_cq.find(num_hw_cqs); it != logical_storage_cores_by_cq.end()) {
-        return it->second;
-    }
-    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
-    std::vector<CoreCoord>& logical_storage_cores = logical_storage_cores_by_cq[num_hw_cqs];
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    std::transform(
-        core_desc.relative_storage_cores.cbegin(),
-        core_desc.relative_storage_cores.cend(),
-        std::back_inserter(logical_storage_cores),
-        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
-    return logical_storage_cores;
+    return core_desc.logical_storage_cores;
 }
 
-inline CoreCoord get_compute_grid_size(
+inline const CoreCoord& get_compute_grid_size(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
     return core_desc.compute_grid_size;
@@ -125,50 +110,14 @@ inline CoreCoord get_compute_grid_size(
 
 inline const std::vector<CoreCoord>& get_logical_compute_cores(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
-        logical_compute_cores_by_device;
-    static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
-        logical_compute_cores_by_device.clear();
-        previous_dispatch_core_type = dispatch_core_config.get_core_type();
-    }
-    auto& logical_compute_cores_by_cq = logical_compute_cores_by_device[device_id];
-    if (auto it = logical_compute_cores_by_cq.find(num_hw_cqs); it != logical_compute_cores_by_cq.end()) {
-        return it->second;
-    }
-    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
-    std::vector<CoreCoord>& logical_compute_cores = logical_compute_cores_by_cq[num_hw_cqs];
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    std::transform(
-        core_desc.relative_compute_cores.cbegin(),
-        core_desc.relative_compute_cores.cend(),
-        std::back_inserter(logical_compute_cores),
-        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
-    return logical_compute_cores;
+    return core_desc.logical_compute_cores;
 }
 
 inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    static std::unordered_map<chip_id_t, std::unordered_map<uint8_t, std::vector<CoreCoord>>>
-        logical_dispatch_cores_by_device;
-    static CoreType previous_dispatch_core_type;
-    if (previous_dispatch_core_type != dispatch_core_config.get_core_type()) {
-        logical_dispatch_cores_by_device.clear();
-        previous_dispatch_core_type = dispatch_core_config.get_core_type();
-    }
-    auto& logical_dispatch_cores_by_cq = logical_dispatch_cores_by_device[device_id];
-    if (auto it = logical_dispatch_cores_by_cq.find(num_hw_cqs); it != logical_dispatch_cores_by_cq.end()) {
-        return it->second;
-    }
-    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).worker_grid_size;
-    std::vector<CoreCoord>& logical_dispatch_cores = logical_dispatch_cores_by_cq[num_hw_cqs];
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    std::transform(
-        core_desc.relative_dispatch_cores.cbegin(),
-        core_desc.relative_dispatch_cores.cend(),
-        std::back_inserter(logical_dispatch_cores),
-        [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
-    return logical_dispatch_cores;
+    return core_desc.logical_dispatch_cores;
 }
 
 }  // namespace tt

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -268,66 +268,146 @@ CoreRangeSet num_cores_to_corerangeset_in_subcoregrids(
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
     const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise) {
     ZoneScoped;
-    uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y;
-    auto target_num_cores = std::min(units_to_divide, num_cores_x * num_cores_y);
-    CoreRangeSet all_cores = num_cores_to_corerangeset(target_num_cores, grid_size, row_wise);
+    if (units_to_divide == 0) {
+        return std::make_tuple(0, CoreRangeSet(), CoreRangeSet(), CoreRangeSet(), 0, 0);
+    }
+    uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y, max_num_cores = num_cores_x * num_cores_y,
+             target_num_cores;
+    CoreRangeSet all_cores;
+    if (units_to_divide >= max_num_cores) {
+        target_num_cores = max_num_cores;
+        all_cores = CoreRangeSet(CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1}));
+    } else {
+        target_num_cores = units_to_divide;
+        all_cores = num_cores_to_corerangeset(target_num_cores, grid_size, row_wise);
+    }
 
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
-    uint32_t units_per_core_group_1 = target_num_cores == 0 ? 0 : units_to_divide / target_num_cores;
+    uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
     uint32_t units_per_core_group_2 = 0;
+    uint32_t num_cores_with_more_work = units_to_divide % target_num_cores;
     // Evenly divided units to all target cores
-    if (target_num_cores == 0 || units_to_divide % target_num_cores == 0) {
+    if (units_to_divide % target_num_cores == 0) {
         core_group_1 = all_cores;
-        // Uneven division of units across cores
-        // This case should only be hit when there are more units of work than a full grid of cores
-        // which is implicitly assumed in the following logic
-    } else {
+    }
+    // Uneven division of units across cores
+    // This case should only be hit when there are more units of work than a full grid of cores
+    // which is implicitly assumed in the following logic
+    else {
         // Group of cores that do more work
-        core_group_1 = num_cores_to_corerangeset(units_to_divide % target_num_cores, grid_size, row_wise);
-        const auto& last_block_group_1 = (*core_group_1.ranges().rbegin());
-        const auto& last_block_all_cores = (*all_cores.ranges().rbegin());
+        uint32_t num_core_group_1_cores = num_cores_with_more_work;
+        uint32_t num_core_group_2_cores = target_num_cores - num_core_group_1_cores;
+        core_group_1 = num_cores_to_corerangeset(num_core_group_1_cores, grid_size, row_wise);
+        const auto& last_core_group_1 = (*core_group_1.ranges().rbegin()).end_coord;
         if (row_wise) {
-            // Case where only the last row is divided between core group 1 and 2
-            if (last_block_group_1.end_coord.y == last_block_all_cores.end_coord.y &&
-                last_block_group_1.end_coord.x != last_block_all_cores.end_coord.x) {
-                CoreRange leftover_block(
-                    CoreCoord(last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y),
-                    last_block_all_cores.end_coord);
-                core_group_2 = CoreRangeSet(leftover_block);
-            } else {
-                std::vector<CoreRange> core_group_2_set;
-                // Case where a middle row is divided between core group 1 and 2
-                if (last_block_group_1.end_coord.x != num_cores_x - 1) {
-                    core_group_2_set.emplace_back(
-                        CoreCoord(last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y),
-                        CoreCoord(num_cores_x - 1, last_block_group_1.end_coord.y));
-                }
-                // Remaining rows of cores that does less work
-                core_group_2_set.emplace_back(
-                    CoreCoord(0, last_block_group_1.end_coord.y + 1), last_block_all_cores.end_coord);
-                core_group_2 = CoreRangeSet(std::move(core_group_2_set));
+            // Start in the same row
+            if (last_core_group_1.x != num_cores_x - 1) {
+                core_group_2 = num_cores_to_corerangeset(
+                    {last_core_group_1.x + 1, last_core_group_1.y}, num_core_group_2_cores, grid_size, row_wise);
+            }
+            // Start in the next row
+            else {
+                core_group_2 = num_cores_to_corerangeset(
+                    {0, last_core_group_1.y + 1}, num_core_group_2_cores, grid_size, row_wise);
             }
         } else {
-            // Case where only the last column is divided between core group 1 and 2
-            if (last_block_group_1.end_coord.x == last_block_all_cores.end_coord.x &&
-                last_block_group_1.end_coord.y != last_block_all_cores.end_coord.y) {
-                CoreRange leftover_block(
-                    CoreCoord(last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1),
-                    last_block_all_cores.end_coord);
-                core_group_2 = CoreRangeSet(leftover_block);
-            } else {
-                std::vector<CoreRange> core_group_2_set;
-                // Case where a middle column is divided between core group 1 and 2
-                if (last_block_group_1.end_coord.y != num_cores_y - 1) {
-                    core_group_2_set.emplace_back(
-                        CoreCoord(last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1),
-                        CoreCoord(last_block_group_1.end_coord.x, num_cores_y - 1));
-                }
-                // Remaining columns of cores that does less work
-                core_group_2_set.emplace_back(
-                    CoreCoord(last_block_group_1.end_coord.x + 1, 0), last_block_all_cores.end_coord);
-                core_group_2 = CoreRangeSet(std::move(core_group_2_set));
+            // Start in the same column
+            if (last_core_group_1.y != num_cores_y - 1) {
+                core_group_2 = num_cores_to_corerangeset(
+                    {last_core_group_1.x, last_core_group_1.y + 1}, num_core_group_2_cores, grid_size, row_wise);
+            }
+            // Start in the next column
+            else {
+                core_group_2 = num_cores_to_corerangeset(
+                    {last_core_group_1.x + 1, 0}, num_core_group_2_cores, grid_size, row_wise);
+            }
+        }
+        units_per_core_group_2 = units_per_core_group_1;
+        units_per_core_group_1++;
+    }
+
+    return std::make_tuple(
+        target_num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2);
+}
+
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    const CoreRangeSet& core_grid, const uint32_t units_to_divide, const bool row_wise) {
+    ZoneScoped;
+    if (units_to_divide == 0) {
+        return std::make_tuple(0, CoreRangeSet(), CoreRangeSet(), CoreRangeSet(), 0, 0);
+    }
+    uint32_t max_num_cores = core_grid.num_cores(), target_num_cores;
+    TT_FATAL(max_num_cores > 0, "Core grid must contain at least one core");
+    auto start_core = core_grid.ranges().begin()->start_coord;
+    CoreRangeSet all_cores;
+    if (units_to_divide >= max_num_cores) {
+        target_num_cores = max_num_cores;
+        all_cores = core_grid;
+    } else {
+        target_num_cores = units_to_divide;
+        all_cores = num_cores_to_corerangeset_in_subcoregrids(start_core, target_num_cores, core_grid, row_wise);
+    }
+
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1 = units_to_divide / target_num_cores;
+    uint32_t units_per_core_group_2 = 0;
+    uint32_t num_cores_with_more_work = units_to_divide % target_num_cores;
+    // Evenly divided units to all target cores
+    if (target_num_cores == 0 || num_cores_with_more_work == 0) {
+        core_group_1 = all_cores;
+    }
+    // Uneven division of units across cores
+    // This case should only be hit when there are more units of work than a full grid of cores
+    // which is implicitly assumed in the following logic
+    else {
+        // Group of cores that do more work
+        uint32_t num_core_group_1_cores = num_cores_with_more_work;
+        uint32_t num_core_group_2_cores = target_num_cores - num_core_group_1_cores;
+        core_group_1 =
+            num_cores_to_corerangeset_in_subcoregrids(start_core, num_core_group_1_cores, core_grid, row_wise);
+        const auto& last_core_group_1 = (*core_group_1.ranges().rbegin()).end_coord;
+        const auto& core_grid_ranges = core_grid.ranges();
+        uint32_t num_cores_counted = 0, i;
+        for (i = 0; i < core_grid_ranges.size(); i++) {
+            num_cores_counted += core_grid_ranges[i].size();
+            if (num_cores_counted >= num_core_group_1_cores) {
+                break;
+            }
+        }
+        const auto& range_containing_last_core_group_1 = core_grid_ranges[i];
+        // Start in next core range
+        if (last_core_group_1 == range_containing_last_core_group_1.end_coord) {
+            core_group_2 = num_cores_to_corerangeset_in_subcoregrids(
+                core_grid_ranges[i + 1].start_coord, num_core_group_2_cores, core_grid, row_wise);
+        } else if (row_wise) {
+            // Start in the same row
+            if (last_core_group_1.x != range_containing_last_core_group_1.end_coord.x) {
+                core_group_2 = num_cores_to_corerangeset_in_subcoregrids(
+                    {last_core_group_1.x + 1, last_core_group_1.y}, num_core_group_2_cores, core_grid, row_wise);
+            }
+            // Start in the next row
+            else {
+                core_group_2 = num_cores_to_corerangeset_in_subcoregrids(
+                    {range_containing_last_core_group_1.start_coord.x, last_core_group_1.y + 1},
+                    num_core_group_2_cores,
+                    core_grid,
+                    row_wise);
+            }
+        } else {
+            // Start in the same column
+            if (last_core_group_1.y != range_containing_last_core_group_1.end_coord.y) {
+                core_group_2 = num_cores_to_corerangeset_in_subcoregrids(
+                    {last_core_group_1.x, last_core_group_1.y + 1}, num_core_group_2_cores, core_grid, row_wise);
+            }
+            // Start in the next column
+            else {
+                core_group_2 = num_cores_to_corerangeset_in_subcoregrids(
+                    {last_core_group_1.x + 1, range_containing_last_core_group_1.end_coord.y},
+                    num_core_group_2_cores,
+                    core_grid,
+                    row_wise);
             }
         }
         units_per_core_group_2 = units_per_core_group_1;

--- a/tt_metal/common/work_split.hpp
+++ b/tt_metal/common/work_split.hpp
@@ -53,5 +53,8 @@ CoreRangeSet num_cores_to_corerangeset_in_subcoregrids(
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
     const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise = false);
 
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    const CoreRangeSet& core_grid, const uint32_t units_to_divide, const bool row_wise = false);
+
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -120,7 +120,7 @@ nebula_x1:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [6, 9]
+        end: [6, 8]
 
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
@@ -146,7 +146,7 @@ nebula_x1:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [6, 9]
+        end: [6, 8]
 
       tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
@@ -202,7 +202,7 @@ nebula_x2:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [6, 8]
+        end: [6, 7]
 
       storage_cores: # Relative to grid of tensix cores
         []
@@ -216,7 +216,7 @@ nebula_x2:
     2:
       compute_with_storage_grid_range: # Logical only start and end [x, y]
         start: [0, 0]
-        end: [6, 8]
+        end: [6, 7]
 
       storage_cores: # Relative to grid of tensix cores
         []

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -39,6 +39,13 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_56(uint32_t n) {
     return (((uint64_t)n * 0x24924925) >> 32) >> 3;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_63(uint32_t n) {
+    // Uses embedding style magic number
+    // * fixed point 1/63 then shifting.
+    // https://web.archive.org/web/20190703172151/http://www.hackersdelight.org/magic.htm
+    return (((uint64_t)n * 0x82082083) >> 32) >> 5;
+}
+
 inline __attribute__((always_inline)) uint32_t fast_udiv_70(uint32_t n) {
     // Uses embedding style magic number
     // * fixed point 1/70 then shifting.

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -37,7 +37,7 @@ void validate_num_banks(uint32_t num_banks, const BufferType& buffer_type, bool 
     // Dataflow API does not have a working implementation of generic modulo to determine bank_id for interleaved
     // address gen For non pow2 num banks, special cases need to be added to avoid falling back to generic
     // implementation. See https://github.com/tenstorrent/tt-metal/issues/3321
-    std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {12, 56, 70, 80, 94, 124, 130, 140};
+    std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {12, 56, 63, 70, 80, 94, 124, 130, 140};
     bool custom_mod_bank_id_calculation_exists = acceptable_num_non_pow2_mem_banks.count(num_banks) > 0;
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2983,7 +2983,20 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
     this->using_fast_dispatch = false;
     this->num_hw_cqs_ = num_hw_cqs;
     constexpr uint32_t harvesting_map_bits = 12;
-    this->build_key_ = ((uint32_t)this->num_hw_cqs_ << harvesting_map_bits);
+    constexpr uint32_t num_hw_cq_bits = 8;
+    constexpr uint32_t dispatch_core_axis_bits = 1;
+    constexpr uint32_t dispatch_core_type_bits = 1;
+    static_assert(dispatch_core_manager::MAX_NUM_HW_CQS <= (1 << num_hw_cq_bits));
+    static_assert(static_cast<uint32_t>(DispatchCoreAxis::COUNT) <= (1 << dispatch_core_axis_bits));
+    static_assert(static_cast<uint32_t>(DispatchCoreType::COUNT) <= (1 << dispatch_core_type_bits));
+    static_assert(harvesting_map_bits + num_hw_cq_bits + dispatch_core_axis_bits + dispatch_core_type_bits <= sizeof(this->build_key_) * CHAR_BIT);
+
+    // num_hw_cqs, dispatch_core_axis, dispatch_core_type all change the number of banks, so need to be part of the
+    // build key since we have defines based on number of banks.
+    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(this->id_);
+    this->build_key_ = (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_type()) << (harvesting_map_bits + num_hw_cq_bits + dispatch_core_axis_bits)) |
+                       (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_axis()) << (harvesting_map_bits + num_hw_cq_bits)) |
+                       (static_cast<uint32_t>(num_hw_cqs_) << harvesting_map_bits);
     if (not hal.is_coordinate_virtualization_enabled()) {
         // Coordinate virtualization is not enabled. For a single program, its associated binaries will vary across devices with different cores harvested.
         this->build_key_ = (this->build_key_) | tt::Cluster::instance().get_harvesting_mask(this->id());

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -7,7 +7,7 @@
 #include "common/core_descriptor.hpp"
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/llrt/get_platform_architecture.hpp"
-#include <list>
+#include "tt_metal/tt_stl/reflection.hpp"
 
 namespace tt::tt_metal {
 
@@ -28,15 +28,9 @@ enum DispatchWorkerType : uint32_t {
     COUNT = 13
 };
 
-enum DispatchCoreType : uint32_t {
-    WORKER = 0,
-    ETH = 1,
-};
+enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
 
-enum class DispatchCoreAxis {
-    ROW,
-    COL,
-};
+enum class DispatchCoreAxis { ROW, COL, COUNT };
 
 class DispatchCoreConfig {
 private:
@@ -54,6 +48,9 @@ public:
     DispatchCoreConfig(DispatchCoreType type) : type_(type), axis_(get_default_axis()) {}
 
     DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("type", "axis");
+    const auto attribute_values() const { return std::forward_as_tuple(this->type_, this->axis_); }
 
     CoreType get_core_type() const {
         switch (type_) {
@@ -75,3 +72,14 @@ public:
 };
 
 }  // namespace tt::tt_metal
+
+namespace std {
+
+template <>
+struct hash<tt::tt_metal::DispatchCoreConfig> {
+    std::size_t operator()(const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) const {
+        return tt::stl::hash::hash_objects_with_default_seed(dispatch_core_config.attribute_values());
+    }
+};
+
+}  // namespace std

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -353,6 +353,45 @@ BinaryDeviceOperation::invoke(
             output_dtype.value() == optional_output_tensor.value().get_dtype(),
             "If both output dtype and output tensor provided dtype should match");
     }
+    CoreRangeSet worker_grid;
+    // We assert all shard specs are the same if sharded, so only need to check the first shard spec
+    // This will create the worker grid based on the used sub-devices when sharded
+    // Otherwise this will use all cores of the sub-devices
+    // TODO #13655: Note that the current program ingfrastructure still only supports a single sub-device per program
+    if (input_tensor_a_arg.is_sharded()) {
+        const auto& input_grid = input_tensor_a_arg.shard_spec().value().grid;
+        auto device = input_tensor_a_arg.device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            if (sub_device_workers.intersects(input_grid)) {
+                worker_grid = worker_grid.merge(sub_device_workers);
+            }
+        }
+    } else if (input_tensor_b_arg.is_sharded()) {
+        const auto& input_grid = input_tensor_b_arg.shard_spec().value().grid;
+        auto device = input_tensor_b_arg.device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            if (sub_device_workers.intersects(input_grid)) {
+                worker_grid = worker_grid.merge(sub_device_workers);
+            }
+        }
+    } else if (optional_output_tensor.has_value() && optional_output_tensor->is_sharded()) {
+        const auto& output_grid = optional_output_tensor->shard_spec().value().grid;
+        auto device = optional_output_tensor->device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            if (sub_device_workers.intersects(output_grid)) {
+                worker_grid = worker_grid.merge(sub_device_workers);
+            }
+        }
+    } else {
+        auto device = input_tensor_a_arg.device();
+        for (const auto& sub_device_id : device->get_sub_device_ids()) {
+            const auto& sub_device_workers = device->worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
+            worker_grid = worker_grid.merge(sub_device_workers);
+        }
+    }
 
     return {
         operation_attributes_t{
@@ -360,8 +399,9 @@ BinaryDeviceOperation::invoke(
             std::move(activations),
             std::move(input_tensor_a_activation),
             std::nullopt,
-            memory_config.value_or(input_tensor_a_arg.memory_config()),
+            memory_config.value_or(optional_output_tensor.has_value() ? optional_output_tensor->memory_config() : input_tensor_a_arg.memory_config()),
             output_dtype.value_or(input_tensor_a_arg.get_dtype()),
+            std::move(worker_grid),
             std::nullopt},
         tensor_args_t{input_tensor_a_arg, input_tensor_b_arg, optional_output_tensor}};
 }
@@ -382,6 +422,8 @@ BinaryDeviceOperation::invoke(
             "If both output dtype and output tensor provided dtype should match");
     }
 
+    // Currently unused/unsupported
+    CoreRangeSet worker_grid = CoreRangeSet();
     return {
         operation_attributes_t{
             binary_op_type,
@@ -390,6 +432,7 @@ BinaryDeviceOperation::invoke(
             scalar,
             memory_config.value_or(input_tensor_a_arg.memory_config()),
             output_dtype.value_or(input_tensor_a_arg.get_dtype()),
+            std::move(worker_grid),
             std::nullopt},
         tensor_args_t{input_tensor_a_arg, std::nullopt, optional_output_tensor}};
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -34,6 +34,7 @@ struct BinaryDeviceOperation {
         const std::optional<float> scalar;
         const MemoryConfig memory_config;
         const DataType dtype;
+        const CoreRangeSet worker_grid;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
 
         tt::stl::hash::hash_t to_hash() const {
@@ -58,7 +59,7 @@ struct BinaryDeviceOperation {
             tt::tt_metal::CBHandle cb_src0;
             tt::tt_metal::CBHandle cb_src1;
             tt::tt_metal::CBHandle cb_output;
-            CoreCoord compute_with_storage_grid_size;
+            CoreRangeSet all_device_cores;
             uint32_t src0_single_tile_size;
             uint32_t src1_single_tile_size;
             uint32_t dst_single_tile_size;
@@ -85,7 +86,7 @@ struct BinaryDeviceOperation {
             tt::tt_metal::CBHandle cb_src0;
             tt::tt_metal::CBHandle cb_src1;
             tt::tt_metal::CBHandle cb_output;
-            CoreCoord compute_with_storage_grid_size;
+            CoreRangeSet all_device_cores;
             uint32_t src0_single_tile_size;
             uint32_t src1_single_tile_size;
             uint32_t dst_single_tile_size;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 #include "binary_device_operation.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 #include "tt_metal/common/work_split.hpp"
@@ -15,276 +16,6 @@
 
 namespace ttnn::operations::binary {
 
-template <bool initialize_args>
-inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
-    Program& program,
-    const Tensor& a,
-    const Tensor& b,
-    const Tensor& output,
-    const KernelHandle binary_reader_kernel_id,
-    const KernelHandle unary_writer_kernel_id,
-    const KernelHandle eltwise_binary_kernel_id,
-    const CBHandle cb_src0,
-    const CBHandle cb_src1,
-    const CBHandle cb_output,
-    const CoreCoord compute_with_storage_grid_size,
-    const uint32_t src0_single_tile_size,
-    const uint32_t src1_single_tile_size,
-    const uint32_t dst_single_tile_size) {
-    using namespace tt;
-    using namespace tt::tt_metal;
-    using namespace tt::constants;
-
-    auto src_buffer_a = a.buffer();
-    auto src_buffer_b = b.buffer();
-    auto dst_buffer = output.buffer();
-
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-
-    std::optional<ShardSpec> shard_spec = std::nullopt;
-    std::optional<TensorMemoryLayout> sharded_layout = std::nullopt;
-    bool src0_sharded = a.memory_config().is_sharded();
-    bool src1_sharded = b.memory_config().is_sharded();
-    bool out_sharded = output.memory_config().is_sharded();
-
-    bool block_or_width_sharded = false;
-    if (src0_sharded) {
-        shard_spec = a.shard_spec().value();
-        block_or_width_sharded = a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
-        sharded_layout = a.memory_config().memory_layout;
-    } else if (src1_sharded) {
-        shard_spec = b.shard_spec().value();
-        block_or_width_sharded = b.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
-        sharded_layout = b.memory_config().memory_layout;
-    } else if (out_sharded) {
-        shard_spec = output.shard_spec().value();
-        block_or_width_sharded = output.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
-        sharded_layout = output.memory_config().memory_layout;
-    }
-
-    uint32_t num_tiles = a.volume() / TILE_HW;
-
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t num_cores, num_tiles_per_core_group_1, num_tiles_per_core_group_2;
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
-
-    uint32_t block_size_per_core_group_1 = 1, block_size_per_core_group_2 = 1, max_block_size = 1;
-
-    uint32_t block_cnt_per_core_group_1, block_cnt_per_core_group_2;
-
-    bool row_major;
-    uint32_t block_height = 0, block_width = 0, block_size = 0, output_width = 0, last_unpadded_block_height = 0,
-             last_unpadded_block_width = 0;
-    CoreCoord end_core;
-    std::vector<CoreCoord> cores;
-
-    if (shard_spec.has_value()) {
-        all_cores = shard_spec.value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        core_group_2 = CoreRangeSet();
-        num_tiles_per_core_group_1 = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
-        num_tiles_per_core_group_2 = 0;
-        block_size_per_core_group_1 = find_max_block_size(num_tiles_per_core_group_1);
-        max_block_size = block_size_per_core_group_1;
-
-        block_cnt_per_core_group_1 = num_tiles_per_core_group_1 / block_size_per_core_group_1;
-        block_cnt_per_core_group_2 = num_tiles_per_core_group_2 / block_size_per_core_group_2;
-        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        block_height = shard_spec.value().shape[0] / TILE_HEIGHT;
-        block_width = shard_spec.value().shape[1] / TILE_WIDTH;
-        if (block_or_width_sharded) {
-            block_size = block_width * block_height;
-            end_core = (*shard_spec.value().grid.ranges().begin()).end_coord;
-            output_width = output.get_legacy_shape()[-1] / TILE_WIDTH;
-            uint32_t output_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
-            last_unpadded_block_height = block_height - (round_up(output_height, block_height) - output_height);
-            last_unpadded_block_width = block_width - (round_up(output_width, block_width) - output_width);
-        }
-        auto bbox = core_group_1.bounding_box();
-        cores = grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
-    } else {
-        row_major = true;
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles, row_major);
-        block_cnt_per_core_group_1 = num_tiles_per_core_group_1;
-        block_cnt_per_core_group_2 = num_tiles_per_core_group_2;
-        cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
-    }
-
-    uint32_t g1_numcores = core_group_1.num_cores();
-    uint32_t g2_numcores = core_group_2.num_cores();
-
-    std::vector<std::vector<uint32_t>> binary_reader_args;
-    std::vector<std::vector<uint32_t>> eltwise_binary_args;
-    std::vector<std::vector<uint32_t>> unary_writer_args;
-    if constexpr (initialize_args) {
-        binary_reader_args = {cores.size(), std::vector<uint32_t>(7)};
-        eltwise_binary_args = {cores.size(), std::vector<uint32_t>(2)};
-        if (block_or_width_sharded and not out_sharded) {
-            unary_writer_args = {cores.size(), std::vector<uint32_t>(7)};
-        } else {
-            unary_writer_args = {cores.size(), std::vector<uint32_t>(3)};
-        }
-    }
-
-    auto& cached_reader_args = GetRuntimeArgs(program, binary_reader_kernel_id);
-    auto& cached_eltwise_args = GetRuntimeArgs(program, eltwise_binary_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, unary_writer_kernel_id);
-
-    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_tiles_per_core = 0;
-        uint32_t block_cnt_per_core = 0;
-        uint32_t block_size_per_core = 0;
-        uint32_t num_shardes_per_height = 0;
-        uint32_t num_shardes_per_width = 0;
-        uint32_t start_id = 0;
-        if (shard_spec.has_value()) {
-            if (sharded_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
-                num_shardes_per_height = num_cores;
-                num_shardes_per_width = 1;
-            } else if (sharded_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
-                num_shardes_per_width = num_cores;
-                num_shardes_per_height = 1;
-            } else {  // block sharded
-                auto bbox = core_group_1.bounding_box();
-                if (shard_spec.value().orientation == ShardOrientation::ROW_MAJOR) {
-                    num_shardes_per_height = bbox.end_coord.y - bbox.start_coord.y + 1;
-                    num_shardes_per_width = bbox.end_coord.x - bbox.start_coord.x + 1;
-                } else {
-                    num_shardes_per_height = bbox.end_coord.x - bbox.start_coord.x + 1;
-                    num_shardes_per_width = bbox.end_coord.y - bbox.start_coord.y + 1;
-                }
-            }
-            start_id = (i / num_shardes_per_width) * (block_height * block_width * num_shardes_per_width) +
-                       (i % num_shardes_per_width) * block_width;
-        } else {
-            start_id = num_tiles_read;
-        }
-
-        if (i < g1_numcores) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-            block_cnt_per_core = block_cnt_per_core_group_1;
-            block_size_per_core = block_size_per_core_group_1;
-        } else if (i < num_cores) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-            block_cnt_per_core = block_cnt_per_core_group_2;
-            block_size_per_core = block_size_per_core_group_2;
-        } else {
-            // Zero out non-working cores RT args. Only necessary in override
-            // since initialization pushes zero vectors to unused cores.
-            if constexpr (!initialize_args) {
-                auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-                reader_args[2] = 0;
-                auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
-                eltwise_args[0] = 0;
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-                writer_args[1] = 0;
-            }
-            continue;
-        }
-        if constexpr (initialize_args) {
-            binary_reader_args[i] = {
-                src_buffer_a->address(),
-                src_buffer_b->address(),
-                num_tiles_per_core,
-                start_id,
-                block_height,
-                block_width,
-                num_shardes_per_width,
-                num_shardes_per_width};
-            eltwise_binary_args[i] = {block_cnt_per_core, block_size_per_core};
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            reader_args[0] = src_buffer_a->address();
-            reader_args[1] = src_buffer_b->address();
-            reader_args[2] = num_tiles_per_core;
-            reader_args[3] = start_id;
-            reader_args[4] = block_height;
-            reader_args[5] = block_width;
-            reader_args[6] = num_shardes_per_width;
-            auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
-            eltwise_args[0] = block_cnt_per_core;
-            eltwise_args[1] = block_size_per_core;
-        }
-        if (block_or_width_sharded and not out_sharded) {
-            uint32_t unpadded_block_height = block_height;
-            uint32_t unpadded_block_width = block_width;
-            if (row_major) {
-                if (core.x == end_core.x) {
-                    unpadded_block_width = last_unpadded_block_width;
-                }
-                if (core.y == end_core.y) {
-                    unpadded_block_height = last_unpadded_block_height;
-                }
-            } else {
-                if (core.y == end_core.y) {
-                    unpadded_block_width = last_unpadded_block_width;
-                }
-                if (core.x == end_core.x) {
-                    unpadded_block_height = last_unpadded_block_height;
-                }
-            }
-            if constexpr (initialize_args) {
-                unary_writer_args[i] = {
-                    dst_buffer->address(),
-                    block_height,
-                    block_width,
-                    unpadded_block_height,
-                    unpadded_block_width,
-                    output_width,
-                    block_size,
-                    (i / num_shardes_per_width) * (block_height * block_width * num_shardes_per_width) +
-                        (i % num_shardes_per_width) * block_width,
-                    0};
-            } else {
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-                writer_args[0] = dst_buffer->address();
-                writer_args[1] = block_height;
-                writer_args[2] = block_width;
-                writer_args[3] = unpadded_block_height;
-                writer_args[4] = unpadded_block_width;
-                writer_args[5] = output_width;
-                writer_args[6] = block_size;
-                writer_args[7] = (i / num_shardes_per_width) * (block_height * block_width * num_shardes_per_width) +
-                                 (i % num_shardes_per_width) * block_width;
-                writer_args[8] = 0;
-            }
-        } else {
-            if constexpr (initialize_args) {
-                unary_writer_args[i] = {dst_buffer->address(), num_tiles_per_core, num_tiles_read};
-            } else {
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-                writer_args[0] = dst_buffer->address();
-                writer_args[1] = num_tiles_per_core;
-                writer_args[2] = num_tiles_read;
-            }
-        }
-        num_tiles_read += num_tiles_per_core;
-    }
-
-    if constexpr (initialize_args) {
-        SetRuntimeArgs(program, binary_reader_kernel_id, cores, binary_reader_args);
-        SetRuntimeArgs(program, eltwise_binary_kernel_id, cores, eltwise_binary_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, cores, unary_writer_args);
-    }
-
-    if (src0_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, cb_src0, *src_buffer_a, num_tiles_per_core_group_1 * src0_single_tile_size);
-    }
-    if (src1_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, cb_src1, *src_buffer_b, num_tiles_per_core_group_1 * src1_single_tile_size);
-    }
-    if (out_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, cb_output, *dst_buffer, num_tiles_per_core_group_1 * dst_single_tile_size);
-    }
-}
 BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperation::ElementWiseMultiCore::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -324,10 +55,6 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     bool src1_sharded = b->memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
     bool block_or_width_sharded = false;
 
     if (src0_sharded) {
@@ -350,7 +77,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const auto& all_device_cores = operation_attributes.worker_grid;
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = src0_sharded ? num_tiles_per_shard : 2 * max_block_size;
@@ -465,7 +192,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
         cb_src0,
         cb_src1,
         cb_output,
-        compute_with_storage_grid_size,
+        all_device_cores,
         src0_single_tile_size,
         src1_single_tile_size,
         dst_single_tile_size);
@@ -478,7 +205,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
          cb_src0,
          cb_src1,
          cb_output,
-         compute_with_storage_grid_size,
+         all_device_cores,
          src0_single_tile_size,
          src1_single_tile_size,
          dst_single_tile_size}};
@@ -506,7 +233,7 @@ void BinaryDeviceOperation::ElementWiseMultiCore::override_runtime_arguments(
         shared_variables.cb_src0,
         shared_variables.cb_src1,
         shared_variables.cb_output,
-        shared_variables.compute_with_storage_grid_size,
+        shared_variables.all_device_cores,
         shared_variables.src0_single_tile_size,
         shared_variables.src1_single_tile_size,
         shared_variables.dst_single_tile_size);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_sfpu_pgm_factory.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 #include "binary_device_operation.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 #include "tt_metal/common/work_split.hpp"
@@ -15,276 +16,6 @@
 
 namespace ttnn::operations::binary {
 
-template <bool initialize_args>
-inline __attribute__((always_inline)) void set_eltwise_binary_sfpu_runtime_args(
-    Program& program,
-    const Tensor& a,
-    const Tensor& b,
-    const Tensor& output,
-    const KernelHandle binary_reader_kernel_id,
-    const KernelHandle unary_writer_kernel_id,
-    const KernelHandle eltwise_binary_kernel_id,
-    const CBHandle cb_src0,
-    const CBHandle cb_src1,
-    const CBHandle cb_output,
-    const CoreCoord compute_with_storage_grid_size,
-    const uint32_t src0_single_tile_size,
-    const uint32_t src1_single_tile_size,
-    const uint32_t dst_single_tile_size) {
-    using namespace tt;
-    using namespace tt::tt_metal;
-    using namespace tt::constants;
-
-    auto src_buffer_a = a.buffer();
-    auto src_buffer_b = b.buffer();
-    auto dst_buffer = output.buffer();
-
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-
-    std::optional<ShardSpec> shard_spec = std::nullopt;
-    std::optional<TensorMemoryLayout> sharded_layout = std::nullopt;
-    bool src0_sharded = a.memory_config().is_sharded();
-    bool src1_sharded = b.memory_config().is_sharded();
-    bool out_sharded = output.memory_config().is_sharded();
-
-    bool block_or_width_sharded = false;
-    if (src0_sharded) {
-        shard_spec = a.shard_spec().value();
-        block_or_width_sharded = a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
-        sharded_layout = a.memory_config().memory_layout;
-    } else if (src1_sharded) {
-        shard_spec = b.shard_spec().value();
-        block_or_width_sharded = b.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
-        sharded_layout = b.memory_config().memory_layout;
-    } else if (out_sharded) {
-        shard_spec = output.shard_spec().value();
-        block_or_width_sharded = output.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
-        sharded_layout = output.memory_config().memory_layout;
-    }
-
-    uint32_t num_tiles = a.volume() / TILE_HW;
-
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t num_cores, num_tiles_per_core_group_1, num_tiles_per_core_group_2;
-    uint32_t num_cores_total = num_cores_x * num_cores_y;
-
-    uint32_t block_size_per_core_group_1 = 1, block_size_per_core_group_2 = 1, max_block_size = 1;
-
-    uint32_t block_cnt_per_core_group_1, block_cnt_per_core_group_2;
-
-    bool row_major;
-    uint32_t block_height = 0, block_width = 0, block_size = 0, output_width = 0, last_unpadded_block_height = 0,
-             last_unpadded_block_width = 0;
-    CoreCoord end_core;
-    std::vector<CoreCoord> cores;
-
-    if (shard_spec.has_value()) {
-        all_cores = shard_spec.value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        core_group_2 = CoreRangeSet();
-        num_tiles_per_core_group_1 = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
-        num_tiles_per_core_group_2 = 0;
-        block_size_per_core_group_1 = find_max_block_size(num_tiles_per_core_group_1);
-        max_block_size = block_size_per_core_group_1;
-
-        block_cnt_per_core_group_1 = num_tiles_per_core_group_1 / block_size_per_core_group_1;
-        block_cnt_per_core_group_2 = num_tiles_per_core_group_2 / block_size_per_core_group_2;
-        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        block_height = shard_spec.value().shape[0] / TILE_HEIGHT;
-        block_width = shard_spec.value().shape[1] / TILE_WIDTH;
-        if (block_or_width_sharded) {
-            block_size = block_width * block_height;
-            end_core = (*shard_spec.value().grid.ranges().begin()).end_coord;
-            output_width = output.get_legacy_shape()[-1] / TILE_WIDTH;
-            uint32_t output_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
-            last_unpadded_block_height = block_height - (round_up(output_height, block_height) - output_height);
-            last_unpadded_block_width = block_width - (round_up(output_width, block_width) - output_width);
-        }
-        auto bbox = core_group_1.bounding_box();
-        cores = grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
-    } else {
-        row_major = true;
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles, row_major);
-        block_cnt_per_core_group_1 = num_tiles_per_core_group_1;
-        block_cnt_per_core_group_2 = num_tiles_per_core_group_2;
-        cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
-    }
-
-    uint32_t g1_numcores = core_group_1.num_cores();
-    uint32_t g2_numcores = core_group_2.num_cores();
-
-    std::vector<std::vector<uint32_t>> binary_reader_args;
-    std::vector<std::vector<uint32_t>> eltwise_binary_args;
-    std::vector<std::vector<uint32_t>> unary_writer_args;
-    if constexpr (initialize_args) {
-        binary_reader_args = {cores.size(), std::vector<uint32_t>(7)};
-        eltwise_binary_args = {cores.size(), std::vector<uint32_t>(2)};
-        if (block_or_width_sharded and not out_sharded) {
-            unary_writer_args = {cores.size(), std::vector<uint32_t>(7)};
-        } else {
-            unary_writer_args = {cores.size(), std::vector<uint32_t>(3)};
-        }
-    }
-
-    auto& cached_reader_args = GetRuntimeArgs(program, binary_reader_kernel_id);
-    auto& cached_eltwise_args = GetRuntimeArgs(program, eltwise_binary_kernel_id);
-    auto& cached_writer_args = GetRuntimeArgs(program, unary_writer_kernel_id);
-
-    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_tiles_per_core = 0;
-        uint32_t block_cnt_per_core = 0;
-        uint32_t block_size_per_core = 0;
-        uint32_t num_shardes_per_height = 0;
-        uint32_t num_shardes_per_width = 0;
-        uint32_t start_id = 0;
-        if (shard_spec.has_value()) {
-            if (sharded_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
-                num_shardes_per_height = num_cores;
-                num_shardes_per_width = 1;
-            } else if (sharded_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
-                num_shardes_per_width = num_cores;
-                num_shardes_per_height = 1;
-            } else {  // block sharded
-                auto bbox = core_group_1.bounding_box();
-                if (shard_spec.value().orientation == ShardOrientation::ROW_MAJOR) {
-                    num_shardes_per_height = bbox.end_coord.y - bbox.start_coord.y + 1;
-                    num_shardes_per_width = bbox.end_coord.x - bbox.start_coord.x + 1;
-                } else {
-                    num_shardes_per_height = bbox.end_coord.x - bbox.start_coord.x + 1;
-                    num_shardes_per_width = bbox.end_coord.y - bbox.start_coord.y + 1;
-                }
-            }
-            start_id = (i / num_shardes_per_width) * (block_height * block_width * num_shardes_per_width) +
-                       (i % num_shardes_per_width) * block_width;
-        } else {
-            start_id = num_tiles_read;
-        }
-
-        if (i < g1_numcores) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-            block_cnt_per_core = block_cnt_per_core_group_1;
-            block_size_per_core = block_size_per_core_group_1;
-        } else if (i < num_cores) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-            block_cnt_per_core = block_cnt_per_core_group_2;
-            block_size_per_core = block_size_per_core_group_2;
-        } else {
-            // Zero out non-working cores RT args. Only necessary in override
-            // since initialization pushes zero vectors to unused cores.
-            if constexpr (!initialize_args) {
-                auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-                reader_args[2] = 0;
-                auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
-                eltwise_args[0] = 0;
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-                writer_args[1] = 0;
-            }
-            continue;
-        }
-        if constexpr (initialize_args) {
-            binary_reader_args[i] = {
-                src_buffer_a->address(),
-                src_buffer_b->address(),
-                num_tiles_per_core,
-                start_id,
-                block_height,
-                block_width,
-                num_shardes_per_width,
-                num_shardes_per_width};
-            eltwise_binary_args[i] = {block_cnt_per_core, block_size_per_core};
-        } else {
-            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
-            reader_args[0] = src_buffer_a->address();
-            reader_args[1] = src_buffer_b->address();
-            reader_args[2] = num_tiles_per_core;
-            reader_args[3] = start_id;
-            reader_args[4] = block_height;
-            reader_args[5] = block_width;
-            reader_args[6] = num_shardes_per_width;
-            auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
-            eltwise_args[0] = block_cnt_per_core;
-            eltwise_args[1] = block_size_per_core;
-        }
-        if (block_or_width_sharded and not out_sharded) {
-            uint32_t unpadded_block_height = block_height;
-            uint32_t unpadded_block_width = block_width;
-            if (row_major) {
-                if (core.x == end_core.x) {
-                    unpadded_block_width = last_unpadded_block_width;
-                }
-                if (core.y == end_core.y) {
-                    unpadded_block_height = last_unpadded_block_height;
-                }
-            } else {
-                if (core.y == end_core.y) {
-                    unpadded_block_width = last_unpadded_block_width;
-                }
-                if (core.x == end_core.x) {
-                    unpadded_block_height = last_unpadded_block_height;
-                }
-            }
-            if constexpr (initialize_args) {
-                unary_writer_args[i] = {
-                    dst_buffer->address(),
-                    block_height,
-                    block_width,
-                    unpadded_block_height,
-                    unpadded_block_width,
-                    output_width,
-                    block_size,
-                    (i / num_shardes_per_width) * (block_height * block_width * num_shardes_per_width) +
-                        (i % num_shardes_per_width) * block_width,
-                    0};
-            } else {
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-                writer_args[0] = dst_buffer->address();
-                writer_args[1] = block_height;
-                writer_args[2] = block_width;
-                writer_args[3] = unpadded_block_height;
-                writer_args[4] = unpadded_block_width;
-                writer_args[5] = output_width;
-                writer_args[6] = block_size;
-                writer_args[7] = (i / num_shardes_per_width) * (block_height * block_width * num_shardes_per_width) +
-                                 (i % num_shardes_per_width) * block_width;
-                writer_args[8] = 0;
-            }
-        } else {
-            if constexpr (initialize_args) {
-                unary_writer_args[i] = {dst_buffer->address(), num_tiles_per_core, num_tiles_read};
-            } else {
-                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
-                writer_args[0] = dst_buffer->address();
-                writer_args[1] = num_tiles_per_core;
-                writer_args[2] = num_tiles_read;
-            }
-        }
-        num_tiles_read += num_tiles_per_core;
-    }
-
-    if constexpr (initialize_args) {
-        SetRuntimeArgs(program, binary_reader_kernel_id, cores, binary_reader_args);
-        SetRuntimeArgs(program, eltwise_binary_kernel_id, cores, eltwise_binary_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, cores, unary_writer_args);
-    }
-
-    if (src0_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, cb_src0, *src_buffer_a, num_tiles_per_core_group_1 * src0_single_tile_size);
-    }
-    if (src1_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, cb_src1, *src_buffer_b, num_tiles_per_core_group_1 * src1_single_tile_size);
-    }
-    if (out_sharded) {
-        UpdateDynamicCircularBufferAddressAndTotalSize(
-            program, cb_output, *dst_buffer, num_tiles_per_core_group_1 * dst_single_tile_size);
-    }
-}
 BinaryDeviceOperation::ElementWiseMultiCoreSfpu::cached_program_t
 BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
     const operation_attributes_t& operation_attributes,
@@ -325,10 +56,6 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
     bool src1_sharded = b->memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
     bool block_or_width_sharded = false;
 
     if (src0_sharded) {
@@ -351,7 +78,7 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
     tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    const auto& all_device_cores = operation_attributes.worker_grid;
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = src0_sharded ? num_tiles_per_shard : 2 * max_block_size;
@@ -460,7 +187,7 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
             .unpack_to_dest_mode = unpack_to_dest_mode,
             .defines = eltwise_defines});
 
-    set_eltwise_binary_sfpu_runtime_args<true>(
+    set_eltwise_binary_runtime_args<true>(
         program,
         a,
         *b,
@@ -471,7 +198,7 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
         cb_src0,
         cb_src1,
         cb_output,
-        compute_with_storage_grid_size,
+        all_device_cores,
         src0_single_tile_size,
         src1_single_tile_size,
         dst_single_tile_size);
@@ -484,7 +211,7 @@ BinaryDeviceOperation::ElementWiseMultiCoreSfpu::create(
          cb_src0,
          cb_src1,
          cb_output,
-         compute_with_storage_grid_size,
+         all_device_cores,
          src0_single_tile_size,
          src1_single_tile_size,
          dst_single_tile_size}};
@@ -501,7 +228,7 @@ void BinaryDeviceOperation::ElementWiseMultiCoreSfpu::override_runtime_arguments
 
     const auto& shared_variables = cached_program.shared_variables;
 
-    set_eltwise_binary_sfpu_runtime_args<false>(
+    set_eltwise_binary_runtime_args<false>(
         cached_program.program,
         input_tensor_a,
         *input_tensor_b,
@@ -512,7 +239,7 @@ void BinaryDeviceOperation::ElementWiseMultiCoreSfpu::override_runtime_arguments
         shared_variables.cb_src0,
         shared_variables.cb_src1,
         shared_variables.cb_output,
-        shared_variables.compute_with_storage_grid_size,
+        shared_variables.all_device_cores,
         shared_variables.src0_single_tile_size,
         shared_variables.src1_single_tile_size,
         shared_variables.dst_single_tile_size);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
@@ -1,0 +1,330 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+
+#include "binary_device_operation.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
+
+#include "tt_metal/common/work_split.hpp"
+
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace ttnn::operations::binary {
+
+template <bool initialize_args>
+inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
+    Program& program,
+    const Tensor& a,
+    const Tensor& b,
+    const Tensor& output,
+    const KernelHandle binary_reader_kernel_id,
+    const KernelHandle unary_writer_kernel_id,
+    const KernelHandle eltwise_binary_kernel_id,
+    const CBHandle cb_src0,
+    const CBHandle cb_src1,
+    const CBHandle cb_output,
+    const CoreRangeSet& all_device_cores,
+    const uint32_t src0_single_tile_size,
+    const uint32_t src1_single_tile_size,
+    const uint32_t dst_single_tile_size) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+    using namespace tt::constants;
+
+    auto src_buffer_a = a.buffer();
+    auto src_buffer_b = b.buffer();
+    auto dst_buffer = output.buffer();
+
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+
+    std::optional<ShardSpec> shard_spec = std::nullopt;
+    std::optional<TensorMemoryLayout> sharded_layout = std::nullopt;
+    bool src0_sharded = a.memory_config().is_sharded();
+    bool src1_sharded = b.memory_config().is_sharded();
+    bool out_sharded = output.memory_config().is_sharded();
+
+    bool block_or_width_sharded = false;
+    if (src0_sharded) {
+        shard_spec = a.shard_spec().value();
+        block_or_width_sharded = a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
+        sharded_layout = a.memory_config().memory_layout;
+    } else if (src1_sharded) {
+        shard_spec = b.shard_spec().value();
+        block_or_width_sharded = b.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
+        sharded_layout = b.memory_config().memory_layout;
+    } else if (out_sharded) {
+        shard_spec = output.shard_spec().value();
+        block_or_width_sharded = output.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED;
+        sharded_layout = output.memory_config().memory_layout;
+    }
+
+    // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
+    // as well as having the sharded tensors (if any) start at (0, 0)
+    // This will run the original work/core distribution algorithms that are specifically for this setup, as these
+    // are faster than the generic work/core distribution algorithms that work on arbitrary CoreRangeSets
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid_size;
+    if (all_device_cores.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (shard_spec.has_value()) {
+                const auto& shard_start_coord = shard_spec->grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    zero_start_grid = true;
+                    compute_with_storage_grid_size = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                zero_start_grid = true;
+                compute_with_storage_grid_size = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+
+    uint32_t num_tiles = a.volume() / TILE_HW;
+
+    uint32_t num_cores, num_tiles_per_core_group_1, num_tiles_per_core_group_2, num_cores_total;
+    if (zero_start_grid) {
+        num_cores_total = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+    } else {
+        num_cores_total = all_device_cores.num_cores();
+    }
+
+    uint32_t block_size_per_core_group_1 = 1, block_size_per_core_group_2 = 1, max_block_size = 1;
+
+    uint32_t block_cnt_per_core_group_1, block_cnt_per_core_group_2;
+
+    bool row_major;
+    uint32_t block_height = 0, block_width = 0, block_size = 0, output_width = 0, last_unpadded_block_height = 0,
+             last_unpadded_block_width = 0;
+    CoreCoord end_core;
+    std::vector<CoreCoord> cores;
+
+    if (shard_spec.has_value()) {
+        all_cores = shard_spec.value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet();
+        num_tiles_per_core_group_1 = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
+        num_tiles_per_core_group_2 = 0;
+        block_size_per_core_group_1 = find_max_block_size(num_tiles_per_core_group_1);
+        max_block_size = block_size_per_core_group_1;
+
+        block_cnt_per_core_group_1 = num_tiles_per_core_group_1 / block_size_per_core_group_1;
+        block_cnt_per_core_group_2 = num_tiles_per_core_group_2 / block_size_per_core_group_2;
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        block_height = shard_spec.value().shape[0] / TILE_HEIGHT;
+        block_width = shard_spec.value().shape[1] / TILE_WIDTH;
+        if (block_or_width_sharded) {
+            block_size = block_width * block_height;
+            end_core = (*shard_spec.value().grid.ranges().begin()).end_coord;
+            output_width = output.get_legacy_shape()[-1] / TILE_WIDTH;
+            uint32_t output_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
+            last_unpadded_block_height = block_height - (round_up(output_height, block_height) - output_height);
+            last_unpadded_block_width = block_width - (round_up(output_width, block_width) - output_width);
+        }
+        if (zero_start_grid) {
+            auto bbox = core_group_1.bounding_box();
+            cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                compute_with_storage_grid_size.x,
+                compute_with_storage_grid_size.y,
+                row_major);
+        } else {
+            cores = grid_to_cores_with_noop(all_cores, all_device_cores, row_major);
+        }
+    } else {
+        row_major = true;
+        std::tie(
+            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
+            zero_start_grid ? tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles, row_major)
+                            : tt::tt_metal::split_work_to_cores(all_device_cores, num_tiles, row_major);
+        block_cnt_per_core_group_1 = num_tiles_per_core_group_1;
+        block_cnt_per_core_group_2 = num_tiles_per_core_group_2;
+        if (zero_start_grid) {
+            cores = grid_to_cores(
+                num_cores_total, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, row_major);
+        } else {
+            cores = corerange_to_cores(all_device_cores, {}, row_major);
+        }
+    }
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t g2_numcores = core_group_2.num_cores();
+
+    std::vector<std::vector<uint32_t>> binary_reader_args;
+    std::vector<std::vector<uint32_t>> eltwise_binary_args;
+    std::vector<std::vector<uint32_t>> unary_writer_args;
+    if constexpr (initialize_args) {
+        binary_reader_args = {cores.size(), std::vector<uint32_t>(7)};
+        eltwise_binary_args = {cores.size(), std::vector<uint32_t>(2)};
+        if (block_or_width_sharded and not out_sharded) {
+            unary_writer_args = {cores.size(), std::vector<uint32_t>(7)};
+        } else {
+            unary_writer_args = {cores.size(), std::vector<uint32_t>(3)};
+        }
+    }
+
+    auto& cached_reader_args = GetRuntimeArgs(program, binary_reader_kernel_id);
+    auto& cached_eltwise_args = GetRuntimeArgs(program, eltwise_binary_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, unary_writer_kernel_id);
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; ++i) {
+        const CoreCoord& core = cores.at(i);
+        uint32_t num_tiles_per_core = 0;
+        uint32_t block_cnt_per_core = 0;
+        uint32_t block_size_per_core = 0;
+        uint32_t num_shards_per_height = 0;
+        uint32_t num_shards_per_width = 0;
+        uint32_t start_id = 0;
+        if (shard_spec.has_value()) {
+            if (sharded_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+                num_shards_per_height = num_cores;
+                num_shards_per_width = 1;
+            } else if (sharded_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+                num_shards_per_width = num_cores;
+                num_shards_per_height = 1;
+            } else {  // block sharded
+                auto bbox = core_group_1.bounding_box();
+                if (shard_spec.value().orientation == ShardOrientation::ROW_MAJOR) {
+                    num_shards_per_height = bbox.end_coord.y - bbox.start_coord.y + 1;
+                    num_shards_per_width = bbox.end_coord.x - bbox.start_coord.x + 1;
+                } else {
+                    num_shards_per_height = bbox.end_coord.x - bbox.start_coord.x + 1;
+                    num_shards_per_width = bbox.end_coord.y - bbox.start_coord.y + 1;
+                }
+            }
+            start_id = (i / num_shards_per_width) * (block_height * block_width * num_shards_per_width) +
+                       (i % num_shards_per_width) * block_width;
+        } else {
+            start_id = num_tiles_read;
+        }
+
+        if (i < g1_numcores) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+            block_cnt_per_core = block_cnt_per_core_group_1;
+            block_size_per_core = block_size_per_core_group_1;
+        } else if (i < num_cores) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+            block_cnt_per_core = block_cnt_per_core_group_2;
+            block_size_per_core = block_size_per_core_group_2;
+        } else {
+            // Zero out non-working cores RT args. Only necessary in override
+            // since initialization pushes zero vectors to unused cores.
+            if constexpr (!initialize_args) {
+                auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+                reader_args[2] = 0;
+                auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
+                eltwise_args[0] = 0;
+                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
+                writer_args[1] = 0;
+            }
+            continue;
+        }
+        if constexpr (initialize_args) {
+            binary_reader_args[i] = {
+                src_buffer_a->address(),
+                src_buffer_b->address(),
+                num_tiles_per_core,
+                start_id,
+                block_height,
+                block_width,
+                num_shards_per_width,
+                num_shards_per_width};
+            eltwise_binary_args[i] = {block_cnt_per_core, block_size_per_core};
+        } else {
+            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+            reader_args[0] = src_buffer_a->address();
+            reader_args[1] = src_buffer_b->address();
+            reader_args[2] = num_tiles_per_core;
+            reader_args[3] = start_id;
+            reader_args[4] = block_height;
+            reader_args[5] = block_width;
+            reader_args[6] = num_shards_per_width;
+            auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
+            eltwise_args[0] = block_cnt_per_core;
+            eltwise_args[1] = block_size_per_core;
+        }
+        if (block_or_width_sharded and not out_sharded) {
+            uint32_t unpadded_block_height = block_height;
+            uint32_t unpadded_block_width = block_width;
+            if (row_major) {
+                if (core.x == end_core.x) {
+                    unpadded_block_width = last_unpadded_block_width;
+                }
+                if (core.y == end_core.y) {
+                    unpadded_block_height = last_unpadded_block_height;
+                }
+            } else {
+                if (core.y == end_core.y) {
+                    unpadded_block_width = last_unpadded_block_width;
+                }
+                if (core.x == end_core.x) {
+                    unpadded_block_height = last_unpadded_block_height;
+                }
+            }
+            if constexpr (initialize_args) {
+                unary_writer_args[i] = {
+                    dst_buffer->address(),
+                    block_height,
+                    block_width,
+                    unpadded_block_height,
+                    unpadded_block_width,
+                    output_width,
+                    block_size,
+                    (i / num_shards_per_width) * (block_height * block_width * num_shards_per_width) +
+                        (i % num_shards_per_width) * block_width,
+                    0};
+            } else {
+                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
+                writer_args[0] = dst_buffer->address();
+                writer_args[1] = block_height;
+                writer_args[2] = block_width;
+                writer_args[3] = unpadded_block_height;
+                writer_args[4] = unpadded_block_width;
+                writer_args[5] = output_width;
+                writer_args[6] = block_size;
+                writer_args[7] = (i / num_shards_per_width) * (block_height * block_width * num_shards_per_width) +
+                                 (i % num_shards_per_width) * block_width;
+                writer_args[8] = 0;
+            }
+        } else {
+            if constexpr (initialize_args) {
+                unary_writer_args[i] = {dst_buffer->address(), num_tiles_per_core, num_tiles_read};
+            } else {
+                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
+                writer_args[0] = dst_buffer->address();
+                writer_args[1] = num_tiles_per_core;
+                writer_args[2] = num_tiles_read;
+            }
+        }
+        num_tiles_read += num_tiles_per_core;
+    }
+
+    if constexpr (initialize_args) {
+        SetRuntimeArgs(program, binary_reader_kernel_id, cores, binary_reader_args);
+        SetRuntimeArgs(program, eltwise_binary_kernel_id, cores, eltwise_binary_args);
+        SetRuntimeArgs(program, unary_writer_kernel_id, cores, unary_writer_args);
+    }
+
+    if (src0_sharded) {
+        UpdateDynamicCircularBufferAddressAndTotalSize(
+            program, cb_src0, *src_buffer_a, num_tiles_per_core_group_1 * src0_single_tile_size);
+    }
+    if (src1_sharded) {
+        UpdateDynamicCircularBufferAddressAndTotalSize(
+            program, cb_src1, *src_buffer_b, num_tiles_per_core_group_1 * src1_single_tile_size);
+    }
+    if (out_sharded) {
+        UpdateDynamicCircularBufferAddressAndTotalSize(
+            program, cb_output, *dst_buffer, num_tiles_per_core_group_1 * dst_single_tile_size);
+    }
+}
+
+}  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
@@ -3,12 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This code is temporarily copied from ttnn/cpp/ttnn/operations/datamovement/binary/device/ to demonstrate
-<<<<<<< HEAD
-// the new ability to keep the CircularBufferConfigs continuous during dispatching.  See the use of CBIndex::c_16 below.
-=======
 // the new ability to keep the CircularBufferConfigs continuous during dispatching.  See the use of CBIndex::c_2 below.
->>>>>>> 500923c2b7... #7493: Updating some ops to use c_2 instead of c_16 given the dependency on eltwise
-// When broadcating is properly supported we expect this code to be deleted or refactored substantially.
+// When broadcasting is properly supported we expect this code to be deleted or refactored substantially.
 
 #include <stdint.h>
 #include "dataflow_api.h"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15916

### Problem description
Need eltwise binary to support sharding on an arbitrary grid that doesn't start at 0, and doesn't just use the entire grid when using sub-devices.


### What's changed
1. Find the minimum set of sub-devices used for sharded in/out and use that as the grid instead of the full device grid. This restricts our cores to only cores used by a sub-device when we need to create noop cores since binary is dynamic. Note that programs don't support running on multiple sub-devices yet, so will assert out if it finds more than one sub-device is used.
2. Add new apis for dividing work onto a CoreRangeSet instead of a rectangle starting at (0, 0), as well as generating no-op cores from 2 CoreRangeSets (this function most likely has poor performance and can be optimized, but would prefer to merge now for functionality and improve afterwards).
3. Commonize some code between `element_wise_multi_core_program_factory` and `element_wise_multi_core_sfpu_pgm_factory` for setting runtime args. Code was entirely duplicated, can go back to separate implementations once there is actually a required difference.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12407653758
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12337025004
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
