### PR TITLE
[Llama3.2-11b vLLM Integration] Add support for paged cross attention, fixes for continuous batching, simplified decode forward call 

### DIFF
--- a/models/demos/llama3/demo/simple_vision_demo.py
+++ b/models/demos/llama3/demo/simple_vision_demo.py
@@ -189,22 +189,14 @@ def test_llama_multimodal_demo_text(
                 position_id = prefill_lens + gen_idx
                 next_token_tensor = next_tokens.reshape(max_batch_size, 1)
 
-                if enable_trace:
-                    logits = generator.easy_trace(
-                        position_id,
-                        next_token_tensor,
-                        batch_xattn_masks,
-                        batch_text_masks,
-                        xattn_caches,
-                    )
-                else:
-                    logits = generator.decode_forward(
-                        position_id,
-                        next_token_tensor,
-                        batch_xattn_masks,
-                        batch_text_masks,
-                        xattn_caches,
-                    )
+                logits = generator.decode_forward(
+                    position_id,
+                    next_token_tensor,
+                    batch_xattn_masks,
+                    batch_text_masks,
+                    xattn_caches,
+                    enable_trace=enable_trace,
+                )
 
                 next_tokens, next_texts = sampler(logits)
                 # Update next token

--- a/models/demos/llama3/tt/generator_vllm.py
+++ b/models/demos/llama3/tt/generator_vllm.py
@@ -38,7 +38,7 @@ def input_processor_for_mllama(ctx: InputContext, inputs: Union[DecoderOnlyInput
         inputs["encoder_multi_modal_data"] = {}
         return inputs
 
-    # Set encoder prompt length based on the number of vision tokens so block manager allocates enable blocks (cross block tables).
+    # Set encoder prompt length based on the number of vision tokens so block manager allocates enough blocks (cross block tables).
     hf_config = ctx.model_config.hf_config
     assert hf_config.vision_config.image_size % 14 == 0, "chunk size should be multiple of 14"
     token_per_chunk = nearest_32(

--- a/models/demos/llama3/tt/generator_vllm.py
+++ b/models/demos/llama3/tt/generator_vllm.py
@@ -76,7 +76,6 @@ class TtMllamaForConditionalGeneration(LlamaGenerator, SupportsMultiModal):
         self,
         tokens: torch.Tensor,
         images: List[PIL.Image.Image],
-        start_pos,
         page_table: torch.Tensor,
         kv_cache,
         prompt_lens,

--- a/models/demos/llama3/tt/llama_attention.py
+++ b/models/demos/llama3/tt/llama_attention.py
@@ -92,7 +92,6 @@ class TtLlamaAttention(LightweightModule):
         self.ccl_topology = configuration.ccl_topology()
         self.is_multichip = configuration.is_multichip
 
-        self.layer_num = layer_num
         layer_name = configuration.get_state_dict_prefix(self.__class__.__name__, layer_num)
         if configuration.dummy_weights or (weight_cache_path is None):
             cache_name = lambda _: None
@@ -317,8 +316,8 @@ class TtLlamaAttention(LightweightModule):
         # KV update
         ###
         if kv_cache:
-            keys = kv_cache[self.layer_num][0]
-            values = kv_cache[self.layer_num][1]
+            keys = kv_cache[0]
+            values = kv_cache[1]
         else:
             keys = self.layer_past[0]
             values = self.layer_past[1]
@@ -536,7 +535,7 @@ class TtLlamaAttention(LightweightModule):
 
         # Fill KV-Cache
         if kv_cache:
-            keys_BKSD, values_BKSD = kv_cache[self.layer_num][0], kv_cache[self.layer_num][1]
+            keys_BKSD, values_BKSD = kv_cache[0], kv_cache[1]
         else:
             keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
 

--- a/models/demos/llama3/tt/llama_model.py
+++ b/models/demos/llama3/tt/llama_model.py
@@ -172,7 +172,10 @@ class TtTransformer(LightweightModule):
             mesh_mapper=mesh_mapper,
         )
 
-        rope_idxs = self.rope_setup.get_rot_idxs(current_pos, on_host=True)
+        rot_current_pos = torch.maximum(
+            current_pos, torch.tensor(0, dtype=torch.int64)
+        )  # Ensure position indices are non-negative
+        rope_idxs = self.rope_setup.get_rot_idxs(rot_current_pos, on_host=True)
         current_pos_tt = ttnn.from_torch(
             current_pos,
             device=None,

--- a/models/demos/llama3/tt/multimodal/llama_cross_attention.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_attention.py
@@ -131,7 +131,7 @@ class TtLlamaCrossAttention(LightweightModule):
             eps=self.norm_eps,
         )
 
-    def compute_xattn_kv_cache(self, xattn_tokens, user_id, xattn_cache):
+    def compute_xattn_kv_cache(self, xattn_tokens, user_id, xattn_cache, cross_page_table=None):
         """
         Uses xattn_tokens to compute K, V. Should be run inside of forward_prefill.
         Updates xattn_cache with K, V (TODO: support page table for KV cache)
@@ -188,17 +188,28 @@ class TtLlamaCrossAttention(LightweightModule):
         xk = self.k_norm(xk, mode="decode")
 
         k_cache, v_cache = xattn_cache
-        # Work around fill_cache memory constraint by making these sharded
-        k_fill = ttnn.interleaved_to_sharded(xk, self.model_config["XATTN_KV_PREFILL_MEM_CFG"](seqlen_y))
-        v_fill = ttnn.interleaved_to_sharded(xv, self.model_config["XATTN_KV_PREFILL_MEM_CFG"](seqlen_y))
 
-        ttnn.fill_cache(k_cache, k_fill, user_id)
-        ttnn.fill_cache(v_cache, v_fill, user_id)
+        if cross_page_table:
+            ttnn.experimental.paged_fill_cache(
+                k_cache, ttnn.experimental.typecast(xk, k_cache.dtype), cross_page_table, batch_idx=user_id
+            )
+            ttnn.experimental.paged_fill_cache(
+                v_cache, ttnn.experimental.typecast(xv, v_cache.dtype), cross_page_table, batch_idx=user_id
+            )
+        else:
+            # Work around fill_cache memory constraint by making these sharded
+            k_fill = ttnn.interleaved_to_sharded(xk, self.model_config["XATTN_KV_PREFILL_MEM_CFG"](seqlen_y))
+            v_fill = ttnn.interleaved_to_sharded(xv, self.model_config["XATTN_KV_PREFILL_MEM_CFG"](seqlen_y))
+
+            ttnn.fill_cache(k_cache, k_fill, user_id)
+            ttnn.fill_cache(v_cache, v_fill, user_id)
 
         return xk, xv
 
-    def forward_decode(self, x_11SH, xattn_mask, full_text_row_masked_out_mask_1NSH, xattn_cache):
-        batch = xattn_cache[0].shape[0]
+    def forward_decode(
+        self, x_11SH, xattn_mask, full_text_row_masked_out_mask_1NSH, xattn_cache, cross_page_table=None
+    ):
+        batch = xattn_mask.shape[1]
 
         x_11SH = ttnn.sharded_to_interleaved(x_11SH, ttnn.L1_MEMORY_CONFIG)  # TODO support sharded input
 
@@ -232,17 +243,29 @@ class TtLlamaCrossAttention(LightweightModule):
         )
 
         # TODO: Can I get rid of the KV repeat_interleave?
-
-        output = ttnn.transformer.scaled_dot_product_attention_decode(
-            xq,
-            xk,
-            xv,
-            is_causal=False,
-            attn_mask=xattn_mask,
-            scale=self.scale,
-            program_config=program_config,
-            compute_kernel_config=self.compute_kernel_config_sdpa,
-        )
+        if cross_page_table:
+            output = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                xq,
+                xk,
+                xv,
+                is_causal=False,
+                attn_mask=xattn_mask,
+                page_table_tensor=cross_page_table,
+                scale=self.scale,
+                program_config=program_config,
+                compute_kernel_config=self.compute_kernel_config_sdpa,
+            )
+        else:
+            output = ttnn.transformer.scaled_dot_product_attention_decode(
+                xq,
+                xk,
+                xv,
+                is_causal=False,
+                attn_mask=xattn_mask,
+                scale=self.scale,
+                program_config=program_config,
+                compute_kernel_config=self.compute_kernel_config_sdpa,
+            )
 
         # WARNING: this broadcast is also broken, must broadcast on host
         output = ttnn.mul(output, full_text_row_masked_out_mask_1NSH)
@@ -275,14 +298,23 @@ class TtLlamaCrossAttention(LightweightModule):
         return ttnn.to_memory_config(output, self.model_config["DECODE_RESIDUAL_MEMCFG"])
 
     def forward_prefill(
-        self, x_11SH, xattn_mask, full_text_row_masked_out_mask_1NSH, xattn_cache, user_id, vision_tokens
+        self,
+        x_11SH,
+        xattn_mask,
+        full_text_row_masked_out_mask_1NSH,
+        xattn_cache,
+        user_id,
+        vision_tokens,
+        cross_page_table=None,
     ):
         seq_len = x_11SH.shape[-2]
         # B, S, D
         assert seq_len % 32 == 0 and seq_len > 0, "Seqlen must be divisible by 32"
 
         # Compute cross attention cache. Return contiguous caches
-        k_cache_user, v_cache_user = self.compute_xattn_kv_cache(vision_tokens, user_id, xattn_cache)
+        k_cache_user, v_cache_user = self.compute_xattn_kv_cache(
+            vision_tokens, user_id, xattn_cache, cross_page_table=cross_page_table
+        )
         cache_seq_len = k_cache_user.shape[-2]
 
         if seq_len > 1024:
@@ -357,7 +389,15 @@ class TtLlamaCrossAttention(LightweightModule):
             return output
 
     def forward(
-        self, x_11SH, xattn_mask, full_text_row_masked_out_mask_1NSH, xattn_cache, mode, user_id=0, vision_tokens=None
+        self,
+        x_11SH,
+        xattn_mask,
+        full_text_row_masked_out_mask_1NSH,
+        xattn_cache,
+        mode,
+        user_id=0,
+        vision_tokens=None,
+        cross_page_table=None,
     ):
         if mode == "prefill":
             return self.forward_prefill(
@@ -367,6 +407,9 @@ class TtLlamaCrossAttention(LightweightModule):
                 xattn_cache,
                 user_id=user_id,
                 vision_tokens=vision_tokens,
+                cross_page_table=cross_page_table,
             )
         else:
-            return self.forward_decode(x_11SH, xattn_mask, full_text_row_masked_out_mask_1NSH, xattn_cache)
+            return self.forward_decode(
+                x_11SH, xattn_mask, full_text_row_masked_out_mask_1NSH, xattn_cache, cross_page_table=cross_page_table
+            )

--- a/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_attention_transformer_text.py
@@ -276,10 +276,12 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
         mode="decode",
         page_table=None,
         kv_cache=None,
+        cross_page_table=None,
         text_only_inference=False,
         vision_tokens=None,
         get_last_token=-1,
     ):
+        total_layer_idx = 0  # Used to track the total layer index for accessing the paged kv cache
         for idx, (
             layer,
             xattn_layer,
@@ -289,13 +291,18 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
                 h = xattn_layer(
                     h,
                     xattn_mask=xattn_mask,
-                    xattn_cache=xattn_caches[xattn_layer_idx],
+                    xattn_cache=xattn_caches[xattn_layer_idx]
+                    if cross_page_table is None
+                    else kv_cache[total_layer_idx],
                     full_text_row_masked_out_mask_1NSH=full_text_row_masked_out_mask_1NSH,
                     full_text_row_masked_out_mask_11SD=full_text_row_masked_out_mask_11SD,
                     mode=mode,
                     user_id=user_id,
                     vision_tokens=vision_tokens,
+                    cross_page_table=cross_page_table,
                 )
+            if idx in self.fusion_schedule:
+                total_layer_idx += 1
             h = layer(
                 h,
                 current_pos,
@@ -303,8 +310,9 @@ class TtLlamaCrossAttentionTransformerText(LightweightModule):
                 user_id=user_id,
                 mode=mode,
                 page_table=page_table,
-                kv_cache=kv_cache,
+                kv_cache=kv_cache[total_layer_idx] if kv_cache is not None else None,
             )
+            total_layer_idx += 1
 
         if get_last_token != -1:
             h = ttnn.slice(h, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, h.shape[-1]))

--- a/models/demos/llama3/tt/multimodal/llama_cross_block.py
+++ b/models/demos/llama3/tt/multimodal/llama_cross_block.py
@@ -125,6 +125,7 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
         mode,
         user_id=0,
         vision_tokens=None,
+        cross_page_table=None,
     ):
         skip_mem_cfg = self.model_config["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
         assert (
@@ -139,6 +140,7 @@ class TtLlamaCrossAttentionTransformerBlock(LightweightModule):
             mode=mode,
             user_id=user_id,
             vision_tokens=vision_tokens,
+            cross_page_table=cross_page_table,
         )
         # FIXME: DRAM workaround for No circular buffer with id error
         attn_out = ttnn.to_memory_config(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)

--- a/models/demos/llama3/tt/multimodal/llama_vision_model.py
+++ b/models/demos/llama3/tt/multimodal/llama_vision_model.py
@@ -676,6 +676,12 @@ class CrossAttentionTransformer(torch.nn.Module):
         """
         This method runs prefill forward. It takes ttnn tensors in, returns ttnn tensors.
         """
+
+        if cross_page_table is not None:
+            assert (
+                xattn_caches is None and kv_cache is not None
+            ), "no separate xattn_caches should be allocated when using cross_page_table with paged kv cache"
+
         logits = self.text_model.forward(
             h,
             xattn_mask=xattn_mask,
@@ -710,6 +716,12 @@ class CrossAttentionTransformer(torch.nn.Module):
         """
         This method runs decode forward. It takes ttnn tensors in, returns ttnn tensors.
         """
+
+        if cross_page_table is not None:
+            assert (
+                xattn_caches is None and kv_cache is not None
+            ), "no separate xattn_caches should be allocated when using cross_page_table with paged kv cache"
+
         logits = self.text_model.forward(
             h,
             xattn_mask=xattn_mask,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- For llama3.2-11b, cross attention caches currently need to be allocated separately from the KV cache used for paged self-attention. To be able to integrate within vLLM with proper memory management during continuous batching of requests, we require support for paged cross attention, where there is no separately allocated cross attention cache, and the same kv cache is shared between self-attention and cross-attention layers via a cross block table 

### What's changed
- Added support for paged cross attention to llama3.2-11b (through the addition of the `cross_page_table` argument), with and without ttnn-tracing
- Replaced the existing `decode_forward` function in `generator.py` with `_decode_forward_no_trace` and added a new simplified `decode_forward` function which either calls `_decode_forward_no_trace` or `_easy_trace` depending on the `enable_trace` argument
- Made modifications to enable continuous batching with padded decode batches in vLLM: modified the position ids passed into `get_rot_idxs` (in `prepare_decode_inputs_host` for vision and text models) to always be positive (padded batches may contain position ids containing -1), and added padding for `xattn_mask`/`full_text_mask` along batch if tokens have been padded.
- Modified `input_processor_for_mllama` in `generator_vllm.py` to set encoder prompt length based on the number of vision tokens so block manager allocates enough blocks for cross block tables
- Note: this PR is required to enable https://github.com/tenstorrent/vllm/pull/45

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
