### PR TITLE
#15605: Only force-stall ethernet programs on earlier ethernet programs

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
@@ -2,8 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <sys/types.h>
 #include "gtest/gtest.h"
 #include "tt_metal/impl/dispatch/worker_config_buffer.hpp"
+#include "tt_metal/common/env_lib.hpp"
+
+#include <cstddef>
+#include <deque>
 
 using std::vector;
 using namespace tt::tt_metal;
@@ -52,6 +57,143 @@ TEST(WorkerConfigBuffer, SmallSize) {
         mgr.free(reservation.first.sync_count);
         mgr.alloc(i + 1);
     }
+}
+
+// Test that allocating buffers of size 0 doesn't eventually cause some to be ignored.
+TEST(WorkerConfigBuffer, SizeOne) {
+    WorkerConfigBufferMgr mgr;
+    mgr.init_add_buffer(0, 100);
+    mgr.init_add_buffer(0, 100);
+    mgr.init_add_buffer(0, 5);
+    mgr.init_add_buffer(0, 1);
+
+    mgr.mark_completely_full(0);
+
+    {
+        auto new_reservation = mgr.reserve({1, 0, 1, 0});
+        EXPECT_TRUE(new_reservation.first.need_sync);
+        mgr.free(0);
+        mgr.alloc(1);
+    }
+    {
+        auto new_reservation = mgr.reserve({1, 0, 1, 0});
+        EXPECT_FALSE(new_reservation.first.need_sync);
+        mgr.alloc(2);
+    }
+    {
+        auto new_reservation = mgr.reserve({1, 0, 1, 0});
+        EXPECT_FALSE(new_reservation.first.need_sync);
+        mgr.alloc(3);
+    }
+    {
+        auto new_reservation = mgr.reserve({1, 1, 1, 1});
+        EXPECT_FALSE(new_reservation.first.need_sync);
+        mgr.free(1);
+        mgr.alloc(4);
+    }
+    {
+        auto new_reservation = mgr.reserve({1, 0, 1, 0});
+        EXPECT_FALSE(new_reservation.first.need_sync);
+        mgr.free(2);
+        mgr.alloc(5);
+    }
+    {
+        auto new_reservation = mgr.reserve({0, 1, 0, 1});
+        EXPECT_TRUE(new_reservation.first.need_sync);
+        mgr.alloc(6);
+    }
+}
+
+// Test that we don't throw away the old sync counts when the number of outstanding buffers is >
+// kernel_config_entry_count.
+TEST(WorkerConfigBuffer, LoopAround) {
+    WorkerConfigBufferMgr mgr;
+    mgr.init_add_buffer(0, 10);
+
+    mgr.mark_completely_full(0);
+    for (size_t i = 0; i < 12; i++) {
+        auto reservation = mgr.reserve({1});
+        if (i >= 10) {
+            EXPECT_TRUE(reservation.first.need_sync) << i;
+        }
+        if (reservation.first.need_sync) {
+            mgr.free(reservation.first.sync_count);
+        }
+        mgr.alloc(i + 1);
+    }
+}
+
+TEST(WorkerConfigBuffer, Randomized) {
+    const uint32_t seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(time(nullptr)));
+    log_info(tt::LogTest, "Using seed: {}", seed);
+    srand(seed);
+    const std::vector<uint32_t> kSizes = {1024, 1024, 10, 1};
+    WorkerConfigBufferMgr mgr;
+    for (uint32_t size : kSizes) {
+        mgr.init_add_buffer(0, size);
+    }
+
+    struct UsedRegion {
+        uint32_t sync_count;
+        uint32_t offset;
+        uint32_t size;
+    };
+
+    auto regions_intersect = [](const UsedRegion& a, const UsedRegion& b) {
+        if (b.size == 0 || a.size == 0) {
+            return false;
+        }
+        return a.offset < b.offset + b.size && b.offset < a.offset + a.size;
+    };
+
+    std::vector<std::deque<UsedRegion>> used_regions(kSizes.size());
+
+    for (size_t i = 0; i < 1000; i++) {
+        std::vector<uint32_t> sizes;
+        for (uint32_t size : kSizes) {
+            sizes.push_back(rand() % (size + 1));
+        }
+        auto reservation = mgr.reserve(sizes);
+        if (reservation.first.need_sync) {
+            EXPECT_GE(reservation.first.sync_count, 1u);
+            EXPECT_LT(reservation.first.sync_count, i + 1);
+            mgr.free(reservation.first.sync_count);
+            for (auto& region_type : used_regions) {
+                while (!region_type.empty() && region_type.front().sync_count <= reservation.first.sync_count) {
+                    region_type.pop_front();
+                }
+            }
+        }
+        for (size_t j = 0; j < kSizes.size(); j++) {
+            UsedRegion new_region = {i + 1, reservation.second[j].addr, reservation.second[j].size};
+            for (const auto& region : used_regions[j]) {
+                ASSERT_FALSE(regions_intersect(region, new_region))
+                    << "Region " << new_region.offset << " " << new_region.size << " intersects with " << region.offset
+                    << " " << region.size;
+            }
+            used_regions[j].push_back(new_region);
+        }
+        mgr.alloc(i + 1);
+    }
+}
+
+// Test reserving when one buffer type is completely empty.
+TEST(WorkerConfigBuffer, VeryBasic) {
+    WorkerConfigBufferMgr mgr;
+    mgr.init_add_buffer(0, 1024);
+    mgr.init_add_buffer(0, 10);
+    auto reservation = mgr.reserve({934, 5});
+    EXPECT_FALSE(reservation.first.need_sync);
+    mgr.alloc(1);
+
+    auto reservation2 = mgr.reserve({561, 0});
+    EXPECT_TRUE(reservation2.first.need_sync);
+    EXPECT_EQ(reservation2.first.sync_count, 1u);
+    mgr.free(1);
+    mgr.alloc(2);
+
+    auto reservation3 = mgr.reserve({35, 7});
+    EXPECT_FALSE(reservation3.first.need_sync);
 }
 
 }  // namespace worker_config_buffer_tests

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -678,6 +678,7 @@ TEST_F(RandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::WORKER, false, kernel_properties);
         }
+        program.set_runtime_id(i);
 
         EnqueueProgram(this->device_->command_queue(), program, false);
     }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -517,15 +517,14 @@ void EnqueueProgramCommand::process() {
     program_utils::reserve_space_in_kernel_config_buffer(
         this->config_buffer_mgr,
         program.get_program_config_sizes(),
-        program.kernel_binary_always_stored_in_ringbuffer(),
         program.get_program_binary_status(device->id()),
         num_workers,
         this->expected_num_workers_completed,
         dispatch_metadata);
 
-    // Remove launch buffer from config addrs, since it's not a real core.
+    // Remove launch buffers from config addrs, since they're not real cores.
     const tt::stl::Span<ConfigBufferEntry> kernel_config_addrs{
-        dispatch_metadata.kernel_config_addrs.data(), dispatch_metadata.kernel_config_addrs.size() - 1};
+        dispatch_metadata.kernel_config_addrs.data(), dispatch_metadata.kernel_config_addrs.size() - 2};
 
     RecordProgramRun(program);
 
@@ -1952,6 +1951,9 @@ void HWCommandQueue::reset_config_buffer_mgr(const uint32_t num_entries) {
         // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the
         // previous launch message.
         this->config_buffer_mgr[i].init_add_buffer(0, launch_msg_buffer_num_entries - 1);
+
+        // There's no ring buffer for active ethernet binaries, so keep track of them separately.
+        this->config_buffer_mgr[i].init_add_buffer(0, 1);
     }
 }
 

--- a/tt_metal/impl/dispatch/worker_config_buffer.hpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.hpp
@@ -46,6 +46,8 @@ public:
     // Test/Debug
     uint32_t get_last_slot_addr(HalProgrammableCoreType programmable_core_type) const;
 
+    void PrintStatus();
+
 private:
     std::vector<uint32_t> base_addrs_;
     std::vector<uint32_t> end_addrs_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -335,9 +335,7 @@ detail::Program_::Program_() :
     }
 
     program_configs_.resize(programmable_core_count);
-    program_config_sizes_.resize(programmable_core_count + 1);
-    // Always need one launch buffer msg for a program.
-    program_config_sizes_[programmable_core_count] = 1;
+    program_config_sizes_.resize(programmable_core_count + 2);
 }
 
 Program::Program() : pimpl_(std::make_unique<detail::Program_>()) {}
@@ -1297,6 +1295,9 @@ void detail::Program_::finalize(Device *device) {
                  "Program size ({}) too large for kernel config buffer ({}) on {}",
                  offset, max_size, magic_enum::enum_name(programmable_core_type));
     }
+
+    this->get_program_config_size(hal.get_programmable_core_type_count()) = runs_on_noc_multicast_only_cores();
+    this->get_program_config_size(hal.get_programmable_core_type_count() + 1) = runs_on_noc_unicast_only_cores();
 
     // The sem offsets cross programmable_core_types so must be set after the loop above
     this->set_launch_msg_sem_offsets();

--- a/tt_metal/impl/program/program_dispatch_utils.hpp
+++ b/tt_metal/impl/program/program_dispatch_utils.hpp
@@ -83,7 +83,6 @@ void assemble_device_commands(
 void reserve_space_in_kernel_config_buffer(
     WorkerConfigBufferMgr& config_buffer_mgr,
     const std::vector<uint32_t>& program_config_sizes,
-    bool kernel_binary_always_stored_in_ringbuffer,
     ProgramBinaryStatus program_binary_status,
     uint32_t num_program_workers,
     uint32_t expected_num_workers_completed,


### PR DESCRIPTION
### Ticket
#15605 

### Problem description
Currently programs that dispatch to ethernet cores are forced to wait for all previous programs to finish, even if those previous programs don't run anything on the ethernet cores.

### What's changed
Keep track of when the last program using active ethernet cores was dispatched, so we can wait on that program before sending out binaries. This is better than always waiting on the immediate previous program, since in most cases we don't run programs on the ethernet cores back-to-back.

This is a reland of the original patch that includes a fix for a bug in WorkerConfigBuffer that caused hangs in
RandomProgramTraceFixture.TensixActiveEthTestSimpleProgramsTrace

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
