### PR TITLE
Isolate tracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,18 +253,11 @@ add_link_options(
 if(ENABLE_CODE_TIMERS)
     add_compile_definitions(TT_ENABLE_CODE_TIMERS)
 endif()
-if(ENABLE_TRACY)
-    add_compile_definitions(TRACY_ENABLE)
-    add_compile_options(-fno-omit-frame-pointer)
-    add_link_options(-rdynamic)
-endif()
+include(tracy)
 
 ############################################################################################################################
 # Build subdirectories
 ############################################################################################################################
-if(ENABLE_TRACY)
-    include(tracy)
-endif()
 
 add_subdirectory(tt_metal)
 add_subdirectory(ttnn)

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -1,17 +1,21 @@
 # Built as outlined in Tracy documentation (pg.12)
 set(TRACY_HOME ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy)
 
+if(NOT ENABLE_TRACY)
+    # Stub Tracy::TracyClient to provide the headers which themselves provide stubs
+    add_library(TracyClient INTERFACE)
+    add_library(Tracy::TracyClient ALIAS TracyClient)
+    target_include_directories(TracyClient SYSTEM INTERFACE ${TRACY_HOME}/public)
+    return()
+endif()
+
 add_subdirectory(${TRACY_HOME})
+
 set_target_properties(
     TracyClient
     PROPERTIES
         EXCLUDE_FROM_ALL
             TRUE
-)
-
-set_target_properties(
-    TracyClient
-    PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY
             "${PROJECT_BINARY_DIR}/lib"
         ARCHIVE_OUTPUT_DIRECTORY
@@ -21,6 +25,10 @@ set_target_properties(
         OUTPUT_NAME
             "tracy"
 )
+
+target_compile_definitions(TracyClient PUBLIC TRACY_ENABLE)
+target_compile_options(TracyClient PUBLIC -fno-omit-frame-pointer)
+target_link_options(TracyClient PUBLIC -rdynamic)
 
 # Our current fork of tracy does not have CMake support for these subdirectories
 # Once we update, we can change this

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(
         magic_enum
         fmt::fmt-header-only
         span
-        $<$<BOOL:${ENABLE_TRACY}>:TracyClient>
+        Tracy::TracyClient
     PRIVATE
         profiler
         common

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(
         Metalium::Metal::STL
         Metalium::Metal::LLRT
         umd::Firmware
+    PRIVATE
+        Tracy::TracyClient
 )
 
 target_include_directories(

--- a/tt_metal/common/bfloat16.hpp
+++ b/tt_metal/common/bfloat16.hpp
@@ -11,7 +11,7 @@
 
 #include "tt_metal/common/assert.hpp"
 
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 
 class bfloat16 {
 private:

--- a/tt_metal/common/bfloat4.hpp
+++ b/tt_metal/common/bfloat4.hpp
@@ -11,7 +11,7 @@
 
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "blockfloat_common.hpp"
 
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -11,7 +11,7 @@
 
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "blockfloat_common.hpp"
 
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor

--- a/tt_metal/common/blockfloat_common.hpp
+++ b/tt_metal/common/blockfloat_common.hpp
@@ -11,7 +11,7 @@
 
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "tt_metal/impl/tile/tile.hpp"
 
 inline uint8_t get_max_exp(const std::vector<uint32_t>& vec, bool is_exp_a) {

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -15,7 +15,7 @@
 
 #include "umd/device/tt_xy_pair.h"
 #include "tt_metal/common/assert.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
 #include "tt_metal/tt_stl/span.hpp"
 

--- a/tt_metal/common/test_tiles.hpp
+++ b/tt_metal/common/test_tiles.hpp
@@ -14,7 +14,7 @@
 #include "tt_metal/tt_stl/span.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/common/assert.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "math.hpp"
 
 namespace tests::utils {

--- a/tt_metal/common/utils.cpp
+++ b/tt_metal/common/utils.cpp
@@ -4,7 +4,7 @@
 
 #include "common/utils.hpp"
 #include <mutex>
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "llrt/rtoptions.hpp"
 
 #include <filesystem>

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -13,7 +13,7 @@
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/common/math.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/detail/CMakeLists.txt
+++ b/tt_metal/detail/CMakeLists.txt
@@ -4,4 +4,4 @@ set(DETAIL_SRC
 )
 
 add_library(detail OBJECT ${DETAIL_SRC})
-target_link_libraries(detail PUBLIC common)
+target_link_libraries(detail PUBLIC common PRIVATE Metalium::Metal::Impl)

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -5,4 +5,4 @@ set(DISTRIBUTED_SRC
 )
 
 add_library(distributed OBJECT ${DISTRIBUTED_SRC})
-target_link_libraries(distributed PUBLIC common)
+target_link_libraries(distributed PUBLIC common PRIVATE Metalium::Metal::Impl)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
     PUBLIC
         common
         Metalium::Metal::LLRT
+        Tracy::TracyClient
     PRIVATE
         Boost::smart_ptr
         range-v3::range-v3

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -10,7 +10,7 @@
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/impl/trace/trace.hpp"
 #include "tt_metal/common/core_descriptor.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "impl/debug/dprint_server.hpp"
 #include "impl/debug/watcher_server.hpp"

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -15,8 +15,7 @@
 
 #include "common/env_lib.hpp"
 #include "lock_free_queue.hpp"
-#include "tt_metal/third_party/tracy/public/common/TracySystem.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 
 #if defined(TRACY_ENABLE)
 #define TracyTTThreadName(name, id)                     \

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -27,7 +27,7 @@
 #include "tt_metal/jit_build/genfiles.hpp"
 #include "tt_metal/llrt/llrt.hpp"
 #include "tt_metal/program.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -7,7 +7,7 @@ set(JIT_BUILD_SRCS
 )
 
 add_library(jit_build OBJECT ${JIT_BUILD_SRCS})
-target_link_libraries(jit_build PUBLIC common)
+target_link_libraries(jit_build PUBLIC common PRIVATE Tracy::TracyClient)
 
 if(DEFINED VERSION_HASH)
     target_compile_definitions(jit_build PRIVATE "-DGIT_COMMIT_HASH=\"${VERSION_HASH}\"")

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -14,7 +14,7 @@
 #include "jit_build/data_format.hpp"
 #include "jit_build/settings.hpp"
 #include "hostdevcommon/common_values.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "tt_metal/tt_stl/aligned_allocator.hpp"
 #include "llrt/rtoptions.hpp"
 

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -97,5 +97,6 @@ target_link_libraries(
         HAL::grayskull
         HAL::wormhole
         HAL::blackhole
+        Tracy::TracyClient
 )
 target_compile_options(llrt PRIVATE -Wno-int-to-pointer-cast)

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -42,7 +42,7 @@
 
 #include "llrt/hal.hpp"
 
-#include "third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "umd/device/tt_simulation_device.h"
 
 #include "tt_metal/impl/debug/sanitize_noc_host.hpp"

--- a/tt_metal/tools/profiler/CMakeLists.txt
+++ b/tt_metal/tools/profiler/CMakeLists.txt
@@ -4,4 +4,4 @@ set(PROFILER_SRC
 )
 
 add_library(profiler OBJECT ${PROFILER_SRC})
-target_link_libraries(profiler PUBLIC common)
+target_link_libraries(profiler PUBLIC common PRIVATE Tracy::TracyClient)

--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -16,8 +16,8 @@
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "ttnn/operation.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/TracyC.h"
+#include "tracy/Tracy.hpp"
+#include "tracy/TracyC.h"
 
 using json = nlohmann::json;
 

--- a/tt_metal/tools/profiler/profiler.cpp
+++ b/tt_metal/tools/profiler/profiler.cpp
@@ -15,7 +15,7 @@
 #include "hostdevcommon/profiler_common.h"
 #include "llrt/rtoptions.hpp"
 #include "dev_msgs.h"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 #include "tt_metal/impl/device/device.hpp"
 
 namespace tt {

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -15,8 +15,8 @@
 #include "llrt/llrt.hpp"
 #include "tools/profiler/profiler_state.hpp"
 #include "tools/profiler/common.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/TracyTTDevice.hpp"
-#include "tt_metal/third_party/tracy/public/common/TracyTTDeviceData.hpp"
+#include "tracy/TracyTTDevice.hpp"
+#include "common/TracyTTDeviceData.hpp"
 
 using std::chrono::duration;
 using std::chrono::duration_cast;

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -14,7 +14,7 @@
 
 #include "tt_metal/detail/tt_metal.hpp"
 
-#include "tt_metal/third_party/tracy/public/tracy/TracyTTDevice.hpp"
+#include "tracy/TracyTTDevice.hpp"
 #include "tt_metal/impl/device/device.hpp"
 
 namespace tt {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -30,7 +30,7 @@
 #include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/include/tt_metal/global_circular_buffer.hpp"
 #include "tt_metal/include/tt_metal/program.hpp"
-#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 
 #include "tt_metal/graph/graph_tracking.hpp"
 


### PR DESCRIPTION
### Ticket
#14001

### Problem description
Tracy is being referenced "behind the scenes" which breaks when things are shuffled around.

### What's changed
Create a Tracy::TracyClient target that contains everything appropriate:
* Headers always (even when disabled)
* The #define to enable it, when enabled
* compile/link flags as appropriate

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12387386339
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12398730711