### PR TITLE
#0: Allow ttnn.pad to pad Tensor to an odd width in row major

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -18,7 +18,11 @@ from models.utility_functions import skip_for_wormhole_b0
 @pytest.mark.parametrize("w", [224])
 @pytest.mark.parametrize(
     "padding,torch_padding",
-    [(((0, 1), (3, 25), (32, 32)), (32, 32, 3, 25, 0, 1)), (((0, 1), (3, 25), (4, 6)), (4, 6, 3, 25, 0, 1))],
+    [
+        (((0, 1), (3, 25), (32, 32)), (32, 32, 3, 25, 0, 1)),
+        (((0, 1), (3, 25), (4, 6)), (4, 6, 3, 25, 0, 1)),
+        (((0, 1), (3, 25), (4, 7)), (4, 7, 3, 25, 0, 1)),  # Odd padding widths (5 and 7)
+    ],
 )
 @pytest.mark.parametrize("value", [0])
 def test_pad_rm(device, n, c, h, w, padding, torch_padding, value):

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -45,7 +45,6 @@ void Pad::validate_with_output_tensors(
             input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16,
             "Cannot pad tilized tensor with specified format");
     } else if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(this->output_tensor_shape[3] % 2 == 0, "RM padding requires output X dim to be a multiple of 2");
         TT_FATAL(
             input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16,
             "Cannot pad RM tensor with specified format");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15603

### Problem description
ttnn.pad call throws an error when user attempts to pad a tensor to an odd number of elements in width dimension

### What's changed
Remove the check, it is outdated since we resolved the underlying constraint

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12363708529)