### PR TITLE
#0: Stable Diffusion 3.5 Medium unit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -392,3 +392,27 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
 @pytest.mark.parametrize("w", [128])
 def test_threshold(device, h, w, value, threshold):
     run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold)
+
+
+def run_activation_unary_test_nhw(device, n, h, w, ttnn_function, pcc=0.99):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((n, h, w), dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_function(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn_function(input_tensor)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize(
+    "n,h,w",
+    ((2, 4096, 1536), (2, 333, 1536)),
+)
+def test_sd3_5_medium(device, n, h, w):
+    run_activation_unary_test_nhw(device, n, h, w, ttnn.gelu)

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -2852,3 +2852,67 @@ def test_dram_input_mm_conv(device, tiled_input, input_on_device):
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=0.99)
     logger.info(f"PCC = {pcc_msg}. Threshold = 0.99")
     assert passing
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, groups, use_1d_systolic_array, config_override, use_shallow_conv_variant",
+    ((2, 1536, 16, 128, 128, 2, 2, 2, 2, 0, 0, 1, 1, 1, True, None, False),),
+)
+@pytest.mark.parametrize(
+    "weights_dtype",
+    [ttnn.bfloat8_b, ttnn.bfloat16],
+)
+@pytest.mark.parametrize(
+    "activations_dtype",
+    [ttnn.bfloat8_b, ttnn.bfloat16],
+)
+@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
+def test_sd3_5_medium(
+    device,
+    use_program_cache,
+    math_fidelity,
+    activations_dtype,
+    weights_dtype,
+    batch_size,
+    output_channels,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    dilation_h,
+    dilation_w,
+    groups,
+    use_1d_systolic_array,
+    config_override,
+    use_shallow_conv_variant,
+):
+    run_conv(
+        device,
+        math_fidelity,
+        activations_dtype,
+        weights_dtype,
+        batch_size,
+        output_channels,
+        input_channels,
+        input_height,
+        input_width,
+        filter_height,
+        filter_width,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        use_1d_systolic_array,
+        config_override,
+        use_shallow_conv_variant=use_shallow_conv_variant,
+        dilation=dilation_h,
+        groups=groups,
+        auto_shard=True,
+    )


### PR DESCRIPTION
### Problem description
Unit tests of ops of Stable Diffusion 3.5 Medium model.

Here are the commands to run the unit tests:

- Conv2d: `pytest tests/ttnn/unit_tests/operations/test_new_conv2d.py::test_sd3_5_medium`
- Gelu: `pytest tests/ttnn/unit_tests/operations/eltwise/test_activation.py::test_sd3_5_medium`
- Layer Norm: `pytest tests/ttnn/unit_tests/operations/test_layer_norm.py::test_sd3_5_medium`
- Linear: `pytest tests/ttnn/unit_tests/operations/test_linear.py::test_sd3_5_medium`
- Silu: `pytest tests/ttnn/unit_tests/operations/test_silu.py::test_sd3_5_medium`

### What's changed
Added unit tests of the Stable Diffusion 3.5 Medium model ops.

### Checklist
- [ ] Post commit CI passes
        - All post-commit tests CI: [link](https://github.com/tenstorrent/tt-metal/actions/runs/12388526663)
        - Nightly model and ttnn tests CI: [link](https://github.com/tenstorrent/tt-metal/actions/runs/12387288790)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
