### PR TITLE
Remove setup_core_to_tlb_map

### DIFF
--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -208,8 +208,6 @@ void configure_static_tlbs(
             device_driver.configure_tlb(mmio_device_id, dram_core, tlb_index, dram_addr, TLB_DATA::Posted);
         }
     }
-
-    device_driver.setup_core_to_tlb_map(mmio_device_id, get_static_tlb_index);
 }
 
 }  // namespace ll_api


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-metal/issues/13948

### Problem description
This API call is unnecessary since all the needed information is already passed during "configure_tlb" calls.
Related to https://github.com/tenstorrent/tt-umd/pull/403

### What's changed
- setup_core_to_tlb_map is removed, functionality should stay the same

### Checklist
- [x] All post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376643291
- [ ] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376645486
- [x] (Single-card) Model perf tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376647574
- [x] (Single-card) Device perf regressions : https://github.com/tenstorrent/tt-metal/actions/runs/12376649607
- [ ] (T3K) T3000 unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376651625
- [ ] (T3K) T3000 demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376653954
- [ ] (TG) TG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376656331
- [ ] (TG) TG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376658168
- [ ] (TGG) TGG unit tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376660071
- [x] (TGG) TGG demo tests : https://github.com/tenstorrent/tt-metal/actions/runs/12376661988
