### PR TITLE
Fix wrong output tensor shape for prod

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -123,5 +123,7 @@ def run(
     e2e_perf = stop_measuring_time(start_time)
 
     pcc = check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
+    assert output_tensor.shape == torch_output_tensor.shape
     # print(f"input_shape {input_shape} pcc {pcc}")
     return [pcc, e2e_perf]

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -70,3 +70,28 @@ def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("c", [11])
+@pytest.mark.parametrize("h", [67])
+@pytest.mark.parametrize("w", [77])
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("keepdim", [True])
+def test_prod(device, batch_size, c, h, w, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.float32)
+    torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+
+    output_tensor = ttnn.prod(input_tensor, dim=dim, memory_config=ttnn.L1_MEMORY_CONFIG)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
+    assert output_tensor.shape == torch_output_tensor.shape
+    # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -81,7 +81,7 @@ def test_sum_4d_tensors(device, batch_size, c, h, w, dim, keepdim):
 def test_prod(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.float32)
+    torch_input_tensor = torch.randn((batch_size, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.prod(torch_input_tensor, dim=dim, keepdim=keepdim)
 
     input_tensor = ttnn.from_torch(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -59,7 +59,7 @@ inline Tensor prod_nc(const Tensor& temp, int64_t dim, const MemoryConfig& outpu
     }
     // Apply prod
     ttnn::SmallVector<int64_t> dimension = {(dim == 1 || dim == -3) ? 1 : 0};
-    tt::tt_metal::LegacyShape input_shape = formatted_input_tensor.get_legacy_shape();
+    const auto input_shape = formatted_input_tensor.get_shape();
     std::array<uint32_t, 4> required = {
         ((dim == 1 || dim == -3) ? input_shape[0] : 1),
         ((dim == 1 || dim == -3) ? 1 : input_shape[1]),
@@ -105,7 +105,7 @@ Tensor ProdOperation::invoke(
     } else if (dim == 2 || dim == -2) {
         ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
         Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
-        tt::tt_metal::LegacyShape input_shape = input_a.get_legacy_shape();
+        const auto input_shape = input_a.get_shape();
         ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[3]};
         return ttnn::slice(DefaultQueueId, required, start_index, end_index, step, std::nullopt);
@@ -114,7 +114,7 @@ Tensor ProdOperation::invoke(
         ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
         Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
         // unpad
-        tt::tt_metal::LegacyShape input_shape = input_a.get_legacy_shape();
+        const auto input_shape = input_a.get_shape();
         ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
         Tensor new_unpad_tensor = ttnn::slice(DefaultQueueId, required, start_index, end_index, step, std::nullopt);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14275

### Problem description
Wrong output dimensions for prod operation

### What's changed
Other reduction operations use 'get_shape()' but prod operation use 'get_legacy_shape()'. So replaced all instances with 'get_shape'

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12530540614
- [x] Blackhole Post commit (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12519787646
- [x] Model regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12519790668
- [x] Device performance regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12519793444
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
