### PR TITLE
split ttnn unit tests 8 ways

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -45,17 +45,21 @@ jobs:
         os: ["ubuntu-20.04"]
         test-group:
           - name: ttnn group 1
-            cmd: pytest tests/ttnn/unit_tests -xv --splits 6 --group 1 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 1 -m "not disable_fast_runtime_mode"
           - name: ttnn group 2
-            cmd: pytest tests/ttnn/unit_tests -xv --splits 6 --group 2 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3
-            cmd: pytest tests/ttnn/unit_tests -xv --splits 6 --group 3 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 3 -m "not disable_fast_runtime_mode"
           - name: ttnn group 4
-            cmd: pytest tests/ttnn/unit_tests -xv --splits 6 --group 4 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 4 -m "not disable_fast_runtime_mode"
           - name: ttnn group 5
-            cmd: pytest tests/ttnn/unit_tests -xv --splits 6 --group 5 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 5 -m "not disable_fast_runtime_mode"
           - name: ttnn group 6
-            cmd: pytest tests/ttnn/unit_tests -xv --splits 6 --group 6 -m "not disable_fast_runtime_mode"
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 6 -m "not disable_fast_runtime_mode"
+          - name: ttnn group 7
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 7 -m "not disable_fast_runtime_mode"
+          - name: ttnn group 8
+            cmd: pytest tests/ttnn/unit_tests -xv --splits 8 --group 8 -m "not disable_fast_runtime_mode"
           - name: ttnn fast runtime off
             cmd: pytest tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true


### PR DESCRIPTION
### Ticket
None

### Problem description
We're hitting the 45 minute timeout limit for some TTNN unit test jobs because there's too many tests in some groups

### What's changed
Split TTNN unit tests into 8 groups from 6