### PR TITLE
disable workflow telemetry in prepare-metal-run

### DIFF
--- a/.github/actions/prepare-metal-run/action.yml
+++ b/.github/actions/prepare-metal-run/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Which version of Python to use to run the tests.'
     required: false
     default: '3.8'
+  run-telemetry:
+    description: 'Whether to run telemetry'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -32,5 +36,5 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
     - name: Collect Workflow Telemetry
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && inputs.run-telemetry == 'true' }}
       uses: catchpoint/workflow-telemetry-action@v2


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/16033

### Problem description
Blackhole post commit fails due to workflow telemetry
Disabling until we can triage and let blackhole postcommit run green
https://github.com/tenstorrent/tt-metal/issues/16033

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12324496687/job/34402727781
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
