### PR TITLE
#15338: Fix watcher using the wrong cmd bufs for addr sanitization when using dynamic noc

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -16,6 +16,7 @@
 
 #include "core_config.h"
 #include "circular_buffer.h"
+#include "dataflow_cmd_bufs.h"
 #include "debug/sanitize_noc.h"
 #include "debug/waypoint.h"
 #include "eth_l1_address_map.h"
@@ -47,32 +48,6 @@ extern int32_t bank_to_l1_offset[NUM_L1_BANKS];
 extern uint32_t tt_l1_ptr* rta_l1_base;
 extern uint32_t tt_l1_ptr* crta_l1_base;
 extern uint32_t tt_l1_ptr* sem_l1_base[];
-
-#if defined(KERNEL_BUILD)
-#if defined(COMPILE_FOR_BRISC)
-constexpr uint32_t read_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_RD_CMD_BUF : DYNAMIC_NOC_BRISC_RD_CMD_BUF;
-constexpr uint32_t write_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_WR_CMD_BUF : DYNAMIC_NOC_BRISC_WR_CMD_BUF;
-constexpr uint32_t write_reg_cmd_buf =
-    NOC_MODE == DM_DEDICATED_NOC ? BRISC_WR_REG_CMD_BUF : DYNAMIC_NOC_BRISC_WR_REG_CMD_BUF;
-constexpr uint32_t write_at_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_AT_CMD_BUF : DYNAMIC_NOC_BRISC_AT_CMD_BUF;
-#elif defined(COMPILE_FOR_NCRISC)
-constexpr uint32_t read_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_RD_CMD_BUF : DYNAMIC_NOC_NCRISC_RD_CMD_BUF;
-constexpr uint32_t write_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_WR_CMD_BUF : DYNAMIC_NOC_NCRISC_WR_CMD_BUF;
-constexpr uint32_t write_reg_cmd_buf =
-    NOC_MODE == DM_DEDICATED_NOC ? NCRISC_WR_REG_CMD_BUF : DYNAMIC_NOC_NCRISC_WR_REG_CMD_BUF;
-constexpr uint32_t write_at_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_AT_CMD_BUF : DYNAMIC_NOC_NCRISC_AT_CMD_BUF;
-#else  // use the default cmf buffers for compute/eth
-constexpr uint32_t read_cmd_buf = NCRISC_RD_CMD_BUF;
-constexpr uint32_t write_cmd_buf = NCRISC_WR_CMD_BUF;
-constexpr uint32_t write_reg_cmd_buf = NCRISC_WR_REG_CMD_BUF;
-constexpr uint32_t write_at_cmd_buf = NCRISC_AT_CMD_BUF;
-#endif
-#else  // FW build
-constexpr uint32_t read_cmd_buf = NCRISC_RD_CMD_BUF;
-constexpr uint32_t write_cmd_buf = NCRISC_WR_CMD_BUF;
-constexpr uint32_t write_reg_cmd_buf = NCRISC_WR_REG_CMD_BUF;
-constexpr uint32_t write_at_cmd_buf = NCRISC_AT_CMD_BUF;
-#endif
 
 /** @file */
 

--- a/tt_metal/hw/inc/dataflow_cmd_bufs.h
+++ b/tt_metal/hw/inc/dataflow_cmd_bufs.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "noc_nonblocking_api.h"
+
+#if defined(KERNEL_BUILD)
+#if defined(COMPILE_FOR_BRISC)
+constexpr uint32_t read_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_RD_CMD_BUF : DYNAMIC_NOC_BRISC_RD_CMD_BUF;
+constexpr uint32_t write_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_WR_CMD_BUF : DYNAMIC_NOC_BRISC_WR_CMD_BUF;
+constexpr uint32_t write_reg_cmd_buf =
+    NOC_MODE == DM_DEDICATED_NOC ? BRISC_WR_REG_CMD_BUF : DYNAMIC_NOC_BRISC_WR_REG_CMD_BUF;
+constexpr uint32_t write_at_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? BRISC_AT_CMD_BUF : DYNAMIC_NOC_BRISC_AT_CMD_BUF;
+#elif defined(COMPILE_FOR_NCRISC)
+constexpr uint32_t read_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_RD_CMD_BUF : DYNAMIC_NOC_NCRISC_RD_CMD_BUF;
+constexpr uint32_t write_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_WR_CMD_BUF : DYNAMIC_NOC_NCRISC_WR_CMD_BUF;
+constexpr uint32_t write_reg_cmd_buf =
+    NOC_MODE == DM_DEDICATED_NOC ? NCRISC_WR_REG_CMD_BUF : DYNAMIC_NOC_NCRISC_WR_REG_CMD_BUF;
+constexpr uint32_t write_at_cmd_buf = NOC_MODE == DM_DEDICATED_NOC ? NCRISC_AT_CMD_BUF : DYNAMIC_NOC_NCRISC_AT_CMD_BUF;
+#else  // use the default cmf buffers for compute/eth
+constexpr uint32_t read_cmd_buf = NCRISC_RD_CMD_BUF;
+constexpr uint32_t write_cmd_buf = NCRISC_WR_CMD_BUF;
+constexpr uint32_t write_reg_cmd_buf = NCRISC_WR_REG_CMD_BUF;
+constexpr uint32_t write_at_cmd_buf = NCRISC_AT_CMD_BUF;
+#endif
+#else  // FW build
+constexpr uint32_t read_cmd_buf = NCRISC_RD_CMD_BUF;
+constexpr uint32_t write_cmd_buf = NCRISC_WR_CMD_BUF;
+constexpr uint32_t write_reg_cmd_buf = NCRISC_WR_REG_CMD_BUF;
+constexpr uint32_t write_at_cmd_buf = NCRISC_AT_CMD_BUF;
+#endif

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -24,6 +24,7 @@
 
 #include "watcher_common.h"
 
+#include "dataflow_cmd_bufs.h"
 #include "dev_msgs.h"
 #include "noc_overlay_parameters.h"
 #include "noc_parameters.h"
@@ -397,23 +398,22 @@ void debug_sanitize_noc_and_worker_addr(
 }
 
 // TODO: Clean these up with #7453
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id)                                     \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                           \
-        noc_id,                                                                                    \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE)       \
-         << NOC_ADDR_COORD_SHIFT) |                                                                \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO)),         \
-        NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO),                          \
-        NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id)                                                        \
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                              \
-        noc_id,                                                                                                        \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID) << 32) |                      \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO)),                              \
-        NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO),                                             \
-        NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id)                                                     \
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                           \
+        noc_id,                                                                                                    \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_MID) << 32) |                      \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_LO)),                              \
+        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_RET_ADDR_LO),                                               \
+        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE));
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id)                                                    \
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                          \
+        noc_id,                                                                                                    \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_MID) << 32) |                      \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_LO)),                              \
+        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_LO),                                             \
+        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)                                                   \
     DEBUG_SANITIZE_NOC_ADDR(                                                                                  \
         noc_id,                                                                                               \
@@ -448,30 +448,27 @@ void debug_sanitize_noc_and_worker_addr(
     LOG_LEN(l);                                                                              \
     debug_insert_delay((uint8_t)TransactionWrite);
 
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)             \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                        \
-        noc_id,                                                                                                 \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE)                    \
-         << NOC_ADDR_COORD_SHIFT) |                                                                             \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | noc_a_lower, \
-        worker_a,                                                                                               \
-        NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)                   \
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                        \
-        noc_id,                                                                                                 \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE)                    \
-         << NOC_ADDR_COORD_SHIFT) |                                                                             \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | noc_a_lower, \
-        worker_a,                                                                                               \
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)                \
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                           \
+        noc_id,                                                                                                    \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
+        worker_a,                                                                                                  \
+        NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE));
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)                      \
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                           \
+        noc_id,                                                                                                    \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
+        worker_a,                                                                                                  \
         l);
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)            \
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                       \
-        noc_id,                                                                                                 \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_COORDINATE)                    \
-         << NOC_ADDR_COORD_SHIFT) |                                                                             \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | noc_a_lower, \
-        worker_a,                                                                                               \
-        NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)                \
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                           \
+        noc_id,                                                                                                     \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower,         \
+        worker_a,                                                                                                   \
+        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE));
 #define DEBUG_INSERT_DELAY(transaction_type) debug_insert_delay(transaction_type)
 
 // Delay for debugging purposes


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/15338

### Problem description
Watcher was hardcoded to use the cmd buf definitions in noc_nonblocking_api.h. However, when kernels use dynamic noc setup there is a different mapping of cmd buffers for the different transaction types that was being used in dataflow_api.h. This causes watcher to read values from the wrong command buffer when using stateful apis with dynamic noc.

### What's changed
Factor out the cmd buffer mappings from dataflow_api.h into a new file, dataflow_cmd_bufs.h so that it can be included and used by sanitize_noc.h

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
