### PR TITLE
#16443: Add a programming example of vecadd_multi_core and gtest

### DIFF
--- a/tests/tt_metal/tt_metal/integration/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/integration/CMakeLists.txt
@@ -9,6 +9,7 @@ set(UNIT_TESTS_INTEGRATION_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/matmul/test_matmul_multi_core_X_dram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/matmul/test_matmul_single_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/matmul/test_matmul_X_tile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/vecadd/test_vecadd_multi_core.cpp
 )
 
 add_executable(unit_tests_integration ${UNIT_TESTS_INTEGRATION_SRC})

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -17,9 +17,6 @@ using namespace tt::tt_metal;
 
 using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
 
-constexpr uint32_t TILE_WIDTH = 32;
-constexpr uint32_t TILE_HEIGHT = 32;
-
 std::shared_ptr<Buffer> MakeBuffer(Device* device, uint32_t size, uint32_t page_size, bool sram) {
     InterleavedBufferConfig config{
         .device = device,
@@ -30,7 +27,7 @@ std::shared_ptr<Buffer> MakeBuffer(Device* device, uint32_t size, uint32_t page_
 }
 
 std::shared_ptr<Buffer> MakeBufferBFP16(Device* device, uint32_t n_tiles, bool sram) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
+    constexpr uint32_t tile_size = sizeof(bfloat16) * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
     // For simplicity, all DRAM buffers have page size = tile size.
     const uint32_t page_tiles = sram ? n_tiles : 1;
     return MakeBuffer(device, tile_size * n_tiles, page_tiles * tile_size, sram);
@@ -43,7 +40,7 @@ CBHandle MakeCircularBuffer(
 }
 
 CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t n_tiles) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
+    constexpr uint32_t tile_size = sizeof(bfloat16) * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
     return MakeCircularBuffer(program, core, cb, n_tiles * tile_size, tile_size, tt::DataFormat::Float16_b);
 }
 
@@ -64,7 +61,7 @@ bool vecadd_multi_core(DispatchFixture* fixture, Device* device, uint32_t n_tile
     CoreRange cores(start_core, end_core);
 
     CommandQueue& cq = device->command_queue();
-    const uint32_t tile_size = TILE_WIDTH * TILE_HEIGHT;
+    const uint32_t tile_size = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
     const uint32_t tiles_per_core = n_tiles / num_core;
 
     // Create 3 buffers on DRAM. These will hold the input and output data. A
@@ -80,26 +77,36 @@ bool vecadd_multi_core(DispatchFixture* fixture, Device* device, uint32_t n_tile
     const uint32_t cir_buffer_title = 4;
     CBHandle cb_a = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_0, cir_buffer_title);
     CBHandle cb_b = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_1, cir_buffer_title);
-    CBHandle cb_c = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_16, cir_buffer_title);
+    CBHandle cb_c = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_2, cir_buffer_title);
 
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1};
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)tt::CBIndex::c_2};
+    std::vector<uint32_t> compute_compile_time_args = {
+        (std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1, (std::uint32_t)tt::CBIndex::c_2};
     auto reader = CreateKernel(
         program,
         "tt_metal/programming_examples/vecadd_multi_core/kernels/"
         "interleaved_tile_read_multi_core.cpp",
         cores,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = reader_compile_time_args});
     auto writer = CreateKernel(
         program,
         "tt_metal/programming_examples/vecadd_multi_core/kernels/"
         "tile_write_multi_core.cpp",
         cores,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = writer_compile_time_args});
     auto compute = CreateKernel(
         program,
-        "tt_metal/programming_examples/"
-        "vecadd_multi_core/kernels/add_multi_core.cpp",
+        "tt_metal/programming_examples/vecadd_multi_core/"
+        "kernels/add_multi_core.cpp",
         cores,
-        ComputeConfig{.math_approx_mode = false, .compile_args = {}, .defines = {}});
+        ComputeConfig{.math_approx_mode = false, .compile_args = compute_compile_time_args, .defines = {}});
 
     for (int i = 0; i < num_core; ++i) {
         // Set runtime arguments for each core.

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -55,7 +55,7 @@ bool vecadd_multi_core(DispatchFixture* fixture, Device* device, uint32_t n_tile
 
     bool pass = true;
 
-    int seed = std::random_device{}();
+    int seed = 0x1234567;
     Program program = CreateProgram();
 
     // designate 4 cores for utilization - cores (0,0), (0,1), (0,2), (0,3)
@@ -123,7 +123,7 @@ bool vecadd_multi_core(DispatchFixture* fixture, Device* device, uint32_t n_tile
     size_t data_per_core = tile_size * tiles_per_core;
 
     for (int core = 0; core < num_core; ++core) {
-        const auto core_offset = core * tile_size + tiles_per_core;
+        const auto core_offset = core * (tile_size + tiles_per_core);
         for (int index = 0; index < data_per_core; index++) {
             const auto i = core_offset + index;
             float golden = a_data[i].to_float() + b_data[i].to_float();

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -12,7 +12,6 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 
-// using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -121,11 +120,12 @@ bool vecadd_multi_core(DispatchFixture* fixture, Device* device, uint32_t n_tile
     std::vector<bfloat16> c_data;
     EnqueueReadBuffer(cq, c, c_data, true);
 
-    // Compare partial results (plus or minus some error due to BFP16 precision)
-    size_t n = std::min((size_t)10, (size_t)tile_size * tiles_per_core);
+    size_t data_per_core = tile_size * tiles_per_core;
 
-    for (int j = 0; j < num_core; ++j) {
-        for (int i = j * tile_size * tiles_per_core; i < j * tile_size * tiles_per_core + n; i++) {
+    for (int core = 0; core < num_core; ++core) {
+        const auto core_offset = core * tile_size + tiles_per_core;
+        for (int index = 0; index < data_per_core; index++) {
+            const auto i = core_offset + index;
             float golden = a_data[i].to_float() + b_data[i].to_float();
             pass &= tt::test_utils::is_close<float>(golden, c_data[i].to_float(), 0.015f);
         }

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/bfloat16.hpp"
+#include "dispatch_fixture.hpp"
+#include "test_tiles.hpp"
+#include "tests/tt_metal/test_utils/print_helpers.hpp"
+#include "tests/tt_metal/test_utils/tilization.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/deprecated/tensor.hpp"
+
+// using std::vector;
+using namespace tt;
+using namespace tt::tt_metal;
+
+using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
+
+constexpr uint32_t TILE_WIDTH = 32;
+constexpr uint32_t TILE_HEIGHT = 32;
+
+std::shared_ptr<Buffer> MakeBuffer(Device* device, uint32_t size, uint32_t page_size, bool sram) {
+    InterleavedBufferConfig config{
+        .device = device,
+        .size = size,
+        .page_size = page_size,
+        .buffer_type = (sram ? BufferType::L1 : BufferType::DRAM)};
+    return CreateBuffer(config);
+}
+
+std::shared_ptr<Buffer> MakeBufferBFP16(Device* device, uint32_t n_tiles, bool sram) {
+    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
+    // For simplicity, all DRAM buffers have page size = tile size.
+    const uint32_t page_tiles = sram ? n_tiles : 1;
+    return MakeBuffer(device, tile_size * n_tiles, page_tiles * tile_size, sram);
+}
+
+CBHandle MakeCircularBuffer(
+    Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t size, uint32_t page_size, tt::DataFormat format) {
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(size, {{cb, format}}).set_page_size(cb, page_size);
+    return CreateCircularBuffer(program, core, cb_src0_config);
+}
+
+CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t n_tiles) {
+    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
+    return MakeCircularBuffer(program, core, cb, n_tiles * tile_size, tile_size, tt::DataFormat::Float16_b);
+}
+
+namespace unit_tests_common::vecadd::test_vecadd_multi_core {
+
+bool vecadd_multi_core(DispatchFixture* fixture, Device* device, uint32_t n_tiles) {
+    const uint32_t num_core = 4;
+    TT_FATAL(n_tiles >= num_core, "Parameter mismatch {} {}", n_tiles, num_core);
+
+    bool pass = true;
+
+    int seed = std::random_device{}();
+    Program program = CreateProgram();
+
+    // designate 4 cores for utilization - cores (0,0), (0,1), (0,2), (0,3)
+    CoreCoord start_core = {0, 0};
+    CoreCoord end_core = {0, 3};
+    CoreRange cores(start_core, end_core);
+
+    CommandQueue& cq = device->command_queue();
+    const uint32_t tile_size = TILE_WIDTH * TILE_HEIGHT;
+    const uint32_t tiles_per_core = n_tiles / num_core;
+
+    // Create 3 buffers on DRAM. These will hold the input and output data. A
+    // and B are the input buffers, C is the output buffer.
+    auto a = MakeBufferBFP16(device, n_tiles, false);
+    auto b = MakeBufferBFP16(device, n_tiles, false);
+    auto c = MakeBufferBFP16(device, n_tiles, false);
+
+    std::mt19937 rng(seed);
+    std::vector<bfloat16> a_data = create_random_vector_of_bfloat16_native(tile_size * n_tiles * 2, 10, rng());
+    std::vector<bfloat16> b_data = create_random_vector_of_bfloat16_native(tile_size * n_tiles * 2, 10, rng());
+
+    const uint32_t cir_buffer_title = 4;
+    CBHandle cb_a = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_0, cir_buffer_title);
+    CBHandle cb_b = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_1, cir_buffer_title);
+    CBHandle cb_c = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_16, cir_buffer_title);
+
+    auto reader = CreateKernel(
+        program,
+        "tt_metal/programming_examples/vecadd_multi_core/kernels/"
+        "interleaved_tile_read_multi_core.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    auto writer = CreateKernel(
+        program,
+        "tt_metal/programming_examples/vecadd_multi_core/kernels/"
+        "tile_write_multi_core.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    auto compute = CreateKernel(
+        program,
+        "tt_metal/programming_examples/"
+        "vecadd_multi_core/kernels/add_multi_core.cpp",
+        cores,
+        ComputeConfig{.math_approx_mode = false, .compile_args = {}, .defines = {}});
+
+    for (int i = 0; i < num_core; ++i) {
+        // Set runtime arguments for each core.
+        CoreCoord core = {0, i};
+        SetRuntimeArgs(program, reader, core, {a->address(), b->address(), tiles_per_core, i});
+        SetRuntimeArgs(program, writer, core, {c->address(), tiles_per_core, i});
+        SetRuntimeArgs(program, compute, core, {tiles_per_core, i});
+    }
+
+    EnqueueWriteBuffer(cq, a, a_data, false);
+    EnqueueWriteBuffer(cq, b, b_data, false);
+    // Enqueue the program
+    EnqueueProgram(cq, program, true);
+
+    log_debug(LogTest, "Kernel execution finished");
+
+    // Read the output buffer.
+    std::vector<bfloat16> c_data;
+    EnqueueReadBuffer(cq, c, c_data, true);
+
+    // Compare partial results (plus or minus some error due to BFP16 precision)
+    size_t n = std::min((size_t)10, (size_t)tile_size * tiles_per_core);
+
+    for (int j = 0; j < num_core; ++j) {
+        for (int i = j * tile_size * tiles_per_core; i < j * tile_size * tiles_per_core + n; i++) {
+            float golden = a_data[i].to_float() + b_data[i].to_float();
+            pass &= tt::test_utils::is_close<float>(golden, c_data[i].to_float(), 0.015f);
+        }
+    }
+
+    return pass;
+}
+}  // namespace unit_tests_common::vecadd::test_vecadd_multi_core
+
+TEST_F(DispatchFixture, VecaddMultiCore) {
+    uint32_t num_tiles = 64;
+    ASSERT_TRUE(unit_tests_common::vecadd::test_vecadd_multi_core::vecadd_multi_core(this, devices_.at(0), num_tiles));
+}

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PROGRAMMING_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/matmul_single_core/matmul_single_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pad/pad_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sharding/shard_data_rm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/vecadd_multi_core/vecadd_multi_core.cpp
 )
 
 include(${PROJECT_SOURCE_DIR}/cmake/helper_functions.cmake)

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Martin Chang
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include <cstdint>
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t n_tiles = get_arg_val<uint32_t>(0);
+    uint32_t core_id = get_arg_val<uint32_t>(1);  // Add core ID argument
+
+    // We are going to read from these two circular buffers
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    // and write to the output circular buffer
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    // The destination register.
+    // Quote the doc: "This register is an array of 16 tiles of 32x32 elements
+    // each." If you are familiar with the concept of rotating register file
+    // from computer architecture. Think it like that. Later on we will ensure
+    // that registers are free and then we will submit compute to the FPU/SFPU
+    // that writes to the register. see:
+    // https://tenstorrent-metal.github.io/tt-metal/latest/tt-metalium/tt_metal/apis/kernel_apis/compute/acquire_dst.html
+    constexpr uint32_t dst_reg = 0;
+
+    // Tell the SFPU that we will be using circular buffers c_in0, c_in1 and
+    // c_out0 to perform the computation.
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    // And we are going to add tiles. This function is only called if we ever
+    // need to switch operation to something else. Since we are only adding
+    // tiles, this function is only called once before the loop.
+    add_tiles_init();
+
+    // Calculate the range of tiles this core should process
+    const uint32_t tiles_per_core = n_tiles;
+    const uint32_t start_tile = core_id * tiles_per_core;
+    const uint32_t end_tile = start_tile + tiles_per_core;
+
+    // Loop over the assigned tiles and perform the computation
+    for (uint32_t i = start_tile; i < end_tile; i++) {
+        // Make sure there is a valid register we can use.
+        acquire_dst();
+        // Wait until there is a tile in both input circular buffers
+        cb_wait_front(cb_in0, 1);
+        cb_wait_front(cb_in1, 1);
+        // Add the tiles from the input circular buffers and write the result to
+        // the destination register
+        add_tiles(cb_in0, cb_in1, 0, 0, dst_reg);
+        // Make sure there is space in the output circular buffer
+        cb_reserve_back(cb_out0, 1);
+        // Copy the result from adding the tiles to the output circular buffer
+        pack_tile(dst_reg, cb_out0);
+        // Mark the output tile as ready and pop the input tiles
+        cb_push_back(cb_out0, 1);
+        cb_pop_front(cb_in0, 1);
+        cb_pop_front(cb_in1, 1);
+        // Release the held register
+        release_dst();
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
@@ -5,7 +5,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/eltwise_binary.h"
-#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/tile_move_copy.h"  // #include "compile_time_args.h"
 #include <cstdint>
 
 namespace NAMESPACE {
@@ -14,10 +14,10 @@ void MAIN {
     uint32_t core_id = get_arg_val<uint32_t>(1);  // Add core ID argument
 
     // We are going to read from these two circular buffers
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    constexpr auto cb_in0 = get_compile_time_arg_val(0);
+    constexpr auto cb_in1 = get_compile_time_arg_val(1);
     // and write to the output circular buffer
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    constexpr auto cb_out0 = get_compile_time_arg_val(2);
     // The destination register.
     // Quote the doc: "This register is an array of 16 tiles of 32x32 elements
     // each." If you are familiar with the concept of rotating register file

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: © 2024 Martin Chang
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/eltwise_binary.h"
-#include "compute_kernel_api/tile_move_copy.h"  // #include "compile_time_args.h"
+#include "compute_kernel_api/tile_move_copy.h"
 #include <cstdint>
 
 namespace NAMESPACE {

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -14,8 +14,8 @@ void kernel_main() {
     uint32_t core_id = get_arg_val<uint32_t>(3);  // Add core ID argument
 
     // The circular buffers to read the tiles into
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
+    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_in1 = get_compile_time_arg_val(1);
 
     // Get the tile size used in the circular buffers. We assume the
     // circular buffers are created with the same tile size as the DRAM

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Martin Chang
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2024 Martin Chang
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include <cstdint>
+
+void kernel_main() {
+    // Read parameters from the kernel arguments
+    uint32_t a_addr = get_arg_val<uint32_t>(0);
+    uint32_t b_addr = get_arg_val<uint32_t>(1);
+    uint32_t n_tiles = get_arg_val<uint32_t>(2);
+    uint32_t core_id = get_arg_val<uint32_t>(3);  // Add core ID argument
+
+    // The circular buffers to read the tiles into
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
+
+    // Get the tile size used in the circular buffers. We assume the
+    // circular buffers are created with the same tile size as the DRAM
+    // buffers. (Whis is most of the cases)
+    const uint32_t tile_size_bytes = get_tile_size(cb_in0);
+    // DPRINT_DATA0(DPRINT << "tile_size_bytes " <<  tile_size_bytes << ENDL());
+    //  Create address generators for the input buffers. This is much faster
+    //  then doing plain DRAM reads.
+    //  Setting the page size to be tile_size_bytes works because we set it up
+    //  explicitly in host code. This is usually a good idea as it makes coding
+    //  easy. But may not be the most efficient way to do it in all cases.
+    const InterleavedAddrGenFast<true> a = {
+        .bank_base_address = a_addr,           // The base address of the buffer
+        .page_size = tile_size_bytes,          // The size of a buffer page
+        .data_format = DataFormat::Float16_b,  // The data format of the buffer
+    };
+    const InterleavedAddrGenFast<true> b = {
+        .bank_base_address = b_addr,
+        .page_size = tile_size_bytes,
+        .data_format = DataFormat::Float16_b,
+    };
+
+    // Calculate the range of tiles this core should process
+    const uint32_t tiles_per_core = n_tiles;
+    const uint32_t start_tile = core_id * tiles_per_core;
+    const uint32_t end_tile = start_tile + tiles_per_core;
+
+    // Now we loop over the assigned tiles and read them into the circular
+    // buffers
+    for (uint32_t i = start_tile; i < end_tile; i++) {
+        // First we make sure there is space in the circular buffers
+        cb_reserve_back(cb_in0, 1);
+        cb_reserve_back(
+            cb_in1,
+            1);  // wait until we have 1 free slot. This blocks if the
+                 // other kernels cannot consume the tiles fast enough.
+                 // Deciding how large the buffer should be is a tradeoff.
+        uint32_t cb_in0_addr = get_write_ptr(cb_in0);
+        uint32_t cb_in1_addr = get_write_ptr(cb_in1);
+        noc_async_read_tile(i, a, cb_in0_addr);  // read the tile into the circular buffer
+        noc_async_read_tile(i, b, cb_in1_addr);  // We can overlap async reads and writes
+                                                 // to reduce the data movement overhead.
+
+        // NOTE: Since circular buffers are backed by SRAM, we can actually
+        // access them by casting the address to a pointer. This is not helpful
+        // in most cases as the CPU is quite slow compared to the tensor/simd
+        // engines. But useful for debugging. uint16_t* ptr =
+        // (uint16_t*)cb_in0_addr; DPRINT << "cb_in0_addr: " << ptr << " " <<
+        // *ptr;
+
+        noc_async_read_barrier();  // Wait until tile reads are done
+        cb_push_back(cb_in0, 1);
+        cb_push_back(
+            cb_in1,
+            1);  // mark the tiles as ready. From this point forward
+                 // kernels calling `cb_wait_front` will see this tile
+    }
+}

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Martin Chang
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2024 Martin Chang
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+void kernel_main() {
+    uint32_t c_addr = get_arg_val<uint32_t>(0);
+    uint32_t n_tiles = get_arg_val<uint32_t>(1);
+    uint32_t core_id = get_arg_val<uint32_t>(2);  // Add core ID argument
+
+    // The circular buffer that we are going to read from and write to DRAM
+    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    const uint32_t tile_size_bytes = get_tile_size(cb_out0);
+
+    // Address generator for the output buffer. This is faster than doing plain
+    // DRAM writes.
+    const InterleavedAddrGenFast<true> c = {
+        .bank_base_address = c_addr,
+        .page_size = tile_size_bytes,
+        .data_format = DataFormat::Float16_b,
+    };
+
+    // Calculate the range of tiles this core should process
+    const uint32_t tiles_per_core = n_tiles;
+    const uint32_t start_tile = core_id * tiles_per_core;
+    const uint32_t end_tile = start_tile + tiles_per_core;
+
+    // Loop over the assigned tiles and write them to the output buffer
+    for (uint32_t i = start_tile; i < end_tile; i++) {
+        // Make sure there is a tile in the circular buffer
+        cb_wait_front(cb_out0, 1);
+        uint32_t cb_out0_addr = get_read_ptr(cb_out0);
+        // write the tile to DRAM
+        noc_async_write_tile(i, c, cb_out0_addr);
+        noc_async_write_barrier();  // This will wait until the write is done. As
+                                    // an alternative, noc_async_write_flushed()
+                                    // can be faster because it waits until the
+                                    // write request is sent. In that case, you
+                                    // have to use noc_async_write_barrier() at
+                                    // least once at the end of data movement
+                                    // kernel to make sure all writes are done.
+        // Mark the tile as consumed
+        cb_pop_front(cb_out0, 1);
+    }
+}

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t core_id = get_arg_val<uint32_t>(2);  // Add core ID argument
 
     // The circular buffer that we are going to read from and write to DRAM
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
     const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
     // Address generator for the output buffer. This is faster than doing plain
@@ -33,13 +33,11 @@ void kernel_main() {
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // write the tile to DRAM
         noc_async_write_tile(i, c, cb_out0_addr);
-        noc_async_write_barrier();  // This will wait until the write is done. As
-                                    // an alternative, noc_async_writes_flushed()
-                                    // can be faster because it waits until the
-                                    // write request is sent. In that case, you
-                                    // have to use noc_async_write_barrier() at
-                                    // least once at the end of data movement
-                                    // kernel to make sure all writes are done.
+        // This will wait until the write is done. As an alternative, noc_async_writes_flushed()
+        // can be faster because it waits until the write request is sent. In that case, you
+        // have to use noc_async_write_barrier() at least once at the end of data movement
+        // kernel to make sure all writes are done.
+        noc_async_write_barrier();
         // Mark the tile as consumed
         cb_pop_front(cb_out0, 1);
     }

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
         // write the tile to DRAM
         noc_async_write_tile(i, c, cb_out0_addr);
         noc_async_write_barrier();  // This will wait until the write is done. As
-                                    // an alternative, noc_async_write_flushed()
+                                    // an alternative, noc_async_writes_flushed()
                                     // can be faster because it waits until the
                                     // write request is sent. In that case, you
                                     // have to use noc_async_write_barrier() at

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// this programing example is based on the vecadd single core example in the
+// contributed folder it illustarted using multiple cores to perform vector
+// addition the program will use 4 cores to perform the vector addition
+#include "common/bfloat16.hpp"
+#include "common/core_coord.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/device/device.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string_view>
+#include <vector>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
+
+constexpr uint32_t TILE_WIDTH = 32;
+constexpr uint32_t TILE_HEIGHT = 32;
+
+std::shared_ptr<Buffer> MakeBuffer(Device* device, uint32_t size, uint32_t page_size, bool sram) {
+    InterleavedBufferConfig config{
+        .device = device,
+        .size = size,
+        .page_size = page_size,
+        .buffer_type = (sram ? BufferType::L1 : BufferType::DRAM)};
+    return CreateBuffer(config);
+}
+
+// Allocate a buffer on DRAM or SRAM. Assuming the buffer holds BFP16 data.
+// A tile on Tenstorrent is 32x32 elements, given us using BFP16, we need 2
+// bytes per element. Making the tile size 32x32x2 = 2048 bytes.
+// @param device: The device to allocate the buffer on.
+// @param n_tiles: The number of tiles to allocate.
+// @param sram: If true, allocate the buffer on SRAM, otherwise allocate it on
+// DRAM.
+std::shared_ptr<Buffer> MakeBufferBFP16(Device* device, uint32_t n_tiles, bool sram) {
+    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
+    // For simplicity, all DRAM buffers have page size = tile size.
+    const uint32_t page_tiles = sram ? n_tiles : 1;
+    return MakeBuffer(device, tile_size * n_tiles, page_tiles * tile_size, sram);
+}
+
+CBHandle MakeCircularBuffer(
+    Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t size, uint32_t page_size, tt::DataFormat format) {
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(size, {{cb, format}}).set_page_size(cb, page_size);
+    return CreateCircularBuffer(program, core, cb_src0_config);
+}
+
+// Circular buffers are Tenstorrent's way of communicating between the data
+// movement and the compute kernels. kernels queue tiles into the circular
+// buffer and takes them when they are ready. The circular buffer is backed by
+// SRAM. There can be multiple circular buffers on a single Tensix core.
+// @param program: The program to create the circular buffer on.
+// @param core: The core to create the circular buffer on.
+// @param cb: Which circular buffer to create (c_in0, c_in1, c_out0, c_out1,
+// etc..). This is just an ID
+// @param n_tiles: The number of tiles the circular buffer can hold.
+CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t n_tiles) {
+    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
+    return MakeCircularBuffer(program, core, cb, n_tiles * tile_size, tile_size, tt::DataFormat::Float16_b);
+}
+
+std::string next_arg(int& i, int argc, char** argv) {
+    if (i + 1 >= argc) {
+        std::cerr << "Expected argument after " << argv[i] << std::endl;
+        exit(1);
+    }
+    return argv[++i];
+}
+
+void help(std::string_view program_name) {
+    std::cout << "Usage: " << program_name << " [options]\n";
+    std::cout << "This program demonstrates how to add two vectors using "
+                 "tt-Metalium.\n";
+    std::cout << "\n";
+    std::cout << "Options:\n";
+    std::cout << "  --device, -d <device_id>  Specify the device to run the "
+                 "program on. Default is 0.\n";
+    std::cout << "  --seed, -s <seed>         Specify the seed for the random "
+                 "number generator. Default is random.\n";
+    exit(0);
+}
+
+int main(int argc, char** argv) {
+    int seed = std::random_device{}();
+    int device_id = 0;
+
+    // Quick and dirty argument parsing.
+    for (int i = 1; i < argc; i++) {
+        std::string_view arg = argv[i];
+        if (arg == "--device" || arg == "-d") {
+            device_id = std::stoi(next_arg(i, argc, argv));
+        } else if (arg == "--seed" || arg == "-s") {
+            seed = std::stoi(next_arg(i, argc, argv));
+        } else if (arg == "--help" || arg == "-h") {
+            help(argv[0]);
+            return 0;
+        } else {
+            std::cout << "Unknown argument: " << arg << std::endl;
+            help(argv[0]);
+        }
+    }
+
+    Device* device = CreateDevice(device_id);
+
+    Program program = CreateProgram();
+    // Define 4 cores.
+    const uint32_t num_core = 4;
+    // designate 4 cores for utilization - cores (0,0), (0,1), (0,2), (0,3)
+    CoreCoord start_core = {0, 0};
+    CoreCoord end_core = {0, 3};
+    CoreRange cores(start_core, end_core);
+
+    CommandQueue& cq = device->command_queue();
+    const uint32_t n_tiles = 64;
+    const uint32_t tile_size = TILE_WIDTH * TILE_HEIGHT;
+    const uint32_t tiles_per_core = n_tiles / num_core;
+
+    // Create 3 buffers on DRAM. These will hold the input and output data. A
+    // and B are the input buffers, C is the output buffer.
+    auto a = MakeBufferBFP16(device, n_tiles, false);
+    auto b = MakeBufferBFP16(device, n_tiles, false);
+    auto c = MakeBufferBFP16(device, n_tiles, false);
+
+    std::mt19937 rng(seed);
+    std::vector<bfloat16> a_data = create_random_vector_of_bfloat16_native(tile_size * n_tiles * 2, 10, rng());
+    std::vector<bfloat16> b_data = create_random_vector_of_bfloat16_native(tile_size * n_tiles * 2, 10, rng());
+
+    const uint32_t cir_buf_num_title = 4;
+    CBHandle cb_a = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_0, cir_buf_num_title);
+    CBHandle cb_b = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_1, cir_buf_num_title);
+    CBHandle cb_c = MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_16, cir_buf_num_title);
+
+    // A Tensix core is made up with 5 processors. 2 data movement processors,
+    // and 3 compute processors. The 2 data movement processors act independent
+    // to other cores. And the 3 compute processors act together (hence 1 kerenl
+    // for compute). There is no need to explicitly parallelize the compute
+    // kernels. Unlike traditional CPU/GPU style SPMD programming, the 3 compute
+    // processors moves data from SRAM into the FPU(tensor engine)/SFPU(SIMD
+    // engine), operates on the data, and move it back to SRAM. The data
+    // movement processors moves data from the NoC, or in our case, the DRAM,
+    // into the SRAM.
+    //
+    // The vector add example consists of 3 kernels. `interleaved_tile_read`
+    // reads tiles from the input buffers A and B into 2 circular buffers. `add`
+    // reads tiles from the circular buffers, adds them together, and dumps the
+    // result into a third circular buffer. `tile_write` reads tiles from the
+    // third circular buffer and writes them to the output buffer C.
+    auto reader = CreateKernel(
+        program,
+        "tt_metal/programming_examples/vecadd_multi_core/kernels/"
+        "interleaved_tile_read_multi_core.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    auto writer = CreateKernel(
+        program,
+        "tt_metal/programming_examples/vecadd_multi_core/kernels/"
+        "tile_write_multi_core.cpp",
+        cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    auto compute = CreateKernel(
+        program,
+        "tt_metal/programming_examples/vecadd_multi_core/"
+        "kernels/add_multi_core.cpp",
+        cores,
+        ComputeConfig{.math_approx_mode = false, .compile_args = {}, .defines = {}});
+
+    for (int i = 0; i < num_core; ++i) {
+        // Set runtime arguments for each core.
+        CoreCoord core = {0, i};
+        SetRuntimeArgs(program, reader, core, {a->address(), b->address(), tiles_per_core, i});
+        SetRuntimeArgs(program, writer, core, {c->address(), tiles_per_core, i});
+        SetRuntimeArgs(program, compute, core, {tiles_per_core, i});
+    }
+
+    EnqueueWriteBuffer(cq, a, a_data, false);
+    EnqueueWriteBuffer(cq, b, b_data, false);
+    // Enqueue the program
+    EnqueueProgram(cq, program, true);
+
+    std::cout << "Kernel execution finished" << std::endl;
+
+    // Read the output buffer.
+    std::vector<bfloat16> c_data;
+    EnqueueReadBuffer(cq, c, c_data, true);
+
+    // Print partial results so we can see the output is correct (plus or minus
+    // some error due to BFP16 precision)
+    std::cout << "Partial results: (note we are running under BFP16. It's going "
+                 "to be less accurate)\n";
+    size_t n = std::min((size_t)10, (size_t)tile_size * tiles_per_core);
+
+    for (int j = 0; j < num_core; ++j) {
+        for (int i = j * tile_size * tiles_per_core; i < j * tile_size * tiles_per_core + n; i++) {
+            std::cout << "  " << a_data[i].to_float() << " + " << b_data[i].to_float() << " = " << c_data[i].to_float()
+                      << "\n";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::flush;
+
+    // Finally, we close the device.
+    CloseDevice(device);
+    return 0;
+}

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -89,7 +89,7 @@ void help(std::string_view program_name) {
 }
 
 int main(int argc, char** argv) {
-    int seed = std::random_device{}();
+    int seed = 0x1234567;
     int device_id = 0;
 
     // Quick and dirty argument parsing.
@@ -195,10 +195,12 @@ int main(int argc, char** argv) {
     // some error due to BFP16 precision)
     std::cout << "Partial results: (note we are running under BFP16. It's going "
                  "to be less accurate)\n";
-    size_t n = std::min((size_t)10, (size_t)tile_size * tiles_per_core);
+    size_t data_per_core = std::min((size_t)10, (size_t)tile_size * tiles_per_core);
 
-    for (int j = 0; j < num_core; ++j) {
-        for (int i = j * tile_size * tiles_per_core; i < j * tile_size * tiles_per_core + n; i++) {
+    for (int core = 0; core < num_core; ++core) {
+        const auto core_offset = core * (tile_size + tiles_per_core);
+        for (int index = 0; index < data_per_core; index++) {
+            const auto i = core_offset + index;
             std::cout << "  " << a_data[i].to_float() << " + " << b_data[i].to_float() << " = " << c_data[i].to_float()
                       << "\n";
         }

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent
+// SPDX-FileCopyrightText: © 2025 TenstorrentAI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
The example is based on single core vecadd example from contributed directory. It also add a gtest case to tt_metal unit tests

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16443)

### Problem description
This programing example is based on the vecadd single core example in the
contributed folder. It illustarted using multiple cores to perform vector addition.
The program will use 4 cores to perform the vector addition

### What's changed
All new files. New example and new kernels, and new gtest case.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
