### PR TITLE
#16225: Int32 support for abs

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/abs/abs_forge.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/abs/abs_forge.py
@@ -27,9 +27,9 @@ random.seed(0)
 
 
 parameters = {
-    "int32_abs": {
+    "nightly": {
         "input_shape": [[15, 15]],
-        "input_a_dtype": [ttnn.int32],  # , ttnn.float32],
+        "input_a_dtype": [ttnn.int32],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],

--- a/tests/sweep_framework/sweeps/eltwise/unary/abs/abs_forge.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/abs/abs_forge.py
@@ -27,9 +27,9 @@ random.seed(0)
 
 
 parameters = {
-    "nightly": {
+    "int32_abs": {
         "input_shape": [[15, 15]],
-        "input_a_dtype": [ttnn.float32],  # [ttnn.int32]
+        "input_a_dtype": [ttnn.int32],  # , ttnn.float32],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],

--- a/tests/sweep_framework/sweeps/eltwise/unary/abs/abs_forge.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/abs/abs_forge.py
@@ -29,7 +29,7 @@ random.seed(0)
 parameters = {
     "nightly": {
         "input_shape": [[15, 15]],
-        "input_a_dtype": [ttnn.int32],
+        "input_a_dtype": [ttnn.int32, ttnn.float32],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],

--- a/tests/ttnn/unit_tests/operations/eltwise/test_abs_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_abs_int.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import random
+import pytest
+import ttnn
+from tests.sweep_framework.sweep_utils.utils import gen_shapes
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+random.seed(0)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        (torch.Size([15, 1])),
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([3, 3, 320, 384])),
+        (torch.Size([1, 1, 320, 384])),
+    ),
+)
+def test_abs(input_shape, device):
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), ttnn.int32
+    )(input_shape)
+
+    golden_function = ttnn.get_golden_function(ttnn.abs)
+    torch_output_tensor = golden_function(torch_input_tensor_a)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.abs(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    status, value = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert status

--- a/tests/ttnn/unit_tests/operations/eltwise/test_abs_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_abs_int.py
@@ -13,11 +13,12 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
-from models.utility_functions import torch_random
+from models.utility_functions import torch_random, skip_for_grayskull
 
 random.seed(0)
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shape",
     (
@@ -45,10 +46,8 @@ def test_abs(input_shape, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    start_time = start_measuring_time()
     result = ttnn.abs(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(result)
-    e2e_perf = stop_measuring_time(start_time)
 
-    status, value = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    status, _ = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
     assert status

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -22,5 +22,16 @@ inline void calculate_abs() {
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_abs_int32() {
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        TT_SFPLOAD(1, 12, ADDR_MOD_7, 0);
+        TTI_SFPABS(0, 1, 0, 0);
+        TTI_SFPSTORE(0, 12, ADDR_MOD_7, 0);
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -22,4 +22,10 @@ inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (i
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -29,6 +29,7 @@ enum SfpuType {
     gelu_derivative,
     dropout,
     abs,
+    abs_int32,
     sign,
     max,
     sine,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -23,5 +23,14 @@ inline void calculate_abs() {
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_abs_int32() {
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        vInt v = dst_reg[0];
+        dst_reg[0] = sfpi::abs(v);
+        dst_reg++;
+    }
+}
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -27,8 +27,10 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs_int32() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        vInt v = dst_reg[0];
-        dst_reg[0] = sfpi::abs(v);
+        constexpr uint dst_tile_size = 64;
+        TT_SFPLOAD(1, 4, 3, 0);
+        TTI_SFPABS(0, 1, 0, 0);
+        TTI_SFPSTORE(0, 4, 3, 0);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -27,7 +27,6 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs_int32() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        constexpr uint dst_tile_size = 64;
         TT_SFPLOAD(1, 4, 3, 0);
         TTI_SFPABS(0, 1, 0, 0);
         TTI_SFPSTORE(0, 4, 3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -14,7 +14,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::abs, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_abs.h
@@ -14,12 +14,18 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::abs, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_abs(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_abs<APPROXIMATE>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_abs_int32(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_abs_int32<APPROXIMATE>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -30,6 +30,7 @@ enum SfpuType {
     gelu_derivative,
     dropout,
     abs,
+    abs_int32,
     sign,
     max,
     sine,

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -220,10 +220,25 @@ ALWI void abs_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs<APPROX
  */
 ALWI void abs_tile_init() { MATH((llk_math_eltwise_unary_sfpu_abs_init<APPROX>())); }
 
+#ifndef ARCH_GRAYSKULL
 /**
- * Please refer to documentation for any_init.
+ * Performs element-wise computation of absolute value on each element of a tile
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Note: This version of the function is for int32 datatype
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid
+ * Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be
+ * less than the size of the DST register buffer | True     |
  */
 ALWI void abs_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs_int32<APPROX>(idst))); }
+#endif
 
 /**
  * Will store in the output of the compute core the signum of the tile.

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -221,6 +221,11 @@ ALWI void abs_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs<APPROX
 ALWI void abs_tile_init() { MATH((llk_math_eltwise_unary_sfpu_abs_init<APPROX>())); }
 
 /**
+ * Please refer to documentation for any_init.
+ */
+ALWI void abs_tile_int32(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_abs_int32<APPROX>(idst))); }
+
+/**
  * Will store in the output of the compute core the signum of the tile.
  * The DST register buffer must be in acquired state via *acquire_dst* call.
  * This call is blocking and is only

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -24,6 +24,7 @@ enum class UnaryOpType {
     SIN,
     COS,
     ABS,
+    ABS_INT32,
     SIGN,
     SQUARE,
     EQZ,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -366,7 +366,6 @@ bool get_op_approx_mode(UnaryOpType op_type) {
 }
 
 UnaryWithParam string_to_unary_with_param(const std::string& name) {
-    std::cout << "let us see what is the name we are getting here ................. " << std::endl;
     if (name == "relu") {
         return UnaryWithParam(UnaryOpType::RELU);
     } else if (name == "gelu") {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -292,12 +292,13 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, std:
             // log10[x] = log[x]/log[10] = log[x]*0.4342944819032518; FP32@U32 0x3ede5bd9; FP16@U16 0x36f3;
             op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x36f3u);", idst)};
             break;
-            break;
         case UnaryOpType::LOG2:  // log2[x] = log[x]*1.4426950408889634f; FP32@U32 0x3fb8aa3b; FP16@U16 0x3dc5;
             op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x3dc5u);", idst)};
             break;
-            break;
         case UnaryOpType::ABS: op_init_and_name = {"abs_tile_init();", fmt::format("abs_tile({});", idst)}; break;
+        case UnaryOpType::ABS_INT32:
+            op_init_and_name = {"abs_tile_init();", fmt::format("abs_tile_int32({});", idst)};
+            break;
         case UnaryOpType::SIGN: op_init_and_name = {"sign_tile_init();", fmt::format("sign_tile({});", idst)}; break;
         case UnaryOpType::SQUARE:
             op_init_and_name = {"square_tile_init();", fmt::format("square_tile({});", idst)};
@@ -365,6 +366,7 @@ bool get_op_approx_mode(UnaryOpType op_type) {
 }
 
 UnaryWithParam string_to_unary_with_param(const std::string& name) {
+    std::cout << "let us see what is the name we are getting here ................. " << std::endl;
     if (name == "relu") {
         return UnaryWithParam(UnaryOpType::RELU);
     } else if (name == "gelu") {
@@ -393,6 +395,8 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::COS);
     } else if (name == "abs") {
         return UnaryWithParam(UnaryOpType::ABS);
+    } else if (name == "abs_int32") {
+        return UnaryWithParam(UnaryOpType::ABS_INT32);
     } else if (name == "sign") {
         return UnaryWithParam(UnaryOpType::SIGN);
     } else if (name == "square") {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -71,6 +71,13 @@ void validate_supported_arch_dtype(
                 static_cast<int>(output_datatype),
                 static_cast<int>(op_type));
             break;
+        case UnaryOpType::ABS:
+        case UnaryOpType::ABS_INT32:
+            TT_FATAL(
+                !(arch == tt::ARCH::GRAYSKULL && input_datatype == DataType::INT32),
+                "UnaryOpType '{}' (ABS int32 operation) is not supported on Grayskull architecture.",
+                static_cast<int>(op_type));
+            break;
         default: return;
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -69,12 +69,6 @@ Tensor ExecuteUnary<unary_op_types...>::invoke(
 }
 
 template <>
-Tensor ExecuteUnary<UnaryOpType::ABS>::invoke(
-    const ComplexTensor& input_tensor, const MemoryConfig& output_mem_config) {
-    return ttnn::hypot(input_tensor[0], input_tensor[1], output_mem_config);
-}
-
-template <>
 ComplexTensor ExecuteUnary<UnaryOpType::RECIP>::invoke(
     const ComplexTensor& input, const MemoryConfig& output_mem_config) {
     Tensor a_plus_b = ttnn::add(input[0], input[1], std::nullopt, output_mem_config);
@@ -89,8 +83,6 @@ ComplexTensor ExecuteUnary<UnaryOpType::RECIP>::invoke(
     Tensor conj_re = ttnn::multiply(input[0], inv_dr, std::nullopt, output_mem_config);
     return ComplexTensor({conj_re, conj_im});
 }
-
-template struct ExecuteUnary<UnaryOpType::ABS>;
 template struct ExecuteUnary<UnaryOpType::ACOS>;
 template struct ExecuteUnary<UnaryOpType::ASIN>;
 template struct ExecuteUnary<UnaryOpType::ATAN>;
@@ -333,6 +325,34 @@ Tensor Identity::invoke(
 
     return detail::unary_impl(
         DefaultQueueId, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+}
+
+Tensor Abs::invoke(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::ABS;
+    if (input_tensor.get_dtype() == DataType::INT32) {
+        op_type = UnaryOpType::ABS_INT32;
+    }
+    return detail::unary_impl(queue_id, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+}
+
+Tensor Abs::invoke(
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    UnaryOpType op_type = UnaryOpType::ABS;
+    if (input_tensor.get_dtype() == DataType::INT32) {
+        op_type = UnaryOpType::ABS_INT32;
+    }
+    return detail::unary_impl(
+        DefaultQueueId, input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
+}
+
+Tensor Abs::invoke(const ComplexTensor& input_tensor, const MemoryConfig& output_mem_config) {
+    return ttnn::hypot(input_tensor[0], input_tensor[1], output_mem_config);
 }
 
 Tensor Floor::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -21,11 +21,6 @@ struct ExecuteUnaryInvokeResult {
     using type = ComplexTensor;
 };
 
-template <>
-struct ExecuteUnaryInvokeResult<UnaryOpType::ABS> {
-    using type = Tensor;
-};
-
 template <UnaryOpType... unary_op_types>
 struct ExecuteUnary {
     static Tensor invoke(
@@ -146,6 +141,21 @@ struct Identity {
         const Tensor& input_tensor,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
+struct Abs {
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(const ComplexTensor& input_tensor, const MemoryConfig& memory_config);
 };
 
 struct Floor {
@@ -297,7 +307,6 @@ struct AsymmetricBinop {
         ttnn::operations::unary::                                                                  \
             ExecuteUnaryWithIntegerParameter<ttnn::operations::unary::UnaryOpType::operation_type, data_type>>();
 
-REGISTER_UNARY_OPERATION_OVERLOAD(abs, ABS);
 REGISTER_UNARY_OPERATION(acos, ACOS);
 REGISTER_UNARY_OPERATION(asin, ASIN);
 REGISTER_UNARY_OPERATION(atan, ATAN);
@@ -369,6 +378,7 @@ REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(power, POWER, uint32_t);
 // Other unaries
 constexpr auto identity =
     ttnn::register_operation_with_auto_launch_op<"ttnn::identity", ttnn::operations::unary::Identity>();
+constexpr auto abs = ttnn::register_operation_with_auto_launch_op<"ttnn::abs", ttnn::operations::unary::Abs>();
 constexpr auto floor =
     ttnn::register_operation_with_auto_launch_op<"ttnn::floor", ttnn::operations::unary::Floor>();
 constexpr auto ceil = ttnn::register_operation_with_auto_launch_op<"ttnn::ceil", ttnn::operations::unary::Ceil>();


### PR DESCRIPTION
### Ticket
#16225 
### Problem description
Abs forge test failing for int32

### What's changed
supported int32 support for abs op

### Checklist
- [ ] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12556718322
- [ ] Blackhole Post commit (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12555652079
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes - https://github.com/tenstorrent/tt-metal/actions/runs/12556724264
