### PR TITLE
#0: Enable Local Sweeps and Use a Faster Interprocess Queue

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -18,6 +18,7 @@ runs:
         cache-dependency-path: |
           tt_metal/python_env/requirements-dev.txt
           docs/requirements-docs.txt
+          tests/sweep_framework/requirements-sweeps.txt
           pyproject.toml
           create_venv.sh
         install-cmd: ./create_venv.sh

--- a/tests/sweep_framework/requirements-sweeps.txt
+++ b/tests/sweep_framework/requirements-sweeps.txt
@@ -1,3 +1,4 @@
 elasticsearch
 termcolor
 beautifultable
+faster-fifo


### PR DESCRIPTION
### Problem description
- Running large numbers of sweeps is impractical with ES backend, especially if the sweeps are not reused/rerun
- Interprocess communication in the runner is slow and a bottleneck for running sweeps

### What's changed
- Changed interprocess queues to [faster-fifo](https://github.com/alex-petrenko/faster-fifo) for better throughput/more efficient locking
- Modified the parameter generator to optionally dump vectors to disk as JSON instead of pushing to ES
- Modified the runner to optionally read vectors from a JSON file on disk instead of reading from ES

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
