### PR TITLE
#15891: improve full accuracy and fix full bugs

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_full.py
+++ b/tests/ttnn/unit_tests/operations/test_full.py
@@ -27,14 +27,14 @@ from tests.ttnn.utils_for_testing import assert_equal
 )
 def test_full_int(device, input_shape, fill_value):
     torch_any = torch.randint(0, 100, (input_shape), dtype=torch.int32)
-    torch_output_tensor = torch.full(input_shape, fill_value)
+    torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
 
     any = ttnn.from_torch(torch_any, device=device, layout=ttnn.TILE_LAYOUT)
-    output_tensor = ttnn.moreh_full(input_shape, fill_value, any)
-    assert ttnn.is_tensor_storage_on_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
+    tt_output = ttnn.moreh_full(input_shape, fill_value, any)
+    assert ttnn.is_tensor_storage_on_device(tt_output)
+    tt_output_cpu = ttnn.to_torch(tt_output)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert torch.equal(torch_output, tt_output_cpu)
 
 
 @pytest.mark.parametrize(
@@ -43,12 +43,17 @@ def test_full_int(device, input_shape, fill_value):
         [1, 3],  # single tile
         [32, 32],  # single tile
         [5, 96, 64],  # multiple tiles
-        [3, 91, 67, 77],  # not multiple of 32
     ],
 )
 @pytest.mark.parametrize(
     "fill_value",
-    [0.15, -1.2],
+    [
+        3.14,
+        2.00781250,  # mantissa: 0000 0001, bf16 round down test
+        2.00830080,  # mantissa: 0000 0001 0001, bf16 round up test
+        2.02343750,  # mantissa: 0000 0011, bf16 round up test
+        -3.9921875,  # test mantissa overflow. answer should be 4
+    ],
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -60,13 +65,13 @@ def test_full_int(device, input_shape, fill_value):
 def test_full_float(device, input_shape, fill_value, dtype):
     torch_any = torch.rand((input_shape), dtype=dtype)
 
-    torch_output_tensor = torch.full(input_shape, fill_value)
+    torch_output = torch.full(input_shape, fill_value, dtype=dtype)
     any = ttnn.from_torch(torch_any, device=device, layout=ttnn.TILE_LAYOUT)
-    output_tensor = ttnn.moreh_full(input_shape, fill_value, any)
-    assert ttnn.is_tensor_storage_on_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
+    tt_output = ttnn.moreh_full(input_shape, fill_value, any)
+    assert ttnn.is_tensor_storage_on_device(tt_output)
+    tt_output_cpu = ttnn.to_torch(tt_output)
 
-    assert_equal(torch_output_tensor, output_tensor)
+    assert torch.equal(torch_output, tt_output_cpu)
 
 
 @pytest.mark.parametrize(
@@ -88,12 +93,12 @@ def test_full_float(device, input_shape, fill_value, dtype):
 def test_full_callback(device, input_shape, fill_value, layout, use_program_cache):
     for i in range(2):
         torch_any = torch.randint(0, 100, (input_shape), dtype=torch.int32)
-        torch_output_tensor = torch.full(input_shape, fill_value)
+        torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
 
         any = ttnn.from_torch(torch_any, device=device, layout=ttnn.TILE_LAYOUT)
-        output_tensor = ttnn.moreh_full(input_shape, fill_value, any)
-        assert ttnn.is_tensor_storage_on_device(output_tensor)
-        output_tensor = ttnn.to_torch(output_tensor)
+        tt_output = ttnn.moreh_full(input_shape, fill_value, any)
+        assert ttnn.is_tensor_storage_on_device(tt_output)
+        tt_output_cpu = ttnn.to_torch(tt_output)
         torch_dummy = torch.randn([32, 32])
         ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
         if i == 0:
@@ -101,4 +106,5 @@ def test_full_callback(device, input_shape, fill_value, layout, use_program_cach
             assert num_program_cache_entries > 0
         else:
             assert device.num_program_cache_entries() == num_program_cache_entries
-        assert_equal(torch_output_tensor, output_tensor)
+
+        assert torch.equal(torch_output, tt_output_cpu)

--- a/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_program_factory.cpp
@@ -9,6 +9,28 @@
 using namespace tt;
 using namespace tt::constants;
 
+// After the full modification and if there are no issues in the overall tests, it will be added to `bfloat16.hpp` and
+// applied globally.
+uint32_t get_bfloat16_rounded(const float val) {
+    uint32_t float_bits = *reinterpret_cast<const uint32_t*>(&val);
+
+    // upper 16 bits
+    uint16_t bfloat16_bits = float_bits >> 16;
+
+    // check Guard, Round, Sticky bits from lower 16 bits
+    uint32_t lower_bits = float_bits & 0xFFFF;
+    uint32_t guard_bit = (lower_bits >> 15) & 1;
+    uint32_t round_bit = (lower_bits >> 14) & 1;
+    uint32_t sticky_bit = (lower_bits & 0x3FFF) != 0;
+
+    // Tie-to-even rounding rule
+    if (guard_bit && (round_bit || sticky_bit || (bfloat16_bits & 1))) {
+        bfloat16_bits += 1;
+    }
+
+    return static_cast<uint32_t>(bfloat16_bits) << 16;
+}
+
 union datatype {
     uint32_t u32;
     float f32;
@@ -28,12 +50,6 @@ FullOperation::ProgramFactory::cached_program_t FullOperation::ProgramFactory::c
 
     tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(dtype);
     uint32_t single_tile_size = tt::tt_metal::detail::TileSize(data_format);
-
-    if (std::holds_alternative<int>(fill_value)) {
-        u.u32 = std::get<int>(fill_value);
-    } else if (std::holds_alternative<float>(fill_value)) {
-        u.f32 = std::get<float>(fill_value);
-    }
 
     // Create program
     Program program = Program();
@@ -57,6 +73,17 @@ FullOperation::ProgramFactory::cached_program_t FullOperation::ProgramFactory::c
         default: break;
     }
 
+    if (std::holds_alternative<int>(fill_value)) {
+        u.u32 = std::get<int>(fill_value);
+    } else if (std::holds_alternative<float>(fill_value)) {
+        auto float_fill_value = std::get<float>(fill_value);
+        if (dtype == DataType::BFLOAT16) {
+            u.u32 = get_bfloat16_rounded(float_fill_value);
+        } else {
+            u.f32 = float_fill_value;
+        }
+    }
+
     auto writer_id = CreateWriteKernel(
         program,
         "ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp",
@@ -78,7 +105,7 @@ FullOperation::ProgramFactory::cached_program_t FullOperation::ProgramFactory::c
         } else {
             TT_THROW("Core not in specified core ranges");
         }
-        std::vector<uint32_t> writer_args = {u.u32, output.buffer()->address(), num_tiles_per_core, tile_offset};
+        std::vector<uint32_t> writer_args = {output.buffer()->address(), u.u32, num_tiles_per_core, tile_offset};
         SetRuntimeArgs(program, writer_id, core, writer_args);
         tile_offset += num_tiles_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
@@ -13,8 +13,8 @@ typedef union {
 constexpr uint32_t onetile = 1;
 
 void kernel_main() {
-    uint32_t fill_value = get_arg_val<uint32_t>(0);
-    uint32_t output_addr = get_arg_val<uint32_t>(1);
+    uint32_t output_addr = get_arg_val<uint32_t>(0);
+    uint32_t fill_value = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
     uint32_t start_id = get_arg_val<uint32_t>(3);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15891#issue-2731910389

### Problem description
Many operations accept float scalar values as input, in addition to tensors.
These values are used in computations within the kernel, but when the scalar values are treated as bfloat16, they are truncated without rounding.
And truncation introduces more error compared to rounding.


### What's changed
1. The scalar values are rounded on the host, ensuring that when they are stored in the bfloat16 cb, the values with less error are used.
2. To expedite verification, I plan to apply the changes only to the "full" op and run the GitHub action to check for any issues. The changes for other ops will be included in a subsequent PR.
3. I have added a bfloat16 rounding test to the test_full.
4. I have fixed an issue with the full op's cache implementation.
5. Fix same issue in full_like op


prev bfloat16 full result
```
torch_output tensor([[0.1504, 0.1504, 0.1504]], dtype=torch.bfloat16)
tt_output_cpu TorchTensor([[0.1494, 0.1494, 0.1494]], dtype=torch.bfloat16)

torch_output tensor([[-1.2031, -1.2031, -1.2031]], dtype=torch.bfloat16)
tt_output_cpu TorchTensor([[-1.1953, -1.1953, -1.1953]], dtype=torch.bfloat16)
```

Now the result of "full" is exactly the same.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12414375567/job/34658872329
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
