### PR TITLE
 #16213: Use our own forked Docker Run Action that points to ECR

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -57,7 +57,7 @@ runs:
       shell: bash
       run: |
         docker pull ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
-    - uses: addnab/docker-run-action@v3
+    - uses: tenstorrent/docker-run-action@v4
       with:
         shell: bash
         username: ${{ inputs.docker_username }}

--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -57,7 +57,7 @@ runs:
       shell: bash
       run: |
         docker pull ${{ env.TT_METAL_DOCKER_IMAGE_TAG }}
-    - uses: tenstorrent/docker-run-action@v4
+    - uses: tenstorrent/docker-run-action@v5
       with:
         shell: bash
         username: ${{ inputs.docker_username }}


### PR DESCRIPTION
### Ticket
#16213 

### Problem description

We are hitting docker hub pull limits.

### What's changed
Switched to our repo https://github.com/tenstorrent/docker-run-action/ that was forked and modified to use ECR registry
https://github.com/tenstorrent/docker-run-action/commit/4b36c1dd708253711780ccf331078ae115fe287d

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12424296562
- [x] Blackhole Post commit (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/12424297677
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
