### PR TITLE
Fix remaining minor input/output issues with TG-Llama3 vLLM integration

### DIFF
--- a/models/demos/llama3/demo/demo.py
+++ b/models/demos/llama3/demo/demo.py
@@ -417,7 +417,7 @@ def run_llama3_demo(
                         dims=(3, 1) if model_args.is_galaxy else (1, -1),
                         mesh_shape=model_args.cluster_shape,
                     ),
-                )[0, 0, (decoding_pos[batch_id] - 1) % 32, :]
+                )[0, 0, (decoding_pos[batch_id] - 1) % 32, : model_args.vocab_size]
             )
             ttnn.deallocate(tt_out)
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- There were some minor input and output processing issues when running `LlamaGenerator` with TG

### What's changed
- Fixed token input processing and logit output processing in functions used by `LlamaGenerator` (currently used by vLLM but not model demo)
- Sliced output logits in demo to vocab size (for TG was returning padded vocab size but did not affect output tokens)


### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
