### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -26,7 +26,7 @@
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_block_w);
+    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);
@@ -36,7 +36,7 @@ inline void tilize_in(
             cb_pop_front(in_cb_id, in_block_w);
         }
     }
-    tilize_uninit(in_cb_id);
+    tilize_uninit(in_cb_id, out_cb_id);
 }  // tilize_in()
 
 // NOTE: Bias is not supported with the untilize option

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
@@ -38,6 +38,6 @@ void MAIN {
         cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
     }
 
-    pack_untilize_uninit();
+    pack_untilize_uninit(tt::CBIndex::c_16);
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
@@ -13,7 +13,7 @@
 
 inline void tilize_activation(
     uint32_t in0_cb, uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks, uint32_t out_cb) {
-    tilize_init_short(in0_cb, in0_block_w);
+    tilize_init_short(in0_cb, in0_block_w, out_cb);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t h = 0; h < in0_subblock_h; h++) {
@@ -25,7 +25,7 @@ inline void tilize_activation(
         }
     }
 
-    tilize_uninit(in0_cb);
+    tilize_uninit(in0_cb, out_cb);
 }
 
 inline void reblock_and_untilize(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
@@ -10,7 +10,7 @@
 
 inline void tilize_activation(
     uint32_t in0_cb, uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks, uint32_t out_cb) {
-    tilize_init_short(in0_cb, in0_block_w);
+    tilize_init_short(in0_cb, in0_block_w, out_cb);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t h = 0; h < in0_subblock_h; h++) {
@@ -22,7 +22,7 @@ inline void tilize_activation(
         }
     }
 
-    tilize_uninit(in0_cb);
+    tilize_uninit(in0_cb, out_cb);
 }
 
 inline void reblock_and_untilize(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
@@ -49,7 +49,7 @@ inline void tilize(
     uint32_t in_ntiles_hwc,
     uint32_t window_hw_padded,
     uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_ntiles_hwc);
+    tilize_init_short(in_cb_id, in_ntiles_hwc, out_cb_id);
     for (uint32_t out_elem_i = 0; out_elem_i < out_nelems; ++out_elem_i) {
         cb_wait_front(in_cb_id, 1);
         cb_reserve_back(out_cb_id, in_ntiles_hwc);
@@ -63,7 +63,7 @@ inline void tilize(
         cb_push_back(out_cb_id, in_ntiles_hwc);
         cb_pop_front(in_cb_id, 1);
     }
-    tilize_uninit(in_cb_id);
+    tilize_uninit(in_cb_id, out_cb_id);
 }
 
 inline void reduce_h(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
@@ -49,7 +49,7 @@ inline void tilize(
     uint32_t in_ntiles_hwc,
     uint32_t window_hw_padded,
     uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_ntiles_hwc);
+    tilize_init_short(in_cb_id, in_ntiles_hwc, out_cb_id);
     for (uint32_t out_elem_i = 0; out_elem_i < out_nelems; ++out_elem_i) {
         cb_wait_front(in_cb_id, 1);
         cb_reserve_back(out_cb_id, in_ntiles_hwc);
@@ -63,7 +63,7 @@ inline void tilize(
         cb_push_back(out_cb_id, in_ntiles_hwc);
         cb_pop_front(in_cb_id, 1);
     }
-    tilize_uninit(in_cb_id);
+    tilize_uninit(in_cb_id, out_cb_id);
 }
 
 inline void reduce_h(

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -30,6 +30,6 @@ void MAIN {
         cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
     }
 
-    pack_untilize_uninit();
+    pack_untilize_uninit(tt::CBIndex::c_16);
 }
 }  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
@@ -51,7 +51,7 @@ ALWI void UNTILIZE_TILES(uint32_t in0_cb, uint32_t out_cb, uint32_t num_tiles) {
 }
 
 ALWI void TILIZE_ROWS(uint32_t in0_cb, uint32_t sync_cb, uint32_t out_cb, uint32_t num_tiles) {
-    tilize_init_short(in0_cb, num_tiles);
+    tilize_init_short(in0_cb, num_tiles, out_cb);
     cb_wait_front(sync_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     tilize_block(in0_cb, num_tiles, out_cb);
@@ -60,7 +60,7 @@ ALWI void TILIZE_ROWS(uint32_t in0_cb, uint32_t sync_cb, uint32_t out_cb, uint32
     // Pop shared cbs after tilize
     cb_pop_front(in0_cb, num_tiles);
     cb_pop_front(sync_cb, num_tiles);
-    tilize_uninit(in0_cb);
+    tilize_uninit(in0_cb, out_cb);
 }
 
 namespace NAMESPACE {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transformer_attn_matmul.cpp
@@ -72,12 +72,12 @@ void MAIN {
                 cb_reserve_back(tt::CBIndex::c_16, onetile);
 
                 // tilize CB::intermed2 and write to CBIndex::c_16
-                tilize_init_short(cb_intermed2, 1);
+                tilize_init_short(cb_intermed2, 1, out_cb_id);
                 tilize_block(cb_intermed2, 1, out_cb_id);
                 cb_push_back(out_cb_id, 1);
 
                 cb_pop_front(cb_intermed2, 1);
-                tilize_uninit(cb_intermed2);
+                tilize_uninit(cb_intermed2, out_cb_id);
 
                 mm_init_short(tt::CBIndex::c_0, tt::CBIndex::c_1, transpose_hw);
             }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_untilize.cpp
@@ -12,7 +12,7 @@ void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
 #ifndef SHORT_INIT
-    untilize_init(tt::CBIndex::c_0);
+    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #else
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     untilize_init_short(tt::CBIndex::c_0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/update_cache.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/update_cache.cpp
@@ -42,7 +42,7 @@ void MAIN {
             cb_pop_front(cache_cb, Wt);
             untilize_uninit(cache_cb);
 
-            tilize_init_short(untilized_cache2_cb, Wt);
+            tilize_init_short(untilized_cache2_cb, Wt, out_cb);
             cb_wait_front(untilized_cache2_cb, Wt);
             cb_reserve_back(out_cb, Wt);
             tilize_block(untilized_cache2_cb, Wt, out_cb);
@@ -51,7 +51,7 @@ void MAIN {
             // Compute pops both
             cb_pop_front(untilized_cache2_cb, Wt);
             cb_pop_front(untilized_cache_cb, Wt);
-            tilize_uninit(untilized_cache2_cb);
+            tilize_uninit(untilized_cache2_cb, out_cb);
         }
     }
 }

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -56,7 +56,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb)
 /**
  * Uninitialize untilize operation, to allow initializing another operation.
  */
-ALWI void pack_untilize_uninit(uint32_t ocb = 16) {
+ALWI void pack_untilize_uninit(uint32_t ocb) {
     PACK((llk_pack_init(ocb)));
     PACK((llk_init_packer_dest_offset_registers<false>()));
 

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -207,7 +207,7 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
 /**
  * Uninitialize the tilize operation along with re-configuring unpacker with the CB data types.
  */
-ALWI void tilize_uninit_with_dt(uint32_t old_icb = 0, uint32_t new_icb = 1, uint32_t ocb) {
+ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(old_icb)));
     UNPACK((llk_unpack_reconfig_data_format_srca(old_icb, new_icb)));
     MATH((llk_math_reconfig_data_format_srca(old_icb, new_icb)));

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -19,7 +19,7 @@ namespace ckernel {
 /**
  * Initialize the tilize operation. To be called once at beginning of a kernel.
  */
-ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb = 16) {
+ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           A2D,
           BroadcastType::NONE,
@@ -46,7 +46,7 @@ ALWI void tilizeA_B_reduce_init(
     uint32_t icb0,
     uint32_t icb1_scaler,
     uint32_t block,
-    uint32_t ocb = 16,
+    uint32_t ocb,
     uint32_t num_faces = 4,
     uint32_t face_r_dim = 16) {
     UNPACK((llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1_scaler)));
@@ -80,7 +80,7 @@ ALWI void tilizeA_B_reduce_init(
  * */
 
 ALWI void tilizeA_B_dot_product_init(
-    uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb = 16, uint32_t num_faces = 4, uint32_t face_r_dim = 16) {
+    uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb, uint32_t num_faces = 4, uint32_t face_r_dim = 16) {
     UNPACK((llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_tilizeA_B_init<false, false, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim)));
 
@@ -96,7 +96,7 @@ ALWI void tilizeA_B_dot_product_init(
 /**
  * Re-initialize for the tilize operation. This can be called after a full init.
  */
-ALWI void tilize_init_short(uint32_t icb, uint32_t block, uint32_t ocb = 16) {
+ALWI void tilize_init_short(uint32_t icb, uint32_t block, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           A2D,
           BroadcastType::NONE,
@@ -115,7 +115,7 @@ ALWI void tilize_init_unpack(uint32_t icb, uint32_t block) { UNPACK((llk_unpack_
 /**
  * Re-initialize for the tilize operation. This also reconfigure the unpacker with CB data type.
  */
-ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb = 16) {
+ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           A2D,
           BroadcastType::NONE,
@@ -197,7 +197,7 @@ ALWI void unpack_tilizeA_B_dot_product_block(
 /**
  * Uninitialize tilize operation before re-initializing for another operation.
  */
-ALWI void tilize_uninit(uint32_t icb, uint32_t ocb = 16) {
+ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(icb)));
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init(ocb)));
@@ -207,7 +207,7 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb = 16) {
 /**
  * Uninitialize the tilize operation along with re-configuring unpacker with the CB data types.
  */
-ALWI void tilize_uninit_with_dt(uint32_t old_icb = 0, uint32_t new_icb = 1, uint32_t ocb = 16) {
+ALWI void tilize_uninit_with_dt(uint32_t old_icb = 0, uint32_t new_icb = 1, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(old_icb)));
     UNPACK((llk_unpack_reconfig_data_format_srca(old_icb, new_icb)));
     MATH((llk_math_reconfig_data_format_srca(old_icb, new_icb)));

--- a/tt_metal/include/compute_kernel_api/untilize.h
+++ b/tt_metal/include/compute_kernel_api/untilize.h
@@ -17,7 +17,7 @@ namespace ckernel {
 /**
  * Init function for untilize operations, to be used at the beginning of the kernel.
  */
-ALWI void untilize_init(uint32_t icb, uint32_t ocb = 16) {
+ALWI void untilize_init(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -32,7 +32,7 @@ inline void tilize_in(
     // UNPACK(( kernel_sleep(100) ));
     UNPACK((llk_unpack_reconfig_data_format(1, 0, 0, 0)));
     MATH((llk_math_reconfig_data_format(1, 0, 0, 0)));
-    tilize_init_short(in_cb_id, in_block_w);
+    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);
@@ -42,7 +42,7 @@ inline void tilize_in(
             cb_pop_front(in_cb_id, in_block_w);
         }
     }
-    tilize_uninit_with_dt(0, 1);
+    tilize_uninit_with_dt(0, 1, out_cb_id);
 }  // tilize_in()
 
 // NOTE: Bias is not supported with the untilize option

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -25,7 +25,7 @@ ALWI void REL() { release_dst(); }
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_block_w);
+    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);
@@ -35,7 +35,7 @@ inline void tilize_in(
             cb_pop_front(in_cb_id, in_block_w);
         }
     }
-    tilize_uninit(in_cb_id);
+    tilize_uninit(in_cb_id, out_cb_id);
 }
 
 inline void eltwise_mul_and_add_block_v2(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -27,7 +27,7 @@
 
 inline void tilize_in(
     uint32_t in_cb_id, uint32_t in_subblock_h, uint32_t in_block_w, uint32_t in_num_subblocks, uint32_t out_cb_id) {
-    tilize_init_short(in_cb_id, in_block_w);
+    tilize_init_short(in_cb_id, in_block_w, out_cb_id);
     for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
         for (uint32_t h = 0; h < in_subblock_h; ++h) {
             cb_wait_front(in_cb_id, in_block_w);
@@ -37,7 +37,7 @@ inline void tilize_in(
             cb_pop_front(in_cb_id, in_block_w);
         }
     }
-    tilize_uninit(in_cb_id);
+    tilize_uninit(in_cb_id, out_cb_id);
 }  // tilize_in()
 
 template <uint32_t out_subblock_w, uint32_t out_block_w, bool is_non_tile_height>

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -146,7 +146,7 @@ void MAIN {
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         // tilize input
-        tilize_init_short(cb_in, Wt);
+        tilize_init_short(cb_in, Wt, cb_tilize);
         for (uint32_t h = 0; h < Ht; ++h) {
             cb_wait_front(cb_in, Wt);
             cb_reserve_back(cb_tilize, Wt);
@@ -154,7 +154,7 @@ void MAIN {
             cb_push_back(cb_tilize, Wt);
             cb_pop_front(cb_in, Wt);
         }
-        tilize_uninit(cb_in);
+        tilize_uninit(cb_in, cb_tilize);
 
         // transpose
         cb_wait_front(cb_tilize, HtWt);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -80,7 +80,7 @@ ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, uint32_t c
         }
         tile_idx = tile_idx - HtWt + 1;
     }
-    pack_untilize_uninit();
+    pack_untilize_uninit(cb_out);
 }
 
 template <uint32_t Wt, uint32_t Ht, uint32_t HtWt>
@@ -107,7 +107,7 @@ ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, uint32_t cb_out) {
         cb_wait_front(cb_out, Ht);
         tile_idx = tile_idx - HtWt + 1;
     }
-    pack_untilize_uninit();
+    pack_untilize_uninit(cb_out);
 }
 
 namespace NAMESPACE {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp
@@ -24,6 +24,6 @@ void MAIN {
         cb_pop_front(tt::CBIndex::c_0, per_core_block_tile_cnt);
     }
 
-    pack_untilize_uninit();
+    pack_untilize_uninit(tt::CBIndex::c_16);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp
@@ -11,7 +11,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
-    untilize_init(tt::CBIndex::c_0);
+    untilize_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     // UNPACK(( DPRINT << "Block count=" << uint32_t(per_core_block_cnt) << " tile count=" << per_core_block_tile_cnt <<
     // ENDL() ));

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -28,7 +28,7 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
     tile_regs_commit();
     tile_regs_release();
 
-    pack_untilize_uninit();
+    pack_untilize_uninit(cb_out);
 
     cb_push_back(cb_out, ONE_TILE);
     cb_pop_front(cb_in, ONE_TILE);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -79,12 +79,12 @@ void MAIN {
                 cb_reserve_back(out_cb_id, onetile);
 
                 // tilize CB::intermed2 and write to CBIndex::c_16
-                tilize_init_short_with_dt(cb_in1, cb_intermed2, onetile);
+                tilize_init_short_with_dt(cb_in1, cb_intermed2, onetile, out_cb_id);
                 tilize_block(cb_intermed2, onetile, out_cb_id);
                 cb_push_back(out_cb_id, onetile);
 
                 cb_pop_front(cb_intermed2, onetile);
-                tilize_uninit(cb_intermed2);
+                tilize_uninit(cb_intermed2, out_cb_id);
 
                 pack_reconfig_data_format(out_cb_id, cb_intermed0);
                 mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/compute/transformer_group_attn_matmul.cpp
@@ -160,12 +160,12 @@ void MAIN {
             cb_reserve_back(out_cb_id, out_num_tiles);
 
             // tilize CB::intermed1 and write to CBIndex::c_16
-            tilize_init_short_with_dt(cb_in1, cb_intermed1, out_num_tiles);
+            tilize_init_short_with_dt(cb_in1, cb_intermed1, out_num_tiles, out_cb_id);
             tilize_block(cb_intermed1, out_num_tiles, out_cb_id);
             cb_push_back(out_cb_id, out_num_tiles);
 
             cb_pop_front(cb_intermed1, out_num_tiles);
-            tilize_uninit(cb_intermed1);
+            tilize_uninit(cb_intermed1, out_cb_id);
 
             cb_pop_front(cb_in0, in0_block_num_tiles);
         } // Mt loop

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/update_cache.cpp
@@ -46,7 +46,7 @@ void MAIN {
         reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
         pack_reconfig_data_format(untilized_cache_cb, out_cb);
 
-        tilize_init_short(untilized_cache2_cb, Wt);
+        tilize_init_short(untilized_cache2_cb, Wt, out_cb);
 
         // Wait on writer to update block. Tilize.
         cb_wait_front(untilized_cache2_cb, Wt);
@@ -57,7 +57,7 @@ void MAIN {
 
         cb_push_back(out_cb, Wt);
         cb_pop_front(untilized_cache2_cb, Wt);
-        tilize_uninit_with_dt(untilized_cache2_cb, cache_cb);
+        tilize_uninit_with_dt(untilized_cache2_cb, cache_cb, out_cb);
         pack_reconfig_data_format(out_cb, untilized_cache_cb);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -50,7 +50,7 @@ FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, ui
     reconfig_data_format_srca(cb_in);
     pack_reconfig_data_format(cb_out);
 
-    tilize_init_short(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
+    tilize_init_short(cb_in, NUM_TILES_IN_TILIZED_CHUNK, cb_out);
 
     cb_wait_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
     cb_reserve_back(cb_out, num_tiles);
@@ -60,7 +60,7 @@ FORCE_INLINE void pack_block_tiles_into_rows(uint32_t cb_in, uint32_t cb_out, ui
     cb_push_back(cb_out, num_tiles);
     cb_pop_front(cb_in, NUM_TILES_IN_TILIZED_CHUNK);
 
-    tilize_uninit(cb_in);
+    tilize_uninit(cb_in, cb_out);
 }
 
 FORCE_INLINE void mul(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/compute/update_cache.cpp
@@ -47,7 +47,7 @@ void MAIN {
             reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
             pack_reconfig_data_format(untilized_cache_cb, out_cb);
 
-            tilize_init_short(untilized_cache2_cb, Wt);
+            tilize_init_short(untilized_cache2_cb, Wt, out_cb);
 
             for (uint32_t g = 0; g < granularity; ++g) {
                 // Wait on writer to update block. Tilize.
@@ -58,7 +58,7 @@ void MAIN {
                 cb_pop_front(untilized_cache2_cb, Wt);
             }
 
-            tilize_uninit_with_dt(untilized_cache2_cb, cache_cb);
+            tilize_uninit_with_dt(untilized_cache2_cb, cache_cb, out_cb);
             pack_reconfig_data_format(out_cb, untilized_cache_cb);
         }
         reconfig_data_format_srca(cache_cb, in_cb);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -144,7 +144,7 @@ void MAIN {
 #else
     constexpr uint32_t cb_in_rm = cb_in0;
 #endif
-    tilize_init_short(cb_in_rm, per_core_N);
+    tilize_init_short(cb_in_rm, per_core_N, cb_in);
     for (uint32_t m = 0; m < per_core_M; ++m) {
 #ifdef READER_REPACK
         cb_wait_front(cb_in_rm, per_core_N);
@@ -154,7 +154,7 @@ void MAIN {
         cb_push_back(cb_in, per_core_N);
         cb_pop_front(cb_in_rm, per_core_N);
     }
-    tilize_uninit(cb_in_rm);
+    tilize_uninit(cb_in_rm, cb_in);
     cb_wait_front(cb_in, per_core_MN);
 #else
     binary_op_init_common(cb_in0, cb_input_mask, cb_x);

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/kernels/downsample_compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/kernels/downsample_compute_kernel.cpp
@@ -96,7 +96,7 @@ void MAIN {
     cb_reserve_back(tilize_out_cb_index, num_output_tiles);
 
     reconfig_data_format_srca(input_cb_index, untilize_downsampled_cb_index);
-    tilize_init_short(untilize_downsampled_cb_index, num_output_tiles_in_row);
+    tilize_init_short(untilize_downsampled_cb_index, num_output_tiles_in_row, tilize_out_cb_index);
     pack_reconfig_data_format(tilize_out_cb_index);
 
     for (uint32_t b = 0; b < num_output_rows_of_tiles; ++b) {

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/kernels/downsample_fast_pack_untilize_compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/kernels/downsample_fast_pack_untilize_compute_kernel.cpp
@@ -91,7 +91,7 @@ void MAIN {
             cb_pop_front(halo_next_input_cb_index, num_input_tiles_in_row);
         }
     }
-    pack_untilize_uninit();
+    pack_untilize_uninit(untilize_cb_index);
 
     // Tilize downsampled input
     cb_wait_front(untilize_downsampled_cb_index, num_output_tiles);

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/kernels/downsample_fast_pack_untilize_compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/kernels/downsample_fast_pack_untilize_compute_kernel.cpp
@@ -98,7 +98,7 @@ void MAIN {
     cb_reserve_back(tilize_out_cb_index, num_output_tiles);
 
     reconfig_data_format_srca(input_cb_index, untilize_downsampled_cb_index);
-    tilize_init_short(untilize_downsampled_cb_index, num_output_tiles_in_row);
+    tilize_init_short(untilize_downsampled_cb_index, num_output_tiles_in_row, tilize_out_cb_index);
     pack_reconfig_data_format(tilize_out_cb_index);
 
     for (uint32_t b = 0; b < num_output_rows_of_tiles; ++b) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the tilize, untilize and pack_untilize kernel APIs:
- ./tt_metal/include/compute_kernel_api/tilize.h
- ./tt_metal/include/compute_kernel_api/untilize.h
- ./tt_metal/include/compute_kernel_api/pack_untilize.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

### Checklist
- [x] Post commit CI passes [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12585535013)
- [x] Blackhole Post commit (if applicable) [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12585532927)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
