### PR TITLE
#16391: propagate sub_device_ids to mesh

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -6,7 +6,7 @@ import os
 import math
 from loguru import logger
 import re
-from typing import Tuple
+from typing import Tuple, List
 import numpy as np
 import torch
 import ttnn

--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -70,8 +70,11 @@ class ConcatMesh2DToTensor(MeshToTensor):
         self.cluster_shape = cluster_shape
         self.mesh_device = mesh_device
 
-    def compose(self, tensor: ttnn.Tensor) -> torch.Tensor:
-        tt_shards = [ttnn.to_torch(tt_input_tensor) for tt_input_tensor in ttnn.get_device_tensors(tensor)]
+    def compose(self, tensor: ttnn.Tensor, sub_device_ids: List[ttnn.SubDeviceId] = []) -> torch.Tensor:
+        tt_shards = [
+            ttnn.to_torch(tt_input_tensor, sub_device_ids=sub_device_ids)
+            for tt_input_tensor in ttnn.get_device_tensors(tensor)
+        ]
 
         row_concat = []
         for cluster_row in range(self.cluster_shape[1]):

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -196,16 +196,6 @@ def run_all_gather_impl(
                         output_tensor[w, z, y : y + 32, x : x + 32] = tile_id
                         tile_id += 1
 
-    input_tensors = torch.chunk(output_tensor, num_devices, dim)
-    tt_input_tensors = []
-    for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(
-            ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
-        )
-        logger.info(f"using device {mesh_device.get_devices()[i].id()}")
-
-    input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     worker_sub_device = ttnn.SubDevice(
         [
@@ -215,68 +205,91 @@ def run_all_gather_impl(
         ]
     )
     worker_sub_device_id = ttnn.SubDeviceId(0)
+    worker_subdevice_ids = [worker_sub_device_id]
+    fabric_torn_down = True
     if create_persistent_fabric:
         mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
             mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
         )
+        fabric_torn_down = False
 
-    if trace_mode:
-        tt_out_tensor = run_with_trace(
-            mesh_device,
-            all_gather_topology,
-            input_tensor_mesh,
-            dim,
-            num_links,
-            output_mem_config,
-            num_iter=num_iters,
-            subdevice_id=worker_sub_device_id,
-        )
-    else:
-        for i in range(num_iters):
-            if use_cluster_axis_api:
-                tt_out_tensor = ttnn.experimental.all_gather_async(
-                    input_tensor_mesh,
-                    dim,
-                    cluster_axis=cluster_axis,
-                    mesh_device=mesh_device,
-                    memory_config=output_mem_config,
-                    topology=all_gather_topology,
-                    subdevice_id=worker_sub_device_id,
-                    enable_persistent_fabric_mode=enable_persistent_fabric,
-                    num_preferred_links=num_links,
-                    create_semaphore_handles=True,
-                )
+    try:
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype)
+                .to(layout)
+                .to(mesh_device.get_devices()[i], input_mem_config, sub_device_ids=worker_subdevice_ids)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
 
-            else:
-                tt_out_tensor = ttnn.experimental.all_gather_async(
-                    input_tensor_mesh,
-                    dim,
-                    num_links=num_links,
-                    memory_config=output_mem_config,
-                    topology=all_gather_topology,
-                    subdevice_id=worker_sub_device_id,
-                    enable_persistent_fabric_mode=enable_persistent_fabric,
-                )
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        if trace_mode:
+            tt_out_tensor = run_with_trace(
+                mesh_device,
+                all_gather_topology,
+                input_tensor_mesh,
+                dim,
+                num_links,
+                output_mem_config,
+                num_iter=num_iters,
+                subdevice_id=worker_sub_device_id,
+            )
+        else:
+            for i in range(num_iters):
+                if use_cluster_axis_api:
+                    tt_out_tensor = ttnn.experimental.all_gather_async(
+                        input_tensor_mesh,
+                        dim,
+                        cluster_axis=cluster_axis,
+                        mesh_device=mesh_device,
+                        memory_config=output_mem_config,
+                        topology=all_gather_topology,
+                        subdevice_id=worker_sub_device_id,
+                        enable_persistent_fabric_mode=enable_persistent_fabric,
+                        num_preferred_links=num_links,
+                        create_semaphore_handles=True,
+                    )
+
+                else:
+                    tt_out_tensor = ttnn.experimental.all_gather_async(
+                        input_tensor_mesh,
+                        dim,
+                        num_links=num_links,
+                        memory_config=output_mem_config,
+                        topology=all_gather_topology,
+                        subdevice_id=worker_sub_device_id,
+                        enable_persistent_fabric_mode=enable_persistent_fabric,
+                    )
 
             logger.info(f"Waiting for op {i}")
             for d in mesh_device.get_devices():
                 ttnn.synchronize_device(d, sub_device_ids=[worker_sub_device_id])
             logger.info(f"Done iteration {i}")
 
-    if enable_persistent_fabric and teardown_persistent_fabric:
-        teardown_fabric_interface(mesh_device)
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu(sub_device_ids=worker_subdevice_ids).to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
 
-    for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-        logger.info(f"Checking for device {t.device().id()}")
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+            assert eq, f"{i} FAILED: {output}"
 
-        if input_dtype == ttnn.bfloat16:
-            eq, output = comp_equal(tt_output_tensor, output_tensor)
-        else:
-            eq, output = comp_pcc(tt_output_tensor, output_tensor)
-        if not eq:
-            logger.error(f"output mismatch for tensor {i}")
-        assert eq, f"{i} FAILED: {output}"
+        if enable_persistent_fabric and teardown_persistent_fabric:
+            teardown_fabric_interface(mesh_device)
+            fabric_torn_down = True
+
+    except Exception as e:
+        if create_persistent_fabric and not fabric_torn_down:
+            logger.error(f"Tearing down persistent fabric after failure")
+            teardown_fabric_interface(mesh_device)
+        raise e
 
 
 # Enumerate the post-commit cases explicitly
@@ -301,8 +314,7 @@ def run_all_gather_impl(
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
     ],
 )
-@pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("enable_async, num_iters", [(True, 1), (False, 8)])
 def test_all_gather(
     t3k_mesh_device,
     # pcie_mesh_device,
@@ -395,8 +407,7 @@ def test_all_gather(
         ttnn.bfloat16,
     ],
 )
-@pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("enable_async, num_iters", [(True, 1), (False, 8)])
 def test_all_gather_sharded(
     t3k_mesh_device,
     # pcie_mesh_device,
@@ -499,9 +510,6 @@ def test_line_all_gather_async_on_T3K_cols_transient_fabric_post_commit(
     )
 
 
-@pytest.mark.skip(
-    "persistent fabric test with cluster-axis API and multiple concurrent all-gather instances not enabled yet"
-)
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, per_chip_output_shape, dim, layout",
@@ -636,9 +644,6 @@ def test_line_all_gather_async_on_T3K_rows_transient_fabric_post_commit(
 
 
 # Enumerate the post-commit cases explicitly
-@pytest.mark.skip(
-    "persistent fabric test with cluster-axis API and multiple concurrent all-gather instances not enabled yet"
-)
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, per_chip_output_shape, dim, layout",

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -711,9 +711,6 @@ def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
     )
 
 
-@pytest.mark.skip(
-    "persistent fabric test with cluster-axis API and multiple concurrent all-gather instances not enabled yet"
-)
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices1, num_links1, per_chip_output_shape1, dim1, layout1",
@@ -738,7 +735,7 @@ def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
     ],
 )
 @pytest.mark.parametrize("replication_factor1", [4])
-@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("enable_async", [False])
 @pytest.mark.parametrize(
     "num_devices2, num_links2, per_chip_output_shape2, dim2, layout2",
     [

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CCL_EXPERIMENTAL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/all_gather_async_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/device/all_gather_async_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather_async/device/all_gather_async_program.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/common/ccl_global_semaphore_creation.cpp
     CACHE INTERNAL
     "CCL Experimental sources to reuse in ttnn build"
 )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -258,9 +258,9 @@ Tensor all_gather_async(
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-    std::optional<std::vector<std::shared_ptr<const GlobalSemaphore>>> semaphore_handles_opt;
+    std::optional<std::vector<std::shared_ptr<const GlobalSemaphore>>> semaphores_opt;
     if (create_semaphore_handles) {
-        semaphore_handles_opt = ttnn::ccl::worker_detail::create_global_semaphores(devices, core_grid, subdevice_id);
+        semaphores_opt = ttnn::ccl::worker_detail::create_global_semaphores(devices, core_grid, subdevice_id);
     }
 
     operation::launch_op(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -92,7 +92,7 @@ AllGatherAsync create_all_gather_async_struct(
     const std::optional<MemoryConfig>& memory_config,
     const std::vector<Device*>& devices,
     const ccl::Topology topology,
-    const std::optional<std::vector<GlobalSemaphore>>& semaphores,
+    const std::optional<std::vector<const GlobalSemaphore>>& semaphore_handles,
     bool enable_persistent_fabric_mode);
 }  // namespace all_gather_async_detail
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common/ccl_global_semaphore_creation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common/ccl_global_semaphore_creation.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/common/ccl_global_semaphore_creation.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
+
+namespace ttnn::ccl::worker_detail {
+
+std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> create_global_semaphores(
+    const std::vector<Device*>& devices,
+    const CoreRangeSet& worker_cores,
+    std::optional<SubDeviceId> worker_subdevice_id_opt) {
+    std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> semaphores;
+    for (Device* d : devices) {
+        CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
+        auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+        auto worker_subdevice_id = worker_subdevice_id_opt.has_value()
+                                       ? std::vector<SubDeviceId>{worker_subdevice_id_opt.value()}
+                                       : std::vector<SubDeviceId>{};
+        auto sem = std::make_shared<GlobalSemaphore>(
+            global_semaphore::create_global_semaphore(d, core_grid, 0, BufferType::L1, worker_subdevice_id));
+        semaphores.push_back(sem);
+    }
+
+    auto first_addr = semaphores.front()->address();
+    bool all_same = std::all_of(
+        semaphores.begin(), semaphores.end(), [first_addr](const auto& sem) { return sem->address() == first_addr; });
+
+    if (!all_same) {
+        DeviceAddr lowest_addr = semaphores.front()->address();
+        for (auto i = 1; i < semaphores.size(); i++) {
+            if (semaphores[i]->address() < lowest_addr) {
+                lowest_addr = semaphores[i]->address();
+            }
+        };
+        for (auto i = 0; i < semaphores.size(); i++) {
+            size_t attempts = 1000;
+            size_t attempt = 0;
+            std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> garbage;
+            while (semaphores[i]->address() != lowest_addr) {
+                auto worker_subdevice_id = worker_subdevice_id_opt.has_value()
+                                               ? std::vector<SubDeviceId>{worker_subdevice_id_opt.value()}
+                                               : std::vector<SubDeviceId>{};
+                auto sem = std::make_shared<GlobalSemaphore>(
+                    global_semaphore::create_global_semaphore(devices[i], worker_cores, 0, BufferType::L1, worker_subdevice_id));
+                if (sem->address() == lowest_addr) {
+                    semaphores[i] = sem;
+                } else {
+                    garbage.push_back(std::move(sem));
+                    attempt++;
+                }
+
+                if (attempt > attempts) {
+                    TT_THROW("Failed to create global semaphores with the same address");
+                }
+            }
+        }
+    }
+    return semaphores;
+}
+
+}  // namespace ttnn::ccl::worker_detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/common/ccl_global_semaphore_creation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/common/ccl_global_semaphore_creation.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/buffers/global_semaphore.hpp"
+
+#include <vector>
+#include <optional>
+
+namespace ttnn::ccl::worker_detail {
+
+std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> create_global_semaphores(
+    const std::vector<Device*>& devices,
+    const CoreRangeSet& worker_cores,
+    std::optional<SubDeviceId> worker_subdevice_id_opt = std::nullopt);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -342,9 +342,9 @@ Tensor reduce_scatter(
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> to_remote_inputs_semaphores_opt;
     auto worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(6, 6)));
     if (create_semaphore_handles) {
-        from_remote_inputs_semaphores_opt = 
+        from_remote_inputs_semaphores_opt =
             ttnn::ccl::worker_detail::create_global_semaphores(devices, worker_cores, worker_subdevice_id_opt);
-        to_remote_inputs_semaphores_opt = 
+        to_remote_inputs_semaphores_opt =
             ttnn::ccl::worker_detail::create_global_semaphores(devices, worker_cores, worker_subdevice_id_opt);
     } else {
         from_remote_inputs_semaphores_opt = std::nullopt;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -7,6 +7,8 @@
 #include "tt_metal/host_api.hpp"
 #include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/common/ccl_global_semaphore_creation.hpp"
+
 #include <ranges>
 #include <algorithm>
 #include <cstdint>
@@ -220,62 +222,6 @@ ttnn::operations::binary::BinaryOpType convert_reduce_type_to_eltwise_type(
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> create_global_semaphores(
-    const std::vector<Device*>& devices, std::optional<SubDeviceId> worker_subdevice_id_opt = std::nullopt) {
-    std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> semaphores;
-    auto worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(6, 6)));
-    for (Device* d : devices) {
-        CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
-        auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-        auto worker_subdevice_id = worker_subdevice_id_opt.has_value()
-                                       ? std::vector<SubDeviceId>{worker_subdevice_id_opt.value()}
-                                       : std::vector<SubDeviceId>{};
-        // TODO: Remove shared_ptr
-        auto sem = std::make_shared<GlobalSemaphore>(
-            global_semaphore::create_global_semaphore(d, core_grid, 0, BufferType::L1, worker_subdevice_id));
-        semaphores.push_back(sem);
-    }
-
-    auto first_addr = semaphores.front()->address();
-    bool all_same = std::all_of(
-        semaphores.begin(), semaphores.end(), [first_addr](const auto& sem) { return sem->address() == first_addr; });
-
-    if (!all_same) {
-        DeviceAddr highest_addr = semaphores.front()->address();
-        for (auto i = 1; i < semaphores.size(); i++) {
-            if (semaphores[i]->address() > highest_addr) {
-                highest_addr = semaphores[i]->address();
-            }
-        };
-        for (auto i = 0; i < semaphores.size(); i++) {
-            size_t attempts = 1000;
-            size_t attempt = 0;
-            std::vector<std::shared_ptr<tt::tt_metal::GlobalSemaphore>> garbage;
-            CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
-            auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-            while (semaphores[i]->address() != highest_addr) {
-                auto worker_subdevice_id = worker_subdevice_id_opt.has_value()
-                                               ? std::vector<SubDeviceId>{worker_subdevice_id_opt.value()}
-                                               : std::vector<SubDeviceId>{};
-                // TODO: Remove shared_ptr
-                auto sem = std::make_shared<GlobalSemaphore>(global_semaphore::create_global_semaphore(
-                    devices[i], core_grid, 0, BufferType::L1, worker_subdevice_id));
-                if (sem->address() == highest_addr) {
-                    semaphores[i] = sem;
-                } else {
-                    garbage.push_back(std::move(sem));
-                    attempt++;
-                }
-
-                if (attempt > attempts) {
-                    TT_THROW("Failed to create global semaphores with the same address");
-                }
-            }
-        }
-    }
-    return semaphores;
-}
-
 namespace operations {
 namespace experimental {
 namespace ccl {
@@ -313,9 +259,13 @@ Tensor reduce_scatter(
 
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> from_remote_inputs_semaphores_opt;
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> to_remote_inputs_semaphores_opt;
+    CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
+    auto worker_cores = CoreRangeSet({CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1})});
     if (create_semaphore_handles) {
-        from_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
-        to_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
+        from_remote_inputs_semaphores_opt =
+            ttnn::ccl::worker_detail::create_global_semaphores(devices, worker_cores, worker_subdevice_id_opt);
+        to_remote_inputs_semaphores_opt =
+            ttnn::ccl::worker_detail::create_global_semaphores(devices, worker_cores, worker_subdevice_id_opt);
     } else {
         from_remote_inputs_semaphores_opt = std::nullopt;
         to_remote_inputs_semaphores_opt = std::nullopt;
@@ -390,9 +340,12 @@ Tensor reduce_scatter(
     auto devices = input_tensor.get_workers();
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> from_remote_inputs_semaphores_opt;
     std::optional<std::vector<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>>> to_remote_inputs_semaphores_opt;
+    auto worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(6, 6)));
     if (create_semaphore_handles) {
-        from_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
-        to_remote_inputs_semaphores_opt = create_global_semaphores(devices, worker_subdevice_id_opt);
+        from_remote_inputs_semaphores_opt = 
+            ttnn::ccl::worker_detail::create_global_semaphores(devices, worker_cores, worker_subdevice_id_opt);
+        to_remote_inputs_semaphores_opt = 
+            ttnn::ccl::worker_detail::create_global_semaphores(devices, worker_cores, worker_subdevice_id_opt);
     } else {
         from_remote_inputs_semaphores_opt = std::nullopt;
         to_remote_inputs_semaphores_opt = std::nullopt;

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -400,7 +400,7 @@ class ConcatMesh2dToTensor(MeshToTensor):
         if self.dims[0] == self.dims[1]:
             raise ValueError("Both dimensions in 'dims' must be different")
 
-    def compose(self, tensor: ttnn.Tensor) -> "torch.Tensor":
+    def compose(self, tensor: ttnn.Tensor, sub_device_ids: List[ttnn.SubDeviceId] = []) -> "torch.Tensor":
         """
         Compose the sharded tensors back into a single tensor.
 
@@ -416,7 +416,8 @@ class ConcatMesh2dToTensor(MeshToTensor):
         import torch
 
         device_shards = [
-            ttnn.to_torch(tt_input_tensor, mesh_composer=None) for tt_input_tensor in ttnn.get_device_tensors(tensor)
+            ttnn.to_torch(tt_input_tensor, mesh_composer=None, sub_device_ids=sub_device_ids)
+            for tt_input_tensor in ttnn.get_device_tensors(tensor)
         ]
 
         rows, cols = self.mesh_shape

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -253,7 +253,7 @@ class MeshToTensor:
     You can also "Bring your own MeshToTensor" based on your custom mapping.
     """
 
-    def compose(self, tensor: ttnn.Tensor):
+    def compose(self, tensor: ttnn.Tensor, sub_device_ids: List[ttnn.SubDeviceId] = []):
         raise NotImplementedError("Subclasses must implement this method")
 
 

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -452,11 +452,12 @@ class ConcatMeshToTensor(MeshToTensor):
         self.concat_dim = dim
         self.mesh_device = mesh_device
 
-    def compose(self, tensor: ttnn.Tensor) -> "torch.Tensor":
+    def compose(self, tensor: ttnn.Tensor, sub_device_ids: List[ttnn.SubDeviceId] = []) -> "torch.Tensor":
         import torch
 
         device_shards_converted_to_torch = [
-            ttnn.to_torch(tt_input_tensor, mesh_composer=None) for tt_input_tensor in ttnn.get_device_tensors(tensor)
+            ttnn.to_torch(tt_input_tensor, mesh_composer=None, sub_device_ids=sub_device_ids)
+            for tt_input_tensor in ttnn.get_device_tensors(tensor)
         ]
         return torch.cat(device_shards_converted_to_torch, dim=self.concat_dim)
 
@@ -467,9 +468,10 @@ class ListMeshToTensor(MeshToTensor):
     def __init__(self, mesh_device: MeshDevice):
         self.mesh_device = mesh_device
 
-    def compose(self, tensor: ttnn.Tensor) -> List["torch.Tensor"]:
+    def compose(self, tensor: ttnn.Tensor, sub_device_ids: List[ttnn.SubDeviceId] = []) -> List["torch.Tensor"]:
         return [
-            ttnn.to_torch(tt_input_tensor, mesh_composer=None) for tt_input_tensor in ttnn.get_device_tensors(tensor)
+            ttnn.to_torch(tt_input_tensor, mesh_composer=None, sub_device_ids=sub_device_ids)
+            for tt_input_tensor in ttnn.get_device_tensors(tensor)
         ]
 
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -302,7 +302,7 @@ def to_torch(
                 [ 0.9023, -0.5820,  0.5312]], dtype=torch.bfloat16)
     """
     if mesh_composer:
-        return mesh_composer.compose(tensor)
+        return mesh_composer.compose(tensor, sub_device_ids=sub_device_ids)
 
     if ttnn.is_tensor_storage_on_device(tensor):
         tensor = ttnn.from_device(tensor, cq_id=cq_id, sub_device_ids=sub_device_ids)


### PR DESCRIPTION
- Further update all-gather-async tests to pass subdevice ID information
  - Also modified the test to add fabric teardown in case of exception to avoid hangs :) (longer term this can hopefully be replaced with something cleaner like teardown callback registration exposed by metal so we don't need to wrap in try-catch

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16391)

### Problem description
All-gather v2 hangs when running with cluster axis API on persistent fabric 

### What's changed
In tests:
- Updated tensor to/from calls to take subdevice

Infra:
- Update mesh tensor mesh composer APIs to accept and properly handle subdevice IDs for copying tensors


### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/12600468079
- [x] T3K unit, frequent, nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12592987414
- [x] TG unit, frequent: https://github.com/tenstorrent/tt-metal/actions/runs/12600430907 (same failure as on main)
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes

Closes https://github.com/tenstorrent/tt-metal/issues/16391