### PR TITLE
[TT-Train] Fix tracy deps in the tt-train cmake

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT TARGET Metalium::Metal)
         "$ENV{TT_METAL_HOME}"
         "$ENV{TT_METAL_HOME}/tt_metal"
         "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd"
+        "$ENV{TT_METAL_HOME}/tt_metal/third_party/tracy/public"
         "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/wormhole"
         "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/wormhole/wormhole_b0_defines"
         "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/"

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -40,7 +40,7 @@ autograd::TensorPtr layernorm(
         mean,
         rstd,
         /* memory_config */ std::nullopt,
-        /* compute_kernel_config */ core::ComputeKernelConfig::precise());
+        /* compute_kernel_config */ std::nullopt);
 
     auto out = autograd::create_tensor();
     out->set_value(out_tensors[0].value());
@@ -63,7 +63,7 @@ autograd::TensorPtr layernorm(
             gamma_grad,
             beta_grad,
             /* memory_config */ std::nullopt,
-            /* compute_kernel_config */ core::ComputeKernelConfig::precise());
+            /* compute_kernel_config */ std::nullopt);
 
         tensor->add_grad(res[0].value());
         gamma->add_grad(res[1].value());


### PR DESCRIPTION
### Problem description
Cannot find Tracy.hpp

### What's changed
* Added include dir.
* Reverted precision in layernorm.

### Checklist
- [x] Post commit CI passes
