### PR TITLE
#15221: Post completion messages to dispatch_s

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -406,7 +406,8 @@ int main() {
                     NOC_UNICAST_WRITE_VC,
                     1,
                     31 /*wrap*/,
-                    false /*linked*/);
+                    false /*linked*/,
+                    true /*posted*/);
             }
         }
 
@@ -529,7 +530,8 @@ int main() {
                     NOC_UNICAST_WRITE_VC,
                     1,
                     31 /*wrap*/,
-                    false /*linked*/);
+                    false /*linked*/,
+                    true /*posted*/);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
         }

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -176,7 +176,15 @@ int main() {
                     DISPATCH_MESSAGE_ADDR + mailboxes->go_message.dispatch_message_offset);
                 DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 CLEAR_PREVIOUS_LAUNCH_MESSAGE_ENTRY_FOR_WATCHER();
-                noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
+                noc_fast_atomic_increment(
+                    noc_index,
+                    NCRISC_AT_CMD_BUF,
+                    dispatch_addr,
+                    NOC_UNICAST_WRITE_VC,
+                    1,
+                    31 /*wrap*/,
+                    false /*linked*/,
+                    true /*posted*/);
                 mailboxes->launch_msg_rd_ptr = (launch_msg_rd_ptr + 1) & (launch_msg_buffer_num_entries - 1);
             }
 

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -109,7 +109,14 @@ void notify_dispatch_core_done(uint64_t dispatch_addr) {
     }
     DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
     noc_fast_atomic_increment(
-        noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
+        noc_index,
+        NCRISC_AT_CMD_BUF,
+        dispatch_addr,
+        NOC_UNICAST_WRITE_VC,
+        1,
+        31 /*wrap*/,
+        false /*linked*/,
+        true /*posted*/);
 }
 
 }  // namespace internal_


### PR DESCRIPTION

### Ticket
#15221 

### Problem description
We're seeing a latency of around 500ns from when the dispatch message is sent to when it's received, in the case where a many are sent at the same time.

### What's changed
We never wait on the acks from these completion messages, so make them posted to avoid contention from a lot of replies being sent at once. In the case where every worker is sending them at the same time, this can halve the latency from 500ns to 250ns (on wormhole).

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
