### PR TITLE
Bump MagicEnum to v0.9.7

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 # magic_enum : https://github.com/Neargye/magic_enum
 ############################################################################################################################
 
-CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.6)
+CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.7)
 
 ############################################################################################################################
 # fmt : https://github.com/fmtlib/fmt

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -7,7 +7,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include "common/constants.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <ttnn/operations/functions.hpp>
 
 using namespace tt;

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <sstream>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_backend_api_types.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 std::string tt::get_string(tt::ARCH arch) {
     switch (arch) {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -4,7 +4,7 @@
 
 #include "tt_metal/impl/allocator/allocator.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "tt_metal/common/math.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/impl/allocator/algorithms/free_list.hpp"

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 #include <climits>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <mutex>
 
 #include "tt_metal/common/base.hpp"

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -7,7 +7,7 @@
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/common/core_coord.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -11,7 +11,7 @@
 
 #include "common/bfloat16.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/matmul_common/bmm_op.hpp
+++ b/tt_metal/programming_examples/matmul_common/bmm_op.hpp
@@ -15,7 +15,7 @@
 #include "tt_metal/common/bfloat16.hpp"
 
 #include "umd/device/tt_xy_pair.h"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "tt_metal/common/work_split.hpp"
 

--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -11,7 +11,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include <nlohmann/json.hpp>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "tools/profiler/profiler.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "ttnn/operation.hpp"

--- a/tt_metal/tt_stl/reflection.hpp
+++ b/tt_metal/tt_stl/reflection.hpp
@@ -24,7 +24,7 @@
 
 #include "concepts.hpp"
 #include <nlohmann/json.hpp>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "type_name.hpp"
 #include "tt_metal/common/logger.hpp"
 

--- a/ttnn/cpp/pybind11/export_enum.hpp
+++ b/ttnn/cpp/pybind11/export_enum.hpp
@@ -6,7 +6,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 namespace py = pybind11;
 

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -6,7 +6,7 @@
 #include <csignal>
 #include <optional>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"  // TTNN_TENSOR_PRINT_PROFILE
 #include "ttnn/tensor/types.hpp"

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
@@ -4,7 +4,7 @@
 
 #include "reshard_op.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "reshard_program_factory.hpp"
 #include "tt_metal/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "binary_composite_op.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <utility>
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -8,7 +8,7 @@
 #include <functional>
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/operations/core/core.hpp"
 
 namespace ttnn::operations::binary {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <functional>
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <optional>
 #include <variant>
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -26,7 +26,7 @@
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <utility>
 
 namespace ttnn::operations::binary_backward {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_binary {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_unary {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_unary_backward {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <optional>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/run_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -12,7 +12,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 #include "ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 namespace ttnn::operations::ternary_backward {
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <optional>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <utility>
 #include "tt_metal/common/bfloat16.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -6,7 +6,7 @@
 #include <functional>
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "ttnn/cpp/ttnn/operations/eltwise/ternary/where.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -4,7 +4,7 @@
 
 #include "unary_device_operation.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <utility>
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include "tt_metal/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -4,7 +4,7 @@
 
 #include "moreh_helper_functions.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <utility>
 
 #include "common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -11,7 +11,7 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include <optional>
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
@@ -11,7 +11,7 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include <optional>
 


### PR DESCRIPTION
### Ticket
Closes #16036

### Problem description
Consumers cannot opt to use an external MagicEnum as the #include statements are incompatible.

### What's changed
Bump to MagicEnum v0.9.7 which unifies the way to consume it across source and post-install.

