### PR TITLE
Delete convd_host_weights and update all tests using conv2d

### DIFF
--- a/models/demos/convnet_mnist/tt/convnet_mnist.py
+++ b/models/demos/convnet_mnist/tt/convnet_mnist.py
@@ -35,26 +35,42 @@ def convnet_mnist(
         packer_l1_acc=False,
     )
     x = ttnn.to_layout(input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    tt_weight = parameters.conv1.weight
+    tt_bias = parameters.conv1.bias
+    conv_kwargs = {
+        "in_channels": 1,
+        "out_channels": 32,
+        "batch_size": batch_size,
+        "input_height": input_tensor.shape[1],
+        "input_width": input_tensor.shape[2],
+        "kernel_size": (3, 3),
+        "stride": (1, 1),
+        "padding": (0, 0),
+        "dilation": (1, 1),
+        "groups": 1,
+        "device": device,
+        "conv_config": conv_config,
+    }
+
+    if not ttnn.is_tensor_storage_on_device(tt_weight):
+        tt_weight = ttnn.prepare_conv_weights(
+            weight_tensor=tt_weight,
+            weights_format="OIHW",
+            input_memory_config=x.memory_config(),
+            input_layout=x.get_layout(),
+            **conv_kwargs,
+        )
+        tt_weight = ttnn.to_device(tt_weight, device)
+
     x = ttnn.conv2d(
         input_tensor=x,
-        weight_tensor=parameters.conv1.weight,
-        in_channels=1,
-        out_channels=32,
-        device=device,
-        bias_tensor=parameters.conv1.bias,
-        kernel_size=(3, 3),
-        stride=(1, 1),
-        padding=(0, 0),
-        batch_size=batch_size,
-        input_height=input_tensor.shape[1],
-        input_width=input_tensor.shape[2],
-        conv_config=conv_config,
+        weight_tensor=tt_weight,
+        bias_tensor=tt_bias,
+        **conv_kwargs,
         compute_config=compute_config,
         conv_op_cache={},
         debug=True,
-        groups=1,
-        return_output_dim=False,
-        return_weights_and_bias=False,
     )
     x = ttnn.relu(x)
 
@@ -81,23 +97,40 @@ def convnet_mnist(
             dilation=[1, 1],
         )
 
+    tt_weight = parameters.conv2.weight
+    tt_bias = parameters.conv2.bias
+    conv_kwargs = {
+        "in_channels": 32,
+        "out_channels": 64,
+        "batch_size": batch_size,
+        "input_height": 15,
+        "input_width": 15,
+        "kernel_size": (3, 3),
+        "stride": (1, 1),
+        "padding": (0, 0),
+        "dilation": (1, 1),
+        "groups": 1,
+        "device": device,
+        "conv_config": conv_config,
+    }
+
+    if not ttnn.is_tensor_storage_on_device(tt_weight):
+        tt_weight = ttnn.prepare_conv_weights(
+            weight_tensor=tt_weight,
+            weights_format="OIHW",
+            input_memory_config=x.memory_config(),
+            input_layout=x.get_layout(),
+            **conv_kwargs,
+        )
+        tt_weight = ttnn.to_device(tt_weight, device)
+
     x, [out_height, out_width] = ttnn.conv2d(
         input_tensor=x,
-        weight_tensor=parameters.conv2.weight,
-        in_channels=32,
-        out_channels=64,
-        device=device,
-        bias_tensor=parameters.conv2.bias,
-        kernel_size=(3, 3),
-        stride=(1, 1),
-        padding=(0, 0),
-        batch_size=batch_size,
-        input_height=15,
-        input_width=15,
-        conv_config=conv_config,
+        weight_tensor=tt_weight,
+        bias_tensor=tt_bias,
+        **conv_kwargs,
         conv_op_cache={},
         debug=False,
-        groups=1,
         return_output_dim=True,
         return_weights_and_bias=False,
     )

--- a/models/demos/segformer/tt/common.py
+++ b/models/demos/segformer/tt/common.py
@@ -63,22 +63,44 @@ class Conv:
         if self.act_block_h is not None:
             conv_config.act_block_h_override = self.act_block_h
 
+        conv_kwargs = {
+            "in_channels": input_tensor.shape[3],
+            "out_channels": self.out_channels,
+            "batch_size": input_tensor.shape[0],
+            "input_height": input_tensor.shape[1],
+            "input_width": input_tensor.shape[2],
+            "kernel_size": self.kernel_size,
+            "stride": (self.conv_params[0], self.conv_params[1]),
+            "padding": (self.conv_params[2], self.conv_params[3]),
+            "dilation": (1, 1),
+            "groups": self.groups,
+            "device": device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.weights):
+            self.weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.weights,
+                weights_format="OIHW",
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+            self.bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.bias,
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+            self.weights = ttnn.to_device(self.weights, device)
+            self.bias = ttnn.to_device(self.bias, device)
+
         [output_tensor, [_out_height, _out_width]] = ttnn.conv2d(
             input_tensor=input_tensor,
             weight_tensor=self.weights,
             bias_tensor=self.bias,
-            in_channels=input_tensor.shape[3],
-            out_channels=self.out_channels,
-            device=device,
-            kernel_size=self.kernel_size,
-            stride=(self.conv_params[0], self.conv_params[1]),
-            padding=(self.conv_params[2], self.conv_params[3]),
-            batch_size=input_tensor.shape[0],
-            input_height=input_tensor.shape[1],
-            input_width=input_tensor.shape[2],
-            conv_config=conv_config,
+            **conv_kwargs,
             compute_config=compute_config,
-            groups=self.groups,
             return_output_dim=True,
             return_weights_and_bias=False,
         )

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -160,20 +160,19 @@ class resnet50Bottleneck:
     ):
         if self.downsample:
             logger.debug(f"Running downsample")
-            ds_out, [self.ds_conv_weight_tensor, self.ds_conv_bias_tensor] = ttnn.conv2d(
-                input_tensor=x,
-                weight_tensor=self.ds_conv_weight_tensor,
-                in_channels=self.ds_conv_input_channels,
-                out_channels=self.ds_conv_output_channels,
-                device=device,
-                bias_tensor=self.ds_conv_bias_tensor,
-                kernel_size=(1, 1),
-                stride=(self.stride, self.stride),
-                padding=(0, 0),
-                batch_size=batch_size,
-                input_height=input_height,
-                input_width=input_width,
-                conv_config=ttnn.Conv2dConfig(
+            conv_kwargs = {
+                "in_channels": self.ds_conv_input_channels,
+                "out_channels": self.ds_conv_output_channels,
+                "batch_size": batch_size,
+                "input_height": input_height,
+                "input_width": input_width,
+                "kernel_size": (1, 1),
+                "stride": (self.stride, self.stride),
+                "padding": (0, 0),
+                "dilation": (1, 1),
+                "groups": 1,
+                "device": device,
+                "conv_config": ttnn.Conv2dConfig(
                     dtype=self.model_config["ACTIVATIONS_DTYPE"],
                     weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                     shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
@@ -192,14 +191,37 @@ class resnet50Bottleneck:
                     enable_split_reader=enable_split_reader,
                     enable_subblock_padding=enable_subblock_padding,
                 ),
+            }
+
+            if not ttnn.is_tensor_storage_on_device(self.ds_conv_weight_tensor):
+                self.ds_conv_weight_tensor = ttnn.prepare_conv_weights(
+                    weight_tensor=self.ds_conv_weight_tensor,
+                    weights_format="OIHW",
+                    input_memory_config=x.memory_config(),
+                    input_layout=x.get_layout(),
+                    **conv_kwargs,
+                )
+
+                self.ds_conv_bias_tensor = ttnn.prepare_conv_bias(
+                    bias_tensor=self.ds_conv_bias_tensor,
+                    input_memory_config=x.memory_config(),
+                    input_layout=x.get_layout(),
+                    **conv_kwargs,
+                )
+                self.ds_conv_weight_tensor = ttnn.to_device(self.ds_conv_weight_tensor, device)
+                self.ds_conv_bias_tensor = ttnn.to_device(self.ds_conv_bias_tensor, device)
+
+            ds_out = ttnn.conv2d(
+                input_tensor=x,
+                weight_tensor=self.ds_conv_weight_tensor,
+                bias_tensor=self.ds_conv_bias_tensor,
+                **conv_kwargs,
                 compute_config=ttnn.init_device_compute_kernel_config(
                     device.arch(),
                     math_fidelity=self.model_config["MATH_FIDELITY"],
                     packer_l1_acc=packer_l1_accum_enabled,
                 ),
                 conv_op_cache=conv_op_cache,
-                return_output_dim=False,
-                return_weights_and_bias=True,
             )
             ttnn.deallocate(x)
             ds_out = ttnn.reallocate(ds_out)
@@ -231,20 +253,19 @@ class resnet50Bottleneck:
         # conv1 is 1x1 conv
         logger.debug(f"Running conv1")
         module_input_height = input_height
-        out, [input_height, input_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
-            input_tensor=x,
-            weight_tensor=self.conv1_weight_tensor,
-            in_channels=self.conv1_input_channels,
-            out_channels=self.conv1_output_channels,
-            device=device,
-            bias_tensor=self.conv1_bias_tensor,
-            kernel_size=(1, 1),
-            stride=(1, 1),
-            padding=(0, 0),
-            batch_size=batch_size,
-            input_height=input_height,
-            input_width=input_width,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs_1 = {
+            "in_channels": self.conv1_input_channels,
+            "out_channels": self.conv1_output_channels,
+            "batch_size": batch_size,
+            "input_height": input_height,
+            "input_width": input_width,
+            "kernel_size": (1, 1),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation="relu",
@@ -254,6 +275,31 @@ class resnet50Bottleneck:
                 reshard_if_not_optimal=reshard_if_not_optimal,
                 transpose_shards=transpose_shards,
             ),
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv1_weight_tensor):
+            self.conv1_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv1_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=x.memory_config(),
+                input_layout=x.get_layout(),
+                **conv_kwargs_1,
+            )
+            self.conv1_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv1_bias_tensor,
+                input_memory_config=x.memory_config(),
+                input_layout=x.get_layout(),
+                **conv_kwargs_1,
+            )
+
+            self.conv1_weight_tensor = ttnn.to_device(self.conv1_weight_tensor, device)
+            self.conv1_bias_tensor = ttnn.to_device(self.conv1_bias_tensor, device)
+
+        out, [input_height, input_width] = ttnn.conv2d(
+            input_tensor=x,
+            weight_tensor=self.conv1_weight_tensor,
+            bias_tensor=self.conv1_bias_tensor,
+            **conv_kwargs_1,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(),
                 math_fidelity=self.model_config["MATH_FIDELITY"],
@@ -261,7 +307,7 @@ class resnet50Bottleneck:
             ),
             conv_op_cache=conv_op_cache,
             return_output_dim=True,
-            return_weights_and_bias=True,
+            return_weights_and_bias=False,
         )
 
         act_block_h_override = 0
@@ -317,20 +363,19 @@ class resnet50Bottleneck:
 
         reallocate_halo_output = batch_size == 20
         logger.debug(f"Running conv2")
-        out, [input_height, input_width], [self.conv2_weight_tensor, self.conv2_bias_tensor] = ttnn.conv2d(
-            input_tensor=out,
-            weight_tensor=self.conv2_weight_tensor,
-            in_channels=self.conv2_input_channels,
-            out_channels=self.conv2_output_channels,
-            device=device,
-            bias_tensor=self.conv2_bias_tensor,
-            kernel_size=(3, 3),
-            stride=(self.stride, self.stride),
-            padding=(1, 1),
-            batch_size=batch_size,
-            input_height=input_height,
-            input_width=input_width,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs_2 = {
+            "in_channels": self.conv2_input_channels,
+            "out_channels": self.conv2_output_channels,
+            "batch_size": batch_size,
+            "input_height": input_height,
+            "input_width": input_width,
+            "kernel_size": (3, 3),
+            "stride": (self.stride, self.stride),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation="relu",
@@ -347,6 +392,30 @@ class resnet50Bottleneck:
                 enable_split_reader=enable_split_reader,
                 enable_subblock_padding=enable_subblock_padding,
             ),
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv2_weight_tensor):
+            self.conv2_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv2_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=x.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_2,
+            )
+            self.conv2_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv2_bias_tensor,
+                input_memory_config=x.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_2,
+            )
+            self.conv2_weight_tensor = ttnn.to_device(self.conv2_weight_tensor, device)
+            self.conv2_bias_tensor = ttnn.to_device(self.conv2_bias_tensor, device)
+
+        out, [input_height, input_width] = ttnn.conv2d(
+            input_tensor=out,
+            weight_tensor=self.conv2_weight_tensor,
+            bias_tensor=self.conv2_bias_tensor,
+            **conv_kwargs_2,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(),
                 math_fidelity=self.model_config["MATH_FIDELITY"],
@@ -354,7 +423,7 @@ class resnet50Bottleneck:
             ),
             conv_op_cache=conv_op_cache,
             return_output_dim=True,
-            return_weights_and_bias=True,
+            return_weights_and_bias=False,
         )
 
         logger.debug(
@@ -373,20 +442,19 @@ class resnet50Bottleneck:
 
         # conv3 is 1x1 conv
         logger.debug(f"Running conv3")
-        out, [self.conv3_weight_tensor, self.conv3_bias_tensor] = ttnn.conv2d(
-            input_tensor=out,
-            weight_tensor=self.conv3_weight_tensor,
-            in_channels=self.conv3_input_channels,
-            out_channels=self.conv3_output_channels,
-            device=device,
-            bias_tensor=self.conv3_bias_tensor,
-            kernel_size=(1, 1),
-            stride=(1, 1),
-            padding=(0, 0),
-            batch_size=batch_size,
-            input_height=input_height,
-            input_width=input_width,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs_3 = {
+            "in_channels": self.conv3_input_channels,
+            "out_channels": self.conv3_output_channels,
+            "batch_size": batch_size,
+            "input_height": input_height,
+            "input_width": input_width,
+            "kernel_size": (1, 1),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
@@ -395,14 +463,35 @@ class resnet50Bottleneck:
                 reshard_if_not_optimal=reshard_if_not_optimal,
                 transpose_shards=transpose_shards,
             ),
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv3_weight_tensor):
+            self.conv3_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv3_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=x.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_3,
+            )
+            self.conv3_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv3_bias_tensor,
+                input_memory_config=x.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_3,
+            )
+            self.conv3_weight_tensor = ttnn.to_device(self.conv3_weight_tensor, device)
+            self.conv3_bias_tensor = ttnn.to_device(self.conv3_bias_tensor, device)
+        out = ttnn.conv2d(
+            input_tensor=out,
+            weight_tensor=self.conv3_weight_tensor,
+            bias_tensor=self.conv3_bias_tensor,
+            **conv_kwargs_3,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(),
                 math_fidelity=self.model_config["MATH_FIDELITY"],
                 packer_l1_acc=packer_l1_acc,
             ),
             conv_op_cache=conv_op_cache,
-            return_output_dim=False,
-            return_weights_and_bias=True,
         )
 
         if not run_downsample_before_conv2:
@@ -744,24 +833,47 @@ class resnet50:
         logger.debug(f"==== first conv")
 
         # first conv
-        x, [x_height, x_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
+        conv_kwargs = {
+            "in_channels": self.conv1_input_channels,
+            "out_channels": self.conv1_output_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.conv1_input_height,
+            "input_width": self.conv1_input_width,
+            "kernel_size": self.conv1_kernel_size,
+            "stride": self.conv1_stride,
+            "padding": self.conv1_padding,
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": self.conv1_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv1_weight_tensor):
+            self.conv1_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv1_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=fold_output_tensor.memory_config(),
+                input_layout=fold_output_tensor.get_layout(),
+                **conv_kwargs,
+            )
+
+            self.conv1_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv1_bias_tensor,
+                input_memory_config=fold_output_tensor.memory_config(),
+                input_layout=fold_output_tensor.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv1_weight_tensor = ttnn.to_device(self.conv1_weight_tensor, device)
+            self.conv1_bias_tensor = ttnn.to_device(self.conv1_bias_tensor, device)
+        x, [x_height, x_width] = ttnn.conv2d(
             input_tensor=fold_output_tensor,
             weight_tensor=self.conv1_weight_tensor,
-            in_channels=self.conv1_input_channels,
-            out_channels=self.conv1_output_channels,
-            device=device,
             bias_tensor=self.conv1_bias_tensor,
-            kernel_size=self.conv1_kernel_size,
-            stride=self.conv1_stride,
-            padding=self.conv1_padding,
-            batch_size=self.batch_size,
-            input_height=self.conv1_input_height,
-            input_width=self.conv1_input_width,
-            conv_config=self.conv1_config,
+            **conv_kwargs,
             compute_config=self.conv1_compute_config,
             conv_op_cache=conv_op_cache,
             return_output_dim=True,
-            return_weights_and_bias=True,
+            return_weights_and_bias=False,
         )
         # Relu is fused with conv1
         if self.batch_size == 20:

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
@@ -163,20 +163,19 @@ class resnet50Bottleneck:
         height_sharding=None,
     ):
         if self.downsample:
-            ds_out, [self.ds_conv_weight_tensor, self.ds_conv_bias_tensor] = ttnn.conv2d(
-                input_tensor=x,
-                weight_tensor=self.ds_conv_weight_tensor,
-                in_channels=self.ds_conv_input_channels,
-                out_channels=self.ds_conv_output_channels,
-                device=device,
-                bias_tensor=self.ds_conv_bias_tensor,
-                kernel_size=(1, 1),
-                stride=(self.stride, self.stride),
-                padding=(0, 0),
-                batch_size=batch_size,
-                input_height=input_height,
-                input_width=input_width,
-                conv_config=ttnn.Conv2dConfig(
+            conv_kwargs_1 = {
+                "in_channels": self.ds_conv_input_channels,
+                "out_channels": self.ds_conv_output_channels,
+                "batch_size": batch_size,
+                "input_height": input_height,
+                "input_width": input_width,
+                "kernel_size": (1, 1),
+                "stride": (self.stride, self.stride),
+                "padding": (0, 0),
+                "dilation": (1, 1),
+                "groups": 1,
+                "device": device,
+                "conv_config": ttnn.Conv2dConfig(
                     dtype=self.model_config["ACTIVATIONS_DTYPE"],
                     weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                     shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
@@ -187,6 +186,31 @@ class resnet50Bottleneck:
                     reshard_if_not_optimal=reshard_if_not_optimal,
                     transpose_shards=height_sharding,
                 ),
+            }
+
+            if not ttnn.is_tensor_storage_on_device(self.ds_conv_weight_tensor):
+                self.ds_conv_weight_tensor = ttnn.prepare_conv_weights(
+                    weight_tensor=self.ds_conv_weight_tensor,
+                    weights_format="OIHW",
+                    input_memory_config=x.memory_config(),
+                    input_layout=x.get_layout(),
+                    **conv_kwargs_1,
+                )
+                self.ds_conv_bias_tensor = ttnn.prepare_conv_bias(
+                    bias_tensor=self.ds_conv_bias_tensor,
+                    input_memory_config=x.memory_config(),
+                    input_layout=x.get_layout(),
+                    **conv_kwargs_1,
+                )
+
+                self.ds_conv_weight_tensor = ttnn.to_device(self.ds_conv_weight_tensor, device)
+                self.ds_conv_bias_tensor = ttnn.to_device(self.ds_conv_bias_tensor, device)
+
+            ds_out, [self.ds_conv_weight_tensor, self.ds_conv_bias_tensor] = ttnn.conv2d(
+                input_tensor=x,
+                weight_tensor=self.ds_conv_weight_tensor,
+                bias_tensor=self.ds_conv_bias_tensor,
+                **conv_kwargs_1,
                 compute_config=ttnn.init_device_compute_kernel_config(
                     device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
                 ),
@@ -220,20 +244,19 @@ class resnet50Bottleneck:
         # conv1 is 1x1 conv
         # print("Running conv1")
         module_input_height = input_height
-        out, [input_height, input_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
-            input_tensor=x,
-            weight_tensor=self.conv1_weight_tensor,
-            in_channels=self.conv1_input_channels,
-            out_channels=self.conv1_output_channels,
-            device=device,
-            bias_tensor=self.conv1_bias_tensor,
-            kernel_size=(1, 1),
-            stride=(1, 1),
-            padding=(0, 0),
-            batch_size=batch_size,
-            input_height=input_height,
-            input_width=input_width,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs_2 = {
+            "in_channels": self.conv1_input_channels,
+            "out_channels": self.conv1_output_channels,
+            "batch_size": batch_size,
+            "input_height": input_height,
+            "input_width": input_width,
+            "kernel_size": (1, 1),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation="relu",
@@ -243,6 +266,30 @@ class resnet50Bottleneck:
                 reshard_if_not_optimal=reshard_if_not_optimal,
                 transpose_shards=height_sharding,
             ),
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv1_weight_tensor):
+            self.conv1_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv1_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=x.memory_config(),
+                input_layout=x.get_layout(),
+                **conv_kwargs_2,
+            )
+            self.conv1_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv1_bias_tensor,
+                input_memory_config=x.memory_config(),
+                input_layout=x.get_layout(),
+                **conv_kwargs_2,
+            )
+            self.conv1_weight_tensor = ttnn.to_device(self.conv1_weight_tensor, device)
+            self.conv1_bias_tensor = ttnn.to_device(self.conv1_bias_tensor, device)
+
+        out, [input_height, input_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
+            input_tensor=x,
+            weight_tensor=self.conv1_weight_tensor,
+            bias_tensor=self.conv1_bias_tensor,
+            **conv_kwargs_2,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
             ),
@@ -329,20 +376,19 @@ class resnet50Bottleneck:
             # self.conv1_input_channels == 256 and
             # self.downsample
         )
-        out, [input_height, input_width], [self.conv2_weight_tensor, self.conv2_bias_tensor] = ttnn.conv2d(
-            input_tensor=out,
-            weight_tensor=self.conv2_weight_tensor,
-            in_channels=self.conv2_input_channels,
-            out_channels=self.conv2_output_channels,
-            device=device,
-            bias_tensor=self.conv2_bias_tensor,
-            kernel_size=(3, 3),
-            stride=(self.stride, self.stride),
-            padding=(1, 1),
-            batch_size=batch_size,
-            input_height=input_height,
-            input_width=input_width,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs_3 = {
+            "in_channels": self.conv2_input_channels,
+            "out_channels": self.conv2_output_channels,
+            "batch_size": batch_size,
+            "input_height": input_height,
+            "input_width": input_width,
+            "kernel_size": (3, 3),
+            "stride": (self.stride, self.stride),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation="relu",
@@ -355,6 +401,31 @@ class resnet50Bottleneck:
                 reshard_if_not_optimal=reshard_if_not_optimal,
                 transpose_shards=height_sharding,
             ),
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv2_weight_tensor):
+            self.conv2_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv2_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=out.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_3,
+            )
+            self.conv2_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv2_bias_tensor,
+                input_memory_config=out.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_3,
+            )
+
+            self.conv2_weight_tensor = ttnn.to_device(self.conv2_weight_tensor, device)
+            self.conv2_bias_tensor = ttnn.to_device(self.conv2_bias_tensor, device)
+
+        out, [input_height, input_width], [self.conv2_weight_tensor, self.conv2_bias_tensor] = ttnn.conv2d(
+            input_tensor=out,
+            weight_tensor=self.conv2_weight_tensor,
+            bias_tensor=self.conv2_bias_tensor,
+            **conv_kwargs_3,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
             ),
@@ -365,20 +436,19 @@ class resnet50Bottleneck:
 
         # conv3 is 1x1 conv
         # print("Running conv3")
-        out, [self.conv3_weight_tensor, self.conv3_bias_tensor] = ttnn.conv2d(
-            input_tensor=out,
-            weight_tensor=self.conv3_weight_tensor,
-            in_channels=self.conv3_input_channels,
-            out_channels=self.conv3_output_channels,
-            device=device,
-            bias_tensor=self.conv3_bias_tensor,
-            kernel_size=(1, 1),
-            stride=(1, 1),
-            padding=(0, 0),
-            batch_size=batch_size,
-            input_height=input_height,
-            input_width=input_width,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs_4 = {
+            "in_channels": self.conv3_input_channels,
+            "out_channels": self.conv3_output_channels,
+            "batch_size": batch_size,
+            "input_height": input_height,
+            "input_width": input_width,
+            "kernel_size": (1, 1),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
@@ -387,6 +457,30 @@ class resnet50Bottleneck:
                 reshard_if_not_optimal=reshard_if_not_optimal,
                 transpose_shards=height_sharding,
             ),
+        }
+        if not ttnn.is_tensor_storage_on_device(self.conv3_weight_tensor):
+            self.conv3_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv3_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=out.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_4,
+            )
+            self.conv3_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv3_bias_tensor,
+                input_memory_config=out.memory_config(),
+                input_layout=out.get_layout(),
+                **conv_kwargs_4,
+            )
+
+            self.conv3_weight_tensor = ttnn.to_device(self.conv3_weight_tensor, device)
+            self.conv3_bias_tensor = ttnn.to_device(self.conv3_bias_tensor, device)
+
+        out, [self.conv3_weight_tensor, self.conv3_bias_tensor] = ttnn.conv2d(
+            input_tensor=out,
+            weight_tensor=self.conv3_weight_tensor,
+            bias_tensor=self.conv3_bias_tensor,
+            **conv_kwargs_4,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
             ),
@@ -597,20 +691,19 @@ class resnet50:
         else:
             act_block_h_override = 0
 
-        x, [x_height, x_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
-            input_tensor=input_tensor,
-            weight_tensor=self.conv1_weight_tensor,
-            in_channels=self.conv1_input_channels,
-            out_channels=self.conv1_output_channels,
-            device=device,
-            bias_tensor=self.conv1_bias_tensor,
-            kernel_size=(4, 4),
-            stride=(1, 1),
-            padding=(0, 0),
-            batch_size=self.batch_size,
-            input_height=515,
-            input_width=515,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs = {
+            "in_channels": self.conv1_input_channels,
+            "out_channels": self.conv1_output_channels,
+            "batch_size": self.batch_size,
+            "input_height": 515,
+            "input_width": 515,
+            "kernel_size": (4, 4),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation="relu",
@@ -619,6 +712,30 @@ class resnet50:
                 input_channels_alignment=16 if not is_wormhole_b0() else 32,
                 act_block_h_override=act_block_h_override,
             ),
+        }
+        if not ttnn.is_tensor_storage_on_device(self.conv1_weight_tensor):
+            self.conv1_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv1_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv1_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv1_bias_tensor,
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+
+            self.conv1_weight_tensor = ttnn.to_device(self.conv1_weight_tensor, device)
+            self.conv1_bias_tensor = ttnn.to_device(self.conv1_bias_tensor, device)
+
+        x, [x_height, x_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
+            input_tensor=input_tensor,
+            weight_tensor=self.conv1_weight_tensor,
+            bias_tensor=self.conv1_bias_tensor,
+            **conv_kwargs,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
             ),
@@ -935,20 +1052,19 @@ class resnet50:
             elif batch_size == 1:
                 act_block_h_override = 256
 
-        x, [x_height, x_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
-            input_tensor=input_tensor,
-            weight_tensor=self.conv1_weight_tensor,
-            in_channels=self.conv1_input_channels,
-            out_channels=self.conv1_output_channels,
-            device=device,
-            bias_tensor=self.conv1_bias_tensor,
-            kernel_size=(4, 4),
-            stride=(1, 1),
-            padding=(0, 0),
-            batch_size=self.batch_size,
-            input_height=515,
-            input_width=515,
-            conv_config=ttnn.Conv2dConfig(
+        conv_kwargs = {
+            "in_channels": self.conv1_input_channels,
+            "out_channels": self.conv1_output_channels,
+            "batch_size": self.batch_size,
+            "input_height": 515,
+            "input_width": 515,
+            "kernel_size": (4, 4),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": ttnn.Conv2dConfig(
                 dtype=self.model_config["ACTIVATIONS_DTYPE"],
                 weights_dtype=self.model_config["WEIGHTS_DTYPE"],
                 activation="relu",
@@ -956,6 +1072,31 @@ class resnet50:
                 input_channels_alignment=16 if not is_wormhole_b0() else 32,
                 act_block_h_override=act_block_h_override,
             ),
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv1_weight_tensor):
+            self.conv1_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv1_weight_tensor,
+                weights_format="OIHW",
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv1_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv1_bias_tensor,
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+
+            self.conv1_weight_tensor = ttnn.to_device(self.conv1_weight_tensor, device)
+            self.conv1_bias_tensor = ttnn.to_device(self.conv1_bias_tensor, device)
+
+        x, [x_height, x_width], [self.conv1_weight_tensor, self.conv1_bias_tensor] = ttnn.conv2d(
+            input_tensor=input_tensor,
+            weight_tensor=self.conv1_weight_tensor,
+            bias_tensor=self.conv1_bias_tensor,
+            **conv_kwargs,
             compute_config=ttnn.init_device_compute_kernel_config(
                 device.arch(), math_fidelity=self.model_config["MATH_FIDELITY"]
             ),

--- a/models/demos/vgg/tt/ttnn_vgg.py
+++ b/models/demos/vgg/tt/ttnn_vgg.py
@@ -115,26 +115,49 @@ def ttnn_vgg16(
             tt_weight = ttnn.to_layout(ttnn.from_device(tt_weight), layout=ttnn.ROW_MAJOR_LAYOUT)
             tt_bias = parameters.features[conv_feature_ids[iter_conv_id]].bias
             tt_bias = ttnn.to_layout(ttnn.from_device(tt_bias), layout=ttnn.ROW_MAJOR_LAYOUT)
+
+            conv_kwargs = {
+                "in_channels": conv_ttnn_params[iter_conv_id][0],
+                "out_channels": conv_ttnn_params[iter_conv_id][1],
+                "batch_size": batch_size,
+                "input_height": conv_ttnn_params[iter_conv_id][2],
+                "input_width": conv_ttnn_params[iter_conv_id][3],
+                "kernel_size": (3, 3),
+                "stride": (1, 1),
+                "padding": (1, 1),
+                "dilation": (1, 1),
+                "groups": 1,
+                "device": device,
+                "conv_config": conv_config,
+            }
+
+            if not ttnn.is_tensor_storage_on_device(tt_weight):
+                tt_weight = ttnn.prepare_conv_weights(
+                    weight_tensor=tt_weight,
+                    weights_format="OIHW",
+                    input_memory_config=ttnn.L1_MEMORY_CONFIG,
+                    input_layout=tt_x.get_layout(),
+                    **conv_kwargs,
+                )
+
+                tt_bias = ttnn.prepare_conv_bias(
+                    bias_tensor=tt_bias,
+                    input_memory_config=ttnn.L1_MEMORY_CONFIG,
+                    input_layout=tt_x.get_layout(),
+                    **conv_kwargs,
+                )
+
+                tt_weight = ttnn.to_device(tt_weight, device)
+                tt_bias = ttnn.to_device(tt_bias, device)
             # Call ttnn.conv
             conv_op_cache = {}
-            [tt_output_tensor_on_device, [out_height, out_width], [weights_device, bias_device]] = ttnn.conv2d(
+            tt_output_tensor_on_device = ttnn.conv2d(
                 input_tensor=tt_x,
                 weight_tensor=tt_weight,
-                in_channels=conv_ttnn_params[iter_conv_id][0],
-                out_channels=conv_ttnn_params[iter_conv_id][1],
-                device=device,
                 bias_tensor=tt_bias,
-                kernel_size=(3, 3),
-                stride=(1, 1),
-                padding=(1, 1),
-                batch_size=batch_size,
-                input_height=conv_ttnn_params[iter_conv_id][2],
-                input_width=conv_ttnn_params[iter_conv_id][3],
-                conv_config=conv_config,
+                **conv_kwargs,
                 compute_config=compute_config,
                 conv_op_cache=conv_op_cache,
-                return_output_dim=True,
-                return_weights_and_bias=True,
             )
             tt_x = ttnn.from_device(tt_output_tensor_on_device)
             ttnn.deallocate(tt_output_tensor_on_device)
@@ -245,26 +268,49 @@ def ttnn_vgg11(
             tt_bias = parameters.features[conv_feature_ids_2[iter_conv_id]].bias
             tt_bias = ttnn.to_layout(ttnn.from_device(tt_bias), layout=ttnn.ROW_MAJOR_LAYOUT)
 
+            conv_kwargs = {
+                "in_channels": conv_ttnn_params_2[iter_conv_id][0],
+                "out_channels": conv_ttnn_params_2[iter_conv_id][1],
+                "batch_size": batch_size,
+                "input_height": conv_ttnn_params_2[iter_conv_id][2],
+                "input_width": conv_ttnn_params_2[iter_conv_id][3],
+                "kernel_size": (3, 3),
+                "stride": (1, 1),
+                "padding": (1, 1),
+                "dilation": (1, 1),
+                "groups": 1,
+                "device": device,
+                "conv_config": conv_config,
+            }
+
+            if not ttnn.is_tensor_storage_on_device(tt_weight):
+                tt_weight = ttnn.prepare_conv_weights(
+                    weight_tensor=tt_weight,
+                    weights_format="OIHW",
+                    input_memory_config=ttnn.L1_MEMORY_CONFIG,
+                    input_layout=tt_x.get_layout(),
+                    **conv_kwargs,
+                )
+
+                tt_bias = ttnn.prepare_conv_bias(
+                    bias_tensor=tt_bias,
+                    input_memory_config=ttnn.L1_MEMORY_CONFIG,
+                    input_layout=tt_x.get_layout(),
+                    **conv_kwargs,
+                )
+
+                tt_weight = ttnn.to_device(tt_weight, device)
+                tt_bias = ttnn.to_device(tt_bias, device)
+
             # Call ttnn.conv
             conv_op_cache = {}
-            [tt_output_tensor_on_device, [out_height, out_width], [weights_device, bias_device]] = ttnn.conv2d(
+            tt_output_tensor_on_device = ttnn.conv2d(
                 input_tensor=tt_x,
                 weight_tensor=tt_weight,
-                in_channels=conv_ttnn_params_2[iter_conv_id][0],
-                out_channels=conv_ttnn_params_2[iter_conv_id][1],
-                device=device,
                 bias_tensor=tt_bias,
-                kernel_size=(3, 3),
-                stride=(1, 1),
-                padding=(1, 1),
-                batch_size=batch_size,
-                input_height=conv_ttnn_params_2[iter_conv_id][2],
-                input_width=conv_ttnn_params_2[iter_conv_id][3],
-                conv_config=conv_config,
+                **conv_kwargs,
                 compute_config=compute_config,
                 conv_op_cache=conv_op_cache,
-                return_output_dim=True,
-                return_weights_and_bias=True,
             )
             tt_x = ttnn.from_device(tt_output_tensor_on_device)
             ttnn.deallocate(tt_output_tensor_on_device)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_downsample_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_downsample_2d_new_conv.py
@@ -146,24 +146,45 @@ class downsample_2d:
         if self.conv_config_override and "act_block_h" in self.conv_config_override:
             conv_config.act_block_h_override = self.conv_config_override["act_block_h"]
 
-        [hidden_states, [self.conv_weights, self.conv_bias]] = ttnn.conv2d(
+        conv_kwargs = {
+            "in_channels": self.in_channels,
+            "out_channels": self.out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.input_height,
+            "input_width": self.input_width,
+            "kernel_size": (3, 3),
+            "stride": (self.stride, self.stride),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": self.device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv_weights):
+            self.conv_weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv_weights,
+                weights_format="OIHW",
+                input_memory_config=hidden_states.memory_config(),
+                input_layout=hidden_states.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv_bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv_bias,
+                input_memory_config=hidden_states.memory_config(),
+                input_layout=hidden_states.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv_weights = ttnn.to_device(self.conv_weights, self.device)
+            self.conv_bias = ttnn.to_device(self.conv_bias, self.device)
+
+        hidden_states = ttnn.conv2d(
             input_tensor=hidden_states,
-            in_channels=self.in_channels,
-            out_channels=self.out_channels,
-            kernel_size=(3, 3),
-            stride=(self.stride, self.stride),
-            padding=(1, 1),
-            device=self.device,
-            batch_size=self.batch_size,
-            input_height=self.input_height,
-            input_width=self.input_width,
+            **conv_kwargs,
             weight_tensor=self.conv_weights,
             bias_tensor=self.conv_bias,
-            conv_config=conv_config,
             compute_config=compute_config,
             conv_op_cache=conv_cache,
-            return_output_dim=False,
-            return_weights_and_bias=True,
         )
         # hidden_states = run_ttnn_conv_with_pre_and_post_tensor_formatting(
         #     self.device,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -473,24 +473,48 @@ class resnetBlock2D:
             )
             if self.conv1_config_override and "act_block_h" in self.conv2_config_override:
                 conv_config.act_block_h_override = self.conv1_config_override["act_block_h"]
-            [hidden_states, [self.conv1s_weights[0], self.conv1s_bias[0]]] = ttnn.conv2d(
+
+            conv_kwargs_1 = {
+                "in_channels": self.conv1_in_channels,
+                "out_channels": self.conv1_out_channels,
+                "batch_size": self.batch_size,
+                "input_height": self.conv1_input_height,
+                "input_width": self.conv1_input_width,
+                "kernel_size": (3, 3),
+                "stride": (1, 1),
+                "padding": (1, 1),
+                "dilation": (1, 1),
+                "groups": 1,
+                "device": self.device,
+                "conv_config": conv_config,
+            }
+
+            if not ttnn.is_tensor_storage_on_device(self.conv1s_weights[0]):
+                tt_weight = self.conv1s_weights[0]
+                tt_bias = self.conv1s_bias[0]
+                self.conv1s_weights[0] = ttnn.prepare_conv_weights(
+                    weight_tensor=self.conv1s_weights[0],
+                    weights_format="OIHW",
+                    input_memory_config=hidden_states.memory_config(),
+                    input_layout=hidden_states.get_layout(),
+                    **conv_kwargs_1,
+                )
+                self.conv1s_bias[0] = ttnn.prepare_conv_bias(
+                    bias_tensor=self.conv1s_bias[0],
+                    input_memory_config=hidden_states.memory_config(),
+                    input_layout=hidden_states.get_layout(),
+                    **conv_kwargs_1,
+                )
+                self.conv1s_weights[0] = ttnn.to_device(self.conv1s_weights[0], self.device)
+                self.conv1s_bias[0] = ttnn.to_device(self.conv1s_bias[0], self.device)
+
+            hidden_states = ttnn.conv2d(
                 input_tensor=hidden_states,
                 weight_tensor=self.conv1s_weights[0],
-                in_channels=self.conv1_in_channels,
-                out_channels=self.conv1_out_channels,
-                device=self.device,
                 bias_tensor=self.conv1s_bias[0],
-                kernel_size=(3, 3),
-                stride=(1, 1),
-                padding=(1, 1),
-                batch_size=self.batch_size,
-                input_height=self.conv1_input_height,
-                input_width=self.conv1_input_width,
-                conv_config=conv_config,
+                **conv_kwargs_1,
                 compute_config=compute_config,
                 conv_op_cache=conv_cache,
-                return_output_dim=False,
-                return_weights_and_bias=True,
             )
 
         else:
@@ -550,28 +574,51 @@ class resnetBlock2D:
                 if self.conv1_config_override and "act_block_h" in self.conv2_config_override:
                     conv_config.act_block_h_override = self.conv1_config_override["act_block_h"]
 
+                conv_kwargs_2 = {
+                    "in_channels": self.conv1_in_channels,
+                    "out_channels": self.conv1_out_channels,
+                    "batch_size": self.batch_size,
+                    "input_height": self.conv1_input_height,
+                    "input_width": self.conv1_input_width,
+                    "kernel_size": (3, 3),
+                    "stride": (1, 1),
+                    "padding": (1, 1),
+                    "dilation": (1, 1),
+                    "groups": 1,
+                    "device": self.device,
+                    "conv_config": conv_config,
+                }
+
+                if not ttnn.is_tensor_storage_on_device(self.conv1s_weights[i]):
+                    self.conv1s_weights[i] = ttnn.prepare_conv_weights(
+                        weight_tensor=self.conv1s_weights[i],
+                        weights_format="OIHW",
+                        input_memory_config=split_hidden_states[i].memory_config(),
+                        input_layout=split_hidden_states[i].get_layout(),
+                        **conv_kwargs_2,
+                    )
+                    self.conv1s_bias[i] = ttnn.prepare_conv_bias(
+                        bias_tensor=self.conv1s_bias[i],
+                        input_memory_config=split_hidden_states[i].memory_config(),
+                        input_layout=split_hidden_states[i].get_layout(),
+                        **conv_kwargs_2,
+                    )
+
+                    self.conv1s_weights[i] = ttnn.to_device(self.conv1s_weights[i], self.device)
+                    self.conv1s_bias[i] = ttnn.to_device(self.conv1s_bias[i], self.device)
+
                 [
                     split_hidden_states[i],
                     [_out_height, _out_width],
-                    [self.conv1s_weights[i], self.conv1s_bias[i]],
                 ] = ttnn.conv2d(
                     input_tensor=split_hidden_states[i],
                     weight_tensor=self.conv1s_weights[i],
-                    in_channels=self.conv1_in_channels,
-                    out_channels=self.conv1_out_channels,
-                    device=self.device,
                     bias_tensor=self.conv1s_bias[i],
-                    kernel_size=(3, 3),
-                    stride=(1, 1),
-                    padding=(1, 1),
-                    batch_size=self.batch_size,
-                    input_height=self.conv1_input_height,
-                    input_width=self.conv1_input_width,
-                    conv_config=conv_config,
+                    **conv_kwargs_2,
                     compute_config=compute_config,
                     conv_op_cache=conv_cache,
                     return_output_dim=True,
-                    return_weights_and_bias=True,
+                    return_weights_and_bias=False,
                 )
                 if i != 0:
                     split_hidden_states[i] = ttnn.add(
@@ -681,24 +728,49 @@ class resnetBlock2D:
         )
         if self.conv2_config_override and "act_block_h" in self.conv2_config_override:
             conv_config.act_block_h_override = self.conv2_config_override["act_block_h"]
-        [hidden_states, [_out_height, _out_width], [self.conv2_weights, self.conv2_bias]] = ttnn.conv2d(
+
+        conv_kwargs_3 = {
+            "in_channels": self.conv2_in_channels,
+            "out_channels": self.conv2_out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.conv2_input_height,
+            "input_width": self.conv2_input_width,
+            "kernel_size": (3, 3),
+            "stride": (1, 1),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": self.device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv2_weights):
+            self.conv2_weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv2_weights,
+                weights_format="OIHW",
+                input_memory_config=hidden_states.memory_config(),
+                input_layout=hidden_states.get_layout(),
+                **conv_kwargs_3,
+            )
+            self.conv2_bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv2_bias,
+                input_memory_config=hidden_states.memory_config(),
+                input_layout=hidden_states.get_layout(),
+                **conv_kwargs_3,
+            )
+
+            self.conv2_weights = ttnn.to_device(self.conv2_weights, self.device)
+            self.conv2_bias = ttnn.to_device(self.conv2_bias, self.device)
+
+        [hidden_states, [_out_height, _out_width]] = ttnn.conv2d(
             input_tensor=hidden_states,
             weight_tensor=self.conv2_weights,
             bias_tensor=self.conv2_bias,
-            in_channels=self.conv2_in_channels,
-            out_channels=self.conv2_out_channels,
-            device=self.device,
-            kernel_size=(3, 3),
-            stride=(1, 1),
-            padding=(1, 1),
-            batch_size=self.batch_size,
-            input_height=self.conv2_input_height,
-            input_width=self.conv2_input_width,
-            conv_config=conv_config,
+            **conv_kwargs_3,
             compute_config=compute_config,
             conv_op_cache=conv_cache,
             return_output_dim=True,
-            return_weights_and_bias=True,
+            return_weights_and_bias=False,
         )
         use_in_shortcut = in_channels != out_channels if use_in_shortcut is None else use_in_shortcut
 
@@ -729,28 +801,50 @@ class resnetBlock2D:
                 fp32_dest_acc_en=True,
                 packer_l1_acc=False,
             )
+
+            conv_kwargs_4 = {
+                "in_channels": self.conv_shortcut_in_channels,
+                "out_channels": self.conv_shortcut_out_channels,
+                "batch_size": self.batch_size,
+                "input_height": self.conv_shortcut_input_height,
+                "input_width": self.conv_shortcut_input_width,
+                "kernel_size": (1, 1),
+                "stride": (1, 1),
+                "padding": (0, 0),
+                "dilation": (1, 1),
+                "groups": 1,
+                "device": self.device,
+                "conv_config": conv_config,
+            }
+            if not ttnn.is_tensor_storage_on_device(self.conv_shortcut_weights):
+                self.conv_shortcut_weights = ttnn.prepare_conv_weights(
+                    weight_tensor=self.conv_shortcut_weights,
+                    weights_format="OIHW",
+                    input_memory_config=input_tensor.memory_config(),
+                    input_layout=input_tensor.get_layout(),
+                    **conv_kwargs_4,
+                )
+                self.conv_shortcut_bias = ttnn.prepare_conv_bias(
+                    bias_tensor=self.conv_shortcut_bias,
+                    input_memory_config=input_tensor.memory_config(),
+                    input_layout=input_tensor.get_layout(),
+                    **conv_kwargs_4,
+                )
+                self.conv_shortcut_weights = ttnn.to_device(self.conv_shortcut_weights, self.device)
+                self.conv_shortcut_bias = ttnn.to_device(self.conv_shortcut_bias, self.device)
+
             [
                 input_tensor,
                 [_out_height, _out_width],
-                [self.conv_shortcut_weights, self.conv_shortcut_bias],
             ] = ttnn.conv2d(
                 input_tensor=input_tensor,
                 weight_tensor=self.conv_shortcut_weights,
-                in_channels=self.conv_shortcut_in_channels,
-                out_channels=self.conv_shortcut_out_channels,
-                device=self.device,
                 bias_tensor=self.conv_shortcut_bias,
-                kernel_size=(1, 1),
-                stride=(1, 1),
-                padding=(0, 0),
-                batch_size=self.batch_size,
-                input_height=self.conv_shortcut_input_height,
-                input_width=self.conv_shortcut_input_width,
-                conv_config=conv_config,
+                **conv_kwargs_4,
                 compute_config=compute_config,
                 conv_op_cache=conv_cache,
                 return_output_dim=True,
-                return_weights_and_bias=True,
+                return_weights_and_bias=False,
             )
 
         if ttnn.get_memory_config(input_tensor) != ttnn.get_memory_config(hidden_states):

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -252,24 +252,48 @@ class transformer_2d_model:
             math_fidelity=ttnn.MathFidelity.LoFi,
             fp32_dest_acc_en=self.compute_kernel_config.fp32_dest_acc_en,
         )
-        [hidden_states, [self.proj_in_conv_weights, self.proj_in_conv_bias]] = ttnn.conv2d(
+
+        conv_kwargs = {
+            "in_channels": self.proj_in_in_channels,
+            "out_channels": self.proj_in_out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.input_height,
+            "input_width": self.input_width,
+            "kernel_size": (1, 1),
+            "stride": (1, 1),
+            "padding": (0, 0),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": self.device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.proj_in_conv_weights):
+            self.proj_in_conv_weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.proj_in_conv_weights,
+                weights_format="OIHW",
+                input_memory_config=hidden_states.memory_config(),
+                input_layout=hidden_states.get_layout(),
+                **conv_kwargs,
+            )
+            self.proj_in_conv_bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.proj_in_conv_bias,
+                input_memory_config=hidden_states.memory_config(),
+                input_layout=hidden_states.get_layout(),
+                **conv_kwargs,
+            )
+            self.proj_in_conv_weights = ttnn.to_device(self.proj_in_conv_weights, self.device)
+            self.proj_in_conv_bias = ttnn.to_device(self.proj_in_conv_bias, self.device)
+
+        hidden_states = ttnn.conv2d(
             input_tensor=hidden_states,
-            in_channels=self.proj_in_in_channels,
-            out_channels=self.proj_in_out_channels,
-            kernel_size=(1, 1),
-            stride=(1, 1),
-            padding=(0, 0),
-            device=self.device,
-            batch_size=self.batch_size,
-            input_height=self.input_height,
-            input_width=self.input_width,
             weight_tensor=self.proj_in_conv_weights,
             bias_tensor=self.proj_in_conv_bias,
-            conv_config=conv_config,
+            **conv_kwargs,
             compute_config=compute_config,
             conv_op_cache=conv_cache,
             return_output_dim=False,
-            return_weights_and_bias=True,
+            return_weights_and_bias=False,
         )
 
         inner_dim = hidden_states.shape[-1]
@@ -296,6 +320,37 @@ class transformer_2d_model:
         out_channels = in_channels if out_channels is None else out_channels
         if is_input_continuous:
             if not use_linear_projection:
+                conv_kwargs_1 = {
+                    "in_channels": self.proj_out_in_channels,
+                    "out_channels": self.proj_out_out_channels,
+                    "batch_size": self.batch_size,
+                    "input_height": self.input_height,
+                    "input_width": self.input_width,
+                    "kernel_size": (1, 1),
+                    "stride": (1, 1),
+                    "padding": (0, 0),
+                    "dilation": (1, 1),
+                    "groups": 1,
+                    "device": self.device,
+                    "conv_config": conv_config,
+                }
+
+                if not ttnn.is_tensor_storage_on_device(self.proj_out_conv_weights):
+                    self.proj_out_conv_weights = ttnn.prepare_conv_weights(
+                        weight_tensor=self.proj_out_conv_weights,
+                        weights_format="OIHW",
+                        input_memory_config=hidden_states.memory_config(),
+                        input_layout=hidden_states.get_layout(),
+                        **conv_kwargs_1,
+                    )
+                    self.proj_out_conv_bias = ttnn.prepare_conv_bias(
+                        bias_tensor=self.proj_out_conv_bias,
+                        input_memory_config=hidden_states.memory_config(),
+                        input_layout=hidden_states.get_layout(),
+                        **conv_kwargs_1,
+                    )
+                    self.proj_out_conv_weights = ttnn.to_device(self.proj_out_conv_weights, self.device)
+                    self.proj_out_conv_bias = ttnn.to_device(self.proj_out_conv_bias, self.device)
                 # hidden_states = ttnn.to_memory_config(hidden_states, self.proj_out.conv.input_sharded_memory_config)
                 [
                     hidden_states,
@@ -303,18 +358,9 @@ class transformer_2d_model:
                     [self.proj_out_conv_weights, self.proj_out_conv_bias],
                 ] = ttnn.conv2d(
                     input_tensor=hidden_states,
-                    in_channels=self.proj_out_in_channels,
-                    out_channels=self.proj_out_out_channels,
-                    kernel_size=(1, 1),
-                    stride=(1, 1),
-                    padding=(0, 0),
-                    device=self.device,
-                    batch_size=self.batch_size,
-                    input_height=self.input_height,
-                    input_width=self.input_width,
+                    **conv_kwargs_1,
                     weight_tensor=self.proj_out_conv_weights,
                     bias_tensor=self.proj_out_conv_bias,
-                    conv_config=conv_config,
                     conv_op_cache=conv_cache,
                     return_output_dim=True,
                     return_weights_and_bias=True,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -397,24 +397,45 @@ class UNet2DConditionModel:
             packer_l1_acc=False,
         )
 
-        [sample, [self.conv_in_weights, self.conv_in_bias]] = ttnn.conv2d(
+        conv_kwargs = {
+            "in_channels": in_channels,
+            "out_channels": out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.input_height,
+            "input_width": self.input_width,
+            "kernel_size": (3, 3),
+            "stride": (1, 1),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": self.device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv_in_weights):
+            self.conv_in_weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv_in_weights,
+                weights_format="OIHW",
+                input_memory_config=sample.memory_config(),
+                input_layout=sample.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv_in_bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv_in_bias,
+                input_memory_config=sample.memory_config(),
+                input_layout=sample.get_layout(),
+                **conv_kwargs,
+            )
+            self.conv_in_weights = ttnn.to_device(self.conv_in_weights, self.device)
+            self.conv_in_bias = ttnn.to_device(self.conv_in_bias, self.device)
+
+        sample = ttnn.conv2d(
             input_tensor=sample,
             weight_tensor=self.conv_in_weights,
             bias_tensor=self.conv_in_bias,
-            in_channels=in_channels,
-            out_channels=out_channels,
-            kernel_size=(3, 3),
-            stride=(1, 1),
-            padding=(1, 1),
-            device=self.device,
-            batch_size=self.batch_size,
-            input_height=self.input_height,
-            input_width=self.input_width,
-            conv_config=conv_config,
+            **conv_kwargs,
             compute_config=compute_config,
             conv_op_cache=conv_cache,
-            return_output_dim=False,
-            return_weights_and_bias=True,
         )
         sample = ttnn.reallocate(sample)  # TODO: Test remove
 
@@ -666,24 +687,46 @@ class UNet2DConditionModel:
             fp32_dest_acc_en=True,
             packer_l1_acc=False,
         )
-        [sample, [self.conv_out_weights, self.conv_out_bias]] = ttnn.conv2d(
+
+        conv_kwargs_1 = {
+            "in_channels": self.conv_out_in_channels,
+            "out_channels": self.conv_out_out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.conv_out_input_height,
+            "input_width": self.conv_out_input_width,
+            "kernel_size": (3, 3),
+            "stride": (1, 1),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": self.device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.conv_out_weights):
+            self.conv_out_weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv_out_weights,
+                weights_format="OIHW",
+                input_memory_config=sample.memory_config(),
+                input_layout=sample.get_layout(),
+                **conv_kwargs_1,
+            )
+            self.conv_out_bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv_out_bias,
+                input_memory_config=sample.memory_config(),
+                input_layout=sample.get_layout(),
+                **conv_kwargs_1,
+            )
+            self.conv_out_weights = ttnn.to_device(self.conv_out_weights, self.device)
+            self.conv_out_bias = ttnn.to_device(self.conv_out_bias, self.device)
+
+        sample = ttnn.conv2d(
             input_tensor=sample,
-            in_channels=self.conv_out_in_channels,
-            out_channels=self.conv_out_out_channels,
-            kernel_size=(3, 3),
-            stride=(1, 1),
-            padding=(1, 1),
-            device=self.device,
-            batch_size=self.batch_size,
-            input_height=self.conv_out_input_height,
-            input_width=self.conv_out_input_width,
+            **conv_kwargs_1,
             weight_tensor=self.conv_out_weights,
             bias_tensor=self.conv_out_bias,
-            conv_config=conv_config,
             compute_config=compute_config,
             conv_op_cache=conv_cache,
-            return_output_dim=False,
-            return_weights_and_bias=True,
         )
         sample = ttnn.to_memory_config(sample, ttnn.L1_MEMORY_CONFIG)
         sample = ttnn.clone(sample, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat16)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_2d_new_conv.py
@@ -106,23 +106,45 @@ class upsample2d:
         )
         if self.conv_config_override and "act_block_h" in self.conv_config_override:
             conv_config.act_block_h_override = self.conv_config_override["act_block_h"]
-        [tt_out, [self.conv_weight_tensor, self.conv_bias_tensor]] = ttnn.conv2d(
+
+        conv_kwargs = {
+            "in_channels": self.conv_in_channels,
+            "out_channels": self.conv_out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.conv_input_height,
+            "input_width": self.conv_input_width,
+            "kernel_size": (3, 3),
+            "stride": (1, 1),
+            "padding": (1, 1),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": self.device,
+            "conv_config": conv_config,
+        }
+        if not ttnn.is_tensor_storage_on_device(self.conv_weight_tensor):
+            self.conv_weight_tensor = ttnn.prepare_conv_weights(
+                weight_tensor=self.conv_weight_tensor,
+                weights_format="OIHW",
+                input_layout=tt_out.get_layout(),
+                input_memory_config=tt_out.memory_config(),
+                **conv_kwargs,
+            )
+            self.conv_bias_tensor = ttnn.prepare_conv_bias(
+                bias_tensor=self.conv_bias_tensor,
+                input_memory_config=tt_out.memory_config(),
+                input_layout=tt_out.get_layout(),
+                **conv_kwargs,
+            )
+
+            self.conv_weight_tensor = ttnn.to_device(self.conv_weight_tensor, self.device)
+            self.conv_bias_tensor = ttnn.to_device(self.conv_bias_tensor, self.device)
+
+        tt_out = ttnn.conv2d(
             input_tensor=tt_out,
-            in_channels=self.conv_in_channels,
-            out_channels=self.conv_out_channels,
-            kernel_size=(3, 3),
-            stride=(1, 1),
-            padding=(1, 1),
-            device=self.device,
-            batch_size=self.batch_size,
-            input_height=self.conv_input_height,
-            input_width=self.conv_input_width,
             weight_tensor=self.conv_weight_tensor,
             bias_tensor=self.conv_bias_tensor,
-            conv_config=conv_config,
+            **conv_kwargs,
             compute_config=compute_config,
             conv_op_cache=conv_cache,
-            return_output_dim=False,
-            return_weights_and_bias=True,
         )
         return tt_out

--- a/models/demos/yolov4/demo/demo.py
+++ b/models/demos/yolov4/demo/demo.py
@@ -450,7 +450,7 @@ def do_detect(model, img, conf_thresh, nms_thresh, n_classes, device=None, class
             img = input_tensor
             t1 = time.time()
 
-            output = model(device, img)
+            output = model(img)
 
             output_tensor1 = ttnn.to_torch(output[0])
             output_tensor1 = output_tensor1.reshape(1, 40, 40, 255)
@@ -579,7 +579,7 @@ def test_yolov4_model(device, model_location_generator, reset_seeds, input_path,
         else:
             weights_pth = str(model_path / "yolov4.pth")
 
-        ttnn_model = TtYOLOv4(weights_pth)
+        ttnn_model = TtYOLOv4(device, weights_pth)
         torch_model = Yolov4()
         new_state_dict = {}
         ds_state_dict = {k: v for k, v in ttnn_model.torch_model.items()}
@@ -595,7 +595,7 @@ def test_yolov4_model(device, model_location_generator, reset_seeds, input_path,
     else:
         torch_model = Yolov4.from_random_weights()
         ttnn_weights = update_weight_parameters(OrderedDict(torch_model.state_dict()))
-        ttnn_model = TtYOLOv4(ttnn_weights)
+        ttnn_model = TtYOLOv4(device, ttnn_weights)
 
     n_classes = 80
     namesfile = "models/demos/yolov4/demo/coco.names"

--- a/models/demos/yolov4/tests/test_perf_yolo.py
+++ b/models/demos/yolov4/tests/test_perf_yolo.py
@@ -60,14 +60,14 @@ def test_yolov4(
         weights_pth = "tests/ttnn/integration_tests/yolov4/yolov4.pth"
     else:
         weights_pth = str(model_path / "yolov4.pth")
-    ttnn_model = TtYOLOv4(weights_pth)
+    ttnn_model = TtYOLOv4(device, weights_pth)
 
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
 
     logger.info(f"Compiling model with warmup run")
     profiler.start(f"inference_and_compile_time")
-    out1, out2, out3 = ttnn_model(device, ttnn_input)
+    out1, out2, out3 = ttnn_model(ttnn_input)
     profiler.end(f"inference_and_compile_time")
 
     inference_and_compile_time = profiler.get("inference_and_compile_time")
@@ -79,7 +79,7 @@ def test_yolov4(
     for idx in range(iterations):
         profiler.start("inference_time")
         profiler.start(f"inference_time_{idx}")
-        out1, out2, out3 = ttnn_model(device, ttnn_input)
+        out1, out2, out3 = ttnn_model(ttnn_input)
         outputs.append(ttnn.from_device(out1, blocking=False))
         outputs.append(ttnn.from_device(out2, blocking=False))
         outputs.append(ttnn.from_device(out3, blocking=False))

--- a/models/demos/yolov4/tests/yolov4_test_infra.py
+++ b/models/demos/yolov4/tests/yolov4_test_infra.py
@@ -72,7 +72,7 @@ class Yolov4TestInfra:
         self.act_dtype = act_dtype
         self.weight_dtype = weight_dtype
         self.model_location_generator = model_location_generator
-        self.ttnn_yolov4_model = TtYOLOv4(load_yolov4_weight(self.model_location_generator))
+        self.ttnn_yolov4_model = TtYOLOv4(device, load_yolov4_weight(self.model_location_generator))
         torch_model = load_yolov4_model(self.ttnn_yolov4_model)
         input_shape = (1, 320, 320, 3)
         torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
@@ -81,7 +81,7 @@ class Yolov4TestInfra:
         self.torch_output_tensor = torch_model(self.torch_input_tensor)
 
     def run(self):
-        self.output_tensor = self.ttnn_yolov4_model(self.device, self.input_tensor)
+        self.output_tensor = self.ttnn_yolov4_model(self.input_tensor)
 
     def setup_l1_sharded_input(self, device, torch_input_tensor=None):
         if is_wormhole_b0():

--- a/models/demos/yolov4/ttnn/common.py
+++ b/models/demos/yolov4/ttnn/common.py
@@ -68,14 +68,11 @@ class Conv:
 
         if width_sharding:
             self.shard_layout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
-            self.input_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
         else:
             self.shard_layout = (
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
             )
-            self.input_memory_config = (
-                ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG if height_sharding else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
-            )
+
         self.deallocate = deallocate
         self.activation = activation
         conv_config = ttnn.Conv2dConfig(
@@ -111,6 +108,11 @@ class Conv:
             "device": device,
             "conv_config": conv_config,
         }
+        self.input_memory_config = (
+            ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
+            if height_sharding and not width_sharding
+            else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+        )
 
         if not ttnn.is_tensor_storage_on_device(self.weights):
             self.weights = ttnn.prepare_conv_weights(
@@ -151,4 +153,5 @@ class Conv:
             return_output_dim=False,
             return_weights_and_bias=False,
         )
+        print(ttnn.get_memory_config(output_tensor))
         return output_tensor

--- a/models/demos/yolov4/ttnn/common.py
+++ b/models/demos/yolov4/ttnn/common.py
@@ -102,22 +102,47 @@ class Conv:
         if self.act_block_h is not None:
             conv_config.act_block_h_override = self.act_block_h
 
-        output_tensor, [self.weights, self.bias] = ttnn.conv2d(
+        conv_kwargs = {
+            "in_channels": self.input_params[3],
+            "out_channels": self.out_channels,
+            "batch_size": self.input_params[0],
+            "input_height": self.input_params[1],
+            "input_width": self.input_params[2],
+            "kernel_size": self.kernel_size,
+            "stride": (self.conv_params[0], self.conv_params[1]),
+            "padding": (self.conv_params[2], self.conv_params[3]),
+            "dilation": (1, 1),
+            "groups": 1,
+            "device": device,
+            "conv_config": conv_config,
+        }
+
+        if not ttnn.is_tensor_storage_on_device(self.weights):
+            self.weights = ttnn.prepare_conv_weights(
+                weight_tensor=self.weights,
+                weights_format="OIHW",
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+
+            self.bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.bias,
+                input_memory_config=input_tensor.memory_config(),
+                input_layout=input_tensor.get_layout(),
+                **conv_kwargs,
+            )
+
+            self.weights = ttnn.to_device(self.weights, device)
+            self.bias = ttnn.to_device(self.bias, device)
+
+        output_tensor = ttnn.conv2d(
             input_tensor=input_tensor,
             weight_tensor=self.weights,
             bias_tensor=self.bias,
-            in_channels=self.input_params[3],
-            out_channels=self.out_channels,
-            device=device,
-            kernel_size=self.kernel_size,
-            stride=(self.conv_params[0], self.conv_params[1]),
-            padding=(self.conv_params[2], self.conv_params[3]),
-            batch_size=self.input_params[0],
-            input_height=self.input_params[1],
-            input_width=self.input_params[2],
-            conv_config=conv_config,
+            **conv_kwargs,
             compute_config=compute_config,
             return_output_dim=False,
-            return_weights_and_bias=True,
+            return_weights_and_bias=False,
         )
         return output_tensor

--- a/models/demos/yolov4/ttnn/common.py
+++ b/models/demos/yolov4/ttnn/common.py
@@ -153,5 +153,4 @@ class Conv:
             return_output_dim=False,
             return_weights_and_bias=False,
         )
-        print(ttnn.get_memory_config(output_tensor))
         return output_tensor

--- a/models/demos/yolov4/ttnn/downsample1.py
+++ b/models/demos/yolov4/ttnn/downsample1.py
@@ -10,13 +10,14 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without
 
 
 class Down1:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
+            device,
             torch_model,
             "down1.conv1",
             [1, 320, 320, 3],
@@ -26,6 +27,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv2 = Conv(
+            device,
             torch_model,
             "down1.conv2",
             [1, 320, 320, 32],
@@ -34,6 +36,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv3 = Conv(
+            device,
             torch_model,
             "down1.conv3",
             [1, 160, 160, 64],
@@ -43,6 +46,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv4 = Conv(
+            device,
             torch_model,
             "down1.conv4",
             [1, 160, 160, 64],
@@ -51,6 +55,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv5 = Conv(
+            device,
             torch_model,
             "down1.conv5",
             [1, 160, 160, 64],
@@ -60,6 +65,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv6 = Conv(
+            device,
             torch_model,
             "down1.conv6",
             [1, 160, 160, 32],
@@ -68,6 +74,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv7 = Conv(
+            device,
             torch_model,
             "down1.conv7",
             [1, 160, 160, 64],
@@ -76,6 +83,7 @@ class Down1:
             enable_act_double_buffer=True,
         )
         self.conv8 = Conv(
+            device,
             torch_model,
             "down1.conv8",
             [1, 160, 160, 128],
@@ -85,29 +93,25 @@ class Down1:
         )
         self.convs = [self.conv1, self.conv2, self.conv3, self.conv4, self.conv5, self.conv6, self.conv7, self.conv8]
 
-    def print_tensor(self, tensor):
-        print(tensor)
-        print(ttnn.get_memory_config(tensor))
-
-    def __call__(self, device, input_tensor):
-        output_tensor = self.conv1(device, input_tensor)
+    def __call__(self, input_tensor):
+        output_tensor = self.conv1(input_tensor)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor_split = self.conv2(device, output_tensor)
+        output_tensor_split = self.conv2(output_tensor)
         output_tensor_split = ttnn.mish(output_tensor_split)
 
-        output_tensor_left = self.conv3(device, output_tensor_split)
+        output_tensor_left = self.conv3(output_tensor_split)
         output_tensor_left = ttnn.mish(output_tensor_left)
 
-        output_tensor_split_2 = self.conv4(device, output_tensor_split)
+        output_tensor_split_2 = self.conv4(output_tensor_split)
         output_tensor_split_2 = ttnn.mish(output_tensor_split_2)
-        output_tensor = self.conv5(device, output_tensor_split_2)
+        output_tensor = self.conv5(output_tensor_split_2)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.conv6(device, output_tensor)
+        output_tensor = self.conv6(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         output_tensor = output_tensor_split_2 + output_tensor
 
         ttnn.deallocate(output_tensor_split_2)
-        output_tensor = self.conv7(device, output_tensor)
+        output_tensor = self.conv7(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 
         output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -123,7 +127,7 @@ class Down1:
         )
         ttnn.deallocate(output_tensor_left)
 
-        output_tensor = self.conv8(device, output_tensor)
+        output_tensor = self.conv8(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         return output_tensor
 

--- a/models/demos/yolov4/ttnn/downsample2.py
+++ b/models/demos/yolov4/ttnn/downsample2.py
@@ -8,13 +8,14 @@ from models.demos.yolov4.ttnn.common import Conv
 
 
 class Down2:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
+            device,
             torch_model,
             "down2.conv1",
             [1, 160, 160, 64],
@@ -23,6 +24,7 @@ class Down2:
             enable_act_double_buffer=True,
         )
         self.conv2 = Conv(
+            device,
             torch_model,
             "down2.conv2",
             [1, 80, 80, 128],
@@ -32,6 +34,7 @@ class Down2:
             enable_act_double_buffer=True,
         )
         self.conv3 = Conv(
+            device,
             torch_model,
             "down2.conv3",
             [1, 80, 80, 128],
@@ -40,6 +43,7 @@ class Down2:
             enable_act_double_buffer=True,
         )
         self.conv4 = Conv(
+            device,
             torch_model,
             "down2.conv4",
             [1, 80, 80, 64],
@@ -50,6 +54,7 @@ class Down2:
         )
 
         self.res1_conv1 = Conv(
+            device,
             torch_model,
             "down2.resblock.module_list.0.0",
             [1, 80, 80, 64],
@@ -59,6 +64,7 @@ class Down2:
             enable_act_double_buffer=True,
         )
         self.res1_conv2 = Conv(
+            device,
             torch_model,
             "down2.resblock.module_list.0.1",
             [1, 80, 80, 64],
@@ -67,6 +73,7 @@ class Down2:
             enable_act_double_buffer=True,
         )
         self.res2_conv1 = Conv(
+            device,
             torch_model,
             "down2.resblock.module_list.1.0",
             [1, 80, 80, 64],
@@ -76,6 +83,7 @@ class Down2:
             enable_act_double_buffer=True,
         )
         self.res2_conv2 = Conv(
+            device,
             torch_model,
             "down2.resblock.module_list.1.1",
             [1, 80, 80, 64],
@@ -85,6 +93,7 @@ class Down2:
         )
 
         self.conv5 = Conv(
+            device,
             torch_model,
             "down2.conv5",
             [1, 80, 80, 128],
@@ -93,31 +102,31 @@ class Down2:
             enable_act_double_buffer=True,
         )
 
-    def __call__(self, device, input_tensor):
-        output_tensor_split = self.conv1(device, input_tensor)
+    def __call__(self, input_tensor):
+        output_tensor_split = self.conv1(input_tensor)
         output_tensor_split = ttnn.mish(output_tensor_split)
-        output_tensor_left = self.conv2(device, output_tensor_split)
+        output_tensor_left = self.conv2(output_tensor_split)
         output_tensor_left = ttnn.mish(output_tensor_left)
 
-        res1_split = self.conv3(device, output_tensor_split)
+        res1_split = self.conv3(output_tensor_split)
         res1_split = ttnn.mish(res1_split)
 
-        output_tensor = self.res1_conv1(device, res1_split)
+        output_tensor = self.res1_conv1(res1_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res1_conv2(device, output_tensor)
+        output_tensor = self.res1_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res2_split = res1_split + output_tensor
         ttnn.deallocate(res1_split)
 
-        output_tensor = self.res2_conv1(device, res2_split)
+        output_tensor = self.res2_conv1(res2_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res2_conv2(device, output_tensor)
+        output_tensor = self.res2_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         output_tensor = res2_split + output_tensor
 
         ttnn.deallocate(res2_split)
 
-        output_tensor = self.conv4(device, output_tensor)
+        output_tensor = self.conv4(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 
         output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -133,7 +142,7 @@ class Down2:
         )
         ttnn.deallocate(output_tensor_left)
 
-        output_tensor = self.conv5(device, output_tensor)
+        output_tensor = self.conv5(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         return output_tensor
 

--- a/models/demos/yolov4/ttnn/downsample3.py
+++ b/models/demos/yolov4/ttnn/downsample3.py
@@ -8,131 +8,132 @@ from models.demos.yolov4.ttnn.common import Conv
 
 
 class Down3:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
+            device,
             torch_model,
             "down3.conv1",
             [1, 80, 80, 128],
             (2, 2, 1, 1),
         )
-        self.conv2 = Conv(torch_model, "down3.conv2", [1, 40, 40, 256], (1, 1, 0, 0), deallocate=False)
-        self.conv3 = Conv(torch_model, "down3.conv3", [1, 40, 40, 256], (1, 1, 0, 0))
+        self.conv2 = Conv(device, torch_model, "down3.conv2", [1, 40, 40, 256], (1, 1, 0, 0), deallocate=False)
+        self.conv3 = Conv(device, torch_model, "down3.conv3", [1, 40, 40, 256], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.0.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.0.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res1_conv2 = Conv(torch_model, "down3.resblock.module_list.0.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res1_conv2 = Conv(device, torch_model, "down3.resblock.module_list.0.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res2_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.1.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.1.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res2_conv2 = Conv(torch_model, "down3.resblock.module_list.1.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res2_conv2 = Conv(device, torch_model, "down3.resblock.module_list.1.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res3_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.2.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.2.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res3_conv2 = Conv(torch_model, "down3.resblock.module_list.2.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res3_conv2 = Conv(device, torch_model, "down3.resblock.module_list.2.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res4_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.3.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.3.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res4_conv2 = Conv(torch_model, "down3.resblock.module_list.3.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res4_conv2 = Conv(device, torch_model, "down3.resblock.module_list.3.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res5_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.4.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.4.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res5_conv2 = Conv(torch_model, "down3.resblock.module_list.4.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res5_conv2 = Conv(device, torch_model, "down3.resblock.module_list.4.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res6_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.5.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.5.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res6_conv2 = Conv(torch_model, "down3.resblock.module_list.5.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res6_conv2 = Conv(device, torch_model, "down3.resblock.module_list.5.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res7_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.6.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.6.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res7_conv2 = Conv(torch_model, "down3.resblock.module_list.6.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res7_conv2 = Conv(device, torch_model, "down3.resblock.module_list.6.1", [1, 40, 40, 128], (1, 1, 1, 1))
         self.res8_conv1 = Conv(
-            torch_model, "down3.resblock.module_list.7.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
+            device, torch_model, "down3.resblock.module_list.7.0", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False
         )
-        self.res8_conv2 = Conv(torch_model, "down3.resblock.module_list.7.1", [1, 40, 40, 128], (1, 1, 1, 1))
+        self.res8_conv2 = Conv(device, torch_model, "down3.resblock.module_list.7.1", [1, 40, 40, 128], (1, 1, 1, 1))
 
-        self.conv4 = Conv(torch_model, "down3.conv4", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False)
+        self.conv4 = Conv(device, torch_model, "down3.conv4", [1, 40, 40, 128], (1, 1, 0, 0), deallocate=False)
 
-        self.conv5 = Conv(torch_model, "down3.conv5", [1, 40, 40, 256], (1, 1, 0, 0))
+        self.conv5 = Conv(device, torch_model, "down3.conv5", [1, 40, 40, 256], (1, 1, 0, 0))
 
-    def __call__(self, device, input_tensor):
-        output_tensor_split = self.conv1(device, input_tensor)
+    def __call__(self, input_tensor):
+        output_tensor_split = self.conv1(input_tensor)
         output_tensor_split = ttnn.mish(output_tensor_split)
-        output_tensor_left = self.conv2(device, output_tensor_split)
+        output_tensor_left = self.conv2(output_tensor_split)
         output_tensor_left = ttnn.mish(output_tensor_left)
 
-        res1_split = self.conv3(device, output_tensor_split)
+        res1_split = self.conv3(output_tensor_split)
         res1_split = ttnn.mish(res1_split)
 
-        output_tensor = self.res1_conv1(device, res1_split)
+        output_tensor = self.res1_conv1(res1_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res1_conv2(device, output_tensor)
+        output_tensor = self.res1_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res2_split = res1_split + output_tensor
         ttnn.deallocate(res1_split)
 
-        output_tensor = self.res2_conv1(device, res2_split)
+        output_tensor = self.res2_conv1(res2_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res2_conv2(device, output_tensor)
+        output_tensor = self.res2_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res3_split = res2_split + output_tensor
 
         ttnn.deallocate(res2_split)
 
-        output_tensor = self.res3_conv1(device, res3_split)
+        output_tensor = self.res3_conv1(res3_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res3_conv2(device, output_tensor)
+        output_tensor = self.res3_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res4_split = res3_split + output_tensor
 
         ttnn.deallocate(res3_split)
 
-        output_tensor = self.res4_conv1(device, res4_split)
+        output_tensor = self.res4_conv1(res4_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res4_conv2(device, output_tensor)
+        output_tensor = self.res4_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res5_split = res4_split + output_tensor
 
         ttnn.deallocate(res4_split)
 
-        output_tensor = self.res5_conv1(device, res5_split)
+        output_tensor = self.res5_conv1(res5_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res5_conv2(device, output_tensor)
+        output_tensor = self.res5_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res6_split = res5_split + output_tensor
 
         ttnn.deallocate(res5_split)
 
-        output_tensor = self.res6_conv1(device, res6_split)
+        output_tensor = self.res6_conv1(res6_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res6_conv2(device, output_tensor)
+        output_tensor = self.res6_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res7_split = res6_split + output_tensor
 
         ttnn.deallocate(res6_split)
 
-        output_tensor = self.res7_conv1(device, res7_split)
+        output_tensor = self.res7_conv1(res7_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res7_conv2(device, output_tensor)
+        output_tensor = self.res7_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res8_split = res7_split + output_tensor
 
         ttnn.deallocate(res7_split)
 
-        output_tensor = self.res8_conv1(device, res8_split)
+        output_tensor = self.res8_conv1(res8_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res8_conv2(device, output_tensor)
+        output_tensor = self.res8_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         output_tensor = res8_split + output_tensor
 
         ttnn.deallocate(res8_split)
 
-        output_tensor = self.conv4(device, output_tensor)
+        output_tensor = self.conv4(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 
         output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -148,7 +149,7 @@ class Down3:
         )
         ttnn.deallocate(output_tensor_left)
 
-        output_tensor = self.conv5(device, output_tensor)
+        output_tensor = self.conv5(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         return output_tensor
 

--- a/models/demos/yolov4/ttnn/downsample4.py
+++ b/models/demos/yolov4/ttnn/downsample4.py
@@ -8,13 +8,14 @@ from models.demos.yolov4.ttnn.common import Conv
 
 
 class Down4:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
+            device,
             torch_model,
             "down4.conv1",
             [1, 40, 40, 256],
@@ -23,10 +24,11 @@ class Down4:
             height_sharding=False,
             deallocate=False,
         )
-        self.conv2 = Conv(torch_model, "down4.conv2", [1, 20, 20, 512], (1, 1, 0, 0), deallocate=False)
-        self.conv3 = Conv(torch_model, "down4.conv3", [1, 20, 20, 512], (1, 1, 0, 0))
+        self.conv2 = Conv(device, torch_model, "down4.conv2", [1, 20, 20, 512], (1, 1, 0, 0), deallocate=False)
+        self.conv3 = Conv(device, torch_model, "down4.conv3", [1, 20, 20, 512], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.0.0",
             [1, 20, 20, 256],
@@ -35,6 +37,7 @@ class Down4:
             deallocate=False,
         )
         self.res1_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.0.1",
             [1, 20, 20, 256],
@@ -42,6 +45,7 @@ class Down4:
             height_sharding=False,
         )
         self.res2_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.1.0",
             [1, 20, 20, 256],
@@ -50,6 +54,7 @@ class Down4:
             height_sharding=False,
         )
         self.res2_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.1.1",
             [1, 20, 20, 256],
@@ -57,6 +62,7 @@ class Down4:
             height_sharding=False,
         )
         self.res3_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.2.0",
             [1, 20, 20, 256],
@@ -65,6 +71,7 @@ class Down4:
             height_sharding=False,
         )
         self.res3_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.2.1",
             [1, 20, 20, 256],
@@ -72,6 +79,7 @@ class Down4:
             height_sharding=False,
         )
         self.res4_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.3.0",
             [1, 20, 20, 256],
@@ -80,6 +88,7 @@ class Down4:
             height_sharding=False,
         )
         self.res4_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.3.1",
             [1, 20, 20, 256],
@@ -87,6 +96,7 @@ class Down4:
             height_sharding=False,
         )
         self.res5_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.4.0",
             [1, 20, 20, 256],
@@ -95,6 +105,7 @@ class Down4:
             height_sharding=False,
         )
         self.res5_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.4.1",
             [1, 20, 20, 256],
@@ -102,6 +113,7 @@ class Down4:
             height_sharding=False,
         )
         self.res6_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.5.0",
             [1, 20, 20, 256],
@@ -110,6 +122,7 @@ class Down4:
             height_sharding=False,
         )
         self.res6_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.5.1",
             [1, 20, 20, 256],
@@ -117,6 +130,7 @@ class Down4:
             height_sharding=False,
         )
         self.res7_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.6.0",
             [1, 20, 20, 256],
@@ -125,6 +139,7 @@ class Down4:
             height_sharding=False,
         )
         self.res7_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.6.1",
             [1, 20, 20, 256],
@@ -132,6 +147,7 @@ class Down4:
             height_sharding=False,
         )
         self.res8_conv1 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.7.0",
             [1, 20, 20, 256],
@@ -140,6 +156,7 @@ class Down4:
             height_sharding=False,
         )
         self.res8_conv2 = Conv(
+            device,
             torch_model,
             "down4.resblock.module_list.7.1",
             [1, 20, 20, 256],
@@ -148,6 +165,7 @@ class Down4:
         )
 
         self.conv4 = Conv(
+            device,
             torch_model,
             "down4.conv4",
             [1, 20, 20, 256],
@@ -157,6 +175,7 @@ class Down4:
         )
 
         self.conv5 = Conv(
+            device,
             torch_model,
             "down4.conv5",
             [1, 20, 20, 512],
@@ -164,79 +183,79 @@ class Down4:
             height_sharding=False,
         )
 
-    def __call__(self, device, input_tensor):
-        output_tensor_split = self.conv1(device, input_tensor)
+    def __call__(self, input_tensor):
+        output_tensor_split = self.conv1(input_tensor)
         output_tensor_split = ttnn.mish(output_tensor_split)
-        output_tensor_left = self.conv2(device, output_tensor_split)
+        output_tensor_left = self.conv2(output_tensor_split)
         output_tensor_left = ttnn.mish(output_tensor_left)
 
-        res1_split = self.conv3(device, output_tensor_split)
+        res1_split = self.conv3(output_tensor_split)
         res1_split = ttnn.mish(res1_split)
 
-        output_tensor = self.res1_conv1(device, res1_split)
+        output_tensor = self.res1_conv1(res1_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res1_conv2(device, output_tensor)
+        output_tensor = self.res1_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res2_split = res1_split + output_tensor
         ttnn.deallocate(res1_split)
 
-        output_tensor = self.res2_conv1(device, res2_split)
+        output_tensor = self.res2_conv1(res2_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res2_conv2(device, output_tensor)
+        output_tensor = self.res2_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res3_split = res2_split + output_tensor
 
         ttnn.deallocate(res2_split)
 
-        output_tensor = self.res3_conv1(device, res3_split)
+        output_tensor = self.res3_conv1(res3_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res3_conv2(device, output_tensor)
+        output_tensor = self.res3_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res4_split = res3_split + output_tensor
 
         ttnn.deallocate(res3_split)
 
-        output_tensor = self.res4_conv1(device, res4_split)
+        output_tensor = self.res4_conv1(res4_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res4_conv2(device, output_tensor)
+        output_tensor = self.res4_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res5_split = res4_split + output_tensor
 
         ttnn.deallocate(res4_split)
 
-        output_tensor = self.res5_conv1(device, res5_split)
+        output_tensor = self.res5_conv1(res5_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res5_conv2(device, output_tensor)
+        output_tensor = self.res5_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res6_split = res5_split + output_tensor
 
         ttnn.deallocate(res5_split)
 
-        output_tensor = self.res6_conv1(device, res6_split)
+        output_tensor = self.res6_conv1(res6_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res6_conv2(device, output_tensor)
+        output_tensor = self.res6_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res7_split = res6_split + output_tensor
 
         ttnn.deallocate(res6_split)
 
-        output_tensor = self.res7_conv1(device, res7_split)
+        output_tensor = self.res7_conv1(res7_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res7_conv2(device, output_tensor)
+        output_tensor = self.res7_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res8_split = res7_split + output_tensor
 
         ttnn.deallocate(res7_split)
 
-        output_tensor = self.res8_conv1(device, res8_split)
+        output_tensor = self.res8_conv1(res8_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res8_conv2(device, output_tensor)
+        output_tensor = self.res8_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         output_tensor = res8_split + output_tensor
 
         ttnn.deallocate(res8_split)
 
-        output_tensor = self.conv4(device, output_tensor)
+        output_tensor = self.conv4(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
@@ -244,7 +263,7 @@ class Down4:
         output_tensor = ttnn.concat([output_tensor, output_tensor_left], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
         ttnn.deallocate(output_tensor_left)
 
-        output_tensor = self.conv5(device, output_tensor)
+        output_tensor = self.conv5(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         return output_tensor
 

--- a/models/demos/yolov4/ttnn/downsample5.py
+++ b/models/demos/yolov4/ttnn/downsample5.py
@@ -30,8 +30,7 @@ class Down5:
             "down5.conv2",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
-            width_sharding=False,
-            height_sharding=False,
+            width_sharding=True,
             deallocate=False,
         )
         self.conv3 = Conv(device, torch_model, "down5.conv3", [1, 10, 10, 1024], (1, 1, 0, 0))
@@ -43,7 +42,7 @@ class Down5:
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res1_conv2 = Conv(
             device,
@@ -51,7 +50,7 @@ class Down5:
             "down5.resblock.module_list.0.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res2_conv1 = Conv(
             device,
@@ -60,7 +59,7 @@ class Down5:
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res2_conv2 = Conv(
             device,
@@ -68,7 +67,7 @@ class Down5:
             "down5.resblock.module_list.1.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res3_conv1 = Conv(
             device,
@@ -77,7 +76,7 @@ class Down5:
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res3_conv2 = Conv(
             device,
@@ -85,7 +84,7 @@ class Down5:
             "down5.resblock.module_list.2.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res4_conv1 = Conv(
             device,
@@ -94,7 +93,7 @@ class Down5:
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            height_sharding=False,
+            width_sharding=True,
         )
         self.res4_conv2 = Conv(
             device,
@@ -102,7 +101,7 @@ class Down5:
             "down5.resblock.module_list.3.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
 
         self.conv4 = Conv(
@@ -112,7 +111,7 @@ class Down5:
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            height_sharding=False,
+            width_sharding=True,
         )
 
         self.conv5 = Conv(

--- a/models/demos/yolov4/ttnn/downsample5.py
+++ b/models/demos/yolov4/ttnn/downsample5.py
@@ -8,13 +8,14 @@ from models.demos.yolov4.ttnn.common import Conv
 
 
 class Down5:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
+            device,
             torch_model,
             "down5.conv1",
             [1, 20, 20, 512],
@@ -24,81 +25,98 @@ class Down5:
             deallocate=False,
         )
         self.conv2 = Conv(
-            torch_model, "down5.conv2", [1, 10, 10, 1024], (1, 1, 0, 0), width_sharding=True, deallocate=False
+            device,
+            torch_model,
+            "down5.conv2",
+            [1, 10, 10, 1024],
+            (1, 1, 0, 0),
+            width_sharding=False,
+            height_sharding=False,
+            deallocate=False,
         )
-        self.conv3 = Conv(torch_model, "down5.conv3", [1, 10, 10, 1024], (1, 1, 0, 0))
+        self.conv3 = Conv(device, torch_model, "down5.conv3", [1, 10, 10, 1024], (1, 1, 0, 0))
 
         self.res1_conv1 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.0.0",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res1_conv2 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.0.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res2_conv1 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.1.0",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res2_conv2 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.1.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res3_conv1 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.2.0",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res3_conv2 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.2.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res4_conv1 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.3.0",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            width_sharding=True,
+            height_sharding=False,
         )
         self.res4_conv2 = Conv(
+            device,
             torch_model,
             "down5.resblock.module_list.3.1",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
 
         self.conv4 = Conv(
+            device,
             torch_model,
             "down5.conv4",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
             deallocate=False,
-            width_sharding=True,
+            height_sharding=False,
         )
 
         self.conv5 = Conv(
+            device,
             torch_model,
             "down5.conv5",
             [1, 10, 10, 1024],
@@ -106,47 +124,47 @@ class Down5:
             height_sharding=False,
         )
 
-    def __call__(self, device, input_tensor):
-        output_tensor_split = self.conv1(device, input_tensor)
+    def __call__(self, input_tensor):
+        output_tensor_split = self.conv1(input_tensor)
         output_tensor_split = ttnn.mish(output_tensor_split)
-        output_tensor_left = self.conv2(device, output_tensor_split)
+        output_tensor_left = self.conv2(output_tensor_split)
         output_tensor_left = ttnn.mish(output_tensor_left)
 
-        res1_split = self.conv3(device, output_tensor_split)
+        res1_split = self.conv3(output_tensor_split)
         res1_split = ttnn.mish(res1_split)
 
-        output_tensor = self.res1_conv1(device, res1_split)
+        output_tensor = self.res1_conv1(res1_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res1_conv2(device, output_tensor)
+        output_tensor = self.res1_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res2_split = res1_split + output_tensor
         ttnn.deallocate(res1_split)
 
-        output_tensor = self.res2_conv1(device, res2_split)
+        output_tensor = self.res2_conv1(res2_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res2_conv2(device, output_tensor)
+        output_tensor = self.res2_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res3_split = res2_split + output_tensor
 
         ttnn.deallocate(res2_split)
 
-        output_tensor = self.res3_conv1(device, res3_split)
+        output_tensor = self.res3_conv1(res3_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res3_conv2(device, output_tensor)
+        output_tensor = self.res3_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         res4_split = res3_split + output_tensor
 
         ttnn.deallocate(res3_split)
 
-        output_tensor = self.res4_conv1(device, res4_split)
+        output_tensor = self.res4_conv1(res4_split)
         output_tensor = ttnn.mish(output_tensor)
-        output_tensor = self.res4_conv2(device, output_tensor)
+        output_tensor = self.res4_conv2(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         output_tensor = res4_split + output_tensor
 
         ttnn.deallocate(res4_split)
 
-        output_tensor = self.conv4(device, output_tensor)
+        output_tensor = self.conv4(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
@@ -154,7 +172,7 @@ class Down5:
         output_tensor = ttnn.concat([output_tensor, output_tensor_left], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
         ttnn.deallocate(output_tensor_left)
 
-        output_tensor = self.conv5(device, output_tensor)
+        output_tensor = self.conv5(output_tensor)
         output_tensor = ttnn.mish(output_tensor)
         return output_tensor
 

--- a/models/demos/yolov4/ttnn/head.py
+++ b/models/demos/yolov4/ttnn/head.py
@@ -8,15 +8,18 @@ from models.demos.yolov4.ttnn.common import Conv
 
 
 class TtHead:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
-        self.conv1 = Conv(torch_model, "head.conv1", [1, 40, 40, 128], (1, 1, 1, 1), reshard=True, deallocate=False)
-        self.conv2 = Conv(torch_model, "head.conv2", [1, 40, 40, 256], (1, 1, 0, 0), fused_op=False)
+        self.conv1 = Conv(
+            device, torch_model, "head.conv1", [1, 40, 40, 128], (1, 1, 1, 1), reshard=True, deallocate=False
+        )
+        self.conv2 = Conv(device, torch_model, "head.conv2", [1, 40, 40, 256], (1, 1, 0, 0), fused_op=False)
         self.conv3 = Conv(
+            device,
             torch_model,
             "head.conv3",
             [1, 40, 40, 128],
@@ -26,6 +29,7 @@ class TtHead:
             height_sharding=False,
         )
         self.conv4 = Conv(
+            device,
             torch_model,
             "head.conv4",
             [1, 20, 20, 512],
@@ -33,12 +37,15 @@ class TtHead:
             height_sharding=False,
         )
         self.conv5 = Conv(
+            device,
             torch_model,
             "head.conv5",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
+            height_sharding=False,
         )
         self.conv6 = Conv(
+            device,
             torch_model,
             "head.conv6",
             [1, 20, 20, 512],
@@ -46,12 +53,15 @@ class TtHead:
             height_sharding=False,
         )
         self.conv7 = Conv(
+            device,
             torch_model,
             "head.conv7",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
+            height_sharding=False,
         )
         self.conv8 = Conv(
+            device,
             torch_model,
             "head.conv8",
             [1, 20, 20, 512],
@@ -59,13 +69,16 @@ class TtHead:
             height_sharding=False,
         )
         self.conv9 = Conv(
+            device,
             torch_model,
             "head.conv9",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
             deallocate=False,
+            height_sharding=False,
         )
         self.conv10 = Conv(
+            device,
             torch_model,
             "head.conv10",
             [1, 20, 20, 512],
@@ -74,6 +87,7 @@ class TtHead:
             fused_op=False,
         )
         self.conv11 = Conv(
+            device,
             torch_model,
             "head.conv11",
             [1, 20, 20, 256],
@@ -82,6 +96,7 @@ class TtHead:
             height_sharding=False,
         )
         self.conv12 = Conv(
+            device,
             torch_model,
             "head.conv12",
             [1, 10, 10, 1024],
@@ -89,13 +104,15 @@ class TtHead:
             height_sharding=False,
         )
         self.conv13 = Conv(
+            device,
             torch_model,
             "head.conv13",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.conv14 = Conv(
+            device,
             torch_model,
             "head.conv14",
             [1, 10, 10, 1024],
@@ -103,13 +120,15 @@ class TtHead:
             height_sharding=False,
         )
         self.conv15 = Conv(
+            device,
             torch_model,
             "head.conv15",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.conv16 = Conv(
+            device,
             torch_model,
             "head.conv16",
             [1, 10, 10, 1024],
@@ -117,28 +136,29 @@ class TtHead:
             height_sharding=False,
         )
         self.conv17 = Conv(
+            device,
             torch_model,
             "head.conv17",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.conv18 = Conv(
+            device,
             torch_model,
             "head.conv18",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
             fused_op=False,
-            height_sharding=False,
         )
 
-    def __call__(self, device, input_tensor):
-        output_tensor = self.conv1(device, input_tensor[0])
+    def __call__(self, input_tensor):
+        output_tensor = self.conv1(input_tensor[0])
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor_left_1 = self.conv2(device, output_tensor)
+        output_tensor_left_1 = self.conv2(output_tensor)
 
-        output_tensor = self.conv3(device, input_tensor[0])
+        output_tensor = self.conv3(input_tensor[0])
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
         outfrom_Neck1 = input_tensor[2]
 
@@ -150,27 +170,27 @@ class TtHead:
 
         output_tensor = ttnn.concat([output_tensor, outfrom_Neck1], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-        output_tensor = self.conv4(device, output_tensor)
+        output_tensor = self.conv4(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv5(device, output_tensor)
+        output_tensor = self.conv5(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv6(device, output_tensor)
+        output_tensor = self.conv6(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv7(device, output_tensor)
+        output_tensor = self.conv7(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv8(device, output_tensor)
+        output_tensor = self.conv8(output_tensor)
         output_tensor_split = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv9(device, output_tensor_split)
+        output_tensor = self.conv9(output_tensor_split)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor_left_2 = self.conv10(device, output_tensor)
+        output_tensor_left_2 = self.conv10(output_tensor)
 
-        output_tensor = self.conv11(device, output_tensor_split)
+        output_tensor = self.conv11(output_tensor_split)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         outfromNeck2 = input_tensor[1]
@@ -181,24 +201,24 @@ class TtHead:
             outfromNeck2 = ttnn.sharded_to_interleaved(outfromNeck2, ttnn.L1_MEMORY_CONFIG)
         output_tensor = ttnn.concat([output_tensor, outfromNeck2], dim=3, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-        output_tensor = self.conv12(device, output_tensor)
+        output_tensor = self.conv12(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv13(device, output_tensor)
+        output_tensor = self.conv13(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv14(device, output_tensor)
+        output_tensor = self.conv14(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv15(device, output_tensor)
+        output_tensor = self.conv15(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv16(device, output_tensor)
+        output_tensor = self.conv16(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv17(device, output_tensor)
+        output_tensor = self.conv17(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor_left_3 = self.conv18(device, output_tensor)
+        output_tensor_left_3 = self.conv18(output_tensor)
 
         return output_tensor_left_1, output_tensor_left_2, output_tensor_left_3

--- a/models/demos/yolov4/ttnn/head.py
+++ b/models/demos/yolov4/ttnn/head.py
@@ -109,7 +109,7 @@ class TtHead:
             "head.conv13",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv14 = Conv(
             device,
@@ -125,7 +125,7 @@ class TtHead:
             "head.conv15",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv16 = Conv(
             device,
@@ -141,7 +141,7 @@ class TtHead:
             "head.conv17",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv18 = Conv(
             device,
@@ -150,6 +150,7 @@ class TtHead:
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
             fused_op=False,
+            height_sharding=False,
         )
 
     def __call__(self, input_tensor):

--- a/models/demos/yolov4/ttnn/neck.py
+++ b/models/demos/yolov4/ttnn/neck.py
@@ -30,7 +30,7 @@ class TtNeck:
             "neek.conv2",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv3 = Conv(
             device,
@@ -56,7 +56,7 @@ class TtNeck:
             "neek.conv5",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            height_sharding=False,
+            width_sharding=True,
         )
         self.conv6 = Conv(
             device,
@@ -72,7 +72,7 @@ class TtNeck:
             "neek.conv7",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
-            height_sharding=False,
+            width_sharding=True,
             deallocate=False,
         )
         self.conv7_2 = Conv(

--- a/models/demos/yolov4/ttnn/neck.py
+++ b/models/demos/yolov4/ttnn/neck.py
@@ -9,13 +9,14 @@ from tt_lib.fallback_ops import fallback_ops
 
 
 class TtNeck:
-    def __init__(self, model) -> None:
+    def __init__(self, device, model) -> None:
         if type(model) is str:
             torch_model = torch.load(model)
         else:
             torch_model = model.torch_model
         self.torch_model = torch_model
         self.conv1 = Conv(
+            device,
             torch_model,
             "neek.conv1",
             [1, 10, 10, 1024],
@@ -24,21 +25,25 @@ class TtNeck:
             reshard=True,
         )
         self.conv2 = Conv(
+            device,
             torch_model,
             "neek.conv2",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.conv3 = Conv(
+            device,
             torch_model,
             "neek.conv3",
             [1, 10, 10, 1024],
             (1, 1, 0, 0),
             reshard=False,
+            height_sharding=False,
         )
 
         self.conv4 = Conv(
+            device,
             torch_model,
             "neek.conv4",
             [1, 10, 10, 2048],
@@ -46,13 +51,15 @@ class TtNeck:
             height_sharding=False,
         )
         self.conv5 = Conv(
+            device,
             torch_model,
             "neek.conv5",
             [1, 10, 10, 512],
             (1, 1, 1, 1),
-            width_sharding=True,
+            height_sharding=False,
         )
         self.conv6 = Conv(
+            device,
             torch_model,
             "neek.conv6",
             [1, 10, 10, 1024],
@@ -60,14 +67,16 @@ class TtNeck:
             height_sharding=False,
         )
         self.conv7 = Conv(
+            device,
             torch_model,
             "neek.conv7",
             [1, 10, 10, 512],
             (1, 1, 0, 0),
-            width_sharding=True,
+            height_sharding=False,
             deallocate=False,
         )
         self.conv7_2 = Conv(
+            device,
             torch_model,
             "neek.conv8",
             [1, 20, 20, 512],
@@ -77,6 +86,7 @@ class TtNeck:
             enable_act_double_buffer=True,
         )
         self.conv7_3 = Conv(
+            device,
             torch_model,
             "neek.conv9",
             [1, 20, 20, 512],
@@ -86,12 +96,15 @@ class TtNeck:
             enable_act_double_buffer=True,
         )
         self.conv8 = Conv(
+            device,
             torch_model,
             "neek.conv10",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
+            height_sharding=False,
         )
         self.conv7_4 = Conv(
+            device,
             torch_model,
             "neek.conv11",
             [1, 20, 20, 512],
@@ -101,12 +114,15 @@ class TtNeck:
             enable_act_double_buffer=True,
         )
         self.conv8_2 = Conv(
+            device,
             torch_model,
             "neek.conv12",
             [1, 20, 20, 256],
             (1, 1, 1, 1),
+            height_sharding=False,
         )
         self.conv7_5 = Conv(
+            device,
             torch_model,
             "neek.conv13",
             [1, 20, 20, 512],
@@ -117,6 +133,7 @@ class TtNeck:
         )
 
         self.conv9 = Conv(
+            device,
             torch_model,
             "neek.conv14",
             [1, 20, 20, 256],
@@ -127,18 +144,21 @@ class TtNeck:
             enable_act_double_buffer=True,
         )
         self.conv9_2 = Conv(
+            device,
             torch_model,
             "neek.conv15",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
         )
         self.conv9_3 = Conv(
+            device,
             torch_model,
             "neek.conv16",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
         )
         self.conv10 = Conv(
+            device,
             torch_model,
             "neek.conv17",
             [1, 40, 40, 128],
@@ -146,32 +166,35 @@ class TtNeck:
         )
 
         self.conv9_4 = Conv(
+            device,
             torch_model,
             "neek.conv18",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
         )
         self.conv10_2 = Conv(
+            device,
             torch_model,
             "neek.conv19",
             [1, 40, 40, 128],
             (1, 1, 1, 1),
         )
         self.conv9_5 = Conv(
+            device,
             torch_model,
             "neek.conv20",
             [1, 40, 40, 256],
             (1, 1, 0, 0),
         )
 
-    def __call__(self, device, input_tensor):
-        output_tensor = self.conv1(device, input_tensor[0])
+    def __call__(self, input_tensor):
+        output_tensor = self.conv1(input_tensor[0])
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv2(device, output_tensor)
+        output_tensor = self.conv2(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv3(device, output_tensor)
+        output_tensor = self.conv3(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         pool_1 = ttnn.max_pool2d(
@@ -221,16 +244,16 @@ class TtNeck:
         ttnn.deallocate(pool_2)
         ttnn.deallocate(pool_1)
 
-        output_tensor = self.conv4(device, output_tensor)
+        output_tensor = self.conv4(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv5(device, output_tensor)
+        output_tensor = self.conv5(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv6(device, output_tensor)
+        output_tensor = self.conv6(output_tensor)
         output_tensor_left_1 = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv7(device, output_tensor_left_1)
+        output_tensor = self.conv7(output_tensor_left_1)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_shape = output_tensor.shape
@@ -268,7 +291,7 @@ class TtNeck:
         output_tensor_upsample_1 = ttnn.to_layout(output_tensor_upsample_1, layout=ttnn.TILE_LAYOUT)
 
         outDowSample5 = input_tensor[1]
-        output_tensor = self.conv7_2(device, outDowSample5)
+        output_tensor = self.conv7_2(outDowSample5)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
@@ -278,19 +301,19 @@ class TtNeck:
         )
         ttnn.deallocate(output_tensor_upsample_1)
 
-        output_tensor = self.conv7_3(device, output_tensor)
+        output_tensor = self.conv7_3(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv8(device, output_tensor)
+        output_tensor = self.conv8(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv7_4(device, output_tensor)
+        output_tensor = self.conv7_4(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv8_2(device, output_tensor)
+        output_tensor = self.conv8_2(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv7_5(device, output_tensor)
+        output_tensor = self.conv7_5(output_tensor)
         output_tensor_left_2 = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         shard_grid = ttnn.CoreRangeSet(
@@ -304,7 +327,7 @@ class TtNeck:
         shard_spec = ttnn.ShardSpec(shard_grid, (64, 64), ttnn.ShardOrientation.COL_MAJOR)
         in_sharded_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
         output_tensor_left_2 = ttnn.to_memory_config(output_tensor_left_2, memory_config=in_sharded_mem_config)
-        output_tensor = self.conv9(device, output_tensor_left_2)
+        output_tensor = self.conv9(output_tensor_left_2)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_shape = output_tensor.shape
@@ -343,7 +366,7 @@ class TtNeck:
 
         outDowSample3 = input_tensor[2]
 
-        output_tensor = self.conv9_2(device, outDowSample3)
+        output_tensor = self.conv9_2(outDowSample3)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         output_tensor = ttnn.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
@@ -352,19 +375,19 @@ class TtNeck:
         )
         ttnn.deallocate(output_tensor_upsample_2)
 
-        output_tensor = self.conv9_3(device, output_tensor)
+        output_tensor = self.conv9_3(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv10(device, output_tensor)
+        output_tensor = self.conv10(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv9_4(device, output_tensor)
+        output_tensor = self.conv9_4(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv10_2(device, output_tensor)
+        output_tensor = self.conv10_2(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
-        output_tensor = self.conv9_5(device, output_tensor)
+        output_tensor = self.conv9_5(output_tensor)
         output_tensor = ttnn.leaky_relu(output_tensor, negative_slope=0.1)
 
         return output_tensor, output_tensor_left_1, output_tensor_left_2

--- a/models/demos/yolov4/ttnn/yolov4.py
+++ b/models/demos/yolov4/ttnn/yolov4.py
@@ -24,33 +24,33 @@ from models.demos.yolov4.ttnn.head import TtHead
 
 
 class TtYOLOv4:
-    def __init__(self, path) -> None:
+    def __init__(self, device, path) -> None:
         if type(path) is str:
             self.torch_model = torch.load(path)
         else:
             self.torch_model = path
         self.torch_keys = self.torch_model.keys()
-        self.down1 = Down1(self)
-        self.down2 = Down2(self)
-        self.down3 = Down3(self)
-        self.down4 = Down4(self)
-        self.down5 = Down5(self)
+        self.down1 = Down1(device, self)
+        self.down2 = Down2(device, self)
+        self.down3 = Down3(device, self)
+        self.down4 = Down4(device, self)
+        self.down5 = Down5(device, self)
 
-        self.neck = TtNeck(self)
-        self.head = TtHead(self)
+        self.neck = TtNeck(device, self)
+        self.head = TtHead(device, self)
 
         self.downs = []  # [self.down1]
 
-    def __call__(self, device, input_tensor):
-        d1 = self.down1(device, input_tensor)
-        d2 = self.down2(device, d1)
+    def __call__(self, input_tensor):
+        d1 = self.down1(input_tensor)
+        d2 = self.down2(d1)
         ttnn.deallocate(d1)
-        d3 = self.down3(device, d2)
+        d3 = self.down3(d2)
         ttnn.deallocate(d2)
-        d4 = self.down4(device, d3)
-        d5 = self.down5(device, d4)
-        x20, x13, x6 = self.neck(device, [d5, d4, d3])
-        x4, x5, x6 = self.head(device, [x20, x13, x6])
+        d4 = self.down4(d3)
+        d5 = self.down5(d4)
+        x20, x13, x6 = self.neck([d5, d4, d3])
+        x4, x5, x6 = self.head([x20, x13, x6])
 
         return x4, x5, x6
 

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -183,35 +183,37 @@ class UNetConv2D:
             "device": self.device,
             "conv_config": self.conv_config,
         }
-        if not ttnn.is_tensor_storage_on_device(self.weight):
-            self.weight = ttnn.prepare_conv_weights(
-                weight_tensor=self.weight,
-                weights_format="OIHW",
-                input_memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
-                if self.use_1d_systolic_array
-                else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
-                input_layout=ttnn.TILE_LAYOUT,  # not used for sharded tensor
-                **self.conv_kwargs,
-            )
-            self.bias = ttnn.prepare_conv_bias(
-                bias_tensor=self.bias,
-                input_memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
-                if self.use_1d_systolic_array
-                else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
-                input_layout=ttnn.TILE_LAYOUT,  # not used for sharded tensor
-                **self.conv_kwargs,
-            )
-            self.weight = ttnn.to_device(self.weight, self.device)
-            self.bias = ttnn.to_device(self.bias, self.device)
+        # if not ttnn.is_tensor_storage_on_device(self.weight):
+        #     self.weight = ttnn.prepare_conv_weights(
+        #         weight_tensor=self.weight,
+        #         weights_format="OIHW",
+        #         input_memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
+        #         if self.use_1d_systolic_array
+        #         else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        #         input_layout=ttnn.TILE_LAYOUT,  # not used for sharded tensor
+        #         **self.conv_kwargs,
+        #     )
+        #     self.bias = ttnn.prepare_conv_bias(
+        #         bias_tensor=self.bias,
+        #         input_memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
+        #         if self.use_1d_systolic_array
+        #         else ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        #         input_layout=ttnn.TILE_LAYOUT,  # not used for sharded tensor
+        #         **self.conv_kwargs,
+        #     )
+        #     self.weight = ttnn.to_device(self.weight, self.device)
+        #     self.bias = ttnn.to_device(self.bias, self.device)
 
     def __call__(self, x):
-        x = ttnn.conv2d(
+        x, [self.weight, self.bias] = ttnn.conv2d(
             input_tensor=x,
             weight_tensor=self.weight,
             bias_tensor=self.bias,
             **self.conv_kwargs,
             compute_config=self.compute_config,
             conv_op_cache=self.cache,
+            return_output_dim=False,
+            return_weights_and_bias=True,
         )
         return x
 

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -169,27 +169,45 @@ class UNetConv2D:
 
         self.weight = ttnn.from_torch(weight, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
         self.bias = ttnn.from_torch(bias, dtype=ttnn.float32, mesh_mapper=mesh_mapper)
+        self.conv_kwargs = {
+            "in_channels": self.in_channels,
+            "out_channels": self.out_channels,
+            "batch_size": self.batch_size,
+            "input_height": self.input_height,
+            "input_width": self.input_width,
+            "kernel_size": self.kernel_size,
+            "stride": self.stride,
+            "padding": self.padding,
+            "dilation": [1, 1],
+            "groups": 2,
+            "device": self.device,
+            "conv_config": self.conv_config,
+        }
 
     def __call__(self, x):
-        x, [self.weight, self.bias] = ttnn.conv2d(
+        if not ttnn.is_tensor_storage_on_device(self.weight):
+            self.weight = ttnn.prepare_conv_weights(
+                weight_tensor=self.weight,
+                weights_format="OIHW",
+                input_memory_config=x.memory_config(),
+                input_layout=x.get_layout(),
+                **self.conv_kwargs,
+            )
+            self.bias = ttnn.prepare_conv_bias(
+                bias_tensor=self.bias,
+                input_memory_config=x.memory_config(),
+                input_layout=x.get_layout(),
+                **self.conv_kwargs,
+            )
+            self.weight = ttnn.to_device(self.weight, self.device)
+            self.bias = ttnn.to_device(self.bias, self.device)
+        x = ttnn.conv2d(
             input_tensor=x,
             weight_tensor=self.weight,
             bias_tensor=self.bias,
-            device=self.device,
-            in_channels=self.in_channels,
-            out_channels=self.out_channels,
-            input_height=self.input_height,
-            input_width=self.input_width,
-            batch_size=self.batch_size,
-            kernel_size=self.kernel_size,
-            stride=self.stride,
-            padding=self.padding,
-            conv_config=self.conv_config,
+            **self.conv_kwargs,
             compute_config=self.compute_config,
             conv_op_cache=self.cache,
-            groups=2,
-            return_output_dim=False,
-            return_weights_and_bias=True,
         )
         return x
 

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample1.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample1.py
@@ -30,7 +30,7 @@ def test_down1(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = Down1(weights_pth)
+    ttnn_model = Down1(device, weights_pth)
 
     torch_input = torch.randn((1, 320, 320, 3), dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16)
@@ -49,11 +49,11 @@ def test_down1(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input)
+    result_ttnn = ttnn_model(ttnn_input)
 
     start_time = time.time()
     for x in range(100):
-        result_ttnn = ttnn_model(device, ttnn_input)
+        result_ttnn = ttnn_model(ttnn_input)
     logger.info(f"Time taken: {time.time() - start_time}")
     result = ttnn.to_torch(result_ttnn)
 

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample2.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample2.py
@@ -30,7 +30,7 @@ def test_down2(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = Down2(weights_pth)
+    ttnn_model = Down2(device, weights_pth)
 
     torch_input = torch.randn((1, 160, 160, 64), dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16)
@@ -48,11 +48,11 @@ def test_down2(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input)
+    result_ttnn = ttnn_model(ttnn_input)
 
     start_time = time.time()
     for x in range(2):
-        result_ttnn = ttnn_model(device, ttnn_input)
+        result_ttnn = ttnn_model(ttnn_input)
     logger.info(f"Time taken: {time.time() - start_time}")
     result = ttnn.to_torch(result_ttnn)
     ref = torch_model(torch_input)

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample3.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample3.py
@@ -30,7 +30,7 @@ def test_down3(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = Down3(weights_pth)
+    ttnn_model = Down3(device, weights_pth)
 
     torch_input = torch.randn((1, 80, 80, 128), dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16)
@@ -48,11 +48,11 @@ def test_down3(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input)
+    result_ttnn = ttnn_model(ttnn_input)
 
     start_time = time.time()
     for x in range(2):
-        result_ttnn = ttnn_model(device, ttnn_input)
+        result_ttnn = ttnn_model(ttnn_input)
     logger.info(f"Time taken: {time.time() - start_time}")
     result = ttnn.to_torch(result_ttnn)
     ref = torch_model(torch_input)

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample4.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample4.py
@@ -30,7 +30,7 @@ def test_down4(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = Down4(weights_pth)
+    ttnn_model = Down4(device, weights_pth)
 
     torch_input = torch.randn((1, 40, 40, 256), dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16)
@@ -48,11 +48,11 @@ def test_down4(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input)
+    result_ttnn = ttnn_model(ttnn_input)
 
     start_time = time.time()
     for x in range(2):
-        result_ttnn = ttnn_model(device, ttnn_input)
+        result_ttnn = ttnn_model(ttnn_input)
     logger.info(f"Time taken: {time.time() - start_time}")
     result = ttnn.to_torch(result_ttnn)
     ref = torch_model(torch_input)

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample5.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample5.py
@@ -30,7 +30,7 @@ def test_down5(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = Down5(weights_pth)
+    ttnn_model = Down5(device, weights_pth)
 
     torch_input = torch.randn((1, 20, 20, 512), dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16)
@@ -48,11 +48,11 @@ def test_down5(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input)
+    result_ttnn = ttnn_model(ttnn_input)
 
     start_time = time.time()
     for x in range(2):
-        result_ttnn = ttnn_model(device, ttnn_input)
+        result_ttnn = ttnn_model(ttnn_input)
     logger.info(f"Time taken: {time.time() - start_time}")
     result = ttnn.to_torch(result_ttnn)
     ref = torch_model(torch_input)

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_head.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_head.py
@@ -28,7 +28,7 @@ def test_head(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = TtHead(weights_pth)
+    ttnn_model = TtHead(device, weights_pth)
 
     torch_input_tensor1 = torch.randn(1, 40, 40, 128, dtype=torch.bfloat16)
     torch_input_tensor2 = torch.randn(1, 10, 10, 512, dtype=torch.bfloat16)
@@ -68,10 +68,10 @@ def test_head(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input_tensor)
+    result_ttnn = ttnn_model(ttnn_input_tensor)
     start_time = time.time()
     for x in range(1):
-        result_ttnn = ttnn_model(device, ttnn_input_tensor)
+        result_ttnn = ttnn_model(ttnn_input_tensor)
     logger.info(f"Time taken: {time.time() - start_time}")
 
     result_1 = ttnn.to_torch(result_ttnn[0])

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_neck.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_neck.py
@@ -28,7 +28,7 @@ def test_neck(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = TtNeck(weights_pth)
+    ttnn_model = TtNeck(device, weights_pth)
 
     torch_input_tensor1 = torch.randn(1, 10, 10, 1024, dtype=torch.bfloat16)
     torch_input_tensor2 = torch.randn(1, 20, 20, 512, dtype=torch.bfloat16)
@@ -63,7 +63,7 @@ def test_neck(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_ttnn = ttnn_model(device, ttnn_input_tensor)
+    result_ttnn = ttnn_model(ttnn_input_tensor)
 
     result_1 = ttnn.to_torch(result_ttnn[0])
     result_2 = ttnn.to_torch(result_ttnn[1])

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py
@@ -28,7 +28,7 @@ def test_yolov4(device, reset_seeds, model_location_generator):
     else:
         weights_pth = str(model_path / "yolov4.pth")
 
-    ttnn_model = TtYOLOv4(weights_pth)
+    ttnn_model = TtYOLOv4(device, weights_pth)
 
     torch_input = torch.randn((1, 320, 320, 3), dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16)
@@ -47,7 +47,7 @@ def test_yolov4(device, reset_seeds, model_location_generator):
     torch_model.load_state_dict(new_state_dict)
     torch_model.eval()
 
-    result_1, result_2, result_3 = ttnn_model(device, ttnn_input)
+    result_1, result_2, result_3 = ttnn_model(ttnn_input)
     result_1 = ttnn.to_torch(result_1)
     result_2 = ttnn.to_torch(result_2)
     result_3 = ttnn.to_torch(result_3)

--- a/tests/ttnn/unit_tests/operations/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/test_prepare_conv_weights.py
@@ -164,7 +164,7 @@ def test_prepare_conv_weights(
     tt_weight_tensor_formatted = ttnn.prepare_conv_weights(
         weight_tensor=tt_weight_tensor,
         weights_format="OIHW",
-        input_memory_config=tt_input_tensor.memory_config(),
+        input_memory_config=ttnn.L1_MEMORY_CONFIG,
         **conv_kwargs,
     )
     tt_bias_tensor_formatted = (

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -59,6 +59,12 @@ sliding_window::ParallelConfig determine_output_parallel_config(
     uint32_t out_channels,
     bool is_mm_conv);
 
+sliding_window::ParallelConfig determine_output_parallel_config(
+    const sliding_window::ParallelConfig& input_parallel_config,
+    const CoreCoord& compute_grid_size,
+    uint32_t out_channels,
+    bool is_mm_conv);
+
 uint32_t get_num_cores_nhw_from_parallel_config(const sliding_window::ParallelConfig& pconfig);
 
 uint32_t get_num_cores_channels_from_parallel_config(const sliding_window::ParallelConfig& pconfig);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -569,26 +569,22 @@ static OptimizedConvBlockConfig get_opt_block_config(
     bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
 
     ParallelConfig parallel_config;
-    if (input_memory_config.is_sharded() && !conv_config.reshard_if_not_optimal) {
-        parallel_config = {
-            .grid = input_memory_config.shard_spec.value().grid,
-            .shard_scheme = input_memory_config.memory_layout,
-            .shard_orientation = input_memory_config.shard_spec.value().orientation};
-    } else {
-        parallel_config = determine_parallel_config(
-            conv_config.shard_layout.value(),
-            batch_size,
-            in_channels,
-            output_height,
-            output_width,
-            out_channels,
-            device->compute_with_storage_grid_size(),
-            shard_orientation,
-            !mm_conv,
-            !use_non_tile_height,
-            is_non_tile_mul_width,
-            conv_config.act_block_h_override);
+    if (input_memory_config.is_sharded()) {
+        conv_config.shard_layout = input_memory_config.memory_layout;
     }
+    parallel_config = determine_parallel_config(
+        conv_config.shard_layout.value(),
+        batch_size,
+        in_channels,
+        output_height,
+        output_width,
+        out_channels,
+        device->compute_with_storage_grid_size(),
+        shard_orientation,
+        !mm_conv,
+        !use_non_tile_height,
+        is_non_tile_mul_width,
+        conv_config.act_block_h_override);
 
     auto output_parallel_config = parallel_config;
     if (conv_config.shard_layout.value() == ttnn::TensorMemoryLayout::WIDTH_SHARDED && !mm_conv) {
@@ -812,27 +808,22 @@ ttnn::Tensor prepare_conv_weights(
     const bool use_non_tile_height = check_non_tile_height(conv_config, out_channels);
     bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
 
-    ParallelConfig parallel_config;
-    if (input_memory_config.is_sharded() && !conv_config.reshard_if_not_optimal) {
-        parallel_config = {
-            .grid = input_memory_config.shard_spec.value().grid,
-            .shard_scheme = input_memory_config.memory_layout,
-            .shard_orientation = input_memory_config.shard_spec.value().orientation};
-    } else {
-        parallel_config = determine_parallel_config(
-            conv_config.shard_layout.value(),
-            batch_size,
-            in_channels,
-            output_height,
-            output_width,
-            out_channels,
-            device->compute_with_storage_grid_size(),
-            shard_orientation,
-            !mm_conv,
-            !use_non_tile_height,
-            is_non_tile_mul_width,
-            conv_config.act_block_h_override);
+    if (input_memory_config.is_sharded()) {
+        conv_config.shard_layout = input_memory_config.memory_layout;
     }
+    ParallelConfig parallel_config = determine_parallel_config(
+        conv_config.shard_layout.value(),
+        batch_size,
+        in_channels,
+        output_height,
+        output_width,
+        out_channels,
+        device->compute_with_storage_grid_size(),
+        shard_orientation,
+        !mm_conv,
+        !use_non_tile_height,
+        is_non_tile_mul_width,
+        conv_config.act_block_h_override);
 
     ParallelConfig output_parallel_config = determine_output_parallel_config(
         parallel_config, device->compute_with_storage_grid_size(), out_channels, mm_conv);
@@ -914,30 +905,24 @@ ttnn::Tensor prepare_conv_bias(
 
     const bool use_non_tile_height = check_non_tile_height(conv_config, out_channels);
 
-    bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
-
     ParallelConfig parallel_config;
-    if (input_memory_config.is_sharded() && !conv_config.reshard_if_not_optimal) {
-        parallel_config = {
-            .grid = input_memory_config.shard_spec.value().grid,
-            .shard_scheme = input_memory_config.memory_layout,
-            .shard_orientation = input_memory_config.shard_spec.value().orientation};
-    } else {
-        bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
-        parallel_config = determine_parallel_config(
-            conv_config.shard_layout.value(),
-            batch_size,
-            in_channels,
-            output_height,
-            output_width,
-            out_channels,
-            device->compute_with_storage_grid_size(),
-            shard_orientation,
-            !mm_conv,
-            !use_non_tile_height,
-            is_non_tile_mul_width,
-            conv_config.act_block_h_override);
+    if (input_memory_config.is_sharded()) {
+        conv_config.shard_layout = input_memory_config.memory_layout;
     }
+    bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
+    parallel_config = determine_parallel_config(
+        conv_config.shard_layout.value(),
+        batch_size,
+        in_channels,
+        output_height,
+        output_width,
+        out_channels,
+        device->compute_with_storage_grid_size(),
+        shard_orientation,
+        !mm_conv,
+        !use_non_tile_height,
+        is_non_tile_mul_width,
+        conv_config.act_block_h_override);
     ParallelConfig output_parallel_config = determine_output_parallel_config(
         parallel_config, device->compute_with_storage_grid_size(), out_channels, mm_conv);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -568,11 +568,10 @@ static OptimizedConvBlockConfig get_opt_block_config(
 
     bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
 
-    ParallelConfig parallel_config;
     if (input_memory_config.is_sharded()) {
         conv_config.shard_layout = input_memory_config.memory_layout;
     }
-    parallel_config = determine_parallel_config(
+    ParallelConfig parallel_config = determine_parallel_config(
         conv_config.shard_layout.value(),
         batch_size,
         in_channels,
@@ -905,12 +904,11 @@ ttnn::Tensor prepare_conv_bias(
 
     const bool use_non_tile_height = check_non_tile_height(conv_config, out_channels);
 
-    ParallelConfig parallel_config;
     if (input_memory_config.is_sharded()) {
         conv_config.shard_layout = input_memory_config.memory_layout;
     }
     bool is_non_tile_mul_width = check_non_tile_mul_width(device, conv_config, in_channels);
-    parallel_config = determine_parallel_config(
+    ParallelConfig parallel_config = determine_parallel_config(
         conv_config.shard_layout.value(),
         batch_size,
         in_channels,


### PR DESCRIPTION
### Ticket
#14179

### Problem description
Prepare conv2d_weight and bias in various models.

### What's changed
Using Prepare_conv2d_weight and bias fuction in conv2d api. 

 [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/12464634621)
[Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/12464625557)
[Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/12464621574)


### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12464626874)
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
