### PR TITLE
[tt-train] Add option to disable wandb in examples

### DIFF
--- a/tt-train/README.md
+++ b/tt-train/README.md
@@ -70,6 +70,9 @@ TT_METAL_LOGGER_LEVEL=FATAL ./build/sources/examples/nano_gpt/nano_gpt --model_p
 ### CI only tests
 If CI fails, but local tests pass as expected, please consider changing ENABLE_CI_ONLY_TT_TRAIN_TESTS definition in tests/CMakeLists.txt
 
+### wandb support
+If you don't have an account to wandb (or don't want to use it), use `-w 0` argument or run `wandb offline` beforehand (creates `wandb/settings` file)
+
 # Contributing
 * Create a new branch.
 * Make your changes and commit them.


### PR DESCRIPTION
### Problem description
NanoGPT example crashes if `wandb` credentials are missing. 

### What's changed
Add option to disable wandb when running from command line. Use `-w 0` arguments. Added another option how to disable `wandb`.

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12360978772
- [x] New/Existing tests provide coverage for changes
