### PR TITLE
fix abs path bug for sweeps tests code

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/view/view_tt_torch.py
+++ b/tests/sweep_framework/sweeps/data_movement/view/view_tt_torch.py
@@ -57,7 +57,7 @@ def parse_md_file_simple_no_regex(file_path):
 parameters = {
     "nightly": {
         "view_specs": parse_md_file_simple_no_regex(
-            "/home/jvega/work/reshape_host_merge/tt-metal/tests/sweep_framework/sweeps/data_movement/view/tt_torch_trace.md"
+            "./tests/sweep_framework/sweeps/data_movement/view/tt_torch_trace.md"
         ),
         "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
         "dtype": [ttnn.bfloat16, ttnn.float32],


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/16284

### Problem description
Provide context for the problem.
Custom Abs path is provided which fails sweeps tests for everyone

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.
change abs path to rel path

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
