### PR TITLE
Increase number of cores used to calculate upsample for UNET

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -17,7 +17,7 @@ from models.utility_functions import (
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 2, 1035.0),),
+    ((1, 2, 978.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -343,7 +343,7 @@ def test_unet_trace_2cq_multi_device(
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
+    "device_params", [{"l1_small_size": 68864, "trace_region_size": 442368, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -17,14 +17,13 @@ def nearest_16(x):
 
 
 def determine_num_cores_for_upsample(nhw: int, width: int, max_cores=64) -> int:
-    gcd_nhw_width = math.gcd(nhw, width)
-    cores = nhw // gcd_nhw_width
-    if cores > max_cores:
-        for divisor in range(max_cores, 0, -1):
-            if nhw % divisor == 0 and (nhw // divisor) % width == 0:
-                cores = divisor
-                break
-    return cores
+    max_nshards = min(nhw, max_cores)
+    nshards = max_nshards
+    while nshards > 0:
+        if nhw % nshards == 0:
+            break
+        nshards -= 1
+    return nshards
 
 
 def get_core_grid_from_num_cores(num_cores: int, grid_rows: int = 8, grid_cols: int = 8):


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Currently, Upsample processes one row per core, which can impact the performance.

### What's changed
Instead single row per core granularity, make it work for minimum possible shard size for each core. More than 5% of perf improvement is seen.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
