### PR TITLE
Fix cb allocation errors for halo and conv2d

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -610,7 +610,7 @@ class resnet50:
             if type(device) == ttnn.MeshDevice and device.get_num_devices() > 8:
                 self.conv1_config.act_block_h_override = 64
             else:
-                self.conv1_config.act_block_h_override = 256
+                self.conv1_config.act_block_h_override = 49 * 32
 
         self.conv1_kernel_size = (4, 4)
         self.conv1_stride = (1, 1)

--- a/models/demos/vgg/tt/ttnn_vgg.py
+++ b/models/demos/vgg/tt/ttnn_vgg.py
@@ -50,7 +50,7 @@ conv_ttnn_params = [
 ]
 conv_feature_ids = [0, 2, 5, 7, 10, 12, 14, 17, 19, 21, 24, 26, 28]
 classifier_ids = [0, 3, 6]
-h_override = [None, None, None, None, None, 256, 256, None, None, None, None, None, None]
+h_override = [None, None, None, None, None, 7 * 32, 7 * 32, None, None, None, None, None, None]
 
 
 def ttnn_vgg16(
@@ -181,7 +181,7 @@ conv_ttnn_params_2 = [
     [512, 512, 14, 14],
     [512, 512, 14, 14],
 ]
-height_override_11 = [None, None, None, 256, None, None, None, None]
+height_override_11 = [None, None, None, 7 * 32, None, None, None, None]
 
 
 def ttnn_vgg11(

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -34,7 +34,7 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 2, 1122.0),),
+    ((1, 2, 1053.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -46,11 +46,11 @@ def create_unet_model_parameters(
     for key in parameters.keys():
         parameters[key].module = getattr(model, key)
 
-    parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c1["use_split_reader"] = True
     parameters.c1["use_activation_double_buffer"] = True
     parameters.c1["input_channels_alignment"] = 16
-    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c1_2["use_split_reader"] = True
     parameters.c1_2["use_activation_double_buffer"] = True
     parameters.c1_2["input_channels_alignment"] = 16
@@ -111,6 +111,7 @@ def create_unet_model_parameters(
     parameters.c6_3["use_activation_double_buffer"] = True
     parameters.c6_3["input_channels_alignment"] = 16
 
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c7["use_activation_double_buffer"] = True
     parameters.c7["use_split_reader"] = True
     parameters.c7["input_channels_alignment"] = 16
@@ -136,7 +137,6 @@ def create_unet_model_parameters(
     parameters.c8_3["use_split_reader"] = True
     parameters.c8_3["input_channels_alignment"] = 16
 
-    parameters.output_layer["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
     parameters.output_layer["use_activation_double_buffer"] = True
     parameters.output_layer["use_split_reader"] = True
     parameters.output_layer["input_channels_alignment"] = 16

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -462,6 +462,7 @@ class UNet:
         ttnn.deallocate(c4_residual)
         x = self.upblock2(x, c3_residual)
         ttnn.deallocate(c3_residual)
+        c2_residual = ttnn.to_memory_config(c2_residual, ttnn.L1_MEMORY_CONFIG)
         x = self.upblock3(x, c2_residual)
         ttnn.deallocate(c2_residual)
         x = self.upblock4(x, c1_residual)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -131,14 +131,13 @@ Result conv2d(
         in_channels_padded = tt::round_up(in_channels, conv_config.input_channels_alignment);
     }
 
-    uint32_t nhw_out_padded_ntile = get_num_cores_nhw_from_parallel_config(output_parallel_config) *
-                                    conv_out_memory_config.shard_spec.value().shape[0] / tt::constants::TILE_HEIGHT;
+    uint32_t nhw_out_padded_ntile_per_core = conv_out_memory_config.shard_spec.value().shape[0] / tt::constants::TILE_HEIGHT;
 
     OptimizedConvBlockConfig opt_conv_op_block_config = determine_per_core_conv_block_config(
         parallel_config,
         opt_conv_op_parallel_config,
         in_channels_padded,
-        nhw_out_padded_ntile,
+        nhw_out_padded_ntile_per_core,
         conv_config.act_block_h_override,
         conv_config.act_block_w_div,
         kernel_size[0],

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -108,8 +108,9 @@ sliding_window::ParallelConfig determine_parallel_config(
     const CoreCoord& compute_grid_size,
     ShardOrientation block_shard_orientation,
     bool enable_channels_padding,
-    bool is_out_tiled=true,
-    bool is_non_tile_mul_shard_width=false);
+    bool is_out_tiled = true,
+    bool is_non_tile_mul_shard_width = false,
+    uint32_t act_block_h_override = 0);
 
 sliding_window::ParallelConfig determine_output_parallel_config(
     const sliding_window::ParallelConfig& input_parallel_config,
@@ -139,7 +140,7 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     const sliding_window::ParallelConfig& parallel_config,
     const OptimizedConvParallelizationConfig& conv_op_parallel_config,
     uint32_t padded_in_channels,
-    uint32_t padded_input_height_ntiles,
+    uint32_t padded_output_height_ntiles_per_core,
     uint32_t act_block_h_override,
     uint32_t act_block_w_div,
     uint32_t window_h,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -884,10 +884,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         total_num_cores_per_weight_slice = num_cores_y_per_weight_slice_width * num_cores_x;
         assert(total_num_cores * per_core_out_matrix_height_ntiles >= act_matrix_height_ntiles);
     }
-    // assert(per_core_out_matrix_height_ntiles % act_block_h_ntiles == 0);
-    // uint32_t num_blocks_act_h_per_core = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
-    uint32_t num_blocks_act_h_per_core =
-        (per_core_out_matrix_height_ntiles + act_block_h_ntiles - 1) / act_block_h_ntiles;
+    assert(per_core_out_matrix_height_ntiles % act_block_h_ntiles == 0);
+    uint32_t num_blocks_act_h_per_core = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
     // assert(per_core_out_matrix_height_ntiles % out_block_h_ntiles == 0);
     // uint32_t num_blocks_out_h_per_core = per_core_out_matrix_height_ntiles / out_block_h_ntiles;
     uint32_t num_blocks_out_h_per_core =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -609,7 +609,8 @@ static OptimizedConvBlockConfig get_opt_block_config(
         shard_orientation,
         !mm_conv,
         !use_non_tile_height,
-        is_non_tile_mul_width);
+        is_non_tile_mul_width,
+        conv_config.act_block_h_override);
 
     auto output_parallel_config = parallel_config;
     if (conv_config.shard_layout.value() == ttnn::TensorMemoryLayout::WIDTH_SHARDED && !mm_conv) {
@@ -642,14 +643,14 @@ static OptimizedConvBlockConfig get_opt_block_config(
         in_channels,
         get_num_cores_channels_from_parallel_config(parallel_config) * conv_config.input_channels_alignment);
 
-    uint32_t nhw_out_padded_ntile = get_num_cores_nhw_from_parallel_config(output_parallel_config) *
-                                    conv_out_memory_config.shard_spec.value().shape[0] / tt::constants::TILE_HEIGHT;
+    uint32_t nhw_out_padded_ntile_per_core =
+        conv_out_memory_config.shard_spec.value().shape[0] / tt::constants::TILE_HEIGHT;
 
     return determine_per_core_conv_block_config(
         parallel_config,
         opt_conv_op_parallel_config,
         in_channels_padded,
-        nhw_out_padded_ntile,
+        nhw_out_padded_ntile_per_core,
         conv_config.act_block_h_override,
         conv_config.act_block_w_div,
         kernel_size[0],

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
 
 namespace ttnn::operations::sliding_window::halo {
@@ -33,7 +34,7 @@ void HaloDeviceOperation::validate(const std::vector<Tensor>& input_tensors) con
 std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input = input_tensors.at(0);
     const auto& input_shape = input.get_legacy_shape();
-    tt::tt_metal::LegacyShape output_shape = input_shape;
+    ttnn::SimpleShape output_shape = ttnn::SimpleShape(input_shape.to_array_4D());
 
     uint32_t nbatch = input_shape[0];
     uint32_t total_nsticks = config_.num_cores_nhw * max_out_nsticks_per_core_;
@@ -72,7 +73,7 @@ std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vec
     out_mem_config.shard_spec->shape[1] = input_tensor.memory_config().shard_spec->shape[1];
     out_mem_config.shard_spec->halo = true;
     return {TensorSpec(
-        output_shape.logical_shape(),
+        output_shape,
         TensorLayout::fromLegacyPaddedShape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, ttnn::Shape(output_shape)))};
 }


### PR DESCRIPTION
Halo op has a problem where manipulating
tt::tt_metal::LegacyShape in compute_output_specs
is not doing the expected thing (value is unchanged).

Conv2d has issue when act_block_h_override is used. Assert that act_block_h_override in tiles needs
be a divisor of per_core_out_matrix_height_ntiles
was wrongly disabled.
In turn each core would produce more output than
than it was allocated and override random data.
which is not visible in op unit tests.

This change regress unet shallow device perf.
1122 -> 1053.
Most of the regressino comes from a workaround
to make model work determinically which converts
one sharded tensor to l1 interleaved tensor.
Root cause is unknow but we did hit this issue
before and it went away, not it's back.


### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12356347605
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12376429460
- [x] Device performance regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12371510032
- [x] New/Existing tests provide coverage for changes - https://github.com/tenstorrent/tt-metal/actions/runs/12395925604
