### PR TITLE
[tt-train] Bump magic_enum from 0.9.6 to 0.9.7 

### DIFF
--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -52,7 +52,7 @@ CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.0.1)
 # magic_enum : https://github.com/Neargye/magic_enum
 ############################################################################################################################
 
-CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.6)
+CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.7)
 
 ############################################################################################################################
 # nlohmann/json : https://github.com/nlohmann/json


### PR DESCRIPTION
### Problem description
TT-train main branch is again not building...

### What's changed
Bump `magic_enum` from v0.9.6 to v0.9.7

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12362131879
- [x] New/Existing tests provide coverage for changes
