### PR TITLE
Read from and write to partial buffer regions for interleaved buffers where offset and size of specified buffer region are divisible by buffer page size

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -65,10 +65,12 @@ EltwiseUnary
 EndTraceCapture
 EnqueueProgram
 EnqueueReadBuffer
+EnqueueReadSubBuffer
 EnqueueRecordEvent
 EnqueueTrace
 EnqueueWaitForEvent
 EnqueueWriteBuffer
+EnqueueWriteSubBuffer
 Enum
 Enums
 EventSynchronize

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -2,4 +2,4 @@ EnqueueReadBuffer
 ==================
 
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<DType> &dst, bool blocking)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > &buffer, void * dst, bool blocking)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
@@ -2,4 +2,4 @@ EnqueueReadSubBuffer
 ====================
 
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadSubBuffer
-==================
+====================
 
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadSubBuffer
 ====================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
@@ -1,0 +1,5 @@
+EnqueueReadSubBuffer
+==================
+
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& dst, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadSubBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadSubBuffer
 ====================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, const BufferRegion& region, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadSubBuffer(CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, const BufferRegion& region, bool blocking)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>&, bool blocking)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > &buffer, std::vector<DType>&, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > &buffer, HostDataType src, bool blocking)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
@@ -1,0 +1,5 @@
+EnqueueWriteSubBuffer
+==================
+
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& src, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteSubBuffer
-==================
+=====================
 
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
 .. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& src, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteSubBuffer
 =====================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& src, const BufferRegion region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& src, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteSubBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteSubBuffer
 =====================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& src, const BufferRegion& region, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, const BufferRegion& region, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteSubBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>& src, const BufferRegion& region, bool blocking)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -3,7 +3,9 @@ CommandQueue
 
 .. toctree::
   EnqueueWriteBuffer
+  EnqueueWriteSubBuffer
   EnqueueReadBuffer
+  EnqueueReadSubBuffer
   EnqueueProgram
   EnqueueRecordEvent
   EnqueueWaitForEvent

--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -16,6 +16,7 @@ set(UNIT_TESTS_API_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_banked.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_bit_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_buffer_region.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_CommandQueue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_direct.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dram_to_l1_multicast.cpp

--- a/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
+++ b/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
@@ -11,11 +11,7 @@
 
 TEST_F(DeviceSingleCardBufferFixture, InvalidBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
-        .device = this->device_,
-        .size = 2048,
-        .page_size = 32,
-        .buffer_type = BufferType::DRAM
-    };
+        .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
     const BufferRegion buffer_region1(512, 4096);
@@ -30,11 +26,7 @@ TEST_F(DeviceSingleCardBufferFixture, InvalidBufferRegion) {
 
 TEST_F(DeviceSingleCardBufferFixture, ValidBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
-        .device = this->device_,
-        .size = 2048,
-        .page_size = 32,
-        .buffer_type = BufferType::DRAM
-    };
+        .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
     const BufferRegion buffer_region1(1024, 1024);
@@ -52,11 +44,7 @@ TEST_F(DeviceSingleCardBufferFixture, ValidBufferRegion) {
 
 TEST_F(DeviceSingleCardBufferFixture, PartialBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
-        .device = this->device_,
-        .size = 2048,
-        .page_size = 32,
-        .buffer_type = BufferType::DRAM
-    };
+        .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
     const BufferRegion buffer_region1(512, 2048);
@@ -71,11 +59,7 @@ TEST_F(DeviceSingleCardBufferFixture, PartialBufferRegion) {
 
 TEST_F(DeviceSingleCardBufferFixture, FullBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
-        .device = this->device_,
-        .size = 2048,
-        .page_size = 32,
-        .buffer_type = BufferType::DRAM
-    };
+        .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
     const BufferRegion buffer_region(0, 2048);

--- a/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
+++ b/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
@@ -9,7 +9,7 @@
 
 #include "device_fixture.hpp"
 
-TEST_F(DeviceSingleCardBufferFixture, InvalidBufferRegion) {
+TEST_F(DeviceSingleCardBufferFixture, TestInvalidBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
         .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
@@ -24,7 +24,7 @@ TEST_F(DeviceSingleCardBufferFixture, InvalidBufferRegion) {
     EXPECT_FALSE(buffer.get()->is_valid_region(buffer_region3));
 }
 
-TEST_F(DeviceSingleCardBufferFixture, ValidBufferRegion) {
+TEST_F(DeviceSingleCardBufferFixture, TestValidBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
         .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
@@ -42,26 +42,26 @@ TEST_F(DeviceSingleCardBufferFixture, ValidBufferRegion) {
     EXPECT_TRUE(buffer.get()->is_valid_region(buffer_region4));
 }
 
-TEST_F(DeviceSingleCardBufferFixture, PartialBufferRegion) {
+TEST_F(DeviceSingleCardBufferFixture, TestPartialBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
         .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
     const BufferRegion buffer_region1(1024, 1024);
-    EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region1));
+    EXPECT_TRUE(buffer.get()->is_valid_partial_region(buffer_region1));
 
     const BufferRegion buffer_region2(0, 1024);
-    EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region2));
+    EXPECT_TRUE(buffer.get()->is_valid_partial_region(buffer_region2));
 
     const BufferRegion buffer_region3(512, 1024);
-    EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region3));
+    EXPECT_TRUE(buffer.get()->is_valid_partial_region(buffer_region3));
 }
 
-TEST_F(DeviceSingleCardBufferFixture, FullBufferRegion) {
+TEST_F(DeviceSingleCardBufferFixture, TestFullBufferRegion) {
     const InterleavedBufferConfig& buffer_config{
         .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
     const BufferRegion buffer_region(0, 2048);
-    EXPECT_FALSE(buffer.get()->is_partial_region(buffer_region));
+    EXPECT_FALSE(buffer.get()->is_valid_partial_region(buffer_region));
 }

--- a/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
+++ b/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include "buffers/buffer.hpp"
+#include "buffers/buffer_constants.hpp"
+#include "gtest/gtest.h"
+
+#include "device_fixture.hpp"
+
+TEST_F(DeviceSingleCardBufferFixture, InvalidBufferRegion) {
+    const InterleavedBufferConfig& buffer_config{
+        .device = this->device_,
+        .size = 2048,
+        .page_size = 32,
+        .buffer_type = BufferType::DRAM
+    };
+    std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
+
+    const BufferRegion buffer_region1(512, 4096);
+    EXPECT_FALSE(buffer.get()->is_valid_region(buffer_region1));
+
+    const BufferRegion buffer_region2(3072, 4096);
+    EXPECT_FALSE(buffer.get()->is_valid_region(buffer_region2));
+
+    const BufferRegion buffer_region3(0, 4096);
+    EXPECT_FALSE(buffer.get()->is_valid_region(buffer_region3));
+}
+
+TEST_F(DeviceSingleCardBufferFixture, ValidBufferRegion) {
+    const InterleavedBufferConfig& buffer_config{
+        .device = this->device_,
+        .size = 2048,
+        .page_size = 32,
+        .buffer_type = BufferType::DRAM
+    };
+    std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
+
+    const BufferRegion buffer_region1(1024, 1024);
+    EXPECT_TRUE(buffer.get()->is_valid_region(buffer_region1));
+
+    const BufferRegion buffer_region2(0, 2048);
+    EXPECT_TRUE(buffer.get()->is_valid_region(buffer_region2));
+
+    const BufferRegion buffer_region3(0, 512);
+    EXPECT_TRUE(buffer.get()->is_valid_region(buffer_region3));
+
+    const BufferRegion buffer_region4(512, 512);
+    EXPECT_TRUE(buffer.get()->is_valid_region(buffer_region4));
+}
+
+TEST_F(DeviceSingleCardBufferFixture, PartialBufferRegion) {
+    const InterleavedBufferConfig& buffer_config{
+        .device = this->device_,
+        .size = 2048,
+        .page_size = 32,
+        .buffer_type = BufferType::DRAM
+    };
+    std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
+
+    const BufferRegion buffer_region1(512, 2048);
+    EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region1));
+
+    const BufferRegion buffer_region2(0, 1024);
+    EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region2));
+
+    const BufferRegion buffer_region3(512, 1024);
+    EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region3));
+}
+
+TEST_F(DeviceSingleCardBufferFixture, FullBufferRegion) {
+    const InterleavedBufferConfig& buffer_config{
+        .device = this->device_,
+        .size = 2048,
+        .page_size = 32,
+        .buffer_type = BufferType::DRAM
+    };
+    std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
+
+    const BufferRegion buffer_region(0, 2048);
+    EXPECT_FALSE(buffer.get()->is_partial_region(buffer_region));
+}

--- a/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
+++ b/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
@@ -47,7 +47,7 @@ TEST_F(DeviceSingleCardBufferFixture, PartialBufferRegion) {
         .device = this->device_, .size = 2048, .page_size = 32, .buffer_type = BufferType::DRAM};
     std::shared_ptr<Buffer> buffer = CreateBuffer(buffer_config);
 
-    const BufferRegion buffer_region1(512, 2048);
+    const BufferRegion buffer_region1(1024, 1024);
     EXPECT_TRUE(buffer.get()->is_partial_region(buffer_region1));
 
     const BufferRegion buffer_region2(0, 1024);

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -70,7 +70,7 @@ protected:
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
             tt::log_info(
-                tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
+                tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
             GTEST_SKIP();
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include <memory>
 
 #include "command_queue_fixture.hpp"
@@ -595,8 +596,6 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
 TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
     const uint32_t page_size = 4;
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
-    // const uint32_t offset = ((2 * 0xFFFF) + 25000) * page_size;
-    // const uint32_t size = 32;
     const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
     for (Device* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
@@ -606,6 +605,80 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
         vector<uint32_t> result;
         EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
         EXPECT_EQ(src, result);
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadBufferWriteSubBuffer) {
+    const uint32_t page_size = 128;
+    const uint32_t buffer_size = 100 * page_size;
+    const uint32_t buffer_region_offset = 50 * page_size;
+    const uint32_t buffer_region_size = 128;
+    const BufferRegion region(buffer_region_offset, buffer_region_size);
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
+        auto src = local_test_functions::generate_arange_vector(buffer_region_size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
+        vector<uint32_t> read_buf_result;
+        EnqueueReadBuffer(device->command_queue(), *buffer, read_buf_result, true);
+        vector<uint32_t> result;
+        for (uint32_t i = buffer_region_offset / sizeof(uint32_t);
+             i < (buffer_region_offset + buffer_region_size) / sizeof(uint32_t);
+             i++) {
+            result.push_back(read_buf_result[i]);
+        }
+        EXPECT_EQ(src, result);
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadSubBufferWriteBuffer) {
+    const uint32_t page_size = 128;
+    const uint32_t buffer_size = 100 * page_size;
+    const uint32_t buffer_region_offset = 50 * page_size;
+    const uint32_t buffer_region_size = 128;
+    const BufferRegion region(buffer_region_offset, buffer_region_size);
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
+        auto src = local_test_functions::generate_arange_vector(buffer_size);
+        EnqueueWriteBuffer(device->command_queue(), *buffer, src, false);
+        vector<uint32_t> result;
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
+        vector<uint32_t> expected_result;
+        for (uint32_t i = buffer_region_offset / sizeof(uint32_t);
+             i < (buffer_region_offset + buffer_region_size) / sizeof(uint32_t);
+             i++) {
+            expected_result.push_back(src[i]);
+        }
+        EXPECT_EQ(expected_result, result);
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadSubBufferInvalidRegion) {
+    const uint32_t page_size = 4;
+    const uint32_t buffer_size = 100 * page_size;
+    const uint32_t buffer_region_offset = 25 * page_size;
+    const uint32_t buffer_region_size = buffer_size;
+    const BufferRegion region(buffer_region_offset, buffer_region_size);
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
+        vector<uint32_t> result;
+        EXPECT_ANY_THROW(EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true));
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestWriteSubBufferInvalidRegion) {
+    const uint32_t page_size = 4;
+    const uint32_t buffer_size = 100 * page_size;
+    const uint32_t buffer_region_offset = 25 * page_size;
+    const uint32_t buffer_region_size = buffer_size;
+    const BufferRegion region(buffer_region_offset, buffer_region_size);
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
+        auto src = local_test_functions::generate_arange_vector(buffer_region_size);
+        EXPECT_ANY_THROW(EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, true));
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -577,6 +577,22 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpa
     }
 }
 
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
+    const uint32_t page_size = 1024;
+    const uint32_t offset = 2048;
+    const uint32_t size = 4096;
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, 32 * page_size, page_size, BufferType::DRAM);
+        auto src1 = local_test_functions::generate_arange_vector(buffer->size());
+        // EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, offset, size, false);
+        EnqueueWriteBuffer(device->command_queue(), *buffer, src1, false);
+        vector<uint32_t> result;
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, offset, size, true);
+        EXPECT_EQ(src1, result);
+    }
+}
+
 // Test that command queue wraps when buffer read needs to be split into multiple enqueue_read_buffer commands and
 // available space in completion region is less than a page
 TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpace2) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -578,18 +578,34 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpa
 }
 
 TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
-    const uint32_t page_size = 1024;
-    const uint32_t offset = 2048;
-    const uint32_t size = 4096;
+    const uint32_t page_size = 256;
+    const uint32_t buffer_size = 64 * page_size;
+    const uint32_t offset = 256;
+    const uint32_t size = 512;
     for (Device* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
-        auto buffer = Buffer::create(device, 32 * page_size, page_size, BufferType::DRAM);
-        auto src1 = local_test_functions::generate_arange_vector(buffer->size());
-        // EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, offset, size, false);
-        EnqueueWriteBuffer(device->command_queue(), *buffer, src1, false);
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
+        auto src = local_test_functions::generate_arange_vector(size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, offset, size, false);
         vector<uint32_t> result;
         EnqueueReadSubBuffer(device->command_queue(), *buffer, result, offset, size, true);
-        EXPECT_EQ(src1, result);
+        EXPECT_EQ(src, result);
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
+    const uint32_t page_size = 4;
+    const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
+    const uint32_t offset = ((2 * 0xFFFF) + 25000) * page_size;
+    const uint32_t size = 32;
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
+        auto src = local_test_functions::generate_arange_vector(size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, offset, size, false);
+        vector<uint32_t> result;
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, offset, size, true);
+        EXPECT_EQ(src, result);
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -582,7 +582,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(region.size);
@@ -597,7 +597,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
     const uint32_t page_size = 4;
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
     const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(region.size);
@@ -614,7 +614,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadBufferWriteSubBuffer) {
     const uint32_t buffer_region_offset = 50 * page_size;
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(buffer_region_size);
@@ -637,7 +637,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadSubBufferWriteBuffer) {
     const uint32_t buffer_region_offset = 50 * page_size;
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(buffer_size);
@@ -660,7 +660,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadSubBufferInvalidRegion) {
     const uint32_t buffer_region_offset = 25 * page_size;
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         vector<uint32_t> result;
@@ -674,7 +674,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWriteSubBufferInvalidRegion) {
     const uint32_t buffer_region_offset = 25 * page_size;
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(buffer_region_size);
@@ -924,7 +924,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferForL1) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 128 * page_size;
     const BufferRegion region(2 * page_size, 2048);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);
         auto src = local_test_functions::generate_arange_vector(region.size);
@@ -939,7 +939,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffsetFor
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 512 * page_size;
     const BufferRegion region(400 * page_size, 2048);
-    for (Device* device : devices_) {
+    for (IDevice* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);
         auto src = local_test_functions::generate_arange_vector(region.size);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -580,15 +580,14 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpa
 TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 64 * page_size;
-    const uint32_t offset = 256;
-    const uint32_t size = 512;
+    const BufferRegion region(256, 512);
     for (Device* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
-        auto src = local_test_functions::generate_arange_vector(size);
-        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, offset, size, false);
+        auto src = local_test_functions::generate_arange_vector(region.size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
         vector<uint32_t> result;
-        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, offset, size, true);
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
         EXPECT_EQ(src, result);
     }
 }
@@ -596,15 +595,16 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
 TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
     const uint32_t page_size = 4;
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
-    const uint32_t offset = ((2 * 0xFFFF) + 25000) * page_size;
-    const uint32_t size = 32;
+    // const uint32_t offset = ((2 * 0xFFFF) + 25000) * page_size;
+    // const uint32_t size = 32;
+    const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
     for (Device* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
-        auto src = local_test_functions::generate_arange_vector(size);
-        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, offset, size, false);
+        auto src = local_test_functions::generate_arange_vector(region.size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
         vector<uint32_t> result;
-        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, offset, size, true);
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
         EXPECT_EQ(src, result);
     }
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -920,6 +920,21 @@ TEST_F(MultiCommandQueueSingleDeviceBufferFixture, TestIssueMultipleReadWriteCom
 
 namespace l1_tests {
 
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferForL1) {
+    const uint32_t page_size = 256;
+    const uint32_t buffer_size = 128 * page_size;
+    const BufferRegion region(64 * page_size, 2048);
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);
+        auto src = local_test_functions::generate_arange_vector(region.size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
+        vector<uint32_t> result;
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
+        EXPECT_EQ(src, result);
+    }
+}
+
 TEST_F(CommandQueueSingleCardBufferFixture, WriteOneTileToL1Bank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
     for (IDevice* device : devices_) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -923,7 +923,22 @@ namespace l1_tests {
 TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferForL1) {
     const uint32_t page_size = 256;
     const uint32_t buffer_size = 128 * page_size;
-    const BufferRegion region(64 * page_size, 2048);
+    const BufferRegion region(2 * page_size, 2048);
+    for (Device* device : devices_) {
+        tt::log_info("Running On Device {}", device->id());
+        auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);
+        auto src = local_test_functions::generate_arange_vector(region.size);
+        EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
+        vector<uint32_t> result;
+        EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true);
+        EXPECT_EQ(src, result);
+    }
+}
+
+TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffsetForL1) {
+    const uint32_t page_size = 256;
+    const uint32_t buffer_size = 512 * page_size;
+    const BufferRegion region(400 * page_size, 2048);
     for (Device* device : devices_) {
         tt::log_info("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -283,9 +283,9 @@ void add_prefetcher_paged_read_cmd(
     CQPrefetchCmd cmd;
     cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED;
 
-    cmd.relay_paged.packed_page_flags =
-        (is_dram << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT) | (start_page << CQ_PREFETCH_RELAY_PAGED_START_PAGE_SHIFT);
-    cmd.relay_paged.length_adjust = length_adjust;
+    cmd.relay_paged.start_page = start_page & CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK;
+    cmd.relay_paged.is_dram_and_length_adjust = (is_dram << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT) |
+                                                (length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK);
     cmd.relay_paged.base_addr = base_addr;
     cmd.relay_paged.page_size = page_size;
     cmd.relay_paged.pages = pages;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -887,8 +887,9 @@ void gen_rnd_dram_paged_cmd(
 
     uint32_t length_adjust = std::rand() % page_size;
     length_adjust = (length_adjust >> 5) << 5;
-    if (length_adjust >= 64 * 1024) {
-        length_adjust = 63 * 1024;
+    if (length_adjust > CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK) {
+        length_adjust = CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK;
+        length_adjust = (length_adjust >> 5) << 5;
     }
 
     if (device_data.size() * sizeof(uint32_t) + page_size * pages - length_adjust + l1_buf_base_g >=

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -629,6 +629,39 @@ void EnqueueReadBuffer(CommandQueue& cq, std::shared_ptr<Buffer> buffer, std::ve
     EnqueueReadBuffer(cq, *buffer, dst, blocking);
 }
 
+void EnqueueReadSubBuffer(
+    CommandQueue& cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    void* dst,
+    const size_t offset,
+    const size_t size,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
+template <typename DType>
+void EnqueueReadSubBuffer(
+    CommandQueue& cq,
+    Buffer& buffer,
+    std::vector<DType>& dst,
+    const size_t offset,
+    const size_t size,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
+    dst.resize(buffer.page_size() * buffer.num_pages() / sizeof(DType));
+    EnqueueReadSubBuffer(cq, buffer, static_cast<void*>(dst.data()), offset, size, blocking, sub_device_ids);
+}
+template <typename DType>
+void EnqueueReadSubBuffer(
+    CommandQueue& cq,
+    std::shared_ptr<Buffer> buffer,
+    std::vector<DType>& dst,
+    const size_t offset,
+    const size_t size,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
+    EnqueueReadSubBuffer(cq, *buffer, dst, offset, size, blocking, sub_device_ids);
+}
+
 // clang-format off
 /**
  * Writes a buffer to the device
@@ -671,6 +704,27 @@ void EnqueueWriteBuffer(
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
     bool blocking);
+
+void EnqueueWriteSubBuffer(
+    CommandQueue& cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    HostDataType src,
+    const size_t offset,
+    const size_t size,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
+template <typename DType>
+void EnqueueWriteSubBuffer(
+    CommandQueue& cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<DType>& src,
+    const size_t offset,
+    const size_t size,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
+    EnqueueWriteSubBuffer(cq, buffer, src.data(), offset, size, blocking, sub_device_ids);
+}
 
 // clang-format off
 /**

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -601,7 +601,7 @@ RuntimeArgsData& GetCommonRuntimeArgs(const Program& program, KernelHandle kerne
 // clang-format on
 void EnqueueReadBuffer(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     void* dst,
     bool blocking);
 
@@ -708,7 +708,7 @@ void EnqueueReadSubBuffer(
 template <typename DType>
 void EnqueueWriteBuffer(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     std::vector<DType>& src,
     bool blocking) {
     EnqueueWriteBuffer(cq, buffer, src.data(), blocking);
@@ -730,7 +730,7 @@ void EnqueueWriteBuffer(
 // clang-format on
 void EnqueueWriteBuffer(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     HostDataType src,
     bool blocking);
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -642,7 +642,6 @@ void EnqueueReadBuffer(CommandQueue& cq, std::shared_ptr<Buffer> buffer, std::ve
  * | dst            | The memory where the result will be stored                                        | void*                               |                                    | Yes      |
  * | region         | The region of the buffer that we are reading from                                 | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 // clang-format on
 void EnqueueReadSubBuffer(
@@ -650,8 +649,7 @@ void EnqueueReadSubBuffer(
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
     const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    bool blocking);
 
 // clang-format off
 /**
@@ -666,19 +664,13 @@ void EnqueueReadSubBuffer(
  * | dst            | The vector where the results that are read will be stored                         | vector<DType> &                     |                                    | Yes      |
  * | region         | The region of the buffer that we are reading from                                 | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 // clang-format on
 template <typename DType>
 void EnqueueReadSubBuffer(
-    CommandQueue& cq,
-    Buffer& buffer,
-    std::vector<DType>& dst,
-    const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
+    CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, const BufferRegion& region, bool blocking) {
     dst.resize(region.size / sizeof(DType));
-    EnqueueReadSubBuffer(cq, buffer, static_cast<void*>(dst.data()), region, blocking, sub_device_ids);
+    EnqueueReadSubBuffer(cq, buffer, static_cast<void*>(dst.data()), region, blocking);
 }
 template <typename DType>
 void EnqueueReadSubBuffer(
@@ -686,9 +678,8 @@ void EnqueueReadSubBuffer(
     std::shared_ptr<Buffer> buffer,
     std::vector<DType>& dst,
     const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueReadSubBuffer(cq, *buffer, dst, region, blocking, sub_device_ids);
+    bool blocking) {
+    EnqueueReadSubBuffer(cq, *buffer, dst, region, blocking);
 }
 
 // clang-format off
@@ -747,7 +738,6 @@ void EnqueueWriteBuffer(
  * | src            | The memory we are writing to the device                                           | HostDataType                        |                                    | Yes      |
  * | region         | The region of the buffer that we are writing to                                   | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 // clang-format on
 void EnqueueWriteSubBuffer(
@@ -755,8 +745,7 @@ void EnqueueWriteSubBuffer(
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
     const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    bool blocking);
 
 // clang-format off
 /**
@@ -771,7 +760,6 @@ void EnqueueWriteSubBuffer(
  * | src            | The memory we are writing to the device                                           | std::vector<DType>&                 |                                    | Yes      |
  * | region         | The region of the buffer that we are writing to the device                        | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 // clang-format on
 template <typename DType>
@@ -780,9 +768,8 @@ void EnqueueWriteSubBuffer(
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<DType>& src,
     const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueWriteSubBuffer(cq, buffer, src.data(), region, blocking, sub_device_ids);
+    bool blocking) {
+    EnqueueWriteSubBuffer(cq, buffer, src.data(), region, blocking);
 }
 
 // clang-format off

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -647,7 +647,7 @@ void EnqueueReadSubBuffer(
     const size_t size,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    dst.resize(buffer.page_size() * buffer.num_pages() / sizeof(DType));
+    dst.resize(size / sizeof(DType));
     EnqueueReadSubBuffer(cq, buffer, static_cast<void*>(dst.data()), offset, size, blocking, sub_device_ids);
 }
 template <typename DType>

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -629,37 +629,66 @@ void EnqueueReadBuffer(CommandQueue& cq, std::shared_ptr<Buffer> buffer, std::ve
     EnqueueReadBuffer(cq, *buffer, dst, blocking);
 }
 
+// clang-format off
+/**
+ * Reads a specified region of the buffer from the device
+ *
+ * Return value: void
+ *
+ * | Argument       | Description                                                                       | Type                                | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
+ * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
+ * | dst            | The memory where the result will be stored                                        | void*                               |                                    | Yes      |
+ * | region         | The region of the buffer that we are reading from                                 | const BufferRegion                  |                                    | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
+ */
+// clang-format on
 void EnqueueReadSubBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
-    const size_t offset,
-    const size_t size,
+    const BufferRegion region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
+// clang-format off
+/**
+ * Reads a specified region of the buffer from the device
+ *
+ * Return value: void
+ *
+ * | Argument       | Description                                                                       | Type                                | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
+ * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
+ * | dst            | The vector where the results that are read will be stored                         | vector<DType> &                     |                                    | Yes      |
+ * | region         | The region of the buffer that we are reading from                                 | const BufferRegion                  |                                    | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
+ */
+// clang-format on
 template <typename DType>
 void EnqueueReadSubBuffer(
     CommandQueue& cq,
     Buffer& buffer,
     std::vector<DType>& dst,
-    const size_t offset,
-    const size_t size,
+    const BufferRegion region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    dst.resize(size / sizeof(DType));
-    EnqueueReadSubBuffer(cq, buffer, static_cast<void*>(dst.data()), offset, size, blocking, sub_device_ids);
+    dst.resize(region.size / sizeof(DType));
+    EnqueueReadSubBuffer(cq, buffer, static_cast<void*>(dst.data()), region, blocking, sub_device_ids);
 }
 template <typename DType>
 void EnqueueReadSubBuffer(
     CommandQueue& cq,
     std::shared_ptr<Buffer> buffer,
     std::vector<DType>& dst,
-    const size_t offset,
-    const size_t size,
+    const BufferRegion region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueReadSubBuffer(cq, *buffer, dst, offset, size, blocking, sub_device_ids);
+    EnqueueReadSubBuffer(cq, *buffer, dst, region, blocking, sub_device_ids);
 }
 
 // clang-format off
@@ -705,25 +734,55 @@ void EnqueueWriteBuffer(
     HostDataType src,
     bool blocking);
 
+// clang-format off
+/**
+ * Writes a specified region of the buffer to the device
+ *
+ * Return value: void
+ *
+ * | Argument       | Description                                                                       | Type                                | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
+ * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
+ * | src            | The memory we are writing to the device                                           | HostDataType                        |                                    | Yes      |
+ * | region         | The region of the buffer that we are writing to                                   | const BufferRegion                  |                                    | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
+ */
+// clang-format on
 void EnqueueWriteSubBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
-    const size_t offset,
-    const size_t size,
+    const BufferRegion region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
+// clang-format off
+/**
+ * Writes a specified region of the buffer to the device
+ *
+ * Return value: void
+ *
+ * | Argument       | Description                                                                       | Type                                | Valid Range                        | Required |
+ * |----------------|-----------------------------------------------------------------------------------|-------------------------------------|------------------------------------|----------|
+ * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
+ * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
+ * | src            | The memory we are writing to the device                                           | std::vector<DType>&                 |                                    | Yes      |
+ * | region         | The region of the buffer that we are writing to the device                        | const BufferRegion                  |                                    | Yes      |
+ * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
+ * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
+ */
+// clang-format on
 template <typename DType>
 void EnqueueWriteSubBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<DType>& src,
-    const size_t offset,
-    const size_t size,
+    const BufferRegion region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueWriteSubBuffer(cq, buffer, src.data(), offset, size, blocking, sub_device_ids);
+    EnqueueWriteSubBuffer(cq, buffer, src.data(), region, blocking, sub_device_ids);
 }
 
 // clang-format off

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -640,7 +640,7 @@ void EnqueueReadBuffer(CommandQueue& cq, std::shared_ptr<Buffer> buffer, std::ve
  * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
  * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
  * | dst            | The memory where the result will be stored                                        | void*                               |                                    | Yes      |
- * | region         | The region of the buffer that we are reading from                                 | const BufferRegion                  |                                    | Yes      |
+ * | region         | The region of the buffer that we are reading from                                 | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
  * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
@@ -649,7 +649,7 @@ void EnqueueReadSubBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
-    const BufferRegion region,
+    const BufferRegion& region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
@@ -664,7 +664,7 @@ void EnqueueReadSubBuffer(
  * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
  * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
  * | dst            | The vector where the results that are read will be stored                         | vector<DType> &                     |                                    | Yes      |
- * | region         | The region of the buffer that we are reading from                                 | const BufferRegion                  |                                    | Yes      |
+ * | region         | The region of the buffer that we are reading from                                 | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
  * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
@@ -674,7 +674,7 @@ void EnqueueReadSubBuffer(
     CommandQueue& cq,
     Buffer& buffer,
     std::vector<DType>& dst,
-    const BufferRegion region,
+    const BufferRegion& region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
     dst.resize(region.size / sizeof(DType));
@@ -685,7 +685,7 @@ void EnqueueReadSubBuffer(
     CommandQueue& cq,
     std::shared_ptr<Buffer> buffer,
     std::vector<DType>& dst,
-    const BufferRegion region,
+    const BufferRegion& region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
     EnqueueReadSubBuffer(cq, *buffer, dst, region, blocking, sub_device_ids);
@@ -745,7 +745,7 @@ void EnqueueWriteBuffer(
  * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
  * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
  * | src            | The memory we are writing to the device                                           | HostDataType                        |                                    | Yes      |
- * | region         | The region of the buffer that we are writing to                                   | const BufferRegion                  |                                    | Yes      |
+ * | region         | The region of the buffer that we are writing to                                   | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
  * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
@@ -754,7 +754,7 @@ void EnqueueWriteSubBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
-    const BufferRegion region,
+    const BufferRegion& region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
@@ -769,7 +769,7 @@ void EnqueueWriteSubBuffer(
  * | cq             | The command queue object which dispatches the command to the hardware             | CommandQueue &                      |                                    | Yes      |
  * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
  * | src            | The memory we are writing to the device                                           | std::vector<DType>&                 |                                    | Yes      |
- * | region         | The region of the buffer that we are writing to the device                        | const BufferRegion                  |                                    | Yes      |
+ * | region         | The region of the buffer that we are writing to the device                        | const BufferRegion &                |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
  * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
@@ -779,7 +779,7 @@ void EnqueueWriteSubBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<DType>& src,
-    const BufferRegion region,
+    const BufferRegion& region,
     bool blocking,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
     EnqueueWriteSubBuffer(cq, buffer, src.data(), region, blocking, sub_device_ids);

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -417,13 +417,8 @@ bool Buffer::is_trace() const {
 
 bool Buffer::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= this->size(); }
 
-bool Buffer::is_partial_region(const BufferRegion& region) const {
-    TT_FATAL(
-        this->is_valid_region(region),
-        "Buffer region with offset {} and size {} is invalid!",
-        region.offset,
-        region.size);
-    return region.offset > 0 || region.size != this->size();
+bool Buffer::is_valid_partial_region(const BufferRegion& region) const {
+    return this->is_valid_region(region) && (region.offset > 0 || region.size != this->size());
 }
 
 uint32_t Buffer::dram_channel_from_bank_id(uint32_t bank_id) const {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -415,6 +415,12 @@ bool Buffer::is_trace() const {
 
 }
 
+bool Buffer::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= this->size(); }
+
+bool Buffer::is_partial_region(const BufferRegion& region) const {
+    return region.offset > 0 || region.size != this->size();
+}
+
 uint32_t Buffer::dram_channel_from_bank_id(uint32_t bank_id) const {
     TT_FATAL(this->is_dram(), "Expected DRAM buffer!");
     return allocator::dram_channel_from_bank_id(*this->allocator_, bank_id);

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -418,6 +418,11 @@ bool Buffer::is_trace() const {
 bool Buffer::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= this->size(); }
 
 bool Buffer::is_partial_region(const BufferRegion& region) const {
+    TT_FATAL(
+        this->is_valid_region(region),
+        "Buffer region with offset {} and size {} is invalid!",
+        region.offset,
+        region.size);
     return region.offset > 0 || region.size != this->size();
 }
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -217,7 +217,7 @@ class Buffer final {
     bool is_trace() const;
 
     bool is_valid_region(const BufferRegion& region) const;
-    bool is_partial_region(const BufferRegion& region) const;
+    bool is_valid_partial_region(const BufferRegion& region) const;
 
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -158,6 +158,14 @@ struct BufferPageMapping {
 
 inline namespace v0 {
 
+struct BufferRegion {
+    DeviceAddr offset;
+    DeviceAddr size;
+
+    BufferRegion() = delete;
+    BufferRegion(DeviceAddr offset, DeviceAddr size) : offset(offset), size(size) {}
+};
+
 class Buffer final {
     struct Private { explicit Private() = default; };
 
@@ -207,6 +215,9 @@ class Buffer final {
     bool is_l1() const;
     bool is_dram() const;
     bool is_trace() const;
+
+    bool is_valid_region(const BufferRegion& region) const;
+    bool is_partial_region(const BufferRegion& region) const;
 
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -159,8 +159,8 @@ struct BufferPageMapping {
 inline namespace v0 {
 
 struct BufferRegion {
-    DeviceAddr offset;
-    DeviceAddr size;
+    DeviceAddr offset = 0;
+    DeviceAddr size = 0;
 
     BufferRegion() = delete;
     BufferRegion(DeviceAddr offset, DeviceAddr size) : offset(offset), size(size) {}

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -107,7 +107,6 @@ EnqueueReadBufferCommand::EnqueueReadBufferCommand(
     IDevice* device,
     NOC noc_index,
     Buffer& buffer,
-    void* dst,
     SystemMemoryManager& manager,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
@@ -116,7 +115,6 @@ EnqueueReadBufferCommand::EnqueueReadBufferCommand(
     std::optional<uint32_t> pages_to_read) :
     command_queue_id(command_queue_id),
     noc_index(noc_index),
-    dst(dst),
     manager(manager),
     buffer(buffer),
     expected_num_workers_completed(expected_num_workers_completed),
@@ -1006,7 +1004,6 @@ void HWCommandQueue::enqueue_read_buffer(
                     this->device,
                     this->noc_index,
                     buffer,
-                    dst,
                     this->manager,
                     this->expected_num_workers_completed,
                     sub_device_ids,
@@ -1072,7 +1069,6 @@ void HWCommandQueue::enqueue_read_buffer(
                 this->device,
                 this->noc_index,
                 buffer,
-                dst,
                 this->manager,
                 this->expected_num_workers_completed,
                 sub_device_ids,
@@ -1290,7 +1286,7 @@ void HWCommandQueue::enqueue_write_buffer(
             uint32_t data_offsetB = hal.get_alignment(HalMemType::HOST);  // data appended after CQ_PREFETCH_CMD_RELAY_INLINE
                                                                     // + CQ_DISPATCH_CMD_WRITE_PAGED
             bool issue_wait =
-                (dst_page_index == orig_dst_page_index and // should this change?
+                (dst_page_index == orig_dst_page_index and
                  bank_base_address == buffer.address());  // only stall for the first write of the buffer
             if (issue_wait) {
                 data_offsetB *= 2;  // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1059,10 +1059,10 @@ void HWCommandQueue::enqueue_read_buffer(
         if (pages_to_read > 0) {
             uint32_t bank_base_address = buffer.address();
             src_page_index = region.offset / buffer.page_size();
-            // Only 4 bits are assigned for the page offset in CQPrefetchRelayPagedCmd
+            // Only 8 bits are assigned for the page offset in CQPrefetchRelayPagedCmd
             // To handle larger page offsets move bank base address up and update page offset to be relative to the new
             // bank address
-            if (src_page_index > 15) {
+            if (src_page_index > CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK) {
                 const uint32_t num_banks = this->device->num_banks(buffer.buffer_type());
                 const uint32_t num_pages_per_bank = src_page_index / num_banks;
                 bank_base_address += num_pages_per_bank * buffer.aligned_page_size();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -258,7 +258,6 @@ void EnqueueWriteInterleavedBufferCommand::add_buffer_data(HugepageDeviceCommand
             command_sequence.add_data((char*)this->src + src_address_offset, page_size_to_copy, this->padded_page_size);
             src_address_offset += page_size_to_copy;
         }
-        // try passing in second parameter - pass in start addr or start idx?
     } else {
         uint32_t unpadded_src_offset = (((buffer_addr_offset / this->padded_page_size) * num_banks) +
                                         (this->dst_page_index - this->orig_dst_page_index)) *
@@ -274,7 +273,7 @@ void EnqueueWriteInterleavedBufferCommand::add_buffer_data(HugepageDeviceCommand
                 src_address_offset += this->buffer.page_size();
             }
         } else {
-            command_sequence.add_data((char*)this->src + unpadded_src_offset, data_size_bytes, data_size_bytes/* + (this->dst_page_index * this->buffer.page_size())*/);
+            command_sequence.add_data((char*)this->src + unpadded_src_offset, data_size_bytes, data_size_bytes);
         }
     }
 }
@@ -335,7 +334,6 @@ void EnqueueWriteBufferCommand::process() {
         cmd_sequence_sizeB += hal.get_alignment(HalMemType::HOST) * num_worker_counters;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
     }
 
-    // const uint32_t offset_size_bytes = this->dst_page_index * this->padded_page_size;
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);
 
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
@@ -1584,7 +1582,6 @@ void HWCommandQueue::copy_into_user_space(
 
         remaining_bytes_to_read -= bytes_xfered;
 
-        // interleaved case + height sharded case
         if (buffer_page_mapping == nullptr) {
             void* contiguous_dst = (void*)(uint64_t(dst) + contig_dst_offset);
             if (page_size == padded_page_size) {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1101,7 +1101,7 @@ void HWCommandQueue::enqueue_read_buffer(
 }
 
 void HWCommandQueue::enqueue_write_buffer(
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     HostDataType src,
     const BufferRegion& region,
     bool blocking,
@@ -2003,7 +2003,7 @@ inline namespace v0 {
 
 void EnqueueWriteBuffer(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     std::vector<uint32_t>& src,
     bool blocking) {
     // TODO(agrebenisan): Move to deprecated
@@ -2012,7 +2012,7 @@ void EnqueueWriteBuffer(
 
 void EnqueueReadBuffer(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     void* dst,
     bool blocking) {
     const DeviceAddr offset = 0;
@@ -2045,7 +2045,7 @@ void EnqueueReadSubBuffer(
 
 void EnqueueWriteBuffer(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     HostDataType src,
     bool blocking) {
     const DeviceAddr offset = 0;
@@ -2176,7 +2176,7 @@ void EnqueueReadBufferImpl(
 
 void EnqueueWriteBufferImpl(
     CommandQueue& cq,
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     HostDataType src,
     const BufferRegion& region,
     bool blocking,

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1357,8 +1357,12 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         // Write program binaries to device if it hasn't previously been cached
         program.allocate_kernel_bin_buf_on_device(device);
         if (program.get_program_transfer_info().binary_data.size()) {
+            const BufferRegion buffer_region(0, program.get_kernels_buffer(device)->size());
             this->enqueue_write_buffer(
-                *program.get_kernels_buffer(device), program.get_program_transfer_info().binary_data.data(), false);
+                *program.get_kernels_buffer(device),
+                program.get_program_transfer_info().binary_data.data(),
+                buffer_region,
+                false);
         }
         program.set_program_binary_status(device->id(), ProgramBinaryStatus::InFlight);
     }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1316,12 +1316,8 @@ void HWCommandQueue::enqueue_write_buffer(
                 dst_page_index = dst_page_index % num_banks_to_use;
             }
 
-            uint32_t initial_src_addr_offset;
-            if (write_partial_pages) {
-                initial_src_addr_offset = bank_base_address - buffer.address();
-            } else {
-                initial_src_addr_offset = total_num_pages_written * buffer.page_size();
-            }
+            const uint32_t initial_src_addr_offset = write_partial_pages ? bank_base_address - buffer.address()
+                                                                         : total_num_pages_written * buffer.page_size();
 
             tt::log_debug(tt::LogDispatch, "EnqueueWriteBuffer for command queue {}", this->id);
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2015,12 +2015,8 @@ void EnqueueReadBuffer(
     const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     void* dst,
     bool blocking) {
-    const DeviceAddr offset = 0;
-
     Buffer& buffer_obj = detail::GetBufferObject(buffer);
-    const DeviceAddr size = buffer_obj.size();
-
-    BufferRegion region(offset, size);
+    BufferRegion region(0, buffer_obj.size());
     EnqueueReadSubBuffer(cq, buffer, dst, region, blocking);
 }
 
@@ -2048,12 +2044,8 @@ void EnqueueWriteBuffer(
     const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     HostDataType src,
     bool blocking) {
-    const DeviceAddr offset = 0;
-
     Buffer& buffer_obj = detail::GetBufferObject(buffer);
-    const DeviceAddr size = buffer_obj.size();
-
-    BufferRegion region(offset, size);
+    BufferRegion region(0, buffer_obj.size());
     EnqueueWriteSubBuffer(cq, buffer, std::move(src), region, blocking);
 }
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2025,8 +2025,7 @@ void EnqueueReadSubBuffer(
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
     const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    bool blocking) {
     detail::DispatchStateCheck(true);
     detail::ValidateBufferRegion(buffer, region);
 
@@ -2035,8 +2034,7 @@ void EnqueueReadSubBuffer(
         .blocking = blocking,
         .buffer = buffer,
         .dst = dst,
-        .region = region,
-        .sub_device_ids = sub_device_ids});
+        .region = region});
 }
 
 void EnqueueWriteBuffer(
@@ -2171,8 +2169,7 @@ void EnqueueWriteBufferImpl(
     const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
     HostDataType src,
     const BufferRegion& region,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    bool blocking) {
     cq.hw_command_queue().enqueue_write_buffer(std::move(buffer), std::move(src), region, blocking);
 }
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2063,7 +2063,7 @@ void EnqueueWriteBuffer(
         },
         buffer);
     BufferRegion region(offset, size);
-    EnqueueWriteSubBuffer(cq, buffer, src, region, blocking);
+    EnqueueWriteSubBuffer(cq, buffer, std::move(src), region, blocking);
 }
 
 void EnqueueWriteSubBuffer(

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -72,7 +72,6 @@ class Command {
 class EnqueueReadBufferCommand : public Command {
 private:
     SystemMemoryManager& manager;
-    void* dst;
     CoreType dispatch_core_type;
 
     virtual void add_prefetch_relay(HugepageDeviceCommand& command) = 0;
@@ -94,7 +93,6 @@ public:
         IDevice* device,
         NOC noc_index,
         Buffer& buffer,
-        void* dst,
         SystemMemoryManager& manager,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids,
@@ -119,7 +117,6 @@ public:
         IDevice* device,
         NOC noc_index,
         Buffer& buffer,
-        void* dst,
         SystemMemoryManager& manager,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids,
@@ -131,7 +128,6 @@ public:
             device,
             noc_index,
             buffer,
-            dst,
             manager,
             expected_num_workers_completed,
             sub_device_ids,
@@ -152,7 +148,6 @@ public:
         IDevice* device,
         NOC noc_index,
         Buffer& buffer,
-        void* dst,
         SystemMemoryManager& manager,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids,
@@ -165,7 +160,6 @@ public:
             device,
             noc_index,
             buffer,
-            dst,
             manager,
             expected_num_workers_completed,
             sub_device_ids,

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -70,7 +70,7 @@ class Command {
 };
 
 class EnqueueReadBufferCommand : public Command {
-   private:
+private:
     SystemMemoryManager& manager;
     void* dst;
     CoreType dispatch_core_type;
@@ -85,8 +85,9 @@ class EnqueueReadBufferCommand : public Command {
     tt::stl::Span<const SubDeviceId> sub_device_ids;
     uint32_t src_page_index;
     uint32_t pages_to_read;
+    uint32_t bank_base_address;
 
-   public:
+public:
     Buffer& buffer;
     EnqueueReadBufferCommand(
         uint32_t command_queue_id,
@@ -97,6 +98,7 @@ class EnqueueReadBufferCommand : public Command {
         SystemMemoryManager& manager,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids,
+        uint32_t bank_base_address,
         uint32_t src_page_index = 0,
         std::optional<uint32_t> pages_to_read = std::nullopt);
 
@@ -110,8 +112,6 @@ class EnqueueReadBufferCommand : public Command {
 class EnqueueReadInterleavedBufferCommand : public EnqueueReadBufferCommand {
 private:
     void add_prefetch_relay(HugepageDeviceCommand& command) override;
-
-    uint32_t bank_base_address;
 
 public:
     EnqueueReadInterleavedBufferCommand(
@@ -135,19 +135,18 @@ public:
             manager,
             expected_num_workers_completed,
             sub_device_ids,
+            bank_base_address,
             src_page_index,
             pages_to_read) {
-        this->bank_base_address = bank_base_address;
     }
 };
 
 class EnqueueReadShardedBufferCommand : public EnqueueReadBufferCommand {
-   private:
+private:
     void add_prefetch_relay(HugepageDeviceCommand& command) override;
     const CoreCoord core;
-    const uint32_t bank_base_address;
 
-   public:
+public:
     EnqueueReadShardedBufferCommand(
         uint32_t command_queue_id,
         IDevice* device,
@@ -170,10 +169,10 @@ class EnqueueReadShardedBufferCommand : public EnqueueReadBufferCommand {
             manager,
             expected_num_workers_completed,
             sub_device_ids,
+            bank_base_address,
             src_page_index,
             pages_to_read),
-        core(core),
-        bank_base_address(bank_base_address) {}
+        core(core) {}
 };
 
 class EnqueueWriteShardedBufferCommand;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -220,7 +220,7 @@ private:
     void add_dispatch_write(HugepageDeviceCommand& command) override;
     void add_buffer_data(HugepageDeviceCommand& command) override;
 
-    uint32_t orig_dst_page_index;
+    uint32_t initial_src_addr_offset;
 
 public:
     EnqueueWriteInterleavedBufferCommand(
@@ -229,6 +229,7 @@ public:
         NOC noc_index,
         const Buffer& buffer,
         const void* src,
+        const uint32_t initial_src_addr_offset,
         SystemMemoryManager& manager,
         bool issue_wait,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
@@ -236,7 +237,6 @@ public:
         uint32_t bank_base_address,
         uint32_t padded_page_size,
         uint32_t dst_page_index = 0,
-        uint32_t orig_dst_page_index = 0,
         std::optional<uint32_t> pages_to_write = std::nullopt) :
         EnqueueWriteBufferCommand(
             command_queue_id,
@@ -252,19 +252,19 @@ public:
             padded_page_size,
             dst_page_index,
             pages_to_write) {
-        this->orig_dst_page_index = orig_dst_page_index;
+        this->initial_src_addr_offset = initial_src_addr_offset;
     }
 };
 
 class EnqueueWriteShardedBufferCommand : public EnqueueWriteBufferCommand {
-   private:
+private:
     void add_dispatch_write(HugepageDeviceCommand& command) override;
     void add_buffer_data(HugepageDeviceCommand& command) override;
 
     const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping;
     const CoreCoord core;
 
-   public:
+public:
     EnqueueWriteShardedBufferCommand(
         uint32_t command_queue_id,
         IDevice* device,
@@ -296,9 +296,7 @@ class EnqueueWriteShardedBufferCommand : public EnqueueWriteBufferCommand {
             dst_page_index,
             pages_to_write),
         buffer_page_mapping(buffer_page_mapping),
-        core(core) {
-        ;
-    }
+        core(core) {}
 };
 
 class EnqueueProgramCommand : public Command {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
-#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <span>
@@ -15,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-#include "buffers/buffer.hpp"
 #include "common/env_lib.hpp"
 #include "tt_metal/impl/dispatch/command_queue_interface.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
@@ -29,6 +27,7 @@ namespace tt::tt_metal {
 inline namespace v0 {
 
 class CommandQueue;
+class BufferRegion;
 class Event;
 class Trace;
 using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <span>
@@ -106,10 +107,12 @@ class EnqueueReadBufferCommand : public Command {
 };
 
 class EnqueueReadInterleavedBufferCommand : public EnqueueReadBufferCommand {
-   private:
+private:
     void add_prefetch_relay(HugepageDeviceCommand& command) override;
 
-   public:
+    uint32_t bank_base_address;
+
+public:
     EnqueueReadInterleavedBufferCommand(
         uint32_t command_queue_id,
         IDevice* device,
@@ -119,6 +122,7 @@ class EnqueueReadInterleavedBufferCommand : public EnqueueReadBufferCommand {
         SystemMemoryManager& manager,
         tt::stl::Span<const uint32_t> expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids,
+        uint32_t bank_base_address,
         uint32_t src_page_index = 0,
         std::optional<uint32_t> pages_to_read = std::nullopt) :
         EnqueueReadBufferCommand(
@@ -131,7 +135,9 @@ class EnqueueReadInterleavedBufferCommand : public EnqueueReadBufferCommand {
             expected_num_workers_completed,
             sub_device_ids,
             src_page_index,
-            pages_to_read) {}
+            pages_to_read) {
+        this->bank_base_address = bank_base_address;
+    }
 };
 
 class EnqueueReadShardedBufferCommand : public EnqueueReadBufferCommand {
@@ -217,11 +223,13 @@ class EnqueueWriteBufferCommand : public Command {
 };
 
 class EnqueueWriteInterleavedBufferCommand : public EnqueueWriteBufferCommand {
-   private:
+private:
     void add_dispatch_write(HugepageDeviceCommand& command) override;
     void add_buffer_data(HugepageDeviceCommand& command) override;
 
-   public:
+    uint32_t orig_dst_page_index;
+
+public:
     EnqueueWriteInterleavedBufferCommand(
         uint32_t command_queue_id,
         IDevice* device,
@@ -235,6 +243,7 @@ class EnqueueWriteInterleavedBufferCommand : public EnqueueWriteBufferCommand {
         uint32_t bank_base_address,
         uint32_t padded_page_size,
         uint32_t dst_page_index = 0,
+        uint32_t orig_dst_page_index = 0,
         std::optional<uint32_t> pages_to_write = std::nullopt) :
         EnqueueWriteBufferCommand(
             command_queue_id,
@@ -250,7 +259,7 @@ class EnqueueWriteInterleavedBufferCommand : public EnqueueWriteBufferCommand {
             padded_page_size,
             dst_page_index,
             pages_to_write) {
-        ;
+        this->orig_dst_page_index = orig_dst_page_index;
     }
 };
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -575,25 +575,25 @@ private:
     void enqueue_read_buffer(
         std::shared_ptr<Buffer>& buffer,
         void* dst,
-        const BufferRegion region,
+        const BufferRegion& region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_read_buffer(
         Buffer& buffer,
         void* dst,
-        const BufferRegion region,
+        const BufferRegion& region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
-        const BufferRegion region,
+        const BufferRegion& region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
         Buffer& buffer,
         const void* src,
-        const BufferRegion region,
+        const BufferRegion& region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_program(Program& program, bool blocking);
@@ -613,13 +613,13 @@ private:
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         void* dst,
-        const BufferRegion region,
+        const BufferRegion& region,
         bool blocking);
     friend void EnqueueWriteBufferImpl(
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
-        const BufferRegion region,
+        const BufferRegion& region,
         bool blocking);
     friend void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer);
     friend void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "buffers/buffer.hpp"
 #include "common/env_lib.hpp"
 #include "tt_metal/impl/dispatch/command_queue_interface.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
@@ -584,29 +585,25 @@ private:
     void enqueue_read_buffer(
         std::shared_ptr<Buffer>& buffer,
         void* dst,
-        const size_t offset,
-        const size_t size,
+        const BufferRegion region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_read_buffer(
         Buffer& buffer,
         void* dst,
-        const size_t offset,
-        const size_t size,
+        const BufferRegion region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
-        const size_t offset,
-        const size_t size,
+        const BufferRegion region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
         Buffer& buffer,
         const void* src,
-        const size_t offset,
-        const size_t size,
+        const BufferRegion region,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_program(Program& program, bool blocking);
@@ -626,15 +623,13 @@ private:
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         void* dst,
-        const size_t offset,
-        const size_t size,
+        const BufferRegion region,
         bool blocking);
     friend void EnqueueWriteBufferImpl(
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
-        const size_t offset,
-        const size_t size,
+        const BufferRegion region,
         bool blocking);
     friend void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer);
     friend void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids);
@@ -656,8 +651,7 @@ struct CommandInterface {
     std::optional<void*> dst;
     std::optional<std::shared_ptr<Event>> event;
     std::optional<uint32_t> trace_id;
-    std::optional<size_t> offset;
-    std::optional<size_t> size;
+    std::optional<BufferRegion> region;
     tt::stl::Span<const SubDeviceId> sub_device_ids;
 };
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -585,7 +585,7 @@ private:
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
-        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+        const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         HostDataType src,
         const BufferRegion& region,
         bool blocking,
@@ -617,7 +617,7 @@ private:
         bool blocking);
     friend void EnqueueWriteBufferImpl(
         CommandQueue& cq,
-        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+        const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>>& buffer,
         HostDataType src,
         const BufferRegion& region,
         bool blocking);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -572,11 +572,34 @@ private:
     template <typename T>
     void enqueue_command(T& command, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
 
-    void enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
-    void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
+    void enqueue_read_buffer(
+        std::shared_ptr<Buffer>& buffer,
+        void* dst,
+        const size_t offset,
+        const size_t size,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids={});
+    void enqueue_read_buffer(
+        Buffer& buffer,
+        void* dst,
+        const size_t offset,
+        const size_t size,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
-        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
-    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
+        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+        HostDataType src,
+        const size_t offset,
+        const size_t size,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids={});
+    void enqueue_write_buffer(
+        Buffer& buffer,
+        const void* src,
+        const size_t offset,
+        const size_t size,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_program(Program& program, bool blocking);
     void enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count = false, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void enqueue_wait_for_event(const std::shared_ptr<Event>& sync_event, bool clear_count = false);
@@ -594,11 +617,15 @@ private:
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         void* dst,
+        const size_t offset,
+        const size_t size,
         bool blocking);
     friend void EnqueueWriteBufferImpl(
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
+        const size_t offset,
+        const size_t size,
         bool blocking);
     friend void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer);
     friend void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids);
@@ -620,6 +647,8 @@ struct CommandInterface {
     std::optional<void*> dst;
     std::optional<std::shared_ptr<Event>> event;
     std::optional<uint32_t> trace_id;
+    std::optional<size_t> offset;
+    std::optional<size_t> size;
     tt::stl::Span<const SubDeviceId> sub_device_ids;
 };
 

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -91,13 +91,13 @@ struct CQPrefetchRelayLinearCmd {
 } __attribute__((packed));
 ;
 
-constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_SHIFT = 0;
-constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT = 4;
-constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK = 0x0f;
+constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK = 0xff;
+constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT = 15;
+constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK = 0x7fff;
 
 struct CQPrefetchRelayPagedCmd {
-    uint8_t packed_page_flags;  // start page and is_dram flag
-    uint16_t length_adjust;     // bytes subtracted from size (multiple of 32)
+    uint8_t start_page;
+    uint16_t is_dram_and_length_adjust;  // is_dram flag and bytes subtracted from size (multiple of 32)
     uint32_t base_addr;
     uint32_t page_size;
     uint32_t pages;

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -215,10 +215,10 @@ uint32_t dump_prefetch_cmd(CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream&
                 break;
             case CQ_PREFETCH_CMD_RELAY_PAGED:
                 iq_file << fmt::format(
-                    " (packed_page_flags={:#02x}, length_adjust={:#x}, base_addr={:#010x}, page_size={:#010x}, "
+                    " (start_page={:#02x}, is_dram_and_length_adjust={:#x}, base_addr={:#010x}, page_size={:#010x}, "
                     "pages={:#010x})",
-                    val(cmd->relay_paged.packed_page_flags),
-                    val(cmd->relay_paged.length_adjust),
+                    val(cmd->relay_paged.start_page),
+                    val(cmd->relay_paged.is_dram_and_length_adjust),
                     val(cmd->relay_paged.base_addr),
                     val(cmd->relay_paged.page_size),
                     val(cmd->relay_paged.pages));

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -173,9 +173,10 @@ public:
         uint32_t increment_sizeB = align(sizeof(CQPrefetchCmd), this->pcie_alignment);
         auto initialize_relay_paged_cmd = [&](CQPrefetchCmd* relay_paged_cmd) {
             relay_paged_cmd->base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED;
-            relay_paged_cmd->relay_paged.packed_page_flags = (is_dram << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT) |
-                                                             (start_page << CQ_PREFETCH_RELAY_PAGED_START_PAGE_SHIFT);
-            relay_paged_cmd->relay_paged.length_adjust = length_adjust;
+            relay_paged_cmd->relay_paged.start_page = start_page;
+            relay_paged_cmd->relay_paged.is_dram_and_length_adjust =
+                (is_dram << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT) |
+                (length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK);
             relay_paged_cmd->relay_paged.base_addr = base_addr;
             relay_paged_cmd->relay_paged.page_size = page_size;
             relay_paged_cmd->relay_paged.pages = pages;

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -172,6 +172,7 @@ public:
         uint16_t length_adjust = 0) {
         uint32_t increment_sizeB = align(sizeof(CQPrefetchCmd), this->pcie_alignment);
         auto initialize_relay_paged_cmd = [&](CQPrefetchCmd* relay_paged_cmd) {
+            TT_ASSERT((length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK) == length_adjust);
             relay_paged_cmd->base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED;
             relay_paged_cmd->relay_paged.start_page = start_page;
             relay_paged_cmd->relay_paged.is_dram_and_length_adjust =

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -11,27 +11,36 @@ using namespace tt::tt_metal;
 
 namespace ttnn {
 
-void write_buffer(queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src) {
+void write_buffer(
+    queue_id cq_id,
+    Tensor& dst,
+    std::vector<std::shared_ptr<void>> src,
+    const std::optional<DeviceBufferRegion>& region) {
     uint32_t dst_ref_count = dst.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : dst.get_workers()) {
         auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
-        worker->push_work([worker, src_for_device, dst, cq_id]() {
+        worker->push_work([worker, src_for_device, dst, cq_id, region]() {
             auto shard = tt::tt_metal::get_shard_for_device(dst, worker);
-            tt::tt_metal::memcpy(worker->command_queue(cq_id), shard, src_for_device.get());
+            tt::tt_metal::memcpy(worker->command_queue(cq_id), shard, src_for_device.get(), region);
         });
     }
     dst.tensor_attributes->update_main_thread_ref_count(dst.workers.at(0), dst_ref_count);
 }
 
 void read_buffer(
-    queue_id cq_id, Tensor& src, std::vector<std::shared_ptr<void>> dst, size_t src_offset, bool blocking) {
+    queue_id cq_id,
+    Tensor& src,
+    std::vector<std::shared_ptr<void>> dst,
+    const std::optional<DeviceBufferRegion>& region,
+    size_t src_offset,
+    bool blocking) {
     TT_ASSERT(src_offset == 0, "src_offset is not supported");
     uint32_t src_ref_count = src.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : src.get_workers()) {
         auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
-        worker->push_work([worker, dst_for_device, src, cq_id, src_offset, blocking]() {
+        worker->push_work([worker, dst_for_device, src, cq_id, region, src_offset, blocking]() {
             const auto& shard = tt::tt_metal::get_shard_for_device(src, worker);
-            tt::tt_metal::memcpy(worker->command_queue(cq_id), dst_for_device.get(), shard, blocking);
+            tt::tt_metal::memcpy(worker->command_queue(cq_id), dst_for_device.get(), shard, region, blocking);
         });
     }
     if (blocking) {

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -11,36 +11,27 @@ using namespace tt::tt_metal;
 
 namespace ttnn {
 
-void write_buffer(
-    queue_id cq_id,
-    Tensor& dst,
-    std::vector<std::shared_ptr<void>> src,
-    const std::optional<std::size_t> transfer_size) {
+void write_buffer(queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src) {
     uint32_t dst_ref_count = dst.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : dst.get_workers()) {
         auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
-        worker->push_work([worker, src_for_device, dst, cq_id, transfer_size]() {
+        worker->push_work([worker, src_for_device, dst, cq_id]() {
             auto shard = tt::tt_metal::get_shard_for_device(dst, worker);
-            tt::tt_metal::memcpy(worker->command_queue(cq_id), shard, src_for_device.get(), transfer_size);
+            tt::tt_metal::memcpy(worker->command_queue(cq_id), shard, src_for_device.get());
         });
     }
     dst.tensor_attributes->update_main_thread_ref_count(dst.workers.at(0), dst_ref_count);
 }
 
 void read_buffer(
-    queue_id cq_id,
-    Tensor& src,
-    std::vector<std::shared_ptr<void>> dst,
-    const std::optional<std::size_t> transfer_size,
-    size_t src_offset,
-    bool blocking) {
+    queue_id cq_id, Tensor& src, std::vector<std::shared_ptr<void>> dst, size_t src_offset, bool blocking) {
     TT_ASSERT(src_offset == 0, "src_offset is not supported");
     uint32_t src_ref_count = src.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : src.get_workers()) {
         auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
-        worker->push_work([worker, dst_for_device, src, cq_id, transfer_size, src_offset, blocking]() {
+        worker->push_work([worker, dst_for_device, src, cq_id, src_offset, blocking]() {
             const auto& shard = tt::tt_metal::get_shard_for_device(src, worker);
-            tt::tt_metal::memcpy(worker->command_queue(cq_id), dst_for_device.get(), shard, transfer_size, blocking);
+            tt::tt_metal::memcpy(worker->command_queue(cq_id), dst_for_device.get(), shard, blocking);
         });
     }
     if (blocking) {

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -12,10 +12,7 @@ using namespace tt::tt_metal;
 namespace ttnn {
 
 void write_buffer(
-    queue_id cq_id,
-    Tensor& dst,
-    std::vector<std::shared_ptr<void>> src,
-    const std::optional<DeviceBufferRegion>& region) {
+    queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src, const std::optional<BufferRegion>& region) {
     uint32_t dst_ref_count = dst.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : dst.get_workers()) {
         auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
@@ -31,7 +28,7 @@ void read_buffer(
     queue_id cq_id,
     Tensor& src,
     std::vector<std::shared_ptr<void>> dst,
-    const std::optional<DeviceBufferRegion>& region,
+    const std::optional<BufferRegion>& region,
     size_t src_offset,
     bool blocking) {
     TT_ASSERT(src_offset == 0, "src_offset is not supported");

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -11,19 +11,10 @@
 namespace ttnn {
 using queue_id = uint8_t;
 
-void write_buffer(
-    queue_id cq_id,
-    Tensor& dst,
-    std::vector<std::shared_ptr<void>> src,
-    const std::optional<std::size_t> transfer_size = std::nullopt);
+void write_buffer(queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src);
 
 void read_buffer(
-    queue_id cq_id,
-    Tensor& src,
-    std::vector<std::shared_ptr<void>> dst,
-    const std::optional<std::size_t> transfer_size = std::nullopt,
-    size_t src_offset = 0,
-    bool blocking = true);
+    queue_id cq_id, Tensor& src, std::vector<std::shared_ptr<void>> dst, size_t src_offset = 0, bool blocking = true);
 
 void queue_synchronize(CommandQueue& cq);
 

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/run_operation.hpp"
 #include "types.hpp"
@@ -11,10 +12,19 @@
 namespace ttnn {
 using queue_id = uint8_t;
 
-void write_buffer(queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src);
+void write_buffer(
+    queue_id cq_id,
+    Tensor& dst,
+    std::vector<std::shared_ptr<void>> src,
+    const std::optional<DeviceBufferRegion>& region = std::nullopt);
 
 void read_buffer(
-    queue_id cq_id, Tensor& src, std::vector<std::shared_ptr<void>> dst, size_t src_offset = 0, bool blocking = true);
+    queue_id cq_id,
+    Tensor& src,
+    std::vector<std::shared_ptr<void>> dst,
+    const std::optional<DeviceBufferRegion>& region = std::nullopt,
+    size_t src_offset = 0,
+    bool blocking = true);
 
 void queue_synchronize(CommandQueue& cq);
 

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -16,13 +16,13 @@ void write_buffer(
     queue_id cq_id,
     Tensor& dst,
     std::vector<std::shared_ptr<void>> src,
-    const std::optional<DeviceBufferRegion>& region = std::nullopt);
+    const std::optional<BufferRegion>& region = std::nullopt);
 
 void read_buffer(
     queue_id cq_id,
     Tensor& src,
     std::vector<std::shared_ptr<void>> dst,
-    const std::optional<DeviceBufferRegion>& region = std::nullopt,
+    const std::optional<BufferRegion>& region = std::nullopt,
     size_t src_offset = 0,
     bool blocking = true);
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -925,9 +925,7 @@ void* get_raw_host_data_ptr(const Tensor& tensor) {
     }
 }
 
-void memcpy(
-    CommandQueue& queue, void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size, bool blocking) {
-    TT_ASSERT(not transfer_size.has_value(), "transfer_size is not supported for memcpy right now!");
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const bool blocking) {
     if (not is_device_tensor(src)) {
         TT_THROW("memcpy: src tensor must be on device");
     }
@@ -939,12 +937,28 @@ void memcpy(
     EnqueueReadBuffer(queue, src.device_buffer(), dst, blocking);
 }
 
-void memcpy(void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size, bool blocking) {
-    memcpy(src.device()->command_queue(), dst, src, transfer_size, blocking);
+void memcpy(
+    CommandQueue& queue, void* dst, const Tensor& src, const size_t offset, const size_t size, const bool blocking) {
+    if (not is_device_tensor(src)) {
+        TT_THROW("memcpy: src tensor must be on device");
+    }
+
+    const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
+        TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
+    }
+    EnqueueReadSubBuffer(queue, src.device_buffer(), dst, offset, size, blocking);
 }
 
-void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::optional<std::size_t> transfer_size) {
-    TT_ASSERT(not transfer_size.has_value(), "transfer_size is not supported for memcpy right now!");
+void memcpy(void* dst, const Tensor& src, const bool blocking) {
+    memcpy(src.device()->command_queue(), dst, src, blocking);
+}
+
+void memcpy(void* dst, const Tensor& src, const size_t offset, const size_t size, const bool blocking) {
+    memcpy(src.device()->command_queue(), dst, src, offset, size, blocking);
+}
+
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src) {
     if (not is_device_tensor(dst)) {
         TT_THROW("memcpy: memcpy to non-device tensor is not supported!");
     }
@@ -955,11 +969,24 @@ void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::option
     EnqueueWriteBuffer(queue, dst.device_buffer(), src, false);
 }
 
-void memcpy(Tensor& dst, const void* src, const std::optional<std::size_t> transfer_size) {
-    memcpy(dst.device()->command_queue(), dst, src, transfer_size);
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const size_t offset, const size_t size) {
+    if (not is_device_tensor(dst)) {
+        TT_THROW("memcpy: memcpy to non-device tensor is not supported!");
+    }
+    const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
+        TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
+    }
+    EnqueueWriteBuffer(queue, dst.device_buffer(), src, false);
 }
 
-void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<std::size_t> transfer_size) {
+void memcpy(Tensor& dst, const void* src) { memcpy(dst.device()->command_queue(), dst, src); }
+
+void memcpy(Tensor& dst, const void* src, const size_t offset, const size_t size) {
+    memcpy(dst.device()->command_queue(), dst, src, offset, size);
+}
+
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src) {
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
@@ -969,19 +996,47 @@ void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const std::opti
     TT_ASSERT(dst.get_layout() == src.get_layout());
 
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
-        memcpy(queue, get_raw_host_data_ptr(dst), src, transfer_size);
+        memcpy(queue, get_raw_host_data_ptr(dst), src);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
-        memcpy(queue, dst, get_raw_host_data_ptr(src), transfer_size);
+        memcpy(queue, dst, get_raw_host_data_ptr(src));
     } else {
         TT_THROW("Unsupported memcpy");
     }
 }
 
-void memcpy(Tensor& dst, const Tensor& src, const std::optional<std::size_t> transfer_size) {
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const size_t offset, const size_t size) {
+    const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
+        TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
+    }
+
+    TT_ASSERT(dst.get_dtype() == src.get_dtype());
+    TT_ASSERT(dst.get_layout() == src.get_layout());
+
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
-        memcpy(src.device()->command_queue(), dst, src, transfer_size);
+        memcpy(queue, get_raw_host_data_ptr(dst), src, offset, size);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
-        memcpy(dst.device()->command_queue(), dst, src, transfer_size);
+        memcpy(queue, dst, get_raw_host_data_ptr(src), offset, size);
+    } else {
+        TT_THROW("Unsupported memcpy");
+    }
+}
+
+void memcpy(Tensor& dst, const Tensor& src) {
+    if (is_cpu_tensor(dst) && is_device_tensor(src)) {
+        memcpy(src.device()->command_queue(), dst, src);
+    } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
+        memcpy(dst.device()->command_queue(), dst, src);
+    } else {
+        TT_THROW("Unsupported memcpy");
+    }
+}
+
+void memcpy(Tensor& dst, const Tensor& src, const size_t offset, const size_t size) {
+    if (is_cpu_tensor(dst) && is_device_tensor(src)) {
+        memcpy(src.device()->command_queue(), dst, src, offset, size);
+    } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
+        memcpy(dst.device()->command_queue(), dst, src, offset, size);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -927,7 +927,7 @@ void* get_raw_host_data_ptr(const Tensor& tensor) {
 }
 
 void memcpy(
-    CommandQueue& queue, void* dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region, bool blocking) {
+    CommandQueue& queue, void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
     TT_FATAL(is_device_tensor(src), "memcpy: src tensor must be on device");
 
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -942,11 +942,11 @@ void memcpy(
     }
 }
 
-void memcpy(void* dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region, bool blocking) {
+void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
     memcpy(src.device()->command_queue(), dst, src, region, blocking);
 }
 
-void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::optional<DeviceBufferRegion>& region) {
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     TT_FATAL(is_device_tensor(dst), "memcpy: memcpy to non-device tensor is not supported!");
 
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -961,11 +961,11 @@ void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::option
     }
 }
 
-void memcpy(Tensor& dst, const void* src, const std::optional<DeviceBufferRegion>& region) {
+void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     memcpy(dst.device()->command_queue(), dst, src, region);
 }
 
-void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region) {
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
@@ -983,7 +983,7 @@ void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const std::opti
     }
 }
 
-void memcpy(Tensor& dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region) {
+void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         memcpy(src.device()->command_queue(), dst, src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -10,6 +10,7 @@
 
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/bfloat16.hpp"
+#include "tt_metal/impl/buffers/buffer.hpp"
 #include "impl/buffers/buffer_constants.hpp"
 #include "tt_metal/tt_stl/overloaded.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
@@ -947,7 +948,8 @@ void memcpy(
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
     }
-    EnqueueReadSubBuffer(queue, src.device_buffer(), dst, offset, size, blocking);
+    const BufferRegion region(offset, size);
+    EnqueueReadSubBuffer(queue, src.device_buffer(), dst, region, blocking);
 }
 
 void memcpy(void* dst, const Tensor& src, const bool blocking) {
@@ -977,7 +979,8 @@ void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const size_t offs
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
     }
-    EnqueueWriteBuffer(queue, dst.device_buffer(), src, false);
+    const BufferRegion region(offset, size);
+    EnqueueWriteSubBuffer(queue, dst.device_buffer(), src, region, false);
 }
 
 void memcpy(Tensor& dst, const void* src) { memcpy(dst.device()->command_queue(), dst, src); }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -926,10 +926,8 @@ void* get_raw_host_data_ptr(const Tensor& tensor) {
     }
 }
 
-void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const bool blocking) {
-    if (not is_device_tensor(src)) {
-        TT_THROW("memcpy: src tensor must be on device");
-    }
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, bool blocking) {
+    TT_FATAL(is_device_tensor(src), "memcpy: src tensor must be on device");
 
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
@@ -938,11 +936,8 @@ void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const bool blocki
     EnqueueReadBuffer(queue, src.device_buffer(), dst, blocking);
 }
 
-void memcpy(
-    CommandQueue& queue, void* dst, const Tensor& src, const size_t offset, const size_t size, const bool blocking) {
-    if (not is_device_tensor(src)) {
-        TT_THROW("memcpy: src tensor must be on device");
-    }
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, size_t offset, size_t size, bool blocking) {
+    TT_FATAL(is_device_tensor(src), "memcpy: src tensor must be on device");
 
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
@@ -952,18 +947,15 @@ void memcpy(
     EnqueueReadSubBuffer(queue, src.device_buffer(), dst, region, blocking);
 }
 
-void memcpy(void* dst, const Tensor& src, const bool blocking) {
-    memcpy(src.device()->command_queue(), dst, src, blocking);
-}
+void memcpy(void* dst, const Tensor& src, bool blocking) { memcpy(src.device()->command_queue(), dst, src, blocking); }
 
-void memcpy(void* dst, const Tensor& src, const size_t offset, const size_t size, const bool blocking) {
+void memcpy(void* dst, const Tensor& src, size_t offset, size_t size, bool blocking) {
     memcpy(src.device()->command_queue(), dst, src, offset, size, blocking);
 }
 
 void memcpy(CommandQueue& queue, Tensor& dst, const void* src) {
-    if (not is_device_tensor(dst)) {
-        TT_THROW("memcpy: memcpy to non-device tensor is not supported!");
-    }
+    TT_FATAL(is_device_tensor(dst), "memcpy: memcpy to non-device tensor is not supported!");
+
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
@@ -971,10 +963,9 @@ void memcpy(CommandQueue& queue, Tensor& dst, const void* src) {
     EnqueueWriteBuffer(queue, dst.device_buffer(), src, false);
 }
 
-void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const size_t offset, const size_t size) {
-    if (not is_device_tensor(dst)) {
-        TT_THROW("memcpy: memcpy to non-device tensor is not supported!");
-    }
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src, size_t offset, size_t size) {
+    TT_FATAL(is_device_tensor(dst), "memcpy: memcpy to non-device tensor is not supported!");
+
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
@@ -985,7 +976,7 @@ void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const size_t offs
 
 void memcpy(Tensor& dst, const void* src) { memcpy(dst.device()->command_queue(), dst, src); }
 
-void memcpy(Tensor& dst, const void* src, const size_t offset, const size_t size) {
+void memcpy(Tensor& dst, const void* src, size_t offset, size_t size) {
     memcpy(dst.device()->command_queue(), dst, src, offset, size);
 }
 
@@ -1007,7 +998,7 @@ void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src) {
     }
 }
 
-void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const size_t offset, const size_t size) {
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, size_t offset, size_t size) {
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
@@ -1035,7 +1026,7 @@ void memcpy(Tensor& dst, const Tensor& src) {
     }
 }
 
-void memcpy(Tensor& dst, const Tensor& src, const size_t offset, const size_t size) {
+void memcpy(Tensor& dst, const Tensor& src, size_t offset, size_t size) {
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         memcpy(src.device()->command_queue(), dst, src, offset, size);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -388,24 +388,21 @@ void memcpy(
     CommandQueue& queue,
     void* dst,
     const Tensor& src,
-    const std::optional<DeviceBufferRegion>& region = std::nullopt,
+    const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
 void memcpy(
-    CommandQueue& queue, Tensor& dst, const void* src, const std::optional<DeviceBufferRegion>& region = std::nullopt);
+    CommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy(
-    CommandQueue& queue,
-    Tensor& dst,
-    const Tensor& src,
-    const std::optional<DeviceBufferRegion>& region = std::nullopt);
+    CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy(
-    void* dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region = std::nullopt, bool blocking = true);
+    void* dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt, bool blocking = true);
 
-void memcpy(Tensor& dst, const void* src, const std::optional<DeviceBufferRegion>& region = std::nullopt);
+void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
-void memcpy(Tensor& dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region = std::nullopt);
+void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 Tensor allocate_tensor_on_devices(
     const ttnn::Shape& shape,

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -384,29 +384,23 @@ Tensor create_device_tensor(
 // void *get_host_buffer(const Tensor &tensor);
 void* get_raw_host_data_ptr(const Tensor& tensor);
 
-void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const bool blocking = true);
-void memcpy(
-    CommandQueue& queue,
-    void* dst,
-    const Tensor& src,
-    const size_t offset,
-    const size_t size,
-    const bool blocking = true);
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, bool blocking = true);
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, size_t offset, size_t size, bool blocking = true);
 
 void memcpy(CommandQueue& queue, Tensor& dst, const void* src);
-void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const size_t offset, const size_t size);
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src, size_t offset, size_t size);
 
 void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src);
-void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const size_t offset, const size_t size);
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, size_t offset, size_t size);
 
-void memcpy(void* dst, const Tensor& src, const bool blocking = true);
-void memcpy(void* dst, const Tensor& src, const size_t offset, const size_t size, const bool blocking = true);
+void memcpy(void* dst, const Tensor& src, bool blocking = true);
+void memcpy(void* dst, const Tensor& src, size_t offset, size_t size, bool blocking = true);
 
 void memcpy(Tensor& dst, const void* src);
-void memcpy(Tensor& dst, const void* src, const size_t offset, const size_t size);
+void memcpy(Tensor& dst, const void* src, size_t offset, size_t size);
 
 void memcpy(Tensor& dst, const Tensor& src);
-void memcpy(Tensor& dst, const Tensor& src, const size_t offset, const size_t size);
+void memcpy(Tensor& dst, const Tensor& src, size_t offset, size_t size);
 
 Tensor allocate_tensor_on_devices(
     const ttnn::Shape& shape,

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -384,23 +384,28 @@ Tensor create_device_tensor(
 // void *get_host_buffer(const Tensor &tensor);
 void* get_raw_host_data_ptr(const Tensor& tensor);
 
-void memcpy(CommandQueue& queue, void* dst, const Tensor& src, bool blocking = true);
-void memcpy(CommandQueue& queue, void* dst, const Tensor& src, size_t offset, size_t size, bool blocking = true);
+void memcpy(
+    CommandQueue& queue,
+    void* dst,
+    const Tensor& src,
+    const std::optional<DeviceBufferRegion>& region = std::nullopt,
+    bool blocking = true);
 
-void memcpy(CommandQueue& queue, Tensor& dst, const void* src);
-void memcpy(CommandQueue& queue, Tensor& dst, const void* src, size_t offset, size_t size);
+void memcpy(
+    CommandQueue& queue, Tensor& dst, const void* src, const std::optional<DeviceBufferRegion>& region = std::nullopt);
 
-void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src);
-void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, size_t offset, size_t size);
+void memcpy(
+    CommandQueue& queue,
+    Tensor& dst,
+    const Tensor& src,
+    const std::optional<DeviceBufferRegion>& region = std::nullopt);
 
-void memcpy(void* dst, const Tensor& src, bool blocking = true);
-void memcpy(void* dst, const Tensor& src, size_t offset, size_t size, bool blocking = true);
+void memcpy(
+    void* dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region = std::nullopt, bool blocking = true);
 
-void memcpy(Tensor& dst, const void* src);
-void memcpy(Tensor& dst, const void* src, size_t offset, size_t size);
+void memcpy(Tensor& dst, const void* src, const std::optional<DeviceBufferRegion>& region = std::nullopt);
 
-void memcpy(Tensor& dst, const Tensor& src);
-void memcpy(Tensor& dst, const Tensor& src, size_t offset, size_t size);
+void memcpy(Tensor& dst, const Tensor& src, const std::optional<DeviceBufferRegion>& region = std::nullopt);
 
 Tensor allocate_tensor_on_devices(
     const ttnn::Shape& shape,

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -384,21 +384,29 @@ Tensor create_device_tensor(
 // void *get_host_buffer(const Tensor &tensor);
 void* get_raw_host_data_ptr(const Tensor& tensor);
 
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const bool blocking = true);
 void memcpy(
     CommandQueue& queue,
     void* dst,
     const Tensor& src,
-    const std::optional<std::size_t> transfer_size = std::nullopt,
-    bool blocking = true);
-void memcpy(
-    CommandQueue& queue, Tensor& dst, const void* src, const std::optional<std::size_t> transfer_size = std::nullopt);
-void memcpy(
-    CommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<std::size_t> transfer_size = std::nullopt);
+    const size_t offset,
+    const size_t size,
+    const bool blocking = true);
 
-void memcpy(
-    void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size = std::nullopt, bool blocking = true);
-void memcpy(Tensor& dst, const void* src, const std::optional<std::size_t> transfer_size = std::nullopt);
-void memcpy(Tensor& dst, const Tensor& src, const std::optional<std::size_t> transfer_size = std::nullopt);
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src);
+void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const size_t offset, const size_t size);
+
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src);
+void memcpy(CommandQueue& queue, Tensor& dst, const Tensor& src, const size_t offset, const size_t size);
+
+void memcpy(void* dst, const Tensor& src, const bool blocking = true);
+void memcpy(void* dst, const Tensor& src, const size_t offset, const size_t size, const bool blocking = true);
+
+void memcpy(Tensor& dst, const void* src);
+void memcpy(Tensor& dst, const void* src, const size_t offset, const size_t size);
+
+void memcpy(Tensor& dst, const Tensor& src);
+void memcpy(Tensor& dst, const Tensor& src, const size_t offset, const size_t size);
 
 Tensor allocate_tensor_on_devices(
     const ttnn::Shape& shape,

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -304,6 +304,7 @@ struct OwnedStorage {
 };
 
 using DeviceBuffer = std::shared_ptr<Buffer>;
+using DeviceBufferRegion = tt::tt_metal::BufferRegion;
 struct DeviceStorage {
     DeviceBuffer buffer;
     DeviceStorage() = default;

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -304,7 +304,6 @@ struct OwnedStorage {
 };
 
 using DeviceBuffer = std::shared_ptr<Buffer>;
-using DeviceBufferRegion = tt::tt_metal::BufferRegion;
 struct DeviceStorage {
     DeviceBuffer buffer;
     DeviceStorage() = default;


### PR DESCRIPTION
### Ticket
#14780 

This PR adds support to read from and write to partial buffer regions instead of the entire buffer. Note that this implementation only supports interleaved buffers where the offset and size of the region specified are divisible by the buffer page size.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
