### PR TITLE
#5605: Only force-stall ethernet programs on earlier ethernet programs

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -337,9 +337,7 @@ detail::Program_::Program_() :
     }
 
     program_configs_.resize(programmable_core_count);
-    program_config_sizes_.resize(programmable_core_count + 1);
-    // Always need one launch buffer msg for a program.
-    program_config_sizes_[programmable_core_count] = 1;
+    program_config_sizes_.resize(programmable_core_count + 2);
 }
 
 Program::Program() : pimpl_(std::make_unique<detail::Program_>()) {}
@@ -1503,6 +1501,9 @@ void detail::Program_::finalize(Device *device) {
                  "Program size ({}) too large for kernel config buffer ({}) on {}",
                  offset, max_size, magic_enum::enum_name(programmable_core_type));
     }
+
+    this->get_program_config_size(hal.get_programmable_core_type_count()) = runs_on_noc_multicast_only_cores();
+    this->get_program_config_size(hal.get_programmable_core_type_count() + 1) = runs_on_noc_unicast_only_cores();
 
     // The sem offsets cross programmable_core_types so must be set after the loop above
     this->set_launch_msg_sem_offsets();


### PR DESCRIPTION
### Ticket
#15605

### Problem description
On llama, we're seeing high dispatch latencies on programs that execute on active ethernet cores. This is because we always stall writing program binaries and launch messages until the previous program completes, since we don't support having program binaries in a ring buffer on ethernet cores.

### What's changed
Keep track of when the last program using active ethernet cores was dispatched, so we can wait on that program before sending out binaries. This is better than always waiting on the immediate previous program, since in most cases we don't run programs on the ethernet cores back-to-back.


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
