### PR TITLE
#15944: Fix pybind of create_sub_device_manager_with_fabric to call the correct function.

### DIFF
--- a/tests/ttnn/unit_tests/test_sub_device.py
+++ b/tests/ttnn/unit_tests/test_sub_device.py
@@ -29,8 +29,10 @@ def run_sub_devices(device, create_fabric_sub_device=False):
     sub_devices_1 = [sub_device_1, sub_device_2]
     sub_devices_2 = [sub_device_2]
     if create_fabric_sub_device:
-        sub_device_manager1 = device.create_sub_device_manager_with_fabric(sub_devices_1, 3200)
-        sub_device_manager2 = device.create_sub_device_manager_with_fabric(sub_devices_2, 3200)
+        sub_device_manager1, fabric_sub_device_id1 = device.create_sub_device_manager_with_fabric(sub_devices_1, 3200)
+        sub_device_manager2, fabric_sub_device_id2 = device.create_sub_device_manager_with_fabric(sub_devices_2, 3200)
+        assert fabric_sub_device_id1 == ttnn.SubDeviceId(len(sub_devices_1))
+        assert fabric_sub_device_id2 == ttnn.SubDeviceId(len(sub_devices_2))
     else:
         sub_device_manager1 = device.create_sub_device_manager(sub_devices_1, 3200)
         sub_device_manager2 = device.create_sub_device_manager(sub_devices_2, 3200)
@@ -75,7 +77,8 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     sub_device_2 = ttnn.SubDevice([tensix_cores1])
     sub_devices = [sub_device_1, sub_device_2]
     if create_fabric_sub_device:
-        sub_device_manager = device.create_sub_device_manager_with_fabric(sub_devices, 3200)
+        sub_device_manager, fabric_sub_device_id = device.create_sub_device_manager_with_fabric(sub_devices, 3200)
+        assert fabric_sub_device_id == ttnn.SubDeviceId(len(sub_devices))
     else:
         sub_device_manager = device.create_sub_device_manager(sub_devices, 3200)
     device.load_sub_device_manager(sub_device_manager)
@@ -135,8 +138,9 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-def test_sub_devices(device, enable_async_mode):
-    run_sub_devices(device)
+@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
+def test_sub_devices(device, create_fabric_sub_device, enable_async_mode):
+    run_sub_devices(device, create_fabric_sub_device)
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
@@ -146,8 +150,9 @@ def test_sub_devices_mesh(mesh_device, create_fabric_sub_device, enable_async_mo
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-def test_sub_device_program(device, enable_async_mode):
-    run_sub_devices_program(device)
+@pytest.mark.parametrize("create_fabric_sub_device", (False, True))
+def test_sub_device_program(device, create_fabric_sub_device, enable_async_mode):
+    run_sub_devices_program(device, create_fabric_sub_device)
 
 
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -4,6 +4,7 @@
 
 #include "device.hpp"
 
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -117,12 +118,15 @@ void device_module(py::module& m_device) {
         )doc");
 
     auto pySubDeviceId = static_cast<py::class_<SubDeviceId>>(m_device.attr("SubDeviceId"));
-    pySubDeviceId.def(
-        py::init<uint8_t>(),
-        py::arg("id"),
-        R"doc(
+    pySubDeviceId
+        .def(
+            py::init<uint8_t>(),
+            py::arg("id"),
+            R"doc(
             Creates a SubDeviceId object with the given ID.
-        )doc");
+        )doc")
+        .def(py::self == py::self)
+        .def(py::self != py::self);
 
     auto pyDevice = static_cast<py::class_<Device, std::unique_ptr<Device, py::nodelete>>>(m_device.attr("Device"));
     pyDevice
@@ -168,7 +172,7 @@ void device_module(py::module& m_device) {
                     [device, sub_devices, local_l1_size, &sub_device_manager_id] {
                         sub_device_manager_id = device->create_sub_device_manager(sub_devices, local_l1_size);
                     },
-                    true);
+                    /*blocking=*/true);
                 return sub_device_manager_id;
             },
             py::arg("sub_devices"),
@@ -184,12 +188,36 @@ void device_module(py::module& m_device) {
                     SubDeviceManagerId: The ID of the created sub-device manager.
             )doc")
         .def(
+            "create_sub_device_manager_with_fabric",
+            [](Device* device, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {
+                std::tuple<SubDeviceManagerId, SubDeviceId> manager_and_sub_device_ids;
+                device->push_work(
+                    [device, sub_devices, local_l1_size, &manager_and_sub_device_ids] {
+                        manager_and_sub_device_ids =
+                            device->create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
+                    },
+                    /*blocking=*/true);
+                return manager_and_sub_device_ids;
+            },
+            py::arg("sub_devices"),
+            py::arg("local_l1_size"),
+            R"doc(
+                Creates a sub-device manager for the given device. This will automatically create a sub-device of ethernet cores for use with fabric.
+                Note that this is a temporary API until migration to actual fabric is complete.
+
+                Args:
+                    sub_devices (List[ttnn.SubDevice]): The sub-devices to include in the sub-device manager. No ethernet cores should be included in this list.
+                    local_l1_size (int): The size of the local allocators of each sub-device. The global allocator will be shrunk by this amount.
+
+                Returns:
+                    SubDeviceManagerId: The ID of the created sub-device manager.
+                    SubDeviceId: The ID of the sub-device that will be used for fabric.
+            )doc")
+        .def(
             "load_sub_device_manager",
             [](Device* device, SubDeviceManagerId sub_device_manager_id) {
-                device->push_work([device, sub_device_manager_id] {
-                    device->push_work(
-                        [device, sub_device_manager_id] { device->load_sub_device_manager(sub_device_manager_id); });
-                });
+                device->push_work(
+                    [device, sub_device_manager_id] { device->load_sub_device_manager(sub_device_manager_id); });
             },
             py::arg("sub_device_manager_id"),
             R"doc(

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -199,7 +199,7 @@ void py_module(py::module& module) {
         .def(
             "create_sub_device_manager_with_fabric",
             [](MeshDevice& self, const std::vector<SubDevice>& sub_devices, DeviceAddr local_l1_size) {
-                return self.create_sub_device_manager(sub_devices, local_l1_size);
+                return self.create_sub_device_manager_with_fabric(sub_devices, local_l1_size);
             },
             py::arg("sub_devices"),
             py::arg("local_l1_size"),


### PR DESCRIPTION
Add binding for single device api as well for uniformity

### Ticket
https://github.com/tenstorrent/tt-metal/issues/15944

### Problem description
create_sub_device_manager_with_fabric was pybound to the wrong function and wasn't creating the fabric sub-device in python.

### What's changed
Fix the pybind and ensure we test the fabric sub-device id is as expected.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12356442274
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
