### PR TITLE
Remove documenation references to "setup_hugepages.py"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,6 @@ MANIFEST.in @tenstorrent/metalium-developers-infra
 setup.py @tenstorrent/metalium-developers-infra
 pyproject.toml @tenstorrent/metalium-developers-infra
 requirements*.txt @tenstorrent/metalium-developers-infra
-setup_hugepages.py @tenstorrent/metalium-developers-infra
 
 scripts/build_scripts/ @tenstorrent/metalium-developers-infra
 cmake/ @tenstorrent/metalium-developers-infra

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,23 +71,6 @@ standards](#contribution-standards).
 
 ## Machine setup
 
-### Hugepages setup
-
-Hugepages is required to both run and develop on the Metalium project.
-
-If you ever need to re-enable Hugepages, you can try the script we homemade
-for this:
-
-```
-sudo python3 infra/machine_setup/scripts/setup_hugepages.py enable
-```
-
-Then to check if Hugepages is enabled:
-
-```
-python3 infra/machine_setup/scripts/setup_hugepages.py check
-```
-
 ## Developing tt-metal
 
 Currently, the most convenient way to develop is to do so on our cloud

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -35,34 +35,7 @@ sudo ./install_dependencies.sh
   - To install `CMake 3.20` see: https://github.com/tenstorrent/tt-metal/blob/4d7730d3e2d22c51d62baa1bfed861b557d9a3c0/dockerfile/ubuntu-20.04-amd64.Dockerfile#L9-L14
 ---
 
-### Step 3. Hugepages
-
-1. Download latest [setup_hugepages.py](https://github.com/tenstorrent/tt-metal/blob/main/infra/machine_setup/scripts/setup_hugepages.py) script.
-
-```sh
-wget https://raw.githubusercontent.com/tenstorrent/tt-metal/main/infra/machine_setup/scripts/setup_hugepages.py
-```
-
-2. Run first setup script.
-
-```sh
-sudo -E python3 setup_hugepages.py first_pass
-```
-
-3. Reboot
-
-```sh
-sudo reboot now
-```
-
-4. Run second setup script & check setup.
-
-```sh
-sudo -E python3 setup_hugepages.py enable && sudo -E python3 setup_hugepages.py check
-```
----
-
-### Step 4. Install and start using TT-NN and TT-Metalium!
+### Step 3. Install and start using TT-NN and TT-Metalium!
 
 > [!NOTE]
 >


### PR DESCRIPTION
Hugepages configuration is now done using tt-system-tools method with linux service.

This setup step is handled by `install_dependencies.sh`