### PR TITLE
#16184: Try using ecr to avoid rate limits of docker.io

### DIFF
--- a/dockerfile/ubuntu-20.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-20.04-amd64.Dockerfile
@@ -1,5 +1,5 @@
 # TT-METAL UBUNTU 20.04 AMD64 DOCKERFILE
-FROM ubuntu:20.04
+FROM public.ecr.aws/ubuntu/ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DOXYGEN_VERSION=1.9.6

--- a/dockerfile/ubuntu-22.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-22.04-amd64.Dockerfile
@@ -1,5 +1,5 @@
 # TT-METAL UBUNTU 22.04 AMD64 DOCKERFILE
-FROM ubuntu:22.04
+FROM public.ecr.aws/ubuntu/ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_VERSION=22.04


### PR DESCRIPTION
### Ticket

#16184 

### Problem description

Docker is hella rate limiting us. Switch to ECR so we don't run into it.

### What's changed

Switch ubuntu base to ECR.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
