### PR TITLE
#15061: Extended {to,from}_vector to support tilized layout, bf4/8 formats

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -7,7 +7,10 @@
 #include <algorithm>
 #include <cstdint>
 
+#include "tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/xtensor/conversion_utils.hpp"
 #include "ttnn/tensor/xtensor/xtensor_all_includes.hpp"
 
@@ -15,7 +18,13 @@ namespace ttnn {
 namespace {
 
 using ::testing::Eq;
+using ::testing::FloatNear;
 using ::testing::Pointwise;
+
+template <typename... Args>
+testing::Matcher<ttnn::SimpleShape> ShapeIs(Args... args) {
+    return testing::Eq(ttnn::SimpleShape({args...}));
+}
 
 const std::vector<ttnn::SimpleShape>& get_shapes_for_test() {
     static auto* shapes = new std::vector<ttnn::SimpleShape>{
@@ -50,7 +59,7 @@ std::vector<T> arange(int64_t start, int64_t end, int64_t step) {
 template <typename T>
 class VectorConversionTest : public ::testing::Test {};
 
-using TestTypes = ::testing::Types<float, bfloat16, uint32_t, int32_t>;
+using TestTypes = ::testing::Types<float, bfloat16, uint8_t, uint16_t, uint32_t, int32_t>;
 TYPED_TEST_SUITE(VectorConversionTest, TestTypes);
 
 TYPED_TEST(VectorConversionTest, Roundtrip) {
@@ -74,21 +83,17 @@ TYPED_TEST(VectorConversionTest, RoundtripTilezedLayout) {
     ttnn::SimpleShape shape{128, 128};
 
     auto input = arange<TypeParam>(0, shape.volume(), 1);
-    // TODO: Support this.
-    EXPECT_ANY_THROW(
-        Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE)));
 
-    auto output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>()))
-                      .to(Layout::TILE)
+    auto output = Tensor::from_vector(input, get_tensor_spec(shape, convert_to_data_type<TypeParam>(), Layout::TILE))
                       .template to_vector<TypeParam>();
+
     EXPECT_THAT(output, Pointwise(Eq(), input));
 }
 
 TYPED_TEST(VectorConversionTest, InvalidDtype) {
     ttnn::SimpleShape shape{32, 32};
-    auto input = arange<TypeParam>(0, 42, 1);
+    auto input = arange<TypeParam>(0, shape.volume(), 1);
 
-    ASSERT_NE(input.size(), shape.volume());
     EXPECT_ANY_THROW(Tensor::from_vector(
         input,
         get_tensor_spec(
@@ -97,7 +102,7 @@ TYPED_TEST(VectorConversionTest, InvalidDtype) {
             (std::is_same_v<TypeParam, int32_t> ? DataType::FLOAT32 : DataType::INT32))));
 }
 
-TEST(FloatVectorConversionTest, RoundtripBfloat16Representation) {
+TEST(FloatVectorConversionTest, RoundtripBfloat16) {
     for (const auto& shape : get_shapes_for_test()) {
         auto input_bf16 = arange<bfloat16>(0, static_cast<int64_t>(shape.volume()), 1);
         std::vector<float> input_ft;
@@ -113,6 +118,70 @@ TEST(FloatVectorConversionTest, RoundtripBfloat16Representation) {
         auto output_ft = Tensor::from_vector(input_bf16, get_tensor_spec(shape, DataType::BFLOAT16)).to_vector<float>();
         EXPECT_THAT(output_ft, Pointwise(Eq(), input_ft)) << "for shape: " << shape;
     }
+}
+
+class BlockFloatVectorConversionTest : public ::testing::TestWithParam<DataType> {};
+
+TEST_P(BlockFloatVectorConversionTest, InvalidLayout) {
+    ttnn::SimpleShape shape{128, 128};
+    EXPECT_ANY_THROW(
+        Tensor::from_vector(std::vector<float>(shape.volume()), get_tensor_spec(shape, GetParam(), Layout::ROW_MAJOR)));
+}
+
+TEST_P(BlockFloatVectorConversionTest, Roundtrip) {
+    ttnn::SimpleShape shape{128, 128};
+    std::vector<float> input;
+    input.reserve(shape.volume());
+    for (int i = 0; i < shape.volume(); ++i) {
+        input.push_back(i % 2 == 0 ? 0.0f : 1.0f);
+    }
+    auto output = Tensor::from_vector(input, get_tensor_spec(shape, GetParam(), Layout::TILE)).to_vector<float>();
+    EXPECT_THAT(output, Pointwise(Eq(), input));
+}
+
+TEST_P(BlockFloatVectorConversionTest, AddPadding) {
+    ttnn::SimpleShape shape{14, 47};
+    std::vector<float> input(shape.volume(), 1.0f);
+
+    auto output = Tensor::from_vector(input, get_tensor_spec(shape, GetParam(), Layout::TILE));
+
+    EXPECT_THAT(output.get_logical_shape(), ShapeIs(14, 47));
+    EXPECT_THAT(output.get_padded_shape(), ShapeIs(32, 64));
+}
+
+TEST_P(BlockFloatVectorConversionTest, AddPaddingWithCustomTile) {
+    ttnn::SimpleShape shape{14, 47};
+    std::vector<float> input(shape.volume(), 1.0f);
+
+    TensorSpec spec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, Tile({16, 16})), MemoryConfig{}));
+    auto output = Tensor::from_vector(input, spec);
+
+    EXPECT_THAT(output.get_logical_shape(), ShapeIs(14, 47));
+    EXPECT_THAT(output.get_padded_shape(), ShapeIs(14, 47));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BlockFloatVectorConversionTest,
+    BlockFloatVectorConversionTest,
+    ::testing::Values(DataType::BFLOAT4_B, DataType::BFLOAT8_B));
+
+using DeviceVectorConversionTest = TTNNFixtureWithDevice;
+
+TEST_F(DeviceVectorConversionTest, RoundtripWithMemoryConfig) {
+    ttnn::SimpleShape shape{128, 128};
+
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    TensorSpec spec(
+        shape, TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{.buffer_type = BufferType::L1}));
+    auto output_tensor = Tensor::from_vector(input, spec, device_);
+
+    EXPECT_TRUE(is_device_tensor(output_tensor));
+    EXPECT_TRUE(output_tensor.memory_config().is_l1());
+
+    auto output = output_tensor.to_vector<float>();
+    EXPECT_THAT(output, Pointwise(Eq(), input));
 }
 
 }  // namespace

--- a/tt_metal/common/bfloat4.hpp
+++ b/tt_metal/common/bfloat4.hpp
@@ -10,15 +10,16 @@
 #include <immintrin.h>
 
 #include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/blockfloat_common.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
+#include "tt_metal/tt_stl/span.hpp"
 #include "tracy/Tracy.hpp"
-#include "blockfloat_common.hpp"
 
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor
 struct bfloat4_b {};
 
 inline std::vector<uint32_t> pack_fp32_vec_as_bfp4_tiles(
-    const std::vector<float>& fp32_vec,
+    tt::stl::Span<const float> fp32_vec,
     bool row_major_input,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -10,9 +10,10 @@
 #include <immintrin.h>
 
 #include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/blockfloat_common.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
+#include "tt_metal/tt_stl/span.hpp"
 #include "tracy/Tracy.hpp"
-#include "blockfloat_common.hpp"
 
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor
 struct bfloat8_b {};
@@ -99,7 +100,7 @@ inline uint32_t create_packed_bfp8_packed_as_u32(
 }
 
 inline std::vector<uint32_t> pack_fp32_vec_as_bfp8_tiles(
-    const std::vector<float>& fp32_vec,
+    tt::stl::Span<const float> fp32_vec,
     bool row_major_input,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {

--- a/tt_metal/common/blockfloat_common.hpp
+++ b/tt_metal/common/blockfloat_common.hpp
@@ -13,6 +13,7 @@
 #include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_metal/impl/tile/tile.hpp"
+#include "tt_metal/tt_stl/span.hpp"
 
 inline uint8_t get_max_exp(const std::vector<uint32_t>& vec, bool is_exp_a) {
     TT_ASSERT(vec.size() == 16);
@@ -288,7 +289,7 @@ inline uint32_t create_packed_bfp_packed_as_u32(
 
 template <tt::DataFormat BfpFormat>
 inline std::vector<uint32_t> pack_fp32_vec_as_bfp_tiles(
-    const std::vector<float>& fp32_vec,
+    tt::stl::Span<const float> fp32_vec,
     bool row_major_input,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile = std::nullopt) {
@@ -344,7 +345,7 @@ inline std::vector<uint32_t> pack_fp32_vec_as_bfp_tiles(
                         } else {
                             data_index = fp32_element_index++;
                         }
-                        float float_num = fp32_vec.at(data_index);
+                        float float_num = fp32_vec[data_index];
                         uint32_t uint32_num = *reinterpret_cast<uint32_t*>(&float_num);
                         single_row.push_back(uint32_num);
                     }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/bfloat16.hpp"
 #include "impl/buffers/buffer_constants.hpp"
 #include "tt_metal/tt_stl/overloaded.hpp"
@@ -32,27 +33,39 @@ namespace tt::tt_metal {
 namespace {
 
 template <typename T>
-Tensor create_owned_tensor_from_span(tt::stl::Span<const T> data, const TensorSpec& spec) {
-    // TODO: support tilized layouts.
-    TT_FATAL(spec.layout() == Layout::ROW_MAJOR, "Unsupported layout: {}", spec.layout());
-    auto buffer = tt::tt_metal::owned_buffer::create(std::vector<T>(data.begin(), data.end()));
-    auto storage = OwnedStorage{std::move(buffer)};
-    return Tensor{std::move(storage), spec};
+Tensor create_owned_tensor_from_row_major_data(
+    std::vector<T>&& data, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt) {
+    TensorSpec result_cpu_spec(
+        spec.logical_shape(),
+        TensorLayout(spec.data_type(), PageConfig(Layout::ROW_MAJOR, spec.tile()), MemoryConfig{}));
+
+    Tensor output(OwnedStorage{owned_buffer::create(std::move(data))}, result_cpu_spec);
+
+    if (spec.layout() == Layout::TILE) {
+        // TODO: whenever possible, perform tiliziation on device.
+        output = output.to(Layout::TILE);
+    }
+
+    if (device.has_value()) {
+        output = output.to(device->get_devices(), spec.memory_config());
+    }
+
+    return output;
 }
 
 // TODO: optimize precomputing multipliers
 template <typename T, typename InternalType>
-std::vector<T> untile_tensor_to_vec(const Tensor& cpu_tensor) {
-    auto tiled_buffer = tt::tt_metal::host_buffer::get_as<InternalType>(cpu_tensor);
-    auto untiled_shape = cpu_tensor.get_logical_shape();
-    auto tiled_shape = cpu_tensor.get_padded_shape();
+std::vector<T> unpad_tensor_to_vec(const Tensor& cpu_tensor) {
+    auto tiled_buffer = host_buffer::get_as<InternalType>(cpu_tensor);
+    const auto untiled_shape = cpu_tensor.get_logical_shape();
+    const auto tiled_shape = cpu_tensor.get_padded_shape();
 
     // Calculate total size of the untiled tensor
     size_t total_size = untiled_shape.volume();
 
     std::vector<T> untiled_data(total_size);
 
-    auto compute_flat_index = [](const std::vector<uint32_t>& indices, ttnn::SimpleShape& shape) -> uint32_t {
+    auto compute_flat_index = [](const std::vector<uint32_t>& indices, const ttnn::SimpleShape& shape) -> uint32_t {
         uint32_t flat_index = 0;
         uint32_t multiplier = 1;
         for (int i = (int)indices.size() - 1; i >= 0; --i) {
@@ -589,28 +602,63 @@ const Storage& Tensor::get_storage() const {
 }
 
 template <>
-Tensor Tensor::from_span<float>(tt::stl::Span<const float> buffer, const TensorSpec& spec) {
+Tensor Tensor::from_span<float>(
+    tt::stl::Span<const float> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device) {
     size_t volume = spec.logical_shape().volume();
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
-    if (spec.data_type() == DataType::FLOAT32) {
-        return create_owned_tensor_from_span(buffer, spec);
-    } else if (spec.data_type() == DataType::BFLOAT16) {
-        std::vector<bfloat16> bfloat16_data;
-        bfloat16_data.reserve(buffer.size());
-        std::transform(std::begin(buffer), std::end(buffer), std::back_inserter(bfloat16_data), [](float value) {
-            return bfloat16(value);
-        });
-        return create_owned_tensor_from_span(
-            tt::stl::Span<const bfloat16>(bfloat16_data.data(), bfloat16_data.size()), spec);
-    } else {
-        // TODO: support bf8 and bf4
-        TT_THROW("Unsupported data type for from_span<float>: {}", spec.data_type());
+    switch (spec.data_type()) {
+        case DataType::FLOAT32:
+            return create_owned_tensor_from_row_major_data(
+                std::vector<float>(buffer.begin(), buffer.end()), spec, device);
+        case DataType::BFLOAT16: {
+            std::vector<bfloat16> bfloat16_data;
+            bfloat16_data.reserve(buffer.size());
+            std::transform(std::begin(buffer), std::end(buffer), std::back_inserter(bfloat16_data), [](float value) {
+                return bfloat16(value);
+            });
+            return create_owned_tensor_from_row_major_data(std::move(bfloat16_data), spec, device);
+        }
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B: {
+            TT_FATAL(
+                spec.tensor_layout().get_layout() == Layout::TILE,
+                "Tile layout is required for BFLOAT8_B and BFLOAT4_B");
+            const auto& tile = spec.tensor_layout().get_page_config().get_tile();
+
+            // Create an intermediate tensor on CPU to perform padding.
+            TensorSpec result_cpu_spec(
+                spec.logical_shape(),
+                TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), MemoryConfig{}));
+            Tensor result_cpu_tensor = create_owned_tensor_from_row_major_data(
+                std::vector<float>(buffer.begin(), buffer.end()), result_cpu_spec);
+            if (result_cpu_spec.logical_shape() != result_cpu_spec.padded_shape()) {
+                result_cpu_tensor = tensor_ops::tensor_pad(
+                    result_cpu_tensor, result_cpu_spec.padded_shape(), ttnn::SimpleShape{0, 0, 0, 0}, 0);
+            }
+
+            std::vector<float> padded_row_major_data = owned_buffer::get_as<float>(result_cpu_tensor).get();
+            std::vector<uint32_t> packed_block_floats =
+                spec.data_type() == DataType::BFLOAT8_B
+                    ? pack_fp32_vec_as_bfp8_tiles(
+                          padded_row_major_data, /*row_major_input=*/true, /*is_exp_a=*/false, tile)
+                    : pack_fp32_vec_as_bfp4_tiles(
+                          padded_row_major_data, /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+
+            Tensor tensor(OwnedStorage{owned_buffer::create(std::move(packed_block_floats))}, spec);
+            if (device.has_value()) {
+                tensor = tensor.to(device->get_devices(), spec.memory_config());
+            }
+            return tensor;
+        }
+        default: {
+            TT_THROW("Unsupported data type for from_span<float>: {}", spec.data_type());
+        }
     }
 }
 
 template <typename T>
-Tensor Tensor::from_span(tt::stl::Span<const T> buffer, const TensorSpec& spec) {
+Tensor Tensor::from_span(tt::stl::Span<const T> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device) {
     size_t volume = spec.logical_shape().volume();
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
@@ -619,19 +667,35 @@ Tensor Tensor::from_span(tt::stl::Span<const T> buffer, const TensorSpec& spec) 
         "Unsupported data type for from_span: got {}, expected: {}",
         spec.data_type(),
         convert_to_data_type<T>());
-    return create_owned_tensor_from_span(buffer, spec);
+    return create_owned_tensor_from_row_major_data(std::vector<T>(buffer.begin(), buffer.end()), spec, device);
 }
 
 template <>
 std::vector<float> Tensor::to_vector<float>() const {
-    auto cpu_tensor = this->cpu().to(Layout::ROW_MAJOR);
-    if (cpu_tensor.get_dtype() == DataType::BFLOAT16) {
-        return untile_tensor_to_vec<float, bfloat16>(cpu_tensor);
-    } else if (cpu_tensor.get_dtype() == DataType::FLOAT32) {
-        return untile_tensor_to_vec<float, float>(cpu_tensor);
-    } else {
-        // TODO: support bf4, bf8.
-        TT_THROW("Cannot convert tensor to vector for data type: {}", cpu_tensor.get_dtype());
+    Tensor cpu_tensor = this->cpu();
+    switch (cpu_tensor.get_dtype()) {
+        case DataType::BFLOAT16: return unpad_tensor_to_vec<float, bfloat16>(cpu_tensor.to(Layout::ROW_MAJOR));
+        case DataType::FLOAT32: return unpad_tensor_to_vec<float, float>(cpu_tensor.to(Layout::ROW_MAJOR));
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B: {
+            const auto& tile = cpu_tensor.get_tensor_spec().tile();
+            std::vector<uint32_t> packed_data =
+                owned_buffer::get_as<std::uint32_t>(std::get<OwnedStorage>(cpu_tensor.storage()).buffer).get();
+            std::vector<float> unpacked_data =
+                cpu_tensor.get_tensor_spec().data_type() == DataType::BFLOAT8_B
+                    ? unpack_bfp8_tiles_into_float_vec(packed_data, /*row_major_output=*/true, /*is_exp_a=*/false, tile)
+                    : unpack_bfp4_tiles_into_float_vec(
+                          packed_data, /*row_major_output=*/true, /*is_exp_a=*/false, tile);
+
+            TensorSpec ft32_cpu_spec(
+                cpu_tensor.get_shape().logical_shape(),
+                TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
+            Tensor ft32_cpu_tensor = create_owned_tensor_from_row_major_data(std::move(unpacked_data), ft32_cpu_spec);
+            return unpad_tensor_to_vec<float, float>(ft32_cpu_tensor);
+        }
+        default: {
+            TT_THROW("Cannot convert tensor to vector for data type: {}", cpu_tensor.get_dtype());
+        }
     }
 }
 
@@ -643,16 +707,26 @@ std::vector<T> Tensor::to_vector() const {
         "Unsupported data type for to_vector: got {}, expected: {}",
         cpu_tensor.get_dtype(),
         convert_to_data_type<T>());
-    return untile_tensor_to_vec<T, T>(cpu_tensor);
+    return unpad_tensor_to_vec<T, T>(cpu_tensor);
 }
 
 // Instantiate explicitly for the supported types.
-template Tensor Tensor::from_span<bfloat16>(tt::stl::Span<const bfloat16> buffer, const TensorSpec& spec);
-template Tensor Tensor::from_span<uint32_t>(tt::stl::Span<const uint32_t> buffer, const TensorSpec& spec);
-template Tensor Tensor::from_span<int32_t>(tt::stl::Span<const int32_t> buffer, const TensorSpec& spec);
+template Tensor Tensor::from_span<bfloat16>(
+    tt::stl::Span<const bfloat16> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::from_span<int32_t>(
+    tt::stl::Span<const int32_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::from_span<uint8_t>(
+    tt::stl::Span<const uint8_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::from_span<uint16_t>(
+    tt::stl::Span<const uint16_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+template Tensor Tensor::from_span<uint32_t>(
+    tt::stl::Span<const uint32_t> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device);
+
 template std::vector<bfloat16> Tensor::to_vector<bfloat16>() const;
-template std::vector<uint32_t> Tensor::to_vector<uint32_t>() const;
 template std::vector<int32_t> Tensor::to_vector<int32_t>() const;
+template std::vector<uint8_t> Tensor::to_vector<uint8_t>() const;
+template std::vector<uint16_t> Tensor::to_vector<uint16_t>() const;
+template std::vector<uint32_t> Tensor::to_vector<uint32_t>() const;
 
 Tensor Tensor::to(
     Device* target_device,

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -145,7 +145,7 @@ struct Tensor {
     // The data in the buffer is copied into a tensor with an owned storage.
     //
     // TODO: add support for returning a tensor with borrowed storage based off the buffer.
-    // TODO: plumb a device, and perform tilization on device, whenever possible.
+    // TODO: handle tilization and padding in face of sharding.
     template <typename T>
     static Tensor from_span(
         tt::stl::Span<const T> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt);
@@ -162,6 +162,8 @@ struct Tensor {
     // the `Tensor`; block float formats such as BFLOAT8_B and BFLOAT4_B require `T` equal `float`.
     //
     // If the tensor resides on a device, it will be brough back to host.
+    //
+    // TODO: handle tilization and padding in face of sharding.
     template <typename T>
     std::vector<T> to_vector() const;
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -15,6 +15,7 @@
 #include "common/bfloat8.hpp"
 #include "common/test_tiles.hpp"
 #include "common/tt_backend_api_types.hpp"
+#include "ttnn/any_device.hpp"
 #include "ttnn/common/constants.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -139,39 +140,28 @@ struct Tensor {
 
     // Converts a buffer of elements of type `T` to a `Tensor`.
     // Elements in the buffer are assumed to be stored in row-major order. The size of the buffer and the type of the
-    // elements have to match `spec`.
+    // elements have to match `spec`; block float formats such as BFLOAT8_B and BFLOAT4_B require `T` equal `float`.
     //
     // The data in the buffer is copied into a tensor with an owned storage.
     //
-    // IMPORTANT: this function supports a limited subset of types (float32, bfloat16, uint32_t, int32_t),
-    // and only row-major layout.
-    //
-    // TODO:
-    //   1. add support for returning a tensor with a borrowed storage based off the buffer.
-    //   2. add support for sharding.
-    //   3. add support for block float formats.
-    //   4. add support for tilized layouts.
-    //   5. add support for on-device tensor creation.
+    // TODO: add support for returning a tensor with borrowed storage based off the buffer.
+    // TODO: plumb a device, and perform tilization on device, whenever possible.
     template <typename T>
-    static Tensor from_span(tt::stl::Span<const T> buffer, const TensorSpec& spec);
+    static Tensor from_span(
+        tt::stl::Span<const T> buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt);
 
     // Same as `from_span`, but takes a vector instead.
     template <typename T>
-    static Tensor from_vector(const std::vector<T>& buffer, const TensorSpec& spec) {
-        return from_span(tt::stl::Span<const T>(buffer.data(), buffer.size()), spec);
+    static Tensor from_vector(
+        const std::vector<T>& buffer, const TensorSpec& spec, std::optional<ttnn::AnyDevice> device = std::nullopt) {
+        return from_span(tt::stl::Span<const T>(buffer.data(), buffer.size()), spec, device);
     }
 
     // Converts a `Tensor` to a `std::vector<T>`.
     // Elements in the vector will be stored in row-major order. The type of the requested vector has to match that of
-    // the `Tensor`.
+    // the `Tensor`; block float formats such as BFLOAT8_B and BFLOAT4_B require `T` equal `float`.
     //
     // If the tensor resides on a device, it will be brough back to host.
-    //
-    // IMPORTANT: this function supports a limited subset of types (float32, bfloat16, uint32_t, int32_t).
-    //
-    // TODO:
-    //   1. add support for sharding.
-    //   2. add support for block float formats.
     template <typename T>
     std::vector<T> to_vector() const;
 

--- a/ttnn/cpp/ttnn/tensor/xtensor/partition.cpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/partition.cpp
@@ -151,9 +151,13 @@ std::vector<Tensor> chunk_impl(const Tensor& tensor, const TensorLayout& layout,
 std::vector<Tensor> chunk(const Tensor& tensor, int num_chunks, int dim) {
     const auto& reference_layout = tensor.tensor_spec().tensor_layout();
     switch (reference_layout.get_data_type()) {
-        case DataType::BFLOAT16: return adaptor::chunk_impl<float>(tensor, reference_layout, num_chunks, dim);
+        case DataType::BFLOAT4_B:
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT16:
         case DataType::FLOAT32: return adaptor::chunk_impl<float>(tensor, reference_layout, num_chunks, dim);
         case DataType::INT32: return adaptor::chunk_impl<int32_t>(tensor, reference_layout, num_chunks, dim);
+        case DataType::UINT8: return adaptor::chunk_impl<uint8_t>(tensor, reference_layout, num_chunks, dim);
+        case DataType::UINT16: return adaptor::chunk_impl<uint16_t>(tensor, reference_layout, num_chunks, dim);
         case DataType::UINT32: return adaptor::chunk_impl<uint32_t>(tensor, reference_layout, num_chunks, dim);
         default: TT_THROW("Unsupported data type: {}", reference_layout.get_data_type());
     }
@@ -163,9 +167,13 @@ Tensor concat(const std::vector<Tensor>& tensors, int dim) {
     TT_FATAL(tensors.size() > 0, "Cannot concatenate an empty list of tensors");
     const auto& reference_layout = tensors.front().tensor_spec().tensor_layout();
     switch (reference_layout.get_data_type()) {
-        case DataType::BFLOAT16: return adaptor::concat_impl<float>(tensors, reference_layout, dim);
+        case DataType::BFLOAT4_B:
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT16:
         case DataType::FLOAT32: return adaptor::concat_impl<float>(tensors, reference_layout, dim);
         case DataType::INT32: return adaptor::concat_impl<int32_t>(tensors, reference_layout, dim);
+        case DataType::UINT8: return adaptor::concat_impl<uint8_t>(tensors, reference_layout, dim);
+        case DataType::UINT16: return adaptor::concat_impl<uint16_t>(tensors, reference_layout, dim);
         case DataType::UINT32: return adaptor::concat_impl<uint32_t>(tensors, reference_layout, dim);
         default: TT_THROW("Unsupported data type: {}", reference_layout.get_data_type());
     }


### PR DESCRIPTION
### Ticket
#15061

### Problem description
`to_vector` / `from_vector` don't support some of the special cases, which prevents a more widespread adoption (distributing tensors across mesh of devices in particular).

### What's changed
* Support tilized layouts.
* Support bf4 / bf8 data types with auto-padding.
* Extended `chunk` / `concat` support for the added types.

### Next steps
* Optimize certain operations on-device, such as tilization, whenever possible.
* Perform auto-padding in tilized layouts / when using sharding.
* Switching pytensor logic to using `from_vector` API.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12422597810)
- [X] New/Existing tests provide coverage for changes
