### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Bcast

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -100,7 +100,7 @@ void MAIN {
                         // Redundant wait since we know data was just pushed
                         cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
                         cb_wait_front(bias_cb_id, in1_per_core_w);
-                        add_bcast_rows_init_short();
+                        add_bcast_rows_init_short(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure unpacker df for src B
                         reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure packer df for out

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -302,7 +302,7 @@ void MAIN {
 #endif
 
         reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
         // reconfigure unpacker df for src B
         cb_wait_front(bias_cb_id, in1_per_core_w);
         for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -100,7 +100,7 @@ void MAIN {
                         // Redundant wait since we know data was just pushed
                         cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
                         cb_wait_front(bias_cb_id, in1_per_core_w);
-                        add_bcast_rows_init_short();
+                        add_bcast_rows_init_short(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure unpacker df for src B
                         reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure packer df for out

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -100,7 +100,7 @@ void MAIN {
                         // Redundant wait since we know data was just pushed
                         cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
                         cb_wait_front(bias_cb_id, in1_per_core_w);
-                        add_bcast_rows_init_short();
+                        add_bcast_rows_init_short(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure unpacker df for src B
                         reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure packer df for out

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -201,7 +201,7 @@ void MAIN {
                             // bcast add data from bias_cb_id
                             cb_wait_front(bias_cb_id, bias_ntiles_w);
                             cb_wait_front(out_for_bias_cb_id, out_subblock_num_tiles);
-                            add_bcast_rows_init_short();
+                            add_bcast_rows_init_short(out_for_bias_cb_id, bias_cb_id);
                             // reconfig packer df for out
                             // pack_reconfig_data_format(out_cb_id);
                             acquire_dst();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -118,7 +118,7 @@ void MAIN {
          */
         cb_wait_front(cb_ex, 1);  // should have 1 tile
         cb_reserve_back(cb_xmm, Wt);
-        sub_bcast_cols_init_short();
+        sub_bcast_cols_init_short(cb_x, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             ACQ();
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
@@ -202,7 +202,7 @@ void MAIN {
             cb_reserve_back(cb_im_or_out, blk);
 
             ACQ();
-            mul_bcast_cols_init_short();
+            mul_bcast_cols_init_short(cb_xmm, cb_ex2pe);
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 // cb_xmm[wt+wtr] since we pop Wt from cb_xmm after the entire loop
                 mul_tiles_bcast_cols(cb_xmm, cb_ex2pe, wt + wtr, 0, wtr);  // tile *= 1/(sum(exp(x)))
@@ -214,7 +214,7 @@ void MAIN {
             if (do_gamma) {
                 ACQ();
                 uint32_t cb_outg = do_beta ? cb_fusion : tt::CBIndex::c_16;
-                mul_bcast_rows_init_short();
+                mul_bcast_rows_init_short(cb_fusion, cb_gamma);
                 cb_reserve_back(cb_outg, blk);
                 cb_wait_front(cb_gamma, wt + blk);  // we don't pop, TODO: only wait on first ht
                 cb_wait_front(cb_fusion, blk);
@@ -230,7 +230,7 @@ void MAIN {
             }
             if (do_beta) {
                 ACQ();
-                add_bcast_rows_init_short();
+                add_bcast_rows_init_short(cb_fusion, cb_beta);
                 cb_reserve_back(tt::CBIndex::c_16, blk);
                 cb_wait_front(cb_beta, wt + blk);  // TODO: optimization - only wait on first ht
                 cb_wait_front(cb_fusion, blk);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp
@@ -62,7 +62,7 @@ void MAIN {
 
         acquire_dst();
 
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(tt::HlkOperand::intermed0, tt::HlkOperand::in2);
         cb_wait_front(tt::CBIndex::c_24, out_block_tile_cnt);
         cb_wait_front(tt::CBIndex::c_2, dst_tile_cols);
         int dst_tile_index = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -159,7 +159,7 @@ void MAIN {
             cb_reserve_back(cb_im_or_out, blk);
 
             ACQ();
-            mul_bcast_cols_init_short();
+            mul_bcast_cols_init_short(cb_x, cb_ex2pe);
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 // cb_xmm[wt+wtr] since we pop Wt from cb_xmm after the entire loop
                 mul_tiles_bcast_cols(cb_x, cb_ex2pe, wt + wtr, 0, wtr);  // tile *= 1/(sum(exp(x)))
@@ -171,7 +171,7 @@ void MAIN {
             if (do_gamma) {
                 ACQ();
                 uint32_t cb_outg = do_beta ? cb_fusion : tt::CBIndex::c_16;
-                mul_bcast_rows_init_short();
+                mul_bcast_rows_init_short(cb_fusion, cb_gamma);
                 cb_reserve_back(cb_outg, blk);
                 cb_wait_front(cb_gamma, wt + blk);  // we don't pop, TODO: only wait on first ht
                 cb_wait_front(cb_fusion, blk);
@@ -187,7 +187,7 @@ void MAIN {
             }
             if (do_beta) {
                 ACQ();
-                add_bcast_rows_init_short();
+                add_bcast_rows_init_short(cb_fusion, cb_beta);
                 cb_reserve_back(tt::CBIndex::c_16, blk);
                 cb_wait_front(cb_beta, wt + blk);  // TODO: optimization - only wait on first ht
                 cb_wait_front(cb_fusion, blk);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
@@ -21,7 +21,7 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 
 #ifdef DECODE_MODE
     ACQ();
-    mul_bcast_rows_init_short();
+    mul_bcast_rows_init_short(in0_cb, in1_cb);
     mul_tiles_bcast_rows(in0_cb, in1_cb, 0, in1_idx, 0);
     pack_tile(0, out_cb);
     REL();
@@ -112,7 +112,7 @@ void MAIN {
                 cb_wait_front(rotated_in_cb, onetile);
                 cb_reserve_back(rotated_in_interm_cb, onetile);
                 ACQ();
-                mul_tiles_bcast_scalar_init_short();
+                mul_tiles_bcast_scalar_init_short(rotated_in_cb, scalar_cb);
                 mul_tiles_bcast_scalar(rotated_in_cb, scalar_cb, 0, 0, 0);
                 pack_tile(0, rotated_in_interm_cb);
                 REL();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -60,7 +60,7 @@ void MAIN {
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             // apply fused scale [*= 1/sqrt(...)]
             ACQ();
-            mul_tiles_bcast_scalar_init_short();
+            mul_tiles_bcast_scalar_init_short(cb_in0, cb_fused_scale);
             cb_wait_front(cb_in0, ndst);
             cb_reserve_back(cb_scale_mask, ndst);
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
@@ -78,7 +78,7 @@ void MAIN {
                 cb_wait_front(cb_fused_attn, wt + ndst);  // cumulative wait for up to Wt tiles, only at first ht
             }
             cb_wait_front(cb_scale_mask, ndst);
-            add_bcast_rows_init_short();
+            add_bcast_rows_init_short(cb_scale_mask, cb_fused_attn);
             for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
                 add_tiles_bcast_rows(cb_scale_mask, cb_fused_attn, wt8, wt + wt8, wt8);  // tile *= 1/(sum(exp(x)))
             }
@@ -143,7 +143,7 @@ void MAIN {
 
         // now cb_sumexps has exp tiles, need to multiply by our DST[2]
         // by now we already did a umulative wait for Wt tiles in cb_exps
-        mul_bcast_cols_init_short();
+        mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             ACQ();
             cb_reserve_back(tt::CBIndex::c_16, ndst);

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -226,7 +226,7 @@ ALWI void mul_tiles_bcast(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for add_bcast_rows to be executed
  * correctly. Required to be called before add_tiles_bcast if using column as broadcast type
  */
-ALWI void add_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_bcast_rows_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init_with_operands<ELWADD, BroadcastType::ROW, MATH_FIDELITY>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1)));
 }
@@ -235,7 +235,7 @@ ALWI void add_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for add_bcast_cols to be executed
  * correctly. Required to be called before add_tiles_bcast if using column as broadcast type
  */
-ALWI void add_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_bcast_cols_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWADD, BroadcastType::COL>()));
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::COL>(icb0, icb1)));
@@ -245,7 +245,7 @@ ALWI void add_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for add_bcast_scalar to be
  * executed correctly.
  */
-ALWI void add_bcast_scalar_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void add_bcast_scalar_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWADD, BroadcastType::SCALAR, MATH_FIDELITY>()));  // TODO(AP)
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::SCALAR>(icb0, icb1)));
@@ -255,7 +255,7 @@ ALWI void add_bcast_scalar_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for mul_bcast_cols to be executed
  * correctly.
  */
-ALWI void mul_tiles_bcast_scalar_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_tiles_bcast_scalar_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWMUL, BroadcastType::SCALAR, MATH_FIDELITY>()));  // TODO(AP)
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::SCALAR>(icb0, icb1)));
@@ -278,7 +278,7 @@ ALWI void mul_tiles_bcast_scalar(uint32_t icb0, uint32_t icb1, uint32_t itile0, 
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for mul_bcast_cols to be executed
  * correctly.
  */
-ALWI void mul_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_bcast_cols_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWMUL, BroadcastType::COL, MATH_FIDELITY>()));  // TODO(AP)
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::COL>(icb0, icb1)));
@@ -287,7 +287,7 @@ ALWI void mul_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
 /**
  * Performs a switch-from-another-op tile hw reconfiguration step needed for mul_bcast_rows to be executed correctly.
  */
-ALWI void mul_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_bcast_rows_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWMUL, BroadcastType::ROW, MATH_FIDELITY>()));
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1)));
@@ -297,7 +297,7 @@ ALWI void mul_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for sub_bcast_cols to be executed
  * correctly.
  */
-ALWI void sub_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void sub_bcast_cols_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::COL, MATH_FIDELITY>()));  // TODO(AP)
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::COL>(icb0, icb1)));
@@ -307,7 +307,7 @@ ALWI void sub_bcast_cols_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
  * Performs a first-call or switch-from-another-op tile hw reconfiguration step needed for sub_tiles_bcast_scalar to be
  * executed correctly.
  */
-ALWI void sub_tiles_bcast_scalar_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void sub_tiles_bcast_scalar_init_short(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::SCALAR, MATH_FIDELITY>()));  // TODO(AP)
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::SCALAR>(icb0, icb1)));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -213,7 +213,7 @@ void MAIN {
                             // bcast add data from bias_cb_id
                             cb_wait_front(bias_cb_id, bias_ntiles_w);
                             cb_wait_front(out_for_bias_cb_id, out_subblock_num_tiles);
-                            add_bcast_rows_init_short();
+                            add_bcast_rows_init_short(out_for_bias_cb_id, bias_cb_id);
                             // reconfig packer df for out
                             // pack_reconfig_data_format(out_cb_id);
                             tile_regs_acquire();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
@@ -328,7 +328,7 @@ ALWI void mul_tiles_bcast_rows_to_cb(
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format(icb0, icb1);
 #endif
-    mul_bcast_rows_init_short();
+    mul_bcast_rows_init_short(icb0, icb1);
     mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
     tile_regs_commit();
 
@@ -366,7 +366,7 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format(icb0, icb1);
 #endif
-    mul_bcast_rows_init_short();
+    mul_bcast_rows_init_short(icb0, icb1);
     mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
 
     log_tile_init();
@@ -407,7 +407,7 @@ ALWI void mul_tiles_bcast_cols_to_cb(
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format(icb0, icb1);
 #endif
-    mul_bcast_cols_init_short();
+    mul_bcast_cols_init_short(icb0, icb1);
     mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
     tile_regs_commit();
 
@@ -445,7 +445,7 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format(icb0, icb1);
 #endif
-    mul_bcast_cols_init_short();
+    mul_bcast_cols_init_short(icb0, icb1);
     mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
 
     log_tile_init();
@@ -643,7 +643,7 @@ ALWI void sub_tiles_bcast_cols_to_cb(
 #if defined FP32_DEST_ACC_EN
     reconfig_data_format(icb0, icb1);
 #endif
-    sub_bcast_cols_init_short();
+    sub_bcast_cols_init_short(icb0, icb1);
     sub_tiles_bcast<BroadcastType::COL>(icb0, icb1, itile0, itile1, dst0);
     tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
@@ -21,7 +21,7 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 
 #ifdef DECODE_MODE
     ACQ();
-    mul_bcast_rows_init_short();
+    mul_bcast_rows_init_short(in0_cb, in1_cb);
     mul_tiles_bcast_rows(in0_cb, in1_cb, 0, in1_idx, 0);
     pack_tile(0, out_cb);
     REL();
@@ -118,7 +118,7 @@ void MAIN {
                 cb_wait_front(rotated_in_cb, onetile);
                 cb_reserve_back(rotated_in_interm_cb, onetile);
                 ACQ();
-                mul_tiles_bcast_scalar_init_short();
+                mul_tiles_bcast_scalar_init_short(rotated_in_cb, scalar_cb);
                 mul_tiles_bcast_scalar(rotated_in_cb, scalar_cb, 0, 0, 0);
                 pack_tile(0, rotated_in_interm_cb);
                 REL();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -67,7 +67,7 @@ void MAIN {
         cb_push_back(rotated_in_interm_cb, Wt);
         cb_wait_front(rotated_in_interm_cb, Wt);
 
-        mul_bcast_rows_init_short();
+        mul_bcast_rows_init_short(rotated_in_interm_cb, sin_cb);
         ACQ();
         for (uint32_t j = 0; j < Wt; ++j) {
             // sin_interim = rotated * sin

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -324,7 +324,7 @@ void MAIN {
 #endif
 
                 reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
-                add_bcast_rows_init_short();
+                add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
                 // reconfigure unpacker df for src B
                 cb_wait_front(bias_cb_id, in1_block_w);
                 for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_inline_untilize_out.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_inline_untilize_out.cpp
@@ -317,7 +317,7 @@ void MAIN {
 #endif
 
         reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
         // reconfigure unpacker df for src B
         cb_wait_front(bias_cb_id, in1_per_core_w);
         for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/moreh_clip_grad_norm_step3_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/moreh_clip_grad_norm_step3_kernel.cpp
@@ -29,7 +29,7 @@ void MAIN {
         cb_wait_front(cb_x, onetile);  // comes from the reader
         cb_reserve_back(cb_y, onetile);
 
-        mul_tiles_bcast_scalar_init_short();
+        mul_tiles_bcast_scalar_init_short(cb_x, cb_clip_coef_clamped);
         mul_tiles_bcast_scalar(cb_x, cb_clip_coef_clamped, 0, 0, dst0);
         cb_pop_front(cb_x, onetile);
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
@@ -14,14 +14,7 @@ void MAIN {
     uint32_t has_other_grad = get_arg_val<uint32_t>(1);
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(2);
 
-    if (has_input_grad) {
-        init_bcast<ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16);
-    }
-
-    if (has_other_grad) {
-        init_bcast<ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_1, tt::CBIndex::c_0, tt::CBIndex::c_17);
-    }
-
+    init_bcast<ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16);
     cb_wait_front(tt::CBIndex::c_0, onetile);
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         if (has_input_grad) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
@@ -14,7 +14,14 @@ void MAIN {
     uint32_t has_other_grad = get_arg_val<uint32_t>(1);
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(2);
 
-    init_bcast<ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16);
+    if (has_input_grad) {
+        init_bcast<ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16);
+    }
+
+    if (has_other_grad) {
+        init_bcast<ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_1, tt::CBIndex::c_0, tt::CBIndex::c_17);
+    }
+
     cb_wait_front(tt::CBIndex::c_0, onetile);
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         if (has_input_grad) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
@@ -121,7 +121,7 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
         reconfig_data_format(cb_tmp1, cb_divisor_recip);
 #endif
-        mul_tiles_bcast_scalar_init_short();
+        mul_tiles_bcast_scalar_init_short(cb_tmp1, cb_divisor_recip);
         mul_tiles_bcast_scalar(cb_tmp1, cb_divisor_recip, 0, 0, dst0);
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -237,7 +237,7 @@ void MAIN {
             }
 
             // x - E[x]
-            sub_tiles_bcast_scalar_init_short();
+            sub_tiles_bcast_scalar_init_short(cb_x, cb_ex_global);
             cb_reserve_back(cb_xmm, block_hw);
             cb_wait_front(cb_ex_global, 1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -379,7 +379,7 @@ void MAIN {
 
             // (x - Ex) * 1/[sqrt(Var + eps)]
             index_h_offset = 0;
-            mul_tiles_bcast_scalar_init_short();
+            mul_tiles_bcast_scalar_init_short(cb_x, cb_ex2pe);
             cb_reserve_back(cb_xmm, block_hw);
             cb_wait_front(cb_ex2pe, 1);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -496,7 +496,7 @@ void MAIN {
 
     if constexpr (do_gamma) {
         index_h_offset = 0;
-        mul_bcast_rows_init_short();
+        mul_bcast_rows_init_short(cb_out, cb_gamma);
         cb_reserve_back(cb_outgamma, per_core_MN);
         cb_wait_front(cb_gamma, per_core_N);
         for (uint32_t i = 0; i < per_core_M; ++i) {
@@ -518,7 +518,7 @@ void MAIN {
 
     if constexpr (do_beta) {
         index_h_offset = 0;
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(cb_inbeta, cb_beta);
         cb_reserve_back(cb_outbeta, per_core_MN);
         cb_wait_front(cb_beta, per_core_N);
         for (uint32_t i = 0; i < per_core_M; ++i) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -145,7 +145,7 @@ void MAIN {
         }
         cb_wait_front(cb_ex, 1);  // should have 1 tile
         cb_reserve_back(cb_xmm, Wt);
-        sub_bcast_cols_init_short();
+        sub_bcast_cols_init_short(cb_x, cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             ACQ();
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
@@ -252,7 +252,7 @@ void MAIN {
             reconfig_data_format_srca(cb_fusion, cb_xmm);
 #endif
             ACQ();
-            mul_bcast_cols_init_short();
+            mul_bcast_cols_init_short(cb_xmm, cb_ex2pe);
             for (uint32_t wtr = 0; wtr < blk; wtr++) {
                 // cb_xmm[wt+wtr] since we pop Wt from cb_xmm after the entire loop
                 mul_tiles_bcast_cols(cb_xmm, cb_ex2pe, wt + wtr, 0, wtr);  // tile *= 1/(sum(exp(x)))
@@ -273,7 +273,7 @@ void MAIN {
                 reconfig_data_format_srcb(cb_ex2pe, cb_gamma);
                 ACQ();
                 uint32_t cb_outg = do_beta ? cb_fusion : cb_out;
-                mul_bcast_rows_init_short();
+                mul_bcast_rows_init_short(cb_fusion, cb_gamma);
                 cb_reserve_back(cb_outg, blk);
                 cb_wait_front(cb_gamma, wt + blk);  // we don't pop, TODO: only wait on first ht
                 cb_wait_front(cb_fusion, blk);
@@ -295,7 +295,7 @@ void MAIN {
                     reconfig_data_format_srcb(cb_ex2pe, cb_beta);
                 }
                 ACQ();
-                add_bcast_rows_init_short();
+                add_bcast_rows_init_short(cb_fusion, cb_beta);
                 cb_reserve_back(cb_out, blk);
                 cb_wait_front(cb_beta, wt + blk);  // TODO: optimization - only wait on first ht
                 cb_wait_front(cb_fusion, blk);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -194,7 +194,7 @@ void MAIN {
     }
     index_h_offset = 0;
     reconfig_data_format_srca(cb_ex_external, cb_in);
-    sub_bcast_cols_init_short();
+    sub_bcast_cols_init_short(cb_in, cb_ex_global);
     cb_reserve_back(cb_xmm, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
@@ -345,7 +345,7 @@ void MAIN {
         reconfig_data_format(cb_xmm, cb_ex_global);
     }
 #endif
-    mul_bcast_cols_init_short();
+    mul_bcast_cols_init_short(cb_xmm, cb_ex_global);
     index_h_offset = 0;
     cb_reserve_back(cb_im, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -380,7 +380,7 @@ void MAIN {
         if constexpr (do_beta == 0) {
             pack_reconfig_data_format(cb_out);
         }
-        mul_bcast_rows_init_short();
+        mul_bcast_rows_init_short(cb_im, cb_gamma);
         cb_wait_front(cb_gamma, block_w);
         index_h_offset = 0;
         cb_reserve_back(cb_outgamma, num_tiles_per_block);
@@ -410,7 +410,7 @@ void MAIN {
     if constexpr (do_beta) {
         reconfig_data_format(cb_fusion, cb_beta);
         pack_reconfig_data_format(cb_out);
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(cb_fusion, cb_beta);
         cb_wait_front(cb_beta, block_w);
         index_h_offset = 0;
         cb_reserve_back(cb_out, num_tiles_per_block);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -202,7 +202,7 @@ void MAIN {
     reconfig_data_format(cb_in0, cb_ex_global);
     pack_reconfig_data_format(cb_xmm);
     index_h_offset = 0;
-    sub_bcast_cols_init_short();
+    sub_bcast_cols_init_short(cb_in0, cb_ex_global);
     cb_reserve_back(cb_xmm, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
@@ -235,7 +235,7 @@ void MAIN {
 
     // (x - Ex) * 1/[sqrt(Var + eps)]
     reconfig_data_format(cb_xmm, cb_ex_global);
-    mul_bcast_cols_init_short();
+    mul_bcast_cols_init_short(cb_xmm, cb_ex_global);
     index_h_offset = 0;
     cb_reserve_back(cb_im, num_tiles_per_block);
 #ifndef RMSNORM
@@ -273,7 +273,7 @@ void MAIN {
         if constexpr (do_beta == 0) {
             pack_reconfig_data_format(cb_out);
         }
-        mul_bcast_rows_init_short();
+        mul_bcast_rows_init_short(cb_im, cb_gamma);
         cb_wait_front(cb_gamma, block_w);
         index_h_offset = 0;
         cb_reserve_back(cb_outgamma, num_tiles_per_block);
@@ -303,7 +303,7 @@ void MAIN {
     if constexpr (do_beta) {
         reconfig_data_format(cb_fusion, cb_beta);
         pack_reconfig_data_format(cb_out);
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(cb_fusion, cb_beta);
         cb_wait_front(cb_beta, block_w);
         index_h_offset = 0;
         cb_reserve_back(cb_out, num_tiles_per_block);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -156,7 +156,7 @@ void MAIN {
          */
         reconfig_data_format(cb_inp, cb_stats_reduced);
         pack_reconfig_data_format(cb_x_minus_mean);
-        sub_bcast_cols_init_short();
+        sub_bcast_cols_init_short(cb_inp, cb_stats_reduced);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_inp, blk);
             cb_reserve_back(cb_x_minus_mean, blk);
@@ -202,7 +202,7 @@ void MAIN {
 
         reconfig_data_format(cb_norm_x_input, cb_recip_sqrt_var);
         pack_reconfig_data_format(cb_x_normed);
-        mul_bcast_cols_init_short();
+        mul_bcast_cols_init_short(cb_norm_x_input, cb_recip_sqrt_var);
         cb_wait_front(cb_recip_sqrt_var, 1);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_norm_x_input, blk);
@@ -224,7 +224,7 @@ void MAIN {
         reconfig_data_format(cb_x_normed, cb_gamma);
         pack_reconfig_data_format(cb_times_gamma_out);
         cb_wait_front(cb_gamma, Wt);
-        mul_bcast_rows_init_short();
+        mul_bcast_rows_init_short(cb_x_normed, cb_gamma);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x_normed, blk);
             cb_reserve_back(cb_times_gamma_out, blk);
@@ -245,7 +245,7 @@ void MAIN {
             reconfig_data_format(cb_times_gamma_out, cb_beta);
             pack_reconfig_data_format(cb_out);
             cb_wait_front(cb_beta, Wt);
-            add_bcast_rows_init_short();
+            add_bcast_rows_init_short(cb_times_gamma_out, cb_beta);
             for (uint32_t wt = 0; wt < Wt; wt += blk) {
                 cb_wait_front(cb_times_gamma_out, blk);
                 cb_reserve_back(cb_out, blk);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -48,7 +48,7 @@ void calc_numeric_stable(
     exp_tile_init<EXP_APPROX>();
     reconfig_data_format_srcb(cb_max);
     cb_wait_front(cb_max, 1);
-    sub_bcast_cols_init_short();
+    sub_bcast_cols_init_short(cb_in, cb_max);
     for (uint32_t wt = 0; wt < Wt; wt += ndst) {
         ACQ();
         for (uint32_t wt8 = 0; wt8 < ndst; wt8++) {
@@ -111,7 +111,7 @@ void MAIN {
 #if FUSED_SCALE_MASK
         reconfig_data_format(cb_in0, cb_fused_scale);
         pack_reconfig_data_format(cb_scale_mask);
-        mul_tiles_bcast_scalar_init_short();
+        mul_tiles_bcast_scalar_init_short(cb_in0, cb_fused_scale);
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             // apply fused scale [*= 1/sqrt(...)]
             ACQ();
@@ -134,7 +134,7 @@ void MAIN {
 #ifdef CAUSAL_MASK
         add_tiles_init();
 #else
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(cb_scale_mask, cb_fused_attn);
 #endif
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             ACQ();
@@ -200,7 +200,7 @@ void MAIN {
                 for (uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
                     if (wt == (Wt - ndst) && (wt8 == ndst - 1)) {
                         reconfig_data_format(cb_in0, cb_mask_padded);
-                        add_bcast_rows_init_short();
+                        add_bcast_rows_init_short(cb_in0, cb_mask_padded);
                         cb_wait_front(cb_mask_padded, 1);
                         add_tiles_bcast_rows(cb_in0, cb_mask_padded, wt8, 0, wt8);
                     } else {
@@ -276,7 +276,7 @@ void MAIN {
         pack_reconfig_data_format(cb_out0);
         // now cb_sumexps has exp tiles, need to multiply by our DST[2]
         // by now we already did a umulative wait for Wt tiles in cb_exps
-        mul_bcast_cols_init_short();
+        mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt += ndst) {
             ACQ();
             cb_reserve_back(cb_out0, ndst);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -40,7 +40,7 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t
     exp_tile_init<EXP_APPROX>();
     reconfig_data_format_srcb(cb_max);
     cb_wait_front(cb_max, 1);
-    sub_bcast_cols_init_short();
+    sub_bcast_cols_init_short(cb_in, cb_max);
     uint32_t index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         ACQ();
@@ -97,7 +97,7 @@ void MAIN {
         reconfig_data_format(cb_in0, cb_fused_scale);
         pack_reconfig_data_format(cb_scale_mask);
         cb_wait_front(cb_fused_scale, 1);
-        mul_tiles_bcast_scalar_init_short();
+        mul_tiles_bcast_scalar_init_short(cb_in0, cb_fused_scale);
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             ACQ();
@@ -126,7 +126,7 @@ void MAIN {
 #ifdef CAUSAL_MASK
         add_tiles_init();
 #else
-        add_bcast_rows_init_short();
+        add_bcast_rows_init_short(cb_scale_mask, cb_fused_attn);
 #endif
 
 #ifndef NUMERIC_STABLE
@@ -222,7 +222,7 @@ void MAIN {
         reconfig_data_format(cb_exps, cb_recipsumexps);
         pack_reconfig_data_format(cb_out0);
         cb_wait_front(cb_recipsumexps, 1);
-        mul_bcast_cols_init_short();
+        mul_bcast_cols_init_short(cb_exps, cb_recipsumexps);
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
             ACQ();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -169,7 +169,7 @@ void mul_block_bcast_scalar_inplace() {
     constexpr uint32_t dst_tiles = MUL_BCAST_GRANULARITY;
     constexpr uint32_t granularity = num_tiles >> LOG2_MUL_BCAST_GRANULARITY;
     reconfig_data_format(in0_cb, in1_scalar_cb);
-    mul_tiles_bcast_scalar_init_short();
+    mul_tiles_bcast_scalar_init_short(in0_cb, in1_scalar_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_scalar_cb, 1);
     for (uint32_t g = 0; g < granularity; ++g) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -193,7 +193,7 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb, uint32_t in1_scalar_cb, uin
     constexpr uint32_t dst_tiles = MUL_BCAST_GRANULARITY;
     uint32_t granularity = num_tiles >> LOG2_MUL_BCAST_GRANULARITY;
     reconfig_data_format(in0_cb, in1_scalar_cb);
-    mul_tiles_bcast_scalar_init_short();
+    mul_tiles_bcast_scalar_init_short(in0_cb, in1_scalar_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_scalar_cb, 1);
     for (uint32_t g = 0; g < granularity; ++g) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the bcast kernel API: ./tt_metal/include/compute_kernel_api/bcast.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within this file. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

This PR incorporates changes from [PR #16376](https://github.com/tenstorrent/tt-metal/pull/16376) 

### Checklist
- [x] Post commit CI passes [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12917892322)
- [x] Blackhole Post commit (if applicable) [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12917895900)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
