### PR TITLE
Port all Moreh OPs to compute_output_specs

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.cpp
@@ -44,12 +44,16 @@ void MorehAbsPowOperation::validate_on_program_cache_hit(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     validate_tensors(operation_attributes, tensor_args);
 };
-MorehAbsPowOperation::shape_return_value_t MorehAbsPowOperation::compute_output_shapes(
+MorehAbsPowOperation::spec_return_value_t MorehAbsPowOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
     const auto& input = tensor_args.input;
-    const auto& input_shape = input.get_shape();
-    return input_shape;
-};
+    return TensorSpec(
+        input.get_logical_shape(),
+        TensorLayout(input.get_dtype(), PageConfig(input.get_layout()), operation_attributes.memory_config));
+}
 
 MorehAbsPowOperation::tensor_return_value_t MorehAbsPowOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
@@ -59,12 +63,7 @@ MorehAbsPowOperation::tensor_return_value_t MorehAbsPowOperation::create_output_
     }
 
     log_debug(tt::LogOp, "{}:{} create output tensor", __func__, __LINE__);
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        tensor_args.input.get_dtype(),
-        tensor_args.input.get_layout(),
-        tensor_args.input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 };
 
 std::tuple<MorehAbsPowOperation::operation_attributes_t, MorehAbsPowOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
@@ -49,7 +49,7 @@ struct MorehAbsPowOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     MOREH_ABS_POW_FACTORY_H(MorehAbsPowFactory)
@@ -58,7 +58,7 @@ struct MorehAbsPowOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -62,57 +62,49 @@ void MorehAdamOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehAdamOperation::shape_return_value_t MorehAdamOperation::compute_output_shapes(
+MorehAdamOperation::spec_return_value_t MorehAdamOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto input_tensor_shape = tensor_args.param_in.get_shape();
+    auto output_shape = tensor_args.param_in.get_logical_shape();
+    auto dtype = tensor_args.param_in.get_dtype();
 
-    return {
-        input_tensor_shape,
-        input_tensor_shape,
-        input_tensor_shape,
-        input_tensor_shape,
-    };
-};
+    std::vector<std::optional<TensorSpec>> ret;
+    TensorSpec out_spec(
+        output_shape, TensorLayout(dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
+    for (int idx = 0; idx < 3; idx++) {
+        if (tensor_args.output_tensors.at(idx).has_value()) {
+            ret.push_back(tensor_args.output_tensors.at(idx)->get_tensor_spec());
+        } else {
+            ret.push_back(out_spec);
+        }
+    }
+    if (tensor_args.output_tensors.at(3).has_value()) {
+        ret.push_back(tensor_args.output_tensors.at(3)->get_tensor_spec());
+    } else if (operation_attributes.amsgrad) {
+        ret.push_back(out_spec);
+    } else {
+        ret.push_back(std::nullopt);
+    }
+
+    return ret;
+}
 
 MorehAdamOperation::tensor_return_value_t MorehAdamOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.param_in.get_dtype();
-    Layout layout{Layout::TILE};
+    const auto output_specs = compute_output_specs(operation_attributes, tensor_args);
     auto device = tensor_args.param_in.device();
 
     std::vector<std::optional<Tensor>> ret;
     auto memory_config = operation_attributes.memory_config;
 
-    auto idx = uint32_t{0};
-    if (tensor_args.output_tensors.at(idx).has_value()) {
-        ret.push_back(tensor_args.output_tensors.at(idx).value());
-    } else {
-        ret.push_back(create_device_tensor(output_shapes.at(idx).value(), dtype, layout, device, memory_config));
-    }
-    ++idx;
-
-    if (tensor_args.output_tensors.at(idx).has_value()) {
-        ret.push_back(tensor_args.output_tensors.at(idx).value());
-    } else {
-        ret.push_back(create_device_tensor(output_shapes.at(idx).value(), dtype, layout, device, memory_config));
-    }
-    ++idx;
-
-    if (tensor_args.output_tensors.at(idx).has_value()) {
-        ret.push_back(tensor_args.output_tensors.at(idx).value());
-    } else {
-        ret.push_back(create_device_tensor(output_shapes.at(idx).value(), dtype, layout, device, memory_config));
-    }
-    ++idx;
-
-    if (tensor_args.output_tensors.at(idx).has_value()) {
-        ret.push_back(tensor_args.output_tensors.at(idx).value());
-    } else if (operation_attributes.amsgrad) {
-        ret.push_back(create_device_tensor(output_shapes.at(idx).value(), dtype, layout, device, memory_config));
+    for (size_t idx = 0; idx < output_specs.size(); idx++) {
+        if (tensor_args.output_tensors.at(idx).has_value()) {
+            ret.push_back(tensor_args.output_tensors.at(idx).value());
+        } else if (output_specs[idx].has_value()) {
+            ret.push_back(create_device_tensor(*output_specs[idx], device));
+        }
     }
 
-    return std::move(ret);
+    return ret;
 }
 
 std::tuple<MorehAdamOperation::operation_attributes_t, MorehAdamOperation::tensor_args_t> MorehAdamOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -37,7 +37,7 @@ struct MorehAdamOperation {
         const std::vector<std::optional<Tensor>> output_tensors;
     };
 
-    using shape_return_value_t = std::vector<std::optional<Shape>>;
+    using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct ProgramFactory {
@@ -72,7 +72,7 @@ struct MorehAdamOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& param_in,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -65,51 +65,73 @@ void MorehAdamWDeviceOperation::validate_on_program_cache_hit(
     validate_inputs(attributes, tensor_args);
 }
 
-MorehAdamWDeviceOperation::shape_return_value_t MorehAdamWDeviceOperation::compute_output_shapes(
+MorehAdamWDeviceOperation::spec_return_value_t MorehAdamWDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto input_tensor_shape = tensor_args.param_in.get_shape();
+    auto output_shape = tensor_args.param_in.get_logical_shape();
+    auto dtype = tensor_args.param_in.get_dtype();
+    auto memory_config = operation_attributes.memory_config;
 
-    return {
-        input_tensor_shape,
-        input_tensor_shape,
-        input_tensor_shape,
-        input_tensor_shape,
-    };
+    std::vector<std::optional<TensorSpec>> result;
+    TensorSpec outSpec(output_shape, TensorLayout(dtype, PageConfig(Layout::TILE), memory_config));
+
+    if (tensor_args.param_out.has_value()) {
+        result.push_back(tensor_args.param_out->get_tensor_spec());
+    } else {
+        result.push_back(outSpec);
+    }
+
+    if (tensor_args.exp_avg_out.has_value()) {
+        result.push_back(tensor_args.exp_avg_out->get_tensor_spec());
+    } else {
+        result.push_back(outSpec);
+    }
+
+    if (tensor_args.exp_avg_sq_out.has_value()) {
+        result.push_back(tensor_args.exp_avg_sq_out->get_tensor_spec());
+    } else {
+        result.push_back(outSpec);
+    }
+
+    if (tensor_args.max_exp_avg_sq_out.has_value()) {
+        result.push_back(tensor_args.max_exp_avg_sq_out->get_tensor_spec());
+    } else if (operation_attributes.amsgrad) {
+        result.push_back(outSpec);
+    } else {
+        result.push_back(std::nullopt);
+    }
+
+    return result;
 }
 
 MorehAdamWDeviceOperation::tensor_return_value_t MorehAdamWDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.param_in.get_dtype();
-    Layout layout{Layout::TILE};
+    auto output_specs = compute_output_specs(operation_attributes, tensor_args);
     auto device = tensor_args.param_in.device();
 
     tensor_return_value_t result;
 
-    auto memory_config = operation_attributes.memory_config;
-
     if (tensor_args.param_out.has_value()) {
         result.push_back(tensor_args.param_out.value());
     } else {
-        result.push_back(create_device_tensor(output_shapes.at(0), dtype, layout, device, memory_config));
+        result.push_back(create_device_tensor(*output_specs[0], device));
     }
 
     if (tensor_args.exp_avg_out.has_value()) {
         result.push_back(tensor_args.exp_avg_out.value());
     } else {
-        result.push_back(create_device_tensor(output_shapes.at(1), dtype, layout, device, memory_config));
+        result.push_back(create_device_tensor(*output_specs[1], device));
     }
 
     if (tensor_args.exp_avg_sq_out.has_value()) {
         result.push_back(tensor_args.exp_avg_sq_out.value());
     } else {
-        result.push_back(create_device_tensor(output_shapes.at(2), dtype, layout, device, memory_config));
+        result.push_back(create_device_tensor(*output_specs[2], device));
     }
 
     if (tensor_args.max_exp_avg_sq_out.has_value()) {
         result.push_back(tensor_args.max_exp_avg_sq_out.value());
-    } else if (operation_attributes.amsgrad) {
-        result.push_back(create_device_tensor(output_shapes.at(3), dtype, layout, device, memory_config));
+    } else if (output_specs[3].has_value()) {
+        result.push_back(create_device_tensor(*output_specs[3], device));
     } else {
         result.push_back(std::nullopt);
     }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -41,7 +41,7 @@ struct MorehAdamWDeviceOperation {
         const std::optional<Tensor>& max_exp_avg_sq_out;
     };
 
-    using shape_return_value_t = std::vector<ttnn::Shape>;
+    using spec_return_value_t = std::vector<std::optional<ttnn::TensorSpec>>;
 
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
@@ -81,7 +81,7 @@ struct MorehAdamWDeviceOperation {
 
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
@@ -55,39 +55,33 @@ void MorehArangeOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehArangeOperation::shape_return_value_t MorehArangeOperation::compute_output_shapes(
+MorehArangeOperation::spec_return_value_t MorehArangeOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
+
     uint32_t num_elems = static_cast<uint32_t>(
         ceil((operation_attributes.end - operation_attributes.start) / operation_attributes.step));
 
     if (operation_attributes.untilize_out) {
-        return ttnn::Shape(tt::tt_metal::LegacyShape({num_elems}));
+        return TensorSpec(
+            SimpleShape({num_elems}),
+            TensorLayout(
+                operation_attributes.dtype, PageConfig(Layout::ROW_MAJOR), operation_attributes.memory_config));
     }
 
-    SmallVector<uint32_t> output_size = {
-        tt::constants::TILE_HEIGHT, tt::round_up(num_elems, tt::constants::TILE_WIDTH)};
-
-    auto dimensions_pads = SmallVector<Padding::PadDimension>();
-    dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 31});
-    dimensions_pads.push_back(
-        Padding::PadDimension{.front = 0, .back = tt::round_up(num_elems, tt::constants::TILE_WIDTH) - num_elems});
-    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
-
-    return ttnn::Shape{tt::tt_metal::LegacyShape(output_size, padding)};
+    return TensorSpec(
+        SimpleShape({1, num_elems}),
+        TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
 };
 
 MorehArangeOperation::tensor_return_value_t MorehArangeOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& output = tensor_args.output;
-    if (output.has_value()) {
-        return output.value();
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output.value();
     }
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        operation_attributes.dtype,
-        operation_attributes.untilize_out ? Layout::ROW_MAJOR : Layout::TILE,
-        tensor_args.any.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.any.device());
 }
 
 std::tuple<MorehArangeOperation::operation_attributes_t, MorehArangeOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.hpp
@@ -23,7 +23,7 @@ struct MorehArangeOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -53,7 +53,7 @@ struct MorehArangeOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.cpp
@@ -36,9 +36,9 @@ void MorehClipGradNormStep1Operation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehClipGradNormStep1Operation::shape_return_value_t MorehClipGradNormStep1Operation::compute_output_shapes(
+MorehClipGradNormStep1Operation::spec_return_value_t MorehClipGradNormStep1Operation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return {};
+    return tensor_args.tmp_pow_sum.get_tensor_spec();
 };
 
 MorehClipGradNormStep1Operation::tensor_return_value_t MorehClipGradNormStep1Operation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.hpp
@@ -26,7 +26,7 @@ struct MorehClipGradNormStep1Operation {
         const Tensor& tmp_pow_sum;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -58,7 +58,7 @@ struct MorehClipGradNormStep1Operation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const std::vector<Tensor>& inputs,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.cpp
@@ -35,10 +35,17 @@ void MorehClipGradNormStep2Operation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehClipGradNormStep2Operation::shape_return_value_t MorehClipGradNormStep2Operation::compute_output_shapes(
+MorehClipGradNormStep2Operation::spec_return_value_t MorehClipGradNormStep2Operation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.total_norm.has_value()) {
+        return tensor_args.total_norm->get_tensor_spec();
+    }
+
     // output total_norm 1 element
-    return SimpleShape{1, 1};
+    return TensorSpec(
+        SimpleShape{1, 1},
+        TensorLayout(
+            tensor_args.tmp_pow_sum.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
 };
 
 MorehClipGradNormStep2Operation::tensor_return_value_t MorehClipGradNormStep2Operation::create_output_tensors(
@@ -46,14 +53,9 @@ MorehClipGradNormStep2Operation::tensor_return_value_t MorehClipGradNormStep2Ope
     if (tensor_args.total_norm.has_value()) {
         return tensor_args.total_norm.value();
     }
-    const auto& total_norm_shape = compute_output_shapes(operation_attributes, tensor_args);
 
     return create_device_tensor(
-        total_norm_shape,
-        tensor_args.tmp_pow_sum.get_dtype(),
-        Layout::TILE,
-        tensor_args.tmp_pow_sum.device(),
-        operation_attributes.memory_config);
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.tmp_pow_sum.device());
 };
 
 std::tuple<MorehClipGradNormStep2Operation::operation_attributes_t, MorehClipGradNormStep2Operation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.hpp
@@ -27,7 +27,7 @@ struct MorehClipGradNormStep2Operation {
         const std::optional<Tensor>& total_norm;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -58,7 +58,7 @@ struct MorehClipGradNormStep2Operation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& tmp_pow_sum,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.cpp
@@ -37,9 +37,14 @@ void MorehClipGradNormStep3Operation::validate_on_program_cache_hit(
 };
 
 // No output
-MorehClipGradNormStep3Operation::shape_return_value_t MorehClipGradNormStep3Operation::compute_output_shapes(
+MorehClipGradNormStep3Operation::spec_return_value_t MorehClipGradNormStep3Operation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return {};
+    std::vector<TensorSpec> output_specs;
+    output_specs.reserve(tensor_args.inputs.size());
+    for (const auto& input : tensor_args.inputs) {
+        output_specs.push_back(input.get_tensor_spec());
+    }
+    return output_specs;
 };
 
 // No output

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp
@@ -26,7 +26,7 @@ struct MorehClipGradNormStep3Operation {
         const Tensor& clip_coef_clamped;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = std::vector<TensorSpec>;
     using tensor_return_value_t = std::vector<Tensor>;
 
     struct ProgramFactory {
@@ -57,7 +57,7 @@ struct MorehClipGradNormStep3Operation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const std::vector<Tensor>& inputs,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_device_operation.cpp
@@ -53,23 +53,24 @@ void MorehCumsumDeviceOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehCumsumDeviceOperation::shape_return_value_t MorehCumsumDeviceOperation::compute_output_shapes(
+MorehCumsumDeviceOperation::spec_return_value_t MorehCumsumDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
+
     const auto& input = tensor_args.input;
-    auto output_shape = input.get_shape();
-    return output_shape;
+    return TensorSpec(
+        input.get_logical_shape(), TensorLayout(input.dtype(), PageConfig(input.layout()), MemoryConfig{}));
 }
 
 MorehCumsumDeviceOperation::tensor_return_value_t MorehCumsumDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input = tensor_args.input;
-    const auto& output = tensor_args.output;
-    if (output.has_value()) {
-        return output.value();
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output.value();
     }
 
-    auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
-    return create_device_tensor(output_shape, input.dtype(), input.layout(), input.device());
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<MorehCumsumDeviceOperation::operation_attributes_t, MorehCumsumDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_device_operation.hpp
@@ -23,7 +23,7 @@ struct MorehCumsumDeviceOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -54,7 +54,7 @@ struct MorehCumsumDeviceOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
@@ -47,15 +47,16 @@ void MorehDotOperation::validate_on_program_cache_hit(
     validate(operation_attributes, tensor_args);
 }
 
-MorehDotOperation::shape_return_value_t MorehDotOperation::compute_output_shapes(
+MorehDotOperation::spec_return_value_t MorehDotOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.output.has_value()) {
-        return tensor_args.output.value().get_logical_shape();
+        return tensor_args.output->get_tensor_spec();
     }
     const auto& input = tensor_args.input_a;
     auto output_shape = input.get_logical_shape();
     output_shape[3] = 1;
-    return ttnn::SimpleShape{std::move(output_shape)};
+    return TensorSpec(
+        output_shape, TensorLayout(input.dtype(), PageConfig(input.layout()), operation_attributes.memory_config));
 }
 
 MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensors(
@@ -63,14 +64,7 @@ MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensor
     if (tensor_args.output.has_value()) {
         return tensor_args.output.value();
     }
-    const auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
-    const auto& input_tensor = tensor_args.input_a;
-    return create_device_tensor(
-        output_shape,
-        input_tensor.dtype(),
-        input_tensor.layout(),
-        input_tensor.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input_a.device());
 }
 
 std::tuple<MorehDotOperation::operation_attributes_t, MorehDotOperation::tensor_args_t> MorehDotOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
@@ -25,7 +25,7 @@ struct MorehDotOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct SingleCore {
@@ -53,7 +53,7 @@ struct MorehDotOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static void validate(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
@@ -69,16 +69,15 @@ void MorehDotBackwardOperation::validate_on_program_cache_hit(
     validate_tensors(operation_attributes, tensor_args);
 }
 
-MorehDotBackwardOperation::shape_return_value_t MorehDotBackwardOperation::compute_output_shapes(
+MorehDotBackwardOperation::spec_return_value_t MorehDotBackwardOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    TT_FATAL(false, "This operation is in place, and as such, should not be computing output shapes.");
     return {};
 }
 
 MorehDotBackwardOperation::tensor_return_value_t MorehDotBackwardOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(tensor_args.output_tensors.size() > 0, "Invalid number of output tensors.");
-    return tensor_args.output_tensors;
+    return {};
 }
 
 std::tuple<MorehDotBackwardOperation::operation_attributes_t, MorehDotBackwardOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
@@ -71,13 +71,22 @@ void MorehDotBackwardOperation::validate_on_program_cache_hit(
 
 MorehDotBackwardOperation::spec_return_value_t MorehDotBackwardOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return {};
+    std::vector<std::optional<TensorSpec>> output_specs;
+    output_specs.reserve(tensor_args.output_tensors.size());
+    for (const auto& output_tensor : tensor_args.output_tensors) {
+        if (output_tensor.has_value()) {
+            output_specs.push_back(output_tensor->get_tensor_spec());
+        } else {
+            output_specs.push_back(std::nullopt);
+        }
+    }
+    return output_specs;
 }
 
 MorehDotBackwardOperation::tensor_return_value_t MorehDotBackwardOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     TT_FATAL(tensor_args.output_tensors.size() > 0, "Invalid number of output tensors.");
-    return {};
+    return tensor_args.output_tensors;
 }
 
 std::tuple<MorehDotBackwardOperation::operation_attributes_t, MorehDotBackwardOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
@@ -28,7 +28,7 @@ struct MorehDotBackwardOperation {
         const std::vector<std::optional<Tensor>> output_tensors;
     };
 
-    using shape_return_value_t = std::vector<std::optional<ttnn::SimpleShape>>;
+    using spec_return_value_t = std::vector<std::optional<ttnn::TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct SingleCore {
@@ -55,7 +55,7 @@ struct MorehDotBackwardOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.cpp
@@ -65,22 +65,31 @@ void MorehFoldOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehFoldOperation::shape_return_value_t MorehFoldOperation::compute_output_shapes(
+MorehFoldOperation::spec_return_value_t MorehFoldOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
+
     auto input_tensor_shape = tensor_args.input.get_logical_shape();
     auto input_tensor_rank = tensor_args.input.get_logical_shape().rank();
     uint32_t kernel_size_product = operation_attributes.kernel_size[0] * operation_attributes.kernel_size[1];
-    if (input_tensor_rank == 3) {
-        uint32_t N = input_tensor_shape[0];
-        uint32_t C = input_tensor_shape[1] / kernel_size_product;
-        auto output_shape =
-            ttnn::SimpleShape{N, C, operation_attributes.output_size[0], operation_attributes.output_size[1]};
-        return output_shape;
-    }
-    // If input_tensor_rank == 2
-    uint32_t C = input_tensor_shape[0] / kernel_size_product;
-    auto output_shape = ttnn::SimpleShape{C, operation_attributes.output_size[0], operation_attributes.output_size[1]};
-    return output_shape;
+    auto output_shape = [&] {
+        if (input_tensor_rank == 3) {
+            uint32_t N = input_tensor_shape[0];
+            uint32_t C = input_tensor_shape[1] / kernel_size_product;
+            return ttnn::SimpleShape{N, C, operation_attributes.output_size[0], operation_attributes.output_size[1]};
+        }
+        // If input_tensor_rank == 2
+        uint32_t C = input_tensor_shape[0] / kernel_size_product;
+        return ttnn::SimpleShape{C, operation_attributes.output_size[0], operation_attributes.output_size[1]};
+    }();
+    return TensorSpec(
+        output_shape,
+        TensorLayout(
+            tensor_args.input.get_dtype(),
+            PageConfig(tensor_args.input.get_layout()),
+            operation_attributes.memory_config));
 };
 
 MorehFoldOperation::tensor_return_value_t MorehFoldOperation::create_output_tensors(
@@ -89,14 +98,7 @@ MorehFoldOperation::tensor_return_value_t MorehFoldOperation::create_output_tens
         return tensor_args.output.value();
     }
 
-    const auto& output_shape = compute_output_shapes(operation_attributes, tensor_args);
-
-    return create_device_tensor(
-        output_shape,
-        tensor_args.input.get_dtype(),
-        tensor_args.input.get_layout(),
-        tensor_args.input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<MorehFoldOperation::operation_attributes_t, MorehFoldOperation::tensor_args_t> MorehFoldOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
@@ -25,7 +25,7 @@ struct MorehFoldOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = SimpleShape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -55,7 +55,7 @@ struct MorehFoldOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
@@ -27,7 +27,7 @@ struct MorehGetItemOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = ttnn::Shape;
+    using spec_return_value_t = ttnn::TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct MorehGetItemRmFactory {
@@ -84,7 +84,7 @@ struct MorehGetItemOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
@@ -78,24 +78,53 @@ void MorehGroupNormOperation::validate_on_program_cache_hit(
     validate_tensors(operation_attributes, tensor_args);
 };
 
-MorehGroupNormOperation::shape_return_value_t MorehGroupNormOperation::compute_output_shapes(
+MorehGroupNormOperation::spec_return_value_t MorehGroupNormOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     using namespace tt::constants;
+    auto dtype = tensor_args.input.get_dtype();
+    Layout layout{Layout::TILE};
     // mean, rstd (1, 1, N, num_groups)
     const auto output_shape = tensor_args.input.get_logical_shape();
     const auto N = output_shape[0];
     const auto num_groups = operation_attributes.num_groups;
-    SmallVector<uint32_t> mean_rstd_origin_shape{1, 1, N, num_groups};
+    SimpleShape mean_rstd_shape({1, 1, N, num_groups});
 
-    SimpleShape mean_rstd_shape(std::move(mean_rstd_origin_shape));
-    return {output_shape, mean_rstd_shape, mean_rstd_shape};
+    std::vector<std::optional<TensorSpec>> result;
+    result.reserve(3);
+
+    // output
+    if (tensor_args.output.has_value()) {
+        result.push_back(tensor_args.output->get_tensor_spec());
+    } else {
+        result.push_back(
+            TensorSpec(output_shape, TensorLayout(dtype, PageConfig(layout), operation_attributes.memory_config)));
+    }
+
+    // mean
+    if (tensor_args.mean.has_value()) {
+        result.push_back(tensor_args.mean->get_tensor_spec());
+    } else if (operation_attributes.are_required_outputs[1]) {
+        result.push_back(
+            TensorSpec(mean_rstd_shape, TensorLayout(dtype, PageConfig(layout), operation_attributes.memory_config)));
+    } else {
+        result.push_back(std::nullopt);
+    }
+
+    // rstd
+    if (tensor_args.rstd.has_value()) {
+        result.push_back(tensor_args.rstd->get_tensor_spec());
+    } else if (operation_attributes.are_required_outputs[2]) {
+        result.push_back(
+            TensorSpec(mean_rstd_shape, TensorLayout(dtype, PageConfig(layout), operation_attributes.memory_config)));
+    } else {
+        result.push_back(std::nullopt);
+    }
+    return result;
 }
 
 MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.input.get_dtype();
-    Layout layout{Layout::TILE};
+    const auto output_specs = compute_output_specs(operation_attributes, tensor_args);
     auto device = tensor_args.input.device();
 
     std::vector<std::optional<Tensor>> result;
@@ -105,16 +134,14 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     if (tensor_args.output.has_value()) {
         result.push_back(tensor_args.output.value());
     } else {
-        result.push_back(
-            create_device_tensor(output_shapes[0].value(), dtype, layout, device, operation_attributes.memory_config));
+        result.push_back(create_device_tensor(*output_specs[0], device));
     }
 
     // mean
     if (tensor_args.mean.has_value()) {
         result.push_back(tensor_args.mean.value());
-    } else if (operation_attributes.are_required_outputs[1]) {
-        result.push_back(create_device_tensor(
-            output_shapes[1].value(), dtype, layout, device, operation_attributes.mean_memory_config));
+    } else if (output_specs[1].has_value()) {
+        result.push_back(create_device_tensor(*output_specs[1], device));
     } else {
         result.push_back(std::nullopt);
     }
@@ -122,13 +149,12 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     // rstd
     if (tensor_args.rstd.has_value()) {
         result.push_back(tensor_args.rstd.value());
-    } else if (operation_attributes.are_required_outputs[2]) {
-        result.push_back(create_device_tensor(
-            output_shapes[2].value(), dtype, layout, device, operation_attributes.rstd_memory_config));
+    } else if (output_specs[2].has_value()) {
+        result.push_back(create_device_tensor(*output_specs[2], device));
     } else {
         result.push_back(std::nullopt);
     }
-    return std::move(result);
+    return result;
 }
 
 std::tuple<MorehGroupNormOperation::operation_attributes_t, MorehGroupNormOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
@@ -29,7 +29,7 @@ struct MorehGroupNormOperation {
         const std::optional<const Tensor> rstd;
     };
 
-    using shape_return_value_t = std::vector<std::optional<SimpleShape>>;
+    using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct MorehGroupNormFactory {
@@ -60,7 +60,7 @@ struct MorehGroupNormOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -71,8 +71,8 @@ void MorehGroupNormBackwardGammaBetaGradOperation::validate_on_program_cache_hit
     validate_tensors(operation_attributes, tensor_args);
 }
 
-MorehGroupNormBackwardGammaBetaGradOperation::shape_return_value_t
-MorehGroupNormBackwardGammaBetaGradOperation::compute_output_shapes(
+MorehGroupNormBackwardGammaBetaGradOperation::spec_return_value_t
+MorehGroupNormBackwardGammaBetaGradOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     using namespace tt::constants;
     const auto& output_grad = tensor_args.output_grad;
@@ -91,38 +91,62 @@ MorehGroupNormBackwardGammaBetaGradOperation::compute_output_shapes(
     dgamma_dbeta_padding[2] = Padding::PadDimension{0, TILE_HEIGHT - 1};
     dgamma_dbeta_padding[3] = Padding::PadDimension{0, TILE_WIDTH - (c % TILE_WIDTH)};
     Shape dgamma_dbeta_shape(tt::tt_metal::LegacyShape(dgamma_dbeta_origin_shape, dgamma_dbeta_padding));
-    return {dgamma_dbeta_shape, dgamma_dbeta_shape};
+
+    auto dtype = tensor_args.output_grad.get_dtype();
+    Layout layout{Layout::TILE};
+
+    std::vector<std::optional<TensorSpec>> result(2);
+    const auto gamma_requires_grad = operation_attributes.are_required_outputs[0];
+    const auto beta_requires_grad = operation_attributes.are_required_outputs[1];
+
+    if (gamma_requires_grad) {
+        if (tensor_args.gamma_grad.has_value()) {
+            result[0] = tensor_args.gamma_grad->get_tensor_spec();
+        } else {
+            result[0] = TensorSpec(
+                dgamma_dbeta_shape.logical_shape(),
+                TensorLayout::fromLegacyPaddedShape(
+                    dtype, PageConfig(layout), operation_attributes.gamma_grad_memory_config, dgamma_dbeta_shape));
+        }
+    }
+
+    if (beta_requires_grad) {
+        if (tensor_args.beta_grad.has_value()) {
+            result[1] = tensor_args.beta_grad->get_tensor_spec();
+        } else {
+            result[1] = TensorSpec(
+                dgamma_dbeta_shape.logical_shape(),
+                TensorLayout::fromLegacyPaddedShape(
+                    dtype, PageConfig(layout), operation_attributes.beta_grad_memory_config, dgamma_dbeta_shape));
+        }
+    }
+
+    return result;
 }
 
 MorehGroupNormBackwardGammaBetaGradOperation::tensor_return_value_t
 MorehGroupNormBackwardGammaBetaGradOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.output_grad.get_dtype();
-    Layout layout{Layout::TILE};
+    const auto output_specs = compute_output_specs(operation_attributes, tensor_args);
     auto device = tensor_args.output_grad.device();
 
     std::vector<std::optional<Tensor>> result(2);
-    const auto gamma_requires_grad = operation_attributes.are_required_outputs[0];
-    const auto beta_requires_grad = operation_attributes.are_required_outputs[1];
 
     // gamma_grad
-    if (gamma_requires_grad) {
+    if (output_specs[0].has_value()) {
         if (tensor_args.gamma_grad.has_value()) {
             result[0] = tensor_args.gamma_grad.value();
         } else {
-            result[0] = create_device_tensor(
-                output_shapes[0].value(), dtype, layout, device, operation_attributes.gamma_grad_memory_config);
+            result[0] = create_device_tensor(*output_specs[0], device);
         }
     }
 
     // beta_grad
-    if (beta_requires_grad) {
+    if (output_specs[1].has_value()) {
         if (tensor_args.beta_grad.has_value()) {
             result[1] = tensor_args.beta_grad.value();
         } else {
-            result[1] = create_device_tensor(
-                output_shapes[1].value(), dtype, layout, device, operation_attributes.beta_grad_memory_config);
+            result[1] = create_device_tensor(*output_specs[1], device);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
@@ -32,7 +32,7 @@ struct MorehGroupNormBackwardGammaBetaGradOperation {
         const std::optional<const Tensor> beta_grad;
     };
 
-    using shape_return_value_t = std::vector<std::optional<Shape>>;
+    using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct MorehGroupNormBackwardGammaBetaGradFactory {
@@ -63,7 +63,7 @@ struct MorehGroupNormBackwardGammaBetaGradOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
@@ -23,7 +23,7 @@ struct MorehGroupNormBackwardInputGradOperation {
         const std::optional<const Tensor> input_grad;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct MorehGroupNormBackwardInputGradFactory {
@@ -54,7 +54,7 @@ struct MorehGroupNormBackwardInputGradOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
@@ -80,71 +80,51 @@ void MorehLayerNormOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehLayerNormOperation::shape_return_value_t MorehLayerNormOperation::compute_output_shapes(
+MorehLayerNormOperation::spec_return_value_t MorehLayerNormOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto input = tensor_args.input;
-    auto normalized_dims = operation_attributes.normalized_dims;
-    auto input_shape = input.get_shape();
-    auto input_shape_without_padding = input_shape.value.without_padding();
-    auto input_rank = input_shape.rank();
-    auto output_rank = input_rank - normalized_dims;
-
-    ttnn::SmallVector<uint32_t> output_size_vec;
-    ttnn::SmallVector<Padding::PadDimension> dimensions_pads;
-
-    if (output_rank == 1) {
-        output_size_vec.push_back(32);
-        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 31});
-    }
-
-    for (uint32_t dim = 0; dim < output_rank; dim++) {
-        auto input_shape_without_padding_size = input_shape_without_padding[dim];
-        if (is_hw_dim(dim, output_rank)) {
-            output_size_vec.push_back(round_up_to_mul32(input_shape_without_padding_size));
-            auto padding_back = output_size_vec[dim] - input_shape_without_padding_size;
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = padding_back});
-        } else {
-            output_size_vec.push_back(input_shape_without_padding_size);
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
-        }
-    }
-
-    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
-    auto mean_rstd_output_shape = Shape{tt::tt_metal::LegacyShape(output_size_vec, padding)};
-    return {input_shape, mean_rstd_output_shape, mean_rstd_output_shape};
-};
-
-MorehLayerNormOperation::tensor_return_value_t MorehLayerNormOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto input = tensor_args.input;
-    auto dtype = input.get_dtype();
-    Layout layout{Layout::TILE};
-    auto device = input.device();
-
-    std::vector<std::optional<Tensor>> result;
-    result.reserve(3);
+    std::vector<std::optional<TensorSpec>> result(3);
 
     if (tensor_args.output.has_value()) {
-        result.push_back(tensor_args.output.value());
+        result[0] = tensor_args.output->get_tensor_spec();
     } else {
-        result.push_back(
-            create_device_tensor(output_shapes.at(0).value, dtype, layout, device, operation_attributes.memory_config));
+        result[0] = TensorSpec(
+            input.get_logical_shape(),
+            TensorLayout(input.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
     }
 
     if (tensor_args.mean.has_value()) {
-        result.push_back(tensor_args.mean.value());
-    } else {
-        result.push_back(std::nullopt);
+        result[1] = tensor_args.mean->get_tensor_spec();
     }
 
     if (tensor_args.rstd.has_value()) {
-        result.push_back(tensor_args.rstd.value());
-    } else {
-        result.push_back(std::nullopt);
+        result[2] = tensor_args.rstd->get_tensor_spec();
     }
 
-    return std::move(result);
+    return result;
+}
+
+MorehLayerNormOperation::tensor_return_value_t MorehLayerNormOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto output_specs = compute_output_specs(operation_attributes, tensor_args);
+
+    std::vector<std::optional<Tensor>> result(3);
+
+    if (tensor_args.output.has_value()) {
+        result[0] = tensor_args.output.value();
+    } else {
+        result[0] = create_device_tensor(*output_specs.at(0), tensor_args.input.device());
+    }
+
+    if (tensor_args.mean.has_value()) {
+        result[1] = tensor_args.mean.value();
+    }
+
+    if (tensor_args.rstd.has_value()) {
+        result[2] = tensor_args.rstd.value();
+    }
+
+    return result;
 }
 
 std::tuple<MorehLayerNormOperation::operation_attributes_t, MorehLayerNormOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
@@ -29,7 +29,7 @@ struct MorehLayerNormOperation {
         const std::optional<const Tensor>& rstd;
     };
 
-    using shape_return_value_t = std::vector<Shape>;
+    using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct ProgramFactory {
@@ -60,7 +60,7 @@ struct MorehLayerNormOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -26,30 +26,32 @@ void MorehLayerNormBackwardGammaBetaGradOperation::validate_on_program_cache_hit
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehLayerNormBackwardGammaBetaGradOperation::shape_return_value_t
-MorehLayerNormBackwardGammaBetaGradOperation::compute_output_shapes(
+MorehLayerNormBackwardGammaBetaGradOperation::spec_return_value_t
+MorehLayerNormBackwardGammaBetaGradOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    TT_FATAL(false, "The compute_output_shapes function in MorehLayerNormBackwardGammaBetaGrad is not implemented.");
-    return {};
+    std::vector<std::optional<TensorSpec>> result(2);
+    if (tensor_args.gamma_grad.has_value()) {
+        result[0] = tensor_args.gamma_grad->get_tensor_spec();
+    }
+
+    if (tensor_args.beta_grad.has_value()) {
+        result[1] = tensor_args.beta_grad->get_tensor_spec();
+    }
+    return result;
 };
 
 MorehLayerNormBackwardGammaBetaGradOperation::tensor_return_value_t
 MorehLayerNormBackwardGammaBetaGradOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    std::vector<std::optional<Tensor>> result;
-    result.reserve(2);
+    std::vector<std::optional<Tensor>> result(2);
     if (tensor_args.gamma_grad.has_value()) {
-        result.push_back(tensor_args.gamma_grad.value());
-    } else {
-        result.push_back(std::nullopt);
+        result[0] = tensor_args.gamma_grad.value();
     }
 
     if (tensor_args.beta_grad.has_value()) {
-        result.push_back(tensor_args.beta_grad.value());
-    } else {
-        result.push_back(std::nullopt);
+        result[1] = tensor_args.beta_grad.value();
     }
-    return std::move(result);
+    return result;
 }
 
 std::tuple<

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
@@ -27,7 +27,7 @@ struct MorehLayerNormBackwardGammaBetaGradOperation {
         const std::optional<const Tensor>& beta_grad;
     };
 
-    using shape_return_value_t = std::vector<Shape>;
+    using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct ProgramFactory {
@@ -58,7 +58,7 @@ struct MorehLayerNormBackwardGammaBetaGradOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
@@ -26,7 +26,7 @@ struct MorehLayerNormBackwardInputGradOperation {
         const std::optional<const Tensor>& gamma;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -57,7 +57,7 @@ struct MorehLayerNormBackwardInputGradOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.cpp
@@ -43,9 +43,16 @@ void MorehBiasAddBackwardOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehBiasAddBackwardOperation::shape_return_value_t MorehBiasAddBackwardOperation::compute_output_shapes(
+MorehBiasAddBackwardOperation::spec_return_value_t MorehBiasAddBackwardOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tensor_args.bias.value().get_shape();
+    if (tensor_args.bias_grad.has_value()) {
+        return tensor_args.bias_grad->get_tensor_spec();
+    }
+    TT_FATAL(tensor_args.bias.has_value(), "bias tensor should not be std::nullopt");
+    auto dtype = tensor_args.bias.value().get_dtype();
+    return TensorSpec(
+        tensor_args.bias->get_logical_shape(),
+        TensorLayout(dtype, PageConfig(Layout::TILE), operation_attributes.bias_grad_memory_config));
 };
 
 MorehBiasAddBackwardOperation::tensor_return_value_t MorehBiasAddBackwardOperation::create_output_tensors(
@@ -54,15 +61,8 @@ MorehBiasAddBackwardOperation::tensor_return_value_t MorehBiasAddBackwardOperati
         return tensor_args.bias_grad.value();
     }
 
-    TT_FATAL(tensor_args.bias.has_value(), "bias tensor should not be std::nullopt");
-    const auto& output_shape = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.bias.value().get_dtype();
-    Layout layout{Layout::TILE};
-    auto device = tensor_args.bias.value().device();
-
-    auto bias_grad_memory_config = operation_attributes.bias_grad_memory_config;
-
-    return create_device_tensor(output_shape, dtype, layout, device, bias_grad_memory_config);
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.bias->device());
 }
 
 std::tuple<MorehBiasAddBackwardOperation::operation_attributes_t, MorehBiasAddBackwardOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.hpp
@@ -26,7 +26,7 @@ struct MorehBiasAddBackwardOperation {
         const std::optional<Tensor>& bias_grad;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct SingleCoreProgramFactory {
@@ -76,7 +76,7 @@ struct MorehBiasAddBackwardOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
@@ -30,7 +30,7 @@ struct MorehMatmulOperation {
         const std::optional<const Tensor>& bias;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct MultiCoreProgramFactory {
@@ -61,7 +61,7 @@ struct MorehMatmulOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
@@ -53,8 +53,12 @@ void MorehMeanOperation::validate_on_program_cache_hit(
     validate_tensors(operation_attributes, tensor_args);
 };
 
-MorehMeanOperation::shape_return_value_t MorehMeanOperation::compute_output_shapes(
+MorehMeanOperation::spec_return_value_t MorehMeanOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return {tensor_args.output->get_tensor_spec()};
+    }
+
     auto input_shape = tensor_args.input.get_shape();
     auto output_shape = input_shape;
     auto input_rank = input_shape.rank();
@@ -73,7 +77,14 @@ MorehMeanOperation::shape_return_value_t MorehMeanOperation::compute_output_shap
             output_shape.value[dim] = 1;
         }
 
-        return Shape(tt::tt_metal::LegacyShape(output_shape.value, padding));
+        Shape result_shape(tt::tt_metal::LegacyShape(output_shape.value, padding));
+        return TensorSpec(
+            result_shape.logical_shape(),
+            TensorLayout::fromLegacyPaddedShape(
+                tensor_args.input.get_dtype(),
+                PageConfig(tensor_args.input.get_layout()),
+                operation_attributes.memory_config,
+                result_shape));
     }
 
     ttnn::SmallVector<uint32_t> shape;
@@ -95,7 +106,14 @@ MorehMeanOperation::shape_return_value_t MorehMeanOperation::compute_output_shap
     }
 
     auto padding = Padding(pad_dimensions, input_padding.pad_value());
-    return Shape(tt::tt_metal::LegacyShape(shape, padding));
+    Shape result_shape(tt::tt_metal::LegacyShape(shape, padding));
+    return TensorSpec(
+        result_shape.logical_shape(),
+        TensorLayout::fromLegacyPaddedShape(
+            tensor_args.input.get_dtype(),
+            PageConfig(tensor_args.input.get_layout()),
+            operation_attributes.memory_config,
+            result_shape));
 }
 
 MorehMeanOperation::tensor_return_value_t MorehMeanOperation::create_output_tensors(
@@ -105,12 +123,7 @@ MorehMeanOperation::tensor_return_value_t MorehMeanOperation::create_output_tens
         return {output.value()};
     }
 
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        tensor_args.input.get_dtype(),
-        tensor_args.input.get_layout(),
-        tensor_args.input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<MorehMeanOperation::operation_attributes_t, MorehMeanOperation::tensor_args_t> MorehMeanOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
@@ -28,7 +28,7 @@ struct MorehMeanOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct MorehMeanHFactory {
@@ -103,7 +103,7 @@ struct MorehMeanOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
@@ -36,31 +36,16 @@ void MorehMeanBackwardOperation::validate_on_program_cache_hit(
     validate_tensors(operation_attributes, tensor_args);
 };
 
-MorehMeanBackwardOperation::shape_return_value_t MorehMeanBackwardOperation::compute_output_shapes(
+MorehMeanBackwardOperation::spec_return_value_t MorehMeanBackwardOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto input_grad_shape = operation_attributes.input_grad_shape.value();
-    auto rank = input_grad_shape.rank();
-
-    ttnn::SmallVector<uint32_t> shape;
-    ttnn::SmallVector<Padding::PadDimension> dimensions_pads;
-
-    for (uint32_t dim = 0; dim < rank; dim++) {
-        if (is_hw_dim(dim, rank)) {
-            uint32_t up32_shape = tt::round_up(input_grad_shape[dim], 32);
-            uint32_t padding_back = up32_shape - input_grad_shape[dim];
-            shape.push_back(up32_shape);
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = padding_back});
-
-        } else {
-            shape.push_back(input_grad_shape[dim]);
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
-        }
+    if (tensor_args.input_grad.has_value()) {
+        return tensor_args.input_grad->get_tensor_spec();
     }
-
-    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
-    auto output_shape = Shape(tt::tt_metal::LegacyShape(shape, padding));
-
-    return output_shape;
+    auto input_grad_shape = operation_attributes.input_grad_shape.value().logical_shape();
+    return TensorSpec(
+        input_grad_shape,
+        TensorLayout(
+            tensor_args.output_grad.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
 }
 
 MorehMeanBackwardOperation::tensor_return_value_t MorehMeanBackwardOperation::create_output_tensors(
@@ -70,12 +55,7 @@ MorehMeanBackwardOperation::tensor_return_value_t MorehMeanBackwardOperation::cr
         return tensor_args.input_grad.value();
     }
 
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        output_grad.get_dtype(),
-        Layout::TILE,
-        output_grad.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), output_grad.device());
 }
 
 std::tuple<MorehMeanBackwardOperation::operation_attributes_t, MorehMeanBackwardOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
@@ -28,7 +28,7 @@ struct MorehMeanBackwardOperation {
         const std::optional<Tensor>& input_grad;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct MorehMeanBackwardFactory {
@@ -59,7 +59,7 @@ struct MorehMeanBackwardOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
@@ -40,7 +40,7 @@ void MorehNllLossStep1DeviceOperation::validate_on_program_cache_hit(
     validate_inputs(attributes, tensor_args);
 }
 
-MorehNllLossStep1DeviceOperation::shape_return_value_t MorehNllLossStep1DeviceOperation::compute_output_shapes(
+MorehNllLossStep1DeviceOperation::spec_return_value_t MorehNllLossStep1DeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& target_tensor = tensor_args.target_tensor;
     auto target_shape = target_tensor.get_shape();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
@@ -43,20 +43,15 @@ void MorehNllLossStep1DeviceOperation::validate_on_program_cache_hit(
 MorehNllLossStep1DeviceOperation::spec_return_value_t MorehNllLossStep1DeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& target_tensor = tensor_args.target_tensor;
-    auto target_shape = target_tensor.get_shape();
-
-    return target_shape;
+    return TensorSpec(
+        target_tensor.get_logical_shape(),
+        TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
 }
 
 MorehNllLossStep1DeviceOperation::tensor_return_value_t MorehNllLossStep1DeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& target_tensor = tensor_args.target_tensor;
-    auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
-    Layout layout{Layout::TILE};
-    auto device = tensor_args.target_tensor.device();
-
     return create_device_tensor(
-        output_shape, operation_attributes.dtype, layout, device, operation_attributes.memory_config);
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.target_tensor.device());
 }
 
 std::tuple<MorehNllLossStep1DeviceOperation::operation_attributes_t, MorehNllLossStep1DeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
@@ -26,7 +26,7 @@ struct MorehNllLossStep1DeviceOperation {
         const std::optional<Tensor>& weight_tensor;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
 
     using tensor_return_value_t = Tensor;
 
@@ -61,7 +61,7 @@ struct MorehNllLossStep1DeviceOperation {
 
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
@@ -65,22 +65,26 @@ void MorehNllLossStep2DeviceOperation::validate_on_program_cache_hit(
     validate_inputs(attributes, tensor_args);
 }
 
-MorehNllLossStep2DeviceOperation::shape_return_value_t MorehNllLossStep2DeviceOperation::compute_output_shapes(
+MorehNllLossStep2DeviceOperation::spec_return_value_t MorehNllLossStep2DeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (operation_attributes.reduction == NONE && tensor_args.output_tensor.has_value()) {
+        return tensor_args.output_tensor->get_tensor_spec();
+    }
+
     const auto& input_tensor = tensor_args.input_tensor;
     auto input_shape = input_tensor.get_shape().value;
     auto input_shape_without_padding = input_shape.without_padding();
     auto input_rank = input_shape.rank();
+    auto dtype = tensor_args.input_tensor.get_dtype();
+    Layout layout{Layout::TILE};
 
     auto C = input_shape[1];
 
-    ttnn::SmallVector<Padding::PadDimension> dimensions_pads;
     ttnn::SmallVector<uint32_t> output_shape_vec;
 
     // Need extend 1d output to 2d, because TT not support 1d tensor
     if (input_rank == 2) {
         output_shape_vec.push_back(1);
-        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
     }
 
     for (uint32_t dim = 0; dim < input_rank; dim++) {
@@ -90,25 +94,10 @@ MorehNllLossStep2DeviceOperation::shape_return_value_t MorehNllLossStep2DeviceOp
         }
 
         output_shape_vec.push_back(input_shape_without_padding[dim]);
-        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
     }
 
-    // padding output
-    {
-        uint32_t output_rank = output_shape_vec.size();
-        for (uint32_t dim = output_rank - 2; dim < output_rank; dim++) {
-            uint32_t up32_shape = tt::round_up(output_shape_vec[dim], 32);
-            uint32_t padding_back = up32_shape - output_shape_vec[dim];
-
-            output_shape_vec[dim] = up32_shape;
-            dimensions_pads[dim].back = padding_back;
-        }
-    }
-
-    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
-    auto output_shape = Shape(tt::tt_metal::LegacyShape{output_shape_vec, padding});
-
-    return output_shape;
+    auto output_shape = SimpleShape{output_shape_vec};
+    return TensorSpec(output_shape, TensorLayout(dtype, PageConfig(layout), operation_attributes.memory_config));
 }
 
 MorehNllLossStep2DeviceOperation::tensor_return_value_t MorehNllLossStep2DeviceOperation::create_output_tensors(
@@ -119,12 +108,8 @@ MorehNllLossStep2DeviceOperation::tensor_return_value_t MorehNllLossStep2DeviceO
 
     // In case reduction is 'sum' or 'mean' we need to create a tensor to save loss result and reduce it to
     // tensor_args.output_tensor using moreh_sum() operation
-    auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.input_tensor.get_dtype();
-    Layout layout{Layout::TILE};
-    auto device = tensor_args.input_tensor.device();
-
-    return create_device_tensor(output_shape, dtype, layout, device, operation_attributes.memory_config);
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
 std::tuple<MorehNllLossStep2DeviceOperation::operation_attributes_t, MorehNllLossStep2DeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
@@ -27,7 +27,7 @@ struct MorehNllLossStep2DeviceOperation {
         const std::optional<Tensor>& output_tensor;
     };
 
-    using shape_return_value_t = ttnn::Shape;
+    using spec_return_value_t = ttnn::TensorSpec;
 
     using tensor_return_value_t = ttnn::Tensor;
 
@@ -62,7 +62,7 @@ struct MorehNllLossStep2DeviceOperation {
 
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
@@ -90,6 +90,10 @@ MorehNllLossBackwardDeviceOperation::spec_return_value_t MorehNllLossBackwardDev
     if (tensor_args.input_grad_tensor.has_value()) {
         return {tensor_args.input_grad_tensor->get_tensor_spec()};
     }
+    return TensorSpec(
+        tensor_args.target_tensor.get_logical_shape(),
+        TensorLayout(
+            tensor_args.target_tensor.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
 }
 
 MorehNllLossBackwardDeviceOperation::tensor_return_value_t MorehNllLossBackwardDeviceOperation::create_output_tensors(
@@ -98,11 +102,8 @@ MorehNllLossBackwardDeviceOperation::tensor_return_value_t MorehNllLossBackwardD
         return {tensor_args.input_grad_tensor.value()};
     }
 
-    auto output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.target_tensor.get_dtype();
-    Layout layout{Layout::TILE};
-    auto device = tensor_args.target_tensor.device();
-    return create_device_tensor(output_shapes, dtype, layout, device, operation_attributes.memory_config);
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.target_tensor.device());
 }
 
 std::tuple<

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
@@ -90,10 +90,9 @@ MorehNllLossBackwardDeviceOperation::spec_return_value_t MorehNllLossBackwardDev
     if (tensor_args.input_grad_tensor.has_value()) {
         return {tensor_args.input_grad_tensor->get_tensor_spec()};
     }
-    return TensorSpec(
-        tensor_args.target_tensor.get_logical_shape(),
-        TensorLayout(
-            tensor_args.target_tensor.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
+    // To calculate the output shape, we need the channel_size. However, the required tensors, target and output_grad,
+    // do not contain the channel_size information.
+    TT_FATAL(false, "moreh_nll_loss_backward not support creating output tensors.");
 }
 
 MorehNllLossBackwardDeviceOperation::tensor_return_value_t MorehNllLossBackwardDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
@@ -85,12 +85,11 @@ void MorehNllLossBackwardDeviceOperation::validate_on_program_cache_hit(
     validate_inputs(attributes, tensor_args);
 }
 
-MorehNllLossBackwardDeviceOperation::shape_return_value_t MorehNllLossBackwardDeviceOperation::compute_output_shapes(
+MorehNllLossBackwardDeviceOperation::spec_return_value_t MorehNllLossBackwardDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // To calculate the output shape, we need the channel_size. However, the required tensors, target and output_grad,
-    // do not contain the channel_size information.
-    TT_FATAL(false, "moreh_nll_loss_backward not support create output tensors.");
-    return tensor_args.target_tensor.get_shape();
+    if (tensor_args.input_grad_tensor.has_value()) {
+        return {tensor_args.input_grad_tensor->get_tensor_spec()};
+    }
 }
 
 MorehNllLossBackwardDeviceOperation::tensor_return_value_t MorehNllLossBackwardDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
@@ -31,7 +31,7 @@ struct MorehNllLossBackwardDeviceOperation {
         const std::optional<Tensor>& input_grad_tensor;
     };
 
-    using shape_return_value_t = ttnn::Shape;
+    using spec_return_value_t = ttnn::TensorSpec;
 
     using tensor_return_value_t = ttnn::Tensor;
 
@@ -66,7 +66,7 @@ struct MorehNllLossBackwardDeviceOperation {
 
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
@@ -83,13 +83,16 @@ void MorehNllLossUnreducedBackwardDeviceOperation::validate_on_program_cache_hit
     validate_inputs(attributes, tensor_args);
 }
 
-MorehNllLossUnreducedBackwardDeviceOperation::shape_return_value_t
-MorehNllLossUnreducedBackwardDeviceOperation::compute_output_shapes(
+MorehNllLossUnreducedBackwardDeviceOperation::spec_return_value_t
+MorehNllLossUnreducedBackwardDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // To calculate the output shape, we need the channel_size. However, the required tensors, target and output_grad,
-    // do not contain the channel_size information.
-    TT_FATAL(false, "moreh_nll_loss_unreduced_backward not support create output tensors.");
-    return tensor_args.target_tensor.get_shape();
+    if (tensor_args.input_grad_tensor.has_value()) {
+        return {tensor_args.input_grad_tensor->get_tensor_spec()};
+    }
+    return TensorSpec(
+        tensor_args.target_tensor.get_logical_shape(),
+        TensorLayout(
+            tensor_args.target_tensor.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
 }
 
 MorehNllLossUnreducedBackwardDeviceOperation::tensor_return_value_t
@@ -99,11 +102,8 @@ MorehNllLossUnreducedBackwardDeviceOperation::create_output_tensors(
         return {tensor_args.input_grad_tensor.value()};
     }
 
-    auto output_shapes = compute_output_shapes(operation_attributes, tensor_args);
-    auto dtype = tensor_args.target_tensor.get_dtype();
-    Layout layout{Layout::TILE};
-    auto device = tensor_args.target_tensor.device();
-    return create_device_tensor(output_shapes, dtype, layout, device, operation_attributes.memory_config);
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.target_tensor.device());
 }
 
 std::tuple<

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
@@ -89,10 +89,9 @@ MorehNllLossUnreducedBackwardDeviceOperation::compute_output_specs(
     if (tensor_args.input_grad_tensor.has_value()) {
         return {tensor_args.input_grad_tensor->get_tensor_spec()};
     }
-    return TensorSpec(
-        tensor_args.target_tensor.get_logical_shape(),
-        TensorLayout(
-            tensor_args.target_tensor.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
+    // To calculate the output shape, we need the channel_size. However, the required tensors, target and output_grad,
+    // do not contain the channel_size information.
+    TT_FATAL(false, "moreh_nll_loss_unreduced_backward not support creating output tensors.");
 }
 
 MorehNllLossUnreducedBackwardDeviceOperation::tensor_return_value_t

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
@@ -28,7 +28,7 @@ struct MorehNllLossUnreducedBackwardDeviceOperation {
         const std::optional<Tensor>& input_grad_tensor;
     };
 
-    using shape_return_value_t = ttnn::Shape;
+    using spec_return_value_t = ttnn::TensorSpec;
 
     using tensor_return_value_t = ttnn::Tensor;
 
@@ -63,7 +63,7 @@ struct MorehNllLossUnreducedBackwardDeviceOperation {
 
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
@@ -131,38 +131,36 @@ void MorehNormOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehNormOperation::shape_return_value_t MorehNormOperation::compute_output_shapes(
+MorehNormOperation::spec_return_value_t MorehNormOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_shape = tensor_args.input.get_legacy_shape();
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
+
+    const auto& input_shape = tensor_args.input.get_logical_shape();
     const auto input_rank = input_shape.rank();
     const auto dim = operation_attributes.dim;
     const bool is_tile_dim = (dim == input_rank - 1 || dim == input_rank - 2);
 
     if (operation_attributes.keepdim) {
         auto shape = input_shape;
-        auto padding = shape.padding();
-        if (is_tile_dim) {
-            shape[dim] = tt::constants::TILE_HEIGHT;
-            padding[dim] = Padding::PadDimension{0, 31};
-        } else {
-            shape[dim] = 1;
-        }
-        return Shape{tt::tt_metal::LegacyShape(shape, padding)};
+        shape[dim] = 1;
+        return TensorSpec(
+            shape,
+            TensorLayout(tensor_args.input.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
     }
 
     ttnn::SmallVector<uint32_t> shape;
-    ttnn::SmallVector<Padding::PadDimension> pad_dimensions;
-    const std::size_t output_rank = is_tile_dim ? input_rank : input_rank - 1;
-    auto input_padding = input_shape.padding();
     for (int i = 0; i < input_rank; ++i) {
         bool is_reduced_dim = (i == dim);
         if (is_reduced_dim && !is_tile_dim) {
             continue;
         }
-        shape.push_back((is_reduced_dim && is_tile_dim) ? (tt::constants::TILE_HEIGHT) : (input_shape[i]));
-        pad_dimensions.push_back((is_reduced_dim && is_tile_dim) ? (Padding::PadDimension{0, 31}) : (input_padding[i]));
+        shape.push_back(input_shape[i]);
     }
-    return Shape{tt::tt_metal::LegacyShape(shape, Padding(pad_dimensions, input_padding.pad_value()))};
+    return TensorSpec(
+        ttnn::SimpleShape(shape),
+        TensorLayout(tensor_args.input.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
 };
 
 MorehNormOperation::tensor_return_value_t MorehNormOperation::create_output_tensors(
@@ -172,12 +170,7 @@ MorehNormOperation::tensor_return_value_t MorehNormOperation::create_output_tens
         return output.value();
     }
     const auto& input = tensor_args.input;
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        input.get_dtype(),
-        Layout::TILE,
-        input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), input.device());
 }
 
 std::tuple<MorehNormOperation::operation_attributes_t, MorehNormOperation::tensor_args_t> MorehNormOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.hpp
@@ -45,7 +45,7 @@ struct MorehNormOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     DEFINE_PROGRAM_FACTORY(ProgramFactoryWOther)
@@ -58,7 +58,7 @@ struct MorehNormOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
@@ -32,9 +32,17 @@ void MorehNormBackwardOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 };
 
-MorehNormBackwardOperation::shape_return_value_t MorehNormBackwardOperation::compute_output_shapes(
+MorehNormBackwardOperation::spec_return_value_t MorehNormBackwardOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tensor_args.input.get_shape();
+    if (tensor_args.input_grad.has_value()) {
+        return tensor_args.input_grad->get_tensor_spec();
+    }
+    return TensorSpec(
+        tensor_args.input.get_logical_shape(),
+        TensorLayout(
+            tensor_args.input.get_dtype(),
+            PageConfig(tensor_args.input.get_layout()),
+            operation_attributes.memory_config));
 };
 
 MorehNormBackwardOperation::tensor_return_value_t MorehNormBackwardOperation::create_output_tensors(
@@ -42,13 +50,7 @@ MorehNormBackwardOperation::tensor_return_value_t MorehNormBackwardOperation::cr
     if (tensor_args.input_grad.has_value()) {
         return tensor_args.input_grad.value();
     }
-    const auto& input = tensor_args.input;
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        input.get_dtype(),
-        input.get_layout(),
-        input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<MorehNormBackwardOperation::operation_attributes_t, MorehNormBackwardOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
@@ -50,7 +50,7 @@ struct MorehNormBackwardOperation {
         const std::optional<Tensor>& input_grad;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     DEFINE_PROGRAM_FACTORY(ProgramFactory)
@@ -61,7 +61,7 @@ struct MorehNormBackwardOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.hpp
@@ -31,7 +31,7 @@ struct MorehSgdOperation {
         const std::optional<Tensor>& momentum_buffer_out;
     };
 
-    using shape_return_value_t = std::vector<std::optional<Shape>>;
+    using spec_return_value_t = std::vector<std::optional<TensorSpec>>;
     using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct ProgramFactory {
@@ -63,7 +63,7 @@ struct MorehSgdOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& param_in,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
@@ -106,9 +106,18 @@ void MorehSoftmaxOperation::validate_on_program_cache_hit(
     validate_inputs(operation_attributes, tensor_args);
 }
 
-MorehSoftmaxOperation::shape_return_value_t MorehSoftmaxOperation::compute_output_shapes(
+MorehSoftmaxOperation::spec_return_value_t MorehSoftmaxOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tensor_args.input.get_shape();
+    if (tensor_args.output.has_value()) {
+        return tensor_args.output->get_tensor_spec();
+    }
+
+    return TensorSpec(
+        tensor_args.input.get_logical_shape(),
+        TensorLayout(
+            tensor_args.input.get_dtype(),
+            PageConfig(tensor_args.input.get_layout()),
+            operation_attributes.memory_config));
 }
 
 MorehSoftmaxOperation::tensor_return_value_t MorehSoftmaxOperation::create_output_tensors(
@@ -118,10 +127,7 @@ MorehSoftmaxOperation::tensor_return_value_t MorehSoftmaxOperation::create_outpu
         return output.value();
     }
 
-    const auto& input = tensor_args.input;
-    const auto& output_shape = input.get_shape();
-    return create_device_tensor(
-        output_shape, input.get_dtype(), input.get_layout(), input.device(), operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<MorehSoftmaxOperation::operation_attributes_t, MorehSoftmaxOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
@@ -41,7 +41,7 @@ struct MorehSoftmaxOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
 #define DEFINE_SOFTMAX_FACTORY(factory_name)                                                \
@@ -84,7 +84,7 @@ struct MorehSoftmaxOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static MorehSoftmaxOpParallelizationStrategy get_parallelization_strategy(
         const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
@@ -42,7 +42,7 @@ struct MorehSoftmaxBackwardOperation {
         const std::optional<Tensor>& input_grad_tensor;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
 #define DEFINE_SOFTMAX_BACKWARD_FACTORY(factory_name)                                       \
@@ -85,7 +85,7 @@ struct MorehSoftmaxBackwardOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static void validate_inputs(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static MorehSoftmaxBackwardOpParallelizationStrategy get_parallelization_strategy(
         const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
@@ -62,8 +62,12 @@ void MorehSumOperation::validate_on_program_cache_hit(
     validate_tensors(operation_attributes, tensor_args);
 };
 
-MorehSumOperation::shape_return_value_t MorehSumOperation::compute_output_shapes(
+MorehSumOperation::spec_return_value_t MorehSumOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        return {tensor_args.output->get_tensor_spec()};
+    }
+
     const auto& input = tensor_args.input;
     const auto& input_shape = input.get_shape();
     const auto input_rank = input_shape.rank();
@@ -115,7 +119,13 @@ MorehSumOperation::shape_return_value_t MorehSumOperation::compute_output_shapes
     }
 
     log_debug(tt::LogOp, "{}:{} output_shape {}", __func__, __LINE__, output_shape);
-    return {output_shape};
+    return TensorSpec(
+        output_shape.logical_shape(),
+        TensorLayout::fromLegacyPaddedShape(
+            tensor_args.input.get_dtype(),
+            PageConfig(tensor_args.input.get_layout()),
+            operation_attributes.memory_config,
+            output_shape));
 };
 
 MorehSumOperation::tensor_return_value_t MorehSumOperation::create_output_tensors(
@@ -126,12 +136,7 @@ MorehSumOperation::tensor_return_value_t MorehSumOperation::create_output_tensor
     }
 
     log_debug(tt::LogOp, "{}:{} create output tensor", __func__, __LINE__);
-    return create_device_tensor(
-        compute_output_shapes(operation_attributes, tensor_args),
-        tensor_args.input.get_dtype(),
-        tensor_args.input.get_layout(),
-        tensor_args.input.device(),
-        operation_attributes.memory_config);
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
 std::tuple<MorehSumOperation::operation_attributes_t, MorehSumOperation::tensor_args_t> MorehSumOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
@@ -48,7 +48,7 @@ struct MorehSumOperation {
         const std::optional<Tensor>& output;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     MOREH_SUM_FACTORY_H(MorehSumHFactory)
@@ -69,7 +69,7 @@ struct MorehSumOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
@@ -23,7 +23,7 @@ struct MorehSumBackwardOperation {
         const std::optional<Tensor>& input_grad;
     };
 
-    using shape_return_value_t = Shape;
+    using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
     struct ProgramFactory {
@@ -54,7 +54,7 @@ struct MorehSumBackwardOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& output_grad,


### PR DESCRIPTION
### Ticket

### Problem description
We're continuing to port all OPs from compute_output_shapes to the new compute_output_specs

### What's changed
Ported all Moreh OPs to compute_output_specs

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12408552437)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
