### PR TITLE
Check that writes don't go to below the ringbuffer

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -95,8 +95,12 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
         case SanitizeAlignmentL1Write:
             output_l1_buffer_addr++;  // This is illegal because reading DRAM->L1 needs DRAM alignment
                                       // requirements (32 byte aligned).
+            l1_buffer_size--;
             break;
-        case SanitizeAlignmentL1Read: input_l1_buffer_addr++; break;
+        case SanitizeAlignmentL1Read:
+            input_l1_buffer_addr++;
+            l1_buffer_size--;
+            break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -154,7 +158,7 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
             break;
         case SanitizeAlignmentL1Write: {
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write 102400 "
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write 102399 "
                 "bytes from local L1[{:#08x}] to Tensix core w/ physical coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
@@ -172,7 +176,7 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
         }
         case SanitizeAlignmentL1Read: {
             expected = fmt::format(
-                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read 102400 "
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read 102399 "
                 "bytes to local L1[{:#08x}] from Tensix core w/ physical coords {} L1[addr=0x{:08x}] (invalid address "
                 "alignment in NOC transaction).",
                 device->id(),
@@ -199,7 +203,7 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
         exception = get_watcher_exception_message();
     } while (exception == "");
     log_info(LogTest, "Reported error: {}", exception);
-    EXPECT_TRUE(get_watcher_exception_message() == expected);
+    EXPECT_EQ(get_watcher_exception_message(), expected);
 }
 
 static void RunTestEth(WatcherFixture* fixture, Device* device) {

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -334,7 +334,7 @@ uint32_t debug_sanitize_noc_addr(
         }
 #endif
     } else if (core_type == AddressableCoreType::TENSIX) {
-        if (!debug_valid_reg_addr(noc_local_addr, noc_len) && !debug_valid_worker_addr(noc_local_addr, noc_len)) {
+        if (!debug_valid_reg_addr(noc_local_addr, noc_len)) {
             debug_sanitize_post_noc_addr_and_hang(
                 noc_id,
                 noc_addr,

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2250,30 +2250,36 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
             this->finish(sub_device_ids);
         }
     } else {
-        // this is a streaming command so we don't need to break down to multiple
-        auto command = EnqueueReadInterleavedBufferCommand(
-            this->id,
-            this->device,
-            this->noc_index,
-            buffer,
-            dst,
-            this->manager,
-            this->expected_num_workers_completed,
-            sub_device_ids,
-            src_page_index,
-            pages_to_read);
+        if (pages_to_read > 0) {
+            // this is a streaming command so we don't need to break down to multiple
+            auto command = EnqueueReadInterleavedBufferCommand(
+                this->id,
+                this->device,
+                this->noc_index,
+                buffer,
+                dst,
+                this->manager,
+                this->expected_num_workers_completed,
+                sub_device_ids,
+                src_page_index,
+                pages_to_read);
 
-        this->issued_completion_q_reads.push(std::make_shared<detail::CompletionReaderVariant>(
-            std::in_place_type<detail::ReadBufferDescriptor>,
-            buffer.buffer_layout(),
-            buffer.page_size(),
-            padded_page_size,
-            dst,
-            unpadded_dst_offset,
-            pages_to_read,
-            src_page_index));
-        this->enqueue_command(command, blocking, sub_device_ids);
-        this->increment_num_entries_in_completion_q();
+            this->issued_completion_q_reads.push(std::make_shared<detail::CompletionReaderVariant>(
+                std::in_place_type<detail::ReadBufferDescriptor>,
+                buffer.buffer_layout(),
+                buffer.page_size(),
+                padded_page_size,
+                dst,
+                unpadded_dst_offset,
+                pages_to_read,
+                src_page_index));
+            this->enqueue_command(command, blocking, sub_device_ids);
+            this->increment_num_entries_in_completion_q();
+        } else {
+            if (blocking) {
+                this->finish(sub_device_ids);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Ticket
#16353 

### Problem description
User code may overwrite the launch message, firmware, or other data.

### What's changed
Extend NOC sanitization to check for writes below DEV_MEM_MAP; the dispatcher is allowed to write to that region, but other kernels aren't.

Also fix a bug where errors from debug_valid_worker_addr were being ignored, and an issue where we're hitting errors attempting to read 0 bytes.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
