### PR TITLE
C++ files should not be part of the API of a library

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
@@ -5,7 +5,6 @@
 #include "moreh_dot_device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "tt_metal/common/constants.hpp"
-#include "tt_metal/tt_metal.cpp"
 
 namespace ttnn::operations::moreh::moreh_dot {
 MorehDotOperation::SingleCore::cached_program_t MorehDotOperation::SingleCore::create(


### PR DESCRIPTION
### Ticket
None

### Problem description
Very very rarely should we include a .cpp file (if intended, should call it .ipp, generally).
This one looks like a typo and doesn't seem to break anything when removing.

### What's changed
rm -rf

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12379363947
