### PR TITLE
Update generating unicast go signal commands to ensure dispatch write linear respects alignment

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -243,9 +243,7 @@ void EnqueueWriteShardedBufferCommand::add_dispatch_write(HugepageDeviceCommand&
     uint32_t data_size_bytes = this->pages_to_write * this->padded_page_size;
     const CoreCoord virtual_core =
         this->buffer.device()->virtual_core_from_logical_core(this->core, this->buffer.core_type());
-    bool flush_prefetch = true;
     command_sequence.add_dispatch_write_linear(
-        flush_prefetch,
         0,
         this->device->get_noc_unicast_encoding(this->noc_index, virtual_core),
         this->bank_base_address,
@@ -288,11 +286,11 @@ void EnqueueWriteShardedBufferCommand::add_buffer_data(HugepageDeviceCommand& co
 void EnqueueWriteBufferCommand::process() {
     uint32_t num_worker_counters = this->sub_device_ids.size();
     uint32_t data_size_bytes = this->pages_to_write * this->padded_page_size;
-
-    uint32_t cmd_sequence_sizeB =
-        CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_RELAY_INLINE + (CQ_DISPATCH_CMD_WRITE_PAGED or
-                                         // CQ_DISPATCH_CMD_WRITE_LINEAR)
-        data_size_bytes;
+    uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
+    uint32_t cmd_sequence_sizeB = align(
+        sizeof(CQPrefetchCmd) + // CQ_PREFETCH_CMD_RELAY_INLINE
+        sizeof(CQDispatchCmd) + // CQ_DISPATCH_CMD_WRITE_PAGED or CQ_DISPATCH_CMD_WRITE_LINEAR
+        data_size_bytes, pcie_alignment);
     if (this->issue_wait) {
         cmd_sequence_sizeB += CQ_PREFETCH_CMD_BARE_MIN_SIZE * num_worker_counters;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
     }
@@ -973,8 +971,8 @@ void EnqueueProgramCommand::assemble_device_commands(
             if (write_linear) {
                 kernel_bins_unicast_cmds.emplace_back(2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE);
                 cmd_sequence_sizeB += 2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-                kernel_bins_unicast_cmds.back().add_dispatch_write_linear(
-                    false,            // flush_prefetch
+                constexpr bool flush_prefetch = false;
+                kernel_bins_unicast_cmds.back().add_dispatch_write_linear<flush_prefetch>(
                     num_mcast_dests,  // num_mcast_dests
                     noc_encoding,     // noc_xy_addr
                     kg_transfer_info.dst_base_addrs[kernel_idx],

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -681,7 +681,7 @@ public:
             return;
         }
 
-        // All data needs to be 32B aligned
+        // All data needs to be PCIE_ALIGNMENT aligned
         uint32_t push_size_16B =
             align(push_size_B, tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST)) >> 4;
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Uncovered alignment issue while bringing up FD to active eriscs. When adding a dispatch_write_linear that doesn't flush prefetch subsequent commands were not written to pcie aligned address resulted in hitting illegal cmd assertions in cq_prefetch

### What's changed
Jump to next pcie aligned address after constructing the dispatch_write_linear cmd.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12400720818)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12400731981)
- [ ] New/Existing tests provide coverage for changes (will be exercised by PR that enables programming active eriscs on BH)
