### PR TITLE
support i/p tensors of all dimensions/rank for prod operation

### DIFF
--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -55,3 +55,44 @@ def run_sum(
     pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
     # print(f"input_shape {input_shape} pcc {pcc}")
     return [pcc, e2e_perf]
+
+
+def run_prod(
+    input_shape,
+    dim,
+    keepdim,
+    input_a_dtype,
+    input_a_layout,
+    input_a_memory_config,
+    output_memory_config,
+    device,
+) -> list:
+    data_seed = random.randint(0, 20000000)
+    torch.manual_seed(data_seed)
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
+    )(input_shape)
+
+    dim = dim % len(input_shape)
+
+    torch_output_tensor = torch.prod(torch_input_tensor_a, dim=dim, keepdim=keepdim)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.prod(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
+    assert output_tensor.shape == torch_output_tensor.shape
+    # print(f"input_shape {input_shape} pcc {pcc}")
+    return [pcc, e2e_perf]

--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -70,6 +70,9 @@ def run_prod(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
+    if input_a_dtype == ttnn.float32 and ttnn.device.is_grayskull(device):
+        return [(False, "Dest Fp32 mode is not supported for arch grayskull"), 0]
+
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)

--- a/tests/sweep_framework/sweep_utils/reduction_common.py
+++ b/tests/sweep_framework/sweep_utils/reduction_common.py
@@ -87,7 +87,7 @@ def run_prod(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.prod(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    result = ttnn.prod(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -73,12 +73,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     ):
         return True, "Row major is only supported for fp32 & fp16"
 
-    device = ttnn.open_device(device_id=0)
-    if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
-        return True, "Dest Fp32 mode is not supported for arch grayskull"
-    ttnn.close_device(device)
-    del device
-
     return False, None
 
 

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -13,6 +13,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
+from tests.sweep_framework.sweep_utils.reduction_common import run_prod
 
 # Override the default timeout in seconds for hang detection.
 TIMEOUT = 30
@@ -96,32 +97,38 @@ def run(
     *,
     device,
 ) -> list:
-    data_seed = random.randint(0, 20000000)
-    torch.manual_seed(data_seed)
-
-    torch_input_tensor_a = gen_func_with_cast_tt(
-        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
-    )(input_shape)
-
-    dim = dim % len(input_shape)
-
-    torch_output_tensor = torch.prod(torch_input_tensor_a, dim=dim, keepdim=keepdim)
-
-    input_tensor_a = ttnn.from_torch(
-        torch_input_tensor_a,
-        dtype=input_a_dtype,
-        layout=input_a_layout,
-        device=device,
-        memory_config=input_a_memory_config,
+    return run_prod(
+        input_shape,
+        dim,
+        keepdim,
+        input_a_dtype,
+        input_a_layout,
+        input_a_memory_config,
+        output_memory_config,
+        device,
     )
 
-    start_time = start_measuring_time()
-    result = ttnn.prod(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
-    output_tensor = ttnn.to_torch(result)
-    e2e_perf = stop_measuring_time(start_time)
 
-    pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
-    assert output_tensor.shape == torch_output_tensor.shape
-    # print(f"input_shape {input_shape} pcc {pcc}")
-    return [pcc, e2e_perf]
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config",
+    [
+        ([7, 32], 3, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([7, 32], 1, False, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([7, 32], 0, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([7], 1, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([7], 2, False, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([5, 7, 32], 1, False, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([5, 7, 32], 0, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        ([5, 7, 32], 3, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+    ],
+)
+def test_reduction_prod_localrun_fail_only(
+    device, input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config
+):
+    run_prod(
+        input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device
+    )

--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -109,26 +109,26 @@ def run(
     )
 
 
-
 import pytest
 
 
 @pytest.mark.parametrize(
-    "input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config",
+    "input_shape, dim, keepdim",
     [
-        ([7, 32], 3, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([7, 32], 1, False, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([7, 32], 0, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([7], 1, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([7], 2, False, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([5, 7, 32], 1, False, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([5, 7, 32], 0, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
-        ([5, 7, 32], 3, True, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG),
+        # 0-D/1-D support is not available yet
+        # ([7, 32], 1, False),
+        # ([7], 0, False),
+        # ([7], 1, True),
+        ([7, 32], 0, True),
+        ([7, 32], 3, True),
+        ([5, 7, 32], 1, False),
+        ([5, 7, 32], 0, True),
+        ([5, 7, 32], 3, True),
+        ([5, 7, 32, 66], 1, True),
+        ([5, 7, 32, 66], 2, False),
     ],
 )
-def test_reduction_prod_localrun_fail_only(
-    device, input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config
-):
+def test_reduction_prod_localrun_fail_only(device, input_shape, dim, keepdim):
     run_prod(
-        input_shape, dim, keepdim, input_a_dtype, input_a_layout, input_a_memory_config, output_memory_config, device
+        input_shape, dim, keepdim, ttnn.float32, ttnn.TILE_LAYOUT, ttnn.L1_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, device
     )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -37,9 +37,6 @@ mem_configs = [
         [[1, 1, 32, 32]],
         [[4, 3, 32, 32]],
         [[2, 2, 32, 32]],
-        [[1, 1, 32]],
-        [[4, 3]],
-        [[2]],
         # [[6, 4, 32, 32]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )
         # [[1, 1, 320, 320]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )
         # [[1, 3, 320, 64]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -37,6 +37,9 @@ mem_configs = [
         [[1, 1, 32, 32]],
         [[4, 3, 32, 32]],
         [[2, 2, 32, 32]],
+        [[1, 1, 32]],
+        [[4, 3]],
+        [[2]],
         # [[6, 4, 32, 32]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )
         # [[1, 1, 320, 320]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )
         # [[1, 3, 320, 64]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -90,9 +90,9 @@ Tensor ProdOperation::invoke(
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config) {
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
-    const size_t size = input_a.get_shape().size();
+    const int size = static_cast<int>(input_a.get_shape().size());
     TT_FATAL(
-        size && dim >= -static_cast<int>(size) && dim <= size - 1,
+        size && dim >= -size && dim <= size - 1,
         "Dimension out of range (expected to be in range of [-{}, {}]",
         size,
         size - 1);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -91,9 +91,16 @@ Tensor ProdOperation::invoke(
     const std::optional<MemoryConfig>& memory_config) {
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     const size_t size = input_a.get_legacy_shape().size();
+
     // FIXME: all the prod code is based on 4D tensors, so we need to convert the input tensor to 4D.
     // TODO: We need to handle the case where the input tensor is not 4D.
+    const auto old_rank = input_a.get_shape().rank();
     auto input_tensor_4d = ttnn::unsqueeze_to_4D(input_a);
+
+    // update the dim because we unsqueezed input to 4d
+    dim = (dim + old_rank) % old_rank;
+    dim = (4 - old_rank + dim);
+
     if (all_dimensions) {
         return prod_all(input_tensor_4d, output_mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -110,7 +110,7 @@ Tensor ProdOperation::invoke(
     TT_FATAL(dim >= -4 && dim <= 3, "Dimension out of range (expected to be in range of [-4, 3]");
 
     if (all_dimensions) {
-        return ttnn::squeeze_from_4D(prod_all(input_tensor_4d, output_mem_config), old_rank);
+        return prod_all(input_tensor_4d, output_mem_config);
     }
     Tensor temp = input_tensor_4d;
     // Permute for dim 2,3


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14276

### Problem description
code assumes prod operation always has 4d tensors. Hence it fails when non 4-d tensor is provided as input

### What's changed
unsqueeze all i/p tensors to 4d to support existing assumption

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/12696680189
- [x] Blackhole Post commit (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12695233628
- [x] Model regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12695235283
- [x] Device performance regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12695237196
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
