### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Transpose and Reduce

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/cumsum.cpp
@@ -22,7 +22,7 @@ void MAIN {
 #ifndef ROWWISE
     init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #else
-    transpose_wh_init(tt::CBIndex::c_0);
+    transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #endif
     cumsum_tile_init();
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -98,7 +98,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, 1 * onetile);
-        reduce_init_delta<false>(cb_ex);
+        reduce_init_delta<false>(cb_ex, cb_x, cb_scaler);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -154,7 +154,7 @@ void MAIN {
          * TODO(AP): can save space here by reusing CB
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(cb_ex2);
+        reduce_init_delta<false>(cb_ex2, cb_xmm2, cb_scaler);
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         // cb_wait_front(cb_xmm, Wt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -98,7 +98,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, 1 * onetile);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -107,7 +107,7 @@ void MAIN {
             // we don't pop cb_x until we compute Ex
         }
         pack_tile(dst0, cb_ex);
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex);
         REL();
 
         cb_push_back(cb_ex, 1);
@@ -154,7 +154,7 @@ void MAIN {
          * TODO(AP): can save space here by reusing CB
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex2);
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         // cb_wait_front(cb_xmm, Wt);
@@ -167,7 +167,7 @@ void MAIN {
         }
         cb_pop_front(cb_xmm2, Wt);
         pack_tile(dst0, cb_ex2);
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex2);
         REL();
 
         cb_push_back(cb_ex2, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
@@ -77,7 +77,7 @@ inline void reduce_h(
     uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id, in_cb_id, in_scalar_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
@@ -77,7 +77,7 @@ inline void reduce_h(
     uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id, in_cb_id, in_scalar_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -46,7 +46,7 @@ void MAIN {
     constexpr bool at_start = get_compile_time_arg_val(3);
     dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2);
 #ifndef SHORT_INIT
-    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #else
     reduce_init_delta<at_start>(tt::CBIndex::c_16, tt::CBIndex::c_0, tt::CBIndex::c_2);
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -46,7 +46,7 @@ void MAIN {
     constexpr bool at_start = get_compile_time_arg_val(3);
     dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2);
 #ifndef SHORT_INIT
-    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #else
     reduce_init_delta<at_start>(tt::CBIndex::c_16, tt::CBIndex::c_0, tt::CBIndex::c_2);
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -46,7 +46,7 @@ void MAIN {
     constexpr bool at_start = get_compile_time_arg_val(3);
     dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2);
 #ifndef SHORT_INIT
-    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #else
     reduce_init_delta<at_start>(tt::CBIndex::c_16, tt::CBIndex::c_0, tt::CBIndex::c_2);
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -111,7 +111,7 @@ void MAIN {
          * compute E[(x)^2]
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(cb_ex2);
+        reduce_init_delta<false>(cb_ex2, cb_x2, cb_scaler);
         ACQ();
         cb_wait_front(cb_x2, Wt);
         // cb_wait_front(cb_xmm, Wt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -111,7 +111,7 @@ void MAIN {
          * compute E[(x)^2]
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex2);
         ACQ();
         cb_wait_front(cb_x2, Wt);
         // cb_wait_front(cb_xmm, Wt);
@@ -123,7 +123,7 @@ void MAIN {
             // reduce_tile(cb_xmm, cb_scaler, wt+wtr, scaler0, dst0);
         }
         cb_pop_front(cb_x2, Wt);
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex2);
         pack_tile(dst0, cb_ex2);
         REL();
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -125,7 +125,7 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>(cb_recipsumexps);
+        reduce_init_delta<false>(cb_recipsumexps, cb_exps, cb_bcast_scaler);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -125,13 +125,13 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_recipsumexps);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
             reduce_tile(cb_exps, cb_bcast_scaler, wt, bcast_scaler0, dst0);
         }
-        reduce_revert_delta();
+        reduce_revert_delta(cb_recipsumexps);
         recip_tile_init();
         recip_tile(dst0);  // DST[0] = 1/sum(exp(x))
         pack_tile(dst0, cb_recipsumexps);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
@@ -11,7 +11,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t NHtWt = get_compile_time_arg_val(0);
 #ifndef SHORT_INIT
-    transpose_wh_init(tt::CBIndex::c_0);
+    transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #else
     unary_op_init_common(tt::CBIndex::c_0);
     transpose_wh_init_short(tt::CBIndex::c_0);

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -16,7 +16,7 @@
 namespace ckernel {
 
 template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16) {
+ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
     UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler)));
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
 
@@ -30,14 +30,14 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16) {
 }
 
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_short(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16) {
+ALWI void reduce_init_short(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>()));
     PACK((llk_pack_reduce_config_v2<reduce_dim, false, false, DST_ACCUM_MODE>(ocb)));
 }
 
 template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta(uint32_t ocb = 16, uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void reduce_init_delta(uint32_t ocb, uint32_t icb0 = 0, uint32_t icb1 = 1) {
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb0, icb1)));
 
@@ -60,7 +60,7 @@ ALWI void reduce_init_delta_math() {
 }
 
 template <ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_revert_delta(uint32_t ocb = 16) {
+ALWI void reduce_revert_delta(uint32_t ocb) {
     PACK((llk_pack_reduce_config_v2<reduce_dim, false, true, DST_ACCUM_MODE>(ocb)));
 }
 

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -37,7 +37,7 @@ ALWI void reduce_init_short(uint32_t icb, uint32_t icb_scaler, uint32_t ocb) {
 }
 
 template <bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta(uint32_t ocb, uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void reduce_init_delta(uint32_t ocb, uint32_t icb0, uint32_t icb1) {
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim>(icb0, icb1)));
 
@@ -47,7 +47,7 @@ ALWI void reduce_init_delta(uint32_t ocb, uint32_t icb0 = 0, uint32_t icb1 = 1) 
 }
 
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta_no_pack(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void reduce_init_delta_no_pack(uint32_t icb0, uint32_t icb1) {
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<>(icb0, icb1)));
 

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -22,7 +22,7 @@ namespace ckernel {
  * |----------------|-------------------------------------------------------------|----------|------------------------------------------------|----------|
  * | icb            | The identifier of the circular buffer (CB) containing input | uint32_t | 0 to 31 | True     |
  */
-ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb = 16) {
+ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(true, true, icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure_disaggregated(icb, icb)));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp
@@ -955,7 +955,7 @@ ALWI void reduce_and_recip_tile_to_cb(
         cb_pop_front(icb1, pop1);
     }
 
-    reduce_revert_delta();
+    reduce_revert_delta(ocb);
 
     recip_tile_init();
     recip_tile(dst0);
@@ -992,7 +992,7 @@ ALWI void reduce_and_log_tile_to_cb(
         cb_pop_front(icb1, pop1);
     }
 
-    reduce_revert_delta();
+    reduce_revert_delta(ocb);
 
     log_tile_init();
     log_tile(dst0);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/transpose_wh.cpp
@@ -9,7 +9,7 @@
 namespace NAMESPACE {
 void MAIN {
     uint32_t NHtWt = get_compile_time_arg_val(0);
-    transpose_wh_init(tt::CBIndex::c_0);
+    transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     // transpose a row-major block:
     // - assumes the tiles come in in column major order from reader

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/kernels/moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/kernels/moreh_matmul.cpp
@@ -200,7 +200,7 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
     // TODO: checking required when the input cb format and intermediate cb format are different.
     mm_init(cb_in0, cb_in1, cb_out0);
     if (transpose_input || transpose_other) {
-        transpose_wh_init(cb_in0);
+        transpose_wh_init(cb_in0, cb_out0);
     }
 
     if (need_input_mask_h || need_input_mask_w) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp
@@ -10,7 +10,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t NHtWt = get_arg_val<uint32_t>(0);
 
-    transpose_wh_init(tt::CBIndex::c_0);
+    transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     // transpose a row-major block:
     // - assumes the tiles come in in column major order from reader

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp
@@ -17,7 +17,7 @@ void MAIN {
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
 
-    transpose_wh_init(cb_id_in);
+    transpose_wh_init(cb_id_in, cb_id_out);
 
     // transpose a row-major block:
     // - uses reader_unary_transpose_wh

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -42,7 +42,7 @@ void MAIN {
     constexpr uint32_t cb_transpose_in = get_compile_time_arg_val(1);
     constexpr uint32_t cb_out = get_compile_time_arg_val(2);
 
-    transpose_wh_init(cb_in);
+    transpose_wh_init(cb_in, cb_transpose_in);
     pack_untilize_init(cb_in, cb_transpose_in);
 
     for (uint32_t idx = 0; idx < total_tiles; idx++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/ssm_1d_sum_reduce.cpp
@@ -63,7 +63,7 @@ void MAIN {
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(4);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(5);
 
-    reduce_init<true>(input_cb_id, scalar_cb_id);
+    reduce_init<true>(input_cb_id, scalar_cb_id, intermed_cb_id1);
     reduce_revert_delta<REDUCE_DIM>(intermed_cb_id1);  // Required or else the first tile is wrong
 
     for (uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/compute/transpose_wh_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/compute/transpose_wh_sharded.cpp
@@ -10,7 +10,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t num_tiles = get_compile_time_arg_val(0);
 
-    transpose_wh_init(tt::CBIndex::c_24);
+    transpose_wh_init(tt::CBIndex::c_24, tt::CBIndex::c_17);
 
     constexpr uint32_t cb_im0 = tt::CBIndex::c_24;
     constexpr uint32_t cb_out1 = tt::CBIndex::c_17;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -134,7 +134,7 @@ void MAIN {
     cb_wait_front(cb_xpowadd, onetile);
     cb_reserve_back(cb_y, onetile);
 
-    reduce_init_delta<false>(cb_y);
+    reduce_init_delta<false>(cb_y, cb_xpowadd, cb_one);
     reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
     reduce_revert_delta(cb_y);
     tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -134,9 +134,9 @@ void MAIN {
     cb_wait_front(cb_xpowadd, onetile);
     cb_reserve_back(cb_y, onetile);
 
-    reduce_init_delta<false>();
+    reduce_init_delta<false>(cb_y);
     reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
-    reduce_revert_delta();
+    reduce_revert_delta(cb_y);
     tile_regs_commit();
 
     tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -47,7 +47,7 @@ void MAIN {
         }
 
         cb_wait_front(tt::CBIndex::c_24, onetile);
-        reduce_init_delta<false>(tt::CBIndex::c_16);
+        reduce_init_delta<false>(tt::CBIndex::c_16, tt::CBIndex::c_24, tt::CBIndex::c_2);
         reduce_tile(tt::CBIndex::c_24, tt::CBIndex::c_2, 0, 0, 0);
         cb_pop_front(tt::CBIndex::c_24, onetile);
         reduce_revert_delta(tt::CBIndex::c_16);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -47,10 +47,10 @@ void MAIN {
         }
 
         cb_wait_front(tt::CBIndex::c_24, onetile);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(tt::CBIndex::c_16);
         reduce_tile(tt::CBIndex::c_24, tt::CBIndex::c_2, 0, 0, 0);
         cb_pop_front(tt::CBIndex::c_24, onetile);
-        reduce_revert_delta();
+        reduce_revert_delta(tt::CBIndex::c_16);
 
         if (last_out) {
             cb_reserve_back(tt::CBIndex::c_16, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -102,9 +102,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format(cb_reduce, cb_scaler);
 #endif
-                reduce_init_delta<false>();
+                reduce_init_delta<false>(cb_out0);
                 reduce_tile(cb_reduce, cb_scaler, 0, 0, 0);
-                reduce_revert_delta();
+                reduce_revert_delta(cb_out0);
 
                 if (do_mask) {
                     cb_pop_front(cb_intermed0, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -102,7 +102,7 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format(cb_reduce, cb_scaler);
 #endif
-                reduce_init_delta<false>(cb_out0);
+                reduce_init_delta<false>(cb_out0, cb_reduce, cb_scaler);
                 reduce_tile(cb_reduce, cb_scaler, 0, 0, 0);
                 reduce_revert_delta(cb_out0);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -101,7 +101,7 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format(cb_reduce, cb_scaler);
 #endif
-                reduce_init_delta<false>(cb_out0);
+                reduce_init_delta<false>(cb_out0, cb_reduce, cb_scaler);
                 reduce_tile((do_mask) ? (cb_intermed0) : (cb_in0), cb_scaler, 0, 0, 0);
                 reduce_revert_delta(cb_out0);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -101,9 +101,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                 reconfig_data_format(cb_reduce, cb_scaler);
 #endif
-                reduce_init_delta<false>();
+                reduce_init_delta<false>(cb_out0);
                 reduce_tile((do_mask) ? (cb_intermed0) : (cb_in0), cb_scaler, 0, 0, 0);
-                reduce_revert_delta();
+                reduce_revert_delta(cb_out0);
 
                 if (do_mask) {
                     cb_pop_front(cb_intermed0, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/kernels/moreh_matmul.cpp
@@ -200,7 +200,7 @@ FORCE_INLINE void matmul_with_transpose_and_mask(
     // TODO: checking required when the input cb format and intermediate cb format are different.
     mm_init(cb_in0, cb_in1, cb_out0);
     if (transpose_input || transpose_other) {
-        transpose_wh_init(cb_in0);
+        transpose_wh_init(cb_in0, cb_out0);
     }
 
     if (need_input_mask_h || need_input_mask_w) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -47,9 +47,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format(cb_input, cb_scaler);
 #endif
-                    reduce_init_delta<false>();
+                    reduce_init_delta<false>(cb_accum_dst);
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-                    reduce_revert_delta();
+                    reduce_revert_delta(cb_accum_dst);
 
                     cb_pop_front(cb_input, onetile);
                 }
@@ -104,9 +104,9 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
             reconfig_data_format(cb_input, cb_scaler);
 #endif
-            reduce_init_delta<false>();
+            reduce_init_delta<false>(cb_out);
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-            reduce_revert_delta();
+            reduce_revert_delta(cb_out);
             tile_regs_commit();
 
             cb_reserve_back(cb_out, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -47,7 +47,7 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
                     reconfig_data_format(cb_input, cb_scaler);
 #endif
-                    reduce_init_delta<false>(cb_accum_dst);
+                    reduce_init_delta<false>(cb_accum_dst, cb_input, cb_scaler);
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
                     reduce_revert_delta(cb_accum_dst);
 
@@ -104,7 +104,7 @@ void MAIN {
 #if defined FP32_DEST_ACC_EN
             reconfig_data_format(cb_input, cb_scaler);
 #endif
-            reduce_init_delta<false>(cb_out);
+            reduce_init_delta<false>(cb_out, cb_input, cb_scaler);
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             reduce_revert_delta(cb_out);
             tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -199,7 +199,7 @@ void MAIN {
 
             // Partial-E[x]
             index_h_offset = 0;
-            reduce_init_delta<false>(cb_ex_partial);
+            reduce_init_delta<false>(cb_ex_partial, cb_x, cb_scaler);
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_scaler, 1);
@@ -219,7 +219,7 @@ void MAIN {
             reduce_revert_delta(cb_ex_partial);
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(cb_ex_global);
+                reduce_init_delta<false>(cb_ex_global, cb_ex_external, cb_scaler_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -316,7 +316,7 @@ void MAIN {
 
             // Partial-Var(x)
             index_h_offset = 0;
-            reduce_init_delta<false>(cb_ex_partial);
+            reduce_init_delta<false>(cb_ex_partial, cb_xmm, cb_scaler);
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_xmm, block_hw);
@@ -337,7 +337,7 @@ void MAIN {
             reduce_revert_delta(cb_ex_partial);
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(cb_ex_global);
+                reduce_init_delta<false>(cb_ex_global, cb_ex_external, cb_scaler_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -199,7 +199,7 @@ void MAIN {
 
             // Partial-E[x]
             index_h_offset = 0;
-            reduce_init_delta<false>();
+            reduce_init_delta<false>(cb_ex_partial);
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_scaler, 1);
@@ -216,10 +216,10 @@ void MAIN {
             pack_tile(dst0, cb_ex_partial);
             tile_regs_release();
             cb_push_back(cb_ex_partial, 1);
-            reduce_revert_delta();
+            reduce_revert_delta(cb_ex_partial);
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>();
+                reduce_init_delta<false>(cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -231,7 +231,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_revert_delta();
+                reduce_revert_delta(cb_ex_global);
                 cb_push_back(cb_ex_global, 1);
                 cb_push_back(cb_ex, 1);
             }
@@ -316,7 +316,7 @@ void MAIN {
 
             // Partial-Var(x)
             index_h_offset = 0;
-            reduce_init_delta<false>();
+            reduce_init_delta<false>(cb_ex_partial);
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_xmm, block_hw);
@@ -334,10 +334,10 @@ void MAIN {
             tile_regs_release();
             cb_push_back(cb_ex_partial, 1);
             cb_pop_front(cb_xmm, block_hw);
-            reduce_revert_delta();
+            reduce_revert_delta(cb_ex_partial);
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>();
+                reduce_init_delta<false>(cb_ex_global);
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -349,7 +349,7 @@ void MAIN {
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex_global);
                 tile_regs_release();
-                reduce_revert_delta();
+                reduce_revert_delta(cb_ex_global);
                 cb_push_back(cb_ex_global, 1);
                 cb_push_back(cb_ex, 1);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -122,7 +122,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, onetile);
-        reduce_init_delta<false>(cb_ex);
+        reduce_init_delta<false>(cb_ex, cb_x, cb_scaler);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -193,7 +193,7 @@ void MAIN {
             reconfig_data_format(cb_xmm2, cb_scaler);
         }
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(cb_ex2);
+        reduce_init_delta<false>(cb_ex2, cb_xmm2, cb_scaler);
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         // cb_wait_front(cb_xmm, Wt);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -122,7 +122,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, onetile);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -131,7 +131,7 @@ void MAIN {
             // we don't pop cb_x until we compute Ex
         }
         pack_tile(dst0, cb_ex);
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex);
         REL();
 
         cb_push_back(cb_ex, 1);
@@ -193,7 +193,7 @@ void MAIN {
             reconfig_data_format(cb_xmm2, cb_scaler);
         }
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex2);
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         // cb_wait_front(cb_xmm, Wt);
@@ -206,7 +206,7 @@ void MAIN {
         }
         cb_pop_front(cb_xmm2, Wt);
         pack_tile(dst0, cb_ex2);
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex2);
         REL();
 
         cb_push_back(cb_ex2, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -142,7 +142,7 @@ void MAIN {
 #ifndef RMSNORM
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>();
+    reduce_init_delta<false>(cb_ex_partial);
     cb_wait_front(cb_scaler, 1);
     cb_reserve_back(cb_ex_partial, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -156,14 +156,14 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta();
+    reduce_revert_delta(cb_ex_partial);
     cb_push_back(cb_ex_partial, block_h);
 
     reconfig_data_format_srca(cb_in, cb_ex_external);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex);
         cb_reserve_back(cb_ex, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -183,7 +183,7 @@ void MAIN {
             pack_tile(dst0, cb_ex);
             tile_regs_release();
         }
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex);
         cb_push_back(cb_ex, num_tiles_per_allgather_worker);
         cb_wait_front(cb_ex, num_tiles_per_allgather_worker);
     }
@@ -262,7 +262,7 @@ void MAIN {
     cb_wait_front(cb_scaler, 1);
 #endif
     cb_reserve_back(cb_ex_partial2, block_h);
-    reduce_init_delta<false>();
+    reduce_init_delta<false>(cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -275,13 +275,13 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta();
+    reduce_revert_delta(cb_ex_partial2);
     cb_pop_front(cb_xmm2, num_tiles_per_block);
     cb_push_back(cb_ex_partial2, block_h);
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_ex2);
         cb_reserve_back(cb_ex2, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -302,7 +302,7 @@ void MAIN {
             pack_tile(dst0, cb_ex2);
             tile_regs_release();
         }
-        reduce_revert_delta();
+        reduce_revert_delta(cb_ex2);
         cb_push_back(cb_ex2, num_tiles_per_allgather_worker);
 
         if (enable_sqrt) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -142,7 +142,7 @@ void MAIN {
 #ifndef RMSNORM
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>(cb_ex_partial);
+    reduce_init_delta<false>(cb_ex_partial, cb_in, cb_scaler);
     cb_wait_front(cb_scaler, 1);
     cb_reserve_back(cb_ex_partial, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -163,7 +163,7 @@ void MAIN {
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init_delta<false>(cb_ex);
+        reduce_init_delta<false>(cb_ex, cb_ex_external, cb_scaler_global);
         cb_reserve_back(cb_ex, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -262,7 +262,7 @@ void MAIN {
     cb_wait_front(cb_scaler, 1);
 #endif
     cb_reserve_back(cb_ex_partial2, block_h);
-    reduce_init_delta<false>(cb_ex_partial2);
+    reduce_init_delta<false>(cb_ex_partial2, cb_xmm2, cb_scaler);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -281,7 +281,7 @@ void MAIN {
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr (is_allgather_worker) {
-        reduce_init_delta<false>(cb_ex2);
+        reduce_init_delta<false>(cb_ex2, cb_ex_external2, cb_scaler_global);
         cb_reserve_back(cb_ex2, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -108,7 +108,7 @@ void MAIN {
 #endif
 
             cb_wait_front(cb_scaler_global, 1);
-            reduce_init_delta<false>(cb_var);
+            reduce_init_delta<false>(cb_var, cb_stats, cb_scaler_global);
             tile_regs_acquire();
             // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
             for (uint32_t w = 0; w < stats_tiles * num_distributed_blocks; w++) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -108,7 +108,7 @@ void MAIN {
 #endif
 
             cb_wait_front(cb_scaler_global, 1);
-            reduce_init_delta<false>();
+            reduce_init_delta<false>(cb_var);
             tile_regs_acquire();
             // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
             for (uint32_t w = 0; w < stats_tiles * num_distributed_blocks; w++) {
@@ -130,7 +130,7 @@ void MAIN {
             pack_tile(dst1, cb_ex2);
 #endif
             tile_regs_release();
-            reduce_revert_delta();
+            reduce_revert_delta(cb_var);
 #ifdef RMSNORM
             cb_push_back(cb_var, stats_tiles);
 #else

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -81,7 +81,7 @@ void MAIN {
     reconfig_data_format_srcb(cb_in0, cb_scaler);
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>(cb_ex_partial2);
+    reduce_init_delta<false>(cb_ex_partial2, cb_in0, cb_scaler);
 
     cb_reserve_back(cb_ex_partial2, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -135,7 +135,7 @@ void MAIN {
 
     cb_reserve_back(cb_ex_partial2, block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
-    reduce_init_delta<false>(cb_ex_partial2);
+    reduce_init_delta<false>(cb_ex_partial2, cb_x2, cb_scaler);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -158,7 +158,7 @@ void MAIN {
         cb_wait_front(cb_scaler_global, 1);
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
-        reduce_init_delta<false>(cb_reduction_out);
+        reduce_init_delta<false>(cb_reduction_out, cb_ex_external2, cb_scaler_global);
         cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -81,7 +81,7 @@ void MAIN {
     reconfig_data_format_srcb(cb_in0, cb_scaler);
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>();
+    reduce_init_delta<false>(cb_ex_partial2);
 
     cb_reserve_back(cb_ex_partial2, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -95,7 +95,7 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta();
+    reduce_revert_delta(cb_ex_partial2);
     cb_push_back(cb_ex_partial2, block_h);
     reconfig_data_format_srcb(cb_scaler, cb_in0);
 #endif  // not RMSNORM
@@ -135,7 +135,7 @@ void MAIN {
 
     cb_reserve_back(cb_ex_partial2, block_h);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
-    reduce_init_delta<false>();
+    reduce_init_delta<false>(cb_ex_partial2);
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -149,7 +149,7 @@ void MAIN {
         tile_regs_release();
         index_h_offset += block_w;
     }
-    reduce_revert_delta();
+    reduce_revert_delta(cb_ex_partial2);
     cb_pop_front(cb_x2, num_tiles_per_block);
     cb_push_back(cb_ex_partial2, block_h);
 
@@ -158,7 +158,7 @@ void MAIN {
         cb_wait_front(cb_scaler_global, 1);
         reconfig_data_format_srca(cb_x2, cb_ex_external2);
         reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_reduction_out);
         cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {  // loops over height
@@ -183,7 +183,7 @@ void MAIN {
 #endif
             tile_regs_release();
         }
-        reduce_revert_delta();
+        reduce_revert_delta(cb_reduction_out);
         cb_push_back(cb_reduction_out, num_tiles_per_partial_result * num_tiles_per_allgather_worker);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -88,7 +88,7 @@ void MAIN {
          * cb_stats = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
          * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
          */
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_stats_reduced);
         cb_wait_front(cb_stats, stats_tiles_cols);
         cb_reserve_back(cb_stats_reduced, stats_tile_stride);
 #ifdef RMSNORM
@@ -117,7 +117,7 @@ void MAIN {
         cb_push_back(cb_var, 1);
 #endif
 
-        reduce_revert_delta();
+        reduce_revert_delta(cb_stats_reduced);
 
 #ifndef RMSNORM
         /*

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -88,7 +88,7 @@ void MAIN {
          * cb_stats = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
          * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
          */
-        reduce_init_delta<false>(cb_stats_reduced);
+        reduce_init_delta<false>(cb_stats_reduced, cb_stats, cb_reduce);
         cb_wait_front(cb_stats, stats_tiles_cols);
         cb_reserve_back(cb_stats_reduced, stats_tile_stride);
 #ifdef RMSNORM

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -68,7 +68,7 @@ void MAIN {
          */
         reconfig_data_format(cb_x2, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>(cb_out);
+        reduce_init_delta<false>(cb_out, cb_x2, cb_reduce);
         cb_wait_front(cb_x2, Wt);
         cb_reserve_back(cb_out, onetile);
         ACQ();
@@ -89,7 +89,7 @@ void MAIN {
          */
         reconfig_data_format(cb_inp, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>(cb_out);
+        reduce_init_delta<false>(cb_out, cb_inp, cb_reduce);
         cb_reserve_back(cb_out, onetile);
         ACQ();
         for (uint32_t wtr = 0; wtr < Wt; wtr++) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_pre_allgather.cpp
@@ -68,7 +68,7 @@ void MAIN {
          */
         reconfig_data_format(cb_x2, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_out);
         cb_wait_front(cb_x2, Wt);
         cb_reserve_back(cb_out, onetile);
         ACQ();
@@ -80,7 +80,7 @@ void MAIN {
         cb_push_back(cb_out, onetile);
         cb_pop_front(cb_x2, Wt);
 
-        reduce_revert_delta();
+        reduce_revert_delta(cb_out);
 
 #ifndef RMSNORM
 
@@ -89,7 +89,7 @@ void MAIN {
          */
         reconfig_data_format(cb_inp, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_out);
         cb_reserve_back(cb_out, onetile);
         ACQ();
         for (uint32_t wtr = 0; wtr < Wt; wtr++) {
@@ -99,7 +99,7 @@ void MAIN {
         REL();
         cb_push_back(cb_out, onetile);
 
-        reduce_revert_delta();
+        reduce_revert_delta(cb_out);
 
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -33,7 +33,7 @@ void calc_numeric_stable(
     reconfig_data_format(cb_in, cb_bcast_scaler);
     cb_reserve_back(cb_max, 1);
     cb_wait_front(cb_bcast_scaler, 1);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_max);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_max, cb_in, cb_bcast_scaler);
     for (uint32_t wt = 0; wt < Wt; wt++) {
         cb_wait_front(cb_in, wt + 1);
         constexpr uint32_t bcast_scaler0 = 0;
@@ -256,7 +256,7 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>(cb_recipsumexps);
+        reduce_init_delta<false>(cb_recipsumexps, cb_exps, cb_bcast_scaler);
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt + 1);        // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -25,13 +25,13 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t
     reconfig_data_format(cb_in, cb_bcast_scaler);
     pack_reconfig_data_format(cb_max);
     cb_reserve_back(cb_max, 1);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>();
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_max);
     cb_wait_front(cb_bcast_scaler, 1);
     for (uint32_t w = 0; w < block_w; w++) {
         constexpr uint32_t bcast_scaler0 = 0;
         reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in, cb_bcast_scaler, w, bcast_scaler0, 0);
     }
-    reduce_revert_delta<ReduceDim::REDUCE_ROW>();
+    reduce_revert_delta<ReduceDim::REDUCE_ROW>(cb_max);
     pack_tile(0, cb_max);
     cb_push_back(cb_max, 1);
     REL();
@@ -203,7 +203,7 @@ void MAIN {
 
         // sum(exp(x))
         ACQ();
-        reduce_init_delta<false>();
+        reduce_init_delta<false>(cb_recipsumexps);
         cb_wait_front(cb_exps, block_w);
         cb_wait_front(cb_bcast_scaler, 1);
         cb_reserve_back(cb_recipsumexps, 1);
@@ -211,7 +211,7 @@ void MAIN {
             constexpr uint32_t bcast_scaler0 = 0;
             reduce_tile(cb_exps, cb_bcast_scaler, w, bcast_scaler0, dst0);
         }
-        reduce_revert_delta();
+        reduce_revert_delta(cb_recipsumexps);
         recip_tile_init();
         recip_tile(dst0);
         pack_tile(dst0, cb_recipsumexps);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -25,7 +25,7 @@ ALWI void calc_numeric_stable(uint32_t cb_in, uint32_t cb_bcast_scaler, uint32_t
     reconfig_data_format(cb_in, cb_bcast_scaler);
     pack_reconfig_data_format(cb_max);
     cb_reserve_back(cb_max, 1);
-    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_max);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_max, cb_in, cb_bcast_scaler);
     cb_wait_front(cb_bcast_scaler, 1);
     for (uint32_t w = 0; w < block_w; w++) {
         constexpr uint32_t bcast_scaler0 = 0;
@@ -203,7 +203,7 @@ void MAIN {
 
         // sum(exp(x))
         ACQ();
-        reduce_init_delta<false>(cb_recipsumexps);
+        reduce_init_delta<false>(cb_recipsumexps, cb_exps, cb_bcast_scaler);
         cb_wait_front(cb_exps, block_w);
         cb_wait_front(cb_bcast_scaler, 1);
         cb_reserve_back(cb_recipsumexps, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h.cpp
@@ -13,7 +13,7 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
     uint32_t row_chunk = get_compile_time_arg_val(3);
 
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CB::c_out0);
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
 
     constexpr int onetile = 1;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_hw.cpp
@@ -12,7 +12,7 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -18,7 +18,7 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
 
 #ifndef REDUCE_ROW_SUM_VIA_MM
-    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #else
     mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2);
 #endif


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the transpose_wh and reduce kernel APIs:
- ./tt_metal/include/compute_kernel_api/transpose_wh.h
- ./tt_metal/include/compute_kernel_api/reduce.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

### Checklist
- [x] Post commit CI passes [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12653818878)
- [x] Blackhole Post commit (if applicable) [Blackhole post-commit test](https://github.com/tenstorrent/tt-metal/actions/runs/12653822690)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
