### PR TITLE
support keepdim for prod

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/prod.py
+++ b/tests/sweep_framework/sweeps/reduction/prod.py
@@ -71,8 +71,6 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
         test_vector["input_a_dtype"] == ttnn.float32 or test_vector["input_a_dtype"] == ttnn.bfloat16
     ):
         return True, "Row major is only supported for fp32 & fp16"
-    if not test_vector["keepdim"]:
-        return True, "keepdim = false is not supported"
 
     device = ttnn.open_device(device_id=0)
     if test_vector["input_a_dtype"] == ttnn.float32 and ttnn.device.is_grayskull(device):
@@ -118,7 +116,7 @@ def run(
     )
 
     start_time = start_measuring_time()
-    result = ttnn.prod(input_tensor_a, dim=dim, memory_config=output_memory_config)
+    result = ttnn.prod(input_tensor_a, dim=dim, keepdim=keepdim, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(result)
     e2e_perf = stop_measuring_time(start_time)
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -30,6 +30,7 @@ mem_configs = [
     (3, 2, 1, 0, -1, -2, -3, -4),
 )
 @pytest.mark.parametrize("all_dimensions", [False, True])
+@pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize(
     "input_shapes",
     [
@@ -50,6 +51,7 @@ class TestProd:
         self,
         all_dimensions,
         dim,
+        keepdim,
         input_shapes,
         dst_mem_config,
         device,
@@ -62,6 +64,7 @@ class TestProd:
             {
                 "all_dimensions": all_dimensions,
                 "dim": dim,
+                "keepdim": keepdim,
             }
         )
         test_args.update({"output_mem_config": dst_mem_config})

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -982,7 +982,7 @@ def prod(x, *args, all_dimensions, dim, **kwargs):
     if all_dimensions:
         result = torch.prod(x)
         return result.view(1, 1, 1, 1)
-    return torch.prod(x, dim, keepdim=True)
+    return torch.prod(x, dim, keepdim=kwargs["keepdim"])
 
 
 def ldexp(x, y, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1256,6 +1256,7 @@ def prod(
     *args,
     all_dimensions,
     dim,
+    keepdim,
     device,
     dtype,
     layout,
@@ -1264,7 +1265,7 @@ def prod(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.prod(t0, all_dimensions, dim, memory_config=output_mem_config)
+    t1 = ttnn.prod(t0, all_dimensions, dim, keepdim=keepdim, memory_config=output_mem_config)
     output_tensor = ttnn.from_device(t1)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py
@@ -74,7 +74,11 @@ def test_prod_dims(input_shape, dims, device):
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     tt_output_cpu = (
-        ttnn.prod(tt_input, tt_output, dims=dims).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
+        ttnn.prod(tt_input, tt_output, dims=dims, keepdim=True)
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
     )
 
     rtol = atol = 0.1

--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py
@@ -74,11 +74,7 @@ def test_prod_dims(input_shape, dims, device):
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     tt_output_cpu = (
-        ttnn.prod(tt_input, tt_output, dims=dims, keepdim=True)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(output_shape)
-        .to_torch()
+        ttnn.prod(tt_input, tt_output, dims=dims).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
     )
 
     rtol = atol = 0.1

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -66,7 +66,7 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
         torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
 
-    output_tensor = ttnn.prod(input_tensor, dim=dim, memory_config=ttnn.L1_MEMORY_CONFIG)
+    output_tensor = ttnn.prod(input_tensor, dim=dim, keepdim=keepdim, memory_config=ttnn.L1_MEMORY_CONFIG)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -75,8 +75,8 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("batch_size", [3])
-@pytest.mark.parametrize("c", [5])
+@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("c", [32])
 @pytest.mark.parametrize("h", [37])
 @pytest.mark.parametrize("w", [63])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -55,7 +55,7 @@ def test_var(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [67])
 @pytest.mark.parametrize("w", [77])
 @pytest.mark.parametrize("dim", [0, 1, 2, 3])
-@pytest.mark.parametrize("keepdim", [True])
+@pytest.mark.parametrize("keepdim", [True, False])
 def test_prod(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -143,7 +143,9 @@ Tensor to_layout_impl(
                 throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
             }
         } else if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-            TT_ASSERT(not dtype.has_value(), "dtype cannot be specified when converting to ROW_MAJOR_LAYOUT!");
+            TT_FATAL(
+                !dtype.has_value() || dtype.value() == tensor_arg.dtype(),
+                "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device!");
 
             if (tensor.is_sharded()) {
                 const auto memory_config = tensor.memory_config();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1857,7 +1857,7 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(
         input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
-    Tensor prod_result = ttnn::prod(input, all_dimensions, dim, output_memory_config);
+    Tensor prod_result = ttnn::prod(input, all_dimensions, dim, true, output_memory_config);
     if (prod_result.get_layout() == Layout::ROW_MAJOR && prod_result.storage_type() == StorageType::DEVICE) {
         prod_result = ttnn::operations::unary_backward::change_layout_to_tile(prod_result, output_memory_config);
     }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -93,6 +93,7 @@ Tensor ProdOperation::invoke(
         return prod_all(input_a, output_mem_config);
     }
     TT_FATAL(dim >= -4 && dim <= 3, "Dimension out of range (expected to be in range of [-4, 3]");
+    TT_ASSERT(input_a.get_legacy_shape().rank() == 4, "As of now, Prod op only supports 4D tensors");
     Tensor temp = input_a;
     // Permute for dim 2,3
     if (dim == 2 || dim == -2) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/common/constants.hpp"
+#include "ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp"
 
 namespace ttnn::operations::reduction {
 
@@ -82,7 +83,11 @@ inline Tensor prod_nc(const Tensor& temp, int64_t dim, const MemoryConfig& outpu
 }
 
 Tensor ProdOperation::invoke(
-    const Tensor& input_a, bool all_dimensions, int64_t dim, const std::optional<MemoryConfig>& memory_config) {
+    const Tensor& input_a,
+    bool all_dimensions,
+    int64_t dim,
+    const bool keepdim,
+    const std::optional<MemoryConfig>& memory_config) {
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     if (all_dimensions) {
         return prod_all(input_a, output_mem_config);
@@ -101,14 +106,15 @@ Tensor ProdOperation::invoke(
     // Permute and unpad result for dim 2,3
     auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
     if (dim == 0 || dim == 1 || dim == -4 || dim == -3) {
-        return result;
+        // Dont return prematurely. We need to manipulate the result tensor based on keepdim flag
+        // return result;
     } else if (dim == 2 || dim == -2) {
         ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
         Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
         const auto input_shape = input_a.get_shape();
         ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[3]};
-        return ttnn::slice(DefaultQueueId, required, start_index, end_index, step, std::nullopt);
+        result = ttnn::slice(DefaultQueueId, required, start_index, end_index, step, std::nullopt);
     } else {  // dim 3
         // permute
         ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
@@ -121,8 +127,9 @@ Tensor ProdOperation::invoke(
         // permute back
         after_permute_dims = {0, 1, 3, 2};
         Tensor res_host = ttnn::permute(new_unpad_tensor, after_permute_dims, output_mem_config);
-        return res_host;
+        result = res_host;
     }
+    return keepdim ? result : ttnn::squeeze(result, dim);
 }
 
 Tensor ProdOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -93,7 +93,7 @@ Tensor ProdOperation::invoke(
         return prod_all(input_a, output_mem_config);
     }
     TT_FATAL(dim >= -4 && dim <= 3, "Dimension out of range (expected to be in range of [-4, 3]");
-    TT_ASSERT(input_a.get_legacy_shape().rank() == 4, "As of now, Prod op only supports 4D tensors");
+    TT_FATAL(input_a.get_shape().rank() == 4, "As of now, Prod op only supports 4D tensors");
     Tensor temp = input_a;
     // Permute for dim 2,3
     if (dim == 2 || dim == -2) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
@@ -18,6 +18,7 @@ struct ProdOperation {
         const Tensor& input,
         bool all_dimensions = false,
         int64_t dim = 0,
+        const bool keepdim = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -28,6 +28,7 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                 input_tensor (ttnn.Tensor): the input tensor.
                 all_dimensions (bool, optional): prod along all dimensions. Defaults to `False`.
                 dim (int, optional): Dimension to perform prod. Defaults to `0`.
+                keepdim (bool, optional): keep original dimension size. Defaults to `False`.
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
@@ -52,12 +53,14 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
                const Tensor& input_tensor,
                bool all_dimensions,
                int dim,
+               const bool keepdim,
                const std::optional<MemoryConfig>& memory_config) {
-                return self(input_tensor, all_dimensions, dim, memory_config);
+                return self(input_tensor, all_dimensions, dim, keepdim, memory_config);
             },
             py::arg("input_tensor"),
             py::arg("all_dimensions") = false,
             py::arg("dim") = 0,
+            py::arg("keepdim") = false,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt},
         // prod along nc dimensions


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14288)

### Problem description
keepdim is not supported

### What's changed
Added support for keepdim flag for prod

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/12674163250
- [x] Blackhole Post commit (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/12639389408
- [x] Model regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12672715174
- [x] Device performance regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/12639391974
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
