### PR TITLE
Add experimental APIs to access Hal

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
     PRIVATE
         tt_metal.cpp
         graph/graph_tracking.cpp
+        experimental/hal.cpp
 )
 
 target_link_libraries(

--- a/tt_metal/experimental/hal.cpp
+++ b/tt_metal/experimental/hal.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "tt_metal/experimental/hal.hpp"
+#include "tt_metal/llrt/hal.hpp"
+
+using tt::tt_metal::HalL1MemAddrType;
+using tt::tt_metal::HalMemType;
+using tt::tt_metal::HalProgrammableCoreType;
+using tt::tt_metal::HalSingleton;
+
+namespace tt::tt_metal::experimental::hal {
+
+uint32_t get_l1_size() {
+    return HalSingleton::getInstance().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
+}
+
+uint32_t get_dram_alignment() { return HalSingleton::getInstance().get_alignment(HalMemType::DRAM); }
+
+uint32_t get_l1_alignment() { return HalSingleton::getInstance().get_alignment(HalMemType::L1); }
+
+uint32_t get_pcie_alignment() { return HalSingleton::getInstance().get_alignment(HalMemType::HOST); }
+
+}  // namespace tt::tt_metal::experimental::hal

--- a/tt_metal/experimental/hal.hpp
+++ b/tt_metal/experimental/hal.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::tt_metal::experimental::hal {
+
+/**
+ * @brief Uses the hardware abstraction layer to inform client of architecture specific L1 Size
+ *
+ * @return Size in bytes of the L1 SRAM buffer associated with the currently present architecture.
+ */
+uint32_t get_l1_size();
+
+/**
+ * @brief Uses the hardware abstraction layer to inform client of architecture specific DRAM alignment.
+ *
+ * @return Alignment requirement in bytes
+ */
+uint32_t get_dram_alignment();
+
+/**
+ * @brief Uses the hardware abstraction layer to inform client of architecture specific L1 alignment.
+ *
+ * @return Alignment requirement in bytes
+ */
+uint32_t get_l1_alignment();
+
+/**
+ * @brief Uses the hardware abstraction layer to inform client of architecture specific PCIE alignment.
+ *
+ * @return Alignment requirement in bytes
+ */
+uint32_t get_pcie_alignment();
+
+}  // namespace tt::tt_metal::experimental::hal

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -7,14 +7,13 @@
 
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
+#include "tt_metal/experimental/hal.hpp"
 
 #include "transpose_program_factory.hpp"
 
-// FIXME: ARCH_NAME specific include
-#include "noc/noc_parameters.h"  // DRAM_ALIGNMENT
-
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::operations::data_movement {
 
@@ -95,8 +94,9 @@ void Transpose::validate(const std::vector<Tensor>& input_tensors) const {
     }
     if (this->dim == TransposeOpDim::HC) {
         if (row_major) {
-            auto BUFFER_ALIGNMENT =
-                input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? DRAM_ALIGNMENT : L1_ALIGNMENT;
+            auto BUFFER_ALIGNMENT = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                        ? hal::get_dram_alignment()
+                                        : hal::get_l1_alignment();
             TT_FATAL(
                 (W * input_tensor.element_size()) % BUFFER_ALIGNMENT == 0,
                 "Buffer is not aligned for this implementation row_size_bytes {} buffer_alignment {}",


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/15633

### Problem description
ttnn wants access to architecture specific constants.
Need an API to abstract away architecture.

### What's changed
New experimental public APIs added.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12600829323)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
