### PR TITLE
Xuncai/ccl global sem

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+from loguru import logger
 
 
 def create_and_load_sub_device_manager_with_fabric_interface(
@@ -23,3 +24,14 @@ def teardown_fabric_interface(mesh_device):
     ttnn.teardown_edm_fabric(mesh_device)
     for device_id in mesh_device.get_device_ids():
         ttnn.synchronize_device(mesh_device.get_device(device_id))
+
+
+def create_global_semaphore_with_same_address(mesh_device, cores, initial_value, sub_device_ids):
+    semaphore_handles = ttnn.create_global_semaphore_with_same_address(
+        mesh_device, cores, initial_value, sub_device_ids=sub_device_ids
+    )
+    addrs = ttnn.get_global_semaphore_address(semaphore_handles)
+    logger.debug(f"from remote semaphore handle addresses: {addrs}")
+    # assert all addresses are the same
+    assert len(set(addrs)) == 1
+    return semaphore_handles

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
@@ -11,6 +11,7 @@ from models.utility_functions import skip_for_grayskull
 from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
     create_and_load_sub_device_manager_with_fabric_interface,
     teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
 )
 from ttnn import ShardTensor2dMesh, ConcatMesh2dToTensor
 
@@ -220,17 +221,10 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
 
     if use_reduce_scatter_async:
         compute_grid_size = mesh_device.compute_with_storage_grid_size()
-        worker_sub_device = ttnn.SubDevice(
-            [
-                ttnn.CoreRangeSet(
-                    {
-                        ttnn.CoreRange(
-                            ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1)
-                        )
-                    }
-                )
-            ]
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
         )
+        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
         worker_sub_device_id = ttnn.SubDeviceId(0)
         if create_persistent_fabric:
             logger.info("Create persistent fabric interface")
@@ -238,6 +232,15 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
                 mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
             )
             logger.info("Done Create persistent fabric interface")
+
+        # create global semaphore handles
+        from_remote_semaphore_handles = create_global_semaphore_with_same_address(
+            mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]
+        )
+        to_remote_semaphore_handles = create_global_semaphore_with_same_address(
+            mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]
+        )
+
     else:
         worker_sub_device_id = None
 
@@ -261,12 +264,13 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
                     dim=dim,
                     cluster_axis=cluster_axis,
                     mesh_device=mesh_device,
+                    from_remote_multi_device_global_semaphore=from_remote_semaphore_handles,
+                    to_remote_multi_device_global_semaphore=to_remote_semaphore_handles,
                     math_op=math_op,
                     memory_config=output_mem_config,
                     topology=ttnn.Topology.Linear,
                     num_links=num_links,
                     subdevice_id=worker_sub_device_id,
-                    create_semaphore_handles=True,
                 )
             else:
                 ttnn_tensor_out = ttnn.reduce_scatter(

--- a/tests/ttnn/unit_tests/test_global_semaphore.py
+++ b/tests/ttnn/unit_tests/test_global_semaphore.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import ttnn
+from loguru import logger
 
 
 def run_global_semaphore(device):
@@ -40,3 +41,34 @@ def test_global_semaphore(device, enable_async_mode):
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_global_semaphore_mesh(mesh_device, enable_async_mode):
     run_global_semaphore(mesh_device)
+
+
+def run_global_semaphore_same_address(mesh_device):
+    tensix_cores0 = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(3, 3),
+            ),
+        }
+    )
+    global_sem0 = ttnn.create_global_semaphore(mesh_device.get_devices()[0], tensix_cores0, 0)
+    global_sem1 = ttnn.create_global_semaphore(mesh_device.get_devices()[1], tensix_cores0, 0)
+    global_sem2 = ttnn.create_global_semaphore(mesh_device.get_devices()[0], tensix_cores0, 0)
+
+    global_sem3 = ttnn.create_global_semaphore_with_same_address(
+        mesh_device, tensix_cores0, 0, attempts=10, search_max=False
+    )
+    addrs0 = ttnn.get_global_semaphore_address(global_sem0)
+    addrs1 = ttnn.get_global_semaphore_address(global_sem1)
+    addrs2 = ttnn.get_global_semaphore_address(global_sem2)
+    addrs3 = ttnn.get_global_semaphore_address(global_sem3)
+    logger.debug(f"addrs0: {addrs0}, addrs1: {addrs1}, addrs2: {addrs2}, addrs3: {addrs3}")
+    assert len(set(addrs3)) == 1
+
+
+@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
+def test_global_semaphore_mesh_same_address(mesh_device, enable_async_mode):
+    if len(mesh_device.get_devices()) < 4:
+        pytest.skip("requires at least 4 devices to run")
+    run_global_semaphore_same_address(mesh_device)

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -104,6 +104,41 @@ void py_module(py::module& module) {
             )doc");
 
     module.def(
+        "create_global_semaphore_with_same_address",
+        [](MeshDevice* mesh_device,
+           const CoreRangeSet& cores,
+           uint32_t initial_value,
+           BufferType buffer_type,
+           const std::vector<SubDeviceId>& sub_device_ids,
+           uint32_t attempts,
+           bool search_max) {
+            return ttnn::global_semaphore::create_global_semaphore_with_same_address(
+                mesh_device, cores, initial_value, buffer_type, sub_device_ids, attempts, search_max);
+        },
+        py::arg("mesh_device"),
+        py::arg("cores"),
+        py::arg("initial_value"),
+        py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("attempts") = 1000,
+        py::arg("search_max") = false,
+        R"doc(
+            Create a GlobalSemaphore Object on multiple devices with the same address by iteratively creating global semaphore until alignment is found.
+            Fails if the address is not the same on all devices after the specified number of attempts.
+            Note: Temperary API until mesh allocator is implemented.
+
+            Args:
+                mesh_device (MeshDevice): The mesh device on which to create the global semaphore.
+                cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
+                initial_value (int): The initial value of the global semaphore.
+                buffer_type (BufferType): The type of buffer to use for the global semaphore.
+                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
+                attempts (int): The number of attempts to create the global semaphore with the same address.
+                Defaults to waiting on all sub-devices.
+                search_max (bool): Whether to search for the maximum address. (default: False, which searches for the minimum address)
+            )doc");
+
+    module.def(
         "get_global_semaphore_address",
         py::overload_cast<const MultiDeviceGlobalSemaphore&>(&get_global_semaphore_address),
         py::arg("global_semaphore"),

--- a/ttnn/cpp/ttnn/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn/global_semaphore.cpp
@@ -51,6 +51,89 @@ MultiDeviceGlobalSemaphore create_global_semaphore(
     }
     return multi_device_global_semaphore;
 }
+MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
+    MeshDevice* mesh_device,
+    const CoreRangeSet& cores,
+    uint32_t initial_value,
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    uint32_t attempts,
+    bool search_max) {
+    MultiDeviceGlobalSemaphore multi_device_global_semaphore(mesh_device);
+    const auto& devices = mesh_device->get_devices();
+    for (uint32_t i = 0; i < devices.size(); ++i) {
+        auto* device = devices[i];
+        multi_device_global_semaphore.global_semaphores.push_back(
+            create_global_semaphore(device, cores, initial_value, buffer_type, sub_device_ids));
+    }
+
+    auto global_semaphores = multi_device_global_semaphore.global_semaphores;
+    auto first_addr = get_global_semaphore_address(global_semaphores.front());
+    bool all_same = std::all_of(global_semaphores.begin(), global_semaphores.end(), [first_addr](const auto& sem) {
+        return get_global_semaphore_address(sem) == first_addr;
+    });
+
+    if (!all_same) {
+        tt::log_debug("chkpt 1, attempts: {}", attempts);
+        DeviceAddr target_addr = get_global_semaphore_address(global_semaphores.front());
+        for (auto i = 1; i < global_semaphores.size(); i++) {
+            tt::log_debug(
+                "chkpt 1.1, i: {}, global_semaphores[i]->address(): {}",
+                i,
+                get_global_semaphore_address(global_semaphores[i]));
+            if (search_max) {
+                if (get_global_semaphore_address(global_semaphores[i]) > target_addr) {
+                    target_addr = get_global_semaphore_address(global_semaphores[i]);
+                }
+            } else {
+                if (get_global_semaphore_address(global_semaphores[i]) < target_addr) {
+                    target_addr = get_global_semaphore_address(global_semaphores[i]);
+                }
+            }
+        };
+        tt::log_debug("chkpt 2, target_addr: {}", target_addr);
+        for (auto i = 0; i < global_semaphores.size(); i++) {
+            auto* device = devices[i];
+            tt::log_debug("pushed, i: {}", i);
+            device->push_work([i,
+                               device,
+                               attempts,
+                               target_addr,
+                               &cores,
+                               initial_value,
+                               buffer_type,
+                               sub_device_ids,
+                               global_semaphore = &multi_device_global_semaphore.global_semaphores[i]] {
+                size_t attempt = 0;
+                std::vector<GlobalSemaphore> garbage;
+                tt::log_debug("global_semaphore->address(): {}", get_global_semaphore_address(*global_semaphore));
+                while (get_global_semaphore_address(*global_semaphore) != target_addr) {
+                    auto sem = create_global_semaphore(device, cores, initial_value, buffer_type, sub_device_ids);
+
+                    if (i == 0) {
+                        tt::log_debug("chkpt 3, sem->address(): {}", get_global_semaphore_address(sem));
+                    }
+
+                    if (get_global_semaphore_address(sem) == target_addr) {
+                        *global_semaphore = std::move(sem);
+                    } else {
+                        garbage.push_back(std::move(sem));
+                        attempt++;
+                    }
+
+                    if (attempt > attempts) {
+                        TT_THROW("Failed to create global semaphores with the same address");
+                    }
+                }
+            });
+        }
+        for (auto device : devices) {
+            device->synchronize();
+        }
+    }
+
+    return multi_device_global_semaphore;
+}
 std::vector<tt::tt_metal::DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSemaphore& global_semaphore) {
     std::vector<tt::tt_metal::DeviceAddr> addresses(global_semaphore.global_semaphores.size());
     const auto& global_semaphores = global_semaphore.global_semaphores;

--- a/ttnn/cpp/ttnn/global_semaphore.hpp
+++ b/ttnn/cpp/ttnn/global_semaphore.hpp
@@ -37,7 +37,14 @@ MultiDeviceGlobalSemaphore create_global_semaphore(
     uint32_t initial_value,
     BufferType buffer_type = BufferType::L1,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
-
+MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
+    MeshDevice* mesh_device,
+    const CoreRangeSet& cores,
+    uint32_t initial_value,
+    BufferType buffer_type,
+    tt::stl::Span<const SubDeviceId> sub_device_ids,
+    uint32_t attempts,
+    bool search_max = false);
 std::vector<tt::tt_metal::DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSemaphore& global_semaphore);
 
 void reset_global_semaphore_value(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -3,29 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "all_gather_async.hpp"
+#include <utility>
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
     const ttnn::Tensor& input_tensor,
     const int32_t dim,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const ttnn::ccl::Topology topology,
     std::optional<SubDeviceId> subdevice_id,
-    bool enable_persistent_fabric_mode,
-    bool create_semaphore_handles) {
+    bool enable_persistent_fabric_mode) {
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensor,
         dim,
+        multi_device_global_semaphore,
         num_links,
         memory_config,
         topology,
         subdevice_id,
-        enable_persistent_fabric_mode,
-        create_semaphore_handles);
+        enable_persistent_fabric_mode);
 }
 
 ttnn::Tensor ExecuteAllGatherAsync::invoke(
@@ -34,22 +36,22 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     const uint32_t cluster_axis,
     const MeshDevice& mesh_device,
     const ttnn::ccl::Topology topology,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<size_t> num_preferred_links,
     std::optional<SubDeviceId> subdevice_id,
-    bool enable_persistent_fabric_mode,
-    bool create_semaphore_handles) {
+    bool enable_persistent_fabric_mode) {
     return ttnn::operations::experimental::ccl::all_gather_async(
         input_tensor,
         dim,
         cluster_axis,
         mesh_device,
         topology,
+        multi_device_global_semaphore,
         memory_config,
         num_preferred_links,
         subdevice_id,
-        enable_persistent_fabric_mode,
-        create_semaphore_handles);
+        enable_persistent_fabric_mode);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 namespace ttnn {
 namespace operations::experimental::ccl {
@@ -14,12 +15,12 @@ struct ExecuteAllGatherAsync {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const int32_t dim,
+        const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
         std::optional<SubDeviceId> subdevice_id = std::nullopt,
-        bool enable_persistent_fabric_mode = false,
-        bool create_semaphore_handles = true);
+        bool enable_persistent_fabric_mode = false);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
@@ -27,11 +28,11 @@ struct ExecuteAllGatherAsync {
         const uint32_t cluster_axis,
         const MeshDevice& mesh_device,
         const ttnn::ccl::Topology topology,
+        const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<size_t> num_preferred_links = std::nullopt,
         std::optional<SubDeviceId> subdevice_id = std::nullopt,
-        bool enable_persistent_fabric_mode = false,
-        bool create_semaphore_handles = true);
+        bool enable_persistent_fabric_mode = false);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::experimental::ccl {
 
@@ -28,31 +29,31 @@ void bind_all_gather_async(pybind11::module& module, const ccl_operation_t& oper
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const int32_t dim,
+               const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const ttnn::ccl::Topology topology,
                std::optional<SubDeviceId> subdevice_id,
-               bool enable_persistent_fabric_mode,
-               bool create_semaphore_handles) -> ttnn::Tensor {
+               bool enable_persistent_fabric_mode) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     dim,
+                    multi_device_global_semaphore,
                     num_links,
                     memory_config,
                     topology,
                     subdevice_id,
-                    enable_persistent_fabric_mode,
-                    create_semaphore_handles);
+                    enable_persistent_fabric_mode);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
+            py::arg("multi_device_global_semaphore"),
             py::kw_only(),
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt,
             py::arg("topology") = ttnn::ccl::Topology::Ring,
             py::arg("subdevice_id") = std::nullopt,
-            py::arg("enable_persistent_fabric_mode") = false,
-            py::arg("create_semaphore_handles") = true},
+            py::arg("enable_persistent_fabric_mode") = false},
 
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
@@ -61,34 +62,34 @@ void bind_all_gather_async(pybind11::module& module, const ccl_operation_t& oper
                const uint32_t cluster_axis,
                const MeshDevice& mesh_device,
                const ttnn::ccl::Topology topology,
+               const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
                const std::optional<size_t> num_preferred_links,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SubDeviceId> subdevice_id,
-               bool enable_persistent_fabric_mode,
-               bool create_semaphore_handles) -> ttnn::Tensor {
+               bool enable_persistent_fabric_mode) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     dim,
                     cluster_axis,
                     mesh_device,
                     topology,
-                    memory_config,                  // = std::nullopt,
-                    num_preferred_links,            // = std::nullopt,
-                    subdevice_id,                   // = std::nullopt,
-                    enable_persistent_fabric_mode,  // = false,
-                    create_semaphore_handles);
+                    multi_device_global_semaphore,
+                    memory_config,                   // = std::nullopt,
+                    num_preferred_links,             // = std::nullopt,
+                    subdevice_id,                    // = std::nullopt,
+                    enable_persistent_fabric_mode);  // = false,
             },
             py::arg("input_tensor"),
             py::arg("dim"),
             py::arg("cluster_axis"),
             py::arg("mesh_device"),
             py::arg("topology"),
+            py::arg("multi_device_global_semaphore"),
             py::kw_only(),
             py::arg("num_links") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
             py::arg("subdevice_id") = std::nullopt,
-            py::arg("enable_persistent_fabric_mode") = false,
-            py::arg("create_semaphore_handles") = true});
+            py::arg("enable_persistent_fabric_mode") = false});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
 #include "tt_metal/impl/buffers/global_semaphore.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 #include "ttnn/run_operation.hpp"
 
@@ -34,7 +35,7 @@ struct AllGatherAsync {
     const uint32_t ring_index;
     const MemoryConfig output_mem_config;
     const ccl::Topology topology;
-    const std::optional<GlobalSemaphore> semaphore;
+    const GlobalSemaphore semaphore;
     bool enable_persistent_fabric_mode;
 
     AllGatherAsync(
@@ -46,7 +47,7 @@ struct AllGatherAsync {
         uint32_t ring_index,
         MemoryConfig output_mem_config,
         ccl::Topology topology,
-        std::optional<GlobalSemaphore> semaphore,
+        GlobalSemaphore semaphore,
         bool enable_persistent_fabric_mode) :
         forward_device(forward_device),
         backward_device(backward_device),
@@ -92,7 +93,7 @@ AllGatherAsync create_all_gather_async_struct(
     const std::optional<MemoryConfig>& memory_config,
     const std::vector<IDevice*>& devices,
     const ccl::Topology topology,
-    const std::optional<std::vector<GlobalSemaphore>>& semaphores,
+    const std::vector<GlobalSemaphore>& semaphores,
     bool enable_persistent_fabric_mode);
 }  // namespace all_gather_async_detail
 }  // namespace ccl
@@ -108,7 +109,7 @@ operation::ProgramWithCallbacks all_gather_async_multi_core_with_workers(
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const std::optional<GlobalSemaphore>& semaphore_opt,
+    const GlobalSemaphore semaphore,
     bool enable_persistent_fabric_mode);
 
 namespace operations {
@@ -118,12 +119,12 @@ namespace ccl {
 Tensor all_gather_async(
     const Tensor& input_tensor,
     const uint32_t dim,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
     const uint32_t num_links = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
     std::optional<SubDeviceId> subdevice_id = std::nullopt,
-    bool enable_persistent_fabric_mode = false,
-    bool create_semaphore_handles = true);  // TODO make reference
+    bool enable_persistent_fabric_mode = false);  // TODO make reference
 
 Tensor all_gather_async(
     const Tensor& input_tensor,
@@ -131,11 +132,11 @@ Tensor all_gather_async(
     const uint32_t cluster_axis,
     const MeshDevice& mesh_device,
     const ttnn::ccl::Topology topology,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<size_t> num_preferred_links = std::nullopt,
     std::optional<SubDeviceId> subdevice_id = std::nullopt,
-    bool enable_persistent_fabric_mode = false,
-    bool create_semaphore_handles = true);
+    bool enable_persistent_fabric_mode = false);
 
 }  // namespace ccl
 }  // namespace experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
@@ -144,15 +144,11 @@ operation::ProgramWithCallbacks all_gather_async_multi_core_with_workers(
     const uint32_t ring_size,
     const uint32_t ring_index,
     ccl::Topology topology,
-    const std::optional<GlobalSemaphore>& semaphore_opt,
+    const GlobalSemaphore semaphore,
     bool enable_persistent_fabric_mode) {
     tt::tt_metal::Program program{};
     const bool enable_async_output_tensor = false;
     const bool lower_command_stream_to_noc_commands = can_command_stream_be_lowered_to_noc_commands(input_tensor);
-
-    TT_FATAL(semaphore_opt.has_value(), "Semaphore is required for compile time");
-
-    const auto& semaphore = semaphore_opt.value();
 
     IDevice* device = input_tensor.device();
     bool is_first_chip = ring_index == 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -2187,16 +2187,10 @@ operation::ProgramWithCallbacks build_reduce_scatter_async_program(
     const uint32_t line_index,
     ttnn::ccl::Topology topology,
     std::optional<size_t> num_links_preferred,
-    std::optional<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> const& from_remote_sem_opt,
-    std::optional<std::shared_ptr<const tt::tt_metal::GlobalSemaphore>> const& to_remote_sem_opt,
+    std::shared_ptr<const tt::tt_metal::GlobalSemaphore> const& from_remote_sem,
+    std::shared_ptr<const tt::tt_metal::GlobalSemaphore> const& to_remote_sem,
     std::optional<ttnn::ccl::EdmLineFabricOpInterface>& fabric_handle_) {
     auto program = tt::tt_metal::Program();
-
-    TT_FATAL(from_remote_sem_opt.has_value(), "Semaphore handle is required for compile time");
-    TT_FATAL(to_remote_sem_opt.has_value(), "Semaphore handle is required for compile time");
-
-    auto from_remote_sem = from_remote_sem_opt.value();
-    auto to_remote_sem = to_remote_sem_opt.value();
 
     bool persistent_fabric = true;
     IDevice* device = input_tensor.device();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter.cpp
@@ -5,28 +5,31 @@
 #include "reduce_scatter.hpp"
 
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor ExecuteReduceScatter::invoke(
     const ttnn::Tensor& input_tensor,
     const int32_t dim,
+    const global_semaphore::MultiDeviceGlobalSemaphore& from_remote_multi_device_global_semaphore,
+    const global_semaphore::MultiDeviceGlobalSemaphore& to_remote_multi_device_global_semaphore,
     ttnn::operations::reduction::ReduceType math_op,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     ttnn::ccl::Topology topology,
     const std::optional<size_t> num_preferred_links,
-    std::optional<SubDeviceId> worker_subdevice_id_opt,
-    bool create_semaphore_handles) {
+    std::optional<SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
     return ttnn::operations::experimental::ccl::reduce_scatter(
         input_tensor,
         dim,
+        from_remote_multi_device_global_semaphore,
+        to_remote_multi_device_global_semaphore,
         math_op,
         out_memory_config,
         topology,
         num_preferred_links,
-        worker_subdevice_id_opt,
-        create_semaphore_handles);
+        worker_subdevice_id_opt);
 }
 
 ttnn::Tensor ExecuteReduceScatter::invoke(
@@ -34,24 +37,26 @@ ttnn::Tensor ExecuteReduceScatter::invoke(
     const int32_t dim,
     const uint32_t cluster_axis,
     const MeshDevice& mesh_device,
+    const global_semaphore::MultiDeviceGlobalSemaphore& from_remote_multi_device_global_semaphore,
+    const global_semaphore::MultiDeviceGlobalSemaphore& to_remote_multi_device_global_semaphore,
     ttnn::operations::reduction::ReduceType math_op,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     ttnn::ccl::Topology topology,
     const std::optional<size_t> num_preferred_links,
-    std::optional<SubDeviceId> worker_subdevice_id_opt,
-    bool create_semaphore_handles) {
+    std::optional<SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
     return ttnn::operations::experimental::ccl::reduce_scatter(
         input_tensor,
         dim,
         cluster_axis,
         mesh_device,
+        from_remote_multi_device_global_semaphore,
+        to_remote_multi_device_global_semaphore,
         math_op,
         out_memory_config,
         topology,
         num_preferred_links,
-        worker_subdevice_id_opt,
-        create_semaphore_handles);
+        worker_subdevice_id_opt);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 
 #include "ttnn/cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 namespace ttnn {
 namespace operations {
@@ -20,24 +21,26 @@ struct ExecuteReduceScatter {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const int32_t dim,
+        const global_semaphore::MultiDeviceGlobalSemaphore& from_remote_multi_device_global_semaphore,
+        const global_semaphore::MultiDeviceGlobalSemaphore& to_remote_multi_device_global_semaphore,
         ttnn::operations::reduction::ReduceType math_op,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
         const std::optional<size_t> num_links = std::nullopt,
-        std::optional<SubDeviceId> worker_subdevice_id_opt = std::nullopt,
-        bool create_semaphore_handles = true);
+        std::optional<SubDeviceId> worker_subdevice_id_opt = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const int32_t dim,
         const uint32_t cluster_axis,
         const MeshDevice& mesh_device,
+        const global_semaphore::MultiDeviceGlobalSemaphore& from_remote_multi_device_global_semaphore,
+        const global_semaphore::MultiDeviceGlobalSemaphore& to_remote_multi_device_global_semaphore,
         ttnn::operations::reduction::ReduceType math_op,
         const std::optional<ttnn::MemoryConfig>& memory_config,
         ttnn::ccl::Topology topology,
         const std::optional<size_t> num_preferred_links,
-        std::optional<SubDeviceId> worker_subdevice_id_opt,
-        bool create_semaphore_handles);
+        std::optional<SubDeviceId> worker_subdevice_id_opt);
 };
 
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/cpp/ttnn/global_semaphore.hpp"
 
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 
@@ -27,31 +28,34 @@ void bind_reduce_scatter(pybind11::module& module, const ccl_operation_t& operat
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,
                const int32_t dim,
+               const global_semaphore::MultiDeviceGlobalSemaphore& from_remote_multi_device_global_semaphore,
+               const global_semaphore::MultiDeviceGlobalSemaphore& to_remote_multi_device_global_semaphore,
                ttnn::operations::reduction::ReduceType math_op,
                const ttnn::MemoryConfig& memory_config,
                ttnn::ccl::Topology topology,
                const std::optional<size_t> num_links,
-               std::optional<SubDeviceId> worker_subdevice_id_opt,
-               bool create_semaphore_handles) -> ttnn::Tensor {
+               std::optional<SubDeviceId> worker_subdevice_id_opt) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     dim,
+                    from_remote_multi_device_global_semaphore,
+                    to_remote_multi_device_global_semaphore,
                     math_op,
                     memory_config,
                     topology,
                     num_links,
-                    worker_subdevice_id_opt,
-                    create_semaphore_handles);
+                    worker_subdevice_id_opt);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
+            py::arg("from_remote_multi_device_global_semaphore"),
+            py::arg("to_remote_multi_device_global_semaphore"),
             py::arg("math_op"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("topology") = ttnn::ccl::Topology::Linear,
             py::arg("num_links") = std::nullopt,
-            py::arg("subdevice_id") = std::nullopt,
-            py::arg("create_semaphore_handles") = true},
+            py::arg("subdevice_id") = std::nullopt},
 
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
@@ -59,35 +63,38 @@ void bind_reduce_scatter(pybind11::module& module, const ccl_operation_t& operat
                const int32_t dim,
                const uint32_t cluster_axis,
                const MeshDevice& mesh_device,
+               const global_semaphore::MultiDeviceGlobalSemaphore& from_remote_multi_device_global_semaphore,
+               const global_semaphore::MultiDeviceGlobalSemaphore& to_remote_multi_device_global_semaphore,
                ttnn::operations::reduction::ReduceType math_op,
                const ttnn::MemoryConfig& memory_config,
                ttnn::ccl::Topology topology,
                const std::optional<size_t> num_links,
-               std::optional<SubDeviceId> worker_subdevice_id_opt,
-               bool create_semaphore_handles) -> ttnn::Tensor {
+               std::optional<SubDeviceId> worker_subdevice_id_opt) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     dim,
                     cluster_axis,
                     mesh_device,
+                    from_remote_multi_device_global_semaphore,
+                    to_remote_multi_device_global_semaphore,
                     math_op,
                     memory_config,
                     topology,
                     num_links,
-                    worker_subdevice_id_opt,
-                    create_semaphore_handles);
+                    worker_subdevice_id_opt);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
             py::arg("cluster_axis"),
             py::arg("mesh_device"),
+            py::arg("from_remote_multi_device_global_semaphore"),
+            py::arg("to_remote_multi_device_global_semaphore"),
             py::arg("math_op"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("topology") = ttnn::ccl::Topology::Linear,
             py::arg("num_links") = std::nullopt,
-            py::arg("subdevice_id") = std::nullopt,
-            py::arg("create_semaphore_handles") = true});
+            py::arg("subdevice_id") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -110,6 +110,7 @@ from ttnn._ttnn.global_semaphore import (
     create_global_semaphore,
     get_global_semaphore_address,
     reset_global_semaphore_value,
+    create_global_semaphore_with_same_address,
 )
 
 from ttnn.types import (


### PR DESCRIPTION
### Ticket
#16396
#16398

### Problem description
To avoid memory leak and resource ownership concerns with global semaphore, we for now must construct CCL op global semaphores outside of op invocations. This is a prerequisite for proper end-to-end integration into the Llama demo. In addition, I created a new global semaphore pybind function called `create_global_semaphore_with_same_address` which tries to create global semaphores such that the addresses are aligned. 

### What's changed
- [x] Expose global semaphore creation function, that reuses existing all-gather and reduce-scatter global semaphore creation logic, to return the global semaphores to caller. Update the op arguments to expect the global semaphore handle.
- [x] Update tests to use new API (replace the old one)
- [x] added `create_global_semaphore_with_same_address`

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12656707760
- [x] T3K Frequent and Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12656720813
- [x] TG Frequent and Unit: https://github.com/tenstorrent/tt-metal/actions/runs/12656729498