### PR TITLE
#12253: Implement Batch norm operation for inference mode

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -444,6 +444,7 @@ Normalization
    ttnn.group_norm
    ttnn.layer_norm
    ttnn.rms_norm
+   ttnn.batch_norm
 
 
 Moreh Operations

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -11,6 +11,27 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 )
 
 
+def data_gen_with_range_batch_norm(input_shapes, low, high, device, is_input=False, required_grad=False):
+    assert high > low, "Incorrect range provided"
+    torch.manual_seed(213919)
+    channels = input_shapes[1]
+    if is_input:
+        pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
+        tt_tensor = ttnn.from_torch(
+            pt_tensor,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    else:
+        pt_tensor = torch.rand(channels, requires_grad=required_grad).bfloat16() * (high - low) + low
+        # pt_tensor = pt_tensor.view(1, channels, 1, 1) # to test each section of TT op
+        reshaped_tensor = pt_tensor.view(1, channels, 1, 1).expand(1, channels, 32, 32)
+        tt_tensor = ttnn.Tensor(reshaped_tensor, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    return pt_tensor, tt_tensor
+
+
 def data_gen_pt_tt(input_shapes, device, required_grad=False):
     torch.manual_seed(213919)
     pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
@@ -104,6 +125,21 @@ def compare_results(tt_tensor, golden_tensor, pcc=0.99):
         logger.debug(comp_all)
         logger.debug(comp_out)
         status = status & (comp_pass | comp_all)
+    return status
+
+
+def compare_results_batch_norm(tt_tensor, golden_tensor, pcc=0.99):
+    status = True
+    for i in range(len(tt_tensor)):
+        tt_out_tensor = tt_tensor[i]
+        pt_out_tensor = golden_tensor[i]
+        comp_pass, comp_out = comparison_funcs.comp_pcc(pt_out_tensor, tt_out_tensor, pcc=pcc)
+        comp_all, comp_out_res = comparison_funcs.comp_allclose(pt_out_tensor, tt_out_tensor, atol=4, rtol=1e-1)
+        logger.debug(comp_pass)
+        logger.debug(comp_all)
+        logger.debug(comp_out)
+        logger.debug(comp_out_res)
+        status = status & comp_pass & comp_all
     return status
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -11,24 +11,29 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 )
 
 
-def data_gen_with_range_batch_norm(input_shapes, low, high, device, is_input=False, required_grad=False):
+def data_gen_with_range_batch_norm(
+    input_shapes,
+    low,
+    high,
+    device,
+    is_input=False,
+    required_grad=False,
+):
     assert high > low, "Incorrect range provided"
     torch.manual_seed(213919)
     channels = input_shapes[1]
-    if is_input:
-        pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
-        tt_tensor = ttnn.from_torch(
-            pt_tensor,
-            device=device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat16,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-    else:
-        pt_tensor = torch.rand(channels, requires_grad=required_grad).bfloat16() * (high - low) + low
-        # pt_tensor = pt_tensor.view(1, channels, 1, 1) # to test each section of TT op
-        reshaped_tensor = pt_tensor.view(1, channels, 1, 1).expand(1, channels, 32, 32)
-        tt_tensor = ttnn.Tensor(reshaped_tensor, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    size = input_shapes if is_input else channels
+    pt_tensor = torch.rand(size, requires_grad=required_grad).bfloat16() * (high - low) + low
+    reshaped_tensor = pt_tensor
+    if not is_input:
+        reshaped_tensor = pt_tensor.view(1, channels, 1, 1)
+    tt_tensor = ttnn.from_torch(
+        reshaped_tensor,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
     return pt_tensor, tt_tensor
 
 

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -9,71 +9,35 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     data_gen_with_range_batch_norm,
     compare_results_batch_norm,
 )
+from itertools import product
 
 
 @pytest.mark.parametrize(
     "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 2, 32, 32])),
-        (torch.Size([1, 3, 32, 32])),
-        (torch.Size([2, 1, 32, 32])),
-        (torch.Size([2, 2, 32, 32])),
-        (torch.Size([2, 3, 32, 32])),
-        (torch.Size([3, 1, 32, 32])),
-        (torch.Size([3, 2, 32, 32])),
-        (torch.Size([3, 3, 32, 32])),
-        (torch.Size([4, 1, 32, 32])),
-        (torch.Size([4, 2, 32, 32])),
-        (torch.Size([4, 3, 32, 32])),
-        (torch.Size([4, 4, 32, 32])),
-        (torch.Size([1, 1, 23, 23])),
-        (torch.Size([1, 2, 23, 23])),
-        (torch.Size([1, 3, 23, 23])),
-        (torch.Size([2, 1, 23, 23])),
-        (torch.Size([2, 2, 23, 23])),
-        (torch.Size([2, 3, 23, 23])),
-        (torch.Size([3, 1, 23, 23])),
-        (torch.Size([3, 2, 23, 23])),
-        (torch.Size([3, 3, 23, 23])),
-        (torch.Size([4, 1, 23, 23])),
-        (torch.Size([4, 2, 23, 23])),
-        (torch.Size([4, 3, 23, 23])),
-        (torch.Size([4, 4, 23, 23])),
-        (torch.Size([1, 1, 64, 120])),
-        (torch.Size([1, 2, 64, 120])),
-        (torch.Size([1, 3, 64, 120])),
-        (torch.Size([2, 1, 64, 120])),
-        (torch.Size([2, 2, 64, 120])),
-        (torch.Size([2, 3, 64, 120])),
-        (torch.Size([3, 1, 64, 120])),
-        (torch.Size([3, 2, 64, 120])),
-    ),
+    [
+        *(torch.Size([n, c, 32, 32]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
+        torch.Size([4, 4, 32, 32]),
+        *(torch.Size([n, c, 23, 23]) for n, c in product([1, 2, 3, 4], [1, 2, 3])),
+        torch.Size([4, 4, 23, 23]),
+        *(torch.Size([n, c, 64, 120]) for n, c in product([1, 2], [1, 2, 3])),
+        torch.Size([3, 1, 64, 120]),
+        torch.Size([3, 2, 64, 120]),
+    ],
 )
 @pytest.mark.parametrize("training", [False])
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
 def test_batch_norm(input_shapes, training, weight, bias, eps, device):
-    in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, True, False)
-    if not training:
-        mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device, False, False)
-        var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device, False, False)
-    else:
-        mean_data = None
-        mean_tensor = None
-        var_data = None
-        var_tensor = None
-    if weight:
-        weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device, False, False)
-    else:
-        weight_data = None
-        weight_tensor = None
-    if bias:
-        bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device, False, False)
-    else:
-        bias_data = None
-        bias_tensor = None
+    in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
+    mean_data, mean_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if (not training) else (None, None)
+    )
+    var_data, var_tensor = (
+        data_gen_with_range_batch_norm(input_shapes, 4, 20, device) if (not training) else (None, None)
+    )
+    weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if weight else (None, None)
+    bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if bias else (None, None)
 
     tt_output_tensor_on_device = ttnn.batch_norm(
         input_tensor,
@@ -98,5 +62,37 @@ def test_batch_norm(input_shapes, training, weight, bias, eps, device):
         eps=eps,
     )
     # print("Torch result : ",torch_result)
+    comp_pass = compare_results_batch_norm([tt_output], [torch_result])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([3, 2, 32, 32]),
+    ],
+)
+@pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.TensorMemoryLayout.HEIGHT_SHARDED])
+def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, device):
+    N, H, W, C = input_shapes
+    in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
+    mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device)
+    var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device)
+
+    grid_size = ttnn.CoreGrid(y=1, x=8)
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_shape = N * H * W // grid_size.x, C // grid_size.y
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR, False)
+    sharded_mem_config = ttnn.MemoryConfig(mem_layout, ttnn.types.BufferType.L1, shard_spec)
+
+    if mem_layout is not ttnn.TensorMemoryLayout.INTERLEAVED:
+        pytest.xfail("Input tensors to batch norm must be interleaved")
+
+    tt_output_tensor_on_device = ttnn.batch_norm(
+        input_tensor, running_mean=mean_tensor, running_var=var_tensor, memory_config=sharded_mem_config
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor_on_device)
+    torch_result = torch.nn.functional.batch_norm(input=in_data, running_mean=mean_data, running_var=var_data)
     comp_pass = compare_results_batch_norm([tt_output], [torch_result])
     assert comp_pass

--- a/tests/ttnn/unit_tests/operations/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_batch_norm.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
+    data_gen_with_range_batch_norm,
+    compare_results_batch_norm,
+)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 32, 32])),
+        (torch.Size([1, 3, 32, 32])),
+        (torch.Size([2, 1, 32, 32])),
+        (torch.Size([2, 2, 32, 32])),
+        (torch.Size([2, 3, 32, 32])),
+        (torch.Size([3, 1, 32, 32])),
+        (torch.Size([3, 2, 32, 32])),
+        (torch.Size([3, 3, 32, 32])),
+        (torch.Size([4, 1, 32, 32])),
+        (torch.Size([4, 2, 32, 32])),
+        (torch.Size([4, 3, 32, 32])),
+        (torch.Size([4, 4, 32, 32])),
+        (torch.Size([1, 1, 23, 23])),
+        (torch.Size([1, 2, 23, 23])),
+        (torch.Size([1, 3, 23, 23])),
+        (torch.Size([2, 1, 23, 23])),
+        (torch.Size([2, 2, 23, 23])),
+        (torch.Size([2, 3, 23, 23])),
+        (torch.Size([3, 1, 23, 23])),
+        (torch.Size([3, 2, 23, 23])),
+        (torch.Size([3, 3, 23, 23])),
+        (torch.Size([4, 1, 23, 23])),
+        (torch.Size([4, 2, 23, 23])),
+        (torch.Size([4, 3, 23, 23])),
+        (torch.Size([4, 4, 23, 23])),
+        (torch.Size([1, 1, 64, 120])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 64, 120])),
+        (torch.Size([2, 1, 64, 120])),
+        (torch.Size([2, 2, 64, 120])),
+        (torch.Size([2, 3, 64, 120])),
+        (torch.Size([3, 1, 64, 120])),
+        (torch.Size([3, 2, 64, 120])),
+    ),
+)
+@pytest.mark.parametrize("training", [False])
+@pytest.mark.parametrize("weight", [True, False])
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize("eps", [1.0, 0.0, 2.34, 1e-05])
+def test_batch_norm(input_shapes, training, weight, bias, eps, device):
+    in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, True, False)
+    if not training:
+        mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device, False, False)
+        var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device, False, False)
+    else:
+        mean_data = None
+        mean_tensor = None
+        var_data = None
+        var_tensor = None
+    if weight:
+        weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device, False, False)
+    else:
+        weight_data = None
+        weight_tensor = None
+    if bias:
+        bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device, False, False)
+    else:
+        bias_data = None
+        bias_tensor = None
+
+    tt_output_tensor_on_device = ttnn.batch_norm(
+        input_tensor,
+        running_mean=mean_tensor,
+        running_var=var_tensor,
+        training=training,
+        eps=eps,
+        weight=weight_tensor,
+        bias=bias_tensor,
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor_on_device)
+    # ttnn.set_printoptions(profile="full")
+    # print("TT result : ", tt_output, tt_output.shape)
+    # torch.set_printoptions(precision=5, sci_mode=False)
+    torch_result = torch.nn.functional.batch_norm(
+        input=in_data,
+        running_mean=mean_data,
+        running_var=var_data,
+        weight=weight_data,
+        bias=bias_data,
+        training=training,
+        eps=eps,
+    )
+    # print("Torch result : ",torch_result)
+    comp_pass = compare_results_batch_norm([tt_output], [torch_result])
+    assert comp_pass

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -296,6 +296,10 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/matmul.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "batch_norm.hpp"
+
+#include "device/batch_norm_device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::normalization {
+
+Tensor BatchNorm::invoke(
+    const Tensor& input,
+    std::optional<Tensor> running_mean,
+    std::optional<Tensor> running_var,
+    const bool training,
+    const float eps,
+    std::optional<Tensor> weight,
+    std::optional<Tensor> bias,
+    std::optional<Tensor> output,
+    const std::optional<MemoryConfig>& memory_config) {
+    // TODO: Implementation for training mode is in progress
+    TT_FATAL((!training), "Support currently provided for inference mode only");
+    TT_FATAL(
+        (running_mean.has_value() && running_var.has_value()),
+        "running_mean and running_var must be defined in evaluation mode");
+    return ttnn::prim::batch_norm(
+        input, running_mean.value(), running_var.value(), eps, weight, bias, output, memory_config);
+}
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn {
+namespace operations::normalization {
+struct BatchNorm {
+    static Tensor invoke(
+        const Tensor& input,
+        std::optional<Tensor> running_mean = std::nullopt,
+        std::optional<Tensor> running_var = std::nullopt,
+        const bool training = false,
+        const float eps = 1e-05,
+        std::optional<Tensor> weight = std::nullopt,
+        std::optional<Tensor> bias = std::nullopt,
+        std::optional<Tensor> output = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+};
+}  // namespace operations::normalization
+
+constexpr auto batch_norm =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::batch_norm", ttnn::operations::normalization::BatchNorm>();
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "batch_norm_pybind.hpp"
+
+#include "batch_norm.hpp"
+
+#include "pybind11/decorators.hpp"
+namespace py = pybind11;
+namespace ttnn::operations::normalization::detail {
+void bind_batch_norm_operation(pybind11::module& module) {
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::batch_norm,
+        R"doc(
+            Applies Spatial Batch Normalization over each channel on :attr:`input_tensor`.Currently support is provided for inference mode only.
+
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+
+
+        Keyword args:
+            eps (float, optional): Epsilon value. Defaults to `1e-05`.
+            running_mean (ttnn.Tensor, optional): the running_mean required for inference mode. Defaults to `None`.
+            running_var (ttnn.Tensor, optional): the running_var required for inference mode. Defaults to `None`.
+            weight (ttnn.Tensor, optional): the weight or gamma value. Defaults to `None`.
+            bias (ttnn.Tensor, optional): the bias or beta value. Defaults to `None`.
+            training (bool, optional): Selection between training mode and inference (evaluation) mode. Defaults to `False` (Inference mode).
+            memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+
+        )doc",
+        ttnn::pybind_arguments_t{
+            py::arg("input"),
+            py::kw_only(),
+            py::arg("running_mean") = std::nullopt,
+            py::arg("running_var") = std::nullopt,
+            py::arg("training") = false,
+            py::arg("eps") = 1e-05,
+            py::arg("weight") = std::nullopt,
+            py::arg("bias") = std::nullopt,
+            py::arg("output") = std::nullopt,
+            py::arg("memory_config") = std::nullopt
+
+        });
+}
+}  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.cpp
@@ -14,20 +14,21 @@ void bind_batch_norm_operation(pybind11::module& module) {
         module,
         ttnn::batch_norm,
         R"doc(
-            Applies Spatial Batch Normalization over each channel on :attr:`input_tensor`.Currently support is provided for inference mode only.
+            Applies Spatial Batch Normalization over each channel on :attr:`input_tensor`. Inputs must be must be tilized and interleaved. Currently support is provided for inference mode only.
 
 
         Args:
-            input_tensor (ttnn.Tensor): the input tensor.
+            input_tensor (ttnn.Tensor): the input tensor of shape `[N, C, H, W]`.
 
 
         Keyword args:
             eps (float, optional): Epsilon value. Defaults to `1e-05`.
-            running_mean (ttnn.Tensor, optional): the running_mean required for inference mode. Defaults to `None`.
-            running_var (ttnn.Tensor, optional): the running_var required for inference mode. Defaults to `None`.
-            weight (ttnn.Tensor, optional): the weight or gamma value. Defaults to `None`.
-            bias (ttnn.Tensor, optional): the bias or beta value. Defaults to `None`.
+            running_mean (ttnn.Tensor, optional): the running_mean of shape `[1, C, 1, 1]`, required in inference mode . Defaults to `None`.
+            running_var (ttnn.Tensor, optional): the running_var of shape `[1, C, 1, 1]`, required in inference mode . Defaults to `None`.
+            weight (ttnn.Tensor, optional): the weight or gamma value of shape `[1, C, 1, 1]`. Defaults to `None`.
+            bias (ttnn.Tensor, optional): the bias or beta value of shape `[1, C, 1, 1]`. Defaults to `None`.
             training (bool, optional): Selection between training mode and inference (evaluation) mode. Defaults to `False` (Inference mode).
+            output (ttnn.Tensor, optional): Preallocated output tensor to store batch norm result of shape `[N, C, H, W]`. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
 
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::normalization::detail {
+void bind_batch_norm_operation(pybind11::module& module);
+}

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -10,14 +10,7 @@
 namespace ttnn::operations::normalization {
 void BatchNormOperation::validate_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input = tensor_args.input;
-    const auto& batch_mean = tensor_args.batch_mean;
-    const auto& batch_var = tensor_args.batch_var;
-    const auto& eps = operation_attributes.eps;
-    const auto& weight = tensor_args.weight;
-    const auto& bias = tensor_args.bias;
-
-    auto& output = tensor_args.output;
+    const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
 
     check_tensor(input, "batch_norm", "input");
     check_tensor(batch_mean, "batch_norm", "batch_mean");
@@ -49,8 +42,8 @@ void BatchNormOperation::validate_tensors(
 
     // bias (1, C, 1, 1)
     if (bias.has_value()) {
-        TT_FATAL(bias.value().get_logical_shape()[1] == C, "weight_shape[1] must be the same as input's channel size.");
-        TT_FATAL(bias.value().get_logical_shape()[1] == C, "weight_shape[1] must be the same as input's channel size.");
+        TT_FATAL(bias.value().get_logical_shape()[1] == C, "bias_shape[1] must be the same as input's channel size.");
+        TT_FATAL(bias.value().get_logical_shape()[1] == C, "bias_shape[1] must be the same as input's channel size.");
     }
 }
 
@@ -61,13 +54,7 @@ BatchNormOperation::program_factory_t BatchNormOperation::select_program_factory
 
 void BatchNormOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // We don't support sharding for now
-    const auto& input = tensor_args.input;
-    const auto& batch_mean = tensor_args.batch_mean;
-    const auto& batch_var = tensor_args.batch_var;
-    const auto& weight = tensor_args.weight;
-    const auto& bias = tensor_args.bias;
-    const auto& output = tensor_args.output;
+    const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
 
     TT_FATAL(input.get_layout() == Layout::TILE, "Input tensor must be must be tilized");
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "batch_norm_device_operation.hpp"
+
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::normalization {
+void BatchNormOperation::validate_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    const auto& batch_mean = tensor_args.batch_mean;
+    const auto& batch_var = tensor_args.batch_var;
+    const auto& eps = operation_attributes.eps;
+    const auto& weight = tensor_args.weight;
+    const auto& bias = tensor_args.bias;
+
+    auto& output = tensor_args.output;
+
+    check_tensor(input, "batch_norm", "input");
+    check_tensor(batch_mean, "batch_norm", "batch_mean");
+    check_tensor(batch_var, "batch_norm", "batch_var");
+    check_tensor(weight, "batch_norm", "weight");
+    check_tensor(bias, "batch_norm", "bias");
+    check_tensor(output, "batch_norm", "output");
+
+    // input (N, C, H, W)
+    auto C = input.get_logical_shape()[1];
+    // output (N, C, H, W)
+    if (output.has_value()) {
+        auto check_C = output.value().get_logical_shape()[1];
+        TT_FATAL(C == check_C, "output_shape[1] must be the same as input's channel size.");
+    }
+
+    // mean (1, C, 1, 1)
+    TT_FATAL(batch_mean.get_logical_shape()[1] == C, "batch_mean_shape[1] must be the same as input's channel size.");
+    // var (1, C, 1, 1)
+    TT_FATAL(batch_var.get_logical_shape()[1] == C, "batch_var_shape[1] must be the same as input's channel size.");
+
+    // weight (1, C, 1, 1)
+    if (weight.has_value()) {
+        TT_FATAL(
+            weight.value().get_logical_shape()[1] == C, "weight_shape[1] must be the same as input's channel size.");
+        TT_FATAL(
+            weight.value().get_logical_shape()[1] == C, "weight_shape[1] must be the same as input's channel size.");
+    }
+
+    // bias (1, C, 1, 1)
+    if (bias.has_value()) {
+        TT_FATAL(bias.value().get_logical_shape()[1] == C, "weight_shape[1] must be the same as input's channel size.");
+        TT_FATAL(bias.value().get_logical_shape()[1] == C, "weight_shape[1] must be the same as input's channel size.");
+    }
+}
+
+BatchNormOperation::program_factory_t BatchNormOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return BatchNormFactory();
+}
+
+void BatchNormOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // We don't support sharding for now
+    const auto& input = tensor_args.input;
+    const auto& batch_mean = tensor_args.batch_mean;
+    const auto& batch_var = tensor_args.batch_var;
+    const auto& weight = tensor_args.weight;
+    const auto& bias = tensor_args.bias;
+    const auto& output = tensor_args.output;
+
+    TT_FATAL(input.get_layout() == Layout::TILE, "Input tensor must be must be tilized");
+    TT_FATAL(
+        input.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Input tensor must be interleaved");
+    TT_FATAL(
+        operation_attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Output tensor to eltwise binary must be interleaved");
+
+    TT_FATAL(batch_mean.get_layout() == Layout::TILE, "batch_mean tensor must be tilized");
+    TT_FATAL(
+        batch_mean.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "batch_mean tensor must be interleaved");
+
+    TT_FATAL(batch_var.get_layout() == Layout::TILE, "batch_var tensor must be tilized");
+    TT_FATAL(
+        batch_var.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "batch_var tensor must be interleaved");
+
+    if (weight.has_value()) {
+        TT_FATAL(weight.value().get_layout() == Layout::TILE, "weight tensor must be tilized");
+        TT_FATAL(
+            weight.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "weight tensor must be interleaved");
+    }
+
+    if (bias.has_value()) {
+        TT_FATAL(bias.value().get_layout() == Layout::TILE, "bias tensor must be tilized");
+        TT_FATAL(
+            bias.value().memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "bias tensor must be interleaved");
+    }
+
+    validate_tensors(operation_attributes, tensor_args);
+};
+
+void BatchNormOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_tensors(operation_attributes, tensor_args);
+};
+
+DataType BatchNormOperation::operation_attributes_t::get_dtype() const {
+    return this->dtype.value_or(this->input_dtype);
+}
+
+BatchNormOperation::spec_return_value_t BatchNormOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+    const auto output_shape = tensor_args.input.get_logical_shape();
+    return TensorSpec(
+        output_shape,
+        TensorLayout(operation_attributes.get_dtype(), PageConfig(Layout::TILE), operation_attributes.memory_config));
+}
+
+BatchNormOperation::tensor_return_value_t BatchNormOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_tensor = tensor_args.output;
+    if (output_tensor.has_value()) {
+        return output_tensor.value();
+    }
+
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+}
+
+std::tuple<BatchNormOperation::operation_attributes_t, BatchNormOperation::tensor_args_t> BatchNormOperation::invoke(
+    const Tensor& input,
+    const Tensor& batch_mean,
+    const Tensor& batch_var,
+    const float eps,
+    std::optional<Tensor> weight,
+    std::optional<Tensor> bias,
+    std::optional<Tensor> output,
+    const std::optional<MemoryConfig>& memory_config) {
+    operation_attributes_t operation_attributes{eps, memory_config.value_or(input.memory_config())};
+    tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
+    return {operation_attributes, tensor_args};
+}
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::normalization {
+struct BatchNormOperation {
+    struct operation_attributes_t {
+        const float eps;
+        const MemoryConfig memory_config;
+
+        DataType input_dtype;
+        std::optional<DataType> dtype;
+        DataType get_dtype() const;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input;
+        const Tensor& batch_mean;
+        const Tensor& batch_var;
+        std::optional<Tensor> weight;
+        std::optional<Tensor> bias;
+        std::optional<Tensor> output;
+    };
+
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct BatchNormFactory {
+        struct shared_variables_t {
+            tt::tt_metal::KernelHandle reader_kernel_id;
+            tt::tt_metal::KernelHandle writer_kernel_id;
+            tt::tt_metal::KernelHandle compute_kernel_id;
+            CoreCoord compute_with_storage_grid_size;
+        };
+
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<BatchNormFactory>;
+
+    static void validate_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        const Tensor& batch_mean,
+        const Tensor& batch_var,
+        const float eps,
+        std::optional<Tensor> weight,
+        std::optional<Tensor> bias,
+        std::optional<Tensor> output,
+        const std::optional<MemoryConfig>& memory_config);
+};
+}  // namespace ttnn::operations::normalization
+
+namespace ttnn::prim {
+constexpr auto batch_norm =
+    ttnn::register_operation<"ttnn::prim::batch_norm", ttnn::operations::normalization::BatchNormOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "batch_norm_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "ttnn/operations/cb_utils.hpp"
+#include <cmath>
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+using namespace ttnn::operations::normalization;
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {shape[-4], shape[-3], shape[-2] / tile.get_height(), shape[-1] / tile.get_width()};
+}
+
+template <typename F>
+void set_or_update_runtime_arguments(
+    Program& program,
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    KernelHandle compute_kernel_id,
+    CoreCoord compute_with_storage_grid_size,
+    const BatchNormOperation::operation_attributes_t& operation_attributes,
+    const BatchNormOperation::tensor_args_t& tensor_args,
+    BatchNormOperation::tensor_return_value_t& c,
+    F handle_args) {
+    const auto& a = tensor_args.input;
+    const auto& b = tensor_args.batch_mean;
+    const auto& d = tensor_args.batch_var;
+    const auto& e = tensor_args.weight;
+    const auto& f = tensor_args.bias;
+    const auto eps = operation_attributes.eps;
+
+    const bool weight_has_value = e.has_value();
+    const bool bias_has_value = f.has_value();
+
+    const auto ashape = a.padded_shape();
+    const auto bshape = b.padded_shape();
+    const auto cshape = c.padded_shape();
+
+    const auto [aN, aC, aHt, aWt] = extract_shape_dims(a);
+    const auto [bN, bC, bHt, bWt] = extract_shape_dims(b);
+    const auto [cN, cC, cHt, cWt] = extract_shape_dims(c);
+
+    uint32_t num_output_tiles = c.volume() / c.tensor_spec().tile().get_tile_hw();
+
+    constexpr bool row_major = true;
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles, row_major);
+
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores_total; i++) {
+        const auto& core = cores[i];
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 11>{0});
+            handle_args(program, writer_kernel_id, core, std::array<uint32_t, 16>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
+            continue;
+        }
+
+        uint32_t cHtWt = cHt * cWt;
+        class bfloat16 bfloat_scalar(eps);
+        uint32_t packed_scalar = pack_two_bfloat16_into_uint32({bfloat_scalar, bfloat_scalar});
+        std::array reader_runtime_args = {
+            packed_scalar,
+            a.buffer()->address(),
+            start_tile_id,
+            num_tiles_per_core,
+            cHtWt,
+            aHt * aWt * aC * (aN > 1),
+            aHt * aWt * (aC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt};
+        handle_args(program, reader_kernel_id, core, reader_runtime_args);
+
+        const auto weight_addr = weight_has_value ? e.value().buffer()->address() : 0;
+        const auto bias_addr = bias_has_value ? f.value().buffer()->address() : 0;
+        std::array writer_runtime_args = {
+            b.buffer()->address(),  //  batch mean
+            d.buffer()->address(),  //  batch var
+            static_cast<uint32_t>(weight_has_value),
+            weight_addr,  // weight
+            static_cast<uint32_t>(bias_has_value),
+            bias_addr,              // bias
+            c.buffer()->address(),  // output
+            start_tile_id,
+            num_tiles_per_core,
+            cHtWt,
+            bHt * bWt * bC * (bN > 1),
+            bHt * bWt * (bC > 1),
+            cN,
+            cC,
+            cHt,
+            cWt};
+        handle_args(program, writer_kernel_id, core, writer_runtime_args);
+
+        auto counter = start_tile_id % cHtWt;
+        auto freq = cHtWt;
+
+        std::array compute_runtime_args = {num_tiles_per_core, freq, counter};
+        handle_args(program, compute_kernel_id, core, compute_runtime_args);
+
+        start_tile_id += num_tiles_per_core;
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+namespace ttnn::operations::normalization {
+BatchNormOperation::BatchNormFactory::cached_program_t BatchNormOperation::BatchNormFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& a = tensor_args.input;
+    const auto& b = tensor_args.batch_mean;
+    const auto& d = tensor_args.batch_var;
+    const auto& eps = operation_attributes.eps;
+    const auto& e = tensor_args.weight;
+    const auto& f = tensor_args.bias;
+
+    auto program = CreateProgram();
+
+    auto* device = a.device();
+
+    const bool weight_has_value = e.has_value();
+    const bool bias_has_value = f.has_value();
+
+    auto a_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    auto b_data_format = datatype_to_dataformat_converter(b.get_dtype());
+    auto c_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    auto d_data_format = datatype_to_dataformat_converter(d.get_dtype());
+    auto e_data_format = weight_has_value ? datatype_to_dataformat_converter(e->get_dtype()) : DataFormat::Float16_b;
+    auto f_data_format = bias_has_value ? datatype_to_dataformat_converter(f->get_dtype()) : DataFormat::Float16_b;
+
+    uint32_t a_single_tile_size = tt_metal::detail::TileSize(a_data_format);
+    uint32_t b_single_tile_size = tt_metal::detail::TileSize(b_data_format);
+    uint32_t c_single_tile_size = tt_metal::detail::TileSize(c_data_format);
+    uint32_t d_single_tile_size = tt_metal::detail::TileSize(d_data_format);
+    uint32_t e_single_tile_size = tt_metal::detail::TileSize(e_data_format);
+    uint32_t f_single_tile_size = tt_metal::detail::TileSize(f_data_format);
+
+    uint32_t num_output_tiles = output.volume() / output.tensor_spec().tile().get_tile_hw();
+
+    // we parallelize the computation across the output tiles
+    constexpr bool row_major = true;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+
+    Buffer* a_buffer = a.buffer();
+    Buffer* b_buffer = b.buffer();
+    Buffer* c_buffer = output.buffer();
+    Buffer* d_buffer = d.buffer();
+    Buffer* e_buffer = nullptr;
+    Buffer* f_buffer = nullptr;
+
+    // Number of tiles to store per input CB (double buffer)
+    constexpr uint32_t num_tiles_per_cb = 2;
+    uint32_t b_num_tiles_per_cb = num_tiles_per_cb;
+
+    // Input buffers
+    auto [a_cb, a_cb_handle] = create_cb(
+        tt::CBIndex::c_0, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);  // input
+    auto [b_cb, b_cb_handle] = create_cb(
+        tt::CBIndex::c_1,
+        program,
+        all_device_cores,
+        b_single_tile_size,
+        b_num_tiles_per_cb,
+        b_data_format);  // batch_mean
+    auto [c_cb, c_cb_handle] = create_cb(
+        tt::CBIndex::c_2, program, all_device_cores, c_single_tile_size, num_tiles_per_cb, c_data_format);  // output
+    auto [d_cb, d_cb_handle] = create_cb(
+        tt::CBIndex::c_3,
+        program,
+        all_device_cores,
+        d_single_tile_size,
+        b_num_tiles_per_cb,
+        d_data_format);  // batch_var
+    auto [eps_cb, eps_cb_handle] = create_cb(
+        tt::CBIndex::c_4, program, all_device_cores, d_single_tile_size, b_num_tiles_per_cb, d_data_format);  // eps
+    auto [e_cb, e_cb_handle] = create_cb(
+        tt::CBIndex::c_16, program, all_device_cores, e_single_tile_size, b_num_tiles_per_cb, e_data_format);  // weight
+    auto [f_cb, f_cb_handle] = create_cb(
+        tt::CBIndex::c_18, program, all_device_cores, f_single_tile_size, b_num_tiles_per_cb, f_data_format);  // bias
+
+    // Temporary buffers to store intermediate results
+    auto [den_cb, den_cb_handle] = create_cb(
+        tt::CBIndex::c_5,
+        program,
+        all_device_cores,
+        a_single_tile_size,
+        num_tiles_per_cb,
+        a_data_format);  // to store 1/(sqrt(batch_var + eps))
+    auto [num_cb, num_cb_handle] = create_cb(
+        tt::CBIndex::c_6,
+        program,
+        all_device_cores,
+        a_single_tile_size,
+        num_tiles_per_cb,
+        a_data_format);  // to store input - batch_mean
+    auto [temp_1_cb, temp_1_cb_handle] =
+        create_cb(tt::CBIndex::c_17, program, all_device_cores, a_single_tile_size, num_tiles_per_cb, a_data_format);
+
+    auto a_is_dram = static_cast<uint32_t>(a_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    auto b_is_dram = static_cast<uint32_t>(b_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    auto c_is_dram = static_cast<uint32_t>(c_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    auto d_is_dram = static_cast<uint32_t>(d_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    bool e_is_dram = false;
+    bool f_is_dram = false;
+
+    // weight
+    if (weight_has_value) {
+        e_buffer = e->buffer();
+        e_is_dram = static_cast<uint32_t>(e_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    }
+
+    // bias
+    if (bias_has_value) {
+        f_buffer = f->buffer();
+        f_is_dram = static_cast<uint32_t>(f_buffer->buffer_type() == tt_metal::BufferType::DRAM);
+    }
+
+    // READER KERNEL
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp",
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig({a_is_dram}));
+
+    // WRITER KERNEL
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp",
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig({b_is_dram, c_is_dram, d_is_dram, e_is_dram, f_is_dram}));
+
+    // COMPUTE KERNEL
+    bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                            c_data_format == tt::DataFormat::Float32;
+    std::vector<uint32_t> compute_kernel_args = {
+        static_cast<uint32_t>(weight_has_value), static_cast<uint32_t>(bias_has_value)};
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp",
+        all_device_cores,
+        tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_kernel_args});
+
+    auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        compute_kernel_id,
+        compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        output,
+        set_runtime_args);
+
+    return {
+        std::move(program), {reader_kernel_id, writer_kernel_id, compute_kernel_id, compute_with_storage_grid_size}};
+}
+
+void BatchNormOperation::BatchNormFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto update_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
+        auto& all_args = GetRuntimeArgs(program, kernel_id);
+        auto& core_args = all_args.at(core.x).at(core.y);
+        std::copy(args.begin(), args.end(), core_args.data());
+    };
+
+    CMAKE_UNIQUE_NAMESPACE::set_or_update_runtime_arguments(
+        cached_program.program,
+        cached_program.shared_variables.reader_kernel_id,
+        cached_program.shared_variables.writer_kernel_id,
+        cached_program.shared_variables.compute_kernel_id,
+        cached_program.shared_variables.compute_with_storage_grid_size,
+        operation_attributes,
+        tensor_args,
+        output,
+        update_args);
+}
+
+}  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -116,7 +116,7 @@ void MAIN {
         cb_pop_front(cb_den, 1);
         cb_push_back(cb_affine_or_out, onetile);
 
-        if (weight_has_value) {  // result = result * weight
+        if constexpr (weight_has_value) {  // result = result * weight
             cb_reserve_back(cb_scaled_output, onetile);
             cb_wait_front(cb_affine_or_out, 1);
             cb_wait_front(cb_weight, 1);
@@ -134,7 +134,7 @@ void MAIN {
             cb_pop_front(cb_weight, 1);
             cb_push_back(cb_scaled_output, onetile);
         }
-        if (bias_has_value) {  // result = result + bias
+        if constexpr (bias_has_value) {  // result = result + bias
             cb_reserve_back(cb_output_0, 1);
             cb_wait_front(cb_tmp_1, 1);
             cb_wait_front(cb_bias, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_binary.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+#include <cstdint>
+
+namespace NAMESPACE {
+
+ALWI void subtract_bcast_tiles(
+    uint32_t cb_bcast, uint32_t cb_other, uint32_t cb_out, uint32_t freq, uint32_t tile_start) {
+    constexpr uint32_t onetile = 1;
+
+    cb_wait_front(cb_bcast, onetile);
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        cb_wait_front(cb_other, onetile);
+        cb_reserve_back(cb_out, onetile);
+
+        tile_regs_acquire();
+        sub_tiles(cb_other, cb_bcast, 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, onetile);
+        cb_pop_front(cb_other, onetile);
+    }
+    cb_pop_front(cb_bcast, onetile);
+}
+
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+    constexpr uint32_t weight_has_value = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t bias_has_value = get_compile_time_arg_val(1) == 1;
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_input = tt::CBIndex::c_0;       // input
+    constexpr auto cb_batch_mean = tt::CBIndex::c_1;  // batch_mean
+    constexpr auto cb_output_0 =
+        tt::CBIndex::c_2;  // output -- > [(input - batch_mean)/(sqrt(batch_var + eps))] * weight
+    constexpr auto cb_batch_var = tt::CBIndex::c_3;  // batch_var
+    constexpr auto cb_eps = tt::CBIndex::c_4;        // eps
+    constexpr auto cb_den = tt::CBIndex::c_5;        // 1/(sqrt(batch_var + eps))
+    constexpr auto cb_num = tt::CBIndex::c_6;        // input - batch_mean
+    constexpr auto cb_weight = tt::CBIndex::c_16;    // weight tensor
+    constexpr auto cb_tmp_1 = tt::CBIndex::c_17;     // (input - batch_mean)/(sqrt(batch_var + eps))
+    constexpr auto cb_bias = tt::CBIndex::c_18;      // bias tensor
+
+    auto cb_bcast = cb_batch_mean;
+    auto cb_other = cb_input;
+
+    binary_op_init_common(cb_bcast, cb_other, cb_output_0);
+
+    // input - batch_mean
+    sub_tiles_init();
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        subtract_bcast_tiles(cb_bcast, cb_other, cb_num, tile_freq, tile_start);
+    }
+    if (remaining_iterations > 0) {
+        subtract_bcast_tiles(cb_bcast, cb_other, cb_num, remaining_iterations, tile_start);
+    }
+
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+
+    constexpr auto cb_affine_or_out = (weight_has_value || bias_has_value) ? cb_tmp_1 : cb_output_0;
+    constexpr auto cb_scaled_output = (bias_has_value) ? cb_tmp_1 : cb_output_0;
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        // 1/(sqrt(batch_var + eps))
+        cb_reserve_back(cb_den, onetile);
+        cb_wait_front(cb_batch_var, 1);
+        cb_wait_front(cb_eps, 1);
+
+        tile_regs_acquire();
+        add_tiles_init_with_dt(cb_batch_var, cb_eps);
+        add_tiles(cb_batch_var, cb_eps, 0, 0, dst0);
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_den);
+        tile_regs_release();
+
+        cb_pop_front(cb_batch_var, 1);
+        cb_pop_front(cb_eps, 1);
+        cb_push_back(cb_den, onetile);
+
+        // (input - batch_mean)/(sqrt(batch_var + eps)) = result
+        cb_reserve_back(cb_affine_or_out, onetile);
+        cb_wait_front(cb_num, 1);
+        cb_wait_front(cb_den, 1);
+
+        tile_regs_acquire();
+        mul_tiles_init_with_dt(cb_num, cb_den);
+        mul_tiles(cb_num, cb_den, 0, 0, dst0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile_with_dt(dst0, cb_affine_or_out);
+        tile_regs_release();
+
+        cb_pop_front(cb_num, 1);
+        cb_pop_front(cb_den, 1);
+        cb_push_back(cb_affine_or_out, onetile);
+
+        if (weight_has_value) {  // result = result * weight
+            cb_reserve_back(cb_scaled_output, onetile);
+            cb_wait_front(cb_affine_or_out, 1);
+            cb_wait_front(cb_weight, 1);
+
+            tile_regs_acquire();
+            mul_tiles_init_with_dt(cb_affine_or_out, cb_weight);
+            mul_tiles(cb_affine_or_out, cb_weight, 0, 0, dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_with_dt(dst0, cb_scaled_output);
+            tile_regs_release();
+
+            cb_pop_front(cb_affine_or_out, 1);
+            cb_pop_front(cb_weight, 1);
+            cb_push_back(cb_scaled_output, onetile);
+        }
+        if (bias_has_value) {  // result = result + bias
+            cb_reserve_back(cb_output_0, 1);
+            cb_wait_front(cb_tmp_1, 1);
+            cb_wait_front(cb_bias, 1);
+
+            tile_regs_acquire();
+            add_tiles_init_with_dt(cb_tmp_1, cb_bias);
+            add_tiles(cb_tmp_1, cb_bias, 0, 0, dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_with_dt(dst0, cb_output_0);
+            tile_regs_release();
+
+            cb_pop_front(cb_tmp_1, 1);
+            cb_pop_front(cb_bias, 1);
+            cb_push_back(cb_output_0, 1);
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const auto eps = get_arg_val<uint32_t>(0);
+    uint32_t src_addr = get_arg_val<uint32_t>(1);  // input tensor
+    uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t HtWt = get_arg_val<uint32_t>(4);
+    uint32_t n_stride = get_arg_val<uint32_t>(5);
+    uint32_t c_stride = get_arg_val<uint32_t>(6);
+    uint32_t N = get_arg_val<uint32_t>(7);
+    uint32_t C = get_arg_val<uint32_t>(8);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr uint32_t onetile = 1;
+
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    constexpr auto cb_id_eps = tt::CBIndex::c_4;
+
+    cb_reserve_back(cb_id_eps, onetile);
+    fill_with_val_bfloat16(cb_id_eps, eps);
+    cb_push_back(cb_id_eps, onetile);
+
+    // Input tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
+
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
+            for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
+                cb_reserve_back(cb_id_src, onetile);
+                uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+                noc_async_read_barrier();
+                cb_push_back(cb_id_src, onetile);
+            }
+            tile_offset += next_channel_shift;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);        // batch_mean
+    uint32_t batch_var_addr = get_arg_val<uint32_t>(1);  // batch_var
+    const bool weight_has_value = get_arg_val<uint32_t>(2) == 1;
+    uint32_t weight_addr = get_arg_val<uint32_t>(3);  // weight
+    const bool bias_has_value = get_arg_val<uint32_t>(4) == 1;
+    uint32_t bias_addr = get_arg_val<uint32_t>(5);  // bias
+    uint32_t dst_addr = get_arg_val<uint32_t>(6);   // output
+    uint32_t start_tile_id = get_arg_val<uint32_t>(7);
+    uint32_t num_tiles = get_arg_val<uint32_t>(8);
+    uint32_t HtWt = get_arg_val<uint32_t>(9);
+    uint32_t n_stride = get_arg_val<uint32_t>(10);
+    uint32_t c_stride = get_arg_val<uint32_t>(11);
+    uint32_t N = get_arg_val<uint32_t>(12);
+    uint32_t C = get_arg_val<uint32_t>(13);
+
+    constexpr uint32_t onetile = 1;
+
+    // batch_mean
+    constexpr auto cb_id_src = tt::CBIndex::c_1;
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+
+    // output
+    constexpr auto cb_id_dst = tt::CBIndex::c_2;
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const DataFormat dst_data_format = get_dataformat(cb_id_dst);
+
+    const InterleavedAddrGenFast<dst_is_dram> dst = {
+        .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
+
+    // batch_var
+    constexpr auto cb_id_batch_var = tt::CBIndex::c_3;
+    constexpr bool batch_var_is_dram = get_compile_time_arg_val(2) == 1;
+    const uint32_t batch_var_tile_bytes = get_tile_size(cb_id_batch_var);
+    const DataFormat batch_var_data_format = get_dataformat(cb_id_batch_var);
+
+    const InterleavedAddrGenFast<batch_var_is_dram> batch_var = {
+        .bank_base_address = batch_var_addr, .page_size = batch_var_tile_bytes, .data_format = batch_var_data_format};
+
+    // weight
+    constexpr auto cb_id_weight = tt::CBIndex::c_16;
+    constexpr bool weight_is_dram = get_compile_time_arg_val(3) == 1;
+    const uint32_t weight_tile_bytes = get_tile_size(cb_id_weight);
+    const DataFormat weight_data_format = get_dataformat(cb_id_weight);
+
+    const InterleavedAddrGenFast<weight_is_dram> weight = {
+        .bank_base_address = weight_addr, .page_size = weight_tile_bytes, .data_format = weight_data_format};
+
+    // bias
+    constexpr auto cb_id_bias = tt::CBIndex::c_18;
+    constexpr bool bias_is_dram = get_compile_time_arg_val(4) == 1;
+    const uint32_t bias_tile_bytes = get_tile_size(cb_id_bias);
+    const DataFormat bias_data_format = get_dataformat(cb_id_bias);
+
+    const InterleavedAddrGenFast<bias_is_dram> bias = {
+        .bank_base_address = bias_addr, .page_size = bias_tile_bytes, .data_format = bias_data_format};
+
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_tile_id / tiles_per_batch;
+    uint32_t start_remaining = start_tile_id % tiles_per_batch;
+    uint32_t start_c = start_remaining / HtWt;
+    uint32_t start_t = start_remaining % HtWt;
+
+    // Input tile offset
+    uint32_t tile_offset = start_n * n_stride + start_c * c_stride;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+
+    uint32_t num_tiles_written = 0;
+    for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
+        for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
+            // read a tile from src
+            cb_reserve_back(cb_id_src, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_src);
+            noc_async_read_tile(tile_offset, src, l1_write_addr);
+            noc_async_read_barrier();
+            fill_tile_with_first_element_bfloat16(cb_id_src);
+            cb_push_back(cb_id_src, onetile);
+
+            // read a tile from batch variance
+            cb_reserve_back(cb_id_batch_var, onetile);
+            uint32_t l1_batch_var_write_addr = get_write_ptr(cb_id_batch_var);
+            noc_async_read_tile(tile_offset, batch_var, l1_batch_var_write_addr);
+            noc_async_read_barrier();
+            fill_tile_with_first_element_bfloat16(cb_id_batch_var);
+            cb_push_back(cb_id_batch_var, onetile);
+
+            if (weight_has_value) {  // read a tile from weight tensor
+                cb_reserve_back(cb_id_weight, onetile);
+                uint32_t l1_weight_write_addr = get_write_ptr(cb_id_weight);
+                noc_async_read_tile(tile_offset, weight, l1_weight_write_addr);
+                noc_async_read_barrier();
+                fill_tile_with_first_element_bfloat16(cb_id_weight);
+                cb_push_back(cb_id_weight, onetile);
+            }
+
+            if (bias_has_value) {  // read a tile from bias tensor
+                cb_reserve_back(cb_id_bias, onetile);
+                uint32_t l1_bias_write_addr = get_write_ptr(cb_id_bias);
+                noc_async_read_tile(tile_offset, bias, l1_bias_write_addr);
+                noc_async_read_barrier();
+                fill_tile_with_first_element_bfloat16(cb_id_bias);
+                cb_push_back(cb_id_bias, onetile);
+            }
+
+            for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
+                // write a tile to dst
+                cb_wait_front(cb_id_dst, onetile);
+                uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
+                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_dst, onetile);
+            }
+            tile_offset += c_stride;
+        }
+        tile_offset += next_batch_shift;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/normalization_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/normalization_pybind.hpp
@@ -15,6 +15,7 @@
 #include "groupnorm/groupnorm_pybind.hpp"
 #include "layernorm_distributed/layernorm_distributed_pybind.hpp"
 #include "rmsnorm_distributed/rmsnorm_distributed_pybind.hpp"
+#include "batch_norm/batch_norm_pybind.hpp"
 
 namespace ttnn::operations::normalization {
 
@@ -25,6 +26,7 @@ void py_module(py::module& module) {
     detail::bind_normalization_group_norm(module);
     detail::bind_normalization_layernorm_distributed(module);
     detail::bind_normalization_rms_norm_distributed(module);
+    detail::bind_batch_norm_operation(module);
 }
 
 }  // namespace ttnn::operations::normalization


### PR DESCRIPTION
### List of Github issues

- https://github.com/tenstorrent/tt-metal/issues/12253 
- https://github.com/tenstorrent/tt-metal/issues/15449

### Problem description
To implement batch normalization as device op

### What's changed
Work done : 

- Provided support for Inference mode

<img width="1254" alt="Screenshot 2025-01-10 at 11 59 49 AM" src="https://github.com/user-attachments/assets/061ccaca-8b7e-44c9-a0f3-e1c87c908403" />

### Checklist
- [x] [All post-commit testsI](https://github.com/tenstorrent/tt-metal/actions/runs/12729863177)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12729863432)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) -  [Link to test](https://github.com/tenstorrent/tt-metal/actions/runs/12732676848)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/12729864298/job/35486219235) - same as main
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/12729865036) - same as main
- [x] [Single-card Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/12729865358) - same as main

