### PR TITLE
#16175: Add DPRINT TileSlice support for int types

### DIFF
--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -88,7 +88,8 @@ An example of how to print data from a CB (in this case, ``CBIndex::c_25``) is s
 to the current CB read or write pointer. This means that for printing a tile read from the front of the CB, the
 ``DPRINT`` call has to occur between the ``cb_wait_front`` and ``cb_pop_front`` calls. For printing a tile from the
 back of the CB, the ``DPRINT`` call has to occur between the ``cb_reserve_back`` and ``cb_push_back`` calls. Currently supported data
-formats for printing from CBs are ``DataFormat::Float32``, ``DataFormat::Float16_b``, ``DataFormat::Bfp8_b``, and ``DataFormat::Bfp4_b``.
+formats for printing from CBs are ``DataFormat::Float32``, ``DataFormat::Float16_b``, ``DataFormat::Bfp8_b``, ``DataFormat::Bfp4_b``,
+``DataFormat::Int8``, ``DataFormat::UInt8``, ``DataFormat::UInt16``, ``DataFormat::Int32``, and ``DataFormat::UInt832``.
 
 .. code-block:: c++
 

--- a/tt_metal/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/dprint_common.h
@@ -227,11 +227,11 @@ static inline constexpr bool is_supported_format(const CommonDataFormat& format)
         case CommonDataFormat::Float16_b: return true;
         case CommonDataFormat::Float32: return true;
         case CommonDataFormat::Int8:
-        case CommonDataFormat::Lf8:
         case CommonDataFormat::UInt8:
         case CommonDataFormat::UInt16:
         case CommonDataFormat::UInt32:
-        case CommonDataFormat::Int32:
+        case CommonDataFormat::Int32: return true;
+        case CommonDataFormat::Lf8:
         case CommonDataFormat::Invalid:
         default: return false;
     }

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -317,6 +317,31 @@ static void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
                     *stream << *reinterpret_cast<float*>(&bit_val);
                     break;
                 }
+                case tt::DataFormat::Int8: {
+                    int8_t* data_ptr = reinterpret_cast<int8_t*>(data);
+                    *stream << (int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::UInt8: {
+                    uint8_t* data_ptr = reinterpret_cast<uint8_t*>(data);
+                    *stream << (unsigned int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::UInt16: {
+                    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(data);
+                    *stream << (unsigned int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::Int32: {
+                    int32_t* data_ptr = reinterpret_cast<int32_t*>(data);
+                    *stream << (int)data_ptr[i];
+                    break;
+                }
+                case tt::DataFormat::UInt32: {
+                    uint32_t* data_ptr = reinterpret_cast<uint32_t*>(data);
+                    *stream << (unsigned int)data_ptr[i];
+                    break;
+                }
                 default: break;
             }
             if (w + ts->slice_range.ws < ts->slice_range.w1) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16175

### Problem description
There's been a request for more datatypes to be supported for TileSlice printing.

### What's changed
Add support for Int8, UInt8, Uint16, Int32, UInt32 w/ test coverage

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/12591170401
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
