### PR TITLE
Fix for stable diffusion tests - ported `untilize_with_unpadding` to `comput_output_specs`

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -90,8 +90,8 @@ Tensor to_layout_impl_on_device(
             output_tensor_end.push_back(tensor_shape[index] - 1);
         }
 
-        auto tensor =
-            ttnn::untilize_with_unpadding(tensor_arg, output_tensor_end, output_memory_config, use_multicore_untilize);
+        auto tensor = ttnn::untilize_with_unpadding(
+            tensor_arg, ttnn::SimpleShape(output_tensor_end), output_memory_config, use_multicore_untilize);
         return ttnn::reshape(tensor, tensor_shape);
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -12,16 +12,14 @@
 namespace ttnn::operations::data_movement {
 
 struct UntilizeWithUnpadding {
-    const tt::tt_metal::LegacyShape output_tensor_end;
+    const ttnn::SimpleShape output_tensor_end;
     const MemoryConfig output_mem_config;
     const bool use_multicore;
     const bool use_pack_untilize;
     const bool fp32_dest_acc_en;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
-    std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -13,7 +13,7 @@
 
 using namespace tt::tt_metal;
 
-LegacyShape squeeze_output_shape(tt::tt_metal::LegacyShape output_shape) {
+ttnn::SimpleShape squeeze_output_shape(ttnn::SimpleShape output_shape) {
     if (output_shape.rank() > 4) {
         std::vector<uint32_t> output_shape_4d(output_shape.rank());
         output_shape_4d[0] = 1;
@@ -25,7 +25,7 @@ LegacyShape squeeze_output_shape(tt::tt_metal::LegacyShape output_shape) {
         output_shape_4d[1] = output_shape[1 + extra_rank];
         output_shape_4d[2] = output_shape[2 + extra_rank];
         output_shape_4d[3] = output_shape[3 + extra_rank];
-        return tt::tt_metal::LegacyShape(output_shape_4d);
+        return ttnn::SimpleShape(output_shape_4d);
     }
     return output_shape;
 }
@@ -58,7 +58,7 @@ MassagedUntilizeVal build_ndiml_untilize_val(BaseUntilizeValType base_untilize) 
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     uint8_t queue_id,
     const ttnn::Tensor& input_tensor,
-    const tt::tt_metal::LegacyShape& output_tensor_end,
+    const ttnn::SimpleShape& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     bool use_pack_untilize) {
@@ -66,12 +66,12 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32;
 
     std::vector<uint32_t> output_end_vector;
-    tt::tt_metal::LegacyShape output_end = tt::tt_metal::LegacyShape{};
+    ttnn::SimpleShape output_end{};
     if (input_tensor.get_shape().rank() > 4) {
         for (auto index = 0; index < input_tensor.get_shape().rank(); ++index) {
             output_end_vector.push_back(input_tensor.get_shape()[index] - 1);
         }
-        output_end = squeeze_output_shape(LegacyShape(output_end_vector));
+        output_end = squeeze_output_shape(ttnn::SimpleShape(output_end_vector));
     } else {
         output_end = output_tensor_end;
     }
@@ -95,7 +95,7 @@ ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
 
 ttnn::Tensor ExecuteUntilizeWithUnpadding::invoke(
     const ttnn::Tensor& input_tensor,
-    const tt::tt_metal::LegacyShape& output_tensor_end,
+    const ttnn::SimpleShape& output_tensor_end,
     const std::optional<MemoryConfig>& memory_config,
     bool use_multicore,
     bool use_pack_untilize) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -13,14 +13,14 @@ struct ExecuteUntilizeWithUnpadding {
     static ttnn::Tensor invoke(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
-        const tt::tt_metal::LegacyShape& output_tensor_end,
+        const ttnn::SimpleShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = false,
         bool use_pack_untilize = true);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        const tt::tt_metal::LegacyShape& output_tensor_end,
+        const ttnn::SimpleShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
         bool use_multicore = false,
         bool use_pack_untilize = true);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
@@ -44,7 +44,7 @@ void bind_untilize_with_unpadding(py::module& module) {
         ttnn::pybind_overload_t{
             [](const OperationType& self,
                const ttnn::Tensor& input_tensor,
-               const tt::tt_metal::LegacyShape& output_tensor_end,
+               const ttnn::SimpleShape& output_tensor_end,
                const std::optional<MemoryConfig>& memory_config,
                bool use_multicore,
                bool use_pack_untilize,

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -199,7 +199,7 @@ Tensor AutoFormat::format_output_tensor(
             } else if (formatted_output.get_layout() == Layout::TILE && AutoFormat::legal_rm_shape(shape)) {
                 formatted_output = ttnn::untilize_with_unpadding(
                     formatted_output,
-                    SmallVector<uint32_t>({shape[0] - 1, shape[1] - 1, shape[2] - 1, shape[3] - 1}),
+                    ttnn::SimpleShape({shape[0] - 1, shape[1] - 1, shape[2] - 1, shape[3] - 1}),
                     mem_config);
                 return formatted_output;
             }
@@ -208,7 +208,7 @@ Tensor AutoFormat::format_output_tensor(
                 AutoFormat::legal_rm_shape(shape)) {
                 formatted_output = ttnn::untilize_with_unpadding(
                     formatted_output,
-                    SmallVector<uint32_t>({shape[0] - 1, shape[1] - 1, shape[2] - 1, shape[3] - 1}),
+                    ttnn::SimpleShape({shape[0] - 1, shape[1] - 1, shape[2] - 1, shape[3] - 1}),
                     mem_config);
                 return formatted_output;
             } else if (


### PR DESCRIPTION
### Ticket

### Problem description
Currently nightly stable diffusion tests are failing on main due to my previous PR for 0D/1D tensor support

### What's changed
Ported `untilize_with_unpadding` to `comput_output_specs`, to properly handle tensor ranks

### Checklist
- [ ] Post commit CI passes
- [x] [Stable diffusion tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/12417236777/job/34668413682)
