### PR TITLE
#0: Don't return shared ptrs of global sems/cbs, and directly return the object instead

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -25,8 +25,8 @@ TEST_F(DispatchFixture, TensixCreateGlobalCircularBuffers) {
         sender_receiver_core_mapping[CoreCoord(0, 0)] = cores;
         auto global_cb = tt::tt_metal::v1::experimental::CreateGlobalCircularBuffer(
             device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
-        auto buffer_address = global_cb->buffer_address();
-        auto config_address = global_cb->config_address();
+        auto buffer_address = global_cb.buffer_address();
+        auto config_address = global_cb.config_address();
     }
     {
         std::unordered_map<CoreCoord, CoreRangeSet> sender_receiver_core_mapping;
@@ -84,14 +84,14 @@ TEST_F(DispatchFixture, TensixProgramGlobalCircularBuffers) {
         EXPECT_THROW(global_cb_config.remote_index(2), std::exception);
         EXPECT_THROW(
             tt::tt_metal::v1::experimental::CreateCircularBuffer(
-                program, CoreRangeSet(CoreRange({3, 3})), global_cb_config, *global_cb),
+                program, CoreRangeSet(CoreRange({3, 3})), global_cb_config, global_cb),
             std::exception);
         auto remote_cb =
-            tt::tt_metal::v1::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, *global_cb);
+            tt::tt_metal::v1::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
         tt::tt_metal::detail::CompileProgram(device, program);
         program.finalize(device);
-        tt::tt_metal::v1::experimental::UpdateDynamicCircularBufferAddress(program, remote_cb, *global_cb);
-        EXPECT_THROW(UpdateDynamicCircularBufferAddress(program, remote_cb, *dummy_global_cb), std::exception);
+        tt::tt_metal::v1::experimental::UpdateDynamicCircularBufferAddress(program, remote_cb, global_cb);
+        EXPECT_THROW(UpdateDynamicCircularBufferAddress(program, remote_cb, dummy_global_cb), std::exception);
     }
     {
         tt::tt_metal::Program program = CreateProgram();
@@ -107,7 +107,7 @@ TEST_F(DispatchFixture, TensixProgramGlobalCircularBuffers) {
         global_cb_config.remote_index(remote_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
         global_cb_config.index(local_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
         auto remote_cb =
-            tt::tt_metal::v1::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, *global_cb);
+            tt::tt_metal::v1::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
         tt::tt_metal::detail::CompileProgram(device, program);
         EXPECT_THROW(program.finalize(device), std::exception);
     }

--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -20,7 +20,7 @@ TEST_F(DispatchFixture, InitializeGlobalSemaphores) {
         {
             uint32_t initial_value = 1;
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
-            auto address = global_semaphore->address();
+            auto address = global_semaphore.address();
             Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
@@ -32,7 +32,7 @@ TEST_F(DispatchFixture, InitializeGlobalSemaphores) {
         {
             uint32_t initial_value = 2;
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
-            auto address = global_semaphore->address();
+            auto address = global_semaphore.address();
             Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
@@ -53,13 +53,13 @@ TEST_F(DispatchFixture, CreateMultipleGlobalSemaphoresOnSameCore) {
     }
     for (auto device : devices_) {
         {
-            std::vector<std::shared_ptr<tt::tt_metal::GlobalSemaphore>> global_semaphores;
+            std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
             global_semaphores.reserve(cores.size());
             std::vector<DeviceAddr> addresses;
             addresses.reserve(cores.size());
             for (size_t i = 0; i < cores.size(); i++) {
                 global_semaphores.push_back(tt::tt_metal::CreateGlobalSemaphore(device, cores[i], initial_values[i]));
-                addresses.push_back(global_semaphores[i]->address());
+                addresses.push_back(global_semaphores[i].address());
             }
             Synchronize(device);
             for (size_t i = 0; i < cores.size(); i++) {
@@ -89,7 +89,7 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
             uint32_t reset_value = 2;
             std::vector<uint32_t> overwrite_value = {2};
             auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(device, cores, initial_value);
-            auto address = global_semaphore->address();
+            auto address = global_semaphore.address();
             Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
@@ -105,7 +105,7 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
 
                 EXPECT_EQ(sem_vals[0], overwrite_value[0]);
             }
-            global_semaphore->reset_semaphore_value(reset_value);
+            global_semaphore.reset_semaphore_value(reset_value);
             Synchronize(device);
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -81,7 +81,7 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
             EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
             input_1_it += page_size_1 / sizeof(uint32_t);
         }
-        auto sem_addr = global_semaphore->address();
+        auto sem_addr = global_semaphore.address();
         auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
         tt::llrt::write_hex_vec_to_core(device->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
 

--- a/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
@@ -9,7 +9,7 @@
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
 
-inline std::tuple<Program, CoreCoord, std::shared_ptr<GlobalSemaphore>> create_single_sync_program(
+inline std::tuple<Program, CoreCoord, GlobalSemaphore> create_single_sync_program(
     Device* device, SubDevice sub_device) {
     auto syncer_coord = sub_device.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
     auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
@@ -21,12 +21,12 @@ inline std::tuple<Program, CoreCoord, std::shared_ptr<GlobalSemaphore>> create_s
         "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/syncer.cpp",
         syncer_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-    std::array<uint32_t, 1> syncer_rt_args = {global_sem->address()};
+    std::array<uint32_t, 1> syncer_rt_args = {global_sem.address()};
     SetRuntimeArgs(syncer_program, syncer_kernel, syncer_core, syncer_rt_args);
     return {std::move(syncer_program), std::move(syncer_coord), std::move(global_sem)};
 }
 
-inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> create_basic_sync_program(
+inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_sync_program(
     Device* device, const SubDevice& sub_device_1, const SubDevice& sub_device_2) {
     auto waiter_coord = sub_device_2.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
     auto waiter_core = CoreRangeSet(CoreRange(waiter_coord, waiter_coord));
@@ -45,7 +45,7 @@ inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> c
         waiter_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
     std::array<uint32_t, 4> waiter_rt_args = {
-        global_sem->address(), incrementer_cores.num_cores(), syncer_core_physical.x, syncer_core_physical.y};
+        global_sem.address(), incrementer_cores.num_cores(), syncer_core_physical.x, syncer_core_physical.y};
     SetRuntimeArgs(waiter_program, waiter_kernel, waiter_core, waiter_rt_args);
 
     Program syncer_program = CreateProgram();
@@ -54,7 +54,7 @@ inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> c
         "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/syncer.cpp",
         syncer_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-    std::array<uint32_t, 1> syncer_rt_args = {global_sem->address()};
+    std::array<uint32_t, 1> syncer_rt_args = {global_sem.address()};
     SetRuntimeArgs(syncer_program, syncer_kernel, syncer_core, syncer_rt_args);
 
     Program incrementer_program = CreateProgram();
@@ -64,13 +64,13 @@ inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> c
         incrementer_cores,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
     std::array<uint32_t, 3> incrementer_rt_args = {
-        global_sem->address(), waiter_core_physical.x, waiter_core_physical.y};
+        global_sem.address(), waiter_core_physical.x, waiter_core_physical.y};
     SetRuntimeArgs(incrementer_program, incrementer_kernel, incrementer_cores, incrementer_rt_args);
     return {
         std::move(waiter_program), std::move(syncer_program), std::move(incrementer_program), std::move(global_sem)};
 }
 
-inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> create_basic_eth_sync_program(
+inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_eth_sync_program(
     Device* device, const SubDevice& sub_device_1, const SubDevice& sub_device_2) {
     auto waiter_coord = sub_device_2.cores(HalProgrammableCoreType::ACTIVE_ETH).ranges().at(0).start_coord;
     auto waiter_core = CoreRangeSet(CoreRange(waiter_coord, waiter_coord));
@@ -92,7 +92,7 @@ inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> c
         waiter_core,
         EthernetConfig{.noc = NOC::RISCV_0_default, .processor = DataMovementProcessor::RISCV_0});
     std::array<uint32_t, 7> waiter_rt_args = {
-        global_sem->address(),
+        global_sem.address(),
         incrementer_cores.num_cores(),
         syncer_core_physical.x,
         syncer_core_physical.y,
@@ -107,7 +107,7 @@ inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> c
         "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/syncer.cpp",
         syncer_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-    std::array<uint32_t, 1> syncer_rt_args = {global_sem->address()};
+    std::array<uint32_t, 1> syncer_rt_args = {global_sem.address()};
     SetRuntimeArgs(syncer_program, syncer_kernel, syncer_core, syncer_rt_args);
 
     Program incrementer_program = CreateProgram();
@@ -117,7 +117,7 @@ inline std::tuple<Program, Program, Program, std::shared_ptr<GlobalSemaphore>> c
         incrementer_cores,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
     std::array<uint32_t, 3> incrementer_rt_args = {
-        global_sem->address(), tensix_waiter_core_physical.x, tensix_waiter_core_physical.y};
+        global_sem.address(), tensix_waiter_core_physical.x, tensix_waiter_core_physical.y};
     SetRuntimeArgs(incrementer_program, incrementer_kernel, incrementer_cores, incrementer_rt_args);
     return {
         std::move(waiter_program), std::move(syncer_program), std::move(incrementer_program), std::move(global_sem)};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -80,7 +80,7 @@ void get_max_page_size_and_num_pages(
     num_pages = total_size / page_size;
 }
 
-std::tuple<std::vector<tt_metal::Program>,std::shared_ptr<tt_metal::v1::experimental::GlobalCircularBuffer>>
+std::tuple<std::vector<tt_metal::Program>, tt_metal::v1::experimental::GlobalCircularBuffer>
 create_programs(
     tt_metal::Device* device,
     const CoreRangeSet& dram_reader_core,
@@ -146,7 +146,7 @@ create_programs(
     tt_metal::CircularBufferConfig writer_cb_config = tt_metal::CircularBufferConfig(receiver_cb_size);
     writer_cb_config.remote_index(writer_cb_index).set_page_size(single_tile_size).set_data_format(tile_format);
     auto writer_cb =
-        tt_metal::v1::experimental::CreateCircularBuffer(sender_program, dram_reader_core, writer_cb_config, *global_cb);
+        tt_metal::v1::experimental::CreateCircularBuffer(sender_program, dram_reader_core, writer_cb_config, global_cb);
 
     // mixed cb dataformat
     uint32_t next_layer_num_blocks = num_blocks * 2;
@@ -178,7 +178,7 @@ create_programs(
     tt_metal::CircularBufferConfig receiver_cb_config = tt_metal::CircularBufferConfig(receiver_cb_size);
     receiver_cb_config.remote_index(receiver_cb_index).set_page_size(single_tile_size).set_data_format(tile_format);
     auto receiver_cb = tt_metal::v1::experimental::CreateCircularBuffer(
-        receiver_program, l1_receiver_cores, receiver_cb_config, *global_cb);
+        receiver_program, l1_receiver_cores, receiver_cb_config, global_cb);
 
     log_info("reader_cb_size: {}", reader_cb_size);
     log_info("receiver_cb_size: {}", receiver_cb_size);
@@ -846,7 +846,7 @@ int main(int argc, char** argv) {
                 tt::DataFormat::Bfp8_b,
                 l1_receiver_core,
                 num_receivers,
-                global_cb->buffer_address());
+                global_cb.buffer_address());
 
         } else {
             // output
@@ -860,7 +860,7 @@ int main(int argc, char** argv) {
                 tt::DataFormat::Float16_b,
                 l1_receiver_core,
                 num_receivers,
-                global_cb->buffer_address());
+                global_cb.buffer_address());
         }
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -95,7 +95,7 @@ std::tuple<uint32_t, uint32_t> get_out_subblock_params(
     return {1, 1};
 }
 
-std::tuple<std::vector<tt_metal::Program>, std::shared_ptr<tt::tt_metal::v1::experimental::GlobalCircularBuffer>>
+std::tuple<std::vector<tt_metal::Program>, ::tt_metal::v1::experimental::GlobalCircularBuffer>
 create_programs(
     tt_metal::Device* device,
     const CoreRangeSet& dram_reader_core,
@@ -169,7 +169,7 @@ create_programs(
     tt_metal::CircularBufferConfig in1_writer_cb_config = tt_metal::CircularBufferConfig(in1_receiver_cb_size);
     in1_writer_cb_config.remote_index(in1_writer_cb_index).set_page_size(single_tile_size).set_data_format(tile_format);
     auto writer_cb = tt_metal::v1::experimental::CreateCircularBuffer(
-        sender_program, dram_reader_core, in1_writer_cb_config, *global_cb);
+        sender_program, dram_reader_core, in1_writer_cb_config, global_cb);
 
     // in0 reader CB
     uint32_t in0_reader_cb_index = 0;
@@ -190,7 +190,7 @@ create_programs(
         .set_data_format(tile_format);
     in1_receiver_cb_config.index(in1_pusher_cb_index).set_page_size(single_tile_size).set_data_format(tile_format);
     auto in1_receiver_cb = tt_metal::v1::experimental::CreateCircularBuffer(
-        receiver_program, l1_receiver_cores, in1_receiver_cb_config, *global_cb);
+        receiver_program, l1_receiver_cores, in1_receiver_cb_config, global_cb);
 
     // output CB
     uint32_t output_cb_index = 16;

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -297,7 +297,7 @@ uint32_t CreateSemaphore(
  * Initializes a global semaphore on all cores within the specified CoreRangeSet.
  * This only supports tensix cores, and can only use L1 buffer types like BufferType::L1 and BufferType::L1_SMALL.
  *
- * Return value: std::shared_ptr<GlobalSemaphore>
+ * Return value: GlobalSemaphore
  *
  * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
  * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
@@ -308,7 +308,7 @@ uint32_t CreateSemaphore(
  * | sub_device_ids | Sub-device ids to wait on before writing the semaphore | tt::stl::Span<const SubDeviceId>                          |              | No       |
  */
 // clang-format on
-std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+GlobalSemaphore CreateGlobalSemaphore(
     Device* device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
@@ -320,7 +320,7 @@ std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
  * Initializes a global semaphore on all cores within the specified CoreRangeSet.
  * This only supports tensix cores, and can only use L1 buffer types like BufferType::L1 and BufferType::L1_SMALL.
  *
- * Return value: std::shared_ptr<GlobalSemaphore>
+ * Return value: GlobalSemaphore
  *
  * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
  * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
@@ -331,7 +331,7 @@ std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
  * | sub_device_ids | Sub-device ids to wait on before writing the semaphore | tt::stl::Span<const SubDeviceId>                          |              | No       |
  */
 // clang-format on
-std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+GlobalSemaphore CreateGlobalSemaphore(
     Device* device,
     CoreRangeSet&& cores,
     uint32_t initial_value,

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -28,8 +28,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
     BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids,
-    Private) :
+    tt::stl::Span<const SubDeviceId> sub_device_ids) :
     device_(device), sender_receiver_core_mapping_(sender_receiver_core_mapping), size_(size) {
     TT_FATAL(this->device_ != nullptr, "Device cannot be null");
     uint32_t num_sender_cores = sender_receiver_core_mapping.size();
@@ -146,16 +145,6 @@ void GlobalCircularBuffer::setup_cb_buffers(
                 device->command_queue(), cb_config_buffer, cb_config_host_buffer.data(), false, sub_device_ids);
         }
     });
-}
-
-std::shared_ptr<GlobalCircularBuffer> GlobalCircularBuffer::create(
-    Device* device,
-    const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
-    uint32_t size,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return std::make_shared<GlobalCircularBuffer>(
-        device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids, Private());
 }
 
 const Buffer& GlobalCircularBuffer::cb_buffer() const { return *this->cb_buffer_; }

--- a/tt_metal/impl/buffers/global_circular_buffer.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.hpp
@@ -26,23 +26,19 @@ namespace v1 {
 namespace experimental {
 
 class GlobalCircularBuffer {
-    struct Private {
-        explicit Private() = default;
-    };
-
 public:
-    static std::shared_ptr<GlobalCircularBuffer> create(
+    GlobalCircularBuffer(
         Device* device,
         const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
         uint32_t size,
         BufferType buffer_type = BufferType::L1,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
-    GlobalCircularBuffer(const GlobalCircularBuffer&) = delete;
-    GlobalCircularBuffer& operator=(const GlobalCircularBuffer&) = delete;
+    GlobalCircularBuffer(const GlobalCircularBuffer&) = default;
+    GlobalCircularBuffer& operator=(const GlobalCircularBuffer&) = default;
 
-    GlobalCircularBuffer(GlobalCircularBuffer&&) noexcept = delete;
-    GlobalCircularBuffer& operator=(GlobalCircularBuffer&&) noexcept = delete;
+    GlobalCircularBuffer(GlobalCircularBuffer&&) noexcept = default;
+    GlobalCircularBuffer& operator=(GlobalCircularBuffer&&) noexcept = default;
 
     const Buffer& cb_buffer() const;
 
@@ -55,16 +51,6 @@ public:
 
     static constexpr auto attribute_names = std::forward_as_tuple("sender_receiver_core_mapping", "size");
     const auto attribute_values() const { return std::make_tuple(this->sender_receiver_core_mapping_, this->size_); }
-
-    // "Private" constructor to prevent direct instantiation
-    // Use GlobalCircularBuffer::create instead
-    GlobalCircularBuffer(
-        Device* device,
-        const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
-        uint32_t size,
-        BufferType buffer_type,
-        tt::stl::Span<const SubDeviceId> sub_device_ids,
-        Private);
 
 private:
     void setup_cb_buffers(

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -24,8 +24,7 @@ GlobalSemaphore::GlobalSemaphore(
     const CoreRangeSet& cores,
     uint32_t initial_value,
     BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids,
-    Private) :
+    tt::stl::Span<const SubDeviceId> sub_device_ids) :
     device_(device), cores_(cores) {
     this->setup_buffer(initial_value, buffer_type, sub_device_ids);
 }
@@ -35,8 +34,7 @@ GlobalSemaphore::GlobalSemaphore(
     CoreRangeSet&& cores,
     uint32_t initial_value,
     BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids,
-    Private) :
+    tt::stl::Span<const SubDeviceId> sub_device_ids) :
     device_(device), cores_(std::move(cores)) {
     this->setup_buffer(initial_value, buffer_type, sub_device_ids);
 }
@@ -64,29 +62,12 @@ void GlobalSemaphore::setup_buffer(
     this->reset_semaphore_value(initial_value, sub_device_ids);
 }
 
-std::shared_ptr<GlobalSemaphore> GlobalSemaphore::create(
-    Device* device,
-    const CoreRangeSet& cores,
-    uint32_t initial_value,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return std::make_shared<GlobalSemaphore>(device, cores, initial_value, buffer_type, sub_device_ids, Private());
-}
-std::shared_ptr<GlobalSemaphore> GlobalSemaphore::create(
-    Device* device,
-    CoreRangeSet&& cores,
-    uint32_t initial_value,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return std::make_shared<GlobalSemaphore>(
-        device, std::move(cores), initial_value, buffer_type, sub_device_ids, Private());
-}
-
 Device* GlobalSemaphore::device() const { return device_; }
 
 DeviceAddr GlobalSemaphore::address() const { return buffer_->address(); }
 
-void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+void GlobalSemaphore::reset_semaphore_value(
+    uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids) const {
     // Write the initial value to the semaphore to the device
     // Only block for the slow dispatch case
     auto* device = this->device_;

--- a/tt_metal/impl/buffers/global_semaphore.hpp
+++ b/tt_metal/impl/buffers/global_semaphore.hpp
@@ -20,57 +20,35 @@ class Buffer;
 class Device;
 
 class GlobalSemaphore {
-    struct Private {
-        explicit Private() = default;
-    };
-
 public:
-    static std::shared_ptr<GlobalSemaphore> create(
+    GlobalSemaphore(
         Device* device,
         const CoreRangeSet& cores,
         uint32_t initial_value,
         BufferType buffer_type = BufferType::L1,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
-    static std::shared_ptr<GlobalSemaphore> create(
+    GlobalSemaphore(
         Device* device,
         CoreRangeSet&& cores,
         uint32_t initial_value,
         BufferType buffer_type = BufferType::L1,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
-    GlobalSemaphore(const GlobalSemaphore&) = delete;
-    GlobalSemaphore& operator=(const GlobalSemaphore&) = delete;
+    GlobalSemaphore(const GlobalSemaphore&) = default;
+    GlobalSemaphore& operator=(const GlobalSemaphore&) = default;
 
-    GlobalSemaphore(GlobalSemaphore&&) noexcept = delete;
-    GlobalSemaphore& operator=(GlobalSemaphore&&) noexcept = delete;
+    GlobalSemaphore(GlobalSemaphore&&) noexcept = default;
+    GlobalSemaphore& operator=(GlobalSemaphore&&) noexcept = default;
 
     Device* device() const;
 
     DeviceAddr address() const;
 
-    void reset_semaphore_value(uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    void reset_semaphore_value(uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids = {}) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("cores");
     const auto attribute_values() const { return std::make_tuple(this->cores_); }
-
-    // "Private" constructor to prevent direct instantiation
-    // Use GlobalSemaphore::create instead
-    GlobalSemaphore(
-        Device* device,
-        const CoreRangeSet& cores,
-        uint32_t initial_value,
-        BufferType buffer_type,
-        tt::stl::Span<const SubDeviceId> sub_device_ids,
-        Private);
-
-    GlobalSemaphore(
-        Device* device,
-        CoreRangeSet&& cores,
-        uint32_t initial_value,
-        BufferType buffer_type,
-        tt::stl::Span<const SubDeviceId> sub_device_ids,
-        Private);
 
 private:
     void setup_buffer(uint32_t initial_value, BufferType buffer_type, tt::stl::Span<const SubDeviceId> sub_device_ids);

--- a/tt_metal/include/tt_metal/global_circular_buffer.hpp
+++ b/tt_metal/include/tt_metal/global_circular_buffer.hpp
@@ -24,9 +24,9 @@ namespace experimental {
  * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.
  * @param sub_device_ids Sub-device IDs to wait on before writing the global circular buffer config to device. Defaults
  * to waiting on all sub-devices.
- * @return Handle to the allocated global circular buffer.
+ * @return The allocated global circular buffer.
  */
-std::shared_ptr<GlobalCircularBuffer> CreateGlobalCircularBuffer(
+GlobalCircularBuffer CreateGlobalCircularBuffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1174,22 +1174,22 @@ uint32_t CreateSemaphore(
         core_spec);
 }
 
-std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+GlobalSemaphore CreateGlobalSemaphore(
     Device* device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
     BufferType buffer_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return GlobalSemaphore::create(device, cores, initial_value, buffer_type, sub_device_ids);
+    return GlobalSemaphore(device, cores, initial_value, buffer_type, sub_device_ids);
 }
 
-std::shared_ptr<GlobalSemaphore> CreateGlobalSemaphore(
+GlobalSemaphore CreateGlobalSemaphore(
     Device* device,
     CoreRangeSet&& cores,
     uint32_t initial_value,
     BufferType buffer_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return GlobalSemaphore::create(device, std::move(cores), initial_value, buffer_type, sub_device_ids);
+    return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type, sub_device_ids);
 }
 
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
@@ -1388,13 +1388,13 @@ namespace v1 {
 
 namespace experimental {
 
-std::shared_ptr<GlobalCircularBuffer> CreateGlobalCircularBuffer(
+GlobalCircularBuffer CreateGlobalCircularBuffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,
     BufferType buffer_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return GlobalCircularBuffer::create(device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
+    return GlobalCircularBuffer(device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
 }
 
 CBHandle CreateCircularBuffer(

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -46,7 +46,7 @@ void py_module(py::module& module) {
 
     module.def(
         "get_global_semaphore_address",
-        py::overload_cast<const std::shared_ptr<GlobalSemaphore>&>(&get_global_semaphore_address),
+        py::overload_cast<const GlobalSemaphore&>(&get_global_semaphore_address),
         py::arg("global_semaphore"),
         R"doc(
             Get the address of the global semaphore.
@@ -57,7 +57,7 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        [](const std::shared_ptr<GlobalSemaphore>& global_semaphore,
+        [](const GlobalSemaphore& global_semaphore,
            uint32_t reset_value,
            const std::vector<SubDeviceId>& sub_device_ids) {
             ttnn::global_semaphore::reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);

--- a/ttnn/cpp/ttnn/global_circular_buffer.hpp
+++ b/ttnn/cpp/ttnn/global_circular_buffer.hpp
@@ -12,11 +12,11 @@ namespace ttnn::global_circular_buffer {
 
 struct MultiDeviceGlobalCircularBuffer {
     MultiDeviceGlobalCircularBuffer(MeshDevice* mesh_device);
-    std::vector<std::shared_ptr<GlobalCircularBuffer>> global_circular_buffers;
+    std::vector<GlobalCircularBuffer> global_circular_buffers;
 };
 
 // Single Device APIs
-std::shared_ptr<GlobalCircularBuffer> create_global_circular_buffer(
+GlobalCircularBuffer create_global_circular_buffer(
     Device* device,
     const std::unordered_map<CoreCoord, CoreRangeSet>& sender_receiver_core_mapping,
     uint32_t size,

--- a/ttnn/cpp/ttnn/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn/global_semaphore.cpp
@@ -15,39 +15,25 @@ MultiDeviceGlobalSemaphore::MultiDeviceGlobalSemaphore(MeshDevice* mesh_device) 
     TT_ASSERT(
         mesh_device != nullptr,
         "Must provide a valid mesh_device when initializing a global semaphore on multiple devices.");
-    this->global_semaphores = std::vector<std::shared_ptr<GlobalSemaphore>>(mesh_device->num_devices());
+    this->global_semaphores.reserve(mesh_device->num_devices());
 }
 
-std::shared_ptr<GlobalSemaphore> create_global_semaphore(
+GlobalSemaphore create_global_semaphore(
     Device* device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
     BufferType buffer_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    std::shared_ptr<GlobalSemaphore> global_semaphore = nullptr;
-    device->push_work(
-        [device, &cores, initial_value, buffer_type, sub_device_ids, &global_semaphore] {
-            global_semaphore = GlobalSemaphore::create(device, cores, initial_value, buffer_type, sub_device_ids);
-        },
-        /*blocking=*/true);
-    return global_semaphore;
+    return CreateGlobalSemaphore(device, cores, initial_value, buffer_type, sub_device_ids);
 }
 
-tt::tt_metal::DeviceAddr get_global_semaphore_address(const std::shared_ptr<GlobalSemaphore>& global_semaphore) {
-    auto* device = global_semaphore->device();
-    tt::tt_metal::DeviceAddr address = 0;
-    device->push_work([&global_semaphore, &address] { address = global_semaphore->address(); }, /*blocking=*/true);
-    return address;
+tt::tt_metal::DeviceAddr get_global_semaphore_address(const GlobalSemaphore& global_semaphore) {
+    return global_semaphore.address();
 }
 
 void reset_global_semaphore_value(
-    const std::shared_ptr<GlobalSemaphore>& global_semaphore,
-    uint32_t reset_value,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    auto* device = global_semaphore->device();
-    device->push_work([global_semaphore, reset_value, sub_device_ids] {
-        global_semaphore->reset_semaphore_value(reset_value, sub_device_ids);
-    });
+    const GlobalSemaphore& global_semaphore, uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    global_semaphore.reset_semaphore_value(reset_value, sub_device_ids);
 }
 
 MultiDeviceGlobalSemaphore create_global_semaphore(
@@ -57,16 +43,11 @@ MultiDeviceGlobalSemaphore create_global_semaphore(
     BufferType buffer_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     MultiDeviceGlobalSemaphore multi_device_global_semaphore(mesh_device);
+    auto& global_semaphores = multi_device_global_semaphore.global_semaphores;
     const auto& devices = mesh_device->get_devices();
     for (uint32_t i = 0; i < devices.size(); ++i) {
         auto* device = devices[i];
-        auto& global_semaphore = multi_device_global_semaphore.global_semaphores[i];
-        device->push_work([device, &cores, initial_value, buffer_type, sub_device_ids, &global_semaphore] {
-            global_semaphore = GlobalSemaphore::create(device, cores, initial_value, buffer_type, sub_device_ids);
-        });
-    }
-    for (auto device : devices) {
-        device->synchronize();
+        global_semaphores.push_back(create_global_semaphore(device, cores, initial_value, buffer_type, sub_device_ids));
     }
     return multi_device_global_semaphore;
 }
@@ -74,13 +55,7 @@ std::vector<tt::tt_metal::DeviceAddr> get_global_semaphore_address(const MultiDe
     std::vector<tt::tt_metal::DeviceAddr> addresses(global_semaphore.global_semaphores.size());
     const auto& global_semaphores = global_semaphore.global_semaphores;
     for (uint32_t i = 0; i < global_semaphores.size(); ++i) {
-        const auto& global_semaphore = global_semaphores[i];
-        auto& address = addresses[i];
-        auto* device = global_semaphore->device();
-        device->push_work([&global_semaphore, &address] { address = global_semaphore->address(); });
-    }
-    for (const auto& global_semaphore : global_semaphores) {
-        global_semaphore->device()->synchronize();
+        addresses[i] = get_global_semaphore_address(global_semaphores[i]);
     }
     return addresses;
 }

--- a/ttnn/cpp/ttnn/global_semaphore.hpp
+++ b/ttnn/cpp/ttnn/global_semaphore.hpp
@@ -12,19 +12,21 @@ namespace ttnn::global_semaphore {
 
 struct MultiDeviceGlobalSemaphore {
     MultiDeviceGlobalSemaphore(MeshDevice* mesh_device);
-    std::vector<std::shared_ptr<GlobalSemaphore>> global_semaphores;
+    std::vector<GlobalSemaphore> global_semaphores;
 };
 
 // Single Device APIs
-std::shared_ptr<GlobalSemaphore> create_global_semaphore(
+GlobalSemaphore create_global_semaphore(
     Device* device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
     BufferType buffer_type = BufferType::L1,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
-tt::tt_metal::DeviceAddr get_global_semaphore_address(const std::shared_ptr<GlobalSemaphore>& global_semaphore);
+
+tt::tt_metal::DeviceAddr get_global_semaphore_address(const GlobalSemaphore& global_semaphore);
+
 void reset_global_semaphore_value(
-    const std::shared_ptr<GlobalSemaphore>& global_semaphore,
+    const GlobalSemaphore& global_semaphore,
     uint32_t reset_value,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
@@ -35,7 +37,9 @@ MultiDeviceGlobalSemaphore create_global_semaphore(
     uint32_t initial_value,
     BufferType buffer_type = BufferType::L1,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
 std::vector<tt::tt_metal::DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSemaphore& global_semaphore);
+
 void reset_global_semaphore_value(
     const MultiDeviceGlobalSemaphore& global_semaphore,
     uint32_t reset_value,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
@@ -54,42 +54,41 @@ void bind_all_gather_async(pybind11::module& module, const ccl_operation_t& oper
             py::arg("enable_persistent_fabric_mode") = false,
             py::arg("create_semaphore_handles") = true},
 
-        ttnn::
-            pybind_overload_t{
-                [](const ccl_operation_t& self,
-                   const ttnn::Tensor& input_tensor,
-                   const int32_t dim,
-                   const uint32_t cluster_axis,
-                   const MeshDevice& mesh_device,
-                   const ttnn::ccl::Topology topology,
-                   const std::optional<size_t> num_preferred_links,
-                   const std::optional<MemoryConfig>& memory_config,
-                   std::optional<SubDeviceId> subdevice_id,
-                   bool enable_persistent_fabric_mode,
-                   bool create_semaphore_handles) -> ttnn::Tensor {
-                    return self(
-                        input_tensor,
-                        dim,
-                        cluster_axis,
-                        mesh_device,
-                        topology,
-                        memory_config,// = std::nullopt,
-                        num_preferred_links,// = std::nullopt,
-                        subdevice_id,// = std::nullopt,
-                        enable_persistent_fabric_mode,// = false,
-                        create_semaphore_handles);
-                },
-                py::arg("input_tensor"),
-                py::arg("dim"),
-                py::arg("cluster_axis"),
-                py::arg("mesh_device"),
-                py::arg("topology"),
-                py::kw_only(),
-                py::arg("num_links") = std::nullopt,
-                py::arg("memory_config") = std::nullopt,
-                py::arg("subdevice_id") = std::nullopt,
-                py::arg("enable_persistent_fabric_mode") = false,
-                py::arg("create_semaphore_handles") = true});
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const int32_t dim,
+               const uint32_t cluster_axis,
+               const MeshDevice& mesh_device,
+               const ttnn::ccl::Topology topology,
+               const std::optional<size_t> num_preferred_links,
+               const std::optional<MemoryConfig>& memory_config,
+               std::optional<SubDeviceId> subdevice_id,
+               bool enable_persistent_fabric_mode,
+               bool create_semaphore_handles) -> ttnn::Tensor {
+                return self(
+                    input_tensor,
+                    dim,
+                    cluster_axis,
+                    mesh_device,
+                    topology,
+                    memory_config,                  // = std::nullopt,
+                    num_preferred_links,            // = std::nullopt,
+                    subdevice_id,                   // = std::nullopt,
+                    enable_persistent_fabric_mode,  // = false,
+                    create_semaphore_handles);
+            },
+            py::arg("input_tensor"),
+            py::arg("dim"),
+            py::arg("cluster_axis"),
+            py::arg("mesh_device"),
+            py::arg("topology"),
+            py::kw_only(),
+            py::arg("num_links") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("enable_persistent_fabric_mode") = false,
+            py::arg("create_semaphore_handles") = true});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -34,7 +34,7 @@ struct AllGatherAsync {
     const uint32_t ring_index;
     const MemoryConfig output_mem_config;
     const ccl::Topology topology;
-    std::optional<std::shared_ptr<const GlobalSemaphore>> semaphore_handle;
+    const std::optional<GlobalSemaphore> semaphore;
     bool enable_persistent_fabric_mode;
 
     AllGatherAsync(
@@ -46,7 +46,7 @@ struct AllGatherAsync {
         uint32_t ring_index,
         MemoryConfig output_mem_config,
         ccl::Topology topology,
-        std::optional<std::shared_ptr<const GlobalSemaphore>> semaphore_handle,
+        std::optional<GlobalSemaphore> semaphore,
         bool enable_persistent_fabric_mode) :
         forward_device(forward_device),
         backward_device(backward_device),
@@ -56,7 +56,7 @@ struct AllGatherAsync {
         ring_index(ring_index),
         output_mem_config(output_mem_config),
         topology(topology),
-        semaphore_handle(semaphore_handle),
+        semaphore(semaphore),
         enable_persistent_fabric_mode(enable_persistent_fabric_mode) {}
 
     // Add attributes method for reflection
@@ -70,7 +70,7 @@ struct AllGatherAsync {
         attrs.emplace_back("ring_index", ring_index);
         attrs.emplace_back("output_mem_config", output_mem_config);
         attrs.emplace_back("topology", topology);
-        attrs.emplace_back("semaphore_handle", semaphore_handle.has_value() ? semaphore_handle.value().get() : nullptr);
+        attrs.emplace_back("semaphore", semaphore);
 
         return attrs;
     }
@@ -92,7 +92,7 @@ AllGatherAsync create_all_gather_async_struct(
     const std::optional<MemoryConfig>& memory_config,
     const std::vector<Device*>& devices,
     const ccl::Topology topology,
-    const std::optional<std::vector<GlobalSemaphore>>& semaphore_handles,
+    const std::optional<std::vector<GlobalSemaphore>>& semaphores,
     bool enable_persistent_fabric_mode);
 }  // namespace all_gather_async_detail
 }  // namespace ccl
@@ -108,7 +108,7 @@ operation::ProgramWithCallbacks all_gather_async_multi_core_with_workers(
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const std::optional<std::shared_ptr<const GlobalSemaphore>>& semaphore_handle_opt,
+    const std::optional<GlobalSemaphore>& semaphore_opt,
     bool enable_persistent_fabric_mode);
 
 namespace operations {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp"
 #include "sub_device/sub_device_types.hpp"
 #include "tt_metal/host_api.hpp"
-#include "tt_metal/impl/buffers/global_semaphore.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 #include <ranges>
 #include <algorithm>
@@ -230,7 +230,9 @@ std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> create_global_
         auto worker_subdevice_id = worker_subdevice_id_opt.has_value()
                                        ? std::vector<SubDeviceId>{worker_subdevice_id_opt.value()}
                                        : std::vector<SubDeviceId>{};
-        auto sem = CreateGlobalSemaphore(d, core_grid, 0, BufferType::L1, worker_subdevice_id);
+        // TODO: Remove shared_ptr
+        auto sem = std::make_shared<GlobalSemaphore>(
+            global_semaphore::create_global_semaphore(d, core_grid, 0, BufferType::L1, worker_subdevice_id));
         semaphores.push_back(sem);
     }
 
@@ -255,7 +257,9 @@ std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> create_global_
                 auto worker_subdevice_id = worker_subdevice_id_opt.has_value()
                                                ? std::vector<SubDeviceId>{worker_subdevice_id_opt.value()}
                                                : std::vector<SubDeviceId>{};
-                auto sem = CreateGlobalSemaphore(devices[i], core_grid, 0, BufferType::L1, worker_subdevice_id);
+                // TODO: Remove shared_ptr
+                auto sem = std::make_shared<GlobalSemaphore>(global_semaphore::create_global_semaphore(
+                    devices[i], core_grid, 0, BufferType::L1, worker_subdevice_id));
                 if (sem->address() == highest_addr) {
                     semaphores[i] = sem;
                 } else {
@@ -310,10 +314,8 @@ Tensor reduce_scatter(
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> from_remote_inputs_semaphores_opt;
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> to_remote_inputs_semaphores_opt;
     if (create_semaphore_handles) {
-        const auto from_remote_inputs_semaphores = create_global_semaphores(devices, worker_subdevice_id_opt);
-        const auto to_remote_inputs_semaphores = create_global_semaphores(devices, worker_subdevice_id_opt);
-        from_remote_inputs_semaphores_opt = from_remote_inputs_semaphores;
-        to_remote_inputs_semaphores_opt = to_remote_inputs_semaphores;
+        from_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
+        to_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
     } else {
         from_remote_inputs_semaphores_opt = std::nullopt;
         to_remote_inputs_semaphores_opt = std::nullopt;
@@ -389,10 +391,8 @@ Tensor reduce_scatter(
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> from_remote_inputs_semaphores_opt;
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> to_remote_inputs_semaphores_opt;
     if (create_semaphore_handles) {
-        const auto from_remote_inputs_semaphores = create_global_semaphores(devices, worker_subdevice_id_opt);
-        const auto to_remote_inputs_semaphores = create_global_semaphores(devices, worker_subdevice_id_opt);
-        from_remote_inputs_semaphores_opt = from_remote_inputs_semaphores;
-        to_remote_inputs_semaphores_opt = to_remote_inputs_semaphores;
+        from_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
+        to_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
     } else {
         from_remote_inputs_semaphores_opt = std::nullopt;
         to_remote_inputs_semaphores_opt = std::nullopt;


### PR DESCRIPTION
global sems/cbs are natively thread safe now, so user can decide whether to use shared ptrs or not

### Ticket
Link to Github Issue

### Problem description
Global semaphore/cb creation do not need to return shared pointers, and user can decide whether to create shared pointers or not.

### What's changed
Change global semaphore/circular buffer creation functions to return the object instead of a shared pointer and update use cases. Enable copy/move ctors for these objects.

### Checklist 
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions?page=3&query=actor%3Att-aho
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
T3K Freq: https://github.com/tenstorrent/tt-metal/actions/runs/12586388211
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12586394930