### PR TITLE
Extend graph capture to include device information

### DIFF
--- a/tech_reports/ttnn/graph-tracing.md
+++ b/tech_reports/ttnn/graph-tracing.md
@@ -103,6 +103,7 @@ Represents the allocation of a memory buffer. This node records details about th
 * `size`: The size of the buffer in bytes.
 * `type`: The type of memory (e.g., "DRAM", "L1").
 * `layout`: The memory layout (e.g., "INTERLEAVED", "SINGLE\_BANK").
+* `device_id`: Id of the device.
 
 #### Connections
 * Single element in the connection list specifies the associated Tensor ID
@@ -115,6 +116,7 @@ Denotes the allocation of a buffer in memory. This node captures the specifics o
 * `address`: The memory address of the buffer.
 * `type`: The type of memory (e.g., "DRAM", "L1").
 * `layout`: The memory layout.
+* `device_id`: Id of the device.
 
 #### Connections
 * Single element in the connections list specifies the allocated buffer ID
@@ -126,6 +128,7 @@ Represents the deallocation of a buffer from memory. This node records the detai
 * `size`: The size of the buffer in bytes.
 * `type`: The type of memory (e.g., "DRAM", "L1").
 * `layout`: The memory layout.
+* `device_id`: Id of the device.
 
 #### Connections
 * Single element in the connections list specifies the deallocated buffer ID
@@ -138,6 +141,7 @@ Represents the allocation of a circular buffer, typically used in handling strea
 * `address`: The memory address associated with the buffer.
 * `core_range_set`: The range of cores involved in the circular buffer.
 * `globally_allocated`: Does the circular buffer has global address set, i.e., does it share space with the corresponding operand.
+* `device_id`: Id of the device.
 
 #### Connections
 Usually empty

--- a/tt-train/sources/examples/graph_capture/main.cpp
+++ b/tt-train/sources/examples/graph_capture/main.cpp
@@ -20,10 +20,11 @@ namespace {
 
 using namespace ttnn::graph;
 
-long long extract_peak_DRAM_memory_usage(const nlohmann::json& trace) {
-    long long total_buffer = 0;
-    long long peak_memory_usage = 0;
+std::unordered_map<std::string, long long> extract_peak_DRAM_memory_usage(const nlohmann::json& trace) {
     std::vector<std::string> current_op;
+
+    std::unordered_map<string, long long> current_buffer;
+    std::unordered_map<string, long long> peak_buffer;
 
     for (size_t i = 0; i < trace.size(); ++i) {
         const auto& v = trace[i];
@@ -33,7 +34,8 @@ long long extract_peak_DRAM_memory_usage(const nlohmann::json& trace) {
                 while (++i < trace.size()) {
                     const auto& inner_v = trace[i];
                     if (inner_v[kNodeType] == "buffer" && inner_v[kParams][kType] == "DRAM") {
-                        total_buffer += std::stoll(inner_v[kParams][kSize].get<std::string>());
+                        auto device_id = inner_v[kParams][kDeviceId].get<std::string>();
+                        current_buffer[device_id] += std::stoll(inner_v[kParams][kSize].get<std::string>());
                     } else if (inner_v[kNodeType] == kNodeTensor) {
                         continue;
                     } else {
@@ -44,21 +46,25 @@ long long extract_peak_DRAM_memory_usage(const nlohmann::json& trace) {
             }
             current_op.push_back(v[kParams][kName]);
         } else if (v[kNodeType] == kNodeBufferAllocate && v[kParams][kType] == "DRAM") {
-            total_buffer += stoll(v[kParams][kSize].get<std::string>());
+            auto device_id = v[kParams][kDeviceId].get<std::string>();
+            current_buffer[device_id] += stoll(v[kParams][kSize].get<std::string>());
         } else if (v[kNodeType] == kNodeBufferDeallocate) {
             auto connection = v[kConnections][0].get<int>();
             auto buffer = trace[connection];
             if (buffer[kParams][kType] == "DRAM") {
-                total_buffer -= stoll(buffer[kParams][kSize].get<std::string>());
+                auto device_id = v[kParams][kDeviceId].get<std::string>();
+                current_buffer[device_id] -= stoll(buffer[kParams][kSize].get<std::string>());
             }
         } else if (v[kNodeType] == kNodeFunctionEnd) {
             current_op.pop_back();
         }
 
-        peak_memory_usage = std::max(peak_memory_usage, total_buffer);
+        for (auto& [device_id, total_buffer] : current_buffer) {
+            peak_buffer[device_id] = std::max(peak_buffer[device_id], total_buffer);
+        }
     }
 
-    return peak_memory_usage;
+    return peak_buffer;
 }
 
 }  // namespace
@@ -107,10 +113,18 @@ int main() {
     backward_trace_file << pretty_backward_trace;
     backward_trace_file.close();
 
+    auto print_dram_memory_usage = [](const std::string& prefix,
+                                      const std::unordered_map<std::string, long long>& memory_usage) {
+        fmt::println("{}", prefix);
+        for (const auto& [device_id, memory] : memory_usage) {
+            fmt::print("    Device id: {} Memory usage: {}", device_id, memory / 1024.0 / 1024.0);
+        }
+    };
+
     fmt::print("Forward peak L1 memory usage (in MB): {}\n", forward_peak_l1_memory_usage / 1024.0 / 1024.0);
-    fmt::print("Forward peak DRAM memory usage (in MB): {}\n", forward_peak_DRAM_memory_usage / 1024.0 / 1024.0);
+    print_dram_memory_usage("Forward peak DRAM memory usage (in MB): ", forward_peak_DRAM_memory_usage);
     fmt::print("Backward peak L1 memory usage (in MB): {}\n", backward_peak_l1_memory_usage / 1024.0 / 1024.0);
-    fmt::print("Backward peak DRAM memory usage (in MB): {}\n", backward_peak_DRAM_memory_usage / 1024.0 / 1024.0);
+    print_dram_memory_usage("Backward peak DRAM memory usage (in MB): ", backward_peak_DRAM_memory_usage);
     fmt::print("Forward trace saved to: {}/forward_trace.json\n", path);
     fmt::print("Backward trace saved to: {}/backward_trace.json\n", path);
     fmt::print("Capture complete\n");

--- a/tt-train/sources/examples/graph_capture/main.cpp
+++ b/tt-train/sources/examples/graph_capture/main.cpp
@@ -20,11 +20,13 @@ namespace {
 
 using namespace ttnn::graph;
 
-std::unordered_map<std::string, long long> extract_peak_DRAM_memory_usage(const nlohmann::json& trace) {
+using DeviceMemoryMap = std::unordered_map<std::string, long long>;
+
+DeviceMemoryMap extract_peak_DRAM_memory_usage(const nlohmann::json& trace) {
     std::vector<std::string> current_op;
 
-    std::unordered_map<string, long long> current_buffer;
-    std::unordered_map<string, long long> peak_buffer;
+    DeviceMemoryMap current_buffer;
+    DeviceMemoryMap peak_buffer;
 
     for (size_t i = 0; i < trace.size(); ++i) {
         const auto& v = trace[i];
@@ -113,11 +115,10 @@ int main() {
     backward_trace_file << pretty_backward_trace;
     backward_trace_file.close();
 
-    auto print_dram_memory_usage = [](const std::string& prefix,
-                                      const std::unordered_map<std::string, long long>& memory_usage) {
+    auto print_dram_memory_usage = [](const std::string& prefix, const DeviceMemoryMap& memory_usage) {
         fmt::println("{}", prefix);
         for (const auto& [device_id, memory] : memory_usage) {
-            fmt::print("    Device id: {} Memory usage: {}", device_id, memory / 1024.0 / 1024.0);
+            fmt::println("    Device id: {} Memory usage: {}", device_id, memory / 1024.0 / 1024.0);
         }
     };
 

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -44,31 +44,36 @@ void GraphTracker::track_deallocate(Buffer* buffer) {
 }
 
 void GraphTracker::track_allocate_cb(
-    const CoreRangeSet& core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated) {
+    const CoreRangeSet& core_range_set,
+    uint64_t addr,
+    uint64_t size,
+    bool is_globally_allocated,
+    const Device* device) {
     if (processors.empty()) {
         return;
     }
     for (auto& it : processors) {
-        it->track_allocate_cb(core_range_set, addr, size, is_globally_allocated);
+        it->track_allocate_cb(core_range_set, addr, size, is_globally_allocated, device);
     }
 }
 
-void GraphTracker::track_deallocate_cb() {
+void GraphTracker::track_deallocate_cb(const Device* device) {
     if (processors.empty()) {
         return;
     }
     for (auto& it : processors) {
-        it->track_deallocate_cb();
+        it->track_deallocate_cb(device);
     }
 }
 
-void GraphTracker::track_program(Program* program) {
+void GraphTracker::track_program(Program* program, const Device* device) {
     TT_ASSERT(program);
+    TT_ASSERT(device);
     if (processors.empty()) {
         return;
     }
     for (auto& it : processors) {
-        it->track_program(program);
+        it->track_program(program, device);
     }
 }
 

--- a/tt_metal/graph/graph_tracking.hpp
+++ b/tt_metal/graph/graph_tracking.hpp
@@ -33,11 +33,15 @@ public:
     virtual void track_deallocate(tt::tt_metal::Buffer* buffer) {};
 
     virtual void track_allocate_cb(
-        const CoreRangeSet& core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated) {};
+        const CoreRangeSet& core_range_set,
+        uint64_t addr,
+        uint64_t size,
+        bool is_globally_allocated,
+        const Device* device) {};
 
-    virtual void track_deallocate_cb() {};
+    virtual void track_deallocate_cb(const Device* device) {};
 
-    virtual void track_program(tt::tt_metal::Program* program) {};
+    virtual void track_program(tt::tt_metal::Program* program, const Device* device) {};
 
     virtual void track_function_start(std::string_view function_name, std::span<std::any> input_parameters) {};
 
@@ -82,11 +86,15 @@ public:
     void track_deallocate(Buffer* buffer);
 
     void track_allocate_cb(
-        const CoreRangeSet& core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated);
+        const CoreRangeSet& core_range_set,
+        uint64_t addr,
+        uint64_t size,
+        bool is_globally_allocated,
+        const Device* device);
 
-    void track_deallocate_cb();
+    void track_deallocate_cb(const Device* device);
 
-    void track_program(Program* program);
+    void track_program(Program* program, const Device* device);
 
     template <class... Args>
     void track_function_start(std::string_view function_name, Args&&... args) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -801,7 +801,7 @@ void detail::Program_::allocate_circular_buffers(const Device *device) {
                 }
             }
         }
-        tt::tt_metal::GraphTracker::instance().track_allocate_cb(circular_buffer->core_ranges(), computed_addr, circular_buffer->size(), circular_buffer->globally_allocated());
+        tt::tt_metal::GraphTracker::instance().track_allocate_cb(circular_buffer->core_ranges(), computed_addr, circular_buffer->size(), circular_buffer->globally_allocated(), device);
         circular_buffer->set_locally_allocated_address(computed_addr);
     }
     this->local_circular_buffer_allocation_needed_ = false;

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -285,7 +285,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
 
         program.set_runtime_id(device_operation_id);
 
-        tt::tt_metal::GraphTracker::instance().track_program(&program);
+        tt::tt_metal::GraphTracker::instance().track_program(&program, device);
         if(tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
             return;
         }
@@ -314,7 +314,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
 
         program->set_runtime_id(device_operation_id);
 
-        tt::tt_metal::GraphTracker::instance().track_program(program.get());
+        tt::tt_metal::GraphTracker::instance().track_program(program.get(), device);
         if(tt::tt_metal::GraphTracker::instance().hook_program(program.get())) {
             return;
         }

--- a/ttnn/cpp/ttnn/graph/graph_consts.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_consts.hpp
@@ -23,6 +23,7 @@ constexpr auto kNumCores = "num_cores";
 constexpr auto kPageSize = "page_size";
 constexpr auto kCoreRangeSet = "core_range_set";
 constexpr auto kGloballyAllocated = "globally_allocated";
+constexpr auto kDeviceId = "device_id";
 
 // node names
 constexpr auto kNodeBuffer = "buffer";

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "graph_processor.hpp"
+#include "graph_consts.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
 #include "ttnn/types.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
@@ -322,7 +323,8 @@ int GraphProcessor::add_buffer(const tt::tt_metal::Buffer* buffer) {
         std::unordered_map<std::string, std::string> params = {
             {kSize, std::to_string(buffer->size())},
             {kType, buffer->is_dram() ? "DRAM" : "L1"},
-            {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())}
+            {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
+            {kDeviceId, std::to_string(buffer->device()->id())}
         };
 
         graph.push_back(Vertex{

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -297,21 +297,9 @@ int GraphProcessor::add_tensor(const Tensor& t) {
     auto tensor_counter = tensor_id_to_counter.count(tensor_id) > 0 ? tensor_id_to_counter[tensor_id] : graph.size();
     auto shape = t.get_shape();
 
-    auto extract_device_ids = [](const std::vector<tt::tt_metal::Buffer*>& buffers) {
-        std::string device_ids;
-        for (size_t idx = 0; idx < buffers.size(); ++idx) {
-            if (idx > 0) {
-                device_ids += ", ";
-            }
-            device_ids += std::to_string(buffers[idx]->device()->id());
-        }
-        return device_ids;
-    };
-
     std::unordered_map<std::string, std::string> params = {
         {kShape, fmt::format("{}", shape)},
         {kTensorId, fmt::format("{}", tensor_id)},
-        {kDeviceId, extract_device_ids(buffers)},
     };
 
     if (tensor_id_to_counter.count(tensor_id) == 0) {

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -44,11 +44,11 @@ namespace ttnn::graph {
 
         void track_deallocate(tt::tt_metal::Buffer* buffer) override;
 
-        void track_allocate_cb(const CoreRangeSet &core_range, uint64_t addr, uint64_t size, bool is_globally_allocated) override;
+        void track_allocate_cb(const CoreRangeSet &core_range, uint64_t addr, uint64_t size, bool is_globally_allocated, const tt::tt_metal::Device* device) override;
 
-        void track_deallocate_cb() override;
+        void track_deallocate_cb(const tt::tt_metal::Device* device) override;
 
-        void track_program(tt::tt_metal::Program* program) override;
+        void track_program(tt::tt_metal::Program* program, const tt::tt_metal::Device* device) override;
 
         void track_function_start(std::string_view function_name, std::span<std::any> args) override;
 


### PR DESCRIPTION
### Ticket
[#15973](https://github.com/tenstorrent/tt-metal/issues/15973)

### Problem description
Graph capture doesn't contain information about device. 

### What's changed
Add device_id to allocate/deallocate parameters (for buffers and circular buffers). 
Add missing connection between buffers and tensor in multi device case.

**N300 (2 chips)**
Peak DRAM memory usage (in MB): 
    Device id: 1 Memory usage: 40.6796875
    Device id: 0 Memory usage: 40.87380027770996

**N300 (1 chip)**
Peak DRAM memory usage (in MB): 
    Device id: 0 Memory usage: 40.87380027770996

P.S. It's not clear why there is 200kb difference between devices. Source of this is model creation. 

### Checklist
- [x] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12589847180
- [x] New/Existing tests provide coverage for changes
