### PR TITLE
Add support for output sharded embeddings

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -717,34 +717,6 @@ std::uint64_t get_noc_addr(std::uint32_t addr, uint8_t noc = noc_index) {
     return NOC_XY_ADDR(my_x[noc], my_y[noc], addr);
 }
 
-/**
- * Initiates an asynchronous read from a specified source node located at NOC
- * coordinates (x,y) at a local address (encoded as a uint64_t using \a
- * get_noc_addr function). The destination is in L1 memory on the Tensix core
- * executing this function call. Also, see \a noc_async_read_barrier.
- *
- * The source node can be either a DRAM bank, a Tensix core or a PCIe controller.
- *
- * Return value: None
- *
- * | Argument          | Description                                        | Data type | Valid range | required |
- * |-------------------|----------------------------------------------------|-----------|------------------------------------------|----------|
- * | src_noc_addr      | Encoding of the source NOC location (x,y)+address  | uint64_t  | DOX-TODO(ref to explain valid
- * coords)    | Yes      | | dst_local_l1_addr | Address in local L1 memory                         | uint32_t  | 0..1MB
- * | Yes      | | size              | Size of data transfer in bytes                     | uint32_t  | 0..1MB | Yes |
- */
-inline void noc_async_read(
-    std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr, std::uint32_t size, uint8_t noc = noc_index) {
-    /*
-        Read requests - use static VC
-        Read responses - assigned VCs dynamically
-    */
-    WAYPOINT("NARW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, src_noc_addr, dst_local_l1_addr, size);
-    ncrisc_noc_fast_read_any_len(noc, read_cmd_buf, src_noc_addr, dst_local_l1_addr, size);
-    WAYPOINT("NARD");
-}
-
 // TODO: write docs
 // this issues only a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
 FORCE_INLINE
@@ -778,6 +750,39 @@ void noc_async_read_one_packet(
     noc_reads_num_issued[noc] += 1;
 
     WAYPOINT("NAOD");
+}
+
+/**
+ * Initiates an asynchronous read from a specified source node located at NOC
+ * coordinates (x,y) at a local address (encoded as a uint64_t using \a
+ * get_noc_addr function). The destination is in L1 memory on the Tensix core
+ * executing this function call. Also, see \a noc_async_read_barrier.
+ *
+ * The source node can be either a DRAM bank, a Tensix core or a PCIe controller.
+ *
+ * Return value: None
+ *
+ * | Argument          | Description                                        | Data type | Valid range | required |
+ * |-------------------|----------------------------------------------------|-----------|------------------------------------------|----------|
+ * | src_noc_addr      | Encoding of the source NOC location (x,y)+address  | uint64_t  | DOX-TODO(ref to explain valid
+ * coords)    | Yes      | | dst_local_l1_addr | Address in local L1 memory                         | uint32_t  | 0..1MB
+ * | Yes      | | size              | Size of data transfer in bytes                     | uint32_t  | 0..1MB | Yes |
+ */
+template <uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1>
+inline void noc_async_read(
+    std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    /*
+        Read requests - use static VC
+        Read responses - assigned VCs dynamically
+    */
+    if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+        noc_async_read_one_packet(src_noc_addr, dst_local_l1_addr, size, noc);
+    } else {
+        WAYPOINT("NARW");
+        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, src_noc_addr, dst_local_l1_addr, size);
+        ncrisc_noc_fast_read_any_len(noc, read_cmd_buf, src_noc_addr, dst_local_l1_addr, size);
+        WAYPOINT("NARD");
+    }
 }
 
 // TODO: write docs
@@ -1369,6 +1374,23 @@ FORCE_INLINE std::uint64_t get_noc_addr(
 }
 
 template <bool DRAM>
+FORCE_INLINE std::uint64_t get_noc_addr(
+    const uint32_t id, const InterleavedPow2AddrGenFast<DRAM>& s, uint32_t offset = 0, uint8_t noc = noc_index) {
+    /*
+        Alternative API for getting the noc address when we are reading using a swizzled
+        layout. This version assumes bank unit size is a power of 2 and less than or equal to NOC_MAX_BURST_SIZE.
+        For arbitrary bank unit size, use get_noc_addr(const uint32_t id, const InterleavedOffset s)
+
+        id: Unique id for the bank_unit you want to read, assuming row major order. We use this to compute the
+        bank for this unit of data.
+
+        InterleavedPow2AddrGenFast: Check struct for attribute definitions.
+    */
+
+    return s.get_noc_addr(id, offset, noc);
+}
+
+template <bool DRAM>
 FORCE_INLINE void noc_async_read_page(
     const uint32_t id,
     const InterleavedAddrGen<DRAM>& s,
@@ -1419,7 +1441,7 @@ template <uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1>
 inline void noc_async_write(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size);
+        noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size, noc);
     } else {
         WAYPOINT("NAWW");
         DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
@@ -2019,4 +2041,21 @@ uint64_t get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offse
         noc_addr = l1_bank_to_noc_xy[noc_index][bank_id];
     }
     return (noc_addr << NOC_ADDR_COORD_SHIFT) | (bank_address_offset);
+}
+
+template <bool DRAM, uint32_t page_size>
+FORCE_INLINE auto get_interleaved_addr_gen(uint32_t base_addr) {
+    constexpr bool is_pow_2 = is_power_of_2(page_size);
+    if constexpr (is_pow_2) {
+        constexpr uint32_t log2_page_size = __builtin_ctz(page_size);
+        if constexpr (page_size <= NOC_MAX_BURST_SIZE) {
+            return InterleavedPow2AddrGenFast<DRAM>{
+                .bank_base_address = base_addr, .log_base_2_of_page_size = log2_page_size};
+        } else {
+            return InterleavedPow2AddrGen<DRAM>{
+                .bank_base_address = base_addr, .log_base_2_of_page_size = log2_page_size};
+        }
+    } else {
+        return InterleavedAddrGen<DRAM>{.bank_base_address = base_addr, .page_size = page_size};
+    }
 }

--- a/tt_metal/hw/inc/utils/utils.h
+++ b/tt_metal/hw/inc/utils/utils.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
-inline __attribute__((always_inline)) uint32_t align(uint32_t addr, uint32_t alignment) {
+inline __attribute__((always_inline)) constexpr uint32_t align(uint32_t addr, uint32_t alignment) {
     return ((addr - 1) | (alignment - 1)) + 1;
 }
+
+inline __attribute__((always_inline)) constexpr bool is_power_of_2(uint32_t n) { return (n & (n - 1)) == 0; }

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -20,10 +20,11 @@ FORCE_INLINE void enhanced_noc_async_read(
     const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
     // If you do not know the max_transfer_size at compile time write 0 to it.
     // only reads is true if we ONLY use noc_async_read and all calls to tt_memmove have use_read_datamover as True
-    if constexpr (((max_transfer_size < NOC_MAX_BURST_SIZE) && (max_transfer_size != 0)) || only_reads) {
+    if constexpr (only_reads) {
         noc_async_read_one_packet(src_noc_addr, dst_l1_addr, bytes);
     } else {
-        noc_async_read(src_noc_addr, dst_l1_addr, bytes);
+        noc_async_read<max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size>(
+            src_noc_addr, dst_l1_addr, bytes);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/tilize.h"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(2);
+    constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(3);
+    tilize_init(cb_id_in0, per_core_block_tile_cnt, cb_id_out0);
+
+    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+        cb_wait_front(cb_id_in0, per_core_block_tile_cnt);
+        cb_reserve_back(cb_id_out0, per_core_block_tile_cnt);
+
+        tilize_block(cb_id_in0, per_core_block_tile_cnt, cb_id_out0);
+
+        cb_push_back(cb_id_out0, per_core_block_tile_cnt);
+        cb_pop_front(cb_id_in0, per_core_block_tile_cnt);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -22,26 +22,34 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(input_tensors.size() == 2, "Must have between 2 input tensors");
     auto &a = input_tensors.at(0);
     const auto &weights = input_tensors.at(1);
-    TT_FATAL(a.get_layout() == Layout::ROW_MAJOR, "Error");
-    TT_FATAL(weights.get_layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(a.get_layout() == Layout::ROW_MAJOR, "Input tensor must be Row Major Layout");
+    TT_FATAL(weights.get_layout() == Layout::ROW_MAJOR, "Weights tensor must be Row Major Layout");
     TT_FATAL(a.get_dtype() == DataType::UINT32 or a.get_dtype() == DataType::BFLOAT16, "Input must be UINT32 or BFLOAT16");
-    TT_FATAL(weights.get_dtype() == DataType::BFLOAT16, "Error");
-    TT_FATAL(a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharding");
-    TT_FATAL(weights.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharding");
-    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharding");
+    TT_FATAL(weights.get_dtype() == DataType::BFLOAT16, "Weights tensor must have BFLOAT16 dtype");
+    TT_FATAL(a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharded inputs");
+    TT_FATAL(weights.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharded weights");
 
     TT_FATAL(weights.get_legacy_shape()[0] == 1 && weights.get_legacy_shape()[1] == 1, "First two dimensions for the weights must be 1");
     if (this->tilized) {
-        TT_FATAL(a.get_legacy_shape()[-1] % TILE_HEIGHT == 0, "Error");
-        TT_FATAL(weights.get_legacy_shape()[-1] % TILE_WIDTH == 0, "Number of columns in table must be factor of tile width");
+        TT_FATAL(a.get_legacy_shape()[-1] % TILE_HEIGHT == 0, "Input tensor width {} must be a multiple of tile height {} to have the output tensor tilized", a.get_legacy_shape()[-1], TILE_HEIGHT);
+        TT_FATAL(weights.get_legacy_shape()[-1] % TILE_WIDTH == 0, "Number of columns in table {} must be factor of tile width {}", weights.get_legacy_shape()[-1], TILE_WIDTH);
+        if (is_sharded(this->output_mem_config.memory_layout)) {
+            const auto& shard_spec = this->output_mem_config.shard_spec;
+            TT_FATAL(shard_spec.has_value(), "Sharded memory config must have a shard spec");
+            TT_FATAL(shard_spec->shape[0] % TILE_HEIGHT == 0, "Shard height {} must be a multiple of tile height {} to have the output tensor tilized", shard_spec->shape[0], TILE_HEIGHT);
+            TT_FATAL(shard_spec->shape[1] % TILE_WIDTH == 0, "Shard width {} must be a multiple of tile width {} to have the output tensor tilized", shard_spec->shape[1], TILE_WIDTH);
+            TT_FATAL(a.volume() % shard_spec->shape[0] == 0, "Input tensor volume {} must be a multiple of shard height {}", a.volume(), shard_spec->shape[0]);
+            TT_FATAL(weights.get_legacy_shape()[-1] % shard_spec->shape[1] == 0, "Number of columns in table {} must be factor of shard width {}", weights.get_legacy_shape()[-1], shard_spec->shape[1]);
+        }
     } else {
-        TT_FATAL(this->output_dtype != DataType::BFLOAT8_B, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding only supports interleaved RM outputs");
+        TT_FATAL(!is_block_float(this->output_dtype), "Output cannot be a block float dtype when not tilized");
     }
     TT_FATAL(a.get_legacy_shape()[1] == 1 && a.get_legacy_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
     switch (this->embeddings_type) {
-        case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value(), "Error"); break;
-        case EmbeddingsType::BINARY: TT_FATAL(weights.get_legacy_shape()[-2] == 2, "Error");
-        default: TT_FATAL(!this->pad_token.has_value(), "Error");
+        case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value(), "Pad token must be specified when PADDED Embeddings Type is specified"); break;
+        case EmbeddingsType::BINARY: TT_FATAL(weights.get_legacy_shape()[-2] == 2, "Weight tensor must have 2 embeddings for BINARY Embeddings Type"); break;
+        default: TT_FATAL(!this->pad_token.has_value(), "Pad token must not be specified when PADDED Embeddings Type is not specified");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
@@ -14,7 +14,7 @@ using namespace tt::constants;
 namespace ttnn::operations::embedding {
 
 enum class EmbeddingsType { GENERIC, PADDED, BINARY };
-enum class EmbeddingsIndexType { UINT32, BFP16};
+enum class EmbeddingsIndexType { UINT32, BFP16 };
 
 struct Embeddings {
     const MemoryConfig output_mem_config;

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
@@ -44,6 +43,8 @@ operation::ProgramWithCallbacks embeddings_tilized(
     bool weights_is_dram = weights.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool out_is_dram = output.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
 
+    bool output_sharded = is_sharded(output.buffer()->buffer_layout());
+
     uint32_t input_element_size_bytes = a.element_size();
     uint32_t weights_element_size_bytes = weights.element_size();
 
@@ -57,27 +58,40 @@ operation::ProgramWithCallbacks embeddings_tilized(
     uint32_t batch_size = a.get_legacy_shape()[0];
     uint32_t num_output_rows_per_batch = a.get_legacy_shape()[-1];
     uint32_t num_output_rows = num_output_rows_per_batch * batch_size;
+    // Note: num_blocks is just blocks along height
     uint32_t num_blocks = num_output_rows / TILE_HEIGHT;
     uint32_t num_blocks_per_batch = num_output_rows_per_batch / TILE_HEIGHT;
-
-    auto num_embedding_dims = weights.get_legacy_shape()[-1];
-
-    // setup problem and grid size
-    uint32_t start_core_x = 0;
-    uint32_t start_core_y = 0;
-
-    uint32_t problem_size = num_blocks;
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, problem_size);
+    uint32_t num_cores, num_blocks_per_core_group_1, num_blocks_per_core_group_2, num_tiles_per_block;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    bool row_major;
+    if (output_sharded) {
+        const auto& shard_spec = output.shard_spec().value();
+        all_cores = shard_spec.grid;
+        core_group_1 = all_cores;
+        num_cores = all_cores.num_cores();
+        num_blocks_per_core_group_1 = shard_spec.shape[0] / TILE_HEIGHT;
+        num_blocks_per_core_group_2 = 0;
+        num_tiles_per_block = shard_spec.shape[1] / TILE_WIDTH;
+        row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    } else {
+        auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+        uint32_t num_cores_x = compute_with_storage_grid_size.x;
+        uint32_t num_cores_y = compute_with_storage_grid_size.y;
+        std::tie(
+            num_cores,
+            all_cores,
+            core_group_1,
+            core_group_2,
+            num_blocks_per_core_group_1,
+            num_blocks_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+        num_tiles_per_block = weights.get_legacy_shape()[-1] / TILE_WIDTH;
+        row_major = false;
+    }
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();
 
     // Create Buffers
-    uint32_t num_tiles_per_block = weights.get_legacy_shape()[-1] / TILE_WIDTH;
     tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
     EmbeddingsIndexType embeddings_index_type;
@@ -92,63 +106,74 @@ operation::ProgramWithCallbacks embeddings_tilized(
     tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     uint32_t output_single_tile_size = tt_metal::detail::TileSize(output_cb_data_format);
 
-    uint32_t buffering = weights.get_legacy_shape()[-1] > 2048 ? 1 : 2;
+    // Hardcoded limit to reduce L1 usage. Should be updated to be tuned based on overall L1 usage
+    constexpr uint32_t max_double_buffer_tiles = 64;
+    uint32_t buffering = num_tiles_per_block > max_double_buffer_tiles ? 1 : 2;
 
-    uint32_t src0_cb_index = 0;
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(
             buffering * num_tiles_per_block * weights_single_tile_size, {{src0_cb_index, weights_cb_data_format}})
             .set_page_size(src0_cb_index, weights_single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t src1_cb_index = 1;
+    constexpr uint32_t src1_cb_index = CBIndex::c_1;
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(TILE_HEIGHT * input_element_size_bytes, {{src1_cb_index, input_cb_data_format}})
             .set_page_size(src1_cb_index, TILE_HEIGHT * input_element_size_bytes);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
+    constexpr uint32_t output_cb_index = CBIndex::c_2;
+    uint32_t output_cb_size;
+    if (output_sharded) {
+        output_cb_size = output.buffer()->aligned_size_per_bank();
+    } else {
+        output_cb_size = buffering * num_tiles_per_block * output_single_tile_size;
+    }
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(output_cb_size, {{output_cb_index, output_cb_data_format}})
+            .set_page_size(output_cb_index, output_single_tile_size);
+    if (output_sharded) {
+        cb_output_config.set_globally_allocated_address(*out_buffer);
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    constexpr uint32_t src2_cb_index = CBIndex::c_3;
     if (embeddings_type == EmbeddingsType::PADDED) {
-        uint32_t src2_cb_index = 2;
         uint32_t cache_page_size = round_up_to_mul32(weight_page_size);
         tt_metal::CircularBufferConfig cb_src2_config =
             tt_metal::CircularBufferConfig(cache_page_size, {{src2_cb_index, weights_cb_data_format}})
                 .set_page_size(src2_cb_index, cache_page_size);
         auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
     } else if (embeddings_type == EmbeddingsType::BINARY) {
-        uint32_t src2_cb_index = 2;
         uint32_t cache_page_size = round_up_to_mul32(weight_page_size);
         tt_metal::CircularBufferConfig cb_src2_config =
             tt_metal::CircularBufferConfig(2 * cache_page_size, {{src2_cb_index, weights_cb_data_format}})
                 .set_page_size(src2_cb_index, cache_page_size);
         auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
     }
+    uint32_t weight_block_size;
+    if (output_sharded) {
+        weight_block_size = output.shard_spec().value().shape[1] * weights_element_size_bytes;
+    } else {
+        weight_block_size = weight_page_size;
+    }
 
-    uint32_t output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(
-            buffering * num_tiles_per_block * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
-            .set_page_size(output_cb_index, output_single_tile_size);
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-
-    bool input_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_page_size);
-    uint32_t input_log2_stick_size = input_stick_size_is_power_of_two ? (std::uint32_t)std::log2(input_page_size) : 0;
-    bool weight_stick_size_is_power_of_two = is_power_of_two_at_least_32(weight_page_size);
-    uint32_t weight_log2_stick_size =
-        weight_stick_size_is_power_of_two ? (std::uint32_t)std::log2(weight_page_size) : 0;
-
+    // TODO: Can increase size for larger reads
+    uint32_t input_block_size_bytes = TILE_HEIGHT * input_element_size_bytes;
     // Create Kernels
     // reader
     std::vector<uint32_t> embedding_compile_time_args = {
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)src1_cb_index,
+        (std::uint32_t)src2_cb_index,
         (std::uint32_t)in0_is_dram,
-        (std::uint32_t)input_stick_size_is_power_of_two,
         (std::uint32_t)input_page_size,
-        (std::uint32_t)input_log2_stick_size,
         (std::uint32_t)weights_is_dram,
-        (std::uint32_t)weight_stick_size_is_power_of_two,
         (std::uint32_t)weight_page_size,
-        (std::uint32_t)weight_log2_stick_size,
+        (std::uint32_t)weight_block_size,
         (std::uint32_t)num_tiles_per_block,
-        (std::uint32_t)TILE_HEIGHT * input_element_size_bytes};
+        (std::uint32_t)input_block_size_bytes};
 
     std::map<string, string> embedding_defines = {
         {magic_enum::enum_name(embeddings_type).data(), "1"},
@@ -162,45 +187,50 @@ operation::ProgramWithCallbacks embeddings_tilized(
 
     if (num_blocks_per_core_group_1 > 0) {
         std::vector<uint32_t> compute_args_1 = {
+            uint32_t(src0_cb_index),                // input embeddings_cb_index
+            uint32_t(output_cb_index),              // output_cb_index
             uint32_t(num_blocks_per_core_group_1),  // per_core_block_cnt
             uint32_t(num_tiles_per_block)           // per_core_block_tile_cnt
         };
         auto tilize_kernel_id_1 = tt_metal::CreateKernel(
             program,
-            "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/tilize.cpp",
+            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp",
             core_group_1,
             tt_metal::ComputeConfig{.compile_args = compute_args_1});
     }
 
     if (num_blocks_per_core_group_2 > 0) {
         std::vector<uint32_t> compute_args_2 = {
+            uint32_t(src0_cb_index),                // input embeddings_cb_index
+            uint32_t(output_cb_index),              // output_cb_index
             uint32_t(num_blocks_per_core_group_2),  // per_core_block_cnt
             uint32_t(num_tiles_per_block)           // per_core_block_tile_cnt
         };
         auto tilize_kernel_id_2 = tt_metal::CreateKernel(
             program,
-            "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/tilize.cpp",
+            "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp",
             core_group_2,
             tt_metal::ComputeConfig{.compile_args = compute_args_2});
     }
+    KernelHandle writer_kernel_id = 0;
+    // TODO: We can use the second risc to do more work in parallel
+    if (!output_sharded) {
+        std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)out_is_dram};
 
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)out_is_dram};
+        // Tilized writer
+        writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+            all_cores,
+            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    }
 
-    // Tilized writer
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    auto cores = corerange_to_cores(all_cores, std::nullopt, row_major);
 
-    uint32_t input_offset = 0;
-    uint32_t weight_offset = 0;
-    uint32_t tile_offset = 0;
-
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
     std::vector<uint32_t> reader_runtime_args = {
         (std::uint32_t)a.buffer()->address(),
         (std::uint32_t)weights.buffer()->address(),
+        (std::uint32_t)0,
         (std::uint32_t)0,
         (std::uint32_t)0,
         (std::uint32_t)0,
@@ -212,54 +242,73 @@ operation::ProgramWithCallbacks embeddings_tilized(
     std::vector<uint32_t> writer_runtime_args = {
         (std::uint32_t)output.buffer()->address(), (std::uint32_t)0, (std::uint32_t)0};
 
+    uint32_t input_offset = 0;
+    uint32_t weight_offset = 0;
+    uint32_t tile_offset = 0;
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
 
-        uint32_t local_input_offset = input_offset;
         uint32_t local_num_blocks = i < g1_numcores ? num_blocks_per_core_group_1 : num_blocks_per_core_group_2;
 
         // Reader
         {
             reader_runtime_args[2] = input_offset / num_blocks_per_batch;
-            reader_runtime_args[3] = input_offset % num_blocks_per_batch * TILE_HEIGHT * input_element_size_bytes;
-            reader_runtime_args[4] = local_num_blocks;
+            reader_runtime_args[3] = input_offset % num_blocks_per_batch * input_block_size_bytes;
+            reader_runtime_args[4] = weight_offset;
+            reader_runtime_args[5] = local_num_blocks;
             tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
         }
 
         // Writer
-        {
+        if (!output_sharded) {
             writer_runtime_args[1] = num_tiles_per_block * local_num_blocks;
             writer_runtime_args[2] = tile_offset;
             tile_offset += local_num_blocks * num_tiles_per_block;
             tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+            input_offset += local_num_blocks;
+        } else {
+            weight_offset += weight_block_size;
+            if (weight_offset == weight_page_size) {
+                weight_offset = 0;
+                input_offset += local_num_blocks;
+            }
         }
-
-        input_offset += local_num_blocks;
     }
 
-    auto override_runtime_args_callback = [num_cores_x, num_cores_y, reader_kernel_id, writer_kernel_id, cores, device](
-                                              const Program& program,
-                                              const std::vector<Buffer*>& input_buffers,
-                                              const std::vector<Buffer*>& output_buffers) {
-        auto output_dram_buffer = output_buffers.at(0);
-        auto input_dram_buffer = input_buffers.at(0);
-        auto weights_dram_buffer = input_buffers.at(1);
+    auto override_runtime_arguments_callback =
+        [reader_kernel_id, writer_kernel_id, cores, cb_output](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto output_buffer = output_tensors.at(0).buffer();
+            auto output_buffer_address = output_buffer->address();
+            auto input_buffer_address = input_tensors.at(0).buffer()->address();
+            auto weights_buffer_address = input_tensors.at(1).buffer()->address();
 
-        for (const auto& core : cores) {
-            {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = input_dram_buffer->address();
-                runtime_args[1] = weights_dram_buffer->address();
+            auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
+            const bool output_sharded = is_sharded(output_buffer->buffer_layout());
+            if (output_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_output, *output_buffer);
             }
 
-            {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-            }
-        }
-    };
+            for (const auto& core : cores) {
+                {
+                    auto& runtime_args = reader_runtime_args[core.x][core.y];
+                    runtime_args[0] = input_buffer_address;
+                    runtime_args[1] = weights_buffer_address;
+                }
 
-    return {std::move(program), override_runtime_args_callback};
+                if (!output_sharded) {
+                    auto& runtime_args = writer_runtime_args[core.x][core.y];
+                    runtime_args[0] = output_buffer_address;
+                }
+            }
+        };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
 operation::ProgramWithCallbacks embeddings_rm(
@@ -307,12 +356,10 @@ operation::ProgramWithCallbacks embeddings_rm(
     uint32_t batch_size = a.get_legacy_shape()[0];
     uint32_t num_output_rows_per_batch = a.get_legacy_shape()[-1];
     uint32_t num_output_rows = num_output_rows_per_batch * batch_size;
-    constexpr uint32_t alignment = 32;
+    auto alignment = a.buffer()->alignment();
     uint32_t block_height = (alignment / input_element_size_bytes);
     uint32_t num_blocks = num_output_rows;
     uint32_t num_blocks_per_batch = num_output_rows_per_batch;
-
-    auto num_embedding_dims = weights.get_legacy_shape()[-1];
 
     // setup problem and grid size
     uint32_t start_core_x = 0;
@@ -335,29 +382,30 @@ operation::ProgramWithCallbacks embeddings_rm(
     tt::DataFormat weights_cb_data_format = tt_metal::datatype_to_dataformat_converter(weights.get_dtype());
     tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
 
-    uint32_t src0_cb_index = 0;
+    constexpr uint32_t src0_cb_index = CBIndex::c_0;
     uint32_t rounded_weight_page_size = round_up_to_mul32(weight_page_size);
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(2 * rounded_weight_page_size, {{src0_cb_index, weights_cb_data_format}})
             .set_page_size(src0_cb_index, rounded_weight_page_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    uint32_t src1_cb_index = 1;
+    constexpr uint32_t src1_cb_index = CBIndex::c_1;
     uint32_t index_page_size = round_up_to_mul32(input_element_size_bytes);
     tt_metal::CircularBufferConfig cb_src1_config =
         tt_metal::CircularBufferConfig(block_height * index_page_size, {{src1_cb_index, input_cb_data_format}})
             .set_page_size(src1_cb_index, block_height * index_page_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
+    constexpr uint32_t output_cb_index = src0_cb_index;
+
+    constexpr uint32_t src2_cb_index = CBIndex::c_2;
     if (embeddings_type == EmbeddingsType::PADDED) {
-        uint32_t src2_cb_index = 2;
         uint32_t cache_page_size = round_up_to_mul32(weight_page_size);
         tt_metal::CircularBufferConfig cb_src2_config =
             tt_metal::CircularBufferConfig(cache_page_size, {{src2_cb_index, weights_cb_data_format}})
                 .set_page_size(src2_cb_index, cache_page_size);
         auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
     } else if (embeddings_type == EmbeddingsType::BINARY) {
-        uint32_t src2_cb_index = 2;
         uint32_t cache_page_size = round_up_to_mul32(weight_page_size);
         tt_metal::CircularBufferConfig cb_src2_config =
             tt_metal::CircularBufferConfig(2 * cache_page_size, {{src2_cb_index, weights_cb_data_format}})
@@ -365,25 +413,16 @@ operation::ProgramWithCallbacks embeddings_rm(
         auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
     }
 
-    uint32_t output_cb_index = src0_cb_index;
-
-    bool input_stick_size_is_power_of_two = is_power_of_two_at_least_32(input_page_size);
-    uint32_t input_log2_stick_size = input_stick_size_is_power_of_two ? (std::uint32_t)std::log2(input_page_size) : 0;
-    bool weight_stick_size_is_power_of_two = is_power_of_two_at_least_32(weight_page_size);
-    uint32_t weight_log2_stick_size =
-        weight_stick_size_is_power_of_two ? (std::uint32_t)std::log2(weight_page_size) : 0;
-
     // Create Kernels
     // reader
     std::vector<uint32_t> embedding_compile_time_args = {
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)src1_cb_index,
+        (std::uint32_t)src2_cb_index,
         (std::uint32_t)in0_is_dram,
-        (std::uint32_t)input_stick_size_is_power_of_two,
         (std::uint32_t)input_page_size,
-        (std::uint32_t)input_log2_stick_size,
         (std::uint32_t)weights_is_dram,
-        (std::uint32_t)weight_stick_size_is_power_of_two,
         (std::uint32_t)weight_page_size,
-        (std::uint32_t)weight_log2_stick_size,
         (std::uint32_t)block_height,
         (std::uint32_t)block_height * input_element_size_bytes};
 
@@ -463,29 +502,35 @@ operation::ProgramWithCallbacks embeddings_rm(
         input_offset += local_num_blocks;
     }
 
-    auto override_runtime_args_callback = [num_cores_x, num_cores_y, reader_kernel_id, writer_kernel_id, cores, device](
-                                              const Program& program,
-                                              const std::vector<Buffer*>& input_buffers,
-                                              const std::vector<Buffer*>& output_buffers) {
-        auto output_dram_buffer = output_buffers.at(0);
-        auto input_dram_buffer = input_buffers.at(0);
-        auto weights_dram_buffer = input_buffers.at(1);
+    auto override_runtime_arguments_callback =
+        [reader_kernel_id, writer_kernel_id, cores](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto output_buffer_address = output_tensors.at(0).buffer()->address();
+            auto input_buffer_address = input_tensors.at(0).buffer()->address();
+            auto weights_buffer_address = input_tensors.at(1).buffer()->address();
 
-        for (const auto& core : cores) {
-            {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = input_dram_buffer->address();
-                runtime_args[1] = weights_dram_buffer->address();
+            auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
+
+            for (const auto& core : cores) {
+                {
+                    auto& runtime_args = reader_runtime_args[core.x][core.y];
+                    runtime_args[0] = input_buffer_address;
+                    runtime_args[1] = weights_buffer_address;
+                }
+
+                {
+                    auto& runtime_args = writer_runtime_args[core.x][core.y];
+                    runtime_args[0] = output_buffer_address;
+                }
             }
+        };
 
-            {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
 operation::ProgramWithCallbacks embeddings_(

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
@@ -3,127 +3,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp"
 
 void kernel_main() {
-    const std::uint32_t input_dram_buffer_src_addr = get_arg_val<uint32_t>(0);
-    const std::uint32_t weights_dram_buffer_src_addr = get_arg_val<uint32_t>(1);
+    const std::uint32_t input_buffer_src_addr = get_arg_val<uint32_t>(0);
+    const std::uint32_t weight_buffer_src_addr = get_arg_val<uint32_t>(1);
     const std::uint32_t batch_offset = get_arg_val<uint32_t>(2);
     const std::uint32_t weights_offset = get_arg_val<uint32_t>(3);
     const std::uint32_t num_blocks = get_arg_val<uint32_t>(4);
 
     const std::uint32_t index_idx = get_arg_val<uint32_t>(5);
 
-#define in_is_dram get_compile_time_arg_val(0) == 1
-#define in_stick_size_is_power_of_two get_compile_time_arg_val(1) == 1
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(2);
-#if (in_stick_size_is_power_of_two)
-    constexpr uint32_t log_base_2_of_input_page_size = get_compile_time_arg_val(3);
-    const InterleavedPow2AddrGen<in_is_dram> input = {
-        .bank_base_address = input_dram_buffer_src_addr,
-        .log_base_2_of_page_size = log_base_2_of_input_page_size  // TODO(AP): refactor
-    };
-#else
-    const InterleavedAddrGen<in_is_dram> input = {
-        .bank_base_address = input_dram_buffer_src_addr, .page_size = input_page_size};
-#endif
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
 
-#define weights_is_dram get_compile_time_arg_val(4) == 1
-#define weight_stick_size_is_power_of_two get_compile_time_arg_val(5) == 1
+    constexpr bool input_in_dram = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
+    const auto input = get_interleaved_addr_gen<input_in_dram, input_page_size>(input_buffer_src_addr);
+
+    constexpr bool weight_in_dram = get_compile_time_arg_val(5) == 1;
     constexpr uint32_t weight_stick_size = get_compile_time_arg_val(6);
-#if (weight_stick_size_is_power_of_two)
-    constexpr uint32_t log_base_2_of_weights_page_size = get_compile_time_arg_val(7);
-    const InterleavedPow2AddrGen<weights_is_dram> weights = {
-        .bank_base_address = weights_dram_buffer_src_addr,
-        .log_base_2_of_page_size = log_base_2_of_weights_page_size  // TODO(AP): refactor
-    };
-#else
-    const InterleavedAddrGen<weights_is_dram> weights = {
-        .bank_base_address = weights_dram_buffer_src_addr, .page_size = weight_stick_size};
-#endif
+    const auto weights = get_interleaved_addr_gen<weight_in_dram, weight_stick_size>(weight_buffer_src_addr);
 
-    constexpr uint32_t rows_per_block = get_compile_time_arg_val(8);
-    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(9);
+    constexpr uint32_t rows_per_block = get_compile_time_arg_val(7);
+    constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(8);
 
-    constexpr uint32_t cb_id_in0 = 0;
-    constexpr uint32_t cb_id_in1 = 1;
-    constexpr uint32_t cb_id_in2 = 2;
-
-    constexpr uint32_t tile_height = 32;
-
-#if defined PADDED
-    const std::uint32_t pad_token = get_arg_val<uint32_t>(6);
-    uint64_t pad_noc_addr;
-    {
-        cb_reserve_back(cb_id_in2, 1);
-        uint32_t local_pad_addr = get_write_ptr(cb_id_in2);
-        uint64_t src_noc_addr = get_noc_addr(pad_token, weights);
-        noc_async_read(src_noc_addr, local_pad_addr, weight_stick_size);
-        noc_async_read_barrier();
-        pad_noc_addr = get_noc_addr(local_pad_addr);
-    }
-#elif defined BINARY
-    uint64_t zero_noc_addr, one_noc_addr;
-    {
-        cb_reserve_back(cb_id_in2, 2);
-        uint32_t local_write_addr = get_write_ptr(cb_id_in2);
-        uint64_t src_noc_addr = get_noc_addr(0, weights);
-        noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
-        zero_noc_addr = get_noc_addr(local_write_addr);
-
-        local_write_addr += weight_stick_size;
-        src_noc_addr = get_noc_addr(1, weights);
-        noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
-        one_noc_addr = get_noc_addr(local_write_addr);
-
-        noc_async_read_barrier();
-    }
-#endif
+    prepare_local_cache(cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
 
     cb_reserve_back(cb_id_in1, 1);
     uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
-#if defined BFP16
-    volatile tt_l1_ptr uint16_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(input_l1_addr);
-#else
-    volatile tt_l1_ptr uint32_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(input_l1_addr);
-#endif
-    auto read_block = [&](const uint32_t& token_idx, const uint32_t& width_size) {
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        uint64_t src_noc_addr;
-        uint32_t token = input_l1_ptr[token_idx];
-#if defined PADDED
-        if (token == pad_token) {
-            src_noc_addr = pad_noc_addr;
-        } else {
-            src_noc_addr = get_noc_addr(token, weights);
-        }
-#elif defined BINARY
-        if (token == 0) {
-            src_noc_addr = zero_noc_addr;
-        } else {
-            src_noc_addr = one_noc_addr;
-        }
-#else
-#if defined BFP16
-        union {
-            float f;
-            uint32_t u;
-        } u;
-        u.u = (uint32_t)input_l1_ptr[token_idx] << 16;
-        uint32_t token_casted = static_cast<uint32_t>(u.f);
-        src_noc_addr = get_noc_addr(token_casted, weights);
-#else
-        src_noc_addr = get_noc_addr(token, weights);
-#endif
-#endif
-        noc_async_read(src_noc_addr, l1_write_addr, width_size);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, 1);
-    };
+    volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
     uint32_t curr_row = batch_offset;
     uint32_t offset = weights_offset;
     uint32_t index = index_idx;
+
     bool read_indices = true;
     for (uint32_t i = 0; i < num_blocks; ++i) {
         if (read_indices) {
@@ -132,7 +47,14 @@ void kernel_main() {
             noc_async_read_barrier();
             read_indices = false;
         }
-        read_block(index, weight_stick_size);
+        cb_reserve_back(cb_id_in0, 1);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        input_token_t token = input_l1_ptr[index];
+        uint64_t src_noc_addr = get_token_noc_addr(token, weights);
+        noc_async_read<weight_stick_size>(src_noc_addr, l1_write_addr, weight_stick_size);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, 1);
+
         index++;
         if (index == rows_per_block) {
             index = 0;

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dataflow_api.h"
+
+// TODO: Should get this from somewhere
+constexpr uint32_t tile_height = 32;
+
+#if defined BFP16
+typedef uint16_t input_token_t;
+#else
+typedef uint32_t input_token_t;
+#endif
+
+// TODO: Can probably make this not global
+uint32_t pad_token;
+uint64_t pad_noc_addr;
+uint64_t zero_noc_addr;
+uint64_t one_noc_addr;
+
+template <typename T>
+FORCE_INLINE constexpr void prepare_local_cache(
+    uint32_t local_cache_cb, const T& weights, uint32_t weight_stick_size, uint32_t pad_token_arg_idx = 0) {
+#if defined PADDED
+    pad_token = get_arg_val<uint32_t>(pad_token_arg_idx);
+    cb_reserve_back(local_cache_cb, 1);
+    uint32_t local_pad_addr = get_write_ptr(local_cache_cb);
+    uint64_t src_noc_addr = get_noc_addr(pad_token, weights);
+    noc_async_read(src_noc_addr, local_pad_addr, weight_stick_size);
+    noc_async_read_barrier();
+    pad_noc_addr = get_noc_addr(local_pad_addr);
+#elif defined BINARY
+    cb_reserve_back(local_cache_cb, 2);
+    uint32_t local_write_addr = get_write_ptr(local_cache_cb);
+    uint64_t src_noc_addr = get_noc_addr(0, weights);
+    noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
+    zero_noc_addr = get_noc_addr(local_write_addr);
+
+    local_write_addr += weight_stick_size;
+    src_noc_addr = get_noc_addr(1, weights);
+    noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
+    one_noc_addr = get_noc_addr(local_write_addr);
+
+    noc_async_read_barrier();
+#endif
+}
+
+template <typename T>
+FORCE_INLINE uint64_t get_token_noc_addr(input_token_t token, const T& weights) {
+#if defined PADDED
+    if (token == pad_token) {
+        return pad_noc_addr;
+    } else {
+        return get_noc_addr(token, weights);
+    }
+#elif defined BINARY
+    if (token == 0) {
+        return zero_noc_addr;
+    } else {
+        return one_noc_addr;
+    }
+#elif defined BFP16
+    union {
+        float f;
+        uint32_t u;
+    } u;
+    u.u = (uint32_t)token << 16;
+    uint32_t token_casted = static_cast<uint32_t>(u.f);
+    return get_noc_addr(token_casted, weights);
+#else
+    return get_noc_addr(token, weights);
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -3,132 +3,57 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp"
 
 void kernel_main() {
-    const std::uint32_t input_dram_buffer_src_addr = get_arg_val<uint32_t>(0);
-    const std::uint32_t weights_dram_buffer_src_addr = get_arg_val<uint32_t>(1);
-    const std::uint32_t batch_offset = get_arg_val<uint32_t>(2);
-    const std::uint32_t weights_offset = get_arg_val<uint32_t>(3);
-    const std::uint32_t num_blocks = get_arg_val<uint32_t>(4);
+    const uint32_t input_buffer_src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t weight_buffer_src_addr = get_arg_val<uint32_t>(1);
+    const uint32_t input_start_id = get_arg_val<uint32_t>(2);
+    const uint32_t input_start_offset = get_arg_val<uint32_t>(3);
+    const uint32_t weight_offset = get_arg_val<uint32_t>(4);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(5);
 
-#define in_is_dram get_compile_time_arg_val(0) == 1
-#define in_stick_size_is_power_of_two get_compile_time_arg_val(1) == 1
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(2);
-#if (in_stick_size_is_power_of_two)
-    constexpr uint32_t log_base_2_of_input_page_size = get_compile_time_arg_val(3);
-    const InterleavedPow2AddrGen<in_is_dram> input = {
-        .bank_base_address = input_dram_buffer_src_addr,
-        .log_base_2_of_page_size = log_base_2_of_input_page_size  // TODO(AP): refactor
-    };
-#else
-    const InterleavedAddrGen<in_is_dram> input = {
-        .bank_base_address = input_dram_buffer_src_addr, .page_size = input_page_size};
-#endif
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
 
-#define weights_is_dram get_compile_time_arg_val(4) == 1
-#define weight_stick_size_is_power_of_two get_compile_time_arg_val(5) == 1
+    constexpr bool input_in_dram = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
+    auto input = get_interleaved_addr_gen<input_in_dram, input_page_size>(input_buffer_src_addr);
+
+    constexpr bool weight_in_dram = get_compile_time_arg_val(5) == 1;
     constexpr uint32_t weight_stick_size = get_compile_time_arg_val(6);
-#if (weight_stick_size_is_power_of_two)
-    constexpr uint32_t log_base_2_of_weights_page_size = get_compile_time_arg_val(7);
-    const InterleavedPow2AddrGen<weights_is_dram> weights = {
-        .bank_base_address = weights_dram_buffer_src_addr,
-        .log_base_2_of_page_size = log_base_2_of_weights_page_size  // TODO(AP): refactor
-    };
-#else
-    const InterleavedAddrGen<weights_is_dram> weights = {
-        .bank_base_address = weights_dram_buffer_src_addr, .page_size = weight_stick_size};
-#endif
+    constexpr uint32_t weight_block_size = get_compile_time_arg_val(7);
+    auto weights = get_interleaved_addr_gen<weight_in_dram, weight_stick_size>(weight_buffer_src_addr + weight_offset);
+
     constexpr uint32_t tiles_per_block = get_compile_time_arg_val(8);
     constexpr uint32_t input_block_size_bytes = get_compile_time_arg_val(9);
 
-    constexpr uint32_t cb_id_in0 = 0;
-    constexpr uint32_t cb_id_in1 = 1;
-    constexpr uint32_t cb_id_in2 = 2;
-
-    constexpr uint32_t tile_height = 32;
-
-#if defined PADDED
-    const std::uint32_t pad_token = get_arg_val<uint32_t>(5);
-    uint64_t pad_noc_addr;
-    {
-        cb_reserve_back(cb_id_in2, 1);
-        uint32_t local_pad_addr = get_write_ptr(cb_id_in2);
-        uint64_t src_noc_addr = get_noc_addr(pad_token, weights);
-        noc_async_read(src_noc_addr, local_pad_addr, weight_stick_size);
-        noc_async_read_barrier();
-        pad_noc_addr = get_noc_addr(local_pad_addr);
-    }
-#elif defined BINARY
-    uint64_t zero_noc_addr, one_noc_addr;
-    {
-        cb_reserve_back(cb_id_in2, 2);
-        uint32_t local_write_addr = get_write_ptr(cb_id_in2);
-        uint64_t src_noc_addr = get_noc_addr(0, weights);
-        noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
-        zero_noc_addr = get_noc_addr(local_write_addr);
-
-        local_write_addr += weight_stick_size;
-        src_noc_addr = get_noc_addr(1, weights);
-        noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
-        one_noc_addr = get_noc_addr(local_write_addr);
-
-        noc_async_read_barrier();
-    }
-#endif
+    prepare_local_cache(cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6);
 
     cb_reserve_back(cb_id_in1, 1);
     uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
-#if defined BFP16
-    volatile tt_l1_ptr uint16_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(input_l1_addr);
-#else
-    volatile tt_l1_ptr uint32_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(input_l1_addr);
-#endif
 
-    auto read_tiles = [&](const uint32_t& num_tiles, const uint32_t& width_size) {
-        cb_reserve_back(cb_id_in0, num_tiles);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        for (uint32_t k = 0; k < tile_height; ++k) {
-            uint64_t src_noc_addr;
-            uint32_t token = input_l1_ptr[k];
-#if defined PADDED
-            if (token == pad_token) {
-                src_noc_addr = pad_noc_addr;
-            } else {
-                src_noc_addr = get_noc_addr(token, weights);
-            }
-#elif defined BINARY
-            if (token == 0) {
-                src_noc_addr = zero_noc_addr;
-            } else {
-                src_noc_addr = one_noc_addr;
-            }
-#else
-#if defined BFP16
-            union {
-                float f;
-                uint32_t u;
-            } u;
-            u.u = (uint32_t)input_l1_ptr[k] << 16;
-            uint32_t token_casted = static_cast<uint32_t>(u.f);
-            src_noc_addr = get_noc_addr(token_casted, weights);
-#else
-            src_noc_addr = get_noc_addr(token, weights);
-#endif
-#endif
-            noc_async_read(src_noc_addr, l1_write_addr, width_size);
-            l1_write_addr += width_size;
-        }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, num_tiles);
-    };
+    volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
-    uint32_t curr_row = batch_offset;
-    uint32_t offset = weights_offset;
+    uint32_t curr_row = input_start_id;
+    uint32_t offset = input_start_offset;
     for (uint32_t i = 0; i < num_blocks; ++i) {
         uint64_t noc_input_src_addr = get_noc_addr(curr_row, input) + offset;
-        noc_async_read(noc_input_src_addr, input_l1_addr, input_block_size_bytes);
+        noc_async_read<input_block_size_bytes>(noc_input_src_addr, input_l1_addr, input_block_size_bytes);
         noc_async_read_barrier();
-        read_tiles(tiles_per_block, weight_stick_size);
+
+        cb_reserve_back(cb_id_in0, tiles_per_block);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        for (uint32_t k = 0; k < tile_height; ++k) {
+            input_token_t token = input_l1_ptr[k];
+            uint64_t src_noc_addr = get_token_noc_addr(token, weights);
+            noc_async_read<weight_block_size>(src_noc_addr, l1_write_addr, weight_block_size);
+            l1_write_addr += weight_block_size;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, tiles_per_block);
+
         offset += input_block_size_bytes;
         if (offset == input_page_size) {
             offset = 0;

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -33,6 +33,24 @@ const Shape Shape::to_rank(size_t new_rank) const {
 
 namespace tt::tt_metal {
 
+bool is_floating_point(DataType dtype) {
+    switch (dtype) {
+        case DataType::BFLOAT16:
+        case DataType::FLOAT32:
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B: return true;
+        default: return false;
+    }
+}
+
+bool is_block_float(DataType dtype) {
+    switch (dtype) {
+        case DataType::BFLOAT8_B:
+        case DataType::BFLOAT4_B: return true;
+        default: return false;
+    }
+}
+
 tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype) {
     switch (datatype) {
         case tt::tt_metal::DataType::BFLOAT16: return tt::DataFormat::Float16_b;

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -61,15 +61,9 @@ consteval inline DataType convert_to_data_type() {
     }
 }
 
-inline bool is_floating_point(DataType dtype) {
-    switch (dtype) {
-        case DataType::BFLOAT16:
-        case DataType::FLOAT32:
-        case DataType::BFLOAT8_B:
-        case DataType::BFLOAT4_B: return true;
-        default: return false;
-    }
-}
+bool is_floating_point(DataType dtype);
+
+bool is_block_float(DataType dtype);
 
 enum class StorageType {
     OWNED,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to support output sharding output on arbitrary core ranges.

### What's changed
Add function to automatically select the best addrgen based on params.
Clean up/refactor some embeddings code to commonize some functionality.
Add support and tests for height, width, block output sharded embeddings.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12443728658
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12439395900
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12443731327/job/34743314196 https://github.com/tenstorrent/tt-metal/actions/runs/12439401062
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12443730039
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
