### PR TITLE
#0: remove spammy warning from conftest

### DIFF
--- a/tests/ttnn/conftest.py
+++ b/tests/ttnn/conftest.py
@@ -32,7 +32,6 @@ def pytest_collection_modifyitems(config, items):
     logger.warning("Fast Runtime Mode is ON. Skipping tests tagged with @pytest.mark.requires_fast_runtime_mode_off")
     skip_unmarked = pytest.mark.skip(reason="Skipping test with requires_fast_runtime_mode_off")
     for item in items:
-        logger.warning(item.keywords)
         if "requires_fast_runtime_mode_off" in item.keywords:
             logger.warning(f"Skipping {item}")
             item.add_marker(skip_unmarked)


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description

There's a lot of spammy warnings in all post commit that are requiring the download of the logs zip. E.g.
https://github.com/tenstorrent/tt-metal/actions/runs/12404868937/job/34631200020
```
2024-12-19 03:05:01.259 | WARNING  | tests.ttnn.conftest:pytest_collection_modifyitems:35 - <NodeKeywords for node <Function test_level2_complex_sub_bw[alpha=-5.0-hw=(32, 64)-bs=(2, 2)-dtype=DataType.BFLOAT16-out_DRAM]>>
202
This step has been truncated due to its large size. Download the full logs from the  menu once the workflow run has completed.
```

### What's changed
Remove the warning.

### Checklist
- [x] Post commit CI passes - failures are random docker issues and what's already on main, nothing related to this change. https://github.com/tenstorrent/tt-metal/actions/runs/12418092901/job/34670695481
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes N/A
