### PR TITLE
#0: Fixes for remote circular buffer synchronization

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/kernels/receiver_l1.cpp
@@ -48,4 +48,5 @@ void kernel_main() {
             experimental::remote_cb_pop_front(remote_cb_id, 1);
         }
     }
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/receiver_l1.cpp
@@ -57,4 +57,5 @@ void kernel_main() {
             cb_pop_front(sync_cb_id, 1);
         }
     }
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/kernels/writer_l1.cpp
@@ -71,4 +71,5 @@ void kernel_main() {
         }
         layer++;
     }
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
 }

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -17,7 +17,7 @@
 #include "firmware_common.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include <kernel_includes.hpp>
-#if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS or defined UPDATE_REMOTE_CB_CONFIGS_IN_L1
+#if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #include "circular_buffer_init.h"
 #endif
 
@@ -44,8 +44,5 @@ void kernel_launch(uint32_t kernel_base_addr) {
         DeviceZoneScopedMainChildN("BRISC-KERNEL");
         kernel_main();
     }
-#ifdef UPDATE_REMOTE_CB_CONFIGS_IN_L1
-    UPDATE_REMOTE_CB_CONFIGS_IN_L1
-#endif
 #endif
 }

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -17,7 +17,7 @@
 #include "tensix_functions.h"
 #include "c_tensix_core.h"
 #include "kernel_includes.hpp"
-#if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS or defined UPDATE_REMOTE_CB_CONFIGS_IN_L1
+#if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #include "circular_buffer_init.h"
 #endif
 
@@ -47,8 +47,5 @@ void kernel_launch(uint32_t kernel_base_addr) {
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #endif
     kernel_main();
-#ifdef UPDATE_REMOTE_CB_CONFIGS_IN_L1
-    UPDATE_REMOTE_CB_CONFIGS_IN_L1
-#endif
 #endif
 }

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -15,7 +15,7 @@
 
 #include "tools/profiler/kernel_profiler.hpp"
 
-#if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS or defined UPDATE_REMOTE_CB_CONFIGS_IN_L1
+#if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #include "circular_buffer_init.h"
 #endif
 
@@ -58,8 +58,5 @@ void kernel_launch(uint32_t kernel_base_addr)
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #endif
     run_kernel();
-#if !defined(UCK_CHLKC_MATH) and defined UPDATE_REMOTE_CB_CONFIGS_IN_L1
-    UPDATE_REMOTE_CB_CONFIGS_IN_L1
-#endif
 #endif
 }

--- a/tt_metal/hw/inc/remote_circular_buffer_api.h
+++ b/tt_metal/hw/inc/remote_circular_buffer_api.h
@@ -13,6 +13,51 @@
 
 namespace experimental {
 
+namespace detail {
+
+#ifndef COMPILE_FOR_TRISC
+FORCE_INLINE void update_pages_sent(
+    const RemoteSenderCBInterface& sender_cb_interface, uint32_t aligned_page_adjustment, uint8_t noc) {
+    uint32_t aligned_pages_sent_addr = sender_cb_interface.aligned_pages_sent_ptr;
+    uint32_t remote_noc_xy_addr = sender_cb_interface.receiver_noc_xy_ptr;
+    uint32_t num_receivers = sender_cb_interface.num_receivers;
+
+    // increment the aligned pages sent because we skipped to next aligned page location
+    volatile tt_l1_ptr uint32_t* pages_sent_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_sent_addr);
+    volatile tt_l1_ptr uint32_t* remote_noc_xy_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_noc_xy_addr);
+    for (uint32_t i = 0; i < num_receivers; ++i) {
+        uint32_t remote_noc_xy = uint32_t(
+            NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, remote_noc_xy_ptr[0]), DYNAMIC_NOC_Y(noc, remote_noc_xy_ptr[1])));
+        *pages_sent_ptr += aligned_page_adjustment;
+        uint64_t remote_ack_ptr_addr = get_noc_addr_helper(remote_noc_xy, (uint32_t)pages_sent_ptr);
+        noc_semaphore_inc(remote_ack_ptr_addr, aligned_page_adjustment, noc);
+        pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
+        remote_noc_xy_ptr += 2;
+    }
+}
+
+FORCE_INLINE void update_pages_acked(
+    const RemoteReceiverCBInterface& receiver_cb_interface, uint32_t aligned_page_adjustment, uint8_t noc) {
+    uint32_t aligned_pages_acked_addr = receiver_cb_interface.aligned_pages_acked_ptr;
+    uint32_t sender_noc_x = receiver_cb_interface.sender_noc_x;
+    uint32_t sender_noc_y = receiver_cb_interface.sender_noc_y;
+
+    // increment the aligned pages acked because we skipped to next aligned page location
+    volatile tt_l1_ptr uint32_t* pages_acked_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_acked_addr);
+    *pages_acked_ptr += aligned_page_adjustment;
+    uint64_t remote_ack_ptr_addr = get_noc_addr(sender_noc_x, sender_noc_y, (uint32_t)pages_acked_ptr, noc);
+    noc_semaphore_inc(remote_ack_ptr_addr, aligned_page_adjustment, noc);
+}
+#else
+FORCE_INLINE void update_pages_sent(
+    const RemoteSenderCBInterface& sender_cb_interface, uint32_t aligned_page_adjustment, uint8_t noc) {}
+FORCE_INLINE void update_pages_acked(
+    const RemoteReceiverCBInterface& receiver_cb_interface, uint32_t aligned_page_adjustment, uint8_t noc) {}
+#endif
+}  // namespace detail
+
 template <bool update_remote_over_noc = false>
 FORCE_INLINE void resize_remote_sender_cb_interface(uint32_t cb_id, uint32_t page_size, uint8_t noc) {
     ASSERT(page_size % REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE == 0);
@@ -24,32 +69,18 @@ FORCE_INLINE void resize_remote_sender_cb_interface(uint32_t cb_id, uint32_t pag
     uint32_t fifo_limit_page_aligned = fifo_start_addr + cb_size_page_aligned;
 
     uint32_t next_fifo_wr_ptr = fifo_start_addr + align(fifo_wr_ptr - fifo_start_addr, page_size);
-    if (next_fifo_wr_ptr > fifo_limit_page_aligned) {
+    uint32_t aligned_page_adjustment = 0;
+    if (next_fifo_wr_ptr >= fifo_limit_page_aligned) {
+        aligned_page_adjustment =
+            (fifo_start_addr + fifo_size - fifo_wr_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
         next_fifo_wr_ptr = fifo_start_addr;
     } else if (next_fifo_wr_ptr != fifo_wr_ptr) {
-#ifndef COMPILE_FOR_TRISC
-        if constexpr (update_remote_over_noc) {
-            uint32_t aligned_pages_sent_addr = sender_cb_interface.aligned_pages_sent_ptr;
-            uint32_t remote_noc_xy_addr = sender_cb_interface.receiver_noc_xy_ptr;
-            uint32_t num_receivers = sender_cb_interface.num_receivers;
-            uint32_t aligned_page_adjustment =
-                (next_fifo_wr_ptr - fifo_wr_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
-            // increment the aligned pages sent because we skipped to next aligned page location
-            volatile tt_l1_ptr uint32_t* pages_sent_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_sent_addr);
-            volatile tt_l1_ptr uint32_t* remote_noc_xy_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_noc_xy_addr);
-            for (uint32_t i = 0; i < num_receivers; ++i) {
-                uint32_t remote_noc_xy = uint32_t(NOC_XY_ENCODING(
-                    DYNAMIC_NOC_X(noc, remote_noc_xy_ptr[0]), DYNAMIC_NOC_Y(noc, remote_noc_xy_ptr[1])));
-                *pages_sent_ptr += aligned_page_adjustment;
-                uint64_t remote_ack_ptr_addr = get_noc_addr_helper(remote_noc_xy, (uint32_t)pages_sent_ptr);
-                noc_semaphore_inc(remote_ack_ptr_addr, aligned_page_adjustment, noc);
-                pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
-                remote_noc_xy_ptr += 2;
-            }
+        aligned_page_adjustment = (next_fifo_wr_ptr - fifo_wr_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+    }
+    if constexpr (update_remote_over_noc) {
+        if (aligned_page_adjustment != 0) {
+            detail::update_pages_sent(sender_cb_interface, aligned_page_adjustment, noc);
         }
-#endif
     }
     sender_cb_interface.fifo_wr_ptr = next_fifo_wr_ptr;
     sender_cb_interface.fifo_limit_page_aligned = fifo_limit_page_aligned;
@@ -65,26 +96,21 @@ FORCE_INLINE void resize_remote_receiver_cb_interface(uint32_t cb_id, uint32_t p
     uint32_t fifo_rd_ptr = receiver_cb_interface.fifo_rd_ptr;
     uint32_t cb_size_page_aligned = fifo_size - fifo_size % page_size;
     uint32_t fifo_limit_page_aligned = fifo_start_addr + cb_size_page_aligned;
+    uint32_t prev_fifo_limit_page_aligned = receiver_cb_interface.fifo_limit_page_aligned;
 
     uint32_t next_fifo_rd_ptr = fifo_start_addr + align(fifo_rd_ptr - fifo_start_addr, page_size);
-    if (next_fifo_rd_ptr > fifo_limit_page_aligned) {
+    uint32_t aligned_page_adjustment = 0;
+    if (next_fifo_rd_ptr >= fifo_limit_page_aligned) {
+        aligned_page_adjustment = (fifo_size - fifo_rd_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
         next_fifo_rd_ptr = fifo_start_addr;
     } else if (next_fifo_rd_ptr != fifo_rd_ptr) {
-#ifndef COMPILE_FOR_TRISC
-        if constexpr (update_remote_over_noc) {
-            uint32_t aligned_pages_acked_addr = receiver_cb_interface.aligned_pages_acked_ptr;
-            uint32_t sender_noc_x = receiver_cb_interface.sender_noc_x;
-            uint32_t sender_noc_y = receiver_cb_interface.sender_noc_y;
-            uint32_t aligned_page_adjustment =
-                (next_fifo_rd_ptr - fifo_rd_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
-            // increment the aligned pages acked because we skipped to next aligned page location
-            volatile tt_l1_ptr uint32_t* pages_acked_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_acked_addr);
-            *pages_acked_ptr += aligned_page_adjustment;
-            uint64_t remote_ack_ptr_addr = get_noc_addr(sender_noc_x, sender_noc_y, (uint32_t)pages_acked_ptr, noc);
-            noc_semaphore_inc(remote_ack_ptr_addr, aligned_page_adjustment, noc);
+        aligned_page_adjustment = (next_fifo_rd_ptr - fifo_rd_ptr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+    }
+
+    if constexpr (update_remote_over_noc) {
+        if (aligned_page_adjustment != 0) {
+            detail::update_pages_acked(receiver_cb_interface, aligned_page_adjustment, noc);
         }
-#endif
     }
     receiver_cb_interface.fifo_rd_ptr = next_fifo_rd_ptr;
     receiver_cb_interface.fifo_limit_page_aligned = fifo_limit_page_aligned;
@@ -94,8 +120,13 @@ FORCE_INLINE void resize_remote_receiver_cb_interface(uint32_t cb_id, uint32_t p
 #ifndef COMPILE_FOR_TRISC
 
 FORCE_INLINE void remote_cb_wait_front(uint32_t cb_id, uint32_t num_pages) {
-    const RemoteReceiverCBInterface& remote_cb = get_remote_receiver_cb_interface(cb_id);
+    RemoteReceiverCBInterface& remote_cb = get_remote_receiver_cb_interface(cb_id);
     uint32_t len_bytes = num_pages * remote_cb.fifo_page_size;
+    uint32_t fifo_limit_page_aligned = remote_cb.fifo_limit_page_aligned;
+    if (remote_cb.fifo_rd_ptr + len_bytes >= fifo_limit_page_aligned) {
+        uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.config_ptr)[3];
+        len_bytes += remote_cb.fifo_start_addr + fifo_size - fifo_limit_page_aligned;
+    }
     uint32_t num_pages_wait = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
     uint32_t num_pages_recv = 0;
     uint32_t pages_acked = 0;
@@ -115,26 +146,31 @@ FORCE_INLINE void remote_cb_wait_front(uint32_t cb_id, uint32_t num_pages) {
 FORCE_INLINE void remote_cb_pop_front(uint32_t cb_id, uint32_t num_pages, uint8_t noc = noc_index) {
     RemoteReceiverCBInterface& remote_cb = get_remote_receiver_cb_interface(cb_id);
     uint32_t len_bytes = num_pages * remote_cb.fifo_page_size;
-    uint32_t num_aligned_pages = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
-
-    volatile tt_l1_ptr uint32_t* pages_acked_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_acked_ptr);
-
-    *pages_acked_ptr += num_aligned_pages;
-    remote_cb.fifo_rd_ptr += len_bytes;
-
-    if (remote_cb.fifo_rd_ptr >= remote_cb.fifo_limit_page_aligned) {
-        remote_cb.fifo_rd_ptr = remote_cb.fifo_start_addr;
+    uint32_t fifo_limit_page_aligned = remote_cb.fifo_limit_page_aligned;
+    uint32_t fifo_rd_ptr = remote_cb.fifo_rd_ptr;
+    if (fifo_rd_ptr + len_bytes >= fifo_limit_page_aligned) {
+        uint32_t fifo_start_addr = remote_cb.fifo_start_addr;
+        uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.config_ptr)[3];
+        remote_cb.fifo_rd_ptr = fifo_start_addr + (fifo_rd_ptr + len_bytes - fifo_limit_page_aligned);
+        len_bytes += fifo_start_addr + fifo_size - fifo_limit_page_aligned;
+    } else {
+        remote_cb.fifo_rd_ptr += len_bytes;
     }
-
-    uint64_t remote_ack_ptr_addr =
-        get_noc_addr(remote_cb.sender_noc_x, remote_cb.sender_noc_y, (uint32_t)pages_acked_ptr, noc);
-    noc_semaphore_inc(remote_ack_ptr_addr, num_aligned_pages, noc);
+    uint32_t num_aligned_pages = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+    detail::update_pages_acked(remote_cb, num_aligned_pages, noc);
 }
 
 FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
-    const RemoteSenderCBInterface& remote_cb = get_remote_sender_cb_interface(cb_id);
+    RemoteSenderCBInterface& remote_cb = get_remote_sender_cb_interface(cb_id);
     uint32_t len_bytes = num_pages * remote_cb.fifo_page_size;
+
+    uint32_t fifo_limit_page_aligned = remote_cb.fifo_limit_page_aligned;
+    uint32_t fifo_start_addr = remote_cb.fifo_start_addr;
+    uint32_t fifo_wr_ptr = remote_cb.fifo_wr_ptr;
+    if (fifo_wr_ptr + len_bytes >= fifo_limit_page_aligned) {
+        uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.config_ptr)[3];
+        len_bytes += fifo_start_addr + fifo_size - fifo_limit_page_aligned;
+    }
     uint32_t num_pages_wait = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
     uint32_t free_pages;
 
@@ -144,12 +180,15 @@ FORCE_INLINE void remote_cb_reserve_back(uint32_t cb_id, uint32_t num_pages) {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.aligned_pages_sent_ptr + L1_ALIGNMENT);
 
     uint32_t num_receivers = remote_cb.num_receivers;
-    uint32_t fifo_aligned_num_pages = remote_cb.fifo_limit_page_aligned / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+    uint32_t fifo_aligned_num_pages =
+        (fifo_limit_page_aligned - fifo_start_addr) / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+
     for (uint32_t i = 0; i < num_receivers; ++i) {
         do {
             uint32_t pages_acked = *pages_acked_ptr;
             uint32_t pages_sent = *pages_sent_ptr;
-            free_pages = fifo_aligned_num_pages - (pages_sent - pages_acked);
+            uint32_t sent_minus_ack = pages_sent - pages_acked;
+            free_pages = fifo_aligned_num_pages >= sent_minus_ack ? (fifo_aligned_num_pages - sent_minus_ack) : 0;
         } while (free_pages < num_pages_wait);
         pages_acked_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
         pages_sent_ptr += 2 * L1_ALIGNMENT / sizeof(uint32_t);
@@ -166,6 +205,13 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
     uint8_t noc = noc_index) {
     RemoteSenderCBInterface& remote_cb = get_remote_sender_cb_interface(cb_id);
     uint32_t len_bytes = num_pages * remote_cb.fifo_page_size;
+    uint32_t fifo_wr_ptr = remote_cb.fifo_wr_ptr;
+    uint32_t fifo_start_addr = remote_cb.fifo_start_addr;
+    uint32_t fifo_limit_page_aligned = remote_cb.fifo_limit_page_aligned;
+    if (fifo_wr_ptr + len_bytes >= fifo_limit_page_aligned) {
+        uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.config_ptr)[3];
+        len_bytes += fifo_start_addr + fifo_size - fifo_limit_page_aligned;
+    }
     uint32_t pages_sent = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
     uint32_t num_receivers = remote_cb.num_receivers;
 
@@ -181,7 +227,7 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_cb.receiver_noc_xy_ptr);
     for (uint32_t i = 0; i < num_receivers; ++i) {
         uint32_t src_addr = local_cb_addr + next_receiver_start_addr_offset;
-        dest_addr = remote_cb.fifo_wr_ptr;
+        dest_addr = fifo_wr_ptr;
 
         uint32_t remote_noc_xy = uint32_t(
             NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, remote_noc_xy_ptr[0]), DYNAMIC_NOC_Y(noc, remote_noc_xy_ptr[1])));
@@ -194,8 +240,8 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
             for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
                 dest_noc_addr = get_noc_addr_helper(remote_noc_xy, dest_addr);
 
-                if ((dest_addr + coalesced_page_size) > remote_cb.fifo_limit_page_aligned) {
-                    uint32_t first_len_bytes = remote_cb.fifo_limit_page_aligned - dest_addr;
+                if ((dest_addr + coalesced_page_size) > fifo_limit_page_aligned) {
+                    uint32_t first_len_bytes = fifo_limit_page_aligned - dest_addr;
                     uint32_t second_len_bytes = coalesced_page_size - first_len_bytes;
 
                     if (first_len_bytes != 0) {
@@ -203,7 +249,7 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
                         src_addr += first_len_bytes;
                     }
 
-                    dest_addr = remote_cb.fifo_start_addr;
+                    dest_addr = fifo_start_addr;
                     dest_noc_addr = get_noc_addr_helper(remote_noc_xy, dest_addr);
 
                     noc_async_write_one_packet(src_addr, dest_noc_addr, second_len_bytes, noc);
@@ -232,6 +278,9 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
         remote_noc_xy_ptr += 2;
     }
 
+    if (dest_addr == fifo_limit_page_aligned) {
+        dest_addr = fifo_start_addr;
+    }
     remote_cb.fifo_wr_ptr = dest_addr;
 }
 
@@ -265,13 +314,6 @@ FORCE_INLINE void update_remote_cb_config_in_l1(uint32_t remote_cb_index) {
     *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
         remote_cb_interface.config_ptr + offsetof(RemoteReceiverCBInterface, fifo_rd_ptr)) =
         remote_cb_interface.fifo_rd_ptr;
-}
-
-template <uint32_t num_remote_cbs>
-FORCE_INLINE void update_remote_cb_configs_in_l1(const uint32_t (&remote_cb_indices)[num_remote_cbs]) {
-    for (auto cb_id : remote_cb_indices) {
-        update_remote_cb_config_in_l1(cb_id);
-    }
 }
 
 }  // namespace experimental

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -909,7 +909,7 @@ std::vector<std::vector<CoreCoord>> Program::logical_cores() const { return pimp
 
 void detail::Program_::set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const {
     const auto& kernel_defines = kernel->defines();
-    const std::string reserved_defines[] = {"ALIGN_LOCAL_CBS_TO_REMOTE_CBS", "UPDATE_REMOTE_CB_CONFIGS_IN_L1"};
+    const std::string reserved_defines[] = {"ALIGN_LOCAL_CBS_TO_REMOTE_CBS"};
     for (const auto& str : reserved_defines) {
         TT_FATAL(
             kernel_defines.find(str) == kernel_defines.end(), "{} is a reserved define and can't be manually set", str);
@@ -943,14 +943,6 @@ void detail::Program_::set_remote_circular_buffer_init(const std::shared_ptr<Ker
     }
     if (!remote_cb_indices.empty()) {
         std::map<std::string, std::string> defines;
-        std::string update_code = fmt::format("experimental::update_remote_cb_configs_in_l1<{}>({{", remote_cb_indices.size());
-        for (auto buffer_index : remote_cb_indices) {
-            update_code += fmt::format("{},", buffer_index);
-        }
-        update_code.back() = '}';
-        update_code.append(");");
-        defines["UPDATE_REMOTE_CB_CONFIGS_IN_L1"] = update_code;
-
         if (!align_code.empty()) {
             defines["ALIGN_LOCAL_CBS_TO_REMOTE_CBS"] = align_code;
         }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Bugs in remote CB synchronization when we need to resize the remote cb related to credits sent/received, especially when we need to wrap the cb when the size is less than the total size. 

Another bug is that we cannot automatically write the cached ptr value to l1 since we don't know which risc has the final updated value.

### What's changed
Update the synchronization to send credits of the full CB size when wrapping so that we are always synchronizing based on a consistent total size.

Remove automated writing of cached ptr to l1. User will manually call this instead.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
