### PR TITLE
#16265: Remove creation op

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -515,13 +515,11 @@ Tensor ExecuteUnaryCompositeClamp::invoke(
     } else if (min.value() > max.value()) {
         return full_like(a, max.value());
     }
-    const Tensor h_const = full_like(a, max.value());
-    Tensor a_max = ttnn::minimum(a, h_const, output_memory_config);
+    Tensor a_max = ttnn::minimum(a, max.value(), output_memory_config);
     if (min.value() == 0.0f) {
         return ttnn::relu(a_max, output_memory_config);
     } else {
-        const Tensor l_const = full_like(a, min.value());
-        return ttnn::maximum(a_max, l_const, output_memory_config);
+        return ttnn::maximum(a_max, min.value(), output_memory_config);
     }
 }
 


### PR DESCRIPTION

### Ticket
#16265 

### Problem description
Getting unsupported dtype issue for Int32 test case which caused by creation op full like 

### What's changed
Full like usage op can be removed to avoid unsupported error. Hence updated the clamp implementation

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12467173463)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes - https://github.com/tenstorrent/tt-metal/actions/runs/12467181857
