### PR TITLE
replace padded calculations with physical_shape

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1672,7 +1672,7 @@ std::vector<ttnn::TensorSpec> Matmul::compute_output_specs(
                     uint32_t M = (program_config.fuse_batch ? input_tensor_a.get_tensor_spec().physical_shape().height()
                                                             : input_tensor_a.get_padded_shape()[-2]) /
                                  in0_tile_shape[0];
-                    uint32_t N = input_tensor_b.get_padded_shape()[-1] / in1_tile_shape[1];
+                    uint32_t N = input_tensor_b.get_tensor_spec().physical_shape().width() / in1_tile_shape[1];
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;
 
@@ -1700,7 +1700,7 @@ std::vector<ttnn::TensorSpec> Matmul::compute_output_specs(
                                          ProgramConfigType,
                                          MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
                     uint32_t M = input_tensor_a.get_tensor_spec().physical_shape().height() / in0_tile_shape[0];
-                    uint32_t N = input_tensor_b.get_padded_shape()[-1] / in1_tile_shape[1];
+                    uint32_t N = input_tensor_b.get_tensor_spec().physical_shape().width() / in1_tile_shape[1];
 
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -141,7 +141,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         TT_ASSERT(beta.value().get_layout() == Layout::ROW_MAJOR);
     }
 
-    bool is_height_sharding = a.get_legacy_shape()[3] == a.shard_spec().value().shape[1];
+    bool is_height_sharding = a.get_tensor_spec().physical_shape().width() == a.shard_spec().value().shape[1];
     // convert data format
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
@@ -293,7 +293,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
 
     if (input_mask.has_value()) {
         TT_ASSERT(
-            input_mask.value().get_legacy_shape()[3] == block_wt * TILE_WIDTH &&
+            input_mask.value().get_tensor_spec().physical_shape().width() == block_wt * TILE_WIDTH &&
             "input mask must have the same width as block_wt");
     }
 
@@ -548,7 +548,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         (std::uint32_t)block_wt};
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[3] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_tensor_spec().physical_shape().width() * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         if (gamma_stick_size_is_power_of_two) {
@@ -559,7 +559,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
             writer_mcast_sender_compile_time_args.push_back(gamma_stick_size);
         }
     } else if (beta.has_value() and beta.value().get_layout() == Layout::ROW_MAJOR) {
-        auto beta_stick_size = beta.value().get_legacy_shape()[3] * beta.value().element_size();
+        auto beta_stick_size = beta.value().get_tensor_spec().physical_shape().width() * beta.value().element_size();
         bool beta_stick_size_is_power_of_two = is_power_of_two_at_least_32(beta_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);
         if (beta_stick_size_is_power_of_two) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -47,10 +47,11 @@ void LayerNorm::validate(
     if (gamma.has_value()) {
         if (gamma.value().get_layout() == Layout::TILE) {
             TT_FATAL(
-                a.get_legacy_shape()[-1] == gamma.value().get_legacy_shape()[-1],
+                a.get_tensor_spec().physical_shape().width() ==
+                    gamma.value().get_tensor_spec().physical_shape().width(),
                 "{} != {}",
-                a.get_legacy_shape()[-1],
-                gamma.value().get_legacy_shape()[-1]);
+                a.get_tensor_spec().physical_shape().width(),
+                gamma.value().get_tensor_spec().physical_shape().width());
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == gamma.value().device(), "Error");
@@ -58,8 +59,8 @@ void LayerNorm::validate(
         } else {
             TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(
-                (gamma.value().get_legacy_shape()[-1] == TILE_WIDTH &&
-                 gamma.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH),
+                (gamma.value().get_tensor_spec().physical_shape().width() == TILE_WIDTH &&
+                 gamma.value().volume() / TILE_WIDTH == a.get_tensor_spec().physical_shape().width() / TILE_WIDTH),
                 "Error");
             TT_FATAL(
                 gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -76,7 +77,9 @@ void LayerNorm::validate(
 
     if (beta.has_value()) {
         if (beta.value().get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[-1] == beta.value().get_legacy_shape()[-1], "Error");
+            TT_FATAL(
+                a.get_tensor_spec().physical_shape().width() == beta.value().get_tensor_spec().physical_shape().width(),
+                "Error");
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
             TT_FATAL(a.device() == beta.value().device(), "Error");
@@ -84,8 +87,8 @@ void LayerNorm::validate(
         } else {
             TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(
-                (beta.value().get_legacy_shape()[-1] == TILE_WIDTH &&
-                 beta.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH),
+                (beta.value().get_tensor_spec().physical_shape().width() == TILE_WIDTH &&
+                 beta.value().volume() / TILE_WIDTH == a.get_tensor_spec().physical_shape().width() / TILE_WIDTH),
                 "Error");
             TT_FATAL(
                 beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
@@ -119,11 +122,11 @@ void LayerNorm::validate(
         TT_FATAL(stats.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         if (this->norm_type == LayerNormType::LAYERNORM) {
             TT_FATAL(
-                stats.value().get_legacy_shape()[-1] % (2 * TILE_WIDTH) == 0,
+                stats.value().get_tensor_spec().physical_shape().width() % (2 * TILE_WIDTH) == 0,
                 "Stats is expected to have E(x) and E(x^2) for each device stacked interleaved in the last dimension");
         } else {
             TT_FATAL(
-                stats.value().get_legacy_shape()[-1] % TILE_WIDTH == 0,
+                stats.value().get_tensor_spec().physical_shape().width() % TILE_WIDTH == 0,
                 "Stats is expected to have E(x) for each device stacked in the last dimension");
         }
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -216,7 +216,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
                                                       (std::uint32_t)block_size};
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[-1] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_tensor_spec().physical_shape().width() * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         reader_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         if (gamma_stick_size_is_power_of_two) {
@@ -227,7 +227,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
             reader_compile_time_args.push_back(gamma_stick_size);
         }
     } else if (beta.has_value() and beta.value().get_layout() == Layout::ROW_MAJOR) {
-        auto beta_stick_size = beta.value().get_legacy_shape()[-1] * beta.value().element_size();
+        auto beta_stick_size = beta.value().get_tensor_spec().physical_shape().width() * beta.value().element_size();
         bool beta_stick_size_is_power_of_two = is_power_of_two_at_least_32(beta_stick_size);
         reader_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);
         if (beta_stick_size_is_power_of_two) {
@@ -619,7 +619,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     uint32_t post_all_gather_stats_block_tiles = 1;
     uint32_t num_distributed_devices = 1;
     if (is_post_all_gather && stats.has_value()) {
-        post_all_gather_stats_block_tiles = stats.value().get_legacy_shape()[-1] / TILE_WIDTH;
+        post_all_gather_stats_block_tiles = stats.value().get_tensor_spec().physical_shape().width() / TILE_WIDTH;
         num_distributed_devices = post_all_gather_stats_block_tiles / pre_all_gather_stats_block_tiles;
     }
 
@@ -1003,7 +1003,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         (std::uint32_t)block_wt};
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[-1] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_tensor_spec().physical_shape().width() * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
         writer_mcast_receiver_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);
@@ -1017,7 +1017,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             writer_mcast_receiver_compile_time_args.push_back(gamma_stick_size);
         }
     } else if (beta.has_value() and beta.value().get_layout() == Layout::ROW_MAJOR) {
-        auto beta_stick_size = beta.value().get_legacy_shape()[-1] * beta.value().element_size();
+        auto beta_stick_size = beta.value().get_tensor_spec().physical_shape().width() * beta.value().element_size();
         bool beta_stick_size_is_power_of_two = is_power_of_two_at_least_32(beta_stick_size);
         writer_mcast_sender_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);
         writer_mcast_receiver_compile_time_args.push_back((std::uint32_t)beta_stick_size_is_power_of_two);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
 
     const uint32_t Wt = W / TILE_WIDTH;
     const uint32_t Ht = H / TILE_HEIGHT;
-    const uint32_t stats_tiles_cols = stats.get_legacy_shape()[-1] / TILE_WIDTH;
+    const uint32_t stats_tiles_cols = stats.get_tensor_spec().physical_shape().width() / TILE_WIDTH;
     const uint32_t tile_cols_per_device = is_rmsnorm ? 1 : 2;
     const uint32_t num_devices = stats_tiles_cols / tile_cols_per_device;
     TT_FATAL(num_devices > 0, "Number of devices must be greater than 0");
@@ -251,7 +251,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
     };
 
     if (gamma.has_value() and gamma.value().get_layout() == Layout::ROW_MAJOR) {
-        auto gamma_stick_size = gamma.value().get_legacy_shape()[-1] * gamma.value().element_size();
+        auto gamma_stick_size = gamma.value().get_tensor_spec().physical_shape().width() * gamma.value().element_size();
         bool gamma_stick_size_is_power_of_two = is_power_of_two_at_least_32(gamma_stick_size);
         TT_FATAL(gamma_stick_size_is_power_of_two, "Only power of 2 gammas are supported");
         reader_compile_time_args.push_back((std::uint32_t)gamma_stick_size_is_power_of_two);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -34,9 +34,9 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     uint32_t num_input_tiles = input_tensor.volume() / TILE_HW;
     uint32_t num_value_tiles = value_tensor.volume() / TILE_HW;
 
-    auto input_shape = input_tensor.get_legacy_shape();
-    uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / TILE_HEIGHT;
-    uint32_t Wt = input_shape[3] / TILE_WIDTH;
+    auto input_shape = input_tensor.get_tensor_spec().physical_shape();
+    uint32_t Ht = input_shape.height() / TILE_HEIGHT;
+    uint32_t Wt = input_shape.width() / TILE_WIDTH;
     // for streaming in input
     uint32_t num_cb_unit = 2;
     uint32_t cb_in_units = 2 * num_cb_unit;


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/15619

### Problem description
Because of new tensor layout implementation, use physical shape instead of padded/legacy shape.

### What's changed
replacing logic of calculting padded shape using physical_shape()

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
