### PR TITLE
Python -> Python3

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -2,6 +2,11 @@ name: "[internal] Single-card Device perf regressions impl"
 
 on:
   workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: "ubuntu-20.04"
 
 jobs:
   device-perf:
@@ -22,22 +27,20 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on: ${{ matrix.test-info.runs-on }}
     steps:
-      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - name: Ensure weka mount is active
         run: |
           sudo systemctl restart mnt-MLPerf.mount
           sudo /etc/rc.local
           ls -al /mnt/MLPerf/bit_error_tests
+      - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/prepare-metal-run
         with:
-          name: TTMetal_build_${{ matrix.test-info.arch }}_profiler
-      - name: Extract files
-        run: tar -xvf ttm_${{ matrix.test-info.arch }}.tar
-      - uses: ./.github/actions/install-python-deps
-      - name: Run device performance regressions
+          arch: ${{ matrix.test-info.arch }}
+          is_profiler: 'true'
+      - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-info.timeout }}
         run: |
           source python_env/bin/activate

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       tracy: true
+      os: "ubuntu-20.04-amd64"
     secrets: inherit
   device-perf:
     needs: build-artifact-profiler

--- a/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/web_demo/web_demo.py
@@ -9,7 +9,7 @@ import os
 
 # Two scripts to run
 script1 = "pytest models/demos/wormhole/stable_diffusion/demo/web_demo/sdserver.py"
-script2 = "python models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py"
+script2 = "python3 models/demos/wormhole/stable_diffusion/demo/web_demo/flaskserver.py"
 script3 = "streamlit run models/demos/wormhole/stable_diffusion/demo/web_demo/streamlit_app.py"
 
 # Start both scripts using subprocess

--- a/tests/scripts/run_build_docs.sh
+++ b/tests/scripts/run_build_docs.sh
@@ -9,6 +9,6 @@ fi
 echo "Checking docs build..."
 
 cd $TT_METAL_HOME/docs
-python -m pip install -r requirements-docs.txt
+python3 -m pip install -r requirements-docs.txt
 make clean
 make html

--- a/tests/scripts/run_ttnn_sweeps.sh
+++ b/tests/scripts/run_ttnn_sweeps.sh
@@ -15,7 +15,7 @@ run_ttnn_sweeps() {
   export PYTHONPATH=$TT_METAL_HOME
   source python_env/bin/activate
 
-  python tests/ttnn/sweep_tests/run_sweeps.py
+  python3 tests/ttnn/sweep_tests/run_sweeps.py
 }
 
 run_ttnn_sweeps

--- a/tests/scripts/set_up_end_to_end_tests_env.sh
+++ b/tests/scripts/set_up_end_to_end_tests_env.sh
@@ -16,10 +16,10 @@ set_up_end_to_end_tests_env() {
 
   source env/bin/activate
 
-  python -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
+  python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
 
-  python -m pip install -r requirements.txt
-  python -m pip install ../../ttnn-*.whl
+  python3 -m pip install -r requirements.txt
+  python3 -m pip install ../../ttnn-*.whl
 
   cd ../../
   rm -rf tt_metal tt_eager ttnn models

--- a/tt_metal/tools/profiler/process_model_log.py
+++ b/tt_metal/tools/profiler/process_model_log.py
@@ -46,7 +46,7 @@ def post_process_ops_log(output_logs_subdir, columns, sum_vals=True, op_name="",
 
 def run_device_profiler(command, output_logs_subdir):
     output_profiler_dir = get_profiler_folder(output_logs_subdir)
-    profiler_cmd = f"python -m tracy -p -r -o {output_profiler_dir} -t 5000 -m {command}"
+    profiler_cmd = f"python3 -m tracy -p -r -o {output_profiler_dir} -t 5000 -m {command}"
     subprocess.run([profiler_cmd], shell=True, check=True)
 
 

--- a/tt_metal/tools/profiler/profile_this.py
+++ b/tt_metal/tools/profiler/profile_this.py
@@ -26,7 +26,7 @@ def profile_command(test_command, output_folder, name_append):
         options += f"-o {output_folder}"
     if name_append:
         options += f" -n {name_append}"
-    opProfilerTestCommand = f"python -m tracy -v -r -p {options} -m {test_command}"
+    opProfilerTestCommand = f"python3 -m tracy -v -r -p {options} -m {test_command}"
     subprocess.run([opProfilerTestCommand], shell=True, check=False, env=currentEnvs)
 
 

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -10,7 +10,7 @@ from tracy import *
 def main():
     from optparse import OptionParser
 
-    usage = "python -m tracy [-m module | scriptfile] [arg] ..."
+    usage = "python3 -m tracy [-m module | scriptfile] [arg] ..."
     parser = OptionParser(usage=usage)
     parser.allow_interspersed_args = False
     parser.add_option("-m", dest="module", action="store_true", help="Profile a library module.", default=False)
@@ -146,7 +146,7 @@ def main():
             originalArgs.remove("-r")
             osCmd = " ".join(originalArgs[1:])
 
-            testCommand = f"python -m tracy {osCmd}"
+            testCommand = f"python3 -m tracy {osCmd}"
 
             envVars = dict(os.environ)
             # No Dispatch cores for op_report


### PR DESCRIPTION
### Ticket
#14393

### Problem description
The scripts do not execute inside a clean Docker container because they call `python` instead of `python3`.

### What's changed
python -> python3

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12360690672
- [x] Device perf regressions passes https://github.com/tenstorrent/tt-metal/actions/runs/12358294738