### PR TITLE
Clean-up the usage of deallocate_activation

### DIFF
--- a/models/demos/yolov4/ttnn/downsample4.py
+++ b/models/demos/yolov4/ttnn/downsample4.py
@@ -15,7 +15,13 @@ class Down4:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
-            torch_model, "down4.conv1", [1, 40, 40, 256], (2, 2, 1, 1), reshard=True, height_sharding=False
+            torch_model,
+            "down4.conv1",
+            [1, 40, 40, 256],
+            (2, 2, 1, 1),
+            reshard=True,
+            height_sharding=False,
+            deallocate=False,
         )
         self.conv2 = Conv(torch_model, "down4.conv2", [1, 20, 20, 512], (1, 1, 0, 0), deallocate=False)
         self.conv3 = Conv(torch_model, "down4.conv3", [1, 20, 20, 512], (1, 1, 0, 0))

--- a/models/demos/yolov4/ttnn/downsample5.py
+++ b/models/demos/yolov4/ttnn/downsample5.py
@@ -15,7 +15,13 @@ class Down5:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
-            torch_model, "down5.conv1", [1, 20, 20, 512], (2, 2, 1, 1), reshard=True, height_sharding=False
+            torch_model,
+            "down5.conv1",
+            [1, 20, 20, 512],
+            (2, 2, 1, 1),
+            reshard=True,
+            height_sharding=False,
+            deallocate=False,
         )
         self.conv2 = Conv(
             torch_model, "down5.conv2", [1, 10, 10, 1024], (1, 1, 0, 0), width_sharding=True, deallocate=False

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_neck.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_neck.py
@@ -64,10 +64,6 @@ def test_neck(device, reset_seeds, model_location_generator):
     torch_model.eval()
 
     result_ttnn = ttnn_model(device, ttnn_input_tensor)
-    start_time = time.time()
-    for x in range(2):
-        result_ttnn = ttnn_model(device, ttnn_input_tensor)
-    logger.info(f"Time taken: {time.time() - start_time}")
 
     result_1 = ttnn.to_torch(result_ttnn[0])
     result_2 = ttnn.to_torch(result_ttnn[1])

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -155,7 +155,7 @@ void adjust_conv_op_config_for_auto_shard_if_necessary(
     std::optional<const MemoryConfig> input_memory_config);
 
 template <typename T>
-std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, sliding_window::ParallelConfig, bool, bool>
+std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, sliding_window::ParallelConfig, bool>
 shard_or_reshard_tensor_if_required(
     T* device,
     const ttnn::Tensor& input_tensor_,


### PR DESCRIPTION
Clean-up the usage of deallocate_activation, avoid overriding the user input

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12391558388
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12393053583
- [x] Device performance regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12393049064
- [x] (Single-card) Nightly model and ttnn tests - https://github.com/tenstorrent/tt-metal/actions/runs/12394540066
