### PR TITLE
Fix bug when calling CreateDevice in a loop on TG

### DIFF
--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -182,7 +182,7 @@ class Cluster {
     //       set_internal_routing_info_for_ethernet_cores(false);
     //       CloseDevice(0)
     //       CloseDevice(1)
-    void set_internal_routing_info_for_ethernet_cores(bool enable_internal_routing) const;
+    void set_internal_routing_info_for_ethernet_cores(bool enable_internal_routing, const std::vector<chip_id_t>& target_mmio_devices = {}) const;
 
     // Returns MMIO device ID (logical) that controls given `device_id`. If `device_id` is MMIO device it is returned.
     chip_id_t get_associated_mmio_device(chip_id_t device_id) const {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16241)

### Problem description
Bug when calling CreateDevice over multiple chips in TG.

`set_internal_routing_info_for_ethernet_cores` was writing to all chips to enable the erisc FW. But this is bugged when you open one set of mmio devices, because the next time you open the other mmio devices, the enable bit is already true before loading FW. Led to random ND timing sensitive hangs.

### What's changed
Split cluster write enable config to be per mmio grouping of devices.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
