### PR TITLE
#0: Reshuffle some logic in resize_remote_sender/receiver_cb_interface to fix perf degradation in some models

### DIFF
--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -18,7 +18,7 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include <kernel_includes.hpp>
 #if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
-#include "circular_buffer_init.h"
+#include "remote_circular_buffer_api.h"
 #endif
 
 void kernel_launch(uint32_t kernel_base_addr) {

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -18,7 +18,7 @@
 #include "c_tensix_core.h"
 #include "kernel_includes.hpp"
 #if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
-#include "circular_buffer_init.h"
+#include "remote_circular_buffer_api.h"
 #endif
 
 uint32_t noc_reads_num_issued[NUM_NOCS];

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -16,7 +16,7 @@
 #include "tools/profiler/kernel_profiler.hpp"
 
 #if defined ALIGN_LOCAL_CBS_TO_REMOTE_CBS
-#include "circular_buffer_init.h"
+#include "remote_circular_buffer_api.h"
 #endif
 
 // Global vars


### PR DESCRIPTION
No functional change, and the code is not even called in the kernels of the model hitting perf degradation. Seems most likely a code size issue or something not getting optimized out properly.

### Ticket
Link to Github Issue

### Problem description
Device perf degradation in convnet_mnist model on WH after recent bug fixes in remote cb apis. I am currently unsure of the exact reason for the degradation, as the code here will be compiled into firmware and not kernel, and won't actually get run. The perf test measures kernel perf and excludes firmware initialization time as well, and the changes in this pr to fix the regression seems like it could have been able to be optimized out by the compiler since `update_remote_over_noc` is a template arg, but seems like that might not have been the case. Haven't looked into it further.

### What's changed
Move some code into the constexpr if.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12603182093
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12603180656
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
