### PR TITLE
#16114: Allow Binarized Programs to be Reused across WH Devices

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UNIT_TESTS_DISPATCH_PROGRAM_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_EnqueueProgram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sub_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_program_reuse.cpp
 )
 
 add_library(unit_tests_dispatch_program_o STATIC ${UNIT_TESTS_DISPATCH_PROGRAM_SRC})

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -1,0 +1,385 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reusing programs in this context means enqueuing them across multiple devices, without creating a copy per device.
+// This requires the program object to track state that is universal across devices (in our case through
+// virtualization). The tests in this file create a single program and enqueue it across multiple devices. These tests
+// are skipped for architectures that don't have Coordinate Virtualization enabled (i.e. GS and BH). These will be
+// enabled on BH once FW is updated to support Virtual Coordinates. These tests are different from Single Device
+// EnqueueProgram tests, since they validate state (Binaries, Semaphores and RTAs) across multiple devices, by comparing
+// it with a single program on host. These tests are also structurally different from single device program tests. While
+// those tests follow the pattern below: for device ... devices:
+//      p = CreateProgram()
+//      EnqueueProgram(p, device)
+// The ones below follow this pattern:
+// p = CreateProgram()
+// for device ... devices:
+//      EnqueueProgram(p, device)
+// This makes it non-trivial to share the host-setup code across tests.
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <random>
+
+#include "command_queue_fixture.hpp"
+
+namespace tt::tt_metal {
+struct CBConfig {
+    uint32_t cb_id;
+    uint32_t num_pages;
+    uint32_t page_size;
+    DataFormat data_format;
+};
+
+struct DummyProgramConfig {
+    CoreRangeSet cr_set;
+    CBConfig cb_config;
+    uint32_t num_cbs;
+    uint32_t num_sems;
+};
+
+struct DummyProgramMultiCBConfig {
+    CoreRangeSet cr_set;
+    std::vector<CBConfig> cb_config_vector;
+    uint32_t num_sems;
+};
+
+std::shared_ptr<Program> create_program_multi_core_rta(
+    const DummyProgramConfig& rta_program_config,
+    const DummyProgramConfig& sem_program_config,
+    const std::vector<uint32_t>& dummy_cr0_args,
+    const std::vector<uint32_t>& dummy_cr1_args,
+    const std::vector<uint32_t>& sem_values,
+    const DummyProgramMultiCBConfig& cb_configs,
+    uint32_t base_addr) {
+    std::shared_ptr<Program> program = std::make_shared<Program>();
+    CoreRangeSet rta_cr_set = rta_program_config.cr_set;
+    uint32_t rta_base_dm0 = base_addr;
+    uint32_t rta_base_dm1 = rta_base_dm0 + 1024 * sizeof(uint32_t);
+    uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
+    std::map<string, string> dm_defines0 = {
+        {"DATA_MOVEMENT", "1"},
+        {"NUM_RUNTIME_ARGS", std::to_string(256)},
+        {"RESULTS_ADDR", std::to_string(rta_base_dm0)}};
+    std::map<string, string> dm_defines1 = {
+        {"DATA_MOVEMENT", "1"},
+        {"NUM_RUNTIME_ARGS", std::to_string(256)},
+        {"RESULTS_ADDR", std::to_string(rta_base_dm1)}};
+    std::map<string, string> compute_defines = {
+        {"COMPUTE", "1"},
+        {"NUM_RUNTIME_ARGS", std::to_string(256)},
+        {"RESULTS_ADDR", std::to_string(rta_base_compute)}};
+
+    auto dummy_kernel0 = CreateKernel(
+        *program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+        rta_cr_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = dm_defines0});
+
+    auto dummy_kernel1 = CreateKernel(
+        *program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+        rta_cr_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .defines = dm_defines1});
+
+    auto dummy_compute_kernel = CreateKernel(
+        *program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+        rta_cr_set,
+        ComputeConfig{.defines = compute_defines});
+
+    auto it = rta_program_config.cr_set.ranges().begin();
+    CoreRange core_range_0 = *it;
+    std::advance(it, 1);
+    CoreRange core_range_1 = *it;
+
+    for (const CoreCoord& core_coord : core_range_0) {
+        SetRuntimeArgs(*program, dummy_kernel0, core_coord, dummy_cr0_args);
+        SetRuntimeArgs(*program, dummy_kernel1, core_coord, dummy_cr0_args);
+        SetRuntimeArgs(*program, dummy_compute_kernel, core_coord, dummy_cr0_args);
+    }
+
+    for (const CoreCoord& core_coord : core_range_1) {
+        SetRuntimeArgs(*program, dummy_kernel0, core_coord, dummy_cr1_args);
+        SetRuntimeArgs(*program, dummy_kernel1, core_coord, dummy_cr1_args);
+        SetRuntimeArgs(*program, dummy_compute_kernel, core_coord, dummy_cr1_args);
+    }
+    for (auto sem_value : sem_values) {
+        CreateSemaphore(*program, sem_program_config.cr_set, sem_value);
+    }
+    for (auto cb_config : cb_configs.cb_config_vector) {
+        const uint32_t cb_id = cb_config.cb_id;
+        const uint32_t cb_num_pages = cb_config.num_pages;
+        const uint32_t page_size = cb_config.page_size;
+        const uint32_t cb_size = cb_num_pages * page_size;
+        const DataFormat data_format = cb_config.data_format;
+        const CircularBufferConfig circular_buffer_config =
+            CircularBufferConfig(cb_size, {{cb_id, data_format}}).set_page_size(cb_id, page_size);
+        const CBHandle cb_handle = CreateCircularBuffer(*program, cb_configs.cr_set, circular_buffer_config);
+    }
+
+    return program;
+}
+
+TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
+    // Sanity test: Create a program with Semaphores, CBs, RTAs and Kernel Binaries.
+    // Enqueue Program across all devices.
+    // Read L1 directly to ensure that all program attributes are correctly present.
+    if (devices_[0]->arch() != ARCH::WORMHOLE_B0) {
+        GTEST_SKIP();
+    }
+    CoreCoord worker_grid_size = devices_[0]->compute_with_storage_grid_size();
+    CoreRange cr0({0, 0}, {worker_grid_size.x - 1, 3});
+    CoreRange cr1({0, 4}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet rta_cr_set(std::vector{cr0, cr1});
+    DummyProgramConfig rta_program_config = {.cr_set = rta_cr_set};
+    CoreRange sem_cr_range({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet sem_cr_set = CoreRangeSet(sem_cr_range);
+    DummyProgramConfig sem_program_config = {.cr_set = sem_cr_set};
+
+    std::vector<uint32_t> dummy_cr0_args;
+    std::vector<uint32_t> dummy_cr1_args;
+    std::vector<uint32_t> dummy_sems;
+    uint32_t num_runtime_args_for_cr0 = 32;
+    uint32_t num_runtime_args_for_cr1 = 35;
+    // Initialize RTA data across core_ranges
+    uint32_t start_idx = 25;
+    for (uint32_t i = 0; i < num_runtime_args_for_cr0; i++) {
+        dummy_cr0_args.push_back(start_idx++);
+    }
+    for (uint32_t i = 0; i < num_runtime_args_for_cr1; i++) {
+        dummy_cr1_args.push_back(start_idx++);
+    }
+    // Initialize Semaphore values
+    for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
+        dummy_sems.push_back(i + 1);
+    }
+
+    // Initialize CB Configs
+    CBConfig cb_config_0 = {.cb_id = 0, .num_pages = 1, .page_size = 2048, .data_format = DataFormat::Float16_b};
+    CBConfig cb_config_1 = {.cb_id = 1, .num_pages = 2, .page_size = 4096, .data_format = DataFormat::Float16_b};
+    CBConfig cb_config_2 = {.cb_id = 2, .num_pages = 2, .page_size = 2048, .data_format = DataFormat::Float16_b};
+    CBConfig cb_config_3 = {.cb_id = 3, .num_pages = 4, .page_size = 2048, .data_format = DataFormat::Float16_b};
+
+    DummyProgramMultiCBConfig cb_config = {
+        .cr_set = sem_cr_set, .cb_config_vector = {cb_config_0, cb_config_1, cb_config_2, cb_config_3}};
+
+    uint32_t rta_base_addr = devices_[0]->get_base_allocator_addr(HalMemType::L1);
+    auto program = create_program_multi_core_rta(
+        rta_program_config, sem_program_config, dummy_cr0_args, dummy_cr1_args, dummy_sems, cb_config, rta_base_addr);
+
+    uint32_t rta_base_dm0 = rta_base_addr;
+    uint32_t rta_base_dm1 = rta_base_dm0 + 1024 * sizeof(uint32_t);
+    uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
+    uint32_t semaphore_buffer_size = dummy_sems.size() * hal.get_alignment(HalMemType::L1);
+    uint32_t cb_config_buffer_size =
+        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    for (auto device : devices_) {
+        log_info(LogTest, "Running test on {}", device->id());
+        EnqueueProgram(device->command_queue(), *program, false);
+        Finish(device->command_queue());
+
+        for (const CoreCoord& core_coord : cr0) {
+            std::vector<uint32_t> dummy_kernel0_args_readback;
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                rta_base_dm0,
+                num_runtime_args_for_cr0 * sizeof(uint32_t),
+                dummy_kernel0_args_readback);
+            EXPECT_EQ(dummy_cr0_args, dummy_kernel0_args_readback);
+
+            std::vector<uint32_t> dummy_kernel1_args_readback;
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                rta_base_dm1,
+                num_runtime_args_for_cr0 * sizeof(uint32_t),
+                dummy_kernel1_args_readback);
+            EXPECT_EQ(dummy_cr0_args, dummy_kernel1_args_readback);
+
+            std::vector<uint32_t> dummy_compute_args_readback;
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                rta_base_compute,
+                num_runtime_args_for_cr0 * sizeof(uint32_t),
+                dummy_compute_args_readback);
+            EXPECT_EQ(dummy_cr0_args, dummy_compute_args_readback);
+        }
+
+        for (const CoreCoord& core_coord : cr1) {
+            std::vector<uint32_t> dummy_kernel0_args_readback;
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                rta_base_dm0,
+                num_runtime_args_for_cr1 * sizeof(uint32_t),
+                dummy_kernel0_args_readback);
+            EXPECT_EQ(dummy_cr1_args, dummy_kernel0_args_readback);
+
+            std::vector<uint32_t> dummy_kernel1_args_readback;
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                rta_base_dm1,
+                num_runtime_args_for_cr1 * sizeof(uint32_t),
+                dummy_kernel1_args_readback);
+            EXPECT_EQ(dummy_cr1_args, dummy_kernel1_args_readback);
+
+            std::vector<uint32_t> dummy_compute_args_readback;
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                rta_base_compute,
+                num_runtime_args_for_cr1 * sizeof(uint32_t),
+                dummy_compute_args_readback);
+            EXPECT_EQ(dummy_cr1_args, dummy_compute_args_readback);
+        }
+        std::vector<uint32_t> semaphore_vals;
+        for (const CoreCoord& core_coord : sem_cr_range) {
+            uint32_t expected_sem_idx = 0;
+            uint32_t sem_base_addr = program->get_sem_base_addr(devices_[0], core_coord, CoreType::WORKER);
+            detail::ReadFromDeviceL1(device, core_coord, sem_base_addr, semaphore_buffer_size, semaphore_vals);
+            for (uint32_t i = 0; i < semaphore_vals.size();
+                 i += (hal.get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
+                EXPECT_EQ(semaphore_vals[i], dummy_sems[expected_sem_idx]);
+                expected_sem_idx++;
+            }
+        }
+        std::vector<uint32_t> cb_config_vector;
+        for (const CoreCoord& core_coord : sem_cr_range) {
+            detail::ReadFromDeviceL1(
+                device,
+                core_coord,
+                program->get_cb_base_addr(device, core_coord, CoreType::WORKER),
+                cb_config_buffer_size,
+                cb_config_vector);
+            uint32_t cb_addr = device->get_base_allocator_addr(HalMemType::L1);
+            for (uint32_t i = 0; i < cb_config.cb_config_vector.size(); i++) {
+                const uint32_t index = cb_config.cb_config_vector[i].cb_id * sizeof(uint32_t);
+                const uint32_t cb_num_pages = cb_config.cb_config_vector[i].num_pages;
+                const uint32_t cb_size = cb_num_pages * cb_config.cb_config_vector[i].page_size;
+                const bool addr_match = cb_config_vector.at(index) == cb_addr;
+                const bool size_match = cb_config_vector.at(index + 1) == cb_size;
+                const bool num_pages_match = cb_config_vector.at(index + 2) == cb_num_pages;
+                EXPECT_TRUE(addr_match and size_match and num_pages_match);
+
+                cb_addr += cb_size;
+            }
+        }
+    }
+}
+
+TEST_F(CommandQueueMultiDeviceFixture, TestDataCopyComputeProgramReuse) {
+    // End to End full-grid test. Creates a Program with the same kernel running on the full logical grid.
+    // Each core reads from a buffer, performs a simple math operation on each datum in the buffer, and writes
+    // outputs in dedicated DRAM memory.
+    // The same program is enqueued across all devices, and results are validated.
+    if (devices_[0]->arch() != ARCH::WORMHOLE_B0) {
+        GTEST_SKIP();
+    }
+    CoreCoord worker_grid_size = this->devices_[0]->compute_with_storage_grid_size();
+    std::vector<std::shared_ptr<Buffer>> input_buffers = {};
+    std::vector<std::shared_ptr<Buffer>> output_buffers = {};
+    uint32_t single_tile_size = detail::TileSize(DataFormat::Float16_b);
+
+    uint32_t num_tiles = 1;
+    uint32_t dram_buffer_size = single_tile_size * num_tiles;
+    for (auto device : this->devices_) {
+        InterleavedBufferConfig dram_config{
+            .device = device, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+                input_buffers.push_back(CreateBuffer(dram_config));
+                output_buffers.push_back(CreateBuffer(dram_config));
+            }
+        }
+    }
+
+    Program program = CreateProgram();
+    auto full_grid = CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    auto reader_writer_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/full_grid_eltwise_device_reuse.cpp",
+        full_grid,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    auto sem_scaling_factor = 2;
+    auto scaling_sem_idx = CreateSemaphore(program, full_grid, sem_scaling_factor);
+    uint32_t scaling_height_toggle = 16;
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(dram_buffer_size, {{src0_cb_index, DataFormat::Float16_b}})
+            .set_page_size(src0_cb_index, single_tile_size);
+
+    uint32_t add_factor = 64;
+    for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+        for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+            CoreCoord curr_core = {col_idx, row_idx};
+            SetRuntimeArgs(
+                program,
+                reader_writer_kernel,
+                curr_core,
+                {input_buffers.at(col_idx * worker_grid_size.y + row_idx)->address(),
+                 output_buffers.at(col_idx * worker_grid_size.y + row_idx)->address(),
+                 0, /* src_bank_id */
+                 0, /* dst_bank_id */
+                 add_factor,
+                 constants::TILE_HEIGHT,
+                 constants::TILE_WIDTH,
+                 scaling_sem_idx,
+                 scaling_height_toggle});
+            CBHandle cb_src0 = CreateCircularBuffer(program, curr_core, cb_src0_config);
+        }
+    }
+
+    std::vector<uint32_t> src_vec = create_constant_vector_of_bfloat16(dram_buffer_size, 1);
+    std::size_t buffer_idx = 0;
+    // Write constant inputs once
+    for (auto device : devices_) {
+        for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+            for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+                EnqueueWriteBuffer(device->command_queue(), input_buffers.at(buffer_idx), src_vec, false);
+                buffer_idx++;
+            }
+        }
+    }
+    // Run program multiple times with different RTAs and validate for each iteration
+    for (int iter = 0; iter < 100; iter++) {
+        log_info(LogTest, "Run iter {}", iter);
+        if (iter) {
+            auto& rtas = GetRuntimeArgs(program, reader_writer_kernel);
+            for (auto core : full_grid) {
+                rtas[core.x][core.y].at(4) = ((iter % 2) + 1) * add_factor;
+            }
+        }
+        for (auto device : devices_) {
+            EnqueueProgram(device->command_queue(), program, false);
+        }
+
+        buffer_idx = 0;
+        for (auto device : devices_) {
+            for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
+                for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
+                    std::vector<bfloat16> dst_vec = {};
+                    EnqueueReadBuffer(device->command_queue(), output_buffers.at(buffer_idx), dst_vec, true);
+                    buffer_idx++;
+                    for (int i = 0; i < dst_vec.size(); i++) {
+                        float ref_val = std::pow(2, (iter % 2) + 1);
+                        if (i >= 512) {
+                            ref_val = std::pow(2, 2 * ((iter % 2) + 1));
+                        }
+                        EXPECT_EQ(dst_vec[i].to_float(), ref_val);
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/misc/full_grid_eltwise_device_reuse.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/full_grid_eltwise_device_reuse.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic Reader, Compute and Writer in RISC, for Program Dispatch Testing purposes only.
+// Uses more Kernel/Program config attributes than other metal test kernels, validating
+// dispatch of Kernel Binaries, CBs, Semaphores and Runtime Args.
+void kernel_main() {
+    // src and dst addrs
+    uint32_t src_dram_addr = get_arg_val<uint32_t>(0);
+    uint32_t dst_dram_addr = get_arg_val<uint32_t>(1);
+    // src and dst bank_ids
+    uint32_t src_bank_id = get_arg_val<uint32_t>(2);
+    uint32_t dst_bank_id = get_arg_val<uint32_t>(3);
+    // Specify eltwise op params
+    uint32_t add_value = get_arg_val<uint32_t>(4);
+    uint32_t tile_size_x = get_arg_val<uint32_t>(5);
+    uint32_t tile_size_y = get_arg_val<uint32_t>(6);
+    uint32_t scaling_sem_idx = get_arg_val<uint32_t>(7);
+    uint32_t tile_toggle_val = get_arg_val<uint32_t>(8);
+
+    // NOC coords (x,y) depending on DRAM location on-chip
+    uint64_t src_dram_noc_addr = get_noc_addr_from_bank_id<true>(src_bank_id, src_dram_addr);
+    uint64_t dst_dram_noc_addr = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_dram_addr);
+    // Input L1 buffer, read into
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;  // index=0
+    uint32_t tile_size_bytes = get_tile_size(cb_id_in0);
+    uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+    // Read data from DRAM -> L1 circular buffers
+    noc_async_read(src_dram_noc_addr, l1_write_addr, tile_size_bytes);
+    noc_async_read_barrier();
+
+    // Perform compute on data that was just read
+    uint16_t* data = (uint16_t*)l1_write_addr;
+    uint32_t* sem_addr = reinterpret_cast<uint32_t*>(get_semaphore(scaling_sem_idx));
+    for (uint32_t i = 0; i < tile_size_x * tile_size_y; i++) {
+        if (i % (tile_size_x * tile_toggle_val) == 0 and i) {
+            noc_semaphore_inc(get_noc_addr(get_semaphore(scaling_sem_idx)), 2);
+            noc_async_atomic_barrier();
+        }
+        data[i] = (*sem_addr) * add_value + data[i];
+    }
+    // Write to dst buffer
+    noc_async_write(l1_write_addr, dst_dram_noc_addr, tile_size_bytes);
+    noc_async_write_barrier();
+}

--- a/tt_metal/impl/dispatch/program_command_sequence.hpp
+++ b/tt_metal/impl/dispatch/program_command_sequence.hpp
@@ -20,9 +20,12 @@ class CircularBuffer;
 
 }  // namespace v0
 
+constexpr uint32_t UncachedStallSequenceIdx = 0;
+constexpr uint32_t CachedStallSequenceIdx = 1;
 struct ProgramCommandSequence {
     HostMemDeviceCommand preamble_command_sequence;
-    HostMemDeviceCommand stall_command_sequence;
+    uint32_t current_stall_seq_idx = 0;
+    HostMemDeviceCommand stall_command_sequences[2];
     std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
     uint32_t runtime_args_fetch_size_bytes;
     HostMemDeviceCommand device_command_sequence;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -51,9 +51,8 @@ void GenerateBinaries(Device *device, JitBuildOptions &build_options, const std:
 #endif
 
 size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions &build_options, uint32_t build_key, size_t device_kernel_defines_hash) {
-    // Account for device id in hash because generated headers are dependent on harvesting config, which can differ per
-    // device This can be removed with https://github.com/tenstorrent/tt-metal/issues/3381
-
+    // Store the build key into the KernelCompile hash. This will be unique per command queue
+    // configuration (necessary for dispatch kernels).
     // Also account for watcher/dprint enabled in hash because they enable additional code to
     // be compiled into the kernel.
     string compile_hash_str = fmt::format(
@@ -131,9 +130,19 @@ class Program_ {
     void allocate_circular_buffers(const Device *device);
 
     bool is_finalized() const;
+    void allocate_kernel_bin_buf_on_device(Device* device);
     void finalize(Device *device);
     bool is_cached() const { return this->cached_; }
+    ProgramBinaryStatus get_program_binary_status(std::size_t device_id) const {
+        if (auto it = this->binaries_on_device_.find(device_id); it != this->binaries_on_device_.end()) {
+            return it->second;
+        }
+        return ProgramBinaryStatus::NotSent;
+    }
     void set_cached() { this->cached_ = true; }
+    void set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) {
+        this->binaries_on_device_[device_id] = status;
+    }
     std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
 
     ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
@@ -156,7 +165,7 @@ class Program_ {
     std::vector<std::shared_ptr<Buffer>> owned_buffer_pool = {};
 
     // The buffer that holds the kernel/binaries/etc for this program
-    std::shared_ptr<Buffer> kernels_buffer = nullptr;
+    std::unordered_map<chip_id_t, std::shared_ptr<Buffer>> kernels_buffer_;
     ProgramTransferInfo program_transfer_info;
 
     bool finalized_;
@@ -202,12 +211,13 @@ class Program_ {
     std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_cb_indices_;
     std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_local_cb_indices_;
     std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_remote_cb_indices_;
+    std::unordered_map<std::size_t, ProgramBinaryStatus> binaries_on_device_;
     // Used to generate circular buffer addresses. There is one CircularBufferAllocator per unique CoreRange
     std::vector<CircularBufferAllocator> cb_allocators_;
 
     std::vector<Semaphore> semaphores_;
 
-    std::unordered_set<chip_id_t> compiled_;
+    std::unordered_set<uint32_t> compiled_;
     bool local_circular_buffer_allocation_needed_;
 
     static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;
@@ -247,11 +257,11 @@ class Program_ {
     // Ensures that statically allocated circular buffers do not grow into L1 buffer space
     void validate_circular_buffer_region(const Device *device);
 
-    void set_remote_circular_buffer_init(Device* device, const std::shared_ptr<Kernel>& kernel) const;
+    void set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const;
 
-    void set_cb_data_fmt( Device *device, const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
+    void set_cb_data_fmt(const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
 
-    void set_cb_tile_dims( Device *device, const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
+    void set_cb_tile_dims(const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
 
     void update_kernel_groups(uint32_t programmable_core_type_index);
 
@@ -584,6 +594,7 @@ void detail::Program_::update_kernel_groups(uint32_t programmable_core_type_inde
             index++;
         }
     }
+
 }
 
 void detail::Program_::CircularBufferAllocator::mark_address(uint64_t address, uint64_t size, uint64_t base_address) {
@@ -888,7 +899,7 @@ std::vector<std::vector<CoreCoord>> detail::Program_::logical_cores() const {
 
 std::vector<std::vector<CoreCoord>> Program::logical_cores() const { return pimpl_->logical_cores(); }
 
-void detail::Program_::set_remote_circular_buffer_init(Device* device, const std::shared_ptr<Kernel>& kernel) const {
+void detail::Program_::set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const {
     const auto& kernel_defines = kernel->defines();
     const std::string reserved_defines[] = {"ALIGN_LOCAL_CBS_TO_REMOTE_CBS", "UPDATE_REMOTE_CB_CONFIGS_IN_L1"};
     for (const auto& str : reserved_defines) {
@@ -939,7 +950,7 @@ void detail::Program_::set_remote_circular_buffer_init(Device* device, const std
     }
 }
 
-void detail::Program_::set_cb_data_fmt(Device *device, const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
+void detail::Program_::set_cb_data_fmt(const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
     //ZoneScoped;
     for (const auto& logical_cr : crs) {
         const auto& cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
@@ -952,7 +963,7 @@ void detail::Program_::set_cb_data_fmt(Device *device, const std::vector<CoreRan
     }
 }
 
-void detail::Program_::set_cb_tile_dims(Device *device, const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
+void detail::Program_::set_cb_tile_dims(const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
     //ZoneScoped;
     for (const auto &logical_cr : crs) {
         const auto& cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
@@ -1090,10 +1101,6 @@ void detail::Program_::populate_dispatch_data(Device *device) {
     }
 
     if (binaries_data.size() > 0) {
-        // We allocate program binaries top down to minimize fragmentation with other buffers in DRAM, which are typically allocated bottom up
-        this->kernels_buffer = Buffer::create(
-            device, binaries_data.size() * sizeof(uint32_t), HostMemDeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM, TensorMemoryLayout::INTERLEAVED, std::nullopt, false);
-
         this->program_transfer_info.binary_data = binaries_data;
     }
 
@@ -1106,7 +1113,6 @@ void detail::Program_::populate_dispatch_data(Device *device) {
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
                     device->extract_dst_noc_multicast_info<std::vector<CoreRange>>(
                         kernel_group.core_ranges.ranges(), core_type);
-
                 std::vector<KernelHandle> kernel_ids;
                 for (int dispatch_class = 0; dispatch_class < kernel_group.kernel_ids.size(); dispatch_class++) {
                     auto &optional_id = kernel_group.kernel_ids[dispatch_class];
@@ -1450,6 +1456,16 @@ const std::vector<SubDeviceId> &detail::Program_::determine_sub_device_ids(const
     return sub_device_ids->second;
 }
 
+void detail::Program_::allocate_kernel_bin_buf_on_device(Device *device) {
+    // Allocate the DRAM kernel binary buffer for this program on the specified device, if not previously allocated.
+    // We allocate program binaries top down to minimize fragmentation with other buffers in DRAM, which are typically allocated bottom up
+    std::size_t binary_data_size_bytes = this->program_transfer_info.binary_data.size() * sizeof(uint32_t);
+    if (this->kernels_buffer_.find(device->id()) == this->kernels_buffer_.end() and binary_data_size_bytes) {
+        std::shared_ptr<Buffer> kernel_bin_buf = Buffer::create(device, binary_data_size_bytes, HostMemDeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM, TensorMemoryLayout::INTERLEAVED, std::nullopt, false);
+        this->kernels_buffer_[device->id()] = kernel_bin_buf;
+    }
+}
+
 void detail::Program_::finalize(Device *device) {
     // Store the number of tensix "go signals" for use by CQ
     // CQ iterates over these to update runtime addresses, needs to know when eth begins (after tensix)
@@ -1499,11 +1515,13 @@ void detail::Program_::finalize(Device *device) {
     finalized_ = true;
 }
 
+void Program::allocate_kernel_bin_buf_on_device(Device* device) { pimpl_->allocate_kernel_bin_buf_on_device(device); }
+
 void Program::finalize(Device *device) { pimpl_->finalize(device); }
 
 void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
     //ZoneScoped;
-    if (compiled_.contains(device->id())) {
+    if (compiled_.contains(device->build_key())) {
         return;
     }
     // Clear the determined sub_device_ids when we compile the program for the first time
@@ -1564,10 +1582,10 @@ void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
                     JitBuildOptions build_options(device->build_env());
                     kernel->set_build_options(build_options);
                     if (this->compiled_.empty()) {
-                        this->set_remote_circular_buffer_init(device, kernel);
+                        this->set_remote_circular_buffer_init(kernel);
                     }
-                    this->set_cb_data_fmt(device, kernel->logical_coreranges(), build_options);
-                    this->set_cb_tile_dims(device, kernel->logical_coreranges(), build_options);
+                    this->set_cb_data_fmt(kernel->logical_coreranges(), build_options);
+                    this->set_cb_tile_dims(kernel->logical_coreranges(), build_options);
 
                     auto kernel_hash = KernelCompileHash(kernel, build_options, device->build_key(), device->get_device_kernel_defines_hash());
                     std::string kernel_path_suffix = kernel->name() + "/" + std::to_string(kernel_hash) + "/";
@@ -1614,7 +1632,7 @@ void detail::Program_::compile(Device *device, bool fd_bootloader_mode) {
     if (detail::MemoryReporter::enabled()) {
         detail::MemoryReporter::inst().flush_program_memory_usage(get_id(), device);
     }
-    compiled_.insert(device->id());
+    compiled_.insert(device->build_key());
 }
 
 void Program::compile(Device *device, bool fd_bootloader_mode) { pimpl_->compile(device, fd_bootloader_mode); }
@@ -1789,11 +1807,19 @@ bool Program::is_finalized() const { return pimpl_->is_finalized(); }
 bool Program::is_cached() const { return pimpl_->is_cached(); }
 void Program::set_cached() { pimpl_->set_cached(); }
 
+ProgramBinaryStatus Program::get_program_binary_status(std::size_t device_id) const { return pimpl_->get_program_binary_status(device_id); }
+void Program::set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) { pimpl_->set_program_binary_status(device_id, status); }
+
 const std::vector<SubDeviceId> &Program::determine_sub_device_ids(const Device *device) { return pimpl_->determine_sub_device_ids(device); }
 
 const ProgramTransferInfo &Program::get_program_transfer_info() const noexcept { return pimpl_->program_transfer_info; }
 
-const std::shared_ptr<Buffer> &Program::get_kernels_buffer() const noexcept { return pimpl_->kernels_buffer; }
+std::shared_ptr<Buffer> Program::get_kernels_buffer(Device* device) const noexcept {
+    if (auto it = pimpl_->kernels_buffer_.find(device->id()); it != pimpl_->kernels_buffer_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
 
 const std::vector<uint32_t> &Program::get_program_config_sizes() const noexcept { return pimpl_->program_config_sizes_; }
 

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -100,6 +100,12 @@ struct ProgramConfig {
 };
 
 inline namespace v0 {
+// Represents the status of Program Kernel Binaries in Device DRAM with respect to the dispatcher
+enum class ProgramBinaryStatus : uint8_t {
+    NotSent = 0, // Binaries have not been written
+    InFlight = 1, // Fast Dispatch Commands to write the binaries to DRAM has been issued
+    Committed = 2, // Binaries have been commited to DRAM
+};
 
 class Program {
    public:
@@ -151,7 +157,10 @@ class Program {
 
     bool is_finalized() const;
     bool is_cached() const;
+    ProgramBinaryStatus get_program_binary_status(std::size_t device_id) const;
     void set_cached();
+    void set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status);
+    void allocate_kernel_bin_buf_on_device(Device* device);
     void finalize(Device *device);
     std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
 
@@ -202,7 +211,7 @@ class Program {
     friend detail::Internal_;
 
     const ProgramTransferInfo &get_program_transfer_info() const noexcept;
-    const std::shared_ptr<Buffer> &get_kernels_buffer() const noexcept;
+    std::shared_ptr<Buffer> get_kernels_buffer(Device* device) const noexcept;
     const std::vector<uint32_t> &get_program_config_sizes() const noexcept;
     std::unordered_map<uint64_t, ProgramCommandSequence> &get_cached_program_command_sequences() noexcept;
 };


### PR DESCRIPTION
### Ticket
[Link to Github Issue  
](https://github.com/tenstorrent/tt-metal/issues/16114)

### Problem description
Programs cannot be Enqueued to more than one device today. With Virtual Coordinates enabled, programs can get cached on host (once) and then reused across devices (identical FD commands and Kernel Binaries). This PR enables this feature on WH.

### What's changed
- Maintain per device kernel binary buffers inside the Program class, since a program can now be enqueued to multiple devices
- Maintain different Host Side and Device side cache states for a program: A program and its associated commands are cached on host, the first time its enqueued to any device. Program binaries are cached on each device when the program is enqueued to each device the first time. The stall command sequence (specifically the prefetch stall) accounts for this.
- Modify the build key to only account for the number of rows harvested, and not the exact harvesting mask for architectures with Coordinate Virtualization enabled
- Track program compile state based on build key
- Add tests for this feature on WH
-  Feature is disabled on GS and BH (for now) ... an assert will be hit

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
