### PR TITLE
#0: Let sharded_to_interleaved handle interleaved input

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
@@ -17,10 +17,12 @@ ttnn::Tensor ShardedToInterleavedOperation::invoke(
     const MemoryConfig& memory_config,
     const std::optional<DataType>& output_dtype,
     const std::optional<bool>& is_l1_aligned) {
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    if (!input_tensor.shard_spec().has_value()) {
+        return input_tensor;
+    }
 
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     auto shard_spec = input_tensor.shard_spec().value();
-    TT_FATAL(input_tensor.shard_spec().has_value(), "Error");
     return operation::run(
                ShardedToInterleavedDeviceOperation{
                    .output_mem_config = memory_config,


### PR DESCRIPTION
### Ticket
None

### Problem description
Found that op fails with wrong_optional_access error due to unchecked sharding spec.

### What's changed
Check if tensor is sharded and return input tensor as is if it is already interleaved

### Checklist
- [ ] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12382900338)