### PR TITLE
Add support for act_block_h_override to Width Sharded Conv2d

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -430,8 +430,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     if (has_bias) {
         bias_buffer = bias.value().buffer();
         bias_dram_addr = bias_buffer->address();
-        bias_ntiles =
-            bias.value().get_legacy_shape()[3] / constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
+        bias_ntiles = weight_block_w_ntiles;
         bias_in_dram = bias_buffer->buffer_type() == BufferType::DRAM;
     }
 
@@ -469,7 +468,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         out_block_h_ntiles * act_block_w_ntiles * tt::tt_metal::detail::TileSize(act_df);
     uint32_t dst_l1_weight_buffer_size_bytes =
         weight_block_h_ntiles * weight_block_w_ntiles * tt::tt_metal::detail::TileSize(weight_df);
-
     // Number of bytes to be read from the channel dimension in one block.
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
 
@@ -665,7 +663,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         tilize_in0,    // tilize_in0
         untilize_out,  // untilize_out
 
-        bias_ntiles_per_core,
+        bias_ntiles,
 
         out0_cb,
         num_output_tiles,
@@ -681,10 +679,12 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
 
     // Local L1 to store temp vars
+    // Used for act_mcast_sender_semaphore_valid_addr_ptr
     CircularBufferConfig cb_for_l1_array_config =
         CircularBufferConfig(32 * 2, {{cb_for_l1_array, tt::DataFormat::Float16_b}})
             .set_page_size(cb_for_l1_array, 32 * 2);
     tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    log_debug(LogOp, "CB for L1 Array CB: {}, npages: {}, pagesize: {}", cb_for_l1_array, 1, 32 * 2);
 
     CircularBufferConfig cb_sharded_act_config =
         CircularBufferConfig(shard_shape[0] * shard_shape[1] * datum_size(act_df), {{sharded_act_cb, act_df}})
@@ -765,13 +765,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
                 .set_page_size(matmul_partials_cb, out_tile_size);
         if (output.is_sharded()) {
             cb_matmul_partials_config = cb_matmul_partials_config.set_globally_allocated_address(*output.buffer());
+        } else {
+            log_debug(
+                LogOp,
+                "Matmul Partials CB: {}, npages: {}, pagesize: {}",
+                matmul_partials_cb,
+                num_output_tiles,
+                out_tile_size);
         }
-        log_debug(
-            LogOp,
-            "Matmul Partials CB: {}, npages: {}, pagesize: {}",
-            matmul_partials_cb,
-            num_output_tiles,
-            out_tile_size);
         cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_matmul_partials_config);
     } else {
         // Separate buffer if not same data format

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -65,15 +65,16 @@ void kernel_main() {
     constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(9);
     constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(10);
     constexpr uint32_t num_input_cores = get_compile_time_arg_val(11);
-    constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(12);
-    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(13));
-    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
-    constexpr uint32_t act_mcast_dest_noc_start_x = get_compile_time_arg_val(15);
-    constexpr uint32_t act_mcast_dest_noc_start_y = get_compile_time_arg_val(16);
-    constexpr uint32_t act_mcast_dest_noc_end_x = get_compile_time_arg_val(17);
-    constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(18);
-    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(19);
-    constexpr uint32_t num_output_cores = get_compile_time_arg_val(20);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(12);
+    constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(13);
+    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
+    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(15));
+    constexpr uint32_t act_mcast_dest_noc_start_x = get_compile_time_arg_val(16);
+    constexpr uint32_t act_mcast_dest_noc_start_y = get_compile_time_arg_val(17);
+    constexpr uint32_t act_mcast_dest_noc_end_x = get_compile_time_arg_val(18);
+    constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(19);
+    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(20);
+    constexpr uint32_t num_output_cores = get_compile_time_arg_val(21);
 
     constexpr uint32_t num_mcast_cores = MAX(num_input_cores, num_output_cores);
     uint32_t i = 0;  // Runtime arg index
@@ -151,125 +152,126 @@ void kernel_main() {
     noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), conv_act_c_read_bytes);
 
     // Reset reader_idx to finish act_block_h_datums
+    for (uint32_t block_h_index = 0; block_h_index < act_num_blocks_h; block_h_index++) {
+        act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+        for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
+            uint32_t reader_idx = block_h_index * (act_block_h_datums / 2);
+            cb_reserve_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
+            if (this_core_id < num_input_cores) {
+                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                for (uint32_t bh = 0; bh < act_block_h_datums / 2; bh++) {
+                    uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                    read_channels<weight_size_h, weight_size_w>(
+                        l1_write_addr_act,
+                        act_l1_read_addr,
+                        two_reader_indices & 0xffff,
+                        conv_act_c_bytes,
+                        conv_act_c_read_bytes,
+                        stride_h_bytes,
+                        stride_w_bytes);
+                    read_channels<weight_size_h, weight_size_w>(
+                        l1_write_addr_act,
+                        act_l1_read_addr,
+                        two_reader_indices >> 16,
+                        conv_act_c_bytes,
+                        conv_act_c_read_bytes,
+                        stride_h_bytes,
+                        stride_w_bytes);
 
-    for (uint32_t block_w_index = 0; block_w_index < act_num_blocks_w; block_w_index++) {
-        uint32_t reader_idx = 0;
-        cb_reserve_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
-        if (this_core_id < num_input_cores) {
-            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_row_major_bfloat16);
+                    reader_idx++;
+                }
 
-            for (uint32_t bh = 0; bh < act_block_h_datums / 2; bh++) {
-                uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
-                read_channels<weight_size_h, weight_size_w>(
-                    l1_write_addr_act,
-                    act_l1_read_addr,
-                    two_reader_indices & 0xffff,
-                    conv_act_c_bytes,
-                    conv_act_c_read_bytes,
-                    stride_h_bytes,
-                    stride_w_bytes);
-                read_channels<weight_size_h, weight_size_w>(
-                    l1_write_addr_act,
-                    act_l1_read_addr,
-                    two_reader_indices >> 16,
-                    conv_act_c_bytes,
-                    conv_act_c_read_bytes,
-                    stride_h_bytes,
-                    stride_w_bytes);
+                // After reading one block, increment the starting read pointer by the width of the block.
+                // Next read uses the next set of channels.
+                act_l1_read_addr += conv_act_c_read_bytes;
 
-                reader_idx++;
+                noc_async_read_barrier();
             }
+            cb_push_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
 
-            // After reading one block, increment the starting read pointer by the width of the block.
-            // Next read uses the next set of channels.
-            act_l1_read_addr += conv_act_c_read_bytes;
+            // Round robin self-mcast and receive tilized act matrix in cb_id_act
+            // Compute should function like regular mm
 
-            noc_async_read_barrier();
-        }
-        cb_push_back(cb_id_act_row_major_bfloat16, act_block_num_tiles);
+            uint32_t act_w_outer_i = 0;
 
-        // Round robin self-mcast and receive tilized act matrix in cb_id_act
-        // Compute should function like regular mm
+            uint32_t sender_noc_x = 0;
+            uint32_t sender_noc_y = 0;
 
-        uint32_t act_w_outer_i = 0;
+            for (uint32_t act_w_outer_i = 0; act_w_outer_i < num_input_cores; act_w_outer_i++) {
+                cb_reserve_back(cb_id_act, act_block_num_tiles);
+                if (act_w_outer_i == this_core_id) {
+                    // MCAST SENDER: send entire tilized input to other cores in column
+                    // wait until all act mcast destinations have atomically incremented the act semaphore_addr (i.e.
+                    // its value should be act_mcast_num_dests), then reset the semaphore_addr value back to zero for
+                    // the next block
 
-        uint32_t sender_noc_x = 0;
-        uint32_t sender_noc_y = 0;
+                    noc_semaphore_wait_min(act_mcast_sender_semaphore_addr_ptr, num_mcast_cores - 1);
+                    noc_semaphore_set(act_mcast_sender_semaphore_addr_ptr, 0);
 
-        for (uint32_t act_w_outer_i = 0; act_w_outer_i < num_input_cores; act_w_outer_i++) {
-            cb_reserve_back(cb_id_act, act_block_num_tiles);
-            if (act_w_outer_i == this_core_id) {
-                // MCAST SENDER: send entire tilized input to other cores in column
-                // wait until all act mcast destinations have atomically incremented the act semaphore_addr (i.e. its
-                // value should be act_mcast_num_dests), then reset the semaphore_addr value back to zero for the next
-                // block
+                    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
 
-                noc_semaphore_wait_min(act_mcast_sender_semaphore_addr_ptr, num_mcast_cores - 1);
-                noc_semaphore_set(act_mcast_sender_semaphore_addr_ptr, 0);
+                    // // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
+                    cb_wait_front(tilized_in0_cb_id, act_block_num_tiles);
 
-                noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
+                    // // Now we have the block in the CB address, we can mcast to dests!
+                    uint32_t tilized_act_start_address = get_read_ptr(tilized_in0_cb_id);
 
-                // // compute tilizes and pops cb_id_act and pushes to tilized_in0_cb_id
-                cb_wait_front(tilized_in0_cb_id, act_block_num_tiles);
+                    // // num_dests will source, since we are copying to a different local CB as well
+                    uint64_t act_multicast_data_addr = act_multicast_noc_addr | get_write_ptr(cb_id_act);
 
-                // // Now we have the block in the CB address, we can mcast to dests!
-                uint32_t tilized_act_start_address = get_read_ptr(tilized_in0_cb_id);
+                    noc_async_write_multicast_loopback_src(
+                        tilized_act_start_address,
+                        act_multicast_data_addr,
+                        act_mcast_sender_size_bytes,
+                        num_mcast_cores,
+                        false,
+                        false);
 
-                // // num_dests will source, since we are copying to a different local CB as well
-                uint64_t act_multicast_data_addr = act_multicast_noc_addr | get_write_ptr(cb_id_act);
-
-                noc_async_write_multicast_loopback_src(
-                    tilized_act_start_address,
-                    act_multicast_data_addr,
-                    act_mcast_sender_size_bytes,
-                    num_mcast_cores,
-                    false,
-                    false);
-
-                // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
-                // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
-                // NOC_CMD_STATIC_VC).
+                    // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
+                    // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
+                    // (using NOC_CMD_STATIC_VC).
 #ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
-                // be sent in order they are issued
-                noc_async_writes_flushed();
+                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
+                    // not be sent in order they are issued
+                    noc_async_writes_flushed();
 #endif
-                // // We should also multicast VALID flag to destinations for receiver semaphore
-                noc_semaphore_set_multicast_loopback_src(
-                    act_mcast_sender_semaphore_valid_addr,
-                    act_mcast_receiver_semaphore_noc_addr,
-                    num_mcast_cores,
-                    false,
-                    false);
+                    // // We should also multicast VALID flag to destinations for receiver semaphore
+                    noc_semaphore_set_multicast_loopback_src(
+                        act_mcast_sender_semaphore_valid_addr,
+                        act_mcast_receiver_semaphore_noc_addr,
+                        num_mcast_cores,
+                        false,
+                        false);
 
-                noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
+                    noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
 
-            } else {
-                // MCAST RECEIVER: receive entire tilized input from sender core
-                // Set act semaphore value to INVALID
-                noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
+                } else {
+                    // MCAST RECEIVER: receive entire tilized input from sender core
+                    // Set act semaphore value to INVALID
+                    noc_semaphore_set(act_mcast_receiver_semaphore_addr_ptr, INVALID);
 
-                uint32_t sender_x = act_mcast_x_lookup[sender_noc_x];
-                uint32_t sender_y = act_mcast_y_lookup[sender_noc_y];
+                    uint32_t sender_x = act_mcast_x_lookup[sender_noc_x];
+                    uint32_t sender_y = act_mcast_y_lookup[sender_noc_y];
 
-                // Atomic increment source core counter
-                uint64_t act_mcast_sender_semaphore_noc_addr =
-                    get_noc_addr(sender_x, sender_y, act_mcast_sender_semaphore_addr);
-                noc_semaphore_inc(act_mcast_sender_semaphore_noc_addr, 1);
+                    // Atomic increment source core counter
+                    uint64_t act_mcast_sender_semaphore_noc_addr =
+                        get_noc_addr(sender_x, sender_y, act_mcast_sender_semaphore_addr);
+                    noc_semaphore_inc(act_mcast_sender_semaphore_noc_addr, 1);
 
-                // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
-                noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
-            }
+                    // wait on act semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
+                }
 
-            cb_push_back(cb_id_act, act_block_num_tiles);
+                cb_push_back(cb_id_act, act_block_num_tiles);
 
-            sender_noc_x++;
-            if (sender_noc_x >= num_cores_x) {
-                sender_noc_x = 0;
-                sender_noc_y++;
-            }
+                sender_noc_x++;
+                if (sender_noc_x >= num_cores_x) {
+                    sender_noc_x = 0;
+                    sender_noc_y++;
+                }
 
-        }  // num_input_cores
-        cb_pop_front(tilized_in0_cb_id, act_block_num_tiles);
+            }  // num_input_cores
+            cb_pop_front(tilized_in0_cb_id, act_block_num_tiles);
+        }
     }
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -54,11 +54,11 @@ void kernel_main() {
         .bank_base_address = bias_addr_dram_base, .page_size = bias_pagesize, .data_format = bias_df};
 
 #endif
+    bool to_load_bias = true;
 
     for (uint32_t act_block_h_index = 0; act_block_h_index < act_num_blocks_h; act_block_h_index++) {
         uint32_t weight_start_tile_id = init_weight_start_tile_id;
         uint32_t bias_start_tile_id = init_weight_start_tile_id;
-        bool to_load_bias = true;
 
         // Outer most loop is each core's block width.
         // This interleaves reader/tilization with compute. Hopefully better perf.
@@ -109,6 +109,7 @@ void kernel_main() {
             weight_start_tile_id += weight_next_block_this_core_stride_h;
             if (to_load_bias) {
 #ifdef FUSE_BIAS
+                cb_reserve_back(bias_cb_id, weight_block_width_ntiles);
                 uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
                 for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
                     s_bias.noc_async_read_tile(bias_start_tile_id, bias_l1_addr);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -20,10 +20,11 @@ void kernel_main() {
     constexpr uint32_t weight_next_block_other_core_stride_h = get_compile_time_arg_val(8);
     constexpr uint32_t remote_weight_height_blocks = get_compile_time_arg_val(9);
     constexpr uint32_t local_weight_height_blocks = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
 
 #ifdef FUSE_BIAS
-    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(11);
-    constexpr uint32_t bias_in_dram = get_compile_time_arg_val(12) == 1;
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(12);
+    constexpr uint32_t bias_in_dram = get_compile_time_arg_val(13) == 1;
     constexpr bool has_bias = true;
 #else
     constexpr bool has_bias = false;
@@ -54,68 +55,71 @@ void kernel_main() {
 
 #endif
 
-    uint32_t weight_start_tile_id = init_weight_start_tile_id;
-    uint32_t bias_start_tile_id = init_weight_start_tile_id;
-    bool to_load_bias = true;
+    for (uint32_t act_block_h_index = 0; act_block_h_index < act_num_blocks_h; act_block_h_index++) {
+        uint32_t weight_start_tile_id = init_weight_start_tile_id;
+        uint32_t bias_start_tile_id = init_weight_start_tile_id;
+        bool to_load_bias = true;
 
-    // Outer most loop is each core's block width.
-    // This interleaves reader/tilization with compute. Hopefully better perf.
-    // Activation reader first sends data from the same block of all cores. Then iterates to the next block and repeats
-    // for all cores. Stride = act_block_w*out_channels*sizeof(elem)
-    for (uint32_t local_weight_block_index = 0; local_weight_block_index < local_weight_height_blocks;
-         local_weight_block_index++) {
-        uint32_t weight_block_start_tile_id = weight_start_tile_id;
+        // Outer most loop is each core's block width.
+        // This interleaves reader/tilization with compute. Hopefully better perf.
+        // Activation reader first sends data from the same block of all cores. Then iterates to the next block and
+        // repeats for all cores. Stride = act_block_w*out_channels*sizeof(elem)
+        for (uint32_t local_weight_block_index = 0; local_weight_block_index < local_weight_height_blocks;
+             local_weight_block_index++) {
+            uint32_t weight_block_start_tile_id = weight_start_tile_id;
 
-        // Iterates over all the cores.
-        // Stride = in_channels*out_channels*sizeof(elem)/num_cores.
-        for (uint32_t remote_weight_block_index = 0; remote_weight_block_index < remote_weight_height_blocks;
-             remote_weight_block_index++) {
-            cb_reserve_back(cb_id_weight, weight_block_num_tiles);
-            if (is_active) {
-                uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
-                uint32_t weights_start_address = weight_write_l1_addr;
-                uint32_t weights_block_size_bytes = 0;
-                uint32_t weight_current_block_start_tile_id = weight_block_start_tile_id;
+            // Iterates over all the cores.
+            // Stride = in_channels*out_channels*sizeof(elem)/num_cores.
+            for (uint32_t remote_weight_block_index = 0; remote_weight_block_index < remote_weight_height_blocks;
+                 remote_weight_block_index++) {
+                cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+                if (is_active) {
+                    uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
+                    uint32_t weights_start_address = weight_write_l1_addr;
+                    uint32_t weights_block_size_bytes = 0;
+                    uint32_t weight_current_block_start_tile_id = weight_block_start_tile_id;
 
-                // for window size, picking up the channels for that window.
-                // Stride is in_channels*out_channels*sizeof(elem).
-                for (uint32_t block_weight_h = 0; block_weight_h < window_size_hw; block_weight_h++) {
-                    uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id;
+                    // for window size, picking up the channels for that window.
+                    // Stride is in_channels*out_channels*sizeof(elem).
+                    for (uint32_t block_weight_h = 0; block_weight_h < window_size_hw; block_weight_h++) {
+                        uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id;
 
-                    // read the channels in one block.
-                    for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < core_in_channels_ntiles; ++weight_tile_h_i) {
-                        uint32_t weight_tile_id = weight_row_start_tile_id;
+                        // read the channels in one block.
+                        for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < core_in_channels_ntiles;
+                             ++weight_tile_h_i) {
+                            uint32_t weight_tile_id = weight_row_start_tile_id;
 
-                        // loop over output channels, width of the output/weights.
-                        for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
-                             ++weight_tile_w_i) {
-                            s_weight.noc_async_read_tile(weight_tile_id, weight_write_l1_addr);
-                            weight_write_l1_addr += weight_tile_nbytes;
-                            weights_block_size_bytes += weight_tile_nbytes;
-                            weight_tile_id += 1;
-                        }  // for weight_block_w
-                        weight_row_start_tile_id += weight_matrix_width_ntiles;
-                    }  // for weight_block_h
-                    weight_current_block_start_tile_id += weight_next_channel_stride_h;
+                            // loop over output channels, width of the output/weights.
+                            for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
+                                 ++weight_tile_w_i) {
+                                s_weight.noc_async_read_tile(weight_tile_id, weight_write_l1_addr);
+                                weight_write_l1_addr += weight_tile_nbytes;
+                                weights_block_size_bytes += weight_tile_nbytes;
+                                weight_tile_id += 1;
+                            }  // for weight_block_w
+                            weight_row_start_tile_id += weight_matrix_width_ntiles;
+                        }  // for weight_block_h
+                        weight_current_block_start_tile_id += weight_next_channel_stride_h;
+                    }
+                    noc_async_read_barrier();
+                }
+                cb_push_back(cb_id_weight, weight_block_num_tiles);
+                weight_block_start_tile_id += weight_next_block_other_core_stride_h;
+            }
+            weight_start_tile_id += weight_next_block_this_core_stride_h;
+            if (to_load_bias) {
+#ifdef FUSE_BIAS
+                uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
+                for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
+                    s_bias.noc_async_read_tile(bias_start_tile_id, bias_l1_addr);
+                    bias_l1_addr += bias_pagesize;
+                    bias_start_tile_id += 1;
                 }
                 noc_async_read_barrier();
-            }
-            cb_push_back(cb_id_weight, weight_block_num_tiles);
-            weight_block_start_tile_id += weight_next_block_other_core_stride_h;
-        }
-        weight_start_tile_id += weight_next_block_this_core_stride_h;
-        if (to_load_bias) {
-#ifdef FUSE_BIAS
-            uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
-            for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
-                s_bias.noc_async_read_tile(bias_start_tile_id, bias_l1_addr);
-                bias_l1_addr += bias_pagesize;
-                bias_start_tile_id += 1;
-            }
-            noc_async_read_barrier();
-            cb_push_back(bias_cb_id, weight_block_width_ntiles);
+                cb_push_back(bias_cb_id, weight_block_width_ntiles);
 #endif
-            to_load_bias = false;
+                to_load_bias = false;
+            }
         }
     }
 }


### PR DESCRIPTION
### Ticket
#16318 

### Problem description
Conv2d with large input height/width leads to OOM due to big CBs.

### What's changed
By enabling act_block_h_override, it reduces the size of CBs, preventing OOM errors. 

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/12592969729)
- [x] New/Existing tests provide coverage for changes
