### PR TITLE
#0: Recip bfloat8_b fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -466,3 +466,22 @@ def test_unary_ceil(input_shapes, device):
     golden_tensor = golden_function(in_data1)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(golden_tensor, output_tensor, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_recip(input_shapes, device):
+    in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-100, 100)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+    torch_input = ttnn.to_torch(input_tensor1).to(torch.bfloat16)
+    output_tensor = ttnn.reciprocal(input_tensor1)
+    golden_function = ttnn.get_golden_function(ttnn.reciprocal)
+    golden_tensor = golden_function(torch_input)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(golden_tensor, output_tensor, 0.999)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -75,6 +75,21 @@ struct ExecuteUnaryWithFloatParameter {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct Recip {
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+    static ComplexTensor invoke(const ComplexTensor& input_tensor, const MemoryConfig& memory_config);
+};
+
 struct Sigmoid_accurate {
     static Tensor invoke(
         uint8_t queue_id,
@@ -323,7 +338,6 @@ REGISTER_UNARY_OPERATION(logical_not, LOGICAL_NOT_UNARY);
 REGISTER_UNARY_OPERATION(ltz, LTZ);
 REGISTER_UNARY_OPERATION(neg, NEG);
 REGISTER_UNARY_OPERATION(nez, NEZ);
-REGISTER_UNARY_OPERATION_OVERLOAD(reciprocal, RECIP);
 REGISTER_UNARY_OPERATION(relu, RELU);
 REGISTER_UNARY_OPERATION(relu6, RELU6);
 REGISTER_UNARY_OPERATION(sigmoid, SIGMOID);
@@ -379,6 +393,7 @@ constexpr auto prelu_sfpu =
 
 constexpr auto sigmoid_accurate =
     ttnn::register_operation_with_auto_launch_op<"ttnn::sigmoid_accurate", ttnn::operations::unary::Sigmoid_accurate>();
+constexpr auto reciprocal = ttnn::register_operation<"ttnn::reciprocal", ttnn::operations::unary::Recip>();
 constexpr auto unary_chain =
     ttnn::register_operation_with_auto_launch_op<"ttnn::unary_chain", ttnn::operations::unary::Unary_chain>();
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #14672 

### Problem description

- ttnn.reciprocal does not give inf when input is 0 but instead gives 1.7014118346046923e+38
- When an input value is 0 in input_tensor(dtype=ttnn.bfloat8_b), the output is 1.7014118346046923e+38 and strangely the nearby values become 0 in the output. [Refer](https://github.com/tenstorrent/tt-metal/issues/14672#issuecomment-2553691938).

This is due to BFP8 format is format where consecutive 16 numbers share the same exponent, the shared exponent being the exponent of the biggest number. Tests with random numbers from uniform distributions could have consecutive numbers of different magnitude and smaller numbers could just get flushed to zero.
You should check groups of consecutive 16 numbers that include erroneous numbers and check if maximum number may be causing these numbers to get flushed to zero. [More Info](https://github.com/tenstorrent/tt-metal/issues/14672#issuecomment-2518193821)

### What's changed
This is one possible approach since the bf8 datatype cannot store inf. For inputs in bf8, the logic of recip has been updated to return 0 instead of inf, while non-zero inputs will produce the usual reciprocal output.

### Feedback Requested from TT
Is the above approach acceptable, or is there an alternative way to handle this behavior?

### Checklist
- [ ] All Post commit CI
