### PR TITLE
Remove more namespace pollution caused by `using namespace tt::tt_metal` in header file

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void DemuxKernel::GenerateStaticConfigs() {
     uint16_t channel =
         tt::Cluster::instance().get_assigned_channel_for_device(servicing_device_id_);  // TODO: this can be mmio

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -10,6 +10,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void DispatchKernel::GenerateStaticConfigs() {
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void DispatchSKernel::GenerateStaticConfigs() {
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void EthRouterKernel::GenerateStaticConfigs() {
     auto& my_dispatch_constants = dispatch_constants::get(GetCoreType());
     if (as_mux_) {

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void EthTunnelerKernel::GenerateStaticConfigs() {
     chip_id_t downstream_device_id = FDKernel::GetDownstreamDeviceId(device_id_);
     // For MMIO devices, the above function just gets one of the possible downstream devices, we've populated this

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -15,6 +15,8 @@
 #include "eth_router.hpp"
 #include "eth_tunneler.hpp"
 
+using namespace tt::tt_metal;
+
 // Helper function to get upstream device in the tunnel from current device, not valid for mmio
 chip_id_t FDKernel::GetUpstreamDeviceId(chip_id_t device_id) {
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -74,13 +74,15 @@ public:
         chip_id_t servicing_device_id,
         uint8_t cq_id,
         noc_selection_t noc_selection,
-        DispatchWorkerType type);
+        tt::tt_metal::DispatchWorkerType type);
 
     // Register another kernel as upstream/downstream of this one
     void AddUpstreamKernel(FDKernel* upstream) { upstream_kernels_.push_back(upstream); }
     void AddDownstreamKernel(FDKernel* downstream) { downstream_kernels_.push_back(downstream); }
 
-    virtual CoreType GetCoreType() { return dispatch_core_manager::instance().get_dispatch_core_type(device_->id()); }
+    virtual CoreType GetCoreType() {
+        return tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(device_->id());
+    }
     tt_cxy_pair GetLogicalCore() { return logical_core_; }
     tt_cxy_pair GetVirtualCore() {
         return tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(logical_core_, GetCoreType());
@@ -90,7 +92,7 @@ public:
     // Get the port index for which a given kernel is upstream/downstream of this one
     int GetUpstreamPort(FDKernel* other) { return GetPort(other, this->upstream_kernels_); }
     int GetDownstreamPort(FDKernel* other) { return GetPort(other, this->downstream_kernels_); }
-    void AddDeviceAndProgram(Device* device, Program* program) {
+    void AddDeviceAndProgram(tt::tt_metal::Device* device, tt::tt_metal::Program* program) {
         device_ = device;
         program_ = program;
     };
@@ -118,8 +120,8 @@ protected:
     static chip_id_t GetDownstreamDeviceId(chip_id_t device_id);
     static uint32_t GetTunnelStop(chip_id_t device_id);
 
-    Device* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
-    Program* program_ = nullptr;
+    tt::tt_metal::Device* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
+    tt::tt_metal::Program* program_ = nullptr;
     tt_cxy_pair logical_core_;
     chip_id_t device_id_;
     chip_id_t servicing_device_id_;  // Remote chip that this PREFETCH_H/DISPATCH_H is servicing

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void MuxKernel::GenerateStaticConfigs() {
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
     logical_core_ = dispatch_core_manager::instance().mux_d_core(device_->id(), channel, this->cq_id_);

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+using namespace tt::tt_metal;
+
 void PrefetchKernel::GenerateStaticConfigs() {
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -18,6 +18,8 @@
 #define DISPATCH_MAX_UPSTREAM 4
 #define DISPATCH_MAX_DOWNSTREAM 4
 
+using namespace tt::tt_metal;
+
 typedef struct {
     int id;
     chip_id_t device_id;                          // Device that this kernel is located on

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -9,7 +9,7 @@
 void populate_fd_kernels(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs);
 
 // Fill out all settings for FD kernels on the given device, and add them to a Program and return it.
-std::unique_ptr<Program> create_and_compile_cq_program(Device* device);
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(tt::tt_metal::Device* device);
 
 // Performa additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
-void configure_dispatch_cores(Device* device);
+void configure_dispatch_cores(tt::tt_metal::Device* device);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -23,10 +23,12 @@
 
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
+
 using namespace tt::constants;
+using namespace tt::tt_metal;
+
 namespace optimized_conv_op_utils {
 using namespace tt;
-using namespace tt::tt_metal;
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(
     const tt::tt_metal::LegacyShape& conv_activation_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -6,6 +6,7 @@
 #include "pad_op.hpp"
 #include "pad_program_factory.hpp"
 
+using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 void Pad::validate_with_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -54,9 +54,9 @@ struct PermuteDeviceOperation {
     struct MultiCoreBlockedGeneric {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
         struct shared_variables_t {
-            KernelHandle unary_reader_kernel_id;
-            KernelHandle unary_writer_kernel_id;
-            KernelHandle compute_kernel_id;
+            tt::tt_metal::KernelHandle unary_reader_kernel_id;
+            tt::tt_metal::KernelHandle unary_writer_kernel_id;
+            tt::tt_metal::KernelHandle compute_kernel_id;
             CoreRangeSet core_range;
         };
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.cpp
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 
+using namespace tt::tt_metal;
+
 namespace ttnn {
 
 void RM_RESHAPE_STRUCT::validate(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_op.hpp
@@ -11,21 +11,20 @@ namespace ttnn {
 
 struct RM_RESHAPE_STRUCT {
     const ttnn::Shape output_shape;
-    MemoryConfig output_mem_config;
-
+    tt::tt_metal::MemoryConfig output_mem_config;
 
     //Required functions to all tensor op functions
     void update_structure (const Tensor& input_tensor);
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<SimpleShape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 
 
 }// namespace ttnn
 namespace ttnn::operations::data_movement::rm_reshape{
 
-operation::ProgramWithCallbacks rm_reshape_preparer(const Tensor& input, const Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks rm_reshape_preparer(const Tensor& input, const Tensor& output);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.hpp
@@ -8,7 +8,7 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
     const Tensor& a,
     const Tensor& output,
     bool is_l1_aligned = false,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
@@ -23,7 +23,7 @@ struct SliceDeviceOperation {
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.hpp
@@ -7,7 +7,7 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks slice_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks slice_multi_core(
     const Tensor& a,
     Tensor& output,
     const tt::tt_metal::LegacyShape& output_tensor_start,

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.hpp
@@ -17,7 +17,7 @@ struct SplitDeviceOperation {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.hpp
@@ -6,6 +6,6 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
+tt::tt_metal::operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
     const Tensor& input_tensor, std::vector<Tensor>& output_tensors, const tt::tt_metal::MemoryConfig& mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -14,6 +14,7 @@
 #include "noc/noc_parameters.h"  // DRAM_ALIGNMENT
 
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.hpp
@@ -20,7 +20,7 @@ struct Transpose {
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     TransposeOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.hpp
@@ -4,14 +4,14 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor& output);
-operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor& a, Tensor& output);
-operation::ProgramWithCallbacks transpose_wh_multi_core_sharded_rm(const Tensor& a, Tensor& output);
-operation::ProgramWithCallbacks transpose_hc_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks transpose_wh_multi_core_sharded_rm(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks transpose_hc_multi_core(
     const Tensor& a, Tensor& output, const std::optional<float>& pad_value);
-operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
+tt::tt_metal::operation::ProgramWithCallbacks transpose_hc_multi_core_tiled_interleaved(
     const Tensor& a, Tensor& output, const std::optional<float>& pad_value);
-operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor& a, Tensor& output);
-operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor& a, Tensor& output);
+tt::tt_metal::operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor& a, Tensor& output);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -18,7 +18,7 @@ uint32_t get_num_cores(CoreCoord grid_size, uint32_t nblocks);
 }  // namespace untilize_helpers
 
 struct Untilize {
-    const MemoryConfig output_mem_config;
+    const tt::tt_metal::MemoryConfig output_mem_config;
     const bool use_multicore;
     const bool use_pack_untilize;
     const bool fp32_dest_acc_en;
@@ -27,7 +27,7 @@ struct Untilize {
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.hpp
@@ -8,10 +8,10 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks untilize_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_multi_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
-operation::ProgramWithCallbacks untilize_single_core(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.hpp
@@ -16,7 +16,7 @@ struct UntilizeWithHaloV2 {
     const uint32_t pad_val_;
     const uint32_t ncores_nhw_;
     const uint32_t max_out_nsticks_per_core_;
-    const MemoryConfig out_mem_config_;
+    const tt::tt_metal::MemoryConfig out_mem_config_;
     const bool remote_read_;
     const bool transpose_mcast_;
 
@@ -24,7 +24,7 @@ struct UntilizeWithHaloV2 {
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.hpp
@@ -8,7 +8,7 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     Program& program,
     const Tensor& input_tensor,
     const uint32_t pad_val,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -8,6 +8,8 @@
 #include "ttnn/run_operation.hpp"
 #include "untilize_with_unpadding_program_factory.hpp"
 
+using namespace tt::tt_metal;
+
 namespace ttnn::operations::data_movement {
 
 void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -22,7 +22,7 @@ struct UntilizeWithUnpadding {
     std::vector<tt::tt_metal::LegacyShape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.hpp
@@ -8,17 +8,17 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
-operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
 // This purely supports input block shard -> output interleaved for now
-operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
-operation::ProgramWithCallbacks untilize_with_unpadding_multi_core(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_with_unpadding_multi_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -8,6 +8,8 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/cpp/ttnn/tensor/types.hpp"
 
+using namespace tt::tt_metal;
+
 namespace ttnn::operations::binary::utils {
 
 using ttnn::operations::unary::UnaryOpType;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -11,6 +11,8 @@
 #include "tt_metal/host_api.hpp"
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 
+using namespace tt::tt_metal;
+
 namespace ttnn::operations::binary {
 
 namespace utils {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
@@ -19,16 +19,16 @@ namespace ttnn::operations::binary {
 
 template <bool initialize_args>
 inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
-    Program& program,
+    tt::tt_metal::Program& program,
     const Tensor& a,
     const Tensor& b,
     const Tensor& output,
-    const KernelHandle binary_reader_kernel_id,
-    const KernelHandle unary_writer_kernel_id,
-    const KernelHandle eltwise_binary_kernel_id,
-    const CBHandle cb_src0,
-    const CBHandle cb_src1,
-    const CBHandle cb_output,
+    const tt::tt_metal::KernelHandle binary_reader_kernel_id,
+    const tt::tt_metal::KernelHandle unary_writer_kernel_id,
+    const tt::tt_metal::KernelHandle eltwise_binary_kernel_id,
+    const tt::tt_metal::CBHandle cb_src0,
+    const tt::tt_metal::CBHandle cb_src1,
+    const tt::tt_metal::CBHandle cb_output,
     const CoreRangeSet& all_device_cores,
     const uint32_t src0_single_tile_size,
     const uint32_t src1_single_tile_size,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -4,6 +4,8 @@
 
 #include "binary_ng_device_operation.hpp"
 
+using namespace tt::tt_metal;
+
 namespace ttnn::operations::binary_ng {
 
 SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint32_t b_h, uint32_t b_w) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -32,7 +32,7 @@ struct BinaryNgDeviceOperation {
     struct operation_attributes_t {
         BinaryOpType binary_op_type;
         std::optional<float> scalar;
-        MemoryConfig memory_config;
+        tt::tt_metal::MemoryConfig memory_config;
         DataType input_dtype;
         std::optional<DataType> dtype;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
@@ -50,9 +50,9 @@ struct BinaryNgDeviceOperation {
 
     struct ProgramFactory {
         struct shared_variables_t {
-            KernelHandle reader_kernel_id;
-            KernelHandle writer_kernel_id;
-            KernelHandle compute_kernel_id;
+            tt::tt_metal::KernelHandle reader_kernel_id;
+            tt::tt_metal::KernelHandle writer_kernel_id;
+            tt::tt_metal::KernelHandle compute_kernel_id;
             CoreCoord compute_with_storage_grid_size;
         };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -6,6 +6,8 @@
 #include "tt_metal/common/work_split.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 
+using namespace tt::tt_metal;
+
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
@@ -7,6 +7,8 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 
+using namespace tt::tt_metal;
+
 namespace ttnn::operations::kv_cache {
 
 using namespace tt::constants;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.hpp
@@ -40,7 +40,7 @@ struct UpdateCache {
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 
-    const operation::Hash compute_program_hash(const std::vector<Tensor>& input_tensors) const;
+    const tt::tt_metal::operation::Hash compute_program_hash(const std::vector<Tensor>& input_tensors) const;
 };
 
 inline Tensor fill_cache_impl(const Tensor& cache_tensor, const Tensor& input_tensor, const uint32_t batch_idx) {
@@ -51,7 +51,7 @@ inline Tensor fill_cache_impl(const Tensor& cache_tensor, const Tensor& input_te
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            return operation::run(UpdateCache{batch_idx, 0, 0, UpdateCacheOpType::FILL}, input_tensors);
+            return tt::tt_metal::operation::run(UpdateCache{batch_idx, 0, 0, UpdateCacheOpType::FILL}, input_tensors);
         },
         {cache_tensor, input_tensor},
         dummy_output_tensors);
@@ -66,7 +66,7 @@ inline Tensor update_cache_impl(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
     std::vector<Tensor> dummy_output_tensors = {
         Tensor(tt::tt_metal::operation::get_workers_for_op_output({cache_tensor, input_tensor}))};
-    operation::launch_op(
+    tt::tt_metal::operation::launch_op(
         [update_idx, batch_offset, compute_kernel_config](
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
@@ -75,7 +75,7 @@ inline Tensor update_cache_impl(
             auto& input_tensor = input_tensors.at(1);
             auto kernel_config_val =
                 init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
-            return operation::run(
+            return tt::tt_metal::operation::run(
                 UpdateCache{0, update_idx, batch_offset, UpdateCacheOpType::UPDATE, kernel_config_val},
                 {cache_tensor, input_tensor});
         },

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -10,6 +10,8 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 
+using namespace tt::tt_metal;
+
 namespace ttnn::operations::kv_cache {
 
 using namespace tt::constants;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -164,7 +164,7 @@ using MatmulProgramConfig = std::variant<
 struct Matmul {
     const std::optional<const MatmulProgramConfig> program_config = std::nullopt;
     const std::optional<bool> bcast_batch = std::nullopt;
-    const MemoryConfig output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
+    const MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
     const std::optional<DataType> output_dtype = std::nullopt;
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
     const bool untilize_out = false;
@@ -185,7 +185,7 @@ struct Matmul {
     std::vector<Tensor> create_output_tensors(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<Tensor>>& optional_output_tensors = {std::nullopt}) const;
-    operation::ProgramWithCallbacks create_program(
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
@@ -201,7 +201,7 @@ Matmul create_matmul_struct(
     const struct Matmul& parameters,
     const std::vector<std::optional<Tensor>>& optional_output_tensors = {std::nullopt});
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helper(
+tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -212,7 +212,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helpe
     const MatmulProgramConfig& program_config,
     bool untilize_out,
     std::optional<ttnn::experimental::ccl::MatmulFusedOpSignaler>& fused_op_signaler);
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_helper(
+tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,


### PR DESCRIPTION
### Ticket
#11568 

### Problem description
See issue

### What's changed
In CPP files I am adding `using namespace tt::tt_metal` to minimize the diff and avoid merge conflicts.
In header files, I am fully qualifying types with tt::tt_metal.

### Checklist

https://github.com/tenstorrent/tt-metal/actions/runs/12528590180

- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
