### PR TITLE
Support subcoregrids in concat_heads

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
@@ -5,8 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
-// #include "debug/dprint.h"  // required in all kernels using DPRINT
-
 void kernel_main() {
     uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(0);
     uint32_t q_start_addr = get_arg_val<uint32_t>(1);
@@ -44,15 +42,12 @@ void kernel_main() {
             // Read first phase
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
                 noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
             }
             // Read second phase
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
                 noc_async_read(
                     qkv_read_addr + 256 * ELEMENT_SIZE, q_write_addr + 256 * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-                // noc_async_read_barrier();
             }
-            // noc_async_read_barrier();
 
             qkv_read_addr += tile_size;
             q_write_addr += tile_size;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+// #include "debug/dprint.h"  // required in all kernels using DPRINT
+
+void kernel_main() {
+    uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(0);
+    uint32_t q_start_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(0);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(2);
+    constexpr uint32_t head_size = get_compile_time_arg_val(3);
+    constexpr uint32_t batch = get_compile_time_arg_val(4);
+    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t PHASES_TO_READ =
+        get_compile_time_arg_val(6);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+
+    constexpr uint32_t in_num_cores = get_compile_time_arg_val(7);
+
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + in_num_cores));
+
+    // Q
+    uint32_t cur_core_idx = 0;
+    uint32_t total_input_cores = in_num_cores;
+    uint32_t num_tiles_per_core = (head_size_num_tiles * batch) / total_input_cores;
+
+    uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                             in_tile_offset_by_head;
+    uint32_t num_tiles_read_cur_core = 0;
+    uint32_t q_write_addr = 0;
+    uint32_t tile_size = head_size / head_size_num_tiles;
+    const uint32_t cb_write_ptr_base = get_write_ptr(cb_id_q_out);
+
+    for (uint32_t q = 0; q < batch; ++q) {
+        uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512 * ELEMENT_SIZE;
+        uint32_t q_write_addr = cb_write_ptr_base + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+                // noc_async_read_barrier();
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(
+                    qkv_read_addr + 256 * ELEMENT_SIZE, q_write_addr + 256 * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                // noc_async_read_barrier();
+            }
+            // noc_async_read_barrier();
+
+            qkv_read_addr += tile_size;
+            q_write_addr += tile_size;
+            num_tiles_read_cur_core++;
+
+            if (num_tiles_read_cur_core == num_tiles_per_core) {
+                cur_core_idx++;
+                qkv_read_addr =
+                    get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                    in_tile_offset_by_head;
+                num_tiles_read_cur_core = 0;
+            }
+        }
+    }
+
+    noc_async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -33,9 +33,11 @@ void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     auto shard_spec = input_tensor.shard_spec().value();
     TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
     TT_FATAL(shard_spec.shape[0] == input_tensor.get_legacy_shape()[-2], "Error");
-    auto shard_grid = shard_spec.grid.bounding_box().grid_size();
-    auto num_cores = shard_grid.x * shard_grid.y;
+    auto num_cores = shard_spec.grid.num_cores();
     TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");
+    if (this->on_subcoregrids) {
+        TT_FATAL(num_cores >= this->num_heads, "For subcoregrid inputs, we only support num_heads<=num_cores");
+    }
 }
 
 std::vector<tt::tt_metal::LegacyShape> NLPConcatHeadsDecodeDeviceOperation::compute_output_shapes(
@@ -66,10 +68,18 @@ std::vector<Tensor> NLPConcatHeadsDecodeDeviceOperation::create_output_tensors(
     auto head_dim = input_shape[3];
     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
     auto batch = output_shape[2];
+    CoreRangeSet output_core_grid;
+    if (this->on_subcoregrids) {
+        const auto input_core_ranges = input_tensor.shard_spec().value().grid.ranges();
+        CoreRangeSet input_core_grid = input_tensor.shard_spec().value().grid;
+        const auto start_coord = input_core_ranges[0].start_coord;
+        output_core_grid = num_cores_to_corerangeset_in_subcoregrids(start_coord, num_heads, input_core_grid, true);
+    } else {
+        output_core_grid =
+            num_cores_to_corerangeset(num_heads, input_tensor.device()->compute_with_storage_grid_size(), true);
+    }
 
-    auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
-    auto shard_grid = num_cores_to_corerangeset(num_heads, core_grid, true);
-    ShardSpec shard_spec{shard_grid, {batch, head_dim}};
+    ShardSpec shard_spec{output_core_grid, {batch, head_dim}};
     auto mem_config = tt::tt_metal::MemoryConfig{TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1};
     mem_config.shard_spec = shard_spec;
 
@@ -83,7 +93,10 @@ operation::ProgramWithCallbacks NLPConcatHeadsDecodeDeviceOperation::create_prog
     auto& output_tensor = output_tensors.at(0);
 
     CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-
+    if (this->on_subcoregrids) {
+        return multi_core_nlp_concat_heads_decode_subcoregrids(
+            input_tensor, output_tensor, compute_with_storage_grid_size);
+    }
     return multi_core_nlp_concat_heads_decode(input_tensor, output_tensor, compute_with_storage_grid_size);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.hpp
@@ -15,8 +15,12 @@ namespace ttnn::operations::experimental::transformer {
 operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(
     const Tensor& input_tensor, Tensor& output, CoreCoord compute_with_storage_grid_size);
 
+operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode_subcoregrids(
+    const Tensor& input_tensor, Tensor& output, CoreCoord compute_with_storage_grid_size);
+
 struct NLPConcatHeadsDecodeDeviceOperation {
     const uint32_t num_heads;
+    const bool on_subcoregrids = false;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -150,5 +150,134 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
+operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode_subcoregrids(
+    const Tensor& input_tensor, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+    tt_metal::Program program = tt_metal::CreateProgram();
 
+    const auto& input_shape = input_tensor.get_legacy_shape();
+    const uint32_t head_dim = input_shape[-1];
+    const uint32_t batch = input_shape[1];
+
+    tt_metal::Device* device = input_tensor.device();
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+
+    const uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+
+    const uint32_t head_tiles = head_dim / TILE_WIDTH;
+    const uint32_t head_size = head_tiles * single_tile_size;
+
+    const uint32_t element_size = input_tensor.element_size();
+    const uint32_t sub_tile_line_bytes = 16 * element_size;
+    const auto q_shard_spec = output.shard_spec().value();
+    const auto q_cores = q_shard_spec.grid;
+    const auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+    const auto in_shard_spec = input_tensor.shard_spec().value();
+    const auto in_cores = in_shard_spec.grid;
+    const auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t q_output_cb_index = CBIndex::c_16;
+    tt_metal::CircularBufferConfig cb_q_output_config =
+        tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
+            .set_page_size(q_output_cb_index, single_tile_size)
+            .set_globally_allocated_address(*output.buffer());
+    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+    uint32_t q_base_addr = input_tensor.buffer()->address();
+
+    // cores to read and write to output
+    const uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
+    const auto& cores = corerange_to_cores(q_cores, num_cores, true);
+
+    // cores for input
+    const uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
+    const auto& in_cores_vec = corerange_to_cores(in_cores, in_num_cores, true);
+
+    std::vector<uint32_t> noc_x_coords;
+    noc_x_coords.reserve(in_num_cores);
+    std::vector<uint32_t> noc_y_coords;
+    noc_y_coords.reserve(in_num_cores);
+    for (uint32_t i = 0; i < in_num_cores; ++i) {
+        noc_x_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).x);
+        noc_y_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).y);
+    }
+
+    // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a
+    // tile respectively)
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)element_size,
+        (std::uint32_t)sub_tile_line_bytes,
+        q_output_cb_index,
+        head_size,
+        batch,
+        head_tiles,
+        1,  // read the first phase
+        in_num_cores};
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp",
+        q_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    reader_compile_time_args[6] = 2;  // read the second phase
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp",
+        q_cores,
+        tt_metal::WriterDataMovementConfig(reader_compile_time_args));
+
+    uint32_t q_start_addr = q_base_addr;
+
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        uint32_t in_tile_offset_by_batch =
+            i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+
+        const auto& core = cores[i];
+        std::vector<uint32_t> reader_runtime_args;
+        reader_runtime_args.reserve(2 + in_num_cores);
+        reader_runtime_args = {
+            in_tile_offset_by_batch,
+            q_start_addr,
+        };
+        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+
+        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+    }
+
+    auto override_runtime_arguments_callback =
+        [reader_kernel_id, writer_kernel_id, num_cores, cb_q_output, cores, element_size, sub_tile_line_bytes](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto src_buffer = input_tensors.at(0).buffer();
+
+            auto dst_buffer_query = output_tensors.at(0).buffer();
+
+            UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
+
+            uint32_t q_base_addr = input_tensors[0].buffer()->address();
+
+            uint32_t q_start_addr = q_base_addr;
+
+            for (uint32_t i = 0; i < num_cores; ++i) {
+                uint32_t in_tile_offset_by_batch =
+                    i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
+                const auto& core = cores[i];
+                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = in_tile_offset_by_batch;
+                runtime_args[1] = q_start_addr;
+
+                auto& runtime_args_writer = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args_writer[0] = in_tile_offset_by_batch;
+                runtime_args_writer[1] = q_start_addr;
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -264,15 +264,18 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode_subcoregrids(
 
             uint32_t q_start_addr = q_base_addr;
 
+            auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+
             for (uint32_t i = 0; i < num_cores; ++i) {
                 uint32_t in_tile_offset_by_batch =
                     i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512 * element_size;
                 const auto& core = cores[i];
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = in_tile_offset_by_batch;
-                runtime_args[1] = q_start_addr;
+                auto& runtime_args_reader = reader_args_by_core[core.x][core.y];
+                runtime_args_reader[0] = in_tile_offset_by_batch;
+                runtime_args_reader[1] = q_start_addr;
 
-                auto& runtime_args_writer = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto& runtime_args_writer = writer_args_by_core[core.x][core.y];
                 runtime_args_writer[0] = in_tile_offset_by_batch;
                 runtime_args_writer[1] = q_start_addr;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.cpp
@@ -17,8 +17,20 @@ ttnn::Tensor NLPConcatHeadsDecodeOperation::invoke(
     const uint32_t num_heads,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
+    bool on_subcoregrids_val = false;
+    if (input_tensor.is_sharded()) {
+        const auto& input_core_ranges = input_tensor.shard_spec().value().grid.ranges();
+        if (input_core_ranges.size() > 1 || !(input_core_ranges[0].start_coord == CoreCoord{0, 0})) {
+            on_subcoregrids_val = true;
+        }
+    }
+    const bool on_subcoregrids = on_subcoregrids_val;
+
     return operation::run(
-               NLPConcatHeadsDecodeDeviceOperation{num_heads}, {input_tensor}, {}, {std::move(optional_output_tensor)})
+               NLPConcatHeadsDecodeDeviceOperation{num_heads, on_subcoregrids},
+               {input_tensor},
+               {},
+               {std::move(optional_output_tensor)})
         .at(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.cpp
@@ -17,15 +17,13 @@ ttnn::Tensor NLPConcatHeadsDecodeOperation::invoke(
     const uint32_t num_heads,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor) {
-    bool on_subcoregrids_val = false;
+    bool on_subcoregrids = false;
     if (input_tensor.is_sharded()) {
         const auto& input_core_ranges = input_tensor.shard_spec().value().grid.ranges();
         if (input_core_ranges.size() > 1 || !(input_core_ranges[0].start_coord == CoreCoord{0, 0})) {
-            on_subcoregrids_val = true;
+            on_subcoregrids = true;
         }
     }
-    const bool on_subcoregrids = on_subcoregrids_val;
-
     return operation::run(
                NLPConcatHeadsDecodeDeviceOperation{num_heads, on_subcoregrids},
                {input_tensor},


### PR DESCRIPTION
### Problem description
For DRAM Prefetcher project, we have a requirement to move compute and storage to custom coregrid which can have arbitrary start or disjoint core ranges. This PR address the assumption of singular rectangular coregrid in `ttnn.nlp_concat_heads`

### What's changed
Based on input shard spec, a bool variable `on_subcoregrid` is defined. This helps to chose right program factory.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12436765431
- [x] New/Existing tests provide coverage for changes
