### PR TITLE
Add full support for creating tensors with logical sharding from python

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
@@ -7,41 +7,13 @@
 #include "tt_metal/common/logger.hpp"
 #include "tt_metal/common/work_split.hpp"
 #include "ttnn/async_runtime.hpp"
+#include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn_test_fixtures.hpp"
 
 namespace {
-// Helpers that potentially need to be moved into TensorLayout
-Size flatten_to_2D(const ttnn::SimpleShape& shape) {
-    const int rank = static_cast<int>(shape.rank());
-
-    size_t width = 1;
-    size_t height = 1;
-
-    // Iterate dims in reverse order
-    // Even tensor of rank 0 or 1
-    for (int i = -1; i >= -rank; --i) {
-        auto& dim = i == -1 ? width : height;
-        dim *= shape[i];
-    }
-
-    Size size{height, width};
-
-    return size;
-}
-
-std::array<size_t, 4> compute_shard_spec(const Size& shape, const Size& shard_shape) {
-    const auto num_shards_height = tt::div_up(shape.height(), shard_shape.height());
-    const auto last_shard_height =
-        shape.height() % shard_shape.height() > 0 ? shape.height() % shard_shape.height() : shard_shape.height();
-    const auto num_shards_width = tt::div_up(shape.width(), shard_shape.width());
-    const auto last_shard_width =
-        shape.width() % shard_shape.width() > 0 ? shape.width() % shard_shape.width() : shard_shape.width();
-
-    return {num_shards_height, last_shard_height, num_shards_width, last_shard_width};
-};
 
 void pretty_print_data_as_shards(
     const std::vector<float>& data, const Size& shape, const Size& shard_shape, const size_t char_count = 3) {
@@ -52,7 +24,7 @@ void pretty_print_data_as_shards(
         shape.height() * shape.width());
 
     const auto [num_shards_height, last_shard_height, num_shards_width, last_shard_width] =
-        compute_shard_spec(shape, shard_shape);
+        tt::tt_metal::compute_shard_division_spec(shape, shard_shape);
 
     std::cout << "2D shape: " << shape << std::endl;
     for (size_t shard_height_idx = 0; shard_height_idx < num_shards_height; shard_height_idx++) {
@@ -80,124 +52,6 @@ void pretty_print_data_as_shards(
     }
     std::cout << std::endl;
 }
-
-using LogicalPhysicalIdxPairs = std::vector<std::array<size_t, 2>>;
-using LogicalPhysicalMapping = std::pair<LogicalPhysicalIdxPairs, size_t>;
-std::vector<LogicalPhysicalMapping> compute_logical_to_physical_shards_mapping(
-    const Size& logical_2D_shape,
-    const Size& logical_shard_shape,
-    const Size& physical_shard_shape,
-    const size_t physical_stride) {
-    const auto logical_stride = logical_2D_shape.width();
-
-    const auto [num_shards_height, last_shard_height, num_shards_width, last_shard_width] =
-        compute_shard_spec(logical_2D_shape, logical_shard_shape);
-
-    std::vector<LogicalPhysicalMapping> logical_physical_mapping(num_shards_height * num_shards_width);
-
-    for (size_t shard_height_idx = 0; shard_height_idx < num_shards_height; shard_height_idx++) {
-        for (size_t shard_width_idx = 0; shard_width_idx < num_shards_width; shard_width_idx++) {
-            const auto num_shard_rows =
-                shard_height_idx == num_shards_height - 1 ? last_shard_height : logical_shard_shape.height();
-            const auto num_shard_cols =
-                shard_width_idx == num_shards_width - 1 ? last_shard_width : logical_shard_shape.width();
-
-            auto indices = LogicalPhysicalIdxPairs(num_shard_rows);
-            const auto logical_start_idx = shard_height_idx * logical_shard_shape.height() * logical_stride +
-                                           shard_width_idx * logical_shard_shape.width();
-            const auto physical_start_idx = shard_height_idx * physical_shard_shape.height() * physical_stride +
-                                            shard_width_idx * physical_shard_shape.width();
-            for (size_t i = 0; i < num_shard_rows; i++) {
-                indices[i] = {i * logical_stride + logical_start_idx, i * physical_stride + physical_start_idx};
-            }
-
-            logical_physical_mapping.push_back((LogicalPhysicalMapping){indices, num_shard_cols});
-        }
-    }
-    return logical_physical_mapping;
-};
-
-std::vector<float> convert_fp32_logical_data_to_physical_data(
-    const std::vector<float>& logical_data, const TensorSpec& tensor_spec) {
-    const auto& logical_shape = tensor_spec.logical_shape();
-    TT_FATAL(
-        logical_data.size() == logical_shape.volume(),
-        "Logical data size {} should be same as volume indicated by logical shape {}",
-        logical_data.size(),
-        logical_shape);
-
-    const auto& logical_shard_shape = tensor_spec.tensor_layout().get_logical_shard_shape();
-    const auto& physical_shard_shape = tensor_spec.tensor_layout().get_physical_shard_shape();
-    const auto& physical_shape = tensor_spec.physical_shape();
-
-    std::vector<float> physical_data(physical_shape.height() * physical_shape.width(), 0);
-
-    auto logical_2D_shape = flatten_to_2D(logical_shape);
-    size_t physical_stride = physical_shape.width();
-
-    const auto logical_physical_mapping = compute_logical_to_physical_shards_mapping(
-        logical_2D_shape, logical_shard_shape, physical_shard_shape, physical_stride);
-
-    for (const auto& [indices, cols] : logical_physical_mapping) {
-        for (const auto& idx_pair : indices) {
-            auto logical_idx_start = idx_pair[0];
-            auto physical_idx_start = idx_pair[1];
-
-            for (size_t col = 0; col < cols; col++) {
-                physical_data[physical_idx_start + col] = logical_data[logical_idx_start + col];
-            }
-        }
-    }
-
-    TT_FATAL(
-        physical_data.size() == physical_shape.height() * physical_shape.width(),
-        "Physical data size {} should be same as volume indicated by physical shape {}",
-        physical_data.size(),
-        physical_shape);
-
-    return physical_data;
-};
-
-std::vector<float> convert_fp32_physical_data_to_logical_data(
-    const std::vector<float>& physical_data, const TensorSpec& tensor_spec) {
-    auto physical_shape = tensor_spec.physical_shape();
-    TT_FATAL(
-        physical_data.size() == physical_shape.height() * physical_shape.width(),
-        "Physical data size {} should be same as volume indicated by physical shape {}",
-        physical_data.size(),
-        physical_shape);
-
-    const auto& logical_shape = tensor_spec.logical_shape();
-    const auto& logical_shard_shape = tensor_spec.tensor_layout().get_logical_shard_shape();
-    const auto& physical_shard_shape = tensor_spec.tensor_layout().get_physical_shard_shape();
-
-    auto logical_2D_shape = flatten_to_2D(logical_shape);
-    std::vector<float> logical_data(logical_2D_shape.height() * logical_2D_shape.width(), 0);
-
-    size_t physical_stride = physical_shape.width();
-
-    const auto logical_physical_mapping = compute_logical_to_physical_shards_mapping(
-        logical_2D_shape, logical_shard_shape, physical_shard_shape, physical_stride);
-
-    for (const auto& [indices, cols] : logical_physical_mapping) {
-        for (const auto& idx_pair : indices) {
-            auto logical_idx_start = idx_pair[0];
-            auto physical_idx_start = idx_pair[1];
-
-            for (size_t col = 0; col < cols; col++) {
-                logical_data[logical_idx_start + col] = physical_data[physical_idx_start + col];
-            }
-        }
-    }
-
-    TT_FATAL(
-        logical_data.size() == logical_shape.volume(),
-        "Logical data size {} should be same as volume indicated by logical shape {}",
-        logical_data.size(),
-        logical_shape);
-
-    return logical_data;
-};
 
 }  // namespace
 
@@ -258,15 +112,21 @@ TEST_P(ShardWithAlignmentTests, LogicalToPhysical) {
     const auto& logical_data = params.inputs.logical_data;
     const auto& expected_physical_data = params.expected.physical_data;
 
-    auto physical_data = convert_fp32_logical_data_to_physical_data(logical_data, tensor_spec);
+    // Convert output physical data to row major (if necessary) for testing
+    auto physical_data = tensor_impl::encode_tensor_data(logical_data, tensor_spec);
+    if (tensor_spec.layout() == Layout::TILE) {
+        // TODO: Fix convert_layout_tile_to_row_major to take in vector instead of buffer?
+        physical_data = tensor_impl::convert_layout_tile_to_row_major(
+            physical_shape, tensor_spec.tile(), owned_buffer::create(std::move(physical_data)));
+    }
 
-    // auto shape_2D = flatten_to_2D(tensor_spec.logical_shape());
+    // auto shape_2D = tt::tt_metal::get_2d_shape(tensor_spec.logical_shape());
     // pretty_print_data_as_shards(logical_data, shape_2D, logical_shard_shape);
     // pretty_print_data_as_shards(physical_data, physical_shape, physical_shard_shape);
 
     ASSERT_EQ(physical_data.size(), expected_physical_data.size());
     for (size_t i = 0; i < physical_data.size(); i++) {
-        EXPECT_EQ(physical_data[i], expected_physical_data[i]);
+        ASSERT_EQ(physical_data[i], expected_physical_data[i]);
     }
 }
 
@@ -301,18 +161,24 @@ TEST_P(ShardWithAlignmentTests, PhysicalToLogical) {
     ASSERT_EQ(physical_shape, params.expected.physical_shape);
 
     // Use expected value as input physical data
-    const auto& physical_data = params.expected.physical_data;
+    auto physical_data = params.expected.physical_data;
     const auto& expected_data = params.inputs.logical_data;
 
-    auto logical_data = convert_fp32_physical_data_to_logical_data(physical_data, tensor_spec);
+    // Convert input physical data to TILE layout (if necessary) for testing
+    if (tensor_spec.layout() == Layout::TILE) {
+        // TODO: Fix convert_layout_row_major_to_tile to take in vector instead of buffer?
+        physical_data = tensor_impl::convert_layout_row_major_to_tile(
+            physical_shape, tensor_spec.tile(), owned_buffer::create(std::move(physical_data)));
+    }
+    auto logical_data = tensor_impl::decode_tensor_data(physical_data, tensor_spec);
 
-    // auto shape_2D = flatten_to_2D(tensor_spec.logical_shape());
+    // auto shape_2D = tt::tt_metal::get_2d_shape(tensor_spec.logical_shape());
     // pretty_print_data_as_shards(physical_data, physical_shape, physical_shard_shape);
     // pretty_print_data_as_shards(logical_data, shape_2D, logical_shard_shape);
 
     ASSERT_EQ(logical_data.size(), expected_data.size());
     for (size_t i = 0; i < logical_data.size(); i++) {
-        EXPECT_EQ(logical_data[i], expected_data[i]);
+        ASSERT_EQ(logical_data[i], expected_data[i]);
     }
 }
 
@@ -330,36 +196,36 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = std::nullopt,
                 .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
                 .logical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
-                          20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
-                          40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-                          60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
-                          80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
-                         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-                         120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-                         140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
-                         160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
-                         180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,
-                         200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
-                         220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
-                         240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259,
-                         260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279,
-                         280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,
+                                  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
+                                  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+                                  60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+                                  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
+                                 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+                                 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+                                 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+                                 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+                                 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,
+                                 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+                                 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+                                 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259,
+                                 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279,
+                                 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,
 
-                         300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319,
-                         320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339,
-                         340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359,
-                         360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379,
-                         380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399,
-                         400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419,
-                         420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439,
-                         440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459,
-                         460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479,
-                         480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499,
-                         500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519,
-                         520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539,
-                         540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559,
-                         560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579,
-                         580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597, 598, 599}
+                                 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319,
+                                 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339,
+                                 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359,
+                                 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379,
+                                 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399,
+                                 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419,
+                                 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439,
+                                 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459,
+                                 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479,
+                                 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499,
+                                 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519,
+                                 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539,
+                                 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559,
+                                 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579,
+                                 580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597, 598, 599}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{16, 32},
@@ -408,22 +274,22 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = std::nullopt,
                 .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
                 .logical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
-                          15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
-                          30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
-                          45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-                          60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,
+                                  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+                                  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+                                  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+                                  60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,
 
-                          75,  76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
-                          90,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
-                         105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-                         120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
-                         135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+                                  75,  76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
+                                  90,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
+                                 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+                                 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
+                                 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
 
-                         150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
-                         165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
-                         180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194,
-                         195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
-                         210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224}
+                                 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
+                                 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+                                 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194,
+                                 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
+                                 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{16, 16},
@@ -488,15 +354,15 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = std::nullopt,
                 .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
                 .logical_data = { 0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  /**/  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,
-                         20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  /**/  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
-                         40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-                         60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  /**/  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
-                         80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  /**/  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
-                        100, 101, 102, 103, 104, 105, 106, 107, 108, 109,  /**/ 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-                        120, 121, 122, 123, 124, 125, 126, 127, 128, 129,  /**/ 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-                        140, 141, 142, 143, 144, 145, 146, 147, 148, 149,  /**/ 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
-                        160, 161, 162, 163, 164, 165, 166, 167, 168, 169,  /**/ 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
-                        180, 181, 182, 183, 184, 185, 186, 187, 188, 189,  /**/ 190, 191, 192, 193, 194, 195, 196, 197, 198, 199}
+                                 20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  /**/  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,
+                                 40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+                                 60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  /**/  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
+                                 80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  /**/  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
+                                100, 101, 102, 103, 104, 105, 106, 107, 108, 109,  /**/ 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+                                120, 121, 122, 123, 124, 125, 126, 127, 128, 129,  /**/ 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+                                140, 141, 142, 143, 144, 145, 146, 147, 148, 149,  /**/ 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+                                160, 161, 162, 163, 164, 165, 166, 167, 168, 169,  /**/ 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+                                180, 181, 182, 183, 184, 185, 186, 187, 188, 189,  /**/ 190, 191, 192, 193, 194, 195, 196, 197, 198, 199}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{16, 16},
@@ -527,36 +393,36 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = std::nullopt,
                 .page_config = PageConfig(Layout::TILE, Tile({16, 16})),
                 .logical_data = {  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  /**/  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
-                          30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
-                          60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  /**/  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
-                          90,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,  /**/ 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
-                         120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,  /**/ 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
-                         150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169,  /**/ 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
-                         180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,  /**/ 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
-                         210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229,  /**/ 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
-                         240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259,  /**/ 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
-                         270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289,  /**/ 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,
-                         300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319,  /**/ 320, 321, 322, 323, 324, 325, 326, 327, 328, 329,
-                         330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349,  /**/ 350, 351, 352, 353, 354, 355, 356, 357, 358, 359,
-                         360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379,  /**/ 380, 381, 382, 383, 384, 385, 386, 387, 388, 389,
-                         390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409,  /**/ 410, 411, 412, 413, 414, 415, 416, 417, 418, 419,
-                         420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439,  /**/ 440, 441, 442, 443, 444, 445, 446, 447, 448, 449,
-                         450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469,  /**/ 470, 471, 472, 473, 474, 475, 476, 477, 478, 479,
-                         480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499,  /**/ 500, 501, 502, 503, 504, 505, 506, 507, 508, 509,
-                         510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529,  /**/ 530, 531, 532, 533, 534, 535, 536, 537, 538, 539,
+                                  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  /**/  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+                                  60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  /**/  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,
+                                  90,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,  /**/ 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+                                 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,  /**/ 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+                                 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169,  /**/ 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+                                 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,  /**/ 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
+                                 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229,  /**/ 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+                                 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259,  /**/ 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
+                                 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289,  /**/ 290, 291, 292, 293, 294, 295, 296, 297, 298, 299,
+                                 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319,  /**/ 320, 321, 322, 323, 324, 325, 326, 327, 328, 329,
+                                 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349,  /**/ 350, 351, 352, 353, 354, 355, 356, 357, 358, 359,
+                                 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379,  /**/ 380, 381, 382, 383, 384, 385, 386, 387, 388, 389,
+                                 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409,  /**/ 410, 411, 412, 413, 414, 415, 416, 417, 418, 419,
+                                 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439,  /**/ 440, 441, 442, 443, 444, 445, 446, 447, 448, 449,
+                                 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469,  /**/ 470, 471, 472, 473, 474, 475, 476, 477, 478, 479,
+                                 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499,  /**/ 500, 501, 502, 503, 504, 505, 506, 507, 508, 509,
+                                 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529,  /**/ 530, 531, 532, 533, 534, 535, 536, 537, 538, 539,
 
-                         540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559,  /**/ 560, 561, 562, 563, 564, 565, 566, 567, 568, 569,
-                         570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589,  /**/ 590, 591, 592, 593, 594, 595, 596, 597, 598, 599,
-                         600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619,  /**/ 620, 621, 622, 623, 624, 625, 626, 627, 628, 629,
-                         630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649,  /**/ 650, 651, 652, 653, 654, 655, 656, 657, 658, 659,
-                         660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679,  /**/ 680, 681, 682, 683, 684, 685, 686, 687, 688, 689,
-                         690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709,  /**/ 710, 711, 712, 713, 714, 715, 716, 717, 718, 719,
-                         720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739,  /**/ 740, 741, 742, 743, 744, 745, 746, 747, 748, 749,
-                         750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769,  /**/ 770, 771, 772, 773, 774, 775, 776, 777, 778, 779,
-                         780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799,  /**/ 800, 801, 802, 803, 804, 805, 806, 807, 808, 809,
-                         810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829,  /**/ 830, 831, 832, 833, 834, 835, 836, 837, 838, 839,
-                         840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859,  /**/ 860, 861, 862, 863, 864, 865, 866, 867, 868, 869,
-                         870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 889,  /**/ 890, 891, 892, 893, 894, 895, 896, 897, 898, 899}
+                                 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559,  /**/ 560, 561, 562, 563, 564, 565, 566, 567, 568, 569,
+                                 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589,  /**/ 590, 591, 592, 593, 594, 595, 596, 597, 598, 599,
+                                 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619,  /**/ 620, 621, 622, 623, 624, 625, 626, 627, 628, 629,
+                                 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649,  /**/ 650, 651, 652, 653, 654, 655, 656, 657, 658, 659,
+                                 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679,  /**/ 680, 681, 682, 683, 684, 685, 686, 687, 688, 689,
+                                 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709,  /**/ 710, 711, 712, 713, 714, 715, 716, 717, 718, 719,
+                                 720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739,  /**/ 740, 741, 742, 743, 744, 745, 746, 747, 748, 749,
+                                 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769,  /**/ 770, 771, 772, 773, 774, 775, 776, 777, 778, 779,
+                                 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799,  /**/ 800, 801, 802, 803, 804, 805, 806, 807, 808, 809,
+                                 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829,  /**/ 830, 831, 832, 833, 834, 835, 836, 837, 838, 839,
+                                 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859,  /**/ 860, 861, 862, 863, 864, 865, 866, 867, 868, 869,
+                                 870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 889,  /**/ 890, 891, 892, 893, 894, 895, 896, 897, 898, 899}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{32, 32},
@@ -621,23 +487,23 @@ INSTANTIATE_TEST_SUITE_P(
                 .page_config = PageConfig(Layout::ROW_MAJOR),
                 .logical_data = {  0,
 
-                           1,
+                                   1,
 
-                           2,
+                                   2,
 
-                           3,
+                                   3,
 
-                           4,
+                                   4,
 
-                           5,
+                                   5,
 
-                           6,
+                                   6,
 
-                           7,
+                                   7,
 
-                           8,
+                                   8,
 
-                           9}
+                                   9}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{1, 1},
@@ -671,18 +537,18 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = Size{3, 4},
                 .page_config = PageConfig(Layout::ROW_MAJOR),
                 .logical_data = {  0,
-                           1,
-                           2,
+                                   1,
+                                   2,
 
-                           3,
-                           4,
-                           5,
+                                   3,
+                                   4,
+                                   5,
 
-                           6,
-                           7,
-                           8,
+                                   6,
+                                   7,
+                                   8,
 
-                           9}
+                                   9}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{3, 4},
@@ -704,6 +570,39 @@ INSTANTIATE_TEST_SUITE_P(
                                     0,   0,   0,   0}
             }
         },
+        // RM width sharded with alignment up to nearest page in last shard (in RM sharded, it is set to physical shard width)
+        ShardWithAlignmentParams{
+            ShardWithAlignmentInputs{
+                .shape = SimpleShape{1, 2, 5, 10},
+                .logical_shard_shape = Size{10, 3},
+                .physical_shard_shape = std::nullopt,
+                .page_config = PageConfig(Layout::ROW_MAJOR),
+                .logical_data = {  0,   1,   2,  /**/   3,   4,   5,  /**/   6,   7,   8,  /**/   9,
+                                  10,  11,  12,  /**/  13,  14,  15,  /**/  16,  17,  18,  /**/  19,
+                                  20,  21,  22,  /**/  23,  24,  25,  /**/  26,  27,  28,  /**/  29,
+                                  30,  31,  32,  /**/  33,  34,  35,  /**/  36,  37,  38,  /**/  39,
+                                  40,  41,  42,  /**/  43,  44,  45,  /**/  46,  47,  48,  /**/  49,
+                                  50,  51,  52,  /**/  53,  54,  55,  /**/  56,  57,  58,  /**/  59,
+                                  60,  61,  62,  /**/  63,  64,  65,  /**/  66,  67,  68,  /**/  69,
+                                  70,  71,  72,  /**/  73,  74,  75,  /**/  76,  77,  78,  /**/  79,
+                                  80,  81,  82,  /**/  83,  84,  85,  /**/  86,  87,  88,  /**/  89,
+                                  90,  91,  92,  /**/  93,  94,  95,  /**/  96,  97,  98,  /**/  99}
+            },
+            ShardWithAlignmentExpected{
+                .physical_shard_shape = Size{10, 3},
+                .physical_shape = Size{10, 12},
+                .physical_data = {  0,   1,   2,  /**/   3,   4,   5,  /**/   6,   7,   8,  /**/   9,   0,   0,
+                                   10,  11,  12,  /**/  13,  14,  15,  /**/  16,  17,  18,  /**/  19,   0,   0,
+                                   20,  21,  22,  /**/  23,  24,  25,  /**/  26,  27,  28,  /**/  29,   0,   0,
+                                   30,  31,  32,  /**/  33,  34,  35,  /**/  36,  37,  38,  /**/  39,   0,   0,
+                                   40,  41,  42,  /**/  43,  44,  45,  /**/  46,  47,  48,  /**/  49,   0,   0,
+                                   50,  51,  52,  /**/  53,  54,  55,  /**/  56,  57,  58,  /**/  59,   0,   0,
+                                   60,  61,  62,  /**/  63,  64,  65,  /**/  66,  67,  68,  /**/  69,   0,   0,
+                                   70,  71,  72,  /**/  73,  74,  75,  /**/  76,  77,  78,  /**/  79,   0,   0,
+                                   80,  81,  82,  /**/  83,  84,  85,  /**/  86,  87,  88,  /**/  89,   0,   0,
+                                   90,  91,  92,  /**/  93,  94,  95,  /**/  96,  97,  98,  /**/  99,   0,   0}
+            }
+        },
         // RM width sharded with padding along width to arbitrary shard width
         ShardWithAlignmentParams{
             ShardWithAlignmentInputs{
@@ -712,15 +611,15 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = Size{10, 4},
                 .page_config = PageConfig(Layout::ROW_MAJOR),
                 .logical_data = {  0,   1,   2,  /**/   3,   4,   5,  /**/   6,   7,   8,  /**/   9,
-                          10,  11,  12,  /**/  13,  14,  15,  /**/  16,  17,  18,  /**/  19,
-                          20,  21,  22,  /**/  23,  24,  25,  /**/  26,  27,  28,  /**/  29,
-                          30,  31,  32,  /**/  33,  34,  35,  /**/  36,  37,  38,  /**/  39,
-                          40,  41,  42,  /**/  43,  44,  45,  /**/  46,  47,  48,  /**/  49,
-                          50,  51,  52,  /**/  53,  54,  55,  /**/  56,  57,  58,  /**/  59,
-                          60,  61,  62,  /**/  63,  64,  65,  /**/  66,  67,  68,  /**/  69,
-                          70,  71,  72,  /**/  73,  74,  75,  /**/  76,  77,  78,  /**/  79,
-                          80,  81,  82,  /**/  83,  84,  85,  /**/  86,  87,  88,  /**/  89,
-                          90,  91,  92,  /**/  93,  94,  95,  /**/  96,  97,  98,  /**/  99}
+                                  10,  11,  12,  /**/  13,  14,  15,  /**/  16,  17,  18,  /**/  19,
+                                  20,  21,  22,  /**/  23,  24,  25,  /**/  26,  27,  28,  /**/  29,
+                                  30,  31,  32,  /**/  33,  34,  35,  /**/  36,  37,  38,  /**/  39,
+                                  40,  41,  42,  /**/  43,  44,  45,  /**/  46,  47,  48,  /**/  49,
+                                  50,  51,  52,  /**/  53,  54,  55,  /**/  56,  57,  58,  /**/  59,
+                                  60,  61,  62,  /**/  63,  64,  65,  /**/  66,  67,  68,  /**/  69,
+                                  70,  71,  72,  /**/  73,  74,  75,  /**/  76,  77,  78,  /**/  79,
+                                  80,  81,  82,  /**/  83,  84,  85,  /**/  86,  87,  88,  /**/  89,
+                                  90,  91,  92,  /**/  93,  94,  95,  /**/  96,  97,  98,  /**/  99}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{10, 4},
@@ -745,31 +644,31 @@ INSTANTIATE_TEST_SUITE_P(
                 .physical_shard_shape = Size{5, 7},
                 .page_config = PageConfig(Layout::ROW_MAJOR),
                 .logical_data = {  0,   1,   2,   3,  /**/   4,   5,   6,   7,  /**/   8,   9,
-                          10,  11,  12,  13,  /**/  14,  15,  16,  17,  /**/  18,  19,
-                          20,  21,  22,  23,  /**/  24,  25,  26,  27,  /**/  28,  29,
+                                  10,  11,  12,  13,  /**/  14,  15,  16,  17,  /**/  18,  19,
+                                  20,  21,  22,  23,  /**/  24,  25,  26,  27,  /**/  28,  29,
 
-                          30,  31,  32,  33,  /**/  34,  35,  36,  37,  /**/  38,  39,
-                          40,  41,  42,  43,  /**/  44,  45,  46,  47,  /**/  48,  49,
-                          50,  51,  52,  53,  /**/  54,  55,  56,  57,  /**/  58,  59,
+                                  30,  31,  32,  33,  /**/  34,  35,  36,  37,  /**/  38,  39,
+                                  40,  41,  42,  43,  /**/  44,  45,  46,  47,  /**/  48,  49,
+                                  50,  51,  52,  53,  /**/  54,  55,  56,  57,  /**/  58,  59,
 
-                          60,  61,  62,  63,  /**/  64,  65,  66,  67,  /**/  68,  69,
-                          70,  71,  72,  73,  /**/  74,  75,  76,  77,  /**/  78,  79,
-                          80,  81,  82,  83,  /**/  84,  85,  86,  87,  /**/  88,  89,
+                                  60,  61,  62,  63,  /**/  64,  65,  66,  67,  /**/  68,  69,
+                                  70,  71,  72,  73,  /**/  74,  75,  76,  77,  /**/  78,  79,
+                                  80,  81,  82,  83,  /**/  84,  85,  86,  87,  /**/  88,  89,
 
-                          90,  91,  92,  93,  /**/  94,  95,  96,  97,  /**/  98,  99,
-                         100, 101, 102, 103,  /**/ 104, 105, 106, 107,  /**/ 108, 109,
-                         110, 111, 112, 113,  /**/ 114, 115, 116, 117,  /**/ 118, 119,
+                                  90,  91,  92,  93,  /**/  94,  95,  96,  97,  /**/  98,  99,
+                                 100, 101, 102, 103,  /**/ 104, 105, 106, 107,  /**/ 108, 109,
+                                 110, 111, 112, 113,  /**/ 114, 115, 116, 117,  /**/ 118, 119,
 
-                         120, 121, 122, 123,  /**/ 124, 125, 126, 127,  /**/ 128, 129,
-                         130, 131, 132, 133,  /**/ 134, 135, 136, 137,  /**/ 138, 139,
-                         140, 141, 142, 143,  /**/ 144, 145, 146, 147,  /**/ 148, 149,
+                                 120, 121, 122, 123,  /**/ 124, 125, 126, 127,  /**/ 128, 129,
+                                 130, 131, 132, 133,  /**/ 134, 135, 136, 137,  /**/ 138, 139,
+                                 140, 141, 142, 143,  /**/ 144, 145, 146, 147,  /**/ 148, 149,
 
-                         150, 151, 152, 153,  /**/ 154, 155, 156, 157,  /**/ 158, 159,
-                         160, 161, 162, 163,  /**/ 164, 165, 166, 167,  /**/ 168, 169,
-                         170, 171, 172, 173,  /**/ 174, 175, 176, 177,  /**/ 178, 179,
+                                 150, 151, 152, 153,  /**/ 154, 155, 156, 157,  /**/ 158, 159,
+                                 160, 161, 162, 163,  /**/ 164, 165, 166, 167,  /**/ 168, 169,
+                                 170, 171, 172, 173,  /**/ 174, 175, 176, 177,  /**/ 178, 179,
 
-                         180, 181, 182, 183,  /**/ 184, 185, 186, 187,  /**/ 188, 189,
-                         190, 191, 192, 193,  /**/ 194, 195, 196, 197,  /**/ 198, 199}
+                                 180, 181, 182, 183,  /**/ 184, 185, 186, 187,  /**/ 188, 189,
+                                 190, 191, 192, 193,  /**/ 194, 195, 196, 197,  /**/ 198, 199}
             },
             ShardWithAlignmentExpected{
                 .physical_shard_shape = Size{5, 7},
@@ -1015,7 +914,7 @@ INSTANTIATE_TEST_SUITE_P(
                         .memory_layout = TensorMemoryLayout::BLOCK_SHARDED,
                         .buffer_type = BufferType::L1,
                         .shard_spec = ShardSpec{
-                            num_cores_to_corerangeset(tt::div_up(8 * 36, 48) * tt::div_up(32, 10), grid_size, /*row_wise=*/true),
+                            CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{3, 5})),
                             {48, 10},
                             {64, 48},
                             ShardOrientation::ROW_MAJOR,
@@ -1039,7 +938,7 @@ INSTANTIATE_TEST_SUITE_P(
                         .memory_layout = TensorMemoryLayout::BLOCK_SHARDED,
                         .buffer_type = BufferType::L1,
                         .shard_spec = ShardSpec{
-                            num_cores_to_corerangeset(tt::div_up(2 * 10, 5) * tt::div_up(5, 2), grid_size, /*row_wise=*/true),
+                            CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{2, 3})),
                             {5, 2},
                             {7, 3},
                             ShardOrientation::ROW_MAJOR,

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -120,3 +120,143 @@ def test_tensor_creation_api_parity(shape, tt_dtype, layout, device):
     passing = torch.allclose(py_tensor, py_tensor_after_round_trip_3, **allclose_kwargs)
     passing = torch.allclose(py_tensor, py_tensor_after_round_trip_4, **allclose_kwargs)
     assert passing
+
+
+grid_size = [8, 7]
+
+
+@pytest.mark.parametrize(
+    "layout, tile",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT, None),
+        (ttnn.TILE_LAYOUT, ttnn.Tile([32, 32])),
+        (ttnn.TILE_LAYOUT, ttnn.Tile([16, 16])),
+        (ttnn.TILE_LAYOUT, ttnn.Tile([32, 16])),
+        (ttnn.TILE_LAYOUT, ttnn.Tile([16, 16])),
+    ],
+)
+@pytest.mark.parametrize(
+    "tt_dtype",
+    [
+        ttnn.uint8,
+        ttnn.uint16,
+        ttnn.uint32,
+        ttnn.int32,
+        ttnn.float32,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+        ttnn.bfloat4_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, memory_config",
+    [
+        (
+            (1, 2, 3, 4),
+            ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.INTERLEAVED,
+                ttnn.BufferType.DRAM,
+            ),
+        ),
+        (
+            (1, 48, 56, 32),
+            ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.num_cores_to_corerangeset(56, grid_size, True),
+                    [48, 32],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                    ttnn.ShardMode.LOGICAL,
+                ),
+            ),
+        ),
+        (
+            (1, 2, 10, 5),
+            ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.num_cores_to_corerangeset(3, grid_size, True),
+                    [20, 2],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                    ttnn.ShardMode.LOGICAL,
+                ),
+            ),
+        ),
+        (
+            (2, 3, 64, 96),
+            ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 5))}),
+                    [64, 64],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                    ttnn.ShardMode.LOGICAL,
+                ),
+            ),
+        ),
+        (
+            (1, 8, 36, 32),
+            ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 5))}),
+                    [48, 10],
+                    [64, 64],  # NOTE: This value is compatible with all PageConfigs in this sweep
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+    ],
+    ids=[
+        "interleaved",
+        "height_sharded",
+        "width_sharded",
+        "block_sharded",
+        "block_sharded_with_custom_physical_shard_shape",
+    ],
+)
+def test_tensor_creation_with_memory_config(shape, memory_config, tt_dtype, layout, tile, device):
+    torch.manual_seed(0)
+
+    if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("{} is only valid for ttnn.TILE_LAYOUT!".format(tt_dtype))
+
+    dtype = tt_dtype_to_torch_dtype[tt_dtype]
+
+    if dtype in {torch.uint8, torch.int16, torch.int32}:
+        py_tensor = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, dtype=dtype)
+    else:
+        py_tensor = torch.rand(shape, dtype=dtype)
+
+    tt_tensor_1 = ttnn.Tensor(py_tensor, tt_dtype, device, layout, memory_config, tile)
+    tt_tensor_2 = ttnn.from_torch(
+        py_tensor, tt_dtype, device=device, layout=layout, memory_config=memory_config, tile=tile
+    )
+
+    tt_tensor_1 = tt_tensor_1.cpu()
+    tt_tensor_2 = tt_tensor_2.cpu()
+
+    py_tensor_after_round_trip_1 = tt_tensor_1.to_torch_with_logical_shape()
+    py_tensor_after_round_trip_2 = tt_tensor_2.to_torch_with_logical_shape()
+    py_tensor_after_round_trip_3 = ttnn.to_torch(tt_tensor_1)
+    py_tensor_after_round_trip_4 = ttnn.to_torch(tt_tensor_2)
+
+    allclose_kwargs = {}
+    if tt_dtype == ttnn.bfloat8_b:
+        allclose_kwargs = dict(atol=1e-2)
+    elif tt_dtype == ttnn.bfloat4_b:
+        allclose_kwargs = dict(atol=0.2)
+
+    passing = torch.allclose(py_tensor, py_tensor_after_round_trip_1, **allclose_kwargs)
+    passing = torch.allclose(py_tensor, py_tensor_after_round_trip_2, **allclose_kwargs)
+    passing = torch.allclose(py_tensor, py_tensor_after_round_trip_3, **allclose_kwargs)
+    passing = torch.allclose(py_tensor, py_tensor_after_round_trip_4, **allclose_kwargs)
+    assert passing

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -68,14 +68,16 @@ void log_external_operation(
 
 template <typename T>
 Tensor create_owned_tensor(T* data_ptr, const ttnn::TensorSpec& tensor_spec) {
+    TT_FATAL(
+        !tensor_spec.memory_config().is_sharded() or tensor_spec.memory_config().shard_spec.has_value(),
+        "Sharded tensors must have a shard spec when converting to tt tensors!");
     std::size_t num_elements = tensor_spec.logical_shape().volume();
-    auto data = std::vector<T>(data_ptr, data_ptr + num_elements);
-    auto buffer = owned_buffer::create(std::move(data));
+    auto logical_data = std::vector<T>(data_ptr, data_ptr + num_elements);
 
-    if (tensor_spec.layout() == Layout::TILE) {
-        data = tensor_impl::convert_layout_row_major_to_tile(tensor_spec.physical_shape(), tensor_spec.tile(), buffer);
-        buffer = owned_buffer::create(std::move(data));
-    }
+    // See implementation for documentation
+    auto physical_data = tensor_impl::encode_tensor_data(logical_data, tensor_spec);
+
+    auto buffer = owned_buffer::create(std::move(physical_data));
     auto storage = OwnedStorage{std::move(buffer)};
     return Tensor(std::move(storage), tensor_spec);
 }
@@ -150,12 +152,15 @@ Tensor create_tt_tensor_from_py_data(
     std::size_t py_data_ptr,
     const TensorSpec& tensor_spec,
     Device* device,
-    bool force_disable_borrow,
+    const bool force_disable_borrow,
     const std::function<void()>& on_creation_callback,
     const std::function<void()>& on_destruction_callback) {
     auto layout = tensor_spec.layout();
 
-    const bool enable_borrow = layout == Layout::ROW_MAJOR and not force_disable_borrow;
+    const bool requires_padding = tensor_spec.logical_shape().volume() !=
+                                  tensor_spec.physical_shape().height() * tensor_spec.physical_shape().width();
+    const bool requires_tilization = layout != Layout::ROW_MAJOR;
+    const bool enable_borrow = !requires_padding and !requires_tilization and !force_disable_borrow;
 
     auto data_type = tensor_spec.data_type();
     std::size_t num_elements = tensor_spec.logical_shape().volume();
@@ -253,7 +258,7 @@ Tensor convert_python_tensor_to_tt_tensor(
     const std::optional<Tile>& optional_tile,
     const MemoryConfig& memory_config,
     Device* device,
-    bool force_disable_borrow = false) {
+    const bool force_disable_borrow = false) {
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::detail::convert_python_tensor_to_tt_tensor",
         py_tensor,
@@ -469,47 +474,62 @@ Tensor convert_python_tensors_to_tt_tensors(
 
 template <typename T>
 owned_buffer::Buffer<T> create_row_major_owned_buffer(
-    owned_buffer::Buffer<T> owned_buffer, const ttnn::TensorSpec& tensor_spec) {
-    if (tensor_spec.layout() == Layout::TILE) {
-        auto data = tensor_impl::convert_layout_tile_to_row_major(
-            tensor_spec.physical_shape(), tensor_spec.tile(), owned_buffer);
-        return owned_buffer::create(std::move(data));
+    owned_buffer::Buffer<T> owned_buffer, const ttnn::TensorSpec& tensor_spec, const bool legacy_output) {
+    TT_FATAL(
+        !tensor_spec.memory_config().is_sharded() or tensor_spec.memory_config().shard_spec.has_value(),
+        "Sharded tensors must have a shard spec when converting to tt tensors!");
+
+    if (legacy_output) {
+        if (tensor_spec.layout() == Layout::TILE) {
+            auto data = tensor_impl::convert_layout_tile_to_row_major(
+                tensor_spec.physical_shape(), tensor_spec.tile(), owned_buffer);
+            return owned_buffer::create(std::move(data));
+        }
+        return owned_buffer;
     }
-    return owned_buffer;
+
+    auto physical_data = owned_buffer.get();
+
+    // See implementation for documentation
+    auto logical_data = tensor_impl::decode_tensor_data(physical_data, tensor_spec);
+
+    return owned_buffer::create(std::move(logical_data));
 }
 
-std::variant<OwnedBuffer, BorrowedBuffer> get_host_buffer_from_tensor(const Tensor& tt_tensor) {
+std::variant<OwnedBuffer, BorrowedBuffer> get_host_buffer_from_tensor(
+    const Tensor& tt_tensor, const bool legacy_output) {
     TT_ASSERT(tt_tensor.storage_type() == StorageType::OWNED or tt_tensor.storage_type() == StorageType::BORROWED);
 
     using RetType = std::variant<OwnedBuffer, BorrowedBuffer>;
     return std::visit(
         tt::stl::overloaded{
-            [&tt_tensor](const OwnedStorage& storage) -> RetType {
+            [&tt_tensor, legacy_output](const OwnedStorage& storage) -> RetType {
                 const auto& tensor_spec = tt_tensor.get_tensor_spec();
                 const auto tt_dtype = tensor_spec.data_type();
                 switch (tt_dtype) {
                     case DataType::UINT8: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<uint8_t>(storage.buffer), tensor_spec);
+                            owned_buffer::get_as<uint8_t>(storage.buffer), tensor_spec, legacy_output);
                     }
                     case DataType::UINT16: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<uint16_t>(storage.buffer), tensor_spec);
+                            owned_buffer::get_as<uint16_t>(storage.buffer), tensor_spec, legacy_output);
                     }
                     case DataType::INT32: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<int32_t>(storage.buffer), tensor_spec);
+                            owned_buffer::get_as<int32_t>(storage.buffer), tensor_spec, legacy_output);
                     }
                     case DataType::UINT32: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<uint32_t>(storage.buffer), tensor_spec);
+                            owned_buffer::get_as<uint32_t>(storage.buffer), tensor_spec, legacy_output);
                     }
                     case DataType::FLOAT32: {
-                        return create_row_major_owned_buffer(owned_buffer::get_as<float>(storage.buffer), tensor_spec);
+                        return create_row_major_owned_buffer(
+                            owned_buffer::get_as<float>(storage.buffer), tensor_spec, legacy_output);
                     }
                     case DataType::BFLOAT16: {
                         return create_row_major_owned_buffer(
-                            owned_buffer::get_as<::bfloat16>(storage.buffer), tensor_spec);
+                            owned_buffer::get_as<::bfloat16>(storage.buffer), tensor_spec, legacy_output);
                     }
                     case DataType::BFLOAT8_B:
                     case DataType::BFLOAT4_B: {
@@ -522,7 +542,7 @@ std::variant<OwnedBuffer, BorrowedBuffer> get_host_buffer_from_tensor(const Tens
                                 : unpack_bfp4_tiles_into_float_vec(
                                       uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
                         auto input_float_buffer = owned_buffer::create<float>(std::move(float_unpacked_data));
-                        return create_row_major_owned_buffer(input_float_buffer, tensor_spec);
+                        return create_row_major_owned_buffer(input_float_buffer, tensor_spec, legacy_output);
                     }
                     default: {
                         TT_THROW("Unsupported DataType: {}", tt_dtype);
@@ -540,10 +560,20 @@ std::variant<OwnedBuffer, BorrowedBuffer> get_host_buffer_from_tensor(const Tens
         tt_tensor.get_storage());
 }
 
-py::object convert_tt_tensor_to_torch_tensor(const Tensor& tt_tensor) {
-    GraphTracker::instance().track_function_start("tt::tt_metal::detail::convert_tt_tensor_to_torch_tensor", tt_tensor);
+py::object convert_tt_tensor_to_torch_tensor(const Tensor& tt_tensor, const bool legacy_output = false) {
+    GraphTracker::instance().track_function_start(
+        "tt::tt_metal::detail::convert_tt_tensor_to_torch_tensor", tt_tensor, legacy_output);
 
-    auto buffer = get_host_buffer_from_tensor(tt_tensor);
+    // TODO: Remove legacy_output flag which supports old behaviour of returning tensors with padded shape.
+    // These cases need to be fixed:
+    //     ROW_MAJOR tensors with padding (since ROW_MAJOR has no alignment, cannot automatically strip data unless
+    //     padded shape is queried) Physical sharding on padded shape (unlike interleaved tensors, cannot derive an
+    //     equivalent logical shard spec to strip out data)
+    // One way to clean this up is:
+    //     1. Update tests to use ttnn.from_torch and ttnn.to_torch
+    //     2. Fix usage of tensor.to_torch inside ttnn functional APIs
+    //     3. Deprecate old tensor.to_torch and rename tensor.to_torch_with_logical_shape back to tensor.to_torch
+    auto buffer = get_host_buffer_from_tensor(tt_tensor, legacy_output);
 
     py::object torch = py::module_::import("torch");
     auto frombuffer = torch.attr("frombuffer");
@@ -576,18 +606,21 @@ py::object convert_tt_tensor_to_torch_tensor(const Tensor& tt_tensor) {
         },
         buffer);
 
-    auto shape = tt_tensor.get_legacy_shape();
-    auto torch_shape = std::vector<std::uint32_t>(std::begin(shape), std::end(shape));
+    auto logical_shape = tt_tensor.get_logical_shape();
+    auto view = logical_shape.view();
+    std::vector<uint32_t> torch_shape(view.begin(), view.end());
     auto tensor = [&]() {
         if (tt_tensor.volume() == 0) {
             auto pytorch_empty = torch.attr("empty");
-            auto logical_shape = tt_tensor.get_logical_shape();
-            auto view = logical_shape.view();
-            std::vector<uint32_t> shape_vector(view.begin(), view.end());
-            return pytorch_empty(shape_vector, py::arg("dtype") = torch_dtype);
+            return pytorch_empty(torch_shape, py::arg("dtype") = torch_dtype);
         }
         return frombuffer(buffer, py::arg("dtype") = torch_dtype);
     }();
+
+    if (legacy_output) {
+        auto shape = tt_tensor.get_legacy_shape();
+        torch_shape = std::vector<std::uint32_t>(std::begin(shape), std::end(shape));
+    }
     tensor = tensor.attr("reshape")(torch_shape);
     tensor = tensor.attr("contiguous")();
     if (tt_tensor.storage_type() == StorageType::BORROWED) {
@@ -600,7 +633,7 @@ py::object convert_tt_tensor_to_torch_tensor(const Tensor& tt_tensor) {
 py::object convert_tt_tensor_to_numpy_tensor(const Tensor& tt_tensor) {
     GraphTracker::instance().track_function_start("tt::tt_metal::detail::convert_tt_tensor_to_numpy_tensor", tt_tensor);
 
-    auto buffer = get_host_buffer_from_tensor(tt_tensor);
+    auto buffer = get_host_buffer_from_tensor(tt_tensor, false);
 
     py::object np = py::module_::import("numpy");
     auto frombuffer = np.attr("frombuffer");
@@ -633,8 +666,9 @@ py::object convert_tt_tensor_to_numpy_tensor(const Tensor& tt_tensor) {
         },
         buffer);
 
-    auto shape = tt_tensor.get_legacy_shape();
-    auto np_shape = std::vector<std::uint32_t>(std::begin(shape), std::end(shape));
+    auto logical_shape = tt_tensor.get_logical_shape();
+    auto view = logical_shape.view();
+    std::vector<uint32_t> np_shape(view.begin(), view.end());
     auto tensor = frombuffer(buffer, py::arg("dtype") = np_dtype);
     tensor = tensor.attr("reshape")(np_shape);
     tensor = np.attr("ascontiguousarray")(tensor);
@@ -1545,6 +1579,20 @@ void pytensor_module(py::module& m_tensor) {
             py::return_value_policy::reference)
         .def(
             "to_torch",
+            [](const Tensor& self) -> py::object { return detail::convert_tt_tensor_to_torch_tensor(self, true); },
+            R"doc(
+            Convert tensor to torch tensor using legacy padded shape.
+            WARNING: Will be deprecated soon!
+
+            The tensor must be on host when calling this function.
+
+            .. code-block:: python
+
+                data = tt_tensor.cpu().to_torch() # move TT Tensor to host and convert it to torch tensor
+
+        )doc")
+        .def(
+            "to_torch_with_logical_shape",
             [](const Tensor& self) -> py::object { return detail::convert_tt_tensor_to_torch_tensor(self); },
             R"doc(
             Convert tensor to torch tensor.
@@ -1553,7 +1601,7 @@ void pytensor_module(py::module& m_tensor) {
 
             .. code-block:: python
 
-                data = tt_tensor.cpu().to_torch() # move TT Tensor to host and convert it to torch tensor
+                data = tt_tensor.cpu().to_torch_with_logical_shape() # move TT Tensor to host and convert it to torch tensor
 
         )doc")
         .def(

--- a/ttnn/cpp/pybind11/tensor.cpp
+++ b/ttnn/cpp/pybind11/tensor.cpp
@@ -274,6 +274,12 @@ void tensor_mem_config_module(py::module& m_tensor) {
                            const bool& halo,
                            const ShardMode& shard_mode) { return ShardSpec(core_sets, shard_shape, shard_orientation, halo, shard_mode); }),
             py::arg("grid"), py::arg("shard_shape"), py::arg("shard_orientation"), py::arg("halo"), py::arg("shard_mode") = ShardMode::PHYSICAL)
+        .def(py::init<>([](const CoreRangeSet& core_sets,
+                           const std::array<uint32_t, 2>& shard_shape,
+                           const std::array<uint32_t, 2>& physical_shard_shape,
+                           const ShardOrientation& shard_orientation,
+                           const bool& halo) { return ShardSpec(core_sets, shard_shape, physical_shard_shape, shard_orientation, halo); }),
+            py::arg("grid"), py::arg("shard_shape"), py::arg("physical_shard_shape"), py::arg("shard_orientation"), py::arg("halo"))
         .def_readwrite("shape", &ShardSpec::shape, "Shape of shard.")
         .def_readwrite("grid", &ShardSpec::grid, "Grid to layout shards.")
         .def_readwrite("orientation", &ShardSpec::orientation, "Orientation of cores to read shards")

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -367,10 +367,11 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     }
     if (shape.logical_shape().volume() != tensor.get_logical_volume()) {
         // This is completely incorrect but it is due to issue 15137 or issue 15558
+        const auto& tile = tensor.tensor_spec().tile();
         bool tile_tensor_view_reshape_possible =
             (layout == ttnn::Layout::TILE and shape.with_tile_padding().rank() >= 2 and
-             shape.with_tile_padding()[-2] % ttnn::TILE_SIZE == 0 and
-             shape.with_tile_padding()[-1] % ttnn::TILE_SIZE == 0 and
+             shape.with_tile_padding()[-2] % tile.get_height() == 0 and
+             shape.with_tile_padding()[-1] % tile.get_width() == 0 and
              tensor_shape.with_tile_padding()[-1] == shape.with_tile_padding()[-1]);
 
         if (tile_tensor_view_reshape_possible) {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -142,6 +142,31 @@ inline std::vector<T> convert_layout_tile_to_row_major(
         transpose_of_faces);
 }
 
+// Converts logical data into physical data based on tensor spec
+// - Logical data: Flat container of row major data corresponding to some ND logical shape
+// - Physical data: Flat container of physical data corresponding to tensor spec. It takes into account:
+//   * Sharding: Each shard will be padded to nearest page (if needed)
+//     ** This is mostly for logical sharding, since logical shards may not be aligned to page in general
+//     ** For interleaved, it will be handled as a "logically sharded" tensor with same shard shard height/width
+//        as the original tensor dims at -2 and -1. In the future, interleaved may be generalized as sharded.
+//     ** This means padding may be inserted in the middle of logical data (if needed)
+//   * Layout: Each aligned shard will be tilized (if needed)
+//     ** Tilization happens after first inserting padding to align shards (if needed)
+//     ** For the last shard, we only align to nearest page instead of full shard size for partial shards
+//   * After conversion, size of physical data will match 2D physical size indicated by tensor_spec.physical_shape()
+template <typename T>
+std::vector<T> encode_tensor_data(const std::vector<T>& logical_data, const TensorSpec& tensor_spec);
+
+// Converts physical data into logical data based on tensor spec (see encode_tensor_data for details)
+// - Physical data: Flat container of physical data corresponding to tensor spec
+//   * Assumes that the physical data already matches tensor spec
+//   * There is a bare minimum check that size of physical data matches size indicated by tensor_spec.physical_shape()
+// - Logical data: Flat container of row major data corresponding to some ND logical shape
+//   * To get logical data, perform the exact inverse process of encode_tensor_data
+//   * Resulting data is safe to be converted to python tensors or general consumption with just a ND logical shape
+template <typename T>
+std::vector<T> decode_tensor_data(const std::vector<T>& physical_data, const TensorSpec& tensor_spec);
+
 // ======================================================================================
 //                                      Validators
 // ======================================================================================

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -677,6 +677,23 @@ Tensor copy_borrowed_tensor_in_async_mode(Device* worker, const Tensor& tensor) 
     return tensor;
 }
 
+Size get_2d_shape(const ttnn::SimpleShape& shape) {
+    size_t width = shape[-1];
+    size_t height = shape.volume() / width;
+    return Size{height, width};
+}
+
+ShardDivisionSpec compute_shard_division_spec(const Size& shape, const Size& shard_shape) {
+    const auto num_shards_height = tt::div_up(shape.height(), shard_shape.height());
+    const auto last_shard_height =
+        shape.height() % shard_shape.height() > 0 ? shape.height() % shard_shape.height() : shard_shape.height();
+    const auto num_shards_width = tt::div_up(shape.width(), shard_shape.width());
+    const auto last_shard_width =
+        shape.width() % shard_shape.width() > 0 ? shape.width() % shard_shape.width() : shard_shape.width();
+
+    return ShardDivisionSpec{num_shards_height, last_shard_height, num_shards_width, last_shard_width};
+};
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -161,5 +161,25 @@ inline uint32_t get_batch_size(const T& shape) {
     return result;
 }
 
+// Flattens input shape into height and width
+// - Height is accumulated over all dims except last
+// - Width is equal to the last dim
+Size get_2d_shape(const ttnn::SimpleShape& shape);
+
+// Useful information about how a shard_shape cuts a 2D shape
+// - num_shards_height: Number of shards along the height (including partial last shard, if any)
+// - last_shard_height: Height of last partial shard (if None, it will be same as full shard shape height)
+// - num_shards_width: Number of shards along the width (including partial last shard, if any)
+// - last_shard_width: Width of last partial shard (if None, it will be same as full shard shape width)
+struct ShardDivisionSpec {
+    size_t num_shards_height = 0;
+    size_t last_shard_height = 0;
+    size_t num_shards_width = 0;
+    size_t last_shard_width = 0;
+};
+
+// Returns ShardDivisionSpecs given 2D shape and shard_shape
+ShardDivisionSpec compute_shard_division_spec(const Size& shape, const Size& shard_shape);
+
 }  // namespace tt_metal
 }  // namespace tt


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13127)

### Problem description
Previous [PR](https://github.com/tenstorrent/tt-metal/pull/14771) added support to create logically sharded tensors in C++ without data. This one adds full support for creating logically sharded tensors from python side.  Also, it adds support for creating ROW_MAJOR block/width sharded tensors with partial shards along width.

### What's changed
- Changes to pytensor:
  * Integrate encode_tensor_data converter into create_owned_tensor
  * Integrate decode_tensor_data data converter into create_row_major_owned_buffer
    ** Update converters to also handle tilize and untilize if needed
    ** Update converters to also handle interleaved tensors with equivalent sharding specs
  * Switch to query logical shape when converting tt tensor to pytorch and numpy tensors
    ** This adds readback support for logically sharded tensors
    ** For pytorch, fork new functionality into tensor.to_torch_with_logical_shape()
    ** Maintain old tensor.to_torch() behaviour which returns data based on padded shape
    *** TODO: This is incorrect and need to fix tests that use tensor.to_torch()
    *** TODO: Then, we can deprecate old tensor.to_torch() and use new one
  * Update enable_borrow logic to account for padding needed for logical sharding
  * Add check for shard spec to have value for sharded memory configs
- Other infra changes/fixes:
  * Integrate tensor APIs into ttnn.from_torch() and ttnn.to_torch() to support logical sharding
  * Update create_default_alignment for ROW_MAJOR logically sharded tensors
  * Add TT_FATAL check to make sure raw data bytes matches expected device buffer size before sharding
  * Add pybind for creating logical shard spec with logical and physical shard shapes
  * Fix bug with reshape view hardcoding tile sizes
- Add test cases for logical sharding to tests/ttnn/unit_tests/tensor/test_tensor_creation.py
  * Tests tensor creation with ttnn.Tensor(...) and ttnn.from_torch(...)
  * Tests tensor readback with tensor.to_torch_with_logical_shape(...) and ttnn.to_torch(...)
  * Tests API parity between tensor and functional ttnn APIs
- Clean up tests/ttnn/unit_tests/gtests/tensor/test_sharding_with_alignment.cpp
  * Move important converters and helper functions into tensor_impl and tensor_utils
  * Convert expected/output data to TILE/ROW_MAJOR layout for ease of testing
    ** Needed since converters now tilize/untilize to match required Layout
  * Change CoreRangeSet to proper 2D grid for BLOCK sharded cases
  * Change EXPECT_EQ to ASSERT_EQ for ShardWithAlignmentTests
  * Fix formatting for test cases

### Checklist
- Post commit CI passes:
  - post commit all: https://github.com/tenstorrent/tt-metal/actions/runs/12382687141
  - post commit all (more rebased): https://github.com/tenstorrent/tt-metal/actions/runs/12439077366
  - nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/12366618448
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
