### PR TITLE
suppport all dim lengths for reduction

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -50,28 +50,6 @@ def test_var(device, batch_size, h, w, dim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("batch_size", [1, 16])
-@pytest.mark.parametrize("c", [1, 4, 8, 16])
-@pytest.mark.parametrize("h", [32, 64, 41, 37])
-@pytest.mark.parametrize("w", [32, 64, 31, 63])
-@pytest.mark.parametrize("dim", [None, [0, 1, 2, 3]])
-@pytest.mark.parametrize("keepdim", [True])
-def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
-    torch.manual_seed(0)
-
-    torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-
-    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
-    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
-    output_tensor = ttnn.from_device(output_tensor)
-
-    output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
-
-
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("c", [11])
 @pytest.mark.parametrize("h", [67])
@@ -101,9 +79,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
 @pytest.mark.parametrize("c", [5])
 @pytest.mark.parametrize("h", [37])
 @pytest.mark.parametrize("w", [63])
-@pytest.mark.parametrize(
-    "dim", [None, [], 0, 1, 2, 3, [0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]]
-)
+@pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
@@ -124,7 +100,7 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [31])
 @pytest.mark.parametrize("w", [32])
-@pytest.mark.parametrize("dim", [None, [], 0, 1, 2, [0, 1], [0, 2], [1, 2], [0, 1, 2]])
+@pytest.mark.parametrize("dim", [[0, 2], [0, 1, 2]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_3d_tensor_dims(device, c, h, w, dim, keepdim):
     torch.manual_seed(0)
@@ -144,7 +120,7 @@ def test_sum_3d_tensor_dims(device, c, h, w, dim, keepdim):
 
 @pytest.mark.parametrize("h", [41])
 @pytest.mark.parametrize("w", [31])
-@pytest.mark.parametrize("dim", [None, [], 0, 1, [0, 1]])
+@pytest.mark.parametrize("dim", [0, 1, [0, 1]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_2d_tensor_dims(device, h, w, dim, keepdim):
     torch.manual_seed(0)
@@ -155,6 +131,69 @@ def test_sum_2d_tensor_dims(device, h, w, dim, keepdim):
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
     output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("batch_size", [3])
+@pytest.mark.parametrize("c", [5])
+@pytest.mark.parametrize("h", [37])
+@pytest.mark.parametrize("w", [63])
+@pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_mean_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("c", [3])
+@pytest.mark.parametrize("h", [31])
+@pytest.mark.parametrize("w", [32])
+@pytest.mark.parametrize("dim", [[0, 2], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_mean_3d_tensor_dims(device, c, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((c, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("h", [41])
+@pytest.mark.parametrize("w", [31])
+@pytest.mark.parametrize("dim", [0, 1, [0, 1]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -54,7 +54,9 @@ def test_var(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("c", [1, 4, 8, 16])
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
-@pytest.mark.parametrize("dim", [None, [0, 1, 2, 3]])
+@pytest.mark.parametrize(
+    "dim", [None, [], 0, 1, 2, 3, [0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]]
+)
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -72,6 +72,31 @@ def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("c", [11])
+@pytest.mark.parametrize("h", [67])
+@pytest.mark.parametrize("w", [77])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("keepdim", [True])
+def test_prod(device, batch_size, c, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    output_tensor = ttnn.prod(input_tensor, dim=dim, memory_config=ttnn.L1_MEMORY_CONFIG)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
+    assert output_tensor.shape == torch_output_tensor.shape
+    # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
 @pytest.mark.parametrize("batch_size", [3])
 @pytest.mark.parametrize("c", [5])
 @pytest.mark.parametrize("h", [37])

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -54,9 +54,7 @@ def test_var(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("c", [1, 4, 8, 16])
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
-@pytest.mark.parametrize(
-    "dim", [None, [], 0, 1, 2, 3, [0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]]
-)
+@pytest.mark.parametrize("dim", [None, [0, 1, 2, 3]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
@@ -74,26 +72,66 @@ def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("c", [11])
-@pytest.mark.parametrize("h", [67])
-@pytest.mark.parametrize("w", [77])
-@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("batch_size", [3])
+@pytest.mark.parametrize("c", [5])
+@pytest.mark.parametrize("h", [37])
+@pytest.mark.parametrize("w", [63])
+@pytest.mark.parametrize(
+    "dim", [None, [], 0, 1, 2, 3, [0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]]
+)
 @pytest.mark.parametrize("keepdim", [True])
-def test_prod(device, batch_size, c, h, w, dim, keepdim):
+def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
 
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
-    )
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.prod(input_tensor, dim=dim, memory_config=ttnn.L1_MEMORY_CONFIG)
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
-    assert output_tensor.shape == torch_output_tensor.shape
-    # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("c", [3])
+@pytest.mark.parametrize("h", [31])
+@pytest.mark.parametrize("w", [32])
+@pytest.mark.parametrize("dim", [None, [], 0, 1, 2, [0, 1], [0, 2], [1, 2], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_3d_tensor_dims(device, c, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((c, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("h", [41])
+@pytest.mark.parametrize("w", [31])
+@pytest.mark.parametrize("dim", [None, [], 0, 1, [0, 1]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_2d_tensor_dims(device, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -12,20 +12,10 @@
 namespace ttnn {
 namespace operations::reduction {
 
-template <ReduceType reduce_type>
-static Tensor reduce_impl(
-    const Tensor& input_tensor_arg,
-    const std::optional<std::variant<int, ttnn::SmallVector<int>>>& dim_arg,
-    const bool keepdim,
-    const std::optional<MemoryConfig>& memory_config_arg,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    bool reshape) {
-    using ttnn::operations::experimental::auto_format::AutoFormat;
+ttnn::SmallVector<int> generate_reduce_dim(
+    const Tensor& input_tensor_arg, const std::optional<std::variant<int, ttnn::SmallVector<int>>>& dim_arg) {
     auto input_shape = input_tensor_arg.get_shape();
     auto rank = input_shape.size();
-    auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
-
     ttnn::SmallVector<int> dim{};
     if (dim_arg.has_value()) {
         if (not std::holds_alternative<ttnn::SmallVector<int>>(dim_arg.value())) {
@@ -55,21 +45,23 @@ static Tensor reduce_impl(
             rank);
     }
 
-    // bail out early if unsupported reduce op is provided
-    constexpr bool reduce_op_has_linear_property = reduce_type == ReduceType::Sum || reduce_type == ReduceType::Mean ||
-                                                   reduce_type == ReduceType::Max || reduce_type == ReduceType::Min;
-    constexpr bool reduce_op_has_nonlinear_property = reduce_type == ReduceType::Var || reduce_type == ReduceType::Std;
-    if (dim.size() == rank) {
-        if constexpr (!reduce_op_has_linear_property) {
-            TT_THROW("Unsupported reduction operation");
-        }
-    } else {
-        if constexpr (!reduce_op_has_linear_property && !reduce_op_has_nonlinear_property) {
-            TT_THROW("Unsupported reduction operation");
-        }
-    }
-
     std::sort(dim.begin(), dim.end());
+    return dim;
+}
+
+template <ReduceType reduce_type>
+static Tensor reduce_impl(
+    const Tensor& input_tensor_arg,
+    const ttnn::SmallVector<int>& dim,
+    const bool keepdim,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    float scalar,
+    bool reshape) {
+    using ttnn::operations::experimental::auto_format::AutoFormat;
+    auto input_shape = input_tensor_arg.get_shape();
+    auto rank = input_shape.size();
+    auto memory_config = memory_config_arg.value_or(input_tensor_arg.memory_config());
 
     ttnn::SmallVector<uint32_t> output_shape;
     for (int axis = 0; axis < input_shape.size(); axis++) {
@@ -83,98 +75,78 @@ static Tensor reduce_impl(
         }
     }
 
-    auto transpose_and_compute_reduction = [&](const Tensor& input_tensor,
-                                               const int dim1,
-                                               const int dim2,
-                                               const std::variant<int, ttnn::SmallVector<int>>& reduce_dim,
-                                               const bool need_additional_reshape) -> Tensor {
-        // edge case: if both the dims are same no need of transpose
-        // if the dims are rank-1 or rank-2, no need of transpose
-        const bool skip_transpose = (dim1 == dim2) || ((dim1 + rank) % rank == (dim2 + rank) % rank) ||
-                                    (dim1 == rank - 1) || (dim1 == rank - 2);
-
-        ttnn::SmallVector<uint32_t> new_output_shape = {
-            input_tensor.get_shape()[0],
-            input_tensor.get_shape()[1],
-            input_tensor.get_shape()[2],
-            input_tensor.get_shape()[3]};
-        new_output_shape[dim1] = 1;
-
-        Tensor output = input_tensor;
-        if (!skip_transpose) {
-            output = ttnn::transpose(input_tensor, dim1, dim2, memory_config);
-        }
-        if constexpr (reduce_type == ReduceType::Mean) {
-            output = reduce_impl<ReduceType::Sum>(
-                output,
-                skip_transpose ? dim1 : reduce_dim,
-                /*keepdim=*/true,
-                memory_config,
-                compute_kernel_config,
-                scalar,
-                need_additional_reshape);
-        } else {
-            output = reduce_impl<reduce_type>(
-                output,
-                skip_transpose ? dim1 : reduce_dim,
-                /*keepdim=*/true,
-                memory_config,
-                compute_kernel_config,
-                scalar,
-                need_additional_reshape);
-        }
-        if (!skip_transpose) {
-            output = ttnn::transpose(output, dim1, dim2, memory_config);
-            if (reshape) {
-                output = ttnn::reshape(output, ttnn::Shape{new_output_shape});
-            }
-        }
-        return output;
-    };
-
-    auto is_w_or_h_or_wh_case = [&](tt::tt_metal::ReduceOpDim& reduce_op_dim) -> bool {
-        if (std::find(dim.begin(), dim.end(), rank - 1) != dim.end() &&
-            std::find(dim.begin(), dim.end(), rank - 2) != dim.end()) {
-            reduce_op_dim = tt::tt_metal::ReduceOpDim::HW;
-        } else if (std::find(dim.begin(), dim.end(), rank - 1) != dim.end()) {
-            reduce_op_dim = tt::tt_metal::ReduceOpDim::W;
-        } else if (std::find(dim.begin(), dim.end(), rank - 2) != dim.end()) {
-            reduce_op_dim = tt::tt_metal::ReduceOpDim::H;
-        } else {
-            return false;
-        }
-        return (reduce_op_dim == tt::tt_metal::ReduceOpDim::HW) ? dim.size() == 2 : dim.size() == 1;
-    };
-
     auto input_tensor = ttnn::unsqueeze_to_4D(input_tensor_arg);
-    Tensor output_tensor;
-    tt::tt_metal::ReduceOpDim reduce_op_dim;
 
-    // if we get dims as vector, we recursively call this function until we reach the case where we deal with W or H or
-    // WH dimensions
-    if (!is_w_or_h_or_wh_case(reduce_op_dim)) {
-        if constexpr (!reduce_op_has_linear_property) {
-            TT_THROW("Unsupported reduction operation");
-        }
-        output_tensor = input_tensor;
-        for (int rank = input_tensor.get_legacy_shape().rank() - 1; rank >= 0; rank--) {
-            if (std::find(dim.begin(), dim.end(), rank) == dim.end()) {
-                continue;
+    Tensor output_tensor;
+    bool single_reduce_op = (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
+                            (dim.size() == 2 && dim[0] == rank - 1 && dim[0] == rank - 2);
+    if (!single_reduce_op) {
+        auto reduce_4d_loop = [&](const bool use_reduce_type) -> Tensor {
+            Tensor output_tensor = input_tensor;
+            int offset = 4 - rank;
+            for (int i_dim = rank - 1; i_dim >= 0; i_dim--) {
+                bool found = std::find(dim.begin(), dim.end(), i_dim) != dim.end();
+                if (found) {
+                    bool transpose = i_dim < rank - 2;
+                    int adjusted_dim = offset + i_dim;
+                    int reduce_dim = adjusted_dim;
+                    if (transpose) {
+                        output_tensor = ttnn::transpose(output_tensor, adjusted_dim, -2, memory_config);
+                        reduce_dim = -2;
+                    }
+                    if (use_reduce_type) {
+                        output_tensor = reduce_impl<reduce_type>(
+                            output_tensor,
+                            {reduce_dim},
+                            /*keepdim=*/true,
+                            memory_config,
+                            compute_kernel_config,
+                            scalar,
+                            /*reshape=*/false);
+                    } else {
+                        output_tensor = reduce_impl<ReduceType::Sum>(
+                            output_tensor,
+                            {reduce_dim},
+                            /*keepdim=*/true,
+                            memory_config,
+                            compute_kernel_config,
+                            scalar,
+                            /*reshape=*/false);
+                    }
+                    if (transpose) {
+                        output_tensor = ttnn::transpose(output_tensor, adjusted_dim, -2, memory_config);
+                    }
+                }
             }
-            output_tensor = transpose_and_compute_reduction(output_tensor, rank, -1, -1, dim.size() != rank);
-        }
-        if constexpr (reduce_type == ReduceType::Mean) {
+            return output_tensor;
+        };
+        constexpr bool linear_type =
+            reduce_type == ReduceType::Sum || reduce_type == ReduceType::Max || reduce_type == ReduceType::Min;
+        if (dim.size() == 1 || linear_type) {
+            output_tensor = reduce_4d_loop(/*use_reduce_type=*/true);
+        } else if constexpr (reduce_type == ReduceType::Mean) {
+            output_tensor = reduce_4d_loop(
+                /*use_reduce_type=*/false);
             float inv_volume = 1.0f / input_tensor.get_logical_volume();
             output_tensor = ttnn::mul_sfpu(inv_volume, output_tensor, memory_config);
+        } else {
+            TT_THROW("Unsupported reduction operation");
         }
     } else {
-        // Only deal with dimension : W, H, WH
-        int reduced_volume = 1;
-        if (std::find(dim.begin(), dim.end(), rank - 1) != dim.end()) {
-            reduced_volume *= input_shape[rank - 1];
+        tt::tt_metal::ReduceOpDim reduce_op_dim;
+        if (dim.size() == 1 and dim[0] == rank - 1) {
+            reduce_op_dim = tt::tt_metal::ReduceOpDim::W;
+        } else if (dim.size() == 1 and dim[0] == rank - 2) {
+            reduce_op_dim = tt::tt_metal::ReduceOpDim::H;
+        } else if (dim.size() == 2 and dim[0] == rank - 2 and dim[1] == rank - 1) {
+            reduce_op_dim = tt::tt_metal::ReduceOpDim::HW;
+        } else {
+            TT_THROW("Unsupported dim");
         }
-        if (std::find(dim.begin(), dim.end(), rank - 2) != dim.end()) {
-            reduced_volume *= input_shape[rank - 2];
+
+        int reduced_volume = 1;
+        for (int axis : dim) {
+            reduced_volume *= input_shape[axis];
         }
 
         if constexpr (reduce_type == ReduceType::Sum) {
@@ -241,7 +213,7 @@ static Tensor reduce_impl(
     }
 
     if (reshape) {
-        output_tensor = ttnn::reshape(output_tensor, ttnn::Shape{output_shape});
+        output_tensor = ttnn::reshape(output_tensor, ttnn::SimpleShape{output_shape});
     }
 
     return output_tensor;
@@ -255,8 +227,9 @@ Tensor Reduce<reduce_type>::invoke(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar) {
+    ttnn::SmallVector<int> dim = generate_reduce_dim(input_tensor_arg, dim_arg);
     return reduce_impl<reduce_type>(
-        input_tensor_arg, dim_arg, keepdim, memory_config_arg, compute_kernel_config, scalar, true);
+        input_tensor_arg, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, true);
 }
 
 template class Reduce<ReduceType::Sum>;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -91,8 +91,8 @@ static Tensor reduce_impl(
                     int adjusted_dim = offset + i_dim;
                     int reduce_dim = adjusted_dim;
                     if (transpose) {
-                        output_tensor = ttnn::transpose(output_tensor, adjusted_dim, -2, memory_config);
-                        reduce_dim = -2;
+                        output_tensor = ttnn::transpose(output_tensor, adjusted_dim, 2, memory_config);
+                        reduce_dim = 2;
                     }
                     if (use_reduce_type) {
                         output_tensor = reduce_impl<reduce_type>(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16233

### Problem description
reduction doesn't support dims of all possible lengths

### What's changed
Added code to support all permutations of dims

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/12585299553
- [x] Blackhole Post commit (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12585300944
- [x] Model regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12585301911
- [x] Device performance regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12585302835
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
