### PR TITLE
Add FP32 support for binary_ng ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -5,8 +5,10 @@
 import torch
 import pytest
 import ttnn
-import random
-from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
+
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
+    compare_pcc,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,7 +19,30 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
         (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
     ),
 )
-def test_binary_scalar_ops(input_shapes, device):
+@pytest.mark.parametrize(
+    "ttnn_fn",
+    [
+        ttnn.experimental.gte,
+        ttnn.experimental.gt,
+        ttnn.experimental.lte,
+        ttnn.experimental.lt,
+        ttnn.experimental.eq,
+        ttnn.experimental.ne,
+        ttnn.experimental.logical_and,
+        ttnn.experimental.logical_or,
+        ttnn.experimental.logical_xor,
+        ttnn.experimental.ldexp,
+        ttnn.experimental.logaddexp,
+        ttnn.experimental.logaddexp2,
+        ttnn.experimental.squared_difference,
+        ttnn.experimental.add,
+        ttnn.experimental.sub,
+        ttnn.experimental.mul,
+        ttnn.experimental.div,
+        ttnn.experimental.bias_gelu,
+    ],
+)
+def test_binary_scalar_ops(input_shapes, ttnn_fn, device):
     a_shape, b_shape = input_shapes
     a_pt = torch.rand(a_shape).bfloat16()
     b_pt = torch.rand(b_shape).bfloat16()
@@ -25,11 +50,57 @@ def test_binary_scalar_ops(input_shapes, device):
     a_tt = ttnn.from_torch(a_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     b_tt = ttnn.from_torch(b_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     cq_id = 0
-    out_tt = ttnn.experimental.add(a_tt, b_tt, queue_id=cq_id)
-    out_pt = a_pt + b_pt
+    out_tt = ttnn_fn(a_tt, b_tt, queue_id=cq_id)
+    golden_fn = ttnn.get_golden_function(ttnn_fn)
+    out_pt = golden_fn(a_pt, b_pt)
 
     comp_pass = compare_pcc([out_tt], [out_pt])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 31, 32]), torch.Size([5, 3, 32, 32])),
+        (torch.Size([5, 2, 64, 1]), torch.Size([1, 3, 1, 128])),
+        (torch.Size([5, 1, 1, 64]), torch.Size([2, 3, 128, 1])),
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_fn",
+    [
+        ttnn.experimental.gte,
+        ttnn.experimental.gt,
+        ttnn.experimental.lte,
+        ttnn.experimental.lt,
+        ttnn.experimental.eq,
+        ttnn.experimental.ne,
+        ttnn.experimental.logical_and,
+        ttnn.experimental.logical_or,
+        ttnn.experimental.logical_xor,
+        ttnn.experimental.ldexp,
+        ttnn.experimental.logaddexp,
+        ttnn.experimental.logaddexp2,
+        ttnn.experimental.squared_difference,
+        ttnn.experimental.add,
+        ttnn.experimental.sub,
+        ttnn.experimental.mul,
+        ttnn.experimental.div,
+        ttnn.experimental.bias_gelu,
+    ],
+)
+def test_binary_scalar_ops_invalid_bcast(input_shapes, ttnn_fn, device):
+    a_shape, b_shape = input_shapes
+    a_pt = torch.rand(a_shape).bfloat16()
+    b_pt = torch.rand(b_shape).bfloat16()
+
+    a_tt = ttnn.from_torch(a_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    b_tt = ttnn.from_torch(b_pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    with pytest.raises(RuntimeError) as e:
+        cq_id = 0
+        _ = ttnn_fn(a_tt, b_tt, queue_id=cq_id)
+        assert "Broadcasting rule violation" in str(e.value)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -123,6 +123,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/binary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -53,6 +53,7 @@ Tensor BinaryNg<binary_op_type>::invoke(
 
 template struct BinaryNg<BinaryOpType::ADD>;
 template struct BinaryNg<BinaryOpType::SUB>;
+template struct BinaryNg<BinaryOpType::RSUB>;
 template struct BinaryNg<BinaryOpType::MUL>;
 template struct BinaryNg<BinaryOpType::DIV>;
 template struct BinaryNg<BinaryOpType::GT>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.cpp
@@ -52,5 +52,22 @@ Tensor BinaryNg<binary_op_type>::invoke(
 }
 
 template struct BinaryNg<BinaryOpType::ADD>;
+template struct BinaryNg<BinaryOpType::SUB>;
+template struct BinaryNg<BinaryOpType::MUL>;
+template struct BinaryNg<BinaryOpType::DIV>;
+template struct BinaryNg<BinaryOpType::GT>;
+template struct BinaryNg<BinaryOpType::LT>;
+template struct BinaryNg<BinaryOpType::LTE>;
+template struct BinaryNg<BinaryOpType::GTE>;
+template struct BinaryNg<BinaryOpType::EQ>;
+template struct BinaryNg<BinaryOpType::NE>;
+template struct BinaryNg<BinaryOpType::SQUARED_DIFFERENCE>;
+template struct BinaryNg<BinaryOpType::BIAS_GELU>;
+template struct BinaryNg<BinaryOpType::LOGICAL_AND>;
+template struct BinaryNg<BinaryOpType::LOGICAL_OR>;
+template struct BinaryNg<BinaryOpType::LOGICAL_XOR>;
+template struct BinaryNg<BinaryOpType::LDEXP>;
+template struct BinaryNg<BinaryOpType::LOGADDEXP>;
+template struct BinaryNg<BinaryOpType::LOGADDEXP2>;
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -54,6 +54,10 @@ constexpr auto sub = ttnn::register_operation_with_auto_launch_op<
     "ttnn::experimental::sub",
     ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::SUB>>();
 
+constexpr auto rsub = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::rsub",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::RSUB>>();
+
 constexpr auto mul = ttnn::register_operation_with_auto_launch_op<
     "ttnn::experimental::mul",
     ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::MUL>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng.hpp
@@ -49,4 +49,72 @@ namespace ttnn::experimental {
 constexpr auto add = ttnn::register_operation_with_auto_launch_op<
     "ttnn::experimental::add",
     ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::ADD>>();
+
+constexpr auto sub = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::sub",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::SUB>>();
+
+constexpr auto mul = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::mul",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::MUL>>();
+
+constexpr auto div = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::div",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::DIV>>();
+
+constexpr auto eq = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::eq",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::EQ>>();
+
+constexpr auto ne = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::ne",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::NE>>();
+
+constexpr auto gt = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::gt",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::GT>>();
+
+constexpr auto gte = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::gte",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::GTE>>();
+
+constexpr auto lt = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::lt",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LT>>();
+
+constexpr auto lte = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::lte",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LTE>>();
+
+constexpr auto squared_difference = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::squared_difference",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::SQUARED_DIFFERENCE>>();
+
+constexpr auto bias_gelu = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::bias_gelu",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::BIAS_GELU>>();
+
+constexpr auto logical_and = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::logical_and",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LOGICAL_AND>>();
+
+constexpr auto logical_or = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::logical_or",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LOGICAL_OR>>();
+
+constexpr auto logical_xor = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::logical_xor",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LOGICAL_XOR>>();
+
+constexpr auto ldexp = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::ldexp",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LDEXP>>();
+
+constexpr auto logaddexp = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::logaddexp",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LOGADDEXP>>();
+
+constexpr auto logaddexp2 = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::logaddexp2",
+    ttnn::operations::binary_ng::BinaryNg<operations::binary_ng::BinaryOpType::LOGADDEXP2>>();
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
@@ -59,6 +59,7 @@ void bind_binary_ng_operation(py::module& module, T op, const std::string& docst
 void py_module(py::module& module) {
     detail::bind_binary_ng_operation(module, ttnn::experimental::add, "Binary Add Operation");
     detail::bind_binary_ng_operation(module, ttnn::experimental::sub, "Binary Sub Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::rsub, "Binary RSub Operation");
     detail::bind_binary_ng_operation(module, ttnn::experimental::mul, "Binary Mul Operation");
     detail::bind_binary_ng_operation(module, ttnn::experimental::div, "Binary Div Operation");
     detail::bind_binary_ng_operation(module, ttnn::experimental::gt, "Binary Greater Than Operation");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.cpp
@@ -9,17 +9,16 @@
 
 namespace ttnn::operations::binary_ng {
 namespace detail {
-void bind_binary_ng_operation(py::module& module) {
-    using OperationType = decltype(ttnn::experimental::add);
-
+template <typename T>
+void bind_binary_ng_operation(py::module& module, T op, const std::string& docstring) {
     bind_registered_operation(
         module,
-        ttnn::experimental::add,
-        "Binary Add Ng Operation",
+        op,
+        docstring,
 
         // tensor and scalar
         ttnn::pybind_overload_t{
-            [](const OperationType& self,
+            [](const T& self,
                const ttnn::Tensor& input_tensor_a,
                const float scalar,
                const std::optional<const DataType>& dtype,
@@ -38,7 +37,7 @@ void bind_binary_ng_operation(py::module& module) {
 
         // tensor and tensor
         ttnn::pybind_overload_t{
-            [](const OperationType& self,
+            [](const T& self,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
                const std::optional<const DataType>& dtype,
@@ -57,5 +56,25 @@ void bind_binary_ng_operation(py::module& module) {
 }
 }  // namespace detail
 
-void py_module(py::module& module) { detail::bind_binary_ng_operation(module); }
+void py_module(py::module& module) {
+    detail::bind_binary_ng_operation(module, ttnn::experimental::add, "Binary Add Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::sub, "Binary Sub Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::mul, "Binary Mul Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::div, "Binary Div Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::gt, "Binary Greater Than Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::lt, "Binary Less Than Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::lte, "Binary Less Than or Equal To Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::gte, "Binary Greater Than or Equal To Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::eq, "Binary Equal Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::ne, "Binary Not Equal Operation");
+    detail::bind_binary_ng_operation(
+        module, ttnn::experimental::squared_difference, "Binary Squared Difference Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::bias_gelu, "Binary Bias GELU Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::logical_and, "Binary Logical And Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::logical_or, "Binary Logical Or Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::logical_xor, "Binary Logical Xor Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::ldexp, "Binary Ldexp Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::logaddexp, "Binary Logaddexp Operation");
+    detail::bind_binary_ng_operation(module, ttnn::experimental::logaddexp2, "Binary Logaddexp2 Operation");
+}
 }  // namespace ttnn::operations::eltwise::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/binary_ng_pybind.hpp
@@ -5,12 +5,14 @@
 #pragma once
 
 #include "pybind11/pybind_fwd.hpp"
+#include <string>
 
 namespace py = pybind11;
 
 namespace ttnn::operations::binary_ng {
 namespace detail {
-void bind_binary_ng_operation(py::module& module);
+template <typename T>
+void bind_binary_ng_operation(py::module& module, T op, const std::string& docstring);
 }
 
 void py_module(py::module& module);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -90,18 +90,18 @@ void BinaryNgDeviceOperation::validate_on_program_cache_hit(
     const auto input_shape_b =
         tensor_args.input_tensor_b.has_value() ? tensor_args.input_tensor_b->get_logical_shape() : ttnn::Shape{1, 1};
 
-    constexpr int max_rank = 4;
-    if (input_shape_a.rank() > 0 && input_shape_b.rank() > 0) {
-        for (int i = 1; i <= max_rank; i++) {
-            auto a_dim = i <= input_shape_a.rank() ? input_shape_a[-i] : 1;
-            auto b_dim = i <= input_shape_b.rank() ? input_shape_b[-i] : 1;
-            TT_FATAL(
-                a_dim == b_dim || a_dim == 1 || b_dim == 1,
-                "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
-                i,
-                a_dim,
-                b_dim);
-        }
+    const int rank_a = input_shape_a.rank();
+    const int rank_b = input_shape_b.rank();
+    const int larger_rank = std::max(rank_a, rank_b);
+    for (int i = -1; i >= -larger_rank; --i) {
+        auto a_dim = (i >= -rank_a) ? input_shape_a[i] : 1;
+        auto b_dim = (i >= -rank_b) ? input_shape_b[i] : 1;
+        TT_FATAL(
+            a_dim == b_dim || a_dim == 1 || b_dim == 1,
+            "Broadcasting rule violation for rank {}, dim a: {}, dim b: {}",
+            i,
+            a_dim,
+            b_dim);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -70,7 +70,29 @@ struct BinaryNgDeviceOperation {
             tensor_return_value_t& output);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    struct SfpuProgramFactory {
+        struct shared_variables_t {
+            KernelHandle reader_kernel_id;
+            KernelHandle writer_kernel_id;
+            KernelHandle compute_kernel_id;
+            CoreCoord compute_with_storage_grid_size;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory, SfpuProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -153,8 +153,12 @@ void set_or_update_runtime_arguments(
             std::array compute_runtime_args = {num_tiles_per_core, freq, counter};
             handle_args(program, compute_kernel_id, core, compute_runtime_args);
         } else {
-            class bfloat16 bfloat_scalar(*operation_attributes.scalar);
-            uint32_t packed_scalar = pack_two_bfloat16_into_uint32({bfloat_scalar, bfloat_scalar});
+            const auto scalar = *operation_attributes.scalar;
+            class bfloat16 bfloat_scalar(scalar);
+            const auto packed_scalar = a.get_dtype() == DataType::FLOAT32 ? std::bit_cast<uint32_t>(scalar)
+                                       : a.get_dtype() == DataType::INT32
+                                           ? std::bit_cast<uint32_t>(static_cast<int32_t>(scalar))
+                                           : pack_two_bfloat16_into_uint32({bfloat_scalar, bfloat_scalar});
             std::array writer_runtime_args = {
                 packed_scalar,
                 c.buffer()->address(),
@@ -262,30 +266,47 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 
     auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
 
+    std::map<std::string, std::string> reader_defines;
+    const auto ashape = a.get_logical_shape();
+    bool is_scalarA = (ashape.rank() >= 2) && ((ashape[-1] == 1) || (ashape[-2] == 1));
+    if (is_scalarA) {
+        reader_defines["BF16_SCALARB"] = "1";
+    }
+
     // READER KERNEL
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(kernel_config.reader_kernel),
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig({a_is_dram}));
+        tt_metal::ReaderDataMovementConfig({a_is_dram}, reader_defines));
 
     std::cout << "reader kernel " << get_kernel_file_path(kernel_config.reader_kernel) << std::endl;
     // WRITER KERNEL
+    // by default the writer and compute kernel is set for B as scalar value
     auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
     auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
+    std::map<std::string, std::string> writer_defines;
     if (b.has_value()) {
         b_buffer = b->buffer();
         b_is_dram = static_cast<uint32_t>(b_buffer->buffer_type() == tt_metal::BufferType::DRAM);
         writer_kernel = kernel_config.writer_kernel;
         compute_kernel = kernel_config.compute_kernel;
+        const auto bshape = b->get_logical_shape();
+        bool is_scalarB = (bshape.rank() >= 2) && ((bshape[-1] == 1) || (bshape[-2] == 1));
+        if (is_scalarB) {
+            writer_defines["BF16_SCALARB"] = "1";
+        }
     }
     std::cout << "writer kernel " << get_kernel_file_path(writer_kernel) << std::endl;
+    if (!b.has_value()) {
+        writer_defines["BF16_SCALARB"] = "1";
+    }
 
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         get_kernel_file_path(writer_kernel),
         all_device_cores,
-        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram}));
+        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram}, writer_defines));
 
     // COMPUTE KERNEL
     bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
@@ -323,6 +344,228 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
 }
 
 void BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& c) {
+    auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        auto& all_args = GetRuntimeArgs(program, kernel_id);
+        auto& core_args = all_args.at(core.x).at(core.y);
+        std::copy(args.begin(), args.end(), core_args.data());
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
+        cached_program.shared_variables.compute_kernel_id,
+        cached_program.shared_variables.compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        c,
+        update_args);
+}
+
+// Implements c = a op b using binary SFPU
+BinaryNgDeviceOperation::SfpuProgramFactory::cached_program_t BinaryNgDeviceOperation::SfpuProgramFactory::create(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+    using ttnn::operations::unary::UnaryWithParam;
+    std::cout << " Enter sfpu pgm factory" << std::endl;
+
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+
+    // std::vector<UnaryWithParam> fused_activations =
+    //     operation_attributes.activations.value_or(std::vector<UnaryWithParam>{});
+    std::vector<UnaryWithParam> fused_activations = std::vector<UnaryWithParam>{};
+
+    auto program = CreateProgram();
+
+    auto* device = a.device();
+
+    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    auto b_data_format = b.has_value() ? datatype_to_dataformat_converter(b->get_dtype()) : a_data_format;
+    auto c_data_format = datatype_to_dataformat_converter(c.get_dtype());
+
+    uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
+    uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
+    uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
+
+    uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
+
+    // we parallelize the computation across the output tiles
+    constexpr bool row_major = true;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    Buffer* a_buffer = a.buffer();
+    Buffer* b_buffer = nullptr;
+    Buffer* c_buffer = c.buffer();
+
+    auto op_type = operation_attributes.binary_op_type;
+    DataType b_dtype = b.has_value() ? b->get_dtype() : a.get_dtype();
+    auto compute_kernel_defines = get_defines_fp32(op_type, a.get_dtype(), b_dtype, fused_activations, std::nullopt);
+    // no operation_attributes.input_tensor_a_activation yet
+    bool op_has_exp =
+        op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LDEXP || op_type == BinaryOpType::LOGADDEXP2;
+
+    // How many tiles to store per input CB (double buffer)
+    constexpr uint32_t num_tiles_per_cb = 2;
+    std::cout << " How many tiles to store per input CB (double buffer) num_tiles_per_cb " << num_tiles_per_cb
+              << std::endl;
+
+    auto [a_cb, a_cb_handle] =
+        create_cb(tt::CBIndex::c_0, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
+
+    if (compute_kernel_defines.find("SFPU_OP_INIT_PRE_IN0_0") != compute_kernel_defines.end()) {
+        auto a_intermediate_format = a_data_format;
+        uint32_t a_intermediate_single_tile_size = tt_metal::detail::TileSize(a_intermediate_format);
+        auto [a_cb_interim, a_cb_interim_handle] = create_cb(
+            tt::CBIndex::c_3, program, all_device_cores, a_intermediate_single_tile_size, 1, a_intermediate_format);
+    }
+
+    auto [c_cb, c_cb_handle] =
+        create_cb(tt::CBIndex::c_2, program, all_device_cores, c_single_tile_size, num_tiles_per_cb, c_data_format);
+
+    // If b is a scalar, we only need one tile in the CB
+    uint32_t b_num_tiles_per_cb = b_buffer != nullptr ? num_tiles_per_cb : 1;
+    auto [b_cb, b_cb_handle] =
+        create_cb(tt::CBIndex::c_1, program, all_device_cores, b_single_tile_size, b_num_tiles_per_cb, b_data_format);
+
+    if (compute_kernel_defines.find("SFPU_OP_INIT_PRE_IN1_0") != compute_kernel_defines.end()) {
+        auto b_intermediate_format = b.has_value() ? b_data_format : a_data_format;
+        uint32_t b_intermediate_single_tile_size = tt_metal::detail::TileSize(b_intermediate_format);
+        auto [b_cb_interim, b_cb_interim_handle] = create_cb(
+            tt::CBIndex::c_4, program, all_device_cores, b_intermediate_single_tile_size, 1, b_intermediate_format);
+    }
+
+    auto a_is_dram = static_cast<uint32_t>(a_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    bool b_is_dram = false;
+    auto c_is_dram = static_cast<uint32_t>(c_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+
+    auto kernel_config = CMAKE_UNIQUE_NAMESPACE::BinaryNgKernelConfig(operation_attributes.subtile_broadcast_type);
+
+    const auto ashape = a.get_logical_shape();
+    tt::log_info(tt::LogOp, "******** a logical shape: {}", ashape);
+    std::map<std::string, std::string> reader_defines;
+    bool is_scalarA = (ashape.rank() >= 2) && ((ashape[-1] == 1) || (ashape[-2] == 1));
+    if (is_scalarA && a.get_dtype() == DataType::FLOAT32) {
+        reader_defines["F32_SCALARB"] = "1";
+    } else if (is_scalarA && a.get_dtype() == DataType::INT32) {
+        reader_defines["INT32_SCALARB"] = "1";
+    } else if (is_scalarA) {
+        reader_defines["BF16_SCALARB"] = "1";
+    }
+    for (const auto& pair : reader_defines) {
+        std::cout << "reader sf" << pair.first << ": " << pair.second << std::endl;
+    }
+
+    // READER KERNEL
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_sfpu_kernel_file_path(kernel_config.reader_kernel),
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram}, reader_defines));
+
+    std::cout << "reader kernel " << get_sfpu_kernel_file_path(kernel_config.reader_kernel) << std::endl;
+
+    // WRITER KERNEL
+    std::map<std::string, std::string> writer_defines;
+    auto writer_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::WriterScalar;
+    auto compute_kernel = CMAKE_UNIQUE_NAMESPACE::KernelName::ComputeScalar;
+    if (b.has_value()) {
+        b_buffer = b->buffer();
+        b_is_dram = static_cast<uint32_t>(b_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+        writer_kernel = kernel_config.writer_kernel;
+        compute_kernel = kernel_config.compute_kernel;
+
+        const auto bshape = b->get_logical_shape();
+        tt::log_info(tt::LogOp, "******** b logical shape: {}", bshape);
+        bool is_scalarB = (bshape.rank() >= 2) && ((bshape[-1] == 1) || (bshape[-2] == 1));
+        if (is_scalarB && b->get_dtype() == DataType::FLOAT32) {
+            writer_defines["F32_SCALARB"] = "1";
+        } else if (is_scalarB && b->get_dtype() == DataType::INT32) {
+            writer_defines["INT32_SCALARB"] = "1";
+        } else if (is_scalarB) {
+            writer_defines["BF16_SCALARB"] = "1";
+        }
+        for (const auto& pair : writer_defines) {
+            std::cout << "writer_defines sf" << pair.first << ": " << pair.second << std::endl;
+        }
+    }
+    if (!b.has_value() && a.get_dtype() == DataType::FLOAT32) {
+        std::cout << " scalar float defines" << std::endl;
+        writer_defines["F32_SCALARB"] = "1";
+    } else if (!b.has_value() && a.get_dtype() == DataType::INT32) {
+        writer_defines["INT32_SCALARB"] = "1";
+    } else if (!b.has_value()) {
+        writer_defines["BF16_SCALARB"] = "1";
+    }
+    for (const auto& pair : writer_defines) {
+        std::cout << "writer sf" << pair.first << ": " << pair.second << std::endl;
+    }
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_sfpu_kernel_file_path(writer_kernel),
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram}, writer_defines));
+
+    std::cout << "writer kernel " << get_sfpu_kernel_file_path(writer_kernel) << std::endl;
+
+    // COMPUTE KERNEL
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32;
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    uint32_t src0interim_cb_index = tt::CBIndex::c_3;
+    uint32_t src1interim_cb_index = tt::CBIndex::c_4;
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    unpack_to_dest_mode[src1_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    unpack_to_dest_mode[src0interim_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    unpack_to_dest_mode[src1interim_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+
+    // Compute kernel needs to know which op it's going to perform
+    // This has to be passed as a compile-time argument
+    // For now we're just going to do addition
+    compute_kernel_defines["BCAST_INPUT"] = kernel_config.bcast_input_str();
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        get_sfpu_kernel_file_path(compute_kernel),
+        all_device_cores,
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .defines = compute_kernel_defines});
+
+    std::cout << "compute_kernel  " << get_sfpu_kernel_file_path(compute_kernel) << std::endl;
+
+    auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        compute_kernel_id,
+        compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        c,
+        set_runtime_args);
+
+    return {
+        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+}
+
+void BinaryNgDeviceOperation::SfpuProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "binary_ng_utils.hpp"
-
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
@@ -117,6 +118,28 @@ std::string get_kernel_file_path(KernelName kernel_name) {
     }
 }
 
+std::string get_sfpu_kernel_file_path(KernelName kernel_name) {
+    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels";
+    constexpr std::string_view dataflow = "{}/dataflow/{}";
+    constexpr std::string_view compute = "{}/compute/{}";
+
+    switch (kernel_name) {
+        case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
+        case KernelName::ReaderRowBcast: return fmt::format(dataflow, root, "reader_interleaved_row_bcast.cpp");
+        case KernelName::ReaderColBcast: return fmt::format(dataflow, root, "reader_interleaved_col_bcast.cpp");
+        case KernelName::ReaderScalarBcast: return fmt::format(dataflow, root, "reader_interleaved_scalar_bcast.cpp");
+        case KernelName::WriterNoBcast: return fmt::format(dataflow, root, "writer_interleaved_no_bcast.cpp");
+        case KernelName::WriterRowBcast: return fmt::format(dataflow, root, "writer_interleaved_row_bcast.cpp");
+        case KernelName::WriterColBcast: return fmt::format(dataflow, root, "writer_interleaved_col_bcast.cpp");
+        case KernelName::WriterScalarBcast: return fmt::format(dataflow, root, "writer_interleaved_scalar_bcast.cpp");
+        case KernelName::WriterScalar: return fmt::format(dataflow, root, "writer_interleaved_scalar.cpp");
+        case KernelName::ComputeNoBcast: return fmt::format(compute, root, "eltwise_binary_sfpu_no_bcast.cpp");
+        case KernelName::ComputeBcast: return fmt::format(compute, root, "eltwise_binary_sfpu.cpp");
+        case KernelName::ComputeScalar: return fmt::format(compute, root, "eltwise_binary_sfpu_scalar.cpp");
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
 constexpr OpConfig::SfpuConfig NezConfig("nez_tile_init", "nez_tile(i)");
 constexpr OpConfig::SfpuConfig GtzConfig("gtz_tile_init", "gtz_tile(i)");
 
@@ -125,6 +148,11 @@ OpConfig::OpConfig(BinaryOpType binary_op_type) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: fpu_binary_op = FpuBinaryOp::ADD; break;
         case BinaryOpType::SUB: break;
+        case BinaryOpType::RSUB:
+            preprocess_a =
+                SfpuConfig("negative_tile_init", "negative_tile(i)", "compute_kernel_api/eltwise_unary/negative.h");
+            fpu_binary_op = FpuBinaryOp::ADD;
+            break;
         case BinaryOpType::MUL: fpu_binary_op = FpuBinaryOp::MUL; break;
         case BinaryOpType::DIV:
             preprocess_b = SfpuConfig("recip_tile_init", "recip_tile(i)", "compute_kernel_api/eltwise_unary/recip.h");
@@ -200,7 +228,154 @@ std::map<std::string, std::string> OpConfig::as_defines() const {
     defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});
     defines["BINARY_OP_TYPE"] = fmt::format("EltwiseBinaryType::ELW{}", binary_op_str);
 
+    for (const auto& pair : defines) {
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
     return defines;
+}
+
+std::map<std::string, std::string> get_defines_fp32(
+    BinaryOpType op_type,
+    const std::optional<tt::tt_metal::DataType> input_a_dtype,
+    const std::optional<tt::tt_metal::DataType> input_b_dtype,
+    const std::optional<std::vector<ttnn::operations::unary::UnaryWithParam>>& fused_activations,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& input_tensor_a_activation) {
+    std::map<std::string, std::string> new_defines;
+    std::string op_name = "sub_binary_tile";
+    std::string idst1 = "i*2";    // tile index for input A in dst and final output
+    std::string idst2 = "i*2+1";  // tile index for input B in dst
+    std::string idst = "i";       // tile index for input prescaling
+
+    using ttnn::operations::unary::UnaryOpType;
+    using ttnn::operations::unary::utils::get_defines;
+
+    switch (op_type) {
+        case BinaryOpType::ADD:
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                new_defines.insert({"ADD_INT32_INIT", fmt::format("add_int32_tile_init();")});
+                op_name = "add_int32_tile";
+            } else {
+                op_name = "add_binary_tile";
+            }
+            break;
+        case BinaryOpType::SUB: op_name = "sub_binary_tile"; break;
+        case BinaryOpType::MUL: op_name = "mul_binary_tile"; break;
+        case BinaryOpType::RSUB: op_name = "rsub_binary_tile"; break;
+        case BinaryOpType::POWER: op_name = "power_binary_tile"; break;
+        case BinaryOpType::DIV: op_name = "div_binary_tile"; break;
+        case BinaryOpType::BITWISE_AND:
+            new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+            op_name = "and_binary_tile";
+            break;
+        case BinaryOpType::BITWISE_OR:
+            new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+            op_name = "or_binary_tile";
+            break;
+        case BinaryOpType::BITWISE_XOR:
+            new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+            op_name = "xor_binary_tile";
+            break;
+        case BinaryOpType::LEFT_SHIFT:
+            new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
+            op_name = "binary_left_shift_tile";
+            break;
+        case BinaryOpType::RIGHT_SHIFT:
+            new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
+            op_name = "binary_right_shift_tile";
+            break;
+        case BinaryOpType::LOGADDEXP:
+            // PRE_IN0_0 ===> Applies prescaling for first input
+            // PRE_IN1_0 ====> Applies prescaling for second input
+            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
+            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LOGADDEXP2:
+            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
+            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LDEXP:
+            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
+            op_name = "mul_binary_tile";
+            break;
+        case BinaryOpType::SQUARED_DIFFERENCE:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LOGICAL_AND:
+            op_name = "mul_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::BIAS_GELU:
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst1));
+            break;
+        case BinaryOpType::LOGICAL_OR:
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0"));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0"));
+            op_name = "add_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LOGICAL_XOR:
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN0_0"));
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "PRE_IN1_0"));
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1));
+            break;
+        // applied on A-B
+        case BinaryOpType::GT:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LT:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::GTE:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::LTE:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::EQ:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::EQZ, std::nullopt, "0", idst1));
+            break;
+        case BinaryOpType::NE:
+            op_name = "sub_binary_tile";
+            new_defines.merge(get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst1));
+            break;
+        default:
+            tt::log_debug(tt::LogOp, "Undefined op type {}", op_type);
+            TT_FATAL(false, "Undefined op type for binary sfpu operation {}", op_type);
+    }
+
+    new_defines.insert({"BINARY_SFPU_OP", fmt::format("{}({}, {});", op_name, idst1, idst2)});
+
+    if (fused_activations.has_value()) {
+        if (op_type == BinaryOpType::ADD and fused_activations.value().size() == 1 and
+            fused_activations.value().at(0).op_type == UnaryOpType::RELU) {
+            new_defines["PACK_RELU"] = "1";
+        } else {
+            new_defines.merge(ttnn::operations::unary::utils::get_block_defines(fused_activations.value(), "0", idst1));
+        }
+    }
+
+    if (input_tensor_a_activation.has_value()) {
+        new_defines.merge(ttnn::operations::unary::utils::get_defines(
+            input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0", idst));
+    }
+
+    for (const auto& pair : new_defines) {
+        std::cout << pair.first << ": " << pair.second << std::endl;
+    }
+
+    return new_defines;
 }
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_ng_utils.hpp"
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <magic_enum/magic_enum.hpp>
+
+template <>
+struct fmt::formatter<ttnn::operations::binary_ng::Lowercase> : fmt::formatter<std::string_view> {
+    auto format(ttnn::operations::binary_ng::Lowercase const& value, fmt::format_context& ctx) const {
+        auto out = ctx.out();
+        for (char c : value.view) {
+            *out++ = std::tolower(static_cast<unsigned char>(c));
+        }
+        return out;
+    }
+};
+
+namespace ttnn::operations::binary_ng {
+
+BinaryNgKernelConfig::BinaryNgKernelConfig(SubtileBroadcastType subtile_broadcast_type) {
+    switch (subtile_broadcast_type) {
+        case SubtileBroadcastType::NONE:
+            reader_kernel = KernelName::ReaderNoBcast;
+            compute_kernel = KernelName::ComputeNoBcast;
+            writer_kernel = KernelName::WriterNoBcast;
+            bcast_input = std::nullopt;
+            break;
+
+        case SubtileBroadcastType::SCALAR_A:
+            reader_kernel = KernelName::ReaderScalarBcast;
+            compute_kernel = KernelName::ComputeBcast;
+            writer_kernel = KernelName::WriterNoBcast;
+            bcast_input = 0;
+            break;
+
+        case SubtileBroadcastType::SCALAR_B:
+            reader_kernel = KernelName::ReaderNoBcast;
+            compute_kernel = KernelName::ComputeBcast;
+            writer_kernel = KernelName::WriterScalarBcast;
+            bcast_input = 1;
+            break;
+
+        case SubtileBroadcastType::ROW_A:
+            reader_kernel = KernelName::ReaderRowBcast;
+            compute_kernel = KernelName::ComputeNoBcast;
+            writer_kernel = KernelName::WriterNoBcast;
+            bcast_input = std::nullopt;
+            break;
+
+        case SubtileBroadcastType::ROW_B:
+            reader_kernel = KernelName::ReaderNoBcast;
+            compute_kernel = KernelName::ComputeNoBcast;
+            writer_kernel = KernelName::WriterRowBcast;
+            bcast_input = std::nullopt;
+            break;
+
+        case SubtileBroadcastType::COL_A:
+            reader_kernel = KernelName::ReaderColBcast;
+            compute_kernel = KernelName::ComputeBcast;
+            writer_kernel = KernelName::WriterNoBcast;
+            bcast_input = 0;
+            break;
+
+        case SubtileBroadcastType::COL_B:
+            reader_kernel = KernelName::ReaderNoBcast;
+            compute_kernel = KernelName::ComputeBcast;
+            writer_kernel = KernelName::WriterColBcast;
+            bcast_input = 1;
+            break;
+
+        case SubtileBroadcastType::ROW_A_COL_B:
+            reader_kernel = KernelName::ReaderRowBcast;
+            compute_kernel = KernelName::ComputeBcast;
+            writer_kernel = KernelName::WriterColBcast;
+            bcast_input = 1;
+            break;
+
+        case SubtileBroadcastType::ROW_B_COL_A:
+            reader_kernel = KernelName::ReaderColBcast;
+            compute_kernel = KernelName::ComputeBcast;
+            writer_kernel = KernelName::WriterRowBcast;
+            bcast_input = 0;
+            break;
+    }
+}
+
+std::string BinaryNgKernelConfig::bcast_input_str() const {
+    if (bcast_input.has_value()) {
+        return std::to_string(*bcast_input);
+    }
+    return "";
+}
+
+std::string get_kernel_file_path(KernelName kernel_name) {
+    constexpr std::string_view root = "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels";
+    constexpr std::string_view dataflow = "{}/dataflow/{}";
+    constexpr std::string_view compute = "{}/compute/{}";
+
+    switch (kernel_name) {
+        case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
+        case KernelName::ReaderRowBcast: return fmt::format(dataflow, root, "reader_interleaved_row_bcast.cpp");
+        case KernelName::ReaderColBcast: return fmt::format(dataflow, root, "reader_interleaved_col_bcast.cpp");
+        case KernelName::ReaderScalarBcast: return fmt::format(dataflow, root, "reader_interleaved_scalar_bcast.cpp");
+        case KernelName::WriterNoBcast: return fmt::format(dataflow, root, "writer_interleaved_no_bcast.cpp");
+        case KernelName::WriterRowBcast: return fmt::format(dataflow, root, "writer_interleaved_row_bcast.cpp");
+        case KernelName::WriterColBcast: return fmt::format(dataflow, root, "writer_interleaved_col_bcast.cpp");
+        case KernelName::WriterScalarBcast: return fmt::format(dataflow, root, "writer_interleaved_scalar_bcast.cpp");
+        case KernelName::WriterScalar: return fmt::format(dataflow, root, "writer_interleaved_scalar.cpp");
+        case KernelName::ComputeNoBcast: return fmt::format(compute, root, "eltwise_binary_no_bcast.cpp");
+        case KernelName::ComputeBcast: return fmt::format(compute, root, "eltwise_binary.cpp");
+        case KernelName::ComputeScalar: return fmt::format(compute, root, "eltwise_binary_scalar.cpp");
+        default: __builtin_unreachable();  // GCC 12 doesn't compile even though we exhaustively match
+    }
+}
+
+constexpr OpConfig::SfpuConfig NezConfig("nez_tile_init", "nez_tile(i)");
+constexpr OpConfig::SfpuConfig GtzConfig("gtz_tile_init", "gtz_tile(i)");
+
+OpConfig::OpConfig(BinaryOpType binary_op_type) {
+    fpu_binary_op = FpuBinaryOp::SUB;
+    switch (binary_op_type) {
+        case BinaryOpType::ADD: fpu_binary_op = FpuBinaryOp::ADD; break;
+        case BinaryOpType::SUB: break;
+        case BinaryOpType::MUL: fpu_binary_op = FpuBinaryOp::MUL; break;
+        case BinaryOpType::DIV:
+            preprocess_b = SfpuConfig("recip_tile_init", "recip_tile(i)", "compute_kernel_api/eltwise_unary/recip.h");
+            fpu_binary_op = FpuBinaryOp::MUL;
+            break;
+        case BinaryOpType::GT: postprocess = GtzConfig; break;
+        case BinaryOpType::LT: postprocess = SfpuConfig("ltz_tile_init", "ltz_tile(i)"); break;
+        case BinaryOpType::GTE: postprocess = SfpuConfig("gez_tile_init", "gez_tile(i)"); break;
+        case BinaryOpType::LTE: postprocess = SfpuConfig("lez_tile_init", "lez_tile(i)"); break;
+        case BinaryOpType::EQ: postprocess = SfpuConfig("eqz_tile_init", "eqz_tile(i)"); break;
+        case BinaryOpType::NE: postprocess = NezConfig; break;
+        case BinaryOpType::SQUARED_DIFFERENCE: postprocess = SfpuConfig("square_tile_init", "square_tile(i)"); break;
+        case BinaryOpType::BIAS_GELU:
+            fpu_binary_op = FpuBinaryOp::ADD;
+            preprocess_a =
+                SfpuConfig("gelu_tile_init<false>", "gelu_tile<false>(i)", "compute_kernel_api/eltwise_unary/gelu.h");
+            break;
+        case BinaryOpType::LOGICAL_AND:
+            fpu_binary_op = FpuBinaryOp::MUL;
+            postprocess = NezConfig;
+            break;
+        case BinaryOpType::LOGICAL_OR:
+            fpu_binary_op = FpuBinaryOp::ADD;
+            preprocess_a = NezConfig;
+            preprocess_b = NezConfig;
+            postprocess = GtzConfig;
+            break;
+        case BinaryOpType::LOGICAL_XOR:
+            preprocess_a = NezConfig;
+            preprocess_b = NezConfig;
+            postprocess = NezConfig;
+            break;
+        case BinaryOpType::LDEXP:
+            fpu_binary_op = FpuBinaryOp::MUL;
+            preprocess_b = SfpuConfig("exp2_tile_init", "exp2_tile(i)");
+            break;
+        case BinaryOpType::LOGADDEXP:
+            fpu_binary_op = FpuBinaryOp::ADD;
+            preprocess_a =
+                SfpuConfig("exp_tile_init<false>", "exp_tile<false>(i)", "compute_kernel_api/eltwise_unary/exp.h");
+            preprocess_b = preprocess_a;
+            postprocess = SfpuConfig("log_tile_init", "log_tile(i)");
+            break;
+        case BinaryOpType::LOGADDEXP2:
+            fpu_binary_op = FpuBinaryOp::ADD;
+            preprocess_a = SfpuConfig("exp2_tile_init", "exp2_tile(i)");
+            preprocess_b = preprocess_a;
+            postprocess = SfpuConfig("log_with_base_tile_init", "log_with_base_tile(i, 0x3dc5u);");
+            break;
+        default: __builtin_unreachable();
+    }
+}
+
+std::map<std::string, std::string> OpConfig::SfpuConfig::as_defines(std::string_view prefix) const {
+    if (init.empty()) {
+        return {};
+    }
+
+    std::map<std::string, std::string> defines;
+    defines[fmt::format("{}_INIT", prefix)] = init;
+    defines[fmt::format("{}_APPLY(i)", prefix)] = apply;
+    defines[fmt::format("{}_INCLUDE", prefix)] = include;
+    return defines;
+}
+
+std::map<std::string, std::string> OpConfig::as_defines() const {
+    std::map<std::string, std::string> defines;
+    defines.merge(preprocess_a.as_defines("PREPROCESS_A"));
+    defines.merge(preprocess_b.as_defines("PREPROCESS_B"));
+    defines.merge(postprocess.as_defines("POSTPROCESS"));
+
+    auto binary_op_str = magic_enum::enum_name(fpu_binary_op);
+    defines["BINARY_OP"] = fmt::format("{}_tiles", Lowercase{binary_op_str});
+    defines["BINARY_OP_TYPE"] = fmt::format("EltwiseBinaryType::ELW{}", binary_op_str);
+
+    return defines;
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -6,6 +6,8 @@
 
 #include "binary_ng_device_operation.hpp"
 #include "ttnn/operations/eltwise/binary_ng/types.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 #include <optional>
 #include <string>
@@ -39,6 +41,7 @@ struct BinaryNgKernelConfig {
 };
 
 std::string get_kernel_file_path(KernelName kernel_name);
+std::string get_sfpu_kernel_file_path(KernelName kernel_name);
 
 struct OpConfig {
     struct SfpuConfig {
@@ -68,5 +71,12 @@ struct OpConfig {
 struct Lowercase {
     std::string_view view;
 };
+
+std::map<std::string, std::string> get_defines_fp32(
+    BinaryOpType op_type,
+    const std::optional<tt::tt_metal::DataType> in_a_dtype = std::nullopt,
+    const std::optional<tt::tt_metal::DataType> in_b_dtype = std::nullopt,
+    const std::optional<ttnn::operations::unary::FusedActivations>& fused_activations = std::nullopt,
+    const std::optional<ttnn::operations::unary::UnaryWithParam>& input_tensor_a_activation = std::nullopt);
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "binary_ng_device_operation.hpp"
+#include "ttnn/operations/eltwise/binary_ng/types.hpp"
+
+#include <optional>
+#include <string>
+
+namespace ttnn::operations::binary_ng {
+
+enum class KernelName {
+    ReaderNoBcast,
+    ReaderRowBcast,
+    ReaderColBcast,
+    ReaderScalarBcast,
+    WriterNoBcast,
+    WriterRowBcast,
+    WriterColBcast,
+    WriterScalarBcast,
+    WriterScalar,
+    ComputeNoBcast,
+    ComputeBcast,
+    ComputeScalar
+};
+
+struct BinaryNgKernelConfig {
+    BinaryNgKernelConfig(SubtileBroadcastType subtile_broadcast_type);
+
+    std::string bcast_input_str() const;
+
+    KernelName reader_kernel;
+    KernelName compute_kernel;
+    KernelName writer_kernel;
+    std::optional<uint32_t> bcast_input;
+};
+
+std::string get_kernel_file_path(KernelName kernel_name);
+
+struct OpConfig {
+    struct SfpuConfig {
+        SfpuConfig() = default;
+        constexpr SfpuConfig(
+            std::string_view init, std::string_view apply, std::string_view include = "compute_kernel_api.h") :
+            init{init}, apply{apply}, include{include} {}
+        std::string_view init{};
+        std::string_view apply{};
+        std::string_view include{};
+
+        std::map<std::string, std::string> as_defines(std::string_view prefix) const;
+    };
+
+    enum class FpuBinaryOp { ADD, SUB, MUL };
+
+    OpConfig(BinaryOpType binary_op_type);
+
+    std::map<std::string, std::string> as_defines() const;
+
+    SfpuConfig preprocess_a{};
+    SfpuConfig preprocess_b{};
+    SfpuConfig postprocess{};
+    FpuBinaryOp fpu_binary_op;
+};
+
+struct Lowercase {
+    std::string_view view;
+};
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -6,35 +6,59 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "dprint.h"
 
+#include "eltwise_defines.hpp"
+#include "eltwise_utils.hpp"
+
 namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_in1 = tt::CBIndex::c_1;
-    constexpr auto cb_out0 = tt::CBIndex::c_2;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
 
-    binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    add_tiles_init();
+    constexpr auto cb_post_lhs = PREPROCESS_A ? tt::CBIndex::c_3 : cb_pre_lhs;
+    constexpr auto cb_post_rhs = PREPROCESS_B ? tt::CBIndex::c_4 : cb_pre_rhs;
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+
+#if not(PREPROCESS_A || PREPROCESS_B)
+    binary_op_specific_init<true, BINARY_OP_TYPE>();
+#endif
 
     constexpr uint32_t onetile = 1;
 
-    for(uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_wait_front(cb_in0, onetile);
-        cb_wait_front(cb_in1, onetile);
-        cb_reserve_back(cb_out0, onetile);
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+#if PREPROCESS_A
+        PREPROCESS(PREPROCESS_A_INIT, PREPROCESS_A_APPLY, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
+#endif
+        cb_wait_front(cb_post_lhs, onetile);
 
+#if PREPROCESS_B
+        PREPROCESS(PREPROCESS_B_INIT, PREPROCESS_B_APPLY, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
+#endif
+        cb_wait_front(cb_post_rhs, onetile);
+
+        cb_reserve_back(cb_out, onetile);
+
+#if PREPROCESS_A || PREPROCESS_B
+        binary_op_specific_init<true, BINARY_OP_TYPE>();
+#endif
         tile_regs_acquire();
-        add_tiles(cb_in0, cb_in1, 0, 0, 0);
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+#if POSTPROCESS
+        POSTPROCESS_INIT();
+        POSTPROCESS_APPLY(0);
+#endif
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile(0, cb_out0);
+        pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_push_back(cb_out0, onetile);
-        cb_pop_front(cb_in0, onetile);
-        cb_pop_front(cb_in1, onetile);
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_post_lhs, onetile);
+        cb_pop_front(cb_post_rhs, onetile);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -4,37 +4,59 @@
 
 #include <cstdint>
 #include "compute_kernel_api/eltwise_binary.h"
-#include "dprint.h"
+
+#include "eltwise_defines.hpp"
+#include "eltwise_utils.hpp"
 
 namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_in1 = tt::CBIndex::c_1;
-    constexpr auto cb_out0 = tt::CBIndex::c_2;
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
 
-    binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    add_tiles_init();
+    constexpr auto cb_post_lhs = PREPROCESS_A ? tt::CBIndex::c_3 : cb_pre_lhs;
+    constexpr auto cb_post_rhs = PREPROCESS_B ? tt::CBIndex::c_4 : cb_pre_rhs;
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+
+#if not(PREPROCESS_A || PREPROCESS_B)
+    binary_op_specific_init<true, BINARY_OP_TYPE>();
+#endif
 
     constexpr uint32_t onetile = 1;
 
-    cb_wait_front(cb_in1, onetile);
+#if PREPROCESS_B
+    PREPROCESS(PREPROCESS_B_INIT, PREPROCESS_B_APPLY, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
+#endif
+    cb_wait_front(cb_post_rhs, onetile);
 
     for(uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        cb_wait_front(cb_in0, onetile);
-        cb_reserve_back(cb_out0, onetile);
+#if PREPROCESS_A
+        PREPROCESS(PREPROCESS_A_INIT, PREPROCESS_A_APPLY, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
+#endif
+        cb_wait_front(cb_post_lhs, onetile);
 
+        cb_reserve_back(cb_out, onetile);
+
+#if PREPROCESS_A || PREPROCESS_B
+        binary_op_specific_init<true, BINARY_OP_TYPE>();
+#endif
         tile_regs_acquire();
-        add_tiles(cb_in0, cb_in1, 0, 0, 0);
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+#if POSTPROCESS
+        POSTPROCESS_INIT();
+        POSTPROCESS_APPLY(0);
+#endif
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile(0, cb_out0);
+        pack_tile(0, cb_out);
         tile_regs_release();
 
-        cb_pop_front(cb_in0, onetile);
-        cb_push_back(cb_out0, onetile);
+        cb_pop_front(cb_post_lhs, onetile);
+        cb_push_back(cb_out, onetile);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+// #include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/binary_bitwise_sfpu.h"
+#include "compute_kernel_api/binary_shift.h"
+#include "compute_kernel_api/add_int32_sfpu.h"
+#include "eltwise_defines.hpp"
+#include "eltwise_utils.hpp"
+
+namespace NAMESPACE {
+
+ALWI void process_tile(
+    tt::CBIndex cb_pre_lhs,
+    tt::CBIndex cb_post_lhs,
+    tt::CBIndex cb_pre_rhs,
+    tt::CBIndex cb_post_rhs,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start) {
+    using namespace ckernel;
+    constexpr uint32_t onetile = 1;
+
+#if BCAST_INPUT
+    auto cb_bcast = cb_post_rhs;
+    auto cb_other = cb_post_lhs;
+#else
+    auto cb_bcast = cb_post_lhs;
+    auto cb_other = cb_post_rhs;
+#endif
+
+#if SFPU_OP_INIT_PRE_IN0_0 && (BCAST_INPUT == 0)
+    PREPROCESS_SFPU_A(cb_pre_lhs, cb_post_lhs, cb_out, onetile);
+#elif SFPU_OP_INIT_PRE_IN1_0 && (BCAST_INPUT == 1)
+    PREPROCESS_SFPU_B(cb_pre_rhs, cb_post_rhs, cb_out, onetile);
+#endif
+
+    cb_wait_front(cb_bcast, onetile);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+#if SFPU_OP_INIT_PRE_IN0_0 && (BCAST_INPUT == 1)
+        PREPROCESS_SFPU_A(PREPROCESS_A_INIT, PREPROCESS_A_APPLY, cb_pre_lhs, cb_post_lhs, cb_out, onetile);
+#elif SFPU_OP_INIT_PRE_IN1_0 && (BCAST_INPUT == 0)
+        PREPROCESS_SFPU_B(PREPROCESS_B_INIT, PREPROCESS_B_APPLY, cb_pre_rhs, cb_post_rhs, cb_out, onetile);
+#endif
+        cb_wait_front(cb_other, onetile);
+
+        cb_reserve_back(cb_out, onetile);
+
+        tile_regs_acquire();
+        tile_regs_wait();
+        copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_post_lhs, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+        for (uint32_t i = 0; i < onetile; ++i) {
+            copy_tile(cb_post_rhs, i, i * 2 + 1);
+
+            // BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+#ifndef INT32_INIT
+            eltwise_binop_tile_init();
+#endif
+
+#ifdef ADD_INT32_INIT
+            ADD_INT32_INIT
+#endif
+#ifdef BITWISE_INIT
+            BITWISE_INIT
+#endif
+#ifdef SHIFT_INIT
+            SHIFT_INIT
+#endif
+
+#ifdef BINARY_SFPU_OP
+            BINARY_SFPU_OP
+#endif
+#ifdef SFPU_OP_INIT_0
+            SFPU_OP_INIT_0
+            SFPU_OP_FUNC_0
+#endif
+
+#ifdef SFPU_OP_CHAIN_0
+            SFPU_OP_CHAIN_0
+#endif
+            tile_regs_commit();
+            pack_tile(i * 2, cb_out);
+        }
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_other, onetile);
+    }
+    cb_pop_front(cb_bcast, onetile);
+}
+
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_pre_lhs = tt::CBIndex::c_0;
+    constexpr auto cb_pre_rhs = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_2;
+
+    constexpr auto cb_post_lhs = PREPROCESS_A ? tt::CBIndex::c_3 : cb_pre_lhs;
+    constexpr auto cb_post_rhs = PREPROCESS_B ? tt::CBIndex::c_4 : cb_pre_rhs;
+
+    // binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+    unary_op_init_common(cb_post_lhs, cb_out);
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, tile_freq, tile_start);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out, remaining_iterations, tile_start);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+// #include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/binary_bitwise_sfpu.h"
+#include "compute_kernel_api/binary_shift.h"
+#include "compute_kernel_api/add_int32_sfpu.h"
+
+#define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
+
+#if defined(ADD_INT32_INIT) || defined(BITWISE_INIT) || defined(SHIFT_INIT)
+#define INT32_INIT
+#endif
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
+    // uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
+    uint32_t per_core_block_size = 1;
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+    constexpr auto cb_inp0 = tt::CBIndex::c_3;
+#else
+    constexpr auto cb_inp0 = cb_in0;
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+    constexpr auto cb_inp1 = tt::CBIndex::c_4;
+#else
+    constexpr auto cb_inp1 = cb_in1;
+#endif
+
+    constexpr auto cb_out0 = tt::CBIndex::c_2;
+
+    unary_op_init_common(cb_in0, cb_out0);
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+#endif
+
+    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
+#if PRE_SCALE
+        copy_tile_to_dst_init_short();  // need to copy from CB to DST to be able to run sfpu math
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+        cb_wait_front(cb_in0, per_core_block_size);
+        cb_reserve_back(cb_inp0, per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN0_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in0, i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN0_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp0);  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_in0, per_core_block_size);
+        cb_push_back(cb_inp0, per_core_block_size);
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+        cb_wait_front(cb_in1, per_core_block_size);
+        cb_reserve_back(cb_inp1, per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN1_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in1, i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN1_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp1);  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_in1, per_core_block_size);
+        cb_push_back(cb_inp1, per_core_block_size);
+#endif
+        cb_wait_front(cb_inp0, per_core_block_size);
+        cb_wait_front(cb_inp1, per_core_block_size);
+        cb_reserve_back(cb_out0, per_core_block_size);
+
+        tile_regs_acquire();
+        tile_regs_wait();
+        copy_tile_to_dst_init_short_with_dt(cb_inp1, cb_inp0);
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_inp0, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_inp0, cb_inp1);
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_inp1, i, i * 2 + 1);
+
+#ifndef INT32_INIT
+            eltwise_binop_tile_init();
+#endif
+
+#ifdef ADD_INT32_INIT
+            ADD_INT32_INIT
+#endif
+#ifdef BITWISE_INIT
+            BITWISE_INIT
+#endif
+#ifdef SHIFT_INIT
+            SHIFT_INIT
+#endif
+
+#ifdef BINARY_SFPU_OP
+            BINARY_SFPU_OP
+#endif
+#ifdef SFPU_OP_INIT_0
+            SFPU_OP_INIT_0
+            SFPU_OP_FUNC_0
+#endif
+
+#ifdef SFPU_OP_CHAIN_0
+            SFPU_OP_CHAIN_0
+#endif
+            pack_tile(i * 2, cb_out0);
+        }
+        tile_regs_commit();
+        tile_regs_release();
+
+        cb_pop_front(cb_inp0, per_core_block_size);
+        cb_pop_front(cb_inp1, per_core_block_size);
+        cb_push_back(cb_out0, per_core_block_size);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+// #include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_binary_sfpu.h"
+#include "compute_kernel_api/binary_bitwise_sfpu.h"
+#include "compute_kernel_api/binary_shift.h"
+#include "compute_kernel_api/add_int32_sfpu.h"
+
+#define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
+
+#if defined(ADD_INT32_INIT) || defined(BITWISE_INIT) || defined(SHIFT_INIT)
+#define INT32_INIT
+#endif
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
+    // uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
+    uint32_t per_core_block_size = 1;
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+    constexpr auto cb_inp0 = tt::CBIndex::c_3;
+#else
+    constexpr auto cb_inp0 = cb_in0;
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+    constexpr auto cb_inp1 = tt::CBIndex::c_4;
+#else
+    constexpr auto cb_inp1 = cb_in1;
+#endif
+
+    constexpr auto cb_out0 = tt::CBIndex::c_2;
+
+    unary_op_init_common(cb_in0, cb_out0);
+
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluType::ZERO_RELU)));
+#endif
+
+    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
+#if PRE_SCALE
+        copy_tile_to_dst_init_short();  // need to copy from CB to DST to be able to run sfpu math
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN0_0
+        cb_wait_front(cb_in0, per_core_block_size);
+        cb_reserve_back(cb_inp0, per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN0_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in0, i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN0_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp0);  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_in0, per_core_block_size);
+        cb_push_back(cb_inp0, per_core_block_size);
+#endif
+
+#ifdef SFPU_OP_INIT_PRE_IN1_0
+        cb_wait_front(cb_in1, per_core_block_size);
+        cb_reserve_back(cb_inp1, per_core_block_size);
+
+        tile_regs_acquire();
+        SFPU_OP_INIT_PRE_IN1_0
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_in1, i, i);  // copy from c_in[0] to DST[0]
+            SFPU_OP_FUNC_PRE_IN1_0
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            pack_tile(i, cb_inp1);  // DST[0]->cb
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_in1, per_core_block_size);
+        cb_push_back(cb_inp1, per_core_block_size);
+#endif
+        cb_wait_front(cb_inp0, per_core_block_size);
+        cb_wait_front(cb_inp1, per_core_block_size);
+        cb_reserve_back(cb_out0, per_core_block_size);
+
+        tile_regs_acquire();
+        tile_regs_wait();
+        copy_tile_to_dst_init_short_with_dt(cb_inp1, cb_inp0);
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_inp0, i, i * 2);
+        }
+        copy_tile_to_dst_init_short_with_dt(cb_inp0, cb_inp1);
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {
+            copy_tile(cb_inp1, i, i * 2 + 1);
+
+#ifndef INT32_INIT
+            eltwise_binop_tile_init();
+#endif
+
+#ifdef ADD_INT32_INIT
+            ADD_INT32_INIT
+#endif
+#ifdef BITWISE_INIT
+            BITWISE_INIT
+#endif
+#ifdef SHIFT_INIT
+            SHIFT_INIT
+#endif
+
+#ifdef BINARY_SFPU_OP
+            BINARY_SFPU_OP
+#endif
+#ifdef SFPU_OP_INIT_0
+            SFPU_OP_INIT_0
+            SFPU_OP_FUNC_0
+#endif
+
+#ifdef SFPU_OP_CHAIN_0
+            SFPU_OP_CHAIN_0
+#endif
+            pack_tile(i * 2, cb_out0);
+        }
+        tile_regs_commit();
+        tile_regs_release();
+
+        cb_pop_front(cb_inp0, per_core_block_size);
+        cb_pop_front(cb_inp1, per_core_block_size);
+        cb_push_back(cb_out0, per_core_block_size);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_defines.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_defines.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define DO_QUOTE(x) #x
+#define QUOTE(x) DO_QUOTE(x)
+
+#if defined(PREPROCESS_A_INIT)
+#define PREPROCESS_A 1
+#else
+#define PREPROCESS_A 0
+#endif
+
+#if defined(PREPROCESS_B_INIT)
+#define PREPROCESS_B 1
+#else
+#define PREPROCESS_B 0
+#endif
+
+#if defined(POSTPROCESS_INIT)
+#define POSTPROCESS 1
+#else
+#define POSTPROCESS 0
+#endif
+
+#ifdef PREPROCESS_A_INCLUDE
+#include QUOTE(PREPROCESS_A_INCLUDE)
+#endif
+
+#ifdef PREPROCESS_B_INCLUDE
+#include QUOTE(PREPROCESS_B_INCLUDE)
+#endif
+
+#ifdef POSTPROCESS_INCLUDE
+#include QUOTE(POSTPROCESS_INCLUDE)
+#endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+#define PREPROCESS(init, apply, cb_pre, cb_post, cb_out, per_core_block_size) \
+    do {                                                                      \
+        using namespace ckernel;                                              \
+                                                                              \
+        copy_tile_to_dst_init_short();                                        \
+                                                                              \
+        reconfig_data_format_srca(/*old*/ cb_post, /*new*/ cb_pre);           \
+        pack_reconfig_data_format(/*old*/ cb_out, /*new*/ cb_post);           \
+                                                                              \
+        cb_wait_front(cb_pre, per_core_block_size);                           \
+        cb_reserve_back(cb_post, per_core_block_size);                        \
+                                                                              \
+        tile_regs_acquire();                                                  \
+        init();                                                               \
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {                  \
+            copy_tile(cb_pre, i, i);                                          \
+            apply(i);                                                         \
+        }                                                                     \
+        tile_regs_commit();                                                   \
+                                                                              \
+        tile_regs_wait();                                                     \
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {                  \
+            pack_tile(i, cb_post); /* DST[0]->cb */                           \
+        }                                                                     \
+        tile_regs_release();                                                  \
+                                                                              \
+        cb_pop_front(cb_pre, per_core_block_size);                            \
+        cb_push_back(cb_post, per_core_block_size);                           \
+                                                                              \
+        reconfig_data_format_srca(/*old*/ cb_pre, /*new*/ cb_post);           \
+        pack_reconfig_data_format(/*old*/ cb_post, /*new*/ cb_out);           \
+    } while (0)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp
@@ -7,6 +7,10 @@
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
+#if defined(ADD_INT32_INIT) || defined(BITWISE_INIT) || defined(SHIFT_INIT)
+#define INT32_INIT
+#endif
+
 #define PREPROCESS(init, apply, cb_pre, cb_post, cb_out, per_core_block_size) \
     do {                                                                      \
         using namespace ckernel;                                              \
@@ -38,4 +42,58 @@
                                                                               \
         reconfig_data_format_srca(/*old*/ cb_pre, /*new*/ cb_post);           \
         pack_reconfig_data_format(/*old*/ cb_post, /*new*/ cb_out);           \
+    } while (0)
+
+#define PREPROCESS_SFPU_A(cb_pre, cb_post, cb_out, per_core_block_size) \
+    do {                                                                \
+        using namespace ckernel;                                        \
+                                                                        \
+        copy_tile_to_dst_init_short();                                  \
+                                                                        \
+        cb_wait_front(cb_pre, per_core_block_size);                     \
+        cb_reserve_back(cb_post, per_core_block_size);                  \
+                                                                        \
+        tile_regs_acquire();                                            \
+        SFPU_OP_INIT_PRE_IN0_0                                          \
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {            \
+            copy_tile(cb_pre, i, i);                                    \
+            SFPU_OP_FUNC_PRE_IN0_0                                      \
+        }                                                               \
+        tile_regs_commit();                                             \
+                                                                        \
+        tile_regs_wait();                                               \
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {            \
+            pack_tile(i, cb_post); /* DST[0]->cb */                     \
+        }                                                               \
+        tile_regs_release();                                            \
+                                                                        \
+        cb_pop_front(cb_pre, per_core_block_size);                      \
+        cb_push_back(cb_post, per_core_block_size);                     \
+    } while (0)
+
+#define PREPROCESS_SFPU_B(cb_pre, cb_post, cb_out, per_core_block_size) \
+    do {                                                                \
+        using namespace ckernel;                                        \
+                                                                        \
+        copy_tile_to_dst_init_short();                                  \
+                                                                        \
+        cb_wait_front(cb_pre, per_core_block_size);                     \
+        cb_reserve_back(cb_post, per_core_block_size);                  \
+                                                                        \
+        tile_regs_acquire();                                            \
+        SFPU_OP_INIT_PRE_IN1_0                                          \
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {            \
+            copy_tile(cb_pre, i, i);                                    \
+            SFPU_OP_FUNC_PRE_IN1_0                                      \
+        }                                                               \
+        tile_regs_commit();                                             \
+                                                                        \
+        tile_regs_wait();                                               \
+        for (uint32_t i = 0; i < per_core_block_size; ++i) {            \
+            pack_tile(i, cb_post); /* DST[0]->cb */                     \
+        }                                                               \
+        tile_regs_release();                                            \
+                                                                        \
+        cb_pop_front(cb_pre, per_core_block_size);                      \
+        cb_push_back(cb_post, per_core_block_size);                     \
     } while (0)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
@@ -17,6 +17,14 @@ FORCE_INLINE void fill_with_val_bfloat16(uint32_t cb_id, uint32_t packed_scalar)
     }
 }
 
+template <uint32_t ElementsV, class ScalarT>
+FORCE_INLINE void fill_with_val(uint32_t cb_id, ScalarT scalar) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr ScalarT*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < ElementsV; ++i) {
+        ptr[i] = scalar;
+    }
+}
+
 // Reads the very first element of the CB and fills the entire tile with that value.
 // Tile is assumed to have 16-bit elements
 FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t cb_id) {
@@ -30,6 +38,19 @@ FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t cb_id) {
     // TODO: should I fill one face like this and then use noc to fill the rest?
     for (uint32_t i = 0; i < 512; ++i) {
         write_ptr[i] = packed_first_elem;
+    }
+}
+
+// Reads the very first element of the CB and fills the entire tile with that value.
+// Tile is assumed to have 32-bit elements (float32 or int32).
+template <typename T>
+FORCE_INLINE void fill_tile_with_first_element(uint32_t cb_id) {
+    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(get_write_ptr(cb_id));
+    const T first_elem = read_ptr[0];
+
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(get_write_ptr(cb_id));
+    for (uint32_t i = 0; i < 1024; ++i) {
+        write_ptr[i] = first_elem;
     }
 }
 
@@ -59,6 +80,30 @@ FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t cb_id) {
     }
 }
 
+// Reads the very first row of the CB and fills the entire tile with the same row.
+// Tile is assumed to have 32-bit elements (float32/int32).
+FORCE_INLINE void fill_tile_with_first_row(uint32_t cb_id) {
+    // Tile with 4 faces (16x16) and 32-bit elements
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+
+    uint32_t row_offset = 16;  // Start at the second row (offset by 16 elements)
+    uint32_t num_rows = 15;    // 15 rows to fill per face
+
+    // Iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += 512) {  // Offset 512 = 256 elements x 2 faces
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            uint32_t dst_offset = face_offset + row_offset;
+            for (uint32_t col = 0; col < 16; ++col) {
+                ptr[dst_offset + col] = ptr[col];              // left face
+                ptr[dst_offset + col + 256] = ptr[col + 256];  // right face
+            }
+            row_offset += 16;  // Move to the next row (16 elements per row)
+        }
+        row_offset = 0;  // Reset for the next face pair
+        num_rows = 16;   // Process all rows for the next face pair
+    }
+}
+
 // Reads the very first column of the CB and fills the entire tile with the same column.
 // Tile is assumed to have 16-bit elements.
 FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t cb_id) {
@@ -79,6 +124,34 @@ FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t cb_id) {
             for (uint32_t col = 1; col < 16; ++col) {
                 ptr[dst_offset + col] = src_val;       // left face
                 ptr[dst_offset + col + 256] = src_val; // right face
+            }
+        }
+    }
+}
+
+// Reads the very first column of the CB and fills the entire tile with the same column.
+// Tile is assumed to have 32-bit elements (float32/int32).
+FORCE_INLINE void fill_tile_with_first_column(uint32_t cb_id) {
+    // Tile with 4 faces (16x16) and 32-bit elements
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+
+    constexpr uint32_t num_rows = 16;             // Number of rows per face
+    constexpr uint32_t face_row_stride = 16;      // Elements per row
+    constexpr uint32_t face_size = 256;           // Total elements per face (16x16)
+    constexpr uint32_t face_offset_stride = 512;  // Total elements per pair of faces (2x16x16)
+
+    // Iterate over face pairs (0,1) and (2,3)
+    for (uint32_t k = 0, face_offset = 0; k < 2; ++k, face_offset += face_offset_stride) {
+        for (uint32_t row = 0, row_offset = 0; row < num_rows; ++row, row_offset += face_row_stride) {
+            uint32_t left_dst_offset = face_offset + row_offset;      // Left face (0 or 2)
+            uint32_t right_dst_offset = left_dst_offset + face_size;  // Right face (1 or 3)
+
+            // Read the first column value for the current row from the left face
+            auto src_val = ptr[left_dst_offset];
+
+            for (uint32_t col = 0; col < face_row_stride; ++col) {
+                ptr[left_dst_offset + col] = src_val;   // left face
+                ptr[right_dst_offset + col] = src_val;  // right face
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_col_bcast.cpp
@@ -49,7 +49,15 @@ void kernel_main() {
                 uint32_t l1_write_addr = get_write_ptr(cb_id_src);
                 noc_async_read_tile(tile_offset + th, src, l1_write_addr);
                 noc_async_read_barrier();
+#ifdef F32_SCALARB
+                fill_tile_with_first_column(cb_id_src);
+#endif
+#ifdef INT32_SCALARB
+                fill_tile_with_first_column(cb_id_src);
+#endif
+#ifdef BF16_SCALARB
                 fill_tile_with_first_column_bfloat16(cb_id_src);
+#endif
                 cb_push_back(cb_id_src, onetile);
 
                 num_tiles_read += Wt - start_tw;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -5,16 +5,17 @@
 #include <stdint.h>
 
 #include "dataflow_api.h"
+#include "debug/dprint.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t start_tile_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    uint32_t HtWt = get_arg_val<uint32_t>(3);
-    uint32_t n_stride = get_arg_val<uint32_t>(4);
-    uint32_t c_stride = get_arg_val<uint32_t>(5);
-    uint32_t N = get_arg_val<uint32_t>(6);
-    uint32_t C = get_arg_val<uint32_t>(7);
+    uint32_t HtWt = get_arg_val<uint32_t>(3);      //  output HtWt
+    uint32_t n_stride = get_arg_val<uint32_t>(4);  // inp A n_stride
+    uint32_t c_stride = get_arg_val<uint32_t>(5);  // inp A c_stride
+    uint32_t N = get_arg_val<uint32_t>(6);         // out N
+    uint32_t C = get_arg_val<uint32_t>(7);         // out C
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
 
@@ -32,15 +33,26 @@ void kernel_main() {
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
+    DPRINT << "tiles_per_batch " << tiles_per_batch << ENDL();
+    DPRINT << "start_n " << start_n << ENDL();
+    DPRINT << "start_remaining " << start_remaining << ENDL();
+    DPRINT << "start_c " << start_c << ENDL();
+    DPRINT << "start_t " << start_t << ENDL();
+
     // this is the INPUT tile offset
     uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
 
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
+    DPRINT << "tile_offset " << tile_offset << ENDL();
+
+    uint32_t next_channel_shift = c_stride - HtWt;        // 4 -4 = 0 for no C bcast, -4 for C bcast
+    uint32_t next_batch_shift = n_stride - c_stride * C;  // -12 for N bcast, 12 - 12 = 0 for no N bcast
 
     uint32_t num_tiles_read = 0;
-    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
-        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {  // runs 0 to N-1
+        DPRINT << "entering rd loop N " << n << ENDL();
+        DPRINT << "next_batch_shift " << next_batch_shift << ENDL();
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {  // runs 0 to C-1
+            DPRINT << "next_channel_shift " << next_channel_shift << ENDL();
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
                 cb_reserve_back(cb_id_src, onetile);
                 uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
@@ -49,7 +61,9 @@ void kernel_main() {
                 cb_push_back(cb_id_src, onetile);
             }
             tile_offset += next_channel_shift;
+            DPRINT << "next_channel_shift tile_offset " << tile_offset << ENDL();
         }
         tile_offset += next_batch_shift;
+        DPRINT << "next_batch_shift tile_offset " << tile_offset << ENDL();
     }
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_row_bcast.cpp
@@ -50,7 +50,15 @@ void kernel_main() {
                     uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
                     noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
                     noc_async_read_barrier();
+#ifdef F32_SCALARB
+                    fill_tile_with_first_row(cb_id_src);
+#endif
+#ifdef INT32_SCALARB
+                    fill_tile_with_first_row(cb_id_src);
+#endif
+#ifdef BF16_SCALARB
                     fill_tile_with_first_row_bfloat16(cb_id_src);
+#endif
                     cb_push_back(cb_id_src, onetile);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -45,9 +45,16 @@ void kernel_main() {
             uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
             noc_async_read_tile(tile_offset, src, l1_write_addr_src);
             noc_async_read_barrier();
+#ifdef F32_SCALARB
+            fill_tile_with_first_element<float>(cb_id_src);  // For float32 data
+#endif
+#ifdef INT32_SCALARB
+            fill_tile_with_first_element<int32_t>(cb_id_src);  // For int32 data
+#endif
+#ifdef BF16_SCALARB
             fill_tile_with_first_element_bfloat16(cb_id_src);
+#endif
             cb_push_back(cb_id_src, onetile);
-
             num_tiles_read += HtWt - start_t;
             tile_offset += c_stride;
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_col_bcast.cpp
@@ -59,7 +59,15 @@ void kernel_main() {
                 uint32_t l1_write_addr = get_write_ptr(cb_id_src);
                 noc_async_read_tile(tile_offset + th, src, l1_write_addr);
                 noc_async_read_barrier();
+#ifdef F32_SCALARB
+                fill_tile_with_first_column(cb_id_src);
+#endif
+#ifdef INT32_SCALARB
+                fill_tile_with_first_column(cb_id_src);
+#endif
+#ifdef BF16_SCALARB
                 fill_tile_with_first_column_bfloat16(cb_id_src);
+#endif
                 cb_push_back(cb_id_src, onetile);
 
                 for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < num_tiles; ++tw, ++num_tiles_written) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_row_bcast.cpp
@@ -60,7 +60,15 @@ void kernel_main() {
                     uint32_t l1_write_addr = get_write_ptr(cb_id_src);
                     noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
                     noc_async_read_barrier();
+#ifdef F32_SCALARB
+                    fill_tile_with_first_row(cb_id_src);
+#endif
+#ifdef INT32_SCALARB
+                    fill_tile_with_first_row(cb_id_src);
+#endif
+#ifdef BF16_SCALARB
                     fill_tile_with_first_row_bfloat16(cb_id_src);
+#endif
                     cb_push_back(cb_id_src, onetile);
 
                     // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -7,9 +7,8 @@
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
-
 void kernel_main() {
-    uint32_t packed_scalar = get_arg_val<uint32_t>(0);
+    uint32_t packed_scalar = get_arg_val<uint32_t>(0);  // u.u32 or packed_scalar
     uint32_t dst_addr = get_arg_val<uint32_t>(1);
     uint32_t start_tile_id = get_arg_val<uint32_t>(2);
     uint32_t num_tiles = get_arg_val<uint32_t>(3);
@@ -39,7 +38,16 @@ void kernel_main() {
 
     // we only need to fill a tile with the scalar value once
     cb_reserve_back(cb_id_src, onetile);
+#ifdef F32_SCALARB
+    float* float_ptr = reinterpret_cast<float*>(&packed_scalar);
+    fill_with_val<1024, float>(cb_id_src, *float_ptr);
+#endif
+#ifdef INT32_SCALARB
+    fill_with_val<1024, int32_t>(cb_id_src, packed_scalar);
+#endif
+#ifdef BF16_SCALARB
     fill_with_val_bfloat16(cb_id_src, packed_scalar);
+#endif
     cb_push_back(cb_id_src, onetile);
 
     uint32_t num_tiles_written = 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_bcast.cpp
@@ -54,7 +54,15 @@ void kernel_main() {
             uint32_t l1_write_addr = get_write_ptr(cb_id_src);
             noc_async_read_tile(tile_offset, src, l1_write_addr);
             noc_async_read_barrier();
+#ifdef F32_SCALARB
+            fill_tile_with_first_element<float>(cb_id_src);
+#endif
+#ifdef INT32_SCALARB
+            fill_tile_with_first_element<int32_t>(cb_id_src);
+#endif
+#ifdef BF16_SCALARB
             fill_tile_with_first_element_bfloat16(cb_id_src);
+#endif
             cb_push_back(cb_id_src, onetile);
 
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
@@ -10,7 +10,6 @@ enum class BinaryOpType {
     ADD,
     SUB,
     MUL,
-    DIV,
     GT,
     LT,
     LTE,
@@ -25,5 +24,13 @@ enum class BinaryOpType {
     LDEXP,
     LOGADDEXP,
     LOGADDEXP2,
+    DIV,
+    RSUB,
+    POWER,
+    BITWISE_XOR,
+    BITWISE_AND,
+    BITWISE_OR,
+    LEFT_SHIFT,
+    RIGHT_SHIFT
 };
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
@@ -10,6 +10,7 @@ enum class BinaryOpType {
     ADD,
     SUB,
     MUL,
+    DIV,
     GT,
     LT,
     LTE,
@@ -18,13 +19,11 @@ enum class BinaryOpType {
     NE,
     SQUARED_DIFFERENCE,
     BIAS_GELU,
-    LOGADDEXP,
     LOGICAL_AND,
     LOGICAL_OR,
     LOGICAL_XOR,
     LDEXP,
+    LOGADDEXP,
     LOGADDEXP2,
-    DIV_FAST
 };
-
 }

--- a/ttnn/ttnn/operations/binary_ng.py
+++ b/ttnn/ttnn/operations/binary_ng.py
@@ -8,6 +8,7 @@ import torch
 
 ttnn.attach_golden_function(ttnn.experimental.add, golden_function=lambda a, b: a + b)
 ttnn.attach_golden_function(ttnn.experimental.sub, golden_function=lambda a, b: a - b)
+ttnn.attach_golden_function(ttnn.experimental.rsub, golden_function=lambda a, b: b - a)
 ttnn.attach_golden_function(ttnn.experimental.mul, golden_function=lambda a, b: a * b)
 ttnn.attach_golden_function(ttnn.experimental.div, golden_function=lambda a, b: torch.divide(a, b))
 ttnn.attach_golden_function(ttnn.experimental.eq, golden_function=lambda a, b: torch.eq(a, b))

--- a/ttnn/ttnn/operations/binary_ng.py
+++ b/ttnn/ttnn/operations/binary_ng.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+
+
+ttnn.attach_golden_function(ttnn.experimental.add, golden_function=lambda a, b: a + b)
+ttnn.attach_golden_function(ttnn.experimental.sub, golden_function=lambda a, b: a - b)
+ttnn.attach_golden_function(ttnn.experimental.mul, golden_function=lambda a, b: a * b)
+ttnn.attach_golden_function(ttnn.experimental.div, golden_function=lambda a, b: torch.divide(a, b))
+ttnn.attach_golden_function(ttnn.experimental.eq, golden_function=lambda a, b: torch.eq(a, b))
+ttnn.attach_golden_function(ttnn.experimental.ne, golden_function=lambda a, b: torch.ne(a, b))
+ttnn.attach_golden_function(ttnn.experimental.gt, golden_function=lambda a, b: torch.gt(a, b))
+ttnn.attach_golden_function(ttnn.experimental.lt, golden_function=lambda a, b: torch.lt(a, b))
+ttnn.attach_golden_function(ttnn.experimental.gte, golden_function=lambda a, b: torch.ge(a, b))
+ttnn.attach_golden_function(ttnn.experimental.lte, golden_function=lambda a, b: torch.le(a, b))
+ttnn.attach_golden_function(ttnn.experimental.ldexp, golden_function=lambda a, b: torch.ldexp(a, b))
+ttnn.attach_golden_function(ttnn.experimental.logaddexp, golden_function=lambda a, b: torch.logaddexp(a, b))
+ttnn.attach_golden_function(ttnn.experimental.logaddexp2, golden_function=lambda a, b: torch.logaddexp2(a, b))
+ttnn.attach_golden_function(ttnn.experimental.logical_and, golden_function=lambda a, b: torch.logical_and(a, b))
+ttnn.attach_golden_function(ttnn.experimental.logical_or, golden_function=lambda a, b: torch.logical_or(a, b))
+ttnn.attach_golden_function(ttnn.experimental.logical_xor, golden_function=lambda a, b: torch.logical_xor(a, b))
+ttnn.attach_golden_function(
+    ttnn.experimental.squared_difference, golden_function=lambda a, b: torch.square(torch.sub(a, b))
+)
+ttnn.attach_golden_function(
+    ttnn.experimental.bias_gelu, golden_function=lambda a, b: torch.nn.functional.gelu(torch.add(a, b))
+)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Binary_ng only supports bfloat16.

### What's changed
Add binary sfpu with float32 support to binary_ng 
Note:
This work is dependant on PR https://github.com/tenstorrent/tt-metal/pull/16068 which hopefully merges to main soon.
this WIP has lot's of prints and comments for understanding

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
