### PR TITLE
Fix CB Overflow issue on certain transposes and permutes

### DIFF
--- a/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
+++ b/models/demos/squeezebert/tests/test_perf_device_squeezebert.py
@@ -18,7 +18,7 @@ def test_perf_device_bare_metal(batch_size, test):
     subdir = "ttnn_squeezebert"
     num_iterations = 1
     margin = 0.03
-    expected_perf = 114.8 if is_grayskull() else 284.5
+    expected_perf = 102.7 if is_grayskull() else 298.7
 
     command = f"pytest tests/ttnn/integration_tests/squeezebert/test_ttnn_squeezebert.py::test_squeezebert_for_question_answering"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1085,7 +1085,13 @@ def test_transpose_hw_sharded_tiled_n_cores(device, n, c, h, w):
 def test_transpose_hw_rm(shape, device):
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(2, 3)
-    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
     tt_output = ttnn.transpose(tt_input, 2, 3)
     tt_output = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output, 0.9999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -304,7 +304,7 @@ def test_transpose_wh_sharded_program_cache(dtype, device, use_program_cache):
 @pytest.mark.parametrize("c", [1])
 @pytest.mark.parametrize("h", [230])
 @pytest.mark.parametrize("w", [256])
-def test_tranpose_hw_rm_with_padding(device, n, c, h, w):
+def test_transpose_hw_rm_with_padding(device, n, c, h, w):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
@@ -334,10 +334,10 @@ def test_tranpose_hw_rm_with_padding(device, n, c, h, w):
 
 @skip_for_grayskull("Grayskull has pcc issue when transpose used untilize")
 @pytest.mark.parametrize("n", [16])
-@pytest.mark.parametrize("c", [128, 4])
-@pytest.mark.parametrize("h", [8, 256])
-@pytest.mark.parametrize("w", [256, 256])
-def test_tranpose_hw_rm_no_padding(device, n, c, h, w):
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [8])
+@pytest.mark.parametrize("w", [256])
+def test_transpose_hw_rm_no_padding(device, n, c, h, w):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
@@ -355,7 +355,7 @@ def test_tranpose_hw_rm_no_padding(device, n, c, h, w):
     assert_with_pcc(torch_output_tensor, activation_pyt_padded_out, 0.9999)
 
 
-def run_tranpose_hw_rm_program_cache(device, n, c, h, w, use_program_cache):
+def run_transpose_hw_rm_program_cache(device, n, c, h, w, use_program_cache):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
@@ -376,9 +376,9 @@ def run_tranpose_hw_rm_program_cache(device, n, c, h, w, use_program_cache):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [8])
 @pytest.mark.parametrize("w", [256])
-def test_tranpose_hw_rm_with_program_cache(device, n, c, h, w, use_program_cache):
+def test_transpose_hw_rm_with_program_cache(device, n, c, h, w, use_program_cache):
     for _ in range(2):
-        run_tranpose_hw_rm_program_cache(device, n, c, h, w, use_program_cache)
+        run_transpose_hw_rm_program_cache(device, n, c, h, w, use_program_cache)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
@@ -433,7 +433,7 @@ def test_transpose_hw_sharded_rm(device, n, c, h, w):
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
 
 
-def run_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w):
+def run_transpose_hw_sharded_rm_with_program_cache(device, n, c, h, w):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
@@ -468,9 +468,9 @@ def run_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w, use_program_cache):
+def test_transpose_hw_sharded_rm_with_program_cache(device, n, c, h, w, use_program_cache):
     for _ in range(2):
-        run_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w)
+        run_transpose_hw_sharded_rm_with_program_cache(device, n, c, h, w)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
@@ -488,7 +488,7 @@ def test_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w, use_progr
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_tranpose_hc_rm(device, n, c, h, w):
+def test_transpose_hc_rm(device, n, c, h, w):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(1, 2)
@@ -507,7 +507,7 @@ def test_tranpose_hc_rm(device, n, c, h, w):
     assert_with_pcc(torch_output_tensor, activation_pyt_padded_out, 0.9999)
 
 
-def run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache):
+def run_transpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(1, 2)
@@ -529,9 +529,9 @@ def run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache)
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
 @pytest.mark.parametrize("w", [16])
-def test_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache):
+def test_transpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache):
     for _ in range(2):
-        run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache)
+        run_transpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
@@ -545,7 +545,7 @@ def test_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache
     assert device.num_program_cache_entries() == 1
 
 
-def run_tranpose_hc_sharded(device, n, c, h, w, grid_size):
+def run_transpose_hc_sharded(device, n, c, h, w, grid_size):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(1, 2)
@@ -589,11 +589,11 @@ def run_tranpose_hc_sharded(device, n, c, h, w, grid_size):
         (16, 128, 128, 16, ttnn.CoreGrid(y=8, x=8)),
     ],
 )
-def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, use_program_cache):
+def test_transpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, use_program_cache):
     if grid_size.y > device.core_grid.y:
         pytest.skip("grid size not for N300")
     for _ in range(2):
-        run_tranpose_hc_sharded(device, n, c, h, w, grid_size)
+        run_transpose_hc_sharded(device, n, c, h, w, grid_size)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
@@ -1012,7 +1012,7 @@ def test_transpose_forge_hc(device, b, h, w, dim0, dim1):
 @pytest.mark.parametrize("c", [1])
 @pytest.mark.parametrize("h", [256])
 @pytest.mark.parametrize("w", [32])
-def test_tranpose_hw_sharded_tiled_8_cores(device, n, c, h, w):
+def test_transpose_hw_sharded_tiled_8_cores(device, n, c, h, w):
     torch.manual_seed(2005)
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.transpose(2, 3)
@@ -1081,7 +1081,7 @@ def test_transpose_hw_sharded_tiled_n_cores(device, n, c, h, w):
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
 
 
-@pytest.mark.parametrize("shape", [[16, 4, 256, 256], [16, 128, 8, 256]])
+@pytest.mark.parametrize("shape", [[16, 4, 256, 256], [16, 128, 8, 256], [1, 1, 32, 32]])
 def test_transpose_hw_rm(shape, device):
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(2, 3)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -655,18 +655,16 @@ def test_transpose_hc(dtype, shape, device):
 )
 @pytest.mark.parametrize(
     "shape",
-    [(9216, 128), (1, 32), (1, 12), (1, 35), (16, 32), (34, 8)],
+    [(9216, 128), (1, 32), (1, 12), (1, 35), (16, 32), (34, 8), [21843, 768]],
 )
 @pytest.mark.parametrize(
     "layout",
-    [ttnn.TILE_LAYOUT],
+    [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 )
 def test_transpose_2D(dtype, shape, layout, device):
     torch.manual_seed(2005)
     if is_grayskull() and dtype == ttnn.float32:
         pytest.skip("Skipping float32 tests on Grayskull")
-    if layout == ttnn.ROW_MAJOR_LAYOUT and dtype == ttnn.bfloat16 and (shape[-1] % 2 or shape[-2] % 2):
-        pytest.skip("Skipping RM odd inner dim test cases")
 
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_output = torch_input.transpose(0, 1)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -672,7 +672,7 @@ def test_transpose_2D(dtype, shape, layout, device):
     tt_input = ttnn.from_torch(torch_input, dtype=ttnn.DataType.BFLOAT16, layout=layout, device=device)
     tt_output = ttnn.transpose(tt_input, 0, 1)
     tt_output = ttnn.to_torch(tt_output)
-    assert_with_pcc(torch_output, tt_output, 0.99)
+    assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
 @pytest.mark.parametrize(
@@ -817,7 +817,7 @@ def test_transpose_former_failures(config, memory_config, device):
     )
     tt_output = ttnn.transpose(tt_input, config[1][0], config[1][1])
     tt_output = ttnn.to_torch(tt_output)
-    assert_with_pcc(torch_output, tt_output, 0.99)
+    assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
@@ -28,7 +28,6 @@ struct ToMemoryConfig {
         std::optional<ttnn::DataType> dtype = std::nullopt) {
         // Temporary until we see why buffer data not being populated
         const auto original_shape = tensor.get_shape();
-
         const auto original_memory_config = ttnn::get_memory_config(tensor);
         if (original_memory_config.has_value() && original_memory_config.value() == memory_config) {
             return tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp"
@@ -61,13 +62,8 @@ std::vector<Tensor> fold_with_transpose_(
 
     tt::log_debug("pad_output: {}", pad_output.shape());
 
-    // transpose
-    auto transpose_hw_output = ttnn::transpose(pad_output, 2, 3, L1_mem_config);
-
-    tt::log_debug("transpose_hw_output: {}", transpose_hw_output.shape());
-
-    // transpose
-    auto transpose_hc_output = ttnn::transpose(transpose_hw_output, 1, 2, L1_mem_config);
+    auto transpose_hc_output = ttnn::prim::permute(
+        pad_output, ttnn::SmallVector<uint32_t>({0, 3, 1, 2}), std::make_optional(L1_mem_config), std::nullopt);
 
     tt::log_debug("transpose_hc_output: {}", transpose_hc_output.shape());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp"
 #include "tt_metal/common/constants.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp"
 
 #include "fold.hpp"
 
@@ -62,7 +63,8 @@ std::vector<Tensor> fold_with_transpose_(
     tt::log_debug("pad_output: {}", pad_output.shape());
 
     // transpose
-    auto transpose_hw_output = ttnn::transpose(pad_output, 2, 3, L1_mem_config);
+    auto transpose_hw_output = operation::run(Transpose{TransposeOpDim::WH, L1_mem_config, 0.0f}, {pad_output})
+                                   .at(0);  // ttnn::transpose(pad_output, 2, 3, L1_mem_config);
 
     tt::log_debug("transpose_hw_output: {}", transpose_hw_output.shape());
 
@@ -80,7 +82,8 @@ std::vector<Tensor> fold_with_transpose_(
     tt::log_debug("reshape_hc_output: {}", reshape_hc_output.shape());
 
     // transpose
-    auto transpose_hw_output2 = ttnn::transpose(reshape_hc_output, 2, 3, L1_mem_config);
+    auto transpose_hw_output2 =
+        operation::run(Transpose{TransposeOpDim::WH, L1_mem_config, 0.0f}, {reshape_hc_output}).at(0);
 
     tt::log_debug("transpose_hw_output2: {}", transpose_hw_output2.shape());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -12,7 +12,6 @@
 #include "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp"
 #include "tt_metal/common/constants.hpp"
-#include "ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp"
 
 #include "fold.hpp"
 
@@ -63,8 +62,7 @@ std::vector<Tensor> fold_with_transpose_(
     tt::log_debug("pad_output: {}", pad_output.shape());
 
     // transpose
-    auto transpose_hw_output = operation::run(Transpose{TransposeOpDim::WH, L1_mem_config, 0.0f}, {pad_output})
-                                   .at(0);  // ttnn::transpose(pad_output, 2, 3, L1_mem_config);
+    auto transpose_hw_output = ttnn::transpose(pad_output, 2, 3, L1_mem_config);
 
     tt::log_debug("transpose_hw_output: {}", transpose_hw_output.shape());
 
@@ -82,8 +80,7 @@ std::vector<Tensor> fold_with_transpose_(
     tt::log_debug("reshape_hc_output: {}", reshape_hc_output.shape());
 
     // transpose
-    auto transpose_hw_output2 =
-        operation::run(Transpose{TransposeOpDim::WH, L1_mem_config, 0.0f}, {reshape_hc_output}).at(0);
+    auto transpose_hw_output2 = ttnn::transpose(reshape_hc_output, 2, 3, L1_mem_config);
 
     tt::log_debug("transpose_hw_output2: {}", transpose_hw_output2.shape());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_rm_single_tile_size.cpp
@@ -25,18 +25,17 @@ void MAIN {
 
     for (uint32_t n = 0; n < num_blocks; n++) {
         // tilize input via unpack and then pack
-        tilize_init_short(cb_in, 1);
+        tilize_init_short(cb_in, 1, cb_tilize);
 
         cb_wait_front(cb_in, x_block_size);
         cb_reserve_back(cb_tilize, 1);
 
         tilize_block(cb_in, 1, cb_tilize);  // tilize and pack into cb_tilize
 
-        // tile slice according to unpacker is garbage after tilize_block in the second iteration, missing an uninit?
         cb_push_back(cb_tilize, 1);
         cb_pop_front(cb_in, x_block_size);
 
-        tilize_uninit(cb_in);
+        tilize_uninit(cb_in, cb_tilize);
 
         // transpose input
         cb_wait_front(cb_tilize, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -51,7 +51,12 @@ PermuteDeviceOperation::tensor_return_value_t PermuteDeviceOperation::create_out
     }
     auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
     const auto& input_tensor = tensor_args.input_tensor;
-    return create_device_tensor(output_shape, input_tensor.dtype(), input_tensor.layout(), input_tensor.device());
+    return create_device_tensor(
+        output_shape,
+        input_tensor.dtype(),
+        input_tensor.layout(),
+        input_tensor.device(),
+        operation_attributes.output_mem_config);
 }
 
 std::tuple<PermuteDeviceOperation::operation_attributes_t, PermuteDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -42,8 +42,7 @@ ttnn::Tensor permute_impl(
         TT_FATAL(
             !(pad_value.has_value() && pad_value.value() != 0.0f),
             "Non-zero padding is not supported for permute on tensors with rank > 4.");
-        SmallVector<uint32_t> permute_dims(dims.begin(), dims.end());
-        input = ttnn::prim::permute(input, permute_dims, output_mem_config, std::nullopt);
+        input = ttnn::prim::permute(input, dims, output_mem_config, std::nullopt);
         return ttnn::to_layout(input, a.get_layout(), std::nullopt, std::nullopt, (Device*)nullptr);
     }
 
@@ -150,7 +149,7 @@ ttnn::Tensor permute_launch(
     return output_tensors.at(0);
 }
 
-bool is_permute_nop(const ttnn::Tensor& a, tt::stl::Span<const uint32_t> dims) {
+bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& dims) {
     if (a.get_shape().rank() <= 1) {
         return true;
     }
@@ -165,7 +164,7 @@ bool is_permute_nop(const ttnn::Tensor& a, tt::stl::Span<const uint32_t> dims) {
 ttnn::Tensor ExecutePermute::invoke(
     uint8_t queue_id,
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int64_t> dims,
+    const ttnn::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<float>& pad_value) {
     const auto input_rank = input_tensor.get_logical_shape().rank();
@@ -182,7 +181,7 @@ ttnn::Tensor ExecutePermute::invoke(
         return ttnn::to_memory_config(input_tensor, memory_config.value_or(input_tensor.memory_config()));
     }
 
-    auto adjust_order = [](tt::stl::Span<const uint32_t> dims) {
+    auto adjust_order = [](const ttnn::SmallVector<uint32_t>& dims) {
         ttnn::SmallVector<uint32_t> new_order;
         TT_FATAL(dims.size() <= 4, "Minimum rank of tensor required is 4");
         int additional_ranks = 4 - dims.size();
@@ -211,14 +210,14 @@ ttnn::Tensor ExecutePermute::invoke(
 
 ttnn::Tensor ExecutePermute::invoke(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int64_t> dims,
+    const ttnn::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<float>& pad_value) {
     return invoke(DefaultQueueId, input_tensor, dims, memory_config, pad_value);
 }
 
 ttnn::Tensor ExecutePermute::invoke(
-    const ttnn::Tensor& input_tensor, tt::stl::Span<const int64_t> dims, const std::optional<float>& pad_value) {
+    const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int64_t>& dims, const std::optional<float>& pad_value) {
     return invoke(input_tensor, dims, std::nullopt, pad_value);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -13,19 +13,19 @@ struct ExecutePermute {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const int64_t> dims,
+        const SmallVector<int64_t>& dims,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<float>& pad_value = 0.0f);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const int64_t> dims,
+        const SmallVector<int64_t>& dims,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<float>& pad_value = 0.0f);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        tt::stl::Span<const int64_t> dims,
+        const SmallVector<int64_t>& dims,
         const std::optional<float>& pad_value = 0.0f);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -58,9 +58,7 @@ inline Tensor transpose_(
             if (a.device()->arch() == tt::ARCH::GRAYSKULL) {
                 tiled_only = a.shape()[-2] > 256;  // hangs right now past this dimension, #13660 will turn it from a
                                                    // hang into a PCC issue for GS and improve perf for WH
-            } else if (!a.is_sharded() && a.layout() == Layout::ROW_MAJOR) {  // rm is L1 intensive, if it overflows we
-                                                                              // can do tiled which allocates much
-                                                                              // smaller CBs
+            } else if (!a.is_sharded() && a.layout() == Layout::ROW_MAJOR) {
                 return ttnn::prim::permute(
                     a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}), output_mem_config, std::nullopt);
             }
@@ -91,7 +89,7 @@ ttnn::Tensor transpose_nd(
     const uint32_t dim2,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<float>& pad_value) {
-    std::vector<int64_t> permutation;
+    ttnn::SmallVector<int64_t> permutation;
     permutation.reserve(input_tensor.get_shape().rank());
     for (uint32_t i = 0; i < input_tensor.get_shape().rank(); ++i) {
         permutation.push_back(i);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/decorators.hpp"
 #include "device/transpose_op.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
+#include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/cpp/ttnn/operations/copy.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp"
@@ -18,36 +19,6 @@
 namespace ttnn::operations::data_movement {
 
 namespace detail {
-
-inline uint32_t get_estimated_size_of_cbs(const Tensor& input_tensor_a) {
-    // Circular Buffer sizes:
-    uint32_t element_size = input_tensor_a.element_size();
-    uint32_t Wt = input_tensor_a.get_padded_shape()[-1] / tt::constants::TILE_WIDTH;
-    uint32_t Ht = input_tensor_a.get_padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-    uint32_t HtWt = Ht * Wt;
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
-    uint32_t tile_size = tt::tt_metal::detail::TileSize(data_format);
-
-    uint32_t cb_src0_size = 2 * Wt * tile_size;
-    uint32_t cb_output_size = 2 * Ht * tile_size;
-    uint32_t cb_im_size = Ht * Wt * tile_size;
-    uint32_t cb_im2_size = Ht * tile_size;
-    return cb_src0_size + cb_output_size + cb_im_size + cb_im2_size;
-}
-
-inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
-    auto device = input_tensor_a.device();
-    auto lowest_address = device->lowest_occupied_compute_l1_address();
-    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
-    max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
-    return max_l1_space;
-}
-
-inline bool rm_enough_available_space(const Tensor& input_tensor_a) {
-    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
-    uint32_t estimated_size_of_cbs = get_estimated_size_of_cbs(input_tensor_a);
-    return max_l1_space > estimated_size_of_cbs;
-}
 
 inline Tensor transpose_(
     const Tensor& a,
@@ -84,16 +55,14 @@ inline Tensor transpose_(
             tiled_only = true;  // CN only has a tiled implementation at the moment
             break;
         case TransposeOpDim::WH:  // THIS NEEDS TO BE FIXED
-            if (((W * a.element_size()) % FACE_WIDTH != 0) || ((H * a.element_size()) % FACE_WIDTH != 0)) {
-                tiled_only = true;
-            } else if (a.device()->arch() == tt::ARCH::GRAYSKULL) {
+            if (a.device()->arch() == tt::ARCH::GRAYSKULL) {
                 tiled_only = a.shape()[-2] > 256;  // hangs right now past this dimension, #13660 will turn it from a
                                                    // hang into a PCC issue for GS and improve perf for WH
-            } else if (
-                !a.is_sharded() && a.layout() == Layout::ROW_MAJOR &&
-                !rm_enough_available_space(
-                    a)) {  // rm is L1 intensive, if it overflows we can do tiled which allocates much smaller CBs
-                tiled_only = true;
+            } else if (!a.is_sharded() && a.layout() == Layout::ROW_MAJOR) {  // rm is L1 intensive, if it overflows we
+                                                                              // can do tiled which allocates much
+                                                                              // smaller CBs
+                return ttnn::prim::permute(
+                    a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}), output_mem_config, std::nullopt);
             }
             break;
         default: break;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -54,11 +54,8 @@ inline Tensor transpose_(
         case TransposeOpDim::CN:
             tiled_only = true;  // CN only has a tiled implementation at the moment
             break;
-        case TransposeOpDim::WH:  // THIS NEEDS TO BE FIXED
-            if (a.device()->arch() == tt::ARCH::GRAYSKULL) {
-                tiled_only = a.shape()[-2] > 256;  // hangs right now past this dimension, #13660 will turn it from a
-                                                   // hang into a PCC issue for GS and improve perf for WH
-            } else if (!a.is_sharded() && a.layout() == Layout::ROW_MAJOR) {
+        case TransposeOpDim::WH:
+            if (!a.is_sharded() && a.layout() == Layout::ROW_MAJOR) {
                 return ttnn::prim::permute(
                     a, ttnn::SmallVector<uint32_t>({0, 1, 3, 2}), output_mem_config, std::nullopt);
             }


### PR DESCRIPTION
### Ticket
#16109 

### Problem description
Transpose WH row major for interleaved scales with O(Height * Width) of the tensor, which causes CB overflows for bigger dimensions on the PT2.0 traces. As well, the kernel requires 16 element requirement for height and width, which forced us to convert to tiled

### What's changed
Use ttnn::prim::permute which allocates constant space and does not have an alignment requirement. Also enable tests on transpose that used to fail due to CB overflows.

This brings ttnn.transpose coverage from 98.4 to 99.2% on sweeps (3 of the "failures" are actually 0.998 pcc not 0.999).
ttnn.permute for ROW major is now 100% for this change from 87%. We are at 85.44% overall as tiled is hanging.

Use permute in fold for perf reasons

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12588859911/job/35088166120
- [ ] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12584878436
- [ ] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12584881248(fail matches main)
- [ ] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12584884092/job/35075829376 (fail matches main)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
