### PR TITLE
#0: Remove hardcoded grid width in all_gather and skip test_sharded_matmul test when the device grid size is too small

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -33,14 +33,15 @@ using namespace ccl;
 
 static std::tuple<CoreRangeSet, CoreRangeSet, std::map<std::pair<uint32_t, uint32_t>, std::vector<CoreRangeSet>>>
 get_all_worker_cores(
-    AllGatherConfig const& all_gather_config,
+    const AllGatherConfig& all_gather_config,
     uint32_t num_links,
     uint32_t num_full_send_directions,
-    CoreCoord const& core_grid_offset,
+    const CoreCoord& core_grid_offset,
     bool is_linear,
     uint32_t ring_size,
-    uint32_t ring_index) {
-    constexpr uint32_t worker_grid_width = 8;
+    uint32_t ring_index,
+    const CoreCoord& grid_size) {
+    uint32_t worker_grid_width = grid_size.x;
     const bool fit_sender_and_receiver_workers_on_same_row =
         (worker_grid_width / 2) >= all_gather_config.get_num_workers_per_link();
 
@@ -62,7 +63,7 @@ get_all_worker_cores(
         bool receiver_enabled = (!is_linear || !is_first_chip_in_chain);
 
         for (uint32_t link = 0; link < num_links; ++link) {
-            uint32_t max_cols = 8;
+            uint32_t max_cols = worker_grid_width;
             uint32_t curr_row = link * (((all_gather_config.get_num_workers_per_link() * 2 - 1) / max_cols) + 1) +
                                 (full_send_direction * num_links *
                                  (((all_gather_config.get_num_workers_per_link() * 2 - 1) / max_cols) + 1)) +
@@ -451,8 +452,15 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     }
 
     // KERNEL CREATION
-    auto const& [all_receiver_workers, all_sender_workers, worker_core_map] = get_all_worker_cores(
-        all_gather_config, num_links, num_full_send_directions, core_grid_offset, is_linear, ring_size, ring_index);
+    const auto& [all_receiver_workers, all_sender_workers, worker_core_map] = get_all_worker_cores(
+        all_gather_config,
+        num_links,
+        num_full_send_directions,
+        core_grid_offset,
+        is_linear,
+        ring_size,
+        ring_index,
+        input_tensor.device()->compute_with_storage_grid_size());
     auto all_sender_worker_cores = corerange_to_cores(all_sender_workers, std::nullopt, true);
     auto all_receiver_worker_cores = corerange_to_cores(all_receiver_workers, std::nullopt, true);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
All gather had hardcoded device width of 8 but should derive from device grid size.
Sharded MM unit test did not check if the shard config actually fits on the device grid.

### What's changed
Change all gather to pull width from device.
Skip sharded MM test if device grid is too small.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
T3K unit: https://github.com/tenstorrent/tt-metal/actions/runs/12501718468
T3K freq: https://github.com/tenstorrent/tt-metal/actions/runs/12506425069
T3K nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12506426406/job/34894919296
T3K perf: https://github.com/tenstorrent/tt-metal/actions/runs/12506429619
TG freq: https://github.com/tenstorrent/tt-metal/actions/runs/12506431709
TG nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12506432943