### PR TITLE
Revert "#5605: Only force-stall ethernet programs on earlier ethernet programs"

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1568,7 +1568,11 @@ void EnqueueProgramCommand::process() {
     uint32_t sync_count = 0;
     bool stall_first = reservation.first.need_sync;
     bool stall_before_program = false;
-    if (reservation.first.need_sync) {
+    if (!program.kernel_binary_always_stored_in_ringbuffer()) {
+        // Wait for all existing commands to run before writing out the kernel binary.
+        sync_count = this->expected_num_workers_completed;
+        stall_before_program = !stall_first;
+    } else if (reservation.first.need_sync) {
         // TODO: attempt to send RTA only without stalling.
         sync_count = reservation.first.sync_count;
         // Check if the launch message is the only thing preventing us from
@@ -1576,7 +1580,6 @@ void EnqueueProgramCommand::process() {
         // would also send the kernel binaries in this case, but the rest of the
         // code isn't set up for that.
         auto config_sizes = program.get_program_config_sizes();
-        config_sizes[config_sizes.size() - 2] = 0;
         config_sizes[config_sizes.size() - 1] = 0;
         const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> memory_reservation =
             this->config_buffer_mgr.reserve(config_sizes);
@@ -1619,9 +1622,9 @@ void EnqueueProgramCommand::process() {
     this->config_buffer_mgr.alloc(this->expected_num_workers_completed + num_workers);
     std::vector<ConfigBufferEntry>& kernel_config_addrs_raw = reservation.second;
 
-    // Remove launch buffers from config addrs, since they're not real cores.
+    // Remove launch buffer from config addrs, since it's not a real core.
     const tt::stl::Span<ConfigBufferEntry> kernel_config_addrs{
-        kernel_config_addrs_raw.data(), kernel_config_addrs_raw.size() - 2};
+        kernel_config_addrs_raw.data(), kernel_config_addrs_raw.size() - 1};
 
     RecordProgramRun(program);
 
@@ -3074,9 +3077,6 @@ void HWCommandQueue::reset_config_buffer_mgr(const uint32_t num_entries) {
         // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the
         // previous launch message.
         this->config_buffer_mgr[i].init_add_buffer(0, launch_msg_buffer_num_entries - 1);
-
-        // There's no ring buffer for active ethernet binaries, so keep track of them separately.
-        this->config_buffer_mgr[i].init_add_buffer(0, 1);
     }
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -337,7 +337,9 @@ detail::Program_::Program_() :
     }
 
     program_configs_.resize(programmable_core_count);
-    program_config_sizes_.resize(programmable_core_count + 2);
+    program_config_sizes_.resize(programmable_core_count + 1);
+    // Always need one launch buffer msg for a program.
+    program_config_sizes_[programmable_core_count] = 1;
 }
 
 Program::Program() : pimpl_(std::make_unique<detail::Program_>()) {}
@@ -1501,9 +1503,6 @@ void detail::Program_::finalize(Device *device) {
                  "Program size ({}) too large for kernel config buffer ({}) on {}",
                  offset, max_size, magic_enum::enum_name(programmable_core_type));
     }
-
-    this->get_program_config_size(hal.get_programmable_core_type_count()) = runs_on_noc_multicast_only_cores();
-    this->get_program_config_size(hal.get_programmable_core_type_count() + 1) = runs_on_noc_unicast_only_cores();
 
     // The sem offsets cross programmable_core_types so must be set after the loop above
     this->set_launch_msg_sem_offsets();


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#16202

This PR caused a test hang:

https://github.com/tenstorrent/tt-metal/actions/runs/12438564678/job/34759976229

```
[ RUN      ] RandomProgramTraceFixture.TensixActiveEthTestSimpleProgramsTrace
                  Metal | INFO     | Initializing device 0. Program cache is NOT enabled
                  Metal | INFO     | AI CLK for device 0 is:   1000 MHz
           BuildKernels | INFO     | GIT_COMMIT_HASH not found
                  Metal | INFO     | MMIO Device 0 : Tunnel 0 : Device 0
                  Metal | INFO     | MMIO Device 0 : Tunnel 0 : Device 1
                   Test | INFO     | Using seed: [1734852831](tel:1734852831)
                   Test | INFO     | Creating Program 0
                   Test | INFO     | Creating Program 10
                   Test | INFO     | Creating Program 20
                   Test | INFO     | Creating Program 30
                   Test | INFO     | Creating Program 40
                   Test | INFO     | Creating Program 50
                   Test | INFO     | Creating Program 60
                   Test | INFO     | Creating Program 70
```