### PR TITLE
Move some Device methods to private section

### DIFF
--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -85,7 +85,8 @@ std::vector<v1::DeviceHandle> get_device_ring(std::vector<tt::tt_metal::v1::Devi
     std::vector<std::vector<int>> adj(devices.size(), std::vector<int>(devices.size(), 0));
     for (uint32_t i = 0; i < devices.size(); ++i) {
         const auto& device = devices[i];
-        for (const auto& connected_device_id : device->get_ethernet_connected_device_ids()) {
+        auto etherent_connected_device_ids = tt::Cluster::instance().get_ethernet_connected_device_ids(device->id());
+        for (const auto& connected_device_id : etherent_connected_device_ids) {
             for (uint32_t j = 0; j < devices.size(); ++j) {
                 if (devices[j]->id() == connected_device_id) {
                     adj[i][j] = 1;

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -85,8 +85,8 @@ std::vector<v1::DeviceHandle> get_device_ring(std::vector<tt::tt_metal::v1::Devi
     std::vector<std::vector<int>> adj(devices.size(), std::vector<int>(devices.size(), 0));
     for (uint32_t i = 0; i < devices.size(); ++i) {
         const auto& device = devices[i];
-        auto etherent_connected_device_ids = tt::Cluster::instance().get_ethernet_connected_device_ids(device->id());
-        for (const auto& connected_device_id : etherent_connected_device_ids) {
+        auto ethernet_connected_device_ids = tt::Cluster::instance().get_ethernet_connected_device_ids(device->id());
+        for (const auto& connected_device_id : ethernet_connected_device_ids) {
             for (uint32_t j = 0; j < devices.size(); ++j) {
                 if (devices[j]->id() == connected_device_id) {
                     adj[i][j] = 1;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -63,6 +63,18 @@ bool Device::is_inactive_ethernet_core(CoreCoord logical_core) const {
     return inactive_ethernet_cores.find(logical_core) != inactive_ethernet_cores.end();
 }
 
+std::tuple<chip_id_t, CoreCoord> Device::get_connected_ethernet_core(CoreCoord eth_core) const {
+    return tt::Cluster::instance().get_connected_ethernet_core(std::make_tuple(this->id_, eth_core));
+}
+
+std::vector<CoreCoord> Device::get_ethernet_sockets(chip_id_t connected_chip_id) const {
+    return tt::Cluster::instance().get_ethernet_sockets(this->id_, connected_chip_id);
+}
+
+bool Device::is_mmio_capable() const {
+    return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
+}
+
 CoreRangeSet Device::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
     return this->active_sub_device_manager_->sub_device(sub_device_id).cores(core_type);
 }
@@ -3223,13 +3235,13 @@ CoreCoord Device::logical_grid_size() const {
     return tt::Cluster::instance().get_soc_desc(id_).worker_grid_size;
 }
 
+CoreCoord Device::dram_grid_size() const {
+    return tt::Cluster::instance().get_soc_desc(id_).get_dram_grid_size();
+}
+
 CoreCoord Device::compute_with_storage_grid_size() const {
     const auto &dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config(id_);
     return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_config);
-}
-
-CoreCoord Device::dram_grid_size() const {
-    return tt::Cluster::instance().get_soc_desc(id_).get_dram_grid_size();
 }
 
 CoreType Device::core_type_from_physical_core(const CoreCoord &physical_coord) const {
@@ -3686,7 +3698,7 @@ void Device::begin_trace(const uint8_t cq_id, const uint32_t tid) {
     ZoneScoped;
     TracyTTMetalBeginTrace(this->id(), tid);
     TT_FATAL(!this->hw_command_queues_[cq_id]->tid.has_value(), "CQ {} is already being used for tracing tid {}", (uint32_t)cq_id, tid);
-    this->MarkAllocationsSafe();
+    this->mark_allocations_safe();
     // Create an empty trace buffer here. This will get initialized in end_trace
     TT_FATAL(this->active_sub_device_manager_->get_trace(tid) == nullptr, "Trace already exists for tid {} on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
     auto &trace_buffer = this->active_sub_device_manager_->create_trace(tid);
@@ -3701,7 +3713,7 @@ void Device::end_trace(const uint8_t cq_id, const uint32_t tid) {
     TT_FATAL(trace_buffer != nullptr, "Trace instance {} must exist on device {}'s active sub-device manager {}", tid, this->id_, this->active_sub_device_manager_id_);
     this->hw_command_queues_[cq_id]->record_end();
     Trace::initialize_buffer(this->command_queue(cq_id), trace_buffer);
-    this->MarkAllocationsUnsafe();
+    this->mark_allocations_unsafe();
 }
 
 void Device::replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking) {
@@ -3724,7 +3736,7 @@ void Device::release_trace(const uint32_t tid) {
 
     // Only enable allocations once all captured traces are released
     if (this->trace_buffers_size_ == 0) {
-        this->MarkAllocationsSafe();
+        this->mark_allocations_safe();
     }
 }
 
@@ -3750,11 +3762,11 @@ std::size_t Device::num_program_cache_entries() {
     return program_cache_.num_entries();
 }
 
-void Device::MarkAllocationsUnsafe() {
+void Device::mark_allocations_unsafe() {
     tt::tt_metal::allocator::mark_allocations_unsafe(*this->get_initialized_allocator());
 }
 
-void Device::MarkAllocationsSafe() {
+void Device::mark_allocations_safe() {
     tt::tt_metal::allocator::mark_allocations_safe(*this->get_initialized_allocator());
 }
 
@@ -3962,6 +3974,37 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
         }
     }
     return this->optimal_dram_bank_to_logical_worker_assignment_;
+}
+
+HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord virtual_core) const {
+
+    HalProgrammableCoreType programmable_core_type = HalProgrammableCoreType::TENSIX;
+    if (tt::Cluster::instance().is_ethernet_core(virtual_core, this->id_)) {
+        // Eth pcores have a different address, but only active ones.
+        CoreCoord logical_core = this->logical_core_from_ethernet_core(virtual_core);
+        if (this->is_active_ethernet_core(logical_core)) {
+            programmable_core_type = HalProgrammableCoreType::ACTIVE_ETH;
+        } else {
+            programmable_core_type = HalProgrammableCoreType::IDLE_ETH;
+        }
+    }
+
+    return programmable_core_type;
+}
+
+// TODO: Find a better home for this function
+std::vector<std::pair<transfer_info_cores, uint32_t>> Device::extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) {
+    // This API extracts all the pairs of noc multicast encodings given a set of core ranges
+    std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
+    dst_noc_multicast_info.reserve(ranges.size());
+    for (const CoreRange& core_range : ranges) {
+        CoreCoord virtual_start = this->virtual_core_from_logical_core(core_range.start_coord, core_type);
+        CoreCoord virtual_end = this->virtual_core_from_logical_core(core_range.end_coord, core_type);
+
+        uint32_t num_receivers = core_range.size();
+        dst_noc_multicast_info.push_back(std::make_pair(CoreRange(virtual_start, virtual_end), num_receivers));
+    }
+    return dst_noc_multicast_info;
 }
 
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -724,7 +724,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands(ProgramCommandSequenc
                         }
                     } else {
                         std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                            device->extract_dst_noc_multicast_info<std::vector<CoreRange>>(
+                            device->extract_dst_noc_multicast_info(
                                 kernel->logical_coreranges(), core_type);
                         common_sub_cmds.emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
                             std::vector<CQDispatchWritePackedMulticastSubCmd>());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1019,7 +1019,7 @@ void detail::Program_::populate_dispatch_data(Device *device) {
         if (semaphore.core_type() == CoreType::WORKER) {
             uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
             std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                device->extract_dst_noc_multicast_info<std::vector<CoreRange>>(
+                device->extract_dst_noc_multicast_info(
                     semaphore.core_range_set().ranges(), CoreType::WORKER);
             transfer_info transfer_info = {
                 .dst_base_addr = semaphore.offset(),
@@ -1111,7 +1111,7 @@ void detail::Program_::populate_dispatch_data(Device *device) {
             // TODO: add a bit in the hal that says if this core type is unicast/multicast
             if (core_type == CoreType::WORKER) {
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                    device->extract_dst_noc_multicast_info<std::vector<CoreRange>>(
+                    device->extract_dst_noc_multicast_info(
                         kernel_group.core_ranges.ranges(), core_type);
                 std::vector<KernelHandle> kernel_ids;
                 for (int dispatch_class = 0; dispatch_class < kernel_group.kernel_ids.size(); dispatch_class++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -36,11 +36,8 @@ inline uint32_t get_estimated_size_of_cbs(const Tensor& input_tensor_a) {
 }
 
 inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
-    tt::tt_metal::Device* device = input_tensor_a.device();
-    const std::vector<uint32_t>& bank_ids =
-        device->bank_ids_from_logical_core(BufferType::L1, *device->get_compute_cores().begin());
-    std::optional<uint64_t> lowest_address =
-        allocator::lowest_occupied_l1_address(*device->get_initialized_allocator(), bank_ids[0]);
+    auto device = input_tensor_a.device();
+    auto lowest_address = device->lowest_occupied_compute_l1_address();
     uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
     max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
     return max_l1_space;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -171,11 +171,8 @@ inline uint32_t get_estimated_size_of_cbs(
 }
 
 inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
-    tt::tt_metal::Device* device = input_tensor_a.device();
-    const std::vector<uint32_t>& bank_ids =
-        device->bank_ids_from_logical_core(BufferType::L1, *device->get_compute_cores().begin());
-    std::optional<uint64_t> lowest_address =
-        allocator::lowest_occupied_l1_address(*device->get_initialized_allocator(), bank_ids[0]);
+    auto device = input_tensor_a.device();
+    auto lowest_address = device->lowest_occupied_compute_l1_address();
     uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
     max_l1_space = max_l1_space - device->get_base_allocator_addr(HalMemType::L1);
     return max_l1_space;


### PR DESCRIPTION
### Ticket
None

### Problem description
There are plenty of Device methods which are only used by device itself but they are in a public section

This PR depends on https://github.com/tenstorrent/tt-metal/pull/16256

### What's changed
This PR does not add any new functionality, nor changes existing. It shuffles things around.
* Moved near every method thats only used by Device to the private section (19)
* Re-groupped methods logically: methods that proxy to allocator, to cluster
* Moved a couple implementations to cpp
* Reviewed usage of some methods, left comments where its desirable to review usage with owners
* Removed template where it was not used

Whats next:
* Discuss and align what we can/want to do about the two outlined groups of methods
* Review notes with owners, align on next steps

### Checklist
- [ ] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12475902305)