### PR TITLE
#0: Enforce tile layout when using bf4/bf8 data types

### DIFF
--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
@@ -23,16 +23,12 @@ def run_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config, 
 
     A = torch.randn(a_shape)
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
 
     out = ttnn.experimental.concatenate_heads(a_t, ttnn.CoreCoord(12, 9), memory_config=out_mem_config)
 
@@ -44,8 +40,7 @@ def run_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config, 
     logger.debug(f"out: {out.memory_config().buffer_type} and {out.get_dtype()}")
 
     assert out.shape.with_tile_padding() == [batch, 1, 384, 1024]
-    tt_host_rm_out = out.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_out = tt_host_rm_out.to_torch()
+    pyt_got_back_rm_out = ttnn.to_torch(out)
 
     ref_out = torch.transpose(A, -3, -2).reshape([batch, 1, 384, 1024])
     passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm_out, ref_out, 0.99)
@@ -98,13 +93,13 @@ def test_bert_large_concatenate_heads_with_program_cache(device, use_program_cac
         run_bert_large_concatenate_heads_test(device, 9, dtype, mem_config, mem_config)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
         run_bert_large_concatenate_heads_test(device, 9, dtype, mem_config, mem_config)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
@@ -64,7 +64,7 @@ def run_bert_large_ff1_matmul_test(
     if bias_mem_config is not None:
         bias_t = ttnn.Tensor(
             bias_padded.flatten().tolist(),
-            bias_padded_shape,
+            bias_pad_shape,
             dtype,
             ttnn.TILE_LAYOUT,
         ).to(device, bias_mem_config)
@@ -91,12 +91,11 @@ def run_bert_large_ff1_matmul_test(
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
     assert t2.shape.with_tile_padding() == [9, 1, 384, 4096]
-    tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     pyt_got_back_rm = ttnn.to_torch(t2)
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
-        ref_bmm = ref_bmm + BIAS
+        ref_bmm = ref_bmm + bias
     if fused_activation is not None:
         if fused_activation[0] == ttnn.UnaryOpType.GELU:
             ref_bmm = torch.nn.functional.gelu(ref_bmm)

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
@@ -45,41 +45,29 @@ def run_bert_large_ff1_matmul_test(
     bias_pad_shape = [1, 1, 32, 4096]
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
-    BIAS = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias_padded = torch.nn.functional.pad(bias, (0, 0, 0, 32 - bias.size(2)))
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
-    b_t = (
-        ttnn.Tensor(
-            B.flatten().tolist(),
-            b_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in1_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
+    b_t = ttnn.Tensor(
+        B.flatten().tolist(),
+        b_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in1_mem_config)
 
     if bias_mem_config is not None:
-        bias_t = (
-            ttnn.Tensor(
-                BIAS.flatten().tolist(),
-                bias_shape,
-                dtype,
-                ttnn.ROW_MAJOR_LAYOUT,
-            )
-            .pad(bias_pad_shape, [0, 0, 0, 0], 0)
-            .to(ttnn.TILE_LAYOUT)
-            .to(device, bias_mem_config)
-        )
+        bias_t = ttnn.Tensor(
+            bias_padded.flatten().tolist(),
+            bias_padded_shape,
+            dtype,
+            ttnn.TILE_LAYOUT,
+        ).to(device, bias_mem_config)
     else:
         bias_t = None
 
@@ -104,7 +92,7 @@ def run_bert_large_ff1_matmul_test(
 
     assert t2.shape.with_tile_padding() == [9, 1, 384, 4096]
     tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm = tt_host_rm.to_torch()
+    pyt_got_back_rm = ttnn.to_torch(t2)
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
@@ -200,7 +188,7 @@ def test_bert_large_ff1_matmul_with_program_cache(device, use_program_cache):
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
@@ -215,6 +203,6 @@ def test_bert_large_ff1_matmul_with_program_cache(device, use_program_cache):
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
@@ -31,41 +31,29 @@ def run_bert_large_ff2_matmul_test(device, dtype, in0_mem_config, in1_mem_config
 
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
-    BIAS = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias_padded = torch.nn.functional.pad(bias, (0, 0, 0, 32 - bias.size(2)))
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
-    b_t = (
-        ttnn.Tensor(
-            B.flatten().tolist(),
-            b_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in1_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
+    b_t = ttnn.Tensor(
+        B.flatten().tolist(),
+        b_shape,
+        dtype,
+        ttnn.ROW_MAJOR_LAYOUT,
+    ).to(device, in1_mem_config)
 
     if bias_mem_config is not None:
-        bias_t = (
-            ttnn.Tensor(
-                BIAS.flatten().tolist(),
-                bias_shape,
-                dtype,
-                ttnn.ROW_MAJOR_LAYOUT,
-            )
-            .pad(bias_pad_shape, [0, 0, 0, 0], 0)
-            .to(ttnn.TILE_LAYOUT)
-            .to(device, bias_mem_config)
-        )
+        bias_t = ttnn.Tensor(
+            bias_padded.flatten().tolist(),
+            bias_pad_shape,
+            dtype,
+            ttnn.TILE_LAYOUT,
+        ).to(device, bias_mem_config)
     else:
         bias_t = None
 
@@ -84,12 +72,11 @@ def run_bert_large_ff2_matmul_test(device, dtype, in0_mem_config, in1_mem_config
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
     assert t2.shape.with_tile_padding() == [9, 1, 384, 1024]
-    tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm = tt_host_rm.to_torch()
+    pyt_got_back_rm = ttnn.to_torch(t2)
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
-        ref_bmm = ref_bmm + BIAS
+        ref_bmm = ref_bmm + bias
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
     logger.debug(f"Passing={passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")
@@ -161,7 +148,7 @@ def test_bert_large_ff2_matmul_with_program_cache(device, use_program_cache):
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
@@ -175,6 +162,6 @@ def test_bert_large_ff2_matmul_with_program_cache(device, use_program_cache):
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
@@ -44,7 +44,7 @@ def run_bert_large_ff2_matmul_test(device, dtype, in0_mem_config, in1_mem_config
         B.flatten().tolist(),
         b_shape,
         dtype,
-        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.TILE_LAYOUT,
     ).to(device, in1_mem_config)
 
     if bias_mem_config is not None:

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
@@ -76,7 +76,7 @@ def run_bert_large_fused_qkv_matmul_test(
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
-        ref_bmm = ref_bmm + BIAS
+        ref_bmm = ref_bmm + bias
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
     logger.debug(f"Passing={passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
@@ -32,40 +32,28 @@ def run_bert_large_fused_qkv_matmul_test(
 
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
-    BIAS = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias_padded = torch.nn.functional.pad(bias, (0, 0, 0, 32 - bias.size(2)))
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
-    b_t = (
-        ttnn.Tensor(
-            B.flatten().tolist(),
-            b_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in1_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
+    b_t = ttnn.Tensor(
+        B.flatten().tolist(),
+        b_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in1_mem_config)
     if bias_mem_config is not None:
-        bias_t = (
-            ttnn.Tensor(
-                BIAS.flatten().tolist(),
-                bias_shape,
-                dtype,
-                ttnn.ROW_MAJOR_LAYOUT,
-            )
-            .pad(bias_pad_shape, [0, 0, 0, 0], 0)
-            .to(ttnn.TILE_LAYOUT)
-            .to(device, bias_mem_config)
-        )
+        bias_t = ttnn.Tensor(
+            bias_padded.flatten().tolist(),
+            bias_pad_shape,
+            dtype,
+            ttnn.TILE_LAYOUT,
+        ).to(device, bias_mem_config)
     else:
         bias_t = None
 
@@ -84,8 +72,7 @@ def run_bert_large_fused_qkv_matmul_test(
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
     assert t2.shape.with_tile_padding() == [9, 1, 384, 3072]
-    tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm = tt_host_rm.to_torch()
+    pyt_got_back_rm = ttnn.to_torch(t2)
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
@@ -161,7 +148,7 @@ def test_bert_large_fused_qkv_matmul_with_program_cache(device, use_program_cach
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
@@ -175,6 +162,6 @@ def test_bert_large_fused_qkv_matmul_with_program_cache(device, use_program_cach
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
@@ -175,26 +175,18 @@ def run_bert_large_bmm_test(
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            in0_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
-    b_t = (
-        ttnn.Tensor(
-            B.flatten().tolist(),
-            b_shape,
-            in1_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in1_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        in0_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
+    b_t = ttnn.Tensor(
+        B.flatten().tolist(),
+        b_shape,
+        in1_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in1_mem_config)
 
     t2 = bert_large_op(a_t, b_t, out_mem_config, out_dtype)
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
@@ -35,26 +35,18 @@ def run_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
-    b_t = (
-        ttnn.Tensor(
-            B.flatten().tolist(),
-            b_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in1_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
+    b_t = ttnn.Tensor(
+        B.flatten().tolist(),
+        b_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in1_mem_config)
 
     t2 = custom_matmuls.bert_large_post_softmax_bmm(a_t, b_t, out_mem_config)
 
@@ -67,8 +59,7 @@ def run_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
     assert t2.shape.with_tile_padding() == out_shape
-    tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm = tt_host_rm.to_torch()
+    pyt_got_back_rm = ttnn.to_torch(t2)
 
     ref_bmm = torch.matmul(A.reshape([9, 16, 384, 384]), B)
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
@@ -121,13 +112,13 @@ def test_bert_large_post_softmax_bmm_with_program_cache(device, use_program_cach
         run_bert_large_post_softmax_bmm_test(device, dtype, mem_config, mem_config, mem_config)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
         run_bert_large_post_softmax_bmm_test(device, dtype, mem_config, mem_config, mem_config)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
@@ -75,7 +75,7 @@ def run_bert_large_selfout_matmul_test(device, dtype, in0_mem_config, in1_mem_co
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
-        ref_bmm = ref_bmm + BIAS
+        ref_bmm = ref_bmm + bias
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
     logger.debug(f"Passing={passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
@@ -31,40 +31,28 @@ def run_bert_large_selfout_matmul_test(device, dtype, in0_mem_config, in1_mem_co
 
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
-    BIAS = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias = torch.randint(-20, 20, bias_shape, dtype=torch.float)
+    bias_padded = torch.nn.functional.pad(bias, (0, 0, 0, 32 - bias.size(2)))
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
-    b_t = (
-        ttnn.Tensor(
-            B.flatten().tolist(),
-            b_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in1_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
+    b_t = ttnn.Tensor(
+        B.flatten().tolist(),
+        b_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in1_mem_config)
     if bias_mem_config is not None:
-        bias_t = (
-            ttnn.Tensor(
-                BIAS.flatten().tolist(),
-                bias_shape,
-                dtype,
-                ttnn.ROW_MAJOR_LAYOUT,
-            )
-            .pad(bias_pad_shape, [0, 0, 0, 0], 0)
-            .to(ttnn.TILE_LAYOUT)
-            .to(device, bias_mem_config)
-        )
+        bias_t = ttnn.Tensor(
+            bias_padded.flatten().tolist(),
+            bias_pad_shape,
+            dtype,
+            ttnn.TILE_LAYOUT,
+        ).to(device, bias_mem_config)
     else:
         bias_t = None
 
@@ -83,8 +71,7 @@ def run_bert_large_selfout_matmul_test(device, dtype, in0_mem_config, in1_mem_co
     logger.debug(f"out is on: {t2.memory_config().buffer_type}")
 
     assert t2.shape.with_tile_padding() == [9, 1, 384, 1024]
-    tt_host_rm = t2.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm = tt_host_rm.to_torch()
+    pyt_got_back_rm = ttnn.to_torch(t2)
 
     ref_bmm = torch.matmul(A, B)
     if bias_mem_config is not None:
@@ -160,7 +147,7 @@ def test_bert_large_selfout_matmul_with_program_cache(device, use_program_cache)
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
@@ -174,6 +161,6 @@ def test_bert_large_selfout_matmul_with_program_cache(device, use_program_cache)
         )
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
@@ -24,16 +24,12 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
 
     A = torch.randn(a_shape)
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
 
     q, k, v = ttnn.experimental.split_query_key_value_and_split_heads(
         a_t, ttnn.CoreCoord(12, 9), memory_config=out_mem_config
@@ -53,12 +49,9 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
     assert k.shape.with_tile_padding() == [batch, 16, 64, 384]
     assert v.shape.with_tile_padding() == [batch, 16, 384, 64]
 
-    tt_host_rm_q = q.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_q = tt_host_rm_q.to_torch()
-    tt_host_rm_k = k.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_k = tt_host_rm_k.to_torch()
-    tt_host_rm_v = v.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_v = tt_host_rm_v.to_torch()
+    pyt_got_back_rm_q = ttnn.to_torch(q)
+    pyt_got_back_rm_k = ttnn.to_torch(k)
+    pyt_got_back_rm_v = ttnn.to_torch(v)
 
     (ref_q, ref_k, ref_v) = torch.split(A, 1024, dim=-1)
 
@@ -125,13 +118,13 @@ def test_split_query_key_value_and_split_heads_with_program_cache(device, use_pr
         run_split_query_key_value_and_split_heads_test(device, 9, dtype, mem_config, mem_config)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     mem_config = ttnn.L1_MEMORY_CONFIG
     for _ in range(2):
         run_split_query_key_value_and_split_heads_test(device, 9, dtype, mem_config, mem_config)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype, device, ttnn.TILE_LAYOUT, mem_config)
 
     assert device.num_program_cache_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
@@ -24,16 +24,12 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
 
     A = torch.randn(a_shape)
 
-    a_t = (
-        ttnn.Tensor(
-            A.flatten().tolist(),
-            a_shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device, in0_mem_config)
-    )
+    a_t = ttnn.Tensor(
+        A.flatten().tolist(),
+        a_shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device, in0_mem_config)
 
     q, k, v = ttnn.experimental.split_query_key_value_and_split_heads(
         a_t, ttnn.CoreCoord(12, 9), memory_config=out_mem_config
@@ -53,12 +49,9 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
     assert k.shape.with_tile_padding() == [batch, 16, 64, 384]
     assert v.shape.with_tile_padding() == [batch, 16, 384, 64]
 
-    tt_host_rm_q = q.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_q = tt_host_rm_q.to_torch()
-    tt_host_rm_k = k.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_k = tt_host_rm_k.to_torch()
-    tt_host_rm_v = v.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm_v = tt_host_rm_v.to_torch()
+    pyt_got_back_rm_q = ttnn.to_torch(q)
+    pyt_got_back_rm_k = ttnn.to_torch(k)
+    pyt_got_back_rm_v = ttnn.to_torch(v)
 
     (ref_q, ref_k, ref_v) = torch.split(A, 1024, dim=-1)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_kv_cache_load_slice.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_kv_cache_load_slice.py
@@ -24,16 +24,12 @@ def unpadding_test(
     else:
         inp = torch.rand(*kv_cache_shape, dtype=torch.bfloat16)
 
-    test_tensor = (
-        ttnn.Tensor(
-            inp.reshape(-1).tolist(),
-            inp.shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(device)
-    )
+    test_tensor = ttnn.Tensor(
+        inp.reshape(-1).tolist(),
+        inp.shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(device)
     test_tensor_tt = ttnn.experimental.nlp_kv_cache_load_slice(
         test_tensor, seq_len_start=seq_len_start, seq_len_end=seq_len_end
     )
@@ -88,16 +84,12 @@ def test_run_unpadding_test(
     for i in range(3):
         # shift input/output tensor by creating very small tensor between loop
         inp = torch.rand(1, 1, 32, 32)
-        test_tensor = (
-            ttnn.Tensor(
-                inp.reshape(-1).tolist(),
-                inp.shape,
-                dtype,
-                ttnn.ROW_MAJOR_LAYOUT,
-            )
-            .to(ttnn.TILE_LAYOUT)
-            .to(device)
-        )
+        test_tensor = ttnn.Tensor(
+            inp.reshape(-1).tolist(),
+            inp.shape,
+            dtype,
+            ttnn.TILE_LAYOUT,
+        ).to(device)
         shard_spec_1_cores_grid = ttnn.CoreRangeSet(
             {
                 ttnn.CoreRange(
@@ -174,13 +166,9 @@ def test_run_unpadding_test(
 
         # shift input/output tensor by creating very small tensor between loop
         inp = torch.rand(1, 1, 32, 32)
-        test_tensor = (
-            ttnn.Tensor(
-                inp.reshape(-1).tolist(),
-                inp.shape,
-                dtype,
-                ttnn.ROW_MAJOR_LAYOUT,
-            )
-            .to(ttnn.TILE_LAYOUT)
-            .to(device)
-        )
+        test_tensor = ttnn.Tensor(
+            inp.reshape(-1).tolist(),
+            inp.shape,
+            dtype,
+            ttnn.TILE_LAYOUT,
+        ).to(device)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -64,21 +64,17 @@ def test_sharded_tile(
 
     x = torch.arange(input_size.numel()).reshape(input_size).bfloat16().float()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            input_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            ttnn.MemoryConfig(
-                memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
-                buffer_type=ttnn.BufferType.L1,
-            ),
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        input_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+            buffer_type=ttnn.BufferType.L1,
+        ),
     )
 
     yt = ttnn.interleaved_to_sharded(
@@ -218,18 +214,14 @@ def test_sharded_untilize(H, num_cores, in_sharded, out_sharded, dtype, device, 
 
     x = torch.randn((N, C, H, W)).bfloat16()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     if in_sharded:
@@ -991,21 +983,17 @@ def test_sharded_program_cache(device, use_program_cache, function_level_default
     x = torch.ones((N, C, H, W)).bfloat16().float()
     x2 = torch.zeros((N, C, H, W)).bfloat16().float()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            ttnn.bfloat16,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            ttnn.MemoryConfig(
-                memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
-                buffer_type=ttnn.BufferType.L1,
-            ),
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+            buffer_type=ttnn.BufferType.L1,
+        ),
     )
 
     yt = ttnn.interleaved_to_sharded(
@@ -1024,21 +1012,17 @@ def test_sharded_program_cache(device, use_program_cache, function_level_default
         ),
     )
 
-    xt2 = (
-        ttnn.Tensor(
-            x2.reshape(-1).tolist(),
-            x2.shape,
-            ttnn.bfloat16,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            ttnn.MemoryConfig(
-                memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
-                buffer_type=ttnn.BufferType.L1,
-            ),
-        )
+    xt2 = ttnn.Tensor(
+        x2.reshape(-1).tolist(),
+        x2.shape,
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+            buffer_type=ttnn.BufferType.L1,
+        ),
     )
 
     yt2 = ttnn.interleaved_to_sharded(
@@ -1462,18 +1446,14 @@ def test_sharded_untilize_padded_shard(in_sharded, out_sharded, dtype, device, f
 
     x = torch.arange(N * C * H * W).reshape((N, C, H, W)).bfloat16()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     if in_sharded:
@@ -1542,32 +1522,24 @@ def test_sharded_binary_padded_shard(
     x = torch.ones((N, C, H, W)).bfloat16()
     y = torch.ones((N, C, H, W)).bfloat16() * 2
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            activations_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        activations_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
-    yt = (
-        ttnn.Tensor(
-            y.reshape(-1).tolist(),
-            y.shape,
-            activations_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    yt = ttnn.Tensor(
+        y.reshape(-1).tolist(),
+        y.shape,
+        activations_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     if in_sharded:
@@ -1634,18 +1606,14 @@ def test_block_sharded_untilize_with_unpadding(in_sharded, out_sharded, dtype, d
 
     x = torch.randn((N, C, H, W)).bfloat16()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     if in_sharded:
@@ -1726,18 +1694,14 @@ def test_width_sharded_untilize_with_unpadding(
 
     x = torch.randn((N, C, H, W)).bfloat16()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     if in_sharded:
@@ -1871,18 +1835,14 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
 
     x = torch.randn((N, C, H, W)).bfloat16()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     if in_sharded:
@@ -2366,18 +2326,14 @@ def test_interleaved_2_sharded_L1(device, dtype, y):
 
     x = torch.randn((1, 1, y, 144 * 32)).bfloat16().float()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            input_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        input_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     yt = ttnn.interleaved_to_sharded(xt, shard_grid, (y // 8, 18 * 32), shard_scheme, ttnn.ShardOrientation.ROW_MAJOR)
@@ -2408,18 +2364,14 @@ def test_interleaved_2_sharded_DRAM(device, dtype, y):
 
     x = torch.randn((1, 1, y, 144 * 32)).bfloat16().float()
 
-    xt = (
-        ttnn.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            input_dtype,
-            ttnn.ROW_MAJOR_LAYOUT,
-        )
-        .to(ttnn.TILE_LAYOUT)
-        .to(
-            device,
-            interleaved_mem_config,
-        )
+    xt = ttnn.Tensor(
+        x.reshape(-1).tolist(),
+        x.shape,
+        input_dtype,
+        ttnn.TILE_LAYOUT,
+    ).to(
+        device,
+        interleaved_mem_config,
     )
 
     yt = ttnn.interleaved_to_sharded(xt, shard_grid, (y // 8, 18 * 32), shard_scheme, ttnn.ShardOrientation.ROW_MAJOR)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -38,6 +38,9 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
 def test_tensor_creation(shape, tt_dtype, layout, device):
     torch.manual_seed(0)
 
+    if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("{} is only valid for ttnn.TILE_LAYOUT!".format(tt_dtype))
+
     dtype = tt_dtype_to_torch_dtype[tt_dtype]
 
     if dtype in {torch.uint8, torch.int16, torch.int32}:

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -107,14 +107,10 @@ Tensor convert_float_vector_to_tt_tensor(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tile>& tile) {
     if (data_type == DataType::BFLOAT8_B || data_type == DataType::BFLOAT4_B) {
-        if (layout != Layout::TILE) {
-            log_warning(
-                tt::LogAlways,
-                "Tensor layout must be Layout::TILE for bfloat8_b or bfloat4_b! Tensor layout will be {} instead of "
-                "the requested {}!",
-                Layout::TILE,
-                layout);
-        }
+        TT_FATAL(layout == Layout::TILE, "Tile layout is required for BFLOAT8_B and BFLOAT4_B; got {}", layout);
+
+        auto result_cpu_spec = TensorSpec(
+            ttnn::SimpleShape(shape), TensorLayout(data_type, PageConfig(Layout::TILE, tile), MemoryConfig{}));
         auto owned_buffer = create_owned_buffer_from_vector_of_floats(std::move(data), DataType::FLOAT32);
         auto float_tensor = Tensor(OwnedStorage{owned_buffer}, shape, DataType::FLOAT32, Layout::ROW_MAJOR, tile);
         auto tile_val = tile.value_or(Tile());
@@ -409,18 +405,18 @@ Tensor convert_python_tensor_to_tt_tensor(
         num_elements,
         shape.volume());
 
-    Layout layout = optional_layout.value_or(Layout::ROW_MAJOR);
-    if (data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
-        if (optional_layout.has_value() and optional_layout.value() != Layout::TILE) {
-            log_warning(
-                tt::LogAlways,
-                "Tensor layout must be Layout::TILE for bfloat8_b or bfloat4_b! Tensor layout will be {} instead of "
-                "the requested {}!",
-                Layout::TILE,
-                optional_layout.value());
+    const Layout layout = [&]() {
+        // Block float types require tile layout.
+        // Choose tile by default and disallow overriding to anything else.
+        if (data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
+            TT_FATAL(
+                !optional_layout.has_value() or *optional_layout == Layout::TILE,
+                "Tile layout is required for cannot be specified for tensor of type bfloat8_b or bfloat4_b.");
+            return Layout::TILE;
+        } else {
+            return optional_layout.value_or(Layout::ROW_MAJOR);
         }
-        layout = Layout::TILE;
-    }
+    }();
 
     auto tensor_spec = TensorSpec(shape, TensorLayout(data_type, PageConfig(layout, optional_tile), memory_config));
     auto on_creation_callback = [tensor = contiguous_py_tensor] { tensor.inc_ref(); };

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -109,8 +109,6 @@ Tensor convert_float_vector_to_tt_tensor(
     if (data_type == DataType::BFLOAT8_B || data_type == DataType::BFLOAT4_B) {
         TT_FATAL(layout == Layout::TILE, "Tile layout is required for BFLOAT8_B and BFLOAT4_B; got {}", layout);
 
-        auto result_cpu_spec = TensorSpec(
-            ttnn::SimpleShape(shape), TensorLayout(data_type, PageConfig(Layout::TILE, tile), MemoryConfig{}));
         auto owned_buffer = create_owned_buffer_from_vector_of_floats(std::move(data), DataType::FLOAT32);
         auto float_tensor = Tensor(OwnedStorage{owned_buffer}, shape, DataType::FLOAT32, Layout::ROW_MAJOR, tile);
         auto tile_val = tile.value_or(Tile());

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -442,7 +442,13 @@ Tensor convert_python_tensors_to_tt_tensors(
     std::vector<Tensor> tt_shards;
     for (const auto& shard : tensor_shards) {
         tt_shards.push_back(detail::convert_python_tensor_to_tt_tensor(
-            shard, data_type, Layout::ROW_MAJOR, tile, MemoryConfig{}, nullptr, true));
+            shard,
+            data_type,
+            /*optional_layout=*/std::nullopt,
+            tile,
+            MemoryConfig{},
+            /*device=*/nullptr,
+            /*force_disable_borrow=*/true));
     }
     std::vector<OwnedBuffer> host_owned_buffers;
     std::vector<ttnn::Shape> host_owned_shapes;
@@ -931,7 +937,7 @@ void pytensor_module(py::module& m_tensor) {
                     return detail::convert_python_tensors_to_tt_tensors(tensor, data_type, tile, strategy);
                 }
                 return detail::convert_python_tensor_to_tt_tensor(
-                    tensor, data_type, std::nullopt, tile, MemoryConfig{}, nullptr);
+                    tensor, data_type, /*optional_layout=*/std::nullopt, tile, MemoryConfig{}, /*device=*/nullptr);
             }),
             py::arg("tensor"),
             py::arg("data_type") = std::nullopt,

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -409,7 +409,8 @@ Tensor convert_python_tensor_to_tt_tensor(
         if (data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
             TT_FATAL(
                 !optional_layout.has_value() or *optional_layout == Layout::TILE,
-                "Tile layout is required for cannot be specified for tensor of type bfloat8_b or bfloat4_b.");
+                "Tile layout is required for tensor of type bfloat8_b or bfloat4_b; got {}.",
+                *optional_layout);
             return Layout::TILE;
         } else {
             return optional_layout.value_or(Layout::ROW_MAJOR);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
User can specify row major layout when using block float formats, which is not supported.

### What's changed
Instead of silently overriding to use the tilized layout, throw an error.

### Checklist
- [X] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12451630816)
 - [X] [All T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/12439116600) - failures unrelated
