### PR TITLE
 #16070: Use the same Docker image as built

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -24,6 +24,8 @@ jobs:
   build-docker-image:
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
+    with:
+      os: "ubuntu-22.04-amd64"
   build-artifact:
     needs: build-docker-image
     uses: ./.github/workflows/build-artifact.yaml


### PR DESCRIPTION
### Ticket

#16070

### Problem description
For Blackhole Post Commit

- We build and tag Docker image with 20.04 
https://github.com/tenstorrent/tt-metal/actions/runs/12359826668/job/34493376435
```
Run docker push ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64:dev-abhullar-l1-data-cache
The push refers to repository [ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64]
```
- And later request the image that is 22.04
```
Run docker pull ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-amd64:dev-abhullar-l1-data-cache
```

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
