### PR TITLE
delete stale/(now) invalid assert after recent update to use virtual …

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -327,7 +327,6 @@ static void set_reduce_scatter_worker_rt(
             edm_noc_coord = ttnn::ccl::WorkerXY(
                 device->ethernet_core_from_logical_core(sender_edm).x,
                 device->ethernet_core_from_logical_core(sender_edm).y);
-            TT_ASSERT(edm_noc_coord.y == 0 || edm_noc_coord.y == 6);
             edm_core_semaphore_address =
                 edm_interface_addresses.worker_sender_edm_semaphore_addresses.at(global_worker_index);
             edm_core_buffer_address =


### PR DESCRIPTION
…coords

No associated issue. Stale code was identified and will fail if someone builds in Debug or RelWithDebInfo build modes. Deleted the assert that is no longer applicable
