### PR TITLE
Set the test data to be relative to the test binary

### DIFF
--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ add_definitions(-DENABLE_CI_ONLY_TT_TRAIN_TESTS=0)
 
 # Define the target file location
 set(SHAKESPEARE_URL "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt")
-set(SHAKESPEARE_FILE "${CMAKE_SOURCE_DIR}/data/shakespeare.txt")
+set(SHAKESPEARE_FILE "${CMAKE_CURRENT_BINARY_DIR}/shakespeare.txt")
 
 # Check if the file already exists before downloading
 if(NOT EXISTS "${SHAKESPEARE_FILE}")

--- a/tt-train/tests/model/nano_gpt_test.cpp
+++ b/tt-train/tests/model/nano_gpt_test.cpp
@@ -56,7 +56,7 @@ struct TrainingConfig {
 void train_test(bool use_moreh_adamw = false) {
     auto config = TrainingConfig();
     config.transformer_config.dropout_prob = 0.0F;
-    config.data_path = std::string(TEST_DATA_DIR) + "/shakespeare.txt";
+    config.data_path = "/shakespeare.txt";
 
     // set seed
     ttml::autograd::ctx().set_seed(config.seed);


### PR DESCRIPTION
### Ticket
#16115

### Problem description
tt-train tests are a coin toss whether they're build + run on two machines that share the same path (runner+runner or runner_2+runner_2).  A mismatch will fail the test as the abspath to find the test data is wrong.

### What's changed
Moved the test data to be relative to the test binary.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12383793376
