### PR TITLE
#16364: Test prefetcher

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -521,10 +521,9 @@ void DeviceData::overflow_check(Device* device) {
     }
 }
 
-template <bool is_dram_variant, bool is_host_variant>
-void configure_kernel_variant(
+void configure_kernel_variant_for_test(
     Program& program,
-    string path,
+    const string& path,
     std::vector<uint32_t> compile_args,  // yes, copy
     CoreCoord my_core,
     CoreCoord phys_my_core,
@@ -533,7 +532,9 @@ void configure_kernel_variant(
     Device* device,
     NOC my_noc_index,
     NOC upstream_noc_index,
-    NOC downstream_noc_index) {
+    NOC downstream_noc_index,
+    bool is_dram_variant,
+    bool is_host_variant) {
     auto my_virtual_noc_coords = device->virtual_noc0_coordinate(my_noc_index, phys_my_core);
     auto upstream_virtual_noc_coords = device->virtual_noc0_coordinate(upstream_noc_index, phys_upstream_core);
     auto downstream_virtual_noc_coords = device->virtual_noc0_coordinate(downstream_noc_index, phys_downstream_core);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -606,7 +606,7 @@ int main(int argc, char** argv) {
         constexpr NOC my_noc_index = NOC::NOC_0;
         constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
 
-        configure_kernel_variant<true, true>(
+        configure_kernel_variant_for_test(
             program,
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             dispatch_compile_args,
@@ -617,7 +617,9 @@ int main(int argc, char** argv) {
             device,
             my_noc_index,
             dispatch_upstream_noc_index,
-            my_noc_index);
+            my_noc_index,
+            true,
+            true);
 
         switch (test_type_g) {
             case 0: log_info(LogTest, "Running linear unicast test"); break;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1824,6 +1824,51 @@ void configure_for_single_chip(
                                     noc_read_alignment * noc_read_alignment);
         TT_ASSERT(scratch_db_base < 1024 * 1024);  // L1 size
 
+        // prefetch_h
+        std::vector<uint32_t> prefetch_h_compile_args = {
+            prefetch_d_buffer_base,
+            dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
+            prefetch_d_buffer_pages,
+            prefetch_downstream_cb_sem,  // my_downstream_cb_sem_id
+            prefetch_d_upstream_cb_sem,  // downstream_cb_sem_id
+            dev_hugepage_base,
+            hugepage_issue_buffer_size_g,
+            prefetch_q_base,
+            prefetch_q_entries_g * (uint32_t)sizeof(dispatch_constants::prefetch_q_entry_type),
+            prefetch_q_rd_ptr_addr,
+            prefetch_q_rd_pcie_ptr_addr,
+            cmddat_q_base,
+            cmddat_q_size_g,
+            0,  // unused
+            0,  // unused
+            0,  // unused
+            0,  // unused
+            0,  // unused
+            0,  // unused
+            dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
+            dispatch_constants::PREFETCH_D_BUFFER_BLOCKS,
+            0,  // unused
+            0,  // unused
+            0,  // unused
+            0,  // unused
+            0,  // unused
+        };
+
+        CoreCoord phys_prefetch_h_downstream_core =
+            packetized_path_en_g ? phys_prefetch_relay_mux_core : phys_prefetch_d_core;
+        configure_kernel_variant<false, true>(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
+            prefetch_h_compile_args,
+            prefetch_core,
+            phys_prefetch_core_g,
+            {0xffffffff, 0xffffffff},  // upstream core unused
+            phys_prefetch_h_downstream_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
+
         // In the case of packetized_enable_g, the prefetch_h downstream is
         // mux and the prefetch_d upstream is the demux
         // set the semaphores accordingly
@@ -1833,8 +1878,8 @@ void configure_for_single_chip(
             dispatch_buffer_pages,
             prefetch_d_downstream_cb_sem,  // my_downstream_cb_sem_id
             dispatch_cb_sem,               // downstream_cb_sem_id
-            dev_hugepage_base,
-            hugepage_issue_buffer_size_g,
+            0,
+            0,
             prefetch_q_base,
             prefetch_q_entries_g * (uint32_t)sizeof(dispatch_constants::prefetch_q_entry_type),
             prefetch_q_rd_ptr_addr,
@@ -1866,51 +1911,6 @@ void configure_for_single_chip(
             phys_prefetch_d_core,
             phys_prefetch_d_upstream_core,
             phys_dispatch_core,
-            device,
-            my_noc_index,
-            my_noc_index,
-            my_noc_index);
-
-        // prefetch_h
-        std::vector<uint32_t> prefetch_h_compile_args = {
-            prefetch_d_buffer_base,
-            dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
-            prefetch_d_buffer_pages,
-            prefetch_downstream_cb_sem,
-            prefetch_d_upstream_cb_sem,
-            dev_hugepage_base,
-            hugepage_issue_buffer_size_g,
-            prefetch_q_base,
-            prefetch_q_entries_g * (uint32_t)sizeof(dispatch_constants::prefetch_q_entry_type),
-            prefetch_q_rd_ptr_addr,
-            prefetch_q_rd_pcie_ptr_addr,
-            cmddat_q_base,
-            cmddat_q_size_g,
-            0,
-            scratch_db_size_g,
-            prefetch_sync_sem,
-            prefetch_d_buffer_pages,
-            prefetch_d_upstream_cb_sem,
-            prefetch_downstream_cb_sem,
-            dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
-            dispatch_constants::PREFETCH_D_BUFFER_BLOCKS,
-            0,
-            0,
-            0,
-            0,
-            0,
-        };
-
-        CoreCoord phys_prefetch_h_downstream_core =
-            packetized_path_en_g ? phys_prefetch_relay_mux_core : phys_prefetch_d_core;
-        configure_kernel_variant<false, true>(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-            prefetch_h_compile_args,
-            prefetch_core,
-            phys_prefetch_core_g,
-            {0xffffffff, 0xffffffff},  // upstream core unused
-            phys_prefetch_h_downstream_core,
             device,
             my_noc_index,
             my_noc_index,
@@ -2101,8 +2101,8 @@ void configure_for_single_chip(
             scratch_db_size_g,                                    // scratch_db_size
             prefetch_sync_sem,                                    // my_downstream_sync_sem_id
             prefetch_d_buffer_pages,                              // cmddat_q_pages
-            prefetch_d_upstream_cb_sem,                           // my_upstream_cb_sem_id
-            prefetch_downstream_cb_sem,                           // upstream_cb_sem_id
+            0,                                                    // my_upstream_cb_sem_id
+            0,                                                    // upstream_cb_sem_id
             dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,  // cmddat_q_log_page_size
             dispatch_constants::PREFETCH_D_BUFFER_BLOCKS,         // cmddat_q_blocks
             0,
@@ -2150,8 +2150,8 @@ void configure_for_single_chip(
             dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS,
             prefetch_sync_sem,
             0,  // true base of hugepage
-            dev_hugepage_completion_buffer_base,
-            DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE,
+            0,
+            0,
             dispatch_buffer_base,
             (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE) * dispatch_buffer_pages,
             dispatch_downstream_cb_sem,
@@ -2202,7 +2202,7 @@ void configure_for_single_chip(
             DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE,
             dispatch_buffer_base,
             (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE) * dispatch_buffer_pages,
-            dispatch_h_cb_sem,
+            0,
             dispatch_downstream_cb_sem,
             0,
             split_prefetcher_g,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.hpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Graph
+#include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
+// Compile args struct
+#include "tt_metal/impl/dispatch/kernel_config/dispatch.hpp"
+#include "tt_metal/impl/dispatch/kernel_config/prefetch.hpp"
+#include "tt_metal/impl/dispatch/kernel_config/mux.hpp"
+#include "tt_metal/impl/dispatch/kernel_config/demux.hpp"
+
+namespace tt::tt_metal::dispatch_test {
+
+using namespace tt::tt_metal::dispatch;
+
+static constexpr int x = -1;  // unset
+constexpr NOC MY_NOC_INDEX = NOC::NOC_0;
+constexpr NOC DISPATCH_UPSTREAM_NOC_INDEX = NOC::NOC_1;
+
+static const std::vector<dispatch_kernel_node_t> default_topology = {
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+};
+
+class TestPrefetcherMuxKernel : public FDKernel {
+public:
+    TestPrefetcherMuxKernel(
+        int node_id, chip_id_t device_id, chip_id_t servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
+        FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {}
+
+    void CreateKernel() override;
+    void GenerateStaticConfigs() override;
+    void GenerateDependentConfigs() override;
+    void ConfigureCore() override;
+
+    mux_static_config_t static_config;
+    mux_dependent_config_t dependent_config;
+};
+
+class TestPrefetcherDemuxKernel : public FDKernel {
+public:
+    TestPrefetcherDemuxKernel(
+        int node_id, chip_id_t device_id, chip_id_t servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
+        FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {}
+
+    void CreateKernel() override;
+    void GenerateStaticConfigs() override;
+    void GenerateDependentConfigs() override;
+    void ConfigureCore() override;
+
+    demux_static_config_t static_config;
+    demux_dependent_config_t dependent_config;
+};
+
+class TestPrefetcherDispatchKernel : public FDKernel {
+public:
+    TestPrefetcherDispatchKernel(
+        int node_id,
+        chip_id_t device_id,
+        chip_id_t servicing_device_id,
+        uint8_t cq_id,
+        noc_selection_t noc_selection,
+        bool h_variant,
+        bool d_variant,
+        uint32_t dev_hugepage_completion_buffer_base) :
+        FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
+        static_config.is_h_variant = h_variant;
+        static_config.is_d_variant = d_variant;
+        static_config.completion_queue_base_addr = dev_hugepage_completion_buffer_base;
+        if (h_variant && !dev_hugepage_completion_buffer_base) {
+            TT_THROW("dev_hugepage_completion_buffer_base is required to be non zero for variants that talk to host");
+        }
+    }
+
+    void CreateKernel() override;
+    void GenerateStaticConfigs() override;
+    void GenerateDependentConfigs() override;
+    void ConfigureCore() override;
+
+    dispatch_static_config_t static_config;
+    dispatch_dependent_config_t dependent_config;
+};
+
+class TestPrefetcherPrefetchKernel : public FDKernel {
+public:
+    TestPrefetcherPrefetchKernel(
+        int node_id,
+        chip_id_t device_id,
+        chip_id_t servicing_device_id,
+        uint8_t cq_id,
+        noc_selection_t noc_selection,
+        bool h_variant,
+        bool d_variant,
+        uint32_t dev_hugepage_issue_base) :
+        FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
+        static_config.is_h_variant = h_variant;
+        static_config.is_d_variant = d_variant;
+        if (h_variant && !dev_hugepage_issue_base) {
+            TT_THROW("dev_hugepage_issue_base is required to be non-zero for prefetch variants that talk to host");
+        }
+        static_config.pcie_base = dev_hugepage_issue_base;
+    }
+
+    void CreateKernel() override;
+    void GenerateStaticConfigs() override;
+    void GenerateDependentConfigs() override;
+    void ConfigureCore() override;
+
+    prefetch_static_config_t static_config;
+    prefetch_dependent_config_t dependent_config;
+};
+
+}  // namespace tt::tt_metal::dispatch_test

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.hpp
@@ -22,8 +22,27 @@ constexpr NOC MY_NOC_INDEX = NOC::NOC_0;
 constexpr NOC DISPATCH_UPSTREAM_NOC_INDEX = NOC::NOC_1;
 
 static const std::vector<dispatch_kernel_node_t> default_topology = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, x, x, x}, MY_NOC_INDEX, MY_NOC_INDEX, MY_NOC_INDEX},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, MY_NOC_INDEX, DISPATCH_UPSTREAM_NOC_INDEX, MY_NOC_INDEX},
+};
+
+static const std::vector<dispatch_kernel_node_t> split_prefetcher_topology = {
+    {0, 0, 0, 0, PREFETCH_H, {x, x, x, x}, {1, x, x, x}, MY_NOC_INDEX, MY_NOC_INDEX, MY_NOC_INDEX},
+    {1, 0, 0, 0, PREFETCH_D, {0, x, x, x}, {2, x, x, x}, MY_NOC_INDEX, MY_NOC_INDEX, MY_NOC_INDEX},
+    {2, 0, 0, 0, DISPATCH_HD, {1, x, x, x}, {x, x, x, x}, MY_NOC_INDEX, DISPATCH_UPSTREAM_NOC_INDEX, MY_NOC_INDEX},
+};
+
+static const std::vector<dispatch_kernel_node_t> split_dispatcher_topology = {
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, x, x, x}, MY_NOC_INDEX, MY_NOC_INDEX, MY_NOC_INDEX},
+    {1, 0, 0, 0, DISPATCH_D, {0, x, x, x}, {2, x, x, x}, MY_NOC_INDEX, DISPATCH_UPSTREAM_NOC_INDEX, MY_NOC_INDEX},
+    {2, 0, 0, 0, DISPATCH_H, {1, x, x, x}, {0, x, x, x}, MY_NOC_INDEX, DISPATCH_UPSTREAM_NOC_INDEX, MY_NOC_INDEX},
+};
+
+static const std::vector<dispatch_kernel_node_t> split_dispatcher_prefetcher_topology = {
+    {0, 0, 0, 0, PREFETCH_H, {x, x, x, x}, {1, x, x, x}, MY_NOC_INDEX, MY_NOC_INDEX, MY_NOC_INDEX},
+    {1, 0, 0, 0, PREFETCH_D, {0, x, x, x}, {2, x, x, x}, MY_NOC_INDEX, MY_NOC_INDEX, MY_NOC_INDEX},
+    {2, 0, 0, 0, DISPATCH_D, {1, x, x, x}, {3, x, x, x}, MY_NOC_INDEX, DISPATCH_UPSTREAM_NOC_INDEX, MY_NOC_INDEX},
+    {3, 0, 0, 0, DISPATCH_H, {2, x, x, x}, {0, x, x, x}, MY_NOC_INDEX, DISPATCH_UPSTREAM_NOC_INDEX, MY_NOC_INDEX},
 };
 
 class TestPrefetcherMuxKernel : public FDKernel {
@@ -70,9 +89,12 @@ public:
         FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
         static_config.is_h_variant = h_variant;
         static_config.is_d_variant = d_variant;
-        static_config.completion_queue_base_addr = dev_hugepage_completion_buffer_base;
-        if (h_variant && !dev_hugepage_completion_buffer_base) {
-            TT_THROW("dev_hugepage_completion_buffer_base is required to be non zero for variants that talk to host");
+        if (h_variant) {
+            if (!dev_hugepage_completion_buffer_base)
+                TT_THROW("dev_hugepage_completion_buffer_base is required to be non zero for variants that talk to host");
+            static_config.completion_queue_base_addr = dev_hugepage_completion_buffer_base;
+        } else {
+            static_config.completion_queue_base_addr = 0;
         }
     }
 
@@ -80,6 +102,8 @@ public:
     void GenerateStaticConfigs() override;
     void GenerateDependentConfigs() override;
     void ConfigureCore() override;
+
+    std::vector<uint32_t> CreateCompileArgs();
 
     dispatch_static_config_t static_config;
     dispatch_dependent_config_t dependent_config;
@@ -99,16 +123,24 @@ public:
         FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
         static_config.is_h_variant = h_variant;
         static_config.is_d_variant = d_variant;
-        if (h_variant && !dev_hugepage_issue_base) {
-            TT_THROW("dev_hugepage_issue_base is required to be non-zero for prefetch variants that talk to host");
+
+        // pcie is unused for prefetch_d
+        if (h_variant) {
+            if (!dev_hugepage_issue_base)
+                TT_THROW("dev_hugepage_issue_base is required to be non-zero for prefetch variants that talk to host");
+            // pcie base is set in ctor
+            static_config.pcie_base = dev_hugepage_issue_base;
+        } else {
+            static_config.pcie_base = 0;
         }
-        static_config.pcie_base = dev_hugepage_issue_base;
     }
 
     void CreateKernel() override;
     void GenerateStaticConfigs() override;
     void GenerateDependentConfigs() override;
     void ConfigureCore() override;
+
+    std::vector<uint32_t> CreateCompileArgs();
 
     prefetch_static_config_t static_config;
     prefetch_dependent_config_t dependent_config;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -852,7 +852,8 @@ void Device::compile_command_queue_programs() {
     auto command_queue_program_ptr = std::make_unique<Program>();
     auto mmio_command_queue_program_ptr = std::make_unique<Program>();
     if (this->is_mmio_capable()) {
-        auto command_queue_program_ptr = create_and_compile_cq_program(this);
+        auto command_queue_program_ptr =
+            tt::tt_metal::dispatch::create_and_compile_cq_program(this, tt::DevicePool::instance().fd_topology_kernels);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
         // Since devices could be set up in any order, on mmio device do a pass and populate cores for tunnelers.
         if (tt::Cluster::instance().get_mmio_device_tunnel_count(this->id_) > 0) {
@@ -868,7 +869,8 @@ void Device::compile_command_queue_programs() {
             }
         }
     } else {
-        auto command_queue_program_ptr = create_and_compile_cq_program(this);
+        auto command_queue_program_ptr =
+            tt::tt_metal::dispatch::create_and_compile_cq_program(this, tt::DevicePool::instance().fd_topology_kernels);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
     }
 }
@@ -913,7 +915,7 @@ void Device::configure_command_queue_programs() {
     }
 
     // Write device-side cq pointers
-    configure_dispatch_cores(this);
+    tt::tt_metal::dispatch::configure_dispatch_cores(this, tt::DevicePool::instance().fd_topology_kernels);
 
     // Run the cq program
     command_queue_program.finalize(this);

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -93,6 +93,11 @@ public:
 
     bool is_initialized() const { return this->initialized_; }
 
+    // Returns true if the dispatch_s is enabled and it is on the same core as dispatch
+    bool dispatch_s_shared_core() const {
+        return this->dispatch_s_enabled() && dispatch_core_manager::instance().get_dispatch_core_type(this->id()) == CoreType::WORKER;
+    }
+
     int num_dram_channels() const;
     uint32_t l1_size_per_core() const;
     uint32_t dram_size_per_channel() const;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -334,7 +334,8 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
 
-    populate_fd_kernels(devices_to_activate, this->num_hw_cqs);
+    // Reassign from previous run
+    fd_topology_kernels = tt::tt_metal::dispatch::populate_fd_kernels(devices_to_activate, this->num_hw_cqs);
     for (const auto& device_id : devices_to_activate) {
         if (not this->is_device_active(device_id)) {
             this->activate_device(device_id);

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "dispatch/kernel_config/fd_kernel.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/host_api.hpp"
 #include "impl/debug/dprint_server.hpp"
@@ -78,6 +79,8 @@ private:
     void initialize_device(tt_metal::v1::DeviceHandle dev) const;
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
     static DevicePool* _inst;
+
+    std::vector<FDKernel*> fd_topology_kernels;
 
     // TODO remove with v0
     tt_metal::v1::DeviceHandle get_handle(Device* device) const;

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -80,7 +80,7 @@ private:
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
     static DevicePool* _inst;
 
-    std::vector<FDKernel*> fd_topology_kernels;
+    std::vector<tt::tt_metal::dispatch::FDKernel*> fd_topology_kernels;
 
     // TODO remove with v0
     tt_metal::v1::DeviceHandle get_handle(Device* device) const;

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -226,13 +226,13 @@ private:
         uint32_t prefetch_dispatch_unreserved_base =
             device_cq_addrs_[tt::utils::underlying_type<CommandQueueDeviceAddrType>(
                 CommandQueueDeviceAddrType::UNRESERVED)];
-        cmddat_q_base_ = prefetch_dispatch_unreserved_base +
-                         ((prefetch_q_size_ + pcie_alignment - 1) / pcie_alignment * pcie_alignment);
-        scratch_db_base_ = cmddat_q_base_ + ((cmddat_q_size_ + pcie_alignment - 1) / pcie_alignment * pcie_alignment);
+        cmddat_q_base_ = align(prefetch_dispatch_unreserved_base + prefetch_q_size_, pcie_alignment);
+        scratch_db_base_ = align(cmddat_q_base_ + cmddat_q_size_, pcie_alignment);
+
         const uint32_t l1_size = core_type == CoreType::WORKER ? HAL_MEM_L1_SIZE : HAL_MEM_ETH_SIZE;
         TT_ASSERT(scratch_db_base_ + scratch_db_size_ < l1_size);
-        dispatch_buffer_base_ =
-            ((prefetch_dispatch_unreserved_base - 1) | ((1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) - 1)) + 1;
+        dispatch_buffer_base_ = align(prefetch_dispatch_unreserved_base, (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE));
+
         dispatch_buffer_block_size_pages_ =
             dispatch_buffer_block_size / (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) / DISPATCH_BUFFER_SIZE_BLOCKS;
         dispatch_buffer_pages_ = dispatch_buffer_block_size_pages_ * DISPATCH_BUFFER_SIZE_BLOCKS;

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void DemuxKernel::GenerateStaticConfigs() {
@@ -182,3 +184,5 @@ void DemuxKernel::CreateKernel() {
         {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[DEMUX], compile_args, defines, false, false, false);
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/demux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct demux_static_config {
     std::optional<uint32_t> endpoint_id_start_index;
     std::optional<uint32_t> rx_queue_start_addr_words;
@@ -53,3 +55,5 @@ private:
     demux_dependent_config_t dependent_config_;
     int placement_cq_id_;  // TODO: remove channel hard-coding for dispatch core manager
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -10,6 +10,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void DispatchKernel::GenerateStaticConfigs() {
@@ -367,3 +369,5 @@ void DispatchKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, completion_q1_last_event_ptr, zero, GetCoreType());
     }
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct dispatch_static_config {
     std::optional<uint32_t> dispatch_cb_base;  // 0
     std::optional<uint32_t> dispatch_cb_log_page_size;
@@ -78,3 +80,5 @@ private:
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void DispatchSKernel::GenerateStaticConfigs() {
@@ -126,3 +128,5 @@ void DispatchSKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, dispatch_message_addr, zero, GetCoreType());
     }
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -15,18 +15,15 @@ void DispatchSKernel::GenerateStaticConfigs() {
     uint8_t cq_id_ = this->cq_id_;
     auto& my_dispatch_constants = dispatch_constants::get(GetCoreType());
 
-    uint32_t dispatch_s_buffer_base = 0xff;
-    if (device_->dispatch_s_enabled()) {
-        uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base();
-        if (GetCoreType() == CoreType::WORKER) {
-            // dispatch_s is on the same Tensix core as dispatch_d. Shared resources. Offset CB start idx.
-            dispatch_s_buffer_base = dispatch_buffer_base + (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE) *
-                                                                my_dispatch_constants.dispatch_buffer_pages();
-        } else {
-            // dispatch_d and dispatch_s are on different cores. No shared resources: dispatch_s CB starts at base.
-            dispatch_s_buffer_base = dispatch_buffer_base;
-        }
+    uint32_t dispatch_s_buffer_base = my_dispatch_constants.dispatch_buffer_base();
+    if (device_->dispatch_s_shared_core()) {
+        // dispatch_s is on the same Tensix core as dispatch_d. Shared resources. Offset CB start idx.
+        dispatch_s_buffer_base +=
+            (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE) * my_dispatch_constants.dispatch_buffer_pages();
+    } else {
+        // dispatch_d and dispatch_s are on different cores. No shared resources: dispatch_s CB starts at base.
     }
+
     logical_core_ = dispatch_core_manager::instance().dispatcher_s_core(device_->id(), channel, cq_id_);
     static_config_.cb_base = dispatch_s_buffer_base;
     static_config_.cb_log_page_size = dispatch_constants::DISPATCH_S_BUFFER_LOG_PAGE_SIZE;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct dispatch_s_static_config {
     std::optional<uint32_t> cb_base;
     std::optional<uint32_t> cb_log_page_size;
@@ -40,3 +42,5 @@ private:
     dispatch_s_static_config_t static_config_;
     dispatch_s_dependent_config_t dependent_config_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -8,6 +8,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void EthRouterKernel::GenerateStaticConfigs() {
@@ -292,3 +294,5 @@ void EthRouterKernel::CreateKernel() {
         {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[PACKET_ROUTER_MUX], compile_args, defines, false, false, false);
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct eth_router_static_config {
     std::optional<uint32_t> vc_count;                   // Set from arch level
     std::optional<uint32_t> fwd_vc_count;               // # of VCs continuing on to the next chip
@@ -64,3 +66,5 @@ private:
     int placement_cq_id_;  // TODO: remove channel hard-coding for dispatch core manager
     bool as_mux_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void EthTunnelerKernel::GenerateStaticConfigs() {
@@ -347,3 +349,5 @@ uint32_t EthTunnelerKernel::GetRouterId(FDKernel* k, bool upstream) {
     TT_ASSERT(false, "Couldn't find router kernel");
     return router_id;
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct eth_tunneler_static_config {
     std::optional<uint32_t> endpoint_id_start_index;
     std::optional<uint32_t> vc_count;  // Set from arch level
@@ -58,3 +60,5 @@ private:
     eth_tunneler_dependent_config_t dependent_config_;
     bool is_remote_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -15,6 +15,8 @@
 #include "eth_router.hpp"
 #include "eth_tunneler.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 FDKernel* DefaultFDKernelGenerator::Generate(
@@ -148,3 +150,5 @@ void FDKernel::configure_kernel_variant(
                 .defines = defines});
     }
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -10,6 +10,8 @@
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
 #define UNUSED_SEM_ID 0
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct {
     NOC non_dispatch_noc;  // For communicating with workers/DRAM/host
     NOC upstream_noc;      // For communicating with upstream dispatch modules
@@ -137,3 +139,5 @@ protected:
     std::vector<FDKernel*> upstream_kernels_;
     std::vector<FDKernel*> downstream_kernels_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -41,8 +41,21 @@ static std::vector<string> dispatch_kernel_file_names = {
 
 class FDKernel;  // Required by FDKernelGenerator
 
+class FDKernelGenerator {
+public:
+    virtual ~FDKernelGenerator() = default;
+
+    virtual FDKernel* Generate(
+        int node_id,
+        chip_id_t device_id,
+        chip_id_t servicing_device_id,
+        uint8_t cq_id,
+        noc_selection_t noc_selection,
+        uint32_t type_id) = 0;
+};
+
 // Default FD Kernel Generator
-class DefaultFDKernelGenerator {
+class DefaultFDKernelGenerator : public FDKernelGenerator {
 public:
     FDKernel* Generate(
         int node_id,
@@ -50,7 +63,7 @@ public:
         chip_id_t servicing_device_id,
         uint8_t cq_id,
         noc_selection_t noc_selection,
-        uint32_t type_id);
+        uint32_t type) override;
 };
 
 // Top-level class describing a Fast Dispatch Kernel (kernel running on a specific core). All FD kernels should inherit

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void MuxKernel::GenerateStaticConfigs() {
@@ -149,3 +151,5 @@ void MuxKernel::CreateKernel() {
         {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[MUX_D], compile_args, defines, false, false, false);
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct mux_static_config {
     std::optional<uint32_t> reserved;
     std::optional<uint32_t> rx_queue_start_addr_words;
@@ -51,3 +53,5 @@ private:
     mux_static_config_t static_config_;
     mux_dependent_config_t dependent_config_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -9,6 +9,8 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 using namespace tt::tt_metal;
 
 void PrefetchKernel::GenerateStaticConfigs() {
@@ -388,3 +390,5 @@ void PrefetchKernel::ConfigureCore() {
         detail::WriteToDeviceL1(device_, logical_core_, prefetch_q_base, prefetch_q, GetCoreType());
     }
 }
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -4,6 +4,8 @@
 #pragma once
 #include "fd_kernel.hpp"
 
+namespace tt::tt_metal::dispatch {
+
 typedef struct prefetch_static_config {
     std::optional<uint32_t> downstream_cb_log_page_size;
     std::optional<uint32_t> downstream_cb_pages;
@@ -77,3 +79,5 @@ private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
 };
+
+};  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -46,7 +46,7 @@ constexpr uint32_t cmddat_q_size = get_compile_time_arg_val(12);
 // unused for prefetch_h
 constexpr uint32_t scratch_db_base = get_compile_time_arg_val(13);
 constexpr uint32_t scratch_db_size = get_compile_time_arg_val(14);
-constexpr uint32_t downstream_sync_sem_id = get_compile_time_arg_val(15);
+constexpr uint32_t my_downstream_sync_sem_id = get_compile_time_arg_val(15);
 
 // prefetch_d specific
 constexpr uint32_t cmddat_q_pages = get_compile_time_arg_val(16);
@@ -901,7 +901,7 @@ uint32_t process_stall(uint32_t cmd_ptr) {
 
     WAYPOINT("PSW");
     volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(downstream_sync_sem_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_downstream_sync_sem_id));
     uint32_t heartbeat = 0;
     do {
         invalidate_l1_cache();

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -1,15 +1,73 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #pragma once
+
+#include "dispatch/kernel_config/fd_kernel.hpp"
 #include "tt_metal/impl/device/device.hpp"
+
+#define DISPATCH_MAX_UPSTREAM 4
+#define DISPATCH_MAX_DOWNSTREAM 4
+
+namespace tt::tt_metal::dispatch {
+
+typedef struct {
+    int id;
+    chip_id_t device_id;                          // Device that this kernel is located on
+    chip_id_t servicing_device_id;                // Remote device that this kernel services, used for kernels on MMIO
+    uint8_t cq_id;                                // CQ this kernel implements
+    DispatchWorkerType kernel_type;               // Type of dispatch kernel this is
+    int upstream_ids[DISPATCH_MAX_UPSTREAM];      // Upstream dispatch kernels
+    int downstream_ids[DISPATCH_MAX_DOWNSTREAM];  // Downstream dispatch kernels
+    NOC my_noc;                                   // NOC this kernel uses to dispatch kernels
+    NOC upstream_noc;                             // NOC used to communicate upstream
+    NOC downstream_noc;                           // NOC used to communicate downstream
+} dispatch_kernel_node_t;
+
+// Create the graph given the nodes
+template <typename Generator = DefaultFDKernelGenerator>
+std::vector<FDKernel*> connect_fd_graph_edges(std::vector<dispatch_kernel_node_t>& nodes) {
+    std::vector<FDKernel*> node_id_to_kernel;
+
+    // Read the input table, create configs for each node
+    for (const auto& node : nodes) {
+        TT_ASSERT(node_id_to_kernel.size() == node.id);
+        node_id_to_kernel.push_back(Generator().Generate(
+            node.id,
+            node.device_id,
+            node.servicing_device_id,
+            node.cq_id,
+            {node.my_noc, node.upstream_noc, node.downstream_noc},
+            static_cast<uint32_t>(node.kernel_type)));
+    }
+
+    // Connect the graph with upstream/downstream kernels
+    for (const auto& node : nodes) {
+        for (int idx = 0; idx < DISPATCH_MAX_UPSTREAM; idx++) {
+            if (node.upstream_ids[idx] >= 0) {
+                node_id_to_kernel.at(node.id)->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
+            }
+        }
+        for (int idx = 0; idx < DISPATCH_MAX_DOWNSTREAM; idx++) {
+            if (node.downstream_ids[idx] >= 0) {
+                node_id_to_kernel.at(node.id)->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
+            }
+        }
+    }
+
+    return node_id_to_kernel;
+}
 
 // Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use
 // a created Device to fill out the settings.
-void populate_fd_kernels(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs);
+std::vector<FDKernel*> populate_fd_kernels(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs);
 
 // Fill out all settings for FD kernels on the given device, and add them to a Program and return it.
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(tt::tt_metal::Device* device);
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_cq_program(
+    tt::tt_metal::Device* device, std::vector<FDKernel*>& node_id_to_kernel);
 
 // Performa additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
-void configure_dispatch_cores(tt::tt_metal::Device* device);
+void configure_dispatch_cores(tt::tt_metal::Device* device, std::vector<FDKernel*>& node_to_to_kernel);
+
+};  // namespace tt::tt_metal::dispatch


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16364

### Problem description
Generalize the FDKernel generator function so more kernels can be used with the FD init topology system and we can clean up the prefetch/dispatch/tunneler perf microbenchmarks.

### What's changed
- topology code placed in `namespace tt::tt_metal::dispatch`. Code in the header file started to overlap and pollute device.cpp and other files.
- Moved the code to connect the edges in `populate_fd_kernels` out to a separate function called
- Update test prefetcher

```cpp
template <typename Generator = DefaultFDKernelGenerator>
std::vector<FDKernel*> connect_fd_graph_edges(std::vector<dispatch_kernel_node_t>& nodes)
```

- `node_id_to_kernel` is removed from topology.cpp globals. This list to be passed into the functions that need it.
- `dispatch_kernel_node_t` moved to the header file


### Checklist
- [ ] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12551422242
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
