### PR TITLE
support N-D dimensions for reduction

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -78,8 +78,31 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("batch_size", [32])
-@pytest.mark.parametrize("c", [32])
+@pytest.mark.parametrize("dim_1", [3])
+@pytest.mark.parametrize("dim_2", [5])
+@pytest.mark.parametrize("dim_3", [37])
+@pytest.mark.parametrize("dim_4", [44])
+@pytest.mark.parametrize("dim_5", [63])
+@pytest.mark.parametrize("dim", [[1, 4]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("batch_size", [3])
+@pytest.mark.parametrize("c", [5])
 @pytest.mark.parametrize("h", [37])
 @pytest.mark.parametrize("w", [63])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -80,9 +80,84 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
 
 @pytest.mark.parametrize("dim_1", [3])
 @pytest.mark.parametrize("dim_2", [5])
-@pytest.mark.parametrize("dim_3", [37])
-@pytest.mark.parametrize("dim_4", [44])
-@pytest.mark.parametrize("dim_5", [63])
+@pytest.mark.parametrize("dim_3", [6])
+@pytest.mark.parametrize("dim_4", [8])
+@pytest.mark.parametrize("dim_5", [2])
+@pytest.mark.parametrize("dim_6", [4])
+@pytest.mark.parametrize("dim_7", [3])
+@pytest.mark.parametrize("dim_8", [6])
+@pytest.mark.parametrize("dim", [[3, 7]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim_1", [3])
+@pytest.mark.parametrize("dim_2", [5])
+@pytest.mark.parametrize("dim_3", [4])
+@pytest.mark.parametrize("dim_4", [6])
+@pytest.mark.parametrize("dim_5", [2])
+@pytest.mark.parametrize("dim_6", [8])
+@pytest.mark.parametrize("dim_7", [2])
+@pytest.mark.parametrize("dim", [[2, 5]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_7d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim_1", [3])
+@pytest.mark.parametrize("dim_2", [5])
+@pytest.mark.parametrize("dim_3", [2])
+@pytest.mark.parametrize("dim_4", [3])
+@pytest.mark.parametrize("dim_5", [2])
+@pytest.mark.parametrize("dim_6", [9])
+@pytest.mark.parametrize("dim", [[1, 4]])
+@pytest.mark.parametrize("keepdim", [True])
+def test_sum_6d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim, keepdim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6), dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("dim_1", [3])
+@pytest.mark.parametrize("dim_2", [5])
+@pytest.mark.parametrize("dim_3", [7])
+@pytest.mark.parametrize("dim_4", [2])
+@pytest.mark.parametrize("dim_5", [5])
 @pytest.mark.parametrize("dim", [[1, 4]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keepdim):
@@ -103,8 +178,8 @@ def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keep
 
 @pytest.mark.parametrize("batch_size", [3])
 @pytest.mark.parametrize("c", [5])
-@pytest.mark.parametrize("h", [37])
-@pytest.mark.parametrize("w", [63])
+@pytest.mark.parametrize("h", [6])
+@pytest.mark.parametrize("w", [8])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -78,12 +78,12 @@ def test_prod(device, batch_size, c, h, w, dim, keepdim):
     # assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("dim_1", [3])
+@pytest.mark.parametrize("dim_1", [33])
 @pytest.mark.parametrize("dim_2", [5])
 @pytest.mark.parametrize("dim_3", [6])
 @pytest.mark.parametrize("dim_4", [8])
 @pytest.mark.parametrize("dim_5", [2])
-@pytest.mark.parametrize("dim_6", [4])
+@pytest.mark.parametrize("dim_6", [40])
 @pytest.mark.parametrize("dim_7", [3])
 @pytest.mark.parametrize("dim_8", [6])
 @pytest.mark.parametrize("dim", [[3, 7]])
@@ -105,8 +105,8 @@ def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
 
 
 @pytest.mark.parametrize("dim_1", [3])
-@pytest.mark.parametrize("dim_2", [5])
-@pytest.mark.parametrize("dim_3", [4])
+@pytest.mark.parametrize("dim_2", [56])
+@pytest.mark.parametrize("dim_3", [44])
 @pytest.mark.parametrize("dim_4", [6])
 @pytest.mark.parametrize("dim_5", [2])
 @pytest.mark.parametrize("dim_6", [8])
@@ -130,9 +130,9 @@ def test_sum_7d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
 
 
 @pytest.mark.parametrize("dim_1", [3])
-@pytest.mark.parametrize("dim_2", [5])
+@pytest.mark.parametrize("dim_2", [55])
 @pytest.mark.parametrize("dim_3", [2])
-@pytest.mark.parametrize("dim_4", [3])
+@pytest.mark.parametrize("dim_4", [32])
 @pytest.mark.parametrize("dim_5", [2])
 @pytest.mark.parametrize("dim_6", [9])
 @pytest.mark.parametrize("dim", [[1, 4]])
@@ -153,11 +153,11 @@ def test_sum_6d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-@pytest.mark.parametrize("dim_1", [3])
+@pytest.mark.parametrize("dim_1", [33])
 @pytest.mark.parametrize("dim_2", [5])
 @pytest.mark.parametrize("dim_3", [7])
 @pytest.mark.parametrize("dim_4", [2])
-@pytest.mark.parametrize("dim_5", [5])
+@pytest.mark.parametrize("dim_5", [59])
 @pytest.mark.parametrize("dim", [[1, 4]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keepdim):
@@ -178,8 +178,8 @@ def test_sum_5d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim, keep
 
 @pytest.mark.parametrize("batch_size", [3])
 @pytest.mark.parametrize("c", [5])
-@pytest.mark.parametrize("h", [6])
-@pytest.mark.parametrize("w", [8])
+@pytest.mark.parametrize("h", [37])
+@pytest.mark.parametrize("w", [63])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])
 @pytest.mark.parametrize("keepdim", [True])
 def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -250,7 +250,39 @@ ttnn::Shape tiling_reshape_corrector(const ttnn::Shape& shape, const uint32_t ti
         case 4:
             return ttnn::Shape({shape[0],shape[1],shape[2],shape[3]},{padded[0],padded[1],padded[2]+correction_2,padded[3]+correction_1});
             break;
-
+        case 5:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4]},
+                {padded[0], padded[1], padded[2], padded[3] + correction_2, padded[4] + correction_1});
+            break;
+        case 6:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]},
+                {padded[0], padded[1], padded[2], padded[3], padded[4] + correction_2, padded[5] + correction_1});
+            break;
+        case 7:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4], shape[5], shape[6]},
+                {padded[0],
+                 padded[1],
+                 padded[2],
+                 padded[3],
+                 padded[4],
+                 padded[5] + correction_2,
+                 padded[6] + correction_1});
+            break;
+        case 8:
+            return ttnn::Shape(
+                {shape[0], shape[1], shape[2], shape[3], shape[4], shape[5], shape[6], shape[7]},
+                {padded[0],
+                 padded[1],
+                 padded[2],
+                 padded[3],
+                 padded[4],
+                 padded[5],
+                 padded[6] + correction_2,
+                 padded[7] + correction_1});
+            break;
     }
     return shape;
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -144,8 +144,7 @@ static Tensor reduce_impl(
         if (dim.size() == 1 || linear_type) {
             output_tensor = reduce_4d_loop(/*use_reduce_type=*/true);
         } else if constexpr (reduce_type == ReduceType::Mean) {
-            output_tensor = reduce_4d_loop(
-                /*use_reduce_type=*/false);
+            output_tensor = reduce_4d_loop(/*use_reduce_type=*/false);
             float inv_volume = 1.0f / input_tensor.get_logical_volume();
             output_tensor = ttnn::mul_sfpu(inv_volume, output_tensor, memory_config);
         } else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16380)

### Problem description
We only support tensors of size <= 4D for reduction

### What's changed
Add support for N-D tensors using the PR: https://github.com/tenstorrent/tt-metal/pull/16299

### Checklist
- [ ] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/12998192608
- [ ] Blackhole Post commit (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/12992442566
- [ ] Model regression CI testing passes (if applicable) : https://github.com/tenstorrent/tt-metal/actions/runs/13003601410
- [ ] Device performance regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/12998368318
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
