### PR TITLE
#16165: Disabling test that depends on some machine state to pass

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -990,6 +990,7 @@ def test_nei_ttnn(input_shapes, scalar, device):
     assert comp_pass
 
 
+@pytest.mark.skip(reason="#16165: Test is broken if you run after individually.")
 @pytest.mark.parametrize(
     "input_shapes",
     (


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16165)

### Problem description
Test is broken if you run independently.

### What's changed
Skipping in CI.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
