### PR TITLE
#0: Remove incorrect memory span assert

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1059,17 +1059,14 @@ void detail::Program_::populate_dispatch_data(Device *device) {
             for (size_t sub_kernel_index = 0; sub_kernel_index < binaries.size(); ++sub_kernel_index) {
                 const ll_api::memory& kernel_bin = *binaries[sub_kernel_index];
 
-                // Spans are now packed into one
-                // TODO: code below can be simplified w/ a single span
+                // TODO: Pack erisc spans too, and then everthing is
+                // one span
                 uint32_t num_spans = kernel_bin.num_spans();
                 dst_base_addrs.resize(dst_base_addrs.size() + num_spans);
                 page_offsets.resize(page_offsets.size() + num_spans);
                 lengths.resize(lengths.size() + num_spans);
                 riscvs.resize(riscvs.size() + num_spans);
 
-                TT_ASSERT(kernel_bin.num_spans() == 1);
-
-                // TODO: spans are packed into 1 now, just grab it and go
                 kernel_bin.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
 
                     // Set dst for eth kernels until they move to ring buffer


### PR DESCRIPTION
### Ticket
n/A

### Problem description
This assert was added when kernel data packing was implemented (data load address immediately after text).  But that only worked for (non-idle) erisc kernels by accident due to another bug an obsolete workaround.  I fixed this with 
```
* 434bd8e565 2024-12-13 | #13944: Redesign memory packing API (#15980)
```

By not packing such erisc kernels.  This worked in production builds because asserts are disabled, so I didn't fall over this problem.

### What's changed
Remove asserts, update comments to reflect reality.
working on updating non-idle erisc to allow packing
(perhaps CI optimized builds should enable asserts, Remember CMAKE_BUILD_TYPE=RelWithDebInfo doesn't do that)

### Checklist
- [Yes] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
