### PR TITLE
#14530: remove up front padding from generic reduce

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/test_sum.py
@@ -50,3 +50,22 @@ def test_sum_global(device, batch_size, h, w):
     output_tensor = output_tensor[0, 0, 0]
 
     assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("n", [1, 9])
+@pytest.mark.parametrize("c", [1, 9])
+@pytest.mark.parametrize("h", [9, 37])
+@pytest.mark.parametrize("w", [9, 63])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, 3])
+def test_sum_4d(device, n, c, h, w, dim):
+    torch.manual_seed(0)
+
+    keepdim = True
+    torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.float32)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/operations/core/core.hpp"
+
 namespace ttnn {
 namespace operations::reduction {
 
@@ -59,37 +60,18 @@ static Tensor reduce_impl(
 
     if (dim.size() == 1 && rank == 4) {
         if (dim[0] == rank - 3) {
-            // Pad before running the op to only pay cost of formatting once
-            auto input_tensor_pad_shape = AutoFormat::pad_to_tile_shape(input_tensor_arg.get_legacy_shape(), true);
             auto out_shape = input_tensor_arg.get_legacy_shape();
             out_shape[1] = 1;
 
-            auto formatted_input_tensor = input_tensor_arg;
-            float pad_value = (reduce_type == ReduceType::Max)   ? -std::numeric_limits<float>::infinity()
-                              : (reduce_type == ReduceType::Min) ? std::numeric_limits<float>::infinity()
-                                                                 : 0;
-
-            if (!AutoFormat::check_input_tensor_format(input_tensor_arg, input_tensor_pad_shape)) {
-                formatted_input_tensor = AutoFormat::format_input_tensor(
-                    input_tensor_arg, input_tensor_arg.device(), input_tensor_pad_shape, pad_value, Layout::TILE);
-            }
-            Tensor output = ttnn::transpose(formatted_input_tensor, 1, -2, memory_config);
+            Tensor output = ttnn::transpose(input_tensor_arg, 1, -2, memory_config);
             output = reduce_impl<reduce_type>(output, 2, keepdim, memory_config, compute_kernel_config, scalar, false);
             output = ttnn::transpose(output, 1, -2, memory_config);
             return AutoFormat::format_output_tensor(output, out_shape, input_tensor_arg.device(), Layout::TILE);
         } else if (dim[0] == 0) {
-            // Pad before running the op to only pay cost of formatting once
-            auto input_tensor_pad_shape =
-                AutoFormat::pad_to_tile_shape(input_tensor_arg.get_legacy_shape(), false, true);
             auto out_shape = input_tensor_arg.get_legacy_shape();
             out_shape[0] = 1;
 
-            auto formatted_input_tensor = input_tensor_arg;
-            if (!AutoFormat::check_input_tensor_format(input_tensor_arg, input_tensor_pad_shape)) {
-                formatted_input_tensor = AutoFormat::format_input_tensor(
-                    input_tensor_arg, input_tensor_arg.device(), input_tensor_pad_shape, 0.0, Layout::TILE);
-            }
-            Tensor output = ttnn::transpose(formatted_input_tensor, 0, -2, memory_config);
+            Tensor output = ttnn::transpose(input_tensor_arg, 0, -2, memory_config);
             output = reduce_impl<reduce_type>(output, 2, keepdim, memory_config, compute_kernel_config, scalar, false);
             output = ttnn::transpose(output, 0, -2, memory_config);
             return AutoFormat::format_output_tensor(output, out_shape, input_tensor_arg.device(), Layout::TILE);


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/14530

### Problem description
- padding before running the op changed the logical shape

### What's changed
- remove the padding before running the op

### Checklist
- [x] Post commit CI passes between https://github.com/tenstorrent/tt-metal/actions/runs/12355026926 and https://github.com/tenstorrent/tt-metal/actions/runs/12359171831 all tests passed in at least one run
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12355031824
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12355039357
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12355035328
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
