### PR TITLE
Add missing cache invalidates + loads before stores noc optimization for BH

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Get started with [simple kernels](https://docs.tenstorrent.com/tt-metalium/lates
 - [CNNs on TT Architectures](./tech_reports/CNNs/ttcnn.md) (updated Sept 6th)
 - [Ethernet and Multichip Basics](./tech_reports/EthernetMultichip/BasicEthernetGuide.md) (Updated Sept 20th)
 - [Collective Communication Library (CCL)](./tech_reports/EthernetMultichip/CclDeveloperGuide.md) (Updated Sept 20th)
-- [Blackhole Bring-Up Programming Guide](./tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md) (Updated Oct 30th)
+- [Blackhole Bring-Up Programming Guide](./tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md) (Updated Dec 18th)
 
 ## TT-Metalium Programming Examples
 

--- a/tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md
+++ b/tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md
@@ -66,20 +66,21 @@ Information relevant to programming Blackhole while it is being brought up.
 
 ### L1 Data Cache
 
-Blackhole added a data cache in L1. Writing an address on one core and reading it from another only requires the reader to invalidate if the address was previously read.
+Blackhole added a small (4 x 16B cachelines) write-through data cache in L1. Writing an address on one core and reading it from another only requires the reader to invalidate if the address was previously read.
 
-Invalidating the cache can be done via calls to `invalidate_l1_cache()`
+Invalidating the cache can be done via calls to `invalidate_l1_cache()`. Hardware can clear the cache at some randomized time interval but this is slower than explicitly invalidating the cache. By default the hardware timeout is disabled but can be enabled by setting env var `TT_METAL_ENABLE_HW_CACHE_INVALIDATION`
 
 The cache can be disabled through an env var:
 ```
 export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR,ER>
 ```
+where the values specify which riscs to disable cache on.
 
 ### Ethernet Cores
 
-Runtime has not enabled access to second RISC-V on the ethernet cores yet.
+Runtime has enabled access to second RISC-V on idle ethernet cores.
 
-Fast dispatch can be run out of ethernet cores.
+Support for Fast Dispatch out of idle ethernet cores is added but temporarily disabled while bringing up multi-chip ethernet support.
 
 ### DRAM
 
@@ -87,7 +88,7 @@ Runtime has not enabled access to program RISC-V on DRAM yet.
 
 ### NoC
 
-Non-rectangular multicast shapes have not been tested yet.
+Non-rectangular multicast shapes and strided multicast has been brought up and tested. See gtest `DispatchFixture.DRAMtoL1MulticastExcludeRegionUpLeft` for example on usage.
 
 On previous architectures there are instances in kernels where NoC commands are issued without explicit flushes. These were causing ND mismatches or hangs on BH because data and semaphore signals were getting updated faster than NoC has a chance to service the command and are resolved by adding flushes. Previous architectures did not need this because of higher RISC to L1 latency compared to NoC latency.
 

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -345,7 +345,7 @@ inline void wait_ncrisc_trisc() {
 }
 
 int main() {
-    conditionally_disable_l1_cache();
+    configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -338,7 +338,9 @@ inline void finish_ncrisc_copy_and_run(dispatch_core_processor_masks enables) {
 
 inline void wait_ncrisc_trisc() {
     WAYPOINT("NTW");
-    while (mailboxes->slave_sync.all != RUN_SYNC_MSG_ALL_SLAVES_DONE);
+    while (mailboxes->slave_sync.all != RUN_SYNC_MSG_ALL_SLAVES_DONE) {
+        invalidate_l1_cache();
+    }
     WAYPOINT("NTD");
 }
 
@@ -384,6 +386,7 @@ int main() {
         WAYPOINT("GW");
         uint8_t go_message_signal = RUN_MSG_DONE;
         while ((go_message_signal = mailboxes->go_message.signal) != RUN_MSG_GO) {
+            invalidate_l1_cache();
             // While the go signal for kernel execution is not sent, check if the worker was signalled
             // to reset its launch message read pointer.
             if (go_message_signal == RUN_MSG_RESET_READ_PTR) {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -102,7 +102,7 @@ inline void wait_slave_eriscs(uint32_t &heartbeat) {
 }
 
 int main() {
-    conditionally_disable_l1_cache();
+    configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t *)MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -95,6 +95,7 @@ inline void run_slave_eriscs(dispatch_core_processor_masks enables) {
 inline void wait_slave_eriscs(uint32_t &heartbeat) {
     WAYPOINT("SEW");
     while (mailboxes->slave_sync.all != RUN_SYNC_MSG_ALL_SLAVES_DONE) {
+        invalidate_l1_cache();
         RISC_POST_HEARTBEAT(heartbeat);
     }
     WAYPOINT("SED");
@@ -128,8 +129,8 @@ int main() {
         init_sync_registers();
         // Wait...
         WAYPOINT("GW");
-        while (mailboxes->go_message.signal != RUN_MSG_GO)
-        {
+        while (mailboxes->go_message.signal != RUN_MSG_GO) {
+            invalidate_l1_cache();
             RISC_POST_HEARTBEAT(heartbeat);
         };
         WAYPOINT("GD");

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -68,7 +68,9 @@ inline __attribute__((always_inline)) void notify_brisc_and_wait() {
 #ifdef NCRISC_HAS_IRAM
     notify_brisc_and_halt(RUN_SYNC_MSG_DONE);
 #else
-    while (*ncrisc_run != RUN_SYNC_MSG_GO);
+    while (*ncrisc_run != RUN_SYNC_MSG_GO) {
+        invalidate_l1_cache();
+    }
 #endif
 }
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -81,7 +81,7 @@ inline __attribute__((always_inline)) void signal_ncrisc_completion() {
 }
 
 int main(int argc, char *argv[]) {
-    conditionally_disable_l1_cache();
+    configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -51,7 +51,7 @@ inline __attribute__((always_inline)) void signal_slave_idle_erisc_completion() 
 }
 
 int main(int argc, char *argv[]) {
-    conditionally_disable_l1_cache();
+    configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t *)MEM_SLAVE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -61,7 +61,9 @@ int main(int argc, char *argv[]) {
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
         WAYPOINT("W");
-        while (*slave_idle_erisc_run != RUN_SYNC_MSG_GO);
+        while (*slave_idle_erisc_run != RUN_SYNC_MSG_GO) {
+            invalidate_l1_cache();
+        }
         DeviceZoneScopedMainN("SLAVE-IDLE-ERISC-FW");
 
         flush_erisc_icache();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -91,7 +91,9 @@ int main(int argc, char *argv[]) {
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
         WAYPOINT("W");
-        while (*trisc_run != RUN_SYNC_MSG_GO);
+        while (*trisc_run != RUN_SYNC_MSG_GO) {
+            invalidate_l1_cache();
+        }
         DeviceZoneScopedMainN("TRISC-FW");
 
         uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -76,7 +76,7 @@ constexpr bool cb_init_write = false;
 using namespace ckernel;
 
 int main(int argc, char *argv[]) {
-    conditionally_disable_l1_cache();
+    configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -378,11 +378,18 @@ inline __attribute__((always_inline)) void dynamic_noc_init() {
 
 // set noc local memory state for a single kernel from the global state
 inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
-    noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
-    noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
-    noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+    // Hide latency of NOC reg reads by reading first, writing second
+    uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+
+    noc_reads_num_issued[noc] = reads_num_issued;
+    noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
+    noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
+    noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+    noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
 }
 
 inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
@@ -394,11 +401,18 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
 
 inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
     for (int noc = 0; noc < NUM_NOCS; noc++) {
-        noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
-        noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
-        noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-        noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-        noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+        // Hide latency of NOC reg reads by reading first, writing second
+        uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+        uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+        uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+        uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+        uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+
+        noc_reads_num_issued[noc] = reads_num_issued;
+        noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
+        noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
+        noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+        noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
     }
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -473,7 +473,6 @@ bool cb_pages_reservable_at_back(int32_t operand, int32_t num_pages) {
     // "tiles_pushed" is updated by the producer only when the tiles are pushed
     uint32_t pages_received = get_cb_tiles_received_ptr(operand)[0];
 
-    invalidate_l1_cache();
     // uint16_t's here because Tensix updates the val at tiles_acked_ptr as uint16 in llk_pop_tiles
     // TODO: I think we could have TRISC update tiles_acked_ptr, and we wouldn't need uint16 here
     uint16_t pages_acked = (uint16_t)reg_read(pages_acked_ptr);
@@ -512,7 +511,6 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
     int32_t free_space_pages;
     WAYPOINT("CRBW");
     do {
-        invalidate_l1_cache();
         // uint16_t's here because Tensix updates the val at tiles_acked_ptr as uint16 in llk_pop_tiles
         // TODO: I think we could have TRISC update tiles_acked_ptr, and we wouldn't need uint16 here
         uint16_t pages_acked = (uint16_t)reg_read(pages_acked_ptr);
@@ -557,7 +555,6 @@ bool cb_pages_available_at_front(int32_t operand, int32_t num_pages) {
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uint32_t pages_received_ptr = (uint32_t)get_cb_tiles_received_ptr(operand);
 
-    invalidate_l1_cache();
     uint16_t pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     return num_pages <= pages_received;
 }
@@ -594,7 +591,6 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
 
     WAYPOINT("CWFW");
     do {
-        invalidate_l1_cache();
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
     WAYPOINT("CWFD");
@@ -1728,7 +1724,6 @@ inline void noc_async_write_multicast_exclude_region(
  */
 void noc_async_read_barrier(uint8_t noc = noc_index) {
     WAYPOINT("NRBW");
-    // BH cache is write-through so reader must invalidate if reading any address that was previously read
     do {
         invalidate_l1_cache();
     } while (!ncrisc_noc_reads_flushed(noc));

--- a/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
@@ -304,11 +304,18 @@ inline __attribute__((always_inline)) void dynamic_noc_init() {
 
 // set noc local memory state for a single kernel from the global state
 inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
-    noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
-    noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
-    noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+    // Hide latency of NOC reg reads by reading first, writing second
+    uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+
+    noc_reads_num_issued[noc] = reads_num_issued;
+    noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
+    noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
+    noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+    noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
 }
 
 inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
@@ -320,11 +327,18 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
 
 inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
     for (int noc = 0; noc < NUM_NOCS; noc++) {
-        noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
-        noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
-        noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-        noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-        noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+        // Hide latency of NOC reg reads by reading first, writing second
+        uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+        uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+        uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+        uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+        uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+
+        noc_reads_num_issued[noc] = reads_num_issued;
+        noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
+        noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
+        noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+        noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
     }
 }
 

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -166,10 +166,10 @@ inline void riscv_wait(uint32_t cycles) {
 }
 
 // Invalidates Blackhole's entire L1 cache
-// Blackhole L1 cache is a small write-through cache (4x16B L1 lines). If cache is enabled, the entire L1 is cached (no
-// MMU).
-//  Writing an address on one core and reading it from another core only requires the reader to invalidate.
-//  Need to invalidate any address written by noc that may have been previously read
+// Blackhole L1 cache is a small write-through cache (4x16B L1 lines). The cache covers all of L1 (no
+// MMU or range registers).
+//  Writing an address on one proc and reading it from another proc only requires the reader to invalidate.
+//  Need to invalidate any address written by noc that may have been previously read by riscv
 inline __attribute__((always_inline)) void invalidate_l1_cache() {
 #if defined(ARCH_BLACKHOLE) && !defined(DISABLE_L1_DATA_CACHE)
     asm("fence");

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -176,14 +176,12 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 #endif
 }
 
-// Disables Blackhole's L1 cache. Grayskull and Wormhole do not have L1 cache
-// L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
-// export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR,ER>
-inline __attribute__((always_inline)) void conditionally_disable_l1_cache() {
-#if defined(ARCH_BLACKHOLE) && defined(DISABLE_L1_DATA_CACHE)
-    // asm(R"ASM(
-    //         csrrsi zero, 0x7c0, 0x8
-    //       )ASM");
+inline __attribute__((always_inline)) void configure_l1_data_cache() {
+#if defined(ARCH_BLACKHOLE)
+#if defined(DISABLE_L1_DATA_CACHE)
+    // Disables Blackhole's L1 cache. Grayskull and Wormhole do not have L1 cache
+    // L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
+    // export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR,ER>
     asm(R"ASM(
         .option push
         li   t1, 0x1
@@ -192,6 +190,18 @@ inline __attribute__((always_inline)) void conditionally_disable_l1_cache() {
         .option pop
          )ASM" ::
             : "t1");
+#elif !defined(ENABLE_HW_CACHE_INVALIDATION)
+    // Disable gathering to stop HW from invalidating the data cache after 128 transactions
+    // This is default enabled
+    asm(R"ASM(
+        .option push
+        li   t1, 0x1
+        slli t1, t1, 18
+        csrrs zero, 0x7c0, t1
+        .option pop
+         )ASM" ::
+            : "t1");
+#endif
 #endif
 }
 

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -318,11 +318,18 @@ inline __attribute__((always_inline)) void dynamic_noc_init() {
 
 // set noc local memory state for a single kernel from the global state
 inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
-    noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
-    noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
-    noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+    // Hide latency of NOC reg reads by reading first, writing second
+    uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+
+    noc_reads_num_issued[noc] = reads_num_issued;
+    noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
+    noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
+    noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+    noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
 }
 
 inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
@@ -334,11 +341,18 @@ inline __attribute__((always_inline)) void dynamic_noc_local_state_init() {
 
 inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
     for (int noc = 0; noc < NUM_NOCS; noc++) {
-        noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
-        noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
-        noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
-        noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
-        noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+        // Hide latency of NOC reg reads by reading first, writing second
+        uint32_t reads_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+        uint32_t nonposted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+        uint32_t nonposted_writes_acked = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+        uint32_t nonposted_atomics_acked = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+        uint32_t posted_writes_num_issued = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+
+        noc_reads_num_issued[noc] = reads_num_issued;
+        noc_nonposted_writes_num_issued[noc] = nonposted_writes_num_issued;
+        noc_nonposted_writes_acked[noc] = nonposted_writes_acked;
+        noc_nonposted_atomics_acked[noc] = nonposted_atomics_acked;
+        noc_posted_writes_num_issued[noc] = posted_writes_num_issued;
     }
 }
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -915,7 +915,9 @@ void process_go_signal_mcast_cmd() {
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
     *aligned_go_signal_storage = cmd->mcast.go_signal;
 
-    while (*worker_sem_addr < cmd->mcast.wait_count);
+    while (*worker_sem_addr < cmd->mcast.wait_count) {
+        invalidate_l1_cache();
+    }
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     // send go signal update here
     for (uint32_t i = 0, num_mcasts = cmd->mcast.num_mcast_txns; i < num_mcasts; ++i) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -928,6 +928,7 @@ void paged_read_into_cmddat_q(uint32_t read_ptr, PrefetchExecBufState& exec_buf_
     InterleavedAddrGen<true> addr_gen{.bank_base_address = base_addr, .page_size = page_size};
 
     while (pages_at_once != 0) {
+        invalidate_l1_cache();
         uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
         noc_async_read(noc_addr, read_ptr, page_size);
         read_ptr += page_size;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -156,6 +156,10 @@ void JitBuildEnv::init(
             " ";
     }
 
+    if (tt::llrt::RunTimeOptions::get_instance().get_hw_cache_invalidation_enabled()) {
+        this->defines_ += "-DENABLE_HW_CACHE_INVALIDATION ";
+    }
+
     // Includes
     // TODO(pgk) this list is insane
     this->includes_ = string("") + "-I. " + "-I.. " + "-I" + this->root_ + " " + "-I" + this->root_ + "tt_metal " +

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -126,6 +126,8 @@ RunTimeOptions::RunTimeOptions() {
     if (getenv("TT_METAL_SKIP_DELETING_BUILT_CACHE")) {
         this->skip_deleting_built_cache = true;
     }
+
+    this->enable_hw_cache_invalidation = (std::getenv("TT_METAL_ENABLE_HW_CACHE_INVALIDATION") != nullptr);
 }
 
 const std::string& RunTimeOptions::get_root_dir() {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -125,6 +125,10 @@ class RunTimeOptions {
 
     bool enable_dispatch_data_collection = false;
 
+    // HW can clear Blackhole's L1 data cache psuedo-randomly once every 128 transactions
+    // This option will enable this feature to help flush out whether there is a missing cache invalidation
+    bool enable_hw_cache_invalidation = false;
+
     tt_metal::DispatchCoreConfig dispatch_core_config = tt_metal::DispatchCoreConfig{};
 
     bool skip_deleting_built_cache = false;
@@ -296,6 +300,8 @@ public:
 
     inline bool get_dispatch_data_collection_enabled() { return enable_dispatch_data_collection; }
     inline void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
+
+    inline bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
 
     inline tt_metal::DispatchCoreConfig get_dispatch_core_config() { return dispatch_core_config; }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We were missing some cache invalidates in BH and falling back to HW timeout to clear the cache. 

### What's changed
Added cache invalidates + low hanging perf in noc apis to do loads before stores. This has improved dispatch BW. 
Baseline without async changes (on top of 839ecd54):
<img width="863" alt="image" src="https://github.com/user-attachments/assets/b5d938fe-b5a2-4129-9ab6-33c92eea2381" />
on this branch with async changes (on top of https://github.com/tenstorrent/tt-metal/commit/5d0a53211ef2bfbf5f45b9f632bf360a4519a7d8):
<img width="855" alt="image" src="https://github.com/user-attachments/assets/78e3dc0c-af17-4658-9490-3c472990965e" />


From [dispatch bw tracker](https://docs.google.com/spreadsheets/d/1nN1ZPUNc2f0d6YEenBOHS7BdkpGlBysZ6SCArinGOrE/edit?gid=116139123#gid=116139123)


### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12435487586)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12401180294)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12401186278)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12401184606)
