### PR TITLE
Dispatch and routing kernels. Disable debug counters.

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -249,7 +249,7 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
 }
 
 void process_exec_buf_end_h() {
-    if (split_prefetch) {
+    if constexpr (split_prefetch) {
         invalidate_l1_cache();
         volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
             get_semaphore<fd_core_type>(prefetch_h_local_downstream_sem_addr));
@@ -574,7 +574,7 @@ void process_write_packed(
     uint32_t writes = 0;
     uint32_t mcasts = 0;
     auto wait_for_barrier = [&]() {
-        if (!mcast) {
+        if constexpr (!mcast) {
             return;
         }
         noc_nonposted_writes_num_issued[noc_index] += writes;
@@ -993,7 +993,7 @@ re_run_command:
 
         case CQ_DISPATCH_CMD_WRITE_LINEAR_H:
             DPRINT << "cmd_write_linear_h\n";
-            if (is_h_variant) {
+            if constexpr (is_h_variant) {
                 process_write(block_noc_writes_to_clear, block_next_start_addr);
             } else {
                 relay_write_h(block_noc_writes_to_clear, block_next_start_addr);
@@ -1002,7 +1002,7 @@ re_run_command:
 
         case CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST:
             DPRINT << "cmd_write_linear_h_host\n";
-            if (is_h_variant) {
+            if constexpr (is_h_variant) {
                 process_write_host_h(block_noc_writes_to_clear, block_next_start_addr);
             } else {
                 process_write_host_d(block_noc_writes_to_clear, block_next_start_addr);
@@ -1062,7 +1062,7 @@ re_run_command:
 
         case CQ_DISPATCH_CMD_EXEC_BUF_END:
             DPRINT << "cmd_exec_buf_end\n";
-            if (is_h_variant) {
+            if constexpr (is_h_variant) {
                 process_exec_buf_end_h();
             } else {
                 process_exec_buf_end_d(block_noc_writes_to_clear, block_next_start_addr);
@@ -1094,7 +1094,7 @@ re_run_command:
 
         case CQ_DISPATCH_CMD_TERMINATE:
             DPRINT << "dispatch terminate\n";
-            if (is_d_variant && !is_h_variant) {
+            if constexpr (is_d_variant && !is_h_variant) {
                 relay_to_next_cb<split_dispatch_page_preamble_size>(
                     cmd_ptr, sizeof(CQDispatchCmd), block_noc_writes_to_clear, block_next_start_addr);
             }
@@ -1226,7 +1226,7 @@ void kernel_main() {
 
     noc_async_write_barrier();
 
-    if (is_h_variant && !is_d_variant) {
+    if constexpr (is_h_variant && !is_d_variant) {
         // Set upstream semaphore MSB to signal completion and path teardown
         // in case dispatch_h is connected to a depacketizing stage.
         // TODO: This should be replaced with a signal similar to what packetized

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -452,10 +452,8 @@ static uint32_t write_pages_to_dispatcher(
 
     // Grabbing all pages at once is ok if scratch_size < 3 * downstream_cb_block_size
     // test_for_nonzero is an optimization: inner loops moving lots of pages don't bother
-    if constexpr (!test_for_nonzero) {
-        if (npages != 0) {
-            cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(npages);
-        }
+    if (!test_for_nonzero || npages != 0) {
+        cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(npages);
     }
 
     uint64_t noc_addr;
@@ -1157,7 +1155,7 @@ bool process_cmd(
                 uint32_t is_dram = packed_page_flags & (1 << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT);
                 uint32_t start_page = (packed_page_flags >> CQ_PREFETCH_RELAY_PAGED_START_PAGE_SHIFT) &
                                       CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK;
-                if constexpr (is_dram) {
+                if (is_dram) {
                     stride = process_relay_paged_cmd<true>(cmd_ptr, downstream_data_ptr, start_page);
                 } else {
                     stride = process_relay_paged_cmd<false>(cmd_ptr, downstream_data_ptr, start_page);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Need to disable debug info / kernel status code in the routing kernels in prod. They are only used for testing.

### What's changed
- Make `if`s constexpr in dispatch and prefetch kernels
- In the packet queue kernels, timeout cycles can be made `constexpr`. Additionally, the kernel debug status info such as word counter doesn't need to be incremented in prod because nobody will check them. They are only used in test so properly disabling them by passing in an address of 0 should help speed it up a little.
- Writing to L1[0] is already invalid

### Next
- Go into the FDKernels and set the test results address / kernel status to 0 to disable the counting.

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12524321303
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
