### PR TITLE
Fix paged SDPA decode CB sizing issue

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -717,11 +717,8 @@ def run_test_sdpa_decode_paged_attention(
         # Test when page_table does not contain blocks for full sequence length
         k_chunk_size = get_chunk_size(max_start_idx + 1, s)
         padded_layer_len = nearest_n(max_start_idx + 1, n=k_chunk_size) if causal else s
-        if causal:
-            last_block = max(1, math.ceil(padded_layer_len / block_size))
-            tt_page_table = ttnn.Tensor(page_table[:, :last_block], ttnn.int32).to(device)
-        else:
-            tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+        tt_page_table = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
         program_config = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=grid_size,  # device.compute_with_storage_grid_size(),
@@ -853,12 +850,13 @@ def run_test_sdpa_decode_paged_attention(
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d, grid_size, cur_pos_tensor",
     (
-        # [32, 8, 1, 32768, 128, (8, 6), True],  # Llama2-70B
-        # [4, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
-        # [4, 16, 4, 32768, 128, (8, 8), True],
-        # [32, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
+        [32, 8, 1, 32768, 128, (8, 6), True],  # Llama2-70B
+        [4, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
+        [4, 16, 4, 32768, 128, (8, 8), True],
+        [32, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
         [8, 16, 4, 4096, 128, (8, 2), True],  # llama 3.1 8b N300
-        # [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
+        [1, 8, 1, 128 * 1024, 128, (8, 4), True],  # llama 3.1 8b N300
+        [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
         # [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
         # [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
         # [4, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
@@ -869,6 +867,9 @@ def run_test_sdpa_decode_paged_attention(
 def test_sdpa_decode_paged_attention(
     device, b, nh, nkv, s, d, kv_dtype, grid_size, q_dtype, cur_pos_tensor, block_size, use_program_cache
 ):
+    if s == 128 * 1024 and block_size != 64:
+        # 128k sequence, block_size 64 tests the sizing of the page table CB
+        pytest.skip("Skipping test for seq_len=128k with block_size!=64")
     ttnn.device.DisablePersistentKernelCache()
     run_test_sdpa_decode_paged_attention(
         device,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -850,13 +850,13 @@ def run_test_sdpa_decode_paged_attention(
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d, grid_size, cur_pos_tensor",
     (
-        [32, 8, 1, 32768, 128, (8, 6), True],  # Llama2-70B
-        [4, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
-        [4, 16, 4, 32768, 128, (8, 8), True],
-        [32, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
+        # [32, 8, 1, 32768, 128, (8, 6), True],  # Llama2-70B
+        # [4, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
+        # [4, 16, 4, 32768, 128, (8, 8), True],
+        # [32, 32, 8, 4096, 128, (8, 8), True],  # llama 3.1 8b
         [8, 16, 4, 4096, 128, (8, 2), True],  # llama 3.1 8b N300
         [1, 8, 1, 128 * 1024, 128, (8, 4), True],  # llama 3.1 8b N300
-        [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
+        # [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
         # [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
         # [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B
         # [4, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_op.cpp
@@ -260,7 +260,9 @@ operation::Hash ScaledDotProductAttentionDecode::compute_program_hash(
         this->is_causal,
         has_attn_mask,
         has_cur_pos,
-        input_tensors);
+        input_tensors,
+        // Hash on page_table_tensor to properly size page table CB
+        optional_input_tensors.at(1));
 }
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -363,8 +363,8 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         page_table_stick_size = page_table_buffer->aligned_page_size();
 
         // cb page_table
-        auto c_in9_config = CircularBufferConfig(page_table_tile_size, {{CBIndex::c_9, page_table_df}})
-                                .set_page_size(CBIndex::c_9, page_table_tile_size);
+        auto c_in9_config = CircularBufferConfig(page_table_stick_size, {{CBIndex::c_9, page_table_df}})
+                                .set_page_size(CBIndex::c_9, page_table_stick_size);
         auto cb_in9_id = CreateCircularBuffer(program, core_grid, c_in9_config);
     }
 


### PR DESCRIPTION
### Ticket
This issue was uncovered while investigating this ticket https://github.com/tenstorrent/tt-metal/issues/15873

### Problem description
Paged SDPA decode was sizing the `page_table` CB as the tile size according to the dataformat (uint32). This meant that the page table was always expected to be less than 1024 elements. This leads to data corruption when the `page_table` has more than 1024 elements.

### What's changed
This PR sets the `page_table` CB size as the true stick size in bytes, resolving the above issue.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12376385680
- [x] New/Existing tests provide coverage for changes
