### PR TITLE
Clamp op update 

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/clamp/clamp_forge.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/clamp/clamp_forge.py
@@ -19,7 +19,6 @@ from models.utility_functions import torch_random
 
 random.seed(0)
 
-
 # Parameters provided to the test vector generator are defined here.
 # They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
 # Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
@@ -108,7 +107,7 @@ parameters = {
             {"input_shape": [1, 19200, 256], "min": -4.000000e00, "max": 4.000000e00},
             {"input_shape": [1, 19200, 256], "min": -1.000000e00, "max": 1.000000e00},
         ],
-        "input_a_dtype": [ttnn.float32],  # [ttnn.int32, ttnn.float32],
+        "input_a_dtype": [ttnn.float32, ttnn.int32],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],


### PR DESCRIPTION
### Ticket
Link to Github Issue #16047 

### Problem description
Clamp op fails when the dtype is int32

### What's changed
Added int32 support for clamp op with Typecast.  

### TODO:
#21352 

### Checklist
- [ ] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/14747154659)
