### PR TITLE
#0: Add bc to docker container for pgm dispatch math

### DIFF
--- a/scripts/docker/requirements-20.04.txt
+++ b/scripts/docker/requirements-20.04.txt
@@ -22,3 +22,4 @@ cargo
 ninja-build
 patchelf
 graphviz
+bc

--- a/scripts/docker/requirements-22.04.txt
+++ b/scripts/docker/requirements-22.04.txt
@@ -20,3 +20,4 @@ cargo
 ninja-build
 libxml2-dev
 libxslt-dev
+bc


### PR DESCRIPTION
### Ticket

Blocking @jbaumanTT 

### Problem description

the container doesn't come with `bc` by default

### What's changed

Added `bc` for math

I'm wondering if we should take it out later and put it directly as a `sudo apt install` command in the workflow, so we don't set the precedent of chucking stuff into the image.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
