### PR TITLE
add multi-iteration support to reduce scatter async

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -196,6 +196,7 @@ def run_reduce_scatter_test(
             subdevice_id=ttnn.SubDeviceId(0),
         )
     else:
+        logger.info(f"Running {num_iters} iterations of reduce scatter")
         for i in range(num_iters):
             output_tensor_mesh = ttnn.reduce_scatter_async(
                 input_tensor_mesh,
@@ -207,10 +208,10 @@ def run_reduce_scatter_test(
                 subdevice_id=worker_sub_device_id,
             )
 
-            logger.info(f"Waiting for op {i}")
-            for device_id in mesh_device.get_device_ids():
-                ttnn.synchronize_device(mesh_device.get_device(device_id), sub_device_ids=[worker_sub_device_id])
-            logger.info(f"Done iteration {i}")
+        logger.info(f"Waiting for op to finish all iterations")
+        for device_id in mesh_device.get_device_ids():
+            ttnn.synchronize_device(mesh_device.get_device(device_id), sub_device_ids=[worker_sub_device_id])
+        logger.info(f"Done iterations")
 
     teardown_fabric_interface(mesh_device)
     # Compute golden
@@ -321,7 +322,7 @@ def test_line_reduce_scatter_async_post_commit(
     function_level_defaults,
     enable_async,
     trace_mode,
-    num_iters=1,
+    num_iters=16,
 ):
     run_reduce_scatter_test(
         t3k_mesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -111,8 +111,8 @@ def run_reduce_scatter_test(
     mem_config,
     use_program_cache,
     function_level_defaults,
+    num_iters,
     enable_async=True,
-    num_iters=1,
     topology=ttnn.Topology.Ring,
     trace_mode=False,
 ):

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -2106,8 +2106,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
             auto& worker_writer_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.writer);
             if (topology_config.is_at_end_of_line()) {
 
-                for (size_t i = 0; i < worker_cores.final_reducers_vec.size(); i++) {
-                    auto core = worker_cores.final_reducers_vec[i];
+                for (auto const& core : worker_cores.final_reducers_vec) {
                     auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
                     worker_reader_runtime_args.at(0) = partial_output_tensor[LineDirection::FORWARD]->buffer()->address();;
                     worker_reader_runtime_args.at(1) = partial_output_tensor[LineDirection::BACKWARD]->buffer()->address();;
@@ -2117,8 +2116,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
                 }
                 for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
                     bool is_start_of_line = topology_config.is_first_device_in_line(direction);
-                    for (size_t i = 0; i < worker_cores.partial_reducers_vec[direction].size(); i++) {
-                        auto core = worker_cores.partial_reducers_vec[direction][i];
+                    for (auto const& core : worker_cores.partial_reducers_vec[direction]) {
                         auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
                         worker_reader_runtime_args.at(0) = input_tensor.buffer()->address();
                         if (is_start_of_line) {
@@ -2135,8 +2133,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
                 }
             } else {
                 for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
-                    for (size_t i = 0; i < worker_cores.partial_reducers_vec[direction].size(); i++) {
-                        auto core = worker_cores.partial_reducers_vec[LineDirection::FORWARD][i];
+                    for (auto const &core : worker_cores.partial_reducers_vec[direction]) {
                         auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
                         auto& worker_writer_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
                         worker_reader_runtime_args.at(0) = input_tensor.buffer()->address();
@@ -2149,8 +2146,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
                     }
                 }
 
-                for (size_t i = 0; i < worker_cores.final_reducers_vec.size(); i++) {
-                    auto core = worker_cores.final_reducers_vec[i];
+                for (auto const& core : worker_cores.final_reducers_vec) {
                     auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
 
                     worker_reader_runtime_args.at(0) = partial_output_tensor[LineDirection::FORWARD]->buffer()->address();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15006)

### Problem description
reduce scatter async was missing multi-iteration support

### What's changed
Add multi-iteration support to reduce scatter async via the program override args callback

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/12472039457
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/12495410925
  - Same failure signature as on main 
  - T3k Unit after rebase: https://github.com/tenstorrent/tt-metal/actions/runs/12551879406
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
