### PR TITLE
Add native N-dimensional tiled-interleaved permute support when the tiles are now broken.

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -329,3 +329,26 @@ def test_permute_4d_cnwh(shape, device):
     torch_output = torch.permute(torch_tensor, (1, 0, 3, 2))
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("shape", [[2, 2, 2, 2, 2, 2, 32, 32]])
+@pytest.mark.parametrize("dims", [(5, 4, 3, 2, 1, 0, 7, 6), (5, 4, 3, 2, 1, 0, 6, 7)])
+def test_permute_8d_swapped(shape, dims, device):
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, dims)
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, dims)
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("shape", [[1, 1, 32, 32]])
+def test_permute_identity(shape, device):
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (0, 1, 2, 3))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (0, 1, 2, 3))
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -270,3 +270,62 @@ def test_nil_volume_permute(device):
     torch_output = torch.permute(torch_tensor, (0, 1, 3, 2))
     assert torch_output.shape == output_tensor.shape
     assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+def test_permute_5d_tiled_basic(device):
+    torch_tensor = torch.rand([10, 10, 10, 100, 100], dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (2, 1, 0, 3, 4))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (2, 1, 0, 3, 4))
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+def test_permute_5d_tiled_swap(device):
+    torch_tensor = torch.rand([10, 10, 10, 100, 100], dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (2, 1, 0, 4, 3))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (2, 1, 0, 4, 3))
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [32, 32, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 64, 64]]
+)
+def test_permute_4d_cn(shape, device):
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (1, 0, 2, 3))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (1, 0, 2, 3))
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [32, 32, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 64, 64]]
+)
+def test_permute_4d_wh(shape, device):
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (0, 1, 3, 2))
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "shape", [[1, 1, 32, 32], [2, 2, 32, 32], [32, 32, 32, 32], [1, 1, 64, 64], [2, 2, 64, 64], [32, 32, 64, 64]]
+)
+def test_permute_4d_cnwh(shape, device):
+    torch_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.permute(input_tensor, (1, 0, 3, 2))
+    output_tensor = ttnn.to_torch(output_tensor)
+    torch_output = torch.permute(torch_tensor, (1, 0, 3, 2))
+    assert torch_output.shape == output_tensor.shape
+    assert_with_pcc(torch_output, output_tensor, 0.9999)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -72,7 +72,8 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/permute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/permute_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/device/repeat_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/repeat.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr bool src_is_dram = (bool)get_compile_time_arg_val(0);
+    constexpr uint32_t N = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(3);
+
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile = get_arg_val<uint32_t>(1);
+    const uint32_t end_tile = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    // start at runtime arg 3 since address/start_block/end_block make up the first 3 args
+    uint32_t output_tiled_shape[N], inv_perm[N], src_strides[N];
+    for (uint32_t i = 3; i < N + 3; i++) {
+        output_tiled_shape[i - 3] = get_arg_val<uint32_t>(i);
+        inv_perm[i - 3] = get_arg_val<uint32_t>(i + N);
+        src_strides[i - 3] = get_arg_val<uint32_t>(i + 2 * N);
+    }
+
+    uint32_t src_buffer_l1_addr = get_write_ptr(tt::CBIndex::c_0);
+    uint32_t curr_addr = src_addr;
+    for (uint32_t tile = start_tile; tile < end_tile; ++tile) {
+        // Compute multi-dimensional index for the source tile
+        uint32_t dest_multi_idx[N];
+        size_t remaining = tile;
+        for (uint32_t i = 0; i < N; ++i) {
+            size_t dim = N - 1 - i;
+            dest_multi_idx[dim] = remaining % output_tiled_shape[dim];
+            remaining /= output_tiled_shape[dim];
+        }
+
+        // Apply permutation to get destination multi-dimensional index
+        uint32_t src_multi_idx[N];
+        for (uint32_t i = 0; i < N; ++i) {
+            src_multi_idx[i] = dest_multi_idx[inv_perm[i]];
+        }
+
+        // Convert destination multi-dimensional index to linear index
+        uint32_t src_linear_idx = 0;
+        for (uint32_t i = 0; i < N; ++i) {
+            src_linear_idx += src_multi_idx[i] * src_strides[i];
+        }
+
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(src_linear_idx, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_invariant.cpp
@@ -6,7 +6,7 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr bool src_is_dram = (bool)get_compile_time_arg_val(0);
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t N = get_compile_time_arg_val(1);
     constexpr uint32_t page_size = get_compile_time_arg_val(2);
     constexpr uint32_t num_tiles = get_compile_time_arg_val(3);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -27,10 +27,6 @@ PermuteDeviceOperation::program_factory_t PermuteDeviceOperation::select_program
             (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
             return MultiCoreTileInvariant{};
         }
-        // else if (operation_attributes.dims[rank - 1] == tensor_args.input_tensor.get_logical_shape().rank() - 1) {
-        //     return MultiCoreTiledRowInvariant{};
-        // }
-        // return MultiCoreTiledGeneric{};
     }
     return MultiCoreBlockedGeneric{};
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -12,22 +12,43 @@ namespace ttnn::operations::data_movement {
 
 PermuteDeviceOperation::program_factory_t PermuteDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // If the last dimension is not permuted, we can use the row-invariant kernel
-    if (operation_attributes.dims.back() == tensor_args.input_tensor.get_logical_shape().rank() - 1) {
-        return MultiCoreRowInvariant{};
+    auto& dims = operation_attributes.dims;
+    if (tensor_args.input_tensor.get_layout() == Layout::ROW_MAJOR) {
+        // If the last dimension is not permuted, we can use the row-invariant kernel
+        if (dims.back() == tensor_args.input_tensor.get_logical_shape().rank() - 1) {
+            return MultiCoreRowInvariant{};
+        }
+        // Otherwise, we need to use the blocked generic, row moving kernel
+        return MultiCoreBlockedGeneric{};
+    } else {
+        // If the input tensor is not row-major, we need to use the tiled kernels
+        uint32_t rank = tensor_args.input_tensor.get_logical_shape().rank();
+        if ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2) ||
+            (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
+            return MultiCoreTileInvariant{};
+        }
+        // else if (operation_attributes.dims[rank - 1] == tensor_args.input_tensor.get_logical_shape().rank() - 1) {
+        //     return MultiCoreTiledRowInvariant{};
+        // }
+        // return MultiCoreTiledGeneric{};
     }
-    // Otherwise, we need to use the blocked generic, row moving kernel
     return MultiCoreBlockedGeneric{};
 }
 
 void PermuteDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    auto& dims = attributes.dims;
+    auto rank = tensor_args.input_tensor.get_logical_shape().rank();
     TT_FATAL(
         attributes.dims.size() == tensor_args.input_tensor.get_logical_shape().rank(),
         "Permute dimensions must match input tensor rank");
     TT_FATAL(tensor_args.input_tensor.is_sharded() == false, "Permute operation does not support sharded input tensor");
     TT_FATAL(
-        tensor_args.input_tensor.get_layout() == Layout::ROW_MAJOR, "Permute operation only supports row-major layout");
+        tensor_args.input_tensor.get_layout() == Layout::ROW_MAJOR ||
+            (tensor_args.input_tensor.get_layout() == Layout::TILE &&
+             ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2) ||
+              (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1))),
+        "Permute operation only supports row-major layout");
 }
 
 void PermuteDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -94,52 +94,6 @@ struct PermuteDeviceOperation {
             tensor_return_value_t& tensor_return_value);
     };
 
-    // struct MultiCoreTiledRowInvariant {
-    //     // Shared variables are the variables that are shared between the create and override_runtime_arguments
-    //     methods struct shared_variables_t {
-    //         tt::tt_metal::KernelHandle unary_reader_kernel_id;
-    //         tt::tt_metal::KernelHandle unary_writer_kernel_id;
-    //         tt::tt_metal::KernelHandle compute_kernel_id;
-    //         CoreRangeSet core_range;
-    //     };
-    //     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    //     static cached_program_t create(
-    //         const operation_attributes_t& operation_attributes,
-    //         const tensor_args_t& tensor_args,
-    //         tensor_return_value_t& tensor_return_value);
-
-    //     static void override_runtime_arguments(
-    //         cached_program_t& cached_program,
-    //         const operation_attributes_t& operation_attributes,
-    //         const tensor_args_t& tensor_args,
-    //         tensor_return_value_t& tensor_return_value);
-    // };
-
-    // struct MultiCoreTiledGeneric {
-    //     // Shared variables are the variables that are shared between the create and override_runtime_arguments
-    //     methods struct shared_variables_t {
-    //         tt::tt_metal::KernelHandle unary_reader_kernel_id;
-    //         tt::tt_metal::KernelHandle unary_writer_kernel_id;
-    //         tt::tt_metal::KernelHandle compute_kernel_id;
-    //         CoreRangeSet core_range;
-    //     };
-    //     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    //     static cached_program_t create(
-    //         const operation_attributes_t& operation_attributes,
-    //         const tensor_args_t& tensor_args,
-    //         tensor_return_value_t& tensor_return_value);
-
-    //     static void override_runtime_arguments(
-    //         cached_program_t& cached_program,
-    //         const operation_attributes_t& operation_attributes,
-    //         const tensor_args_t& tensor_args,
-    //         tensor_return_value_t& tensor_return_value);
-    // };
-
-    // using program_factory_t = std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric, MultiCoreTileInvariant,
-    // MultiCoreTiledRowInvariant, MultiCoreTiledGeneric>;
     using program_factory_t = std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric, MultiCoreTileInvariant>;
 
     // Mandatory methods

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -72,8 +72,75 @@ struct PermuteDeviceOperation {
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
     };
+    struct MultiCoreTileInvariant {
+        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
+        struct shared_variables_t {
+            tt::tt_metal::KernelHandle unary_reader_kernel_id;
+            tt::tt_metal::KernelHandle unary_writer_kernel_id;
+            tt::tt_metal::KernelHandle compute_kernel_id;
+            CoreRangeSet core_range;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    using program_factory_t = std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric>;
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    // struct MultiCoreTiledRowInvariant {
+    //     // Shared variables are the variables that are shared between the create and override_runtime_arguments
+    //     methods struct shared_variables_t {
+    //         tt::tt_metal::KernelHandle unary_reader_kernel_id;
+    //         tt::tt_metal::KernelHandle unary_writer_kernel_id;
+    //         tt::tt_metal::KernelHandle compute_kernel_id;
+    //         CoreRangeSet core_range;
+    //     };
+    //     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    //     static cached_program_t create(
+    //         const operation_attributes_t& operation_attributes,
+    //         const tensor_args_t& tensor_args,
+    //         tensor_return_value_t& tensor_return_value);
+
+    //     static void override_runtime_arguments(
+    //         cached_program_t& cached_program,
+    //         const operation_attributes_t& operation_attributes,
+    //         const tensor_args_t& tensor_args,
+    //         tensor_return_value_t& tensor_return_value);
+    // };
+
+    // struct MultiCoreTiledGeneric {
+    //     // Shared variables are the variables that are shared between the create and override_runtime_arguments
+    //     methods struct shared_variables_t {
+    //         tt::tt_metal::KernelHandle unary_reader_kernel_id;
+    //         tt::tt_metal::KernelHandle unary_writer_kernel_id;
+    //         tt::tt_metal::KernelHandle compute_kernel_id;
+    //         CoreRangeSet core_range;
+    //     };
+    //     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    //     static cached_program_t create(
+    //         const operation_attributes_t& operation_attributes,
+    //         const tensor_args_t& tensor_args,
+    //         tensor_return_value_t& tensor_return_value);
+
+    //     static void override_runtime_arguments(
+    //         cached_program_t& cached_program,
+    //         const operation_attributes_t& operation_attributes,
+    //         const tensor_args_t& tensor_args,
+    //         tensor_return_value_t& tensor_return_value);
+    // };
+
+    // using program_factory_t = std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric, MultiCoreTileInvariant,
+    // MultiCoreTiledRowInvariant, MultiCoreTiledGeneric>;
+    using program_factory_t = std::variant<MultiCoreRowInvariant, MultiCoreBlockedGeneric, MultiCoreTileInvariant>;
 
     // Mandatory methods
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_rm_program_factory.cpp
@@ -15,7 +15,8 @@ uint32_t num_pages(const ttnn::Tensor& input_tensor) {
 }
 
 uint32_t page_size(const ttnn::Tensor& input_tensor) {
-    auto BUFFER_ALIGNMENT = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? DRAM_ALIGNMENT : L1_ALIGNMENT;
+    auto BUFFER_ALIGNMENT =
+        input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM ? DRAM_ALIGNMENT : L1_ALIGNMENT;
     const auto& shape = input_tensor.get_logical_shape();  // in anticipation of RM padding
     return tt::round_up(shape[-1] * input_tensor.element_size(), BUFFER_ALIGNMENT);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "noc/noc_parameters.h"  // DRAM_ALIGNMENT
+#include <vector>
+
+namespace ttnn::operations::data_movement {
+
+namespace detail {
+uint32_t tile_volume(const ttnn::Tensor& input_tensor) {
+    const auto& tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
+    return tile_shape[0] * tile_shape[1];
+}
+
+uint32_t num_tiles(const ttnn::Tensor& input_tensor) {
+    const auto& shape = input_tensor.get_padded_shape();
+    auto tile_vol = tile_volume(input_tensor);
+    return shape.volume() / tile_vol;
+}
+
+uint32_t tile_size(const ttnn::Tensor& input_tensor) { return tile_volume(input_tensor) * input_tensor.element_size(); }
+
+ttnn::SimpleShape get_tiled_shape(const ttnn::Tensor& input_tensor) {
+    const auto& tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
+    const auto& shape = input_tensor.get_padded_shape();
+    ttnn::SmallVector<uint32_t> tiled_shape;
+    tiled_shape.reserve(shape.rank());
+    for (int i = 0; i < shape.rank(); i++) {
+        uint32_t dim = 0;
+        if (i == shape.rank() - 1) {
+            dim = shape[i] / tile_shape[1];
+        } else if (i == shape.rank() - 2) {
+            dim = shape[i] / tile_shape[0];
+        } else {
+            dim = shape[i];
+        }
+        tiled_shape.push_back(dim);
+    }
+    auto res = ttnn::SimpleShape(tiled_shape);
+    return res;
+}
+
+ttnn::SmallVector<uint32_t> get_strides(const ttnn::SimpleShape& shape) {
+    ttnn::SmallVector<uint32_t> strides(shape.rank());
+    strides[shape.rank() - 1] = 1;
+    for (int i = shape.rank() - 2; i >= 0; i--) {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    return strides;
+}
+
+// Function to compute the inverse of a permutation
+ttnn::SmallVector<uint32_t> get_inverse_permutation(const ttnn::SmallVector<uint32_t>& perm) {
+    // Get the size of the permutation
+    size_t n = perm.size();
+
+    // Create a vector for the inverse permutation
+    ttnn::SmallVector<uint32_t> inverse_permutation(n);
+
+    // Validate the input permutation
+    ttnn::SmallVector<bool> seen(n, false);
+    for (size_t i = 0; i < n; ++i) {
+        if (perm[i] >= n || seen[perm[i]]) {
+            TT_FATAL(false, "Invalid permutation: duplicate or out of range value");
+        }
+        seen[perm[i]] = true;
+        inverse_permutation[perm[i]] = static_cast<uint32_t>(i);
+    }
+
+    return inverse_permutation;
+}
+
+}  // namespace detail
+
+PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOperation::MultiCoreTileInvariant::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor.buffer();
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    uint32_t input_page_size = detail::tile_size(input_tensor);
+
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    uint32_t output_page_size = detail::tile_size(tensor_return_value);
+
+    uint32_t num_tiles = detail::num_tiles(tensor_return_value);
+
+    tt::tt_metal::Device* device = input_tensor.device();
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t num_input_pages_to_read = 2;
+
+    uint32_t N = operation_attributes.dims.size();
+    bool swap_hw = operation_attributes.dims[N - 2] == N - 1 && operation_attributes.dims[N - 1] == N - 2;
+
+    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_pages_to_read * input_page_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, input_page_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t output_cb_index = src0_cb_index;
+    if (swap_hw) {
+        uint32_t src1_cb_index = tt::CBIndex::c_16;
+        tt::tt_metal::CircularBufferConfig cb_src1_config =
+            tt::tt_metal::CircularBufferConfig(
+                num_input_pages_to_read * input_page_size, {{src1_cb_index, cb_data_format}})
+                .set_page_size(src1_cb_index, input_page_size);
+        auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+        output_cb_index = src1_cb_index;
+    }
+
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, N, input_page_size, num_tiles};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/"
+        "reader_permute_interleaved_tiled_invariant.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index, (std::uint32_t)dst_is_dram};
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    uint32_t compute_kernel_id = 0;
+    if (swap_hw) {
+        std::vector<uint32_t> compute_kernel_args = {};
+        bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32;
+        compute_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp",
+            all_cores,
+            tt::tt_metal::ComputeConfig{
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .compile_args = compute_kernel_args,
+            });
+    }
+
+    // think of tensor as its tiled shape rather than its logical shape
+    auto output_tiled_shape = detail::get_tiled_shape(tensor_return_value);
+    auto input_tiled_shape = detail::get_tiled_shape(input_tensor);
+    auto output_shape_view = output_tiled_shape.view();
+
+    // read is less expensive than write, so read in order of output tensor, get relevant pre-permutation input tiles,
+    // and then write it out to determine index in input tensor we need the input strides
+    auto input_tile_strides = detail::get_strides(input_tiled_shape);
+
+    // we also need the inverse permutation to map back to input tensor
+    auto inv_perm = detail::get_inverse_permutation(operation_attributes.dims);
+
+    std::vector<uint32_t> reader_runtime_args = {src_buffer->address(), 0, 0};
+    reader_runtime_args.insert(reader_runtime_args.end(), output_shape_view.begin(), output_shape_view.end());
+    reader_runtime_args.insert(reader_runtime_args.end(), inv_perm.begin(), inv_perm.end());
+    reader_runtime_args.insert(reader_runtime_args.end(), input_tile_strides.begin(), input_tile_strides.end());
+
+    std::vector<uint32_t> writer_runtime_args = {dst_buffer->address(), 0, 0};
+    std::vector<uint32_t> compute_runtime_args = {0};
+
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
+    uint32_t start_tile = 0;
+    uint32_t num_tiles_per_core = 0;
+    for (const auto& core : cores) {
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op
+            num_tiles_per_core = 0;
+        }
+        uint32_t end_tile = start_tile + num_tiles_per_core;
+        reader_runtime_args[1] = start_tile;
+        reader_runtime_args[2] = end_tile;
+
+        writer_runtime_args[1] = num_tiles_per_core;     // for some reason num_tiles comes first in writer unary
+        writer_runtime_args[2] = start_tile;             // start tile is second in writer unary
+
+        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_runtime_args);
+        if (swap_hw) {
+            compute_runtime_args[0] = num_tiles_per_core;  // number of tiles transposed
+            tt::tt_metal::SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
+        }
+        start_tile = end_tile;
+    }
+
+    return {
+        std::move(program),
+        {.unary_reader_kernel_id = unary_reader_kernel_id, .unary_writer_kernel_id = unary_writer_kernel_id}};
+}
+
+void PermuteDeviceOperation::MultiCoreTileInvariant::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor.buffer();
+    auto& all_cores = cached_program.shared_variables.core_range;
+
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
+    for (const auto& core : cores) {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, core);
+        runtime_args[0] = src_buffer->address();
+        auto& runtime_args_writer = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, core);
+        runtime_args_writer[0] = dst_buffer->address();
+    }
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -98,7 +98,7 @@ PermuteDeviceOperation::MultiCoreTileInvariant::cached_program_t PermuteDeviceOp
 
     uint32_t num_tiles = detail::num_tiles(tensor_return_value);
 
-    tt::tt_metal::Device* device = input_tensor.device();
+    tt::tt_metal::IDevice* device = input_tensor.device();
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_pages_to_read = 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -172,27 +172,27 @@ bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& di
         return true;
     }
 
-    // 3) When the input is tiled, it is never a NOP if the last two dimensions are permuted. If the input is row major,
-    // it is never a NOP if the last dimension is permuted.
+    // 3) Otherwise, when the input is tiled, it is never a NOP if the last two dimensions are permuted. When it is row
+    // major, it is never a NOP if the last dimension is permuted.
     if (a.get_layout() == Layout::TILE && (dims[rank - 1] != rank - 1 || dims[rank - 2] != rank - 2)) {
         return false;
     } else if (a.get_layout() == Layout::ROW_MAJOR && dims[rank - 1] != rank - 1) {
         return false;
     }
 
-    // 4) Build permuted shape
+    // Build permuted shape
     const auto& shape = a.get_logical_shape();
     ttnn::SmallVector<uint32_t> perm_shape(rank);
     for (uint32_t i = 0; i < rank; ++i) {
         perm_shape[i] = shape[dims[i]];
     }
 
-    // 5) If the shape changed, definitely not a no-op
+    // 4) If the shape changed, definitely not a no-op
     if (perm_shape != shape) {
         return false;
     }
 
-    // 6) If the shape stayed the same, ensure we didn't
+    // 5) If the shape stayed the same, ensure we didn't
     //    relocate a dimension with size > 1
     for (uint32_t i = 0; i < rank; ++i) {
         const uint32_t j = dims[i];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -172,19 +172,27 @@ bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& di
         return true;
     }
 
-    // 3) Build permuted shape
+    // 3) When the input is tiled, it is never a NOP if the last two dimensions are permuted. If the input is row major,
+    // it is never a NOP if the last dimension is permuted.
+    if (a.get_layout() == Layout::TILE && (dims[rank - 1] != rank - 1 || dims[rank - 2] != rank - 2)) {
+        return false;
+    } else if (a.get_layout() == Layout::ROW_MAJOR && dims[rank - 1] != rank - 1) {
+        return false;
+    }
+
+    // 4) Build permuted shape
     const auto& shape = a.get_logical_shape();
     ttnn::SmallVector<uint32_t> perm_shape(rank);
     for (uint32_t i = 0; i < rank; ++i) {
         perm_shape[i] = shape[dims[i]];
     }
 
-    // 4) If the shape changed, definitely not a no-op
+    // 5) If the shape changed, definitely not a no-op
     if (perm_shape != shape) {
         return false;
     }
 
-    // 5) If the shape stayed the same, ensure we didn't
+    // 6) If the shape stayed the same, ensure we didn't
     //    relocate a dimension with size > 1
     for (uint32_t i = 0; i < rank; ++i) {
         const uint32_t j = dims[i];

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -35,19 +35,23 @@ ttnn::Tensor permute_impl(
     // Get the device
     IDevice* device = a.device();
     uint32_t rank = a.get_shape().rank();
+
+    auto prim_permute = [&](const ttnn::Tensor& input) -> ttnn::Tensor {
+        return ttnn::prim::permute(input, dims, output_mem_config, std::nullopt);
+    };
+
     if (rank > 4) {
         if (a.get_layout() == Layout::TILE && ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2)) ||
             (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
-            return ttnn::prim::permute(a, dims, output_mem_config, std::nullopt);
+            return prim_permute(a);
         }
-
         auto input = a.get_layout() == Layout::TILE
                          ? ttnn::to_layout(a, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr)
                          : a;
         TT_FATAL(
             !(pad_value.has_value() && pad_value.value() != 0.0f),
             "Non-zero padding is not supported for permute on tensors with rank > 4.");
-        input = ttnn::prim::permute(input, dims, output_mem_config, std::nullopt);
+        input = prim_permute(input);
         return ttnn::to_layout(input, a.get_layout(), std::nullopt, std::nullopt, (IDevice*)nullptr);
     }
 
@@ -92,7 +96,7 @@ ttnn::Tensor permute_impl(
     } else if (N == 1 && C == 0 && H == 2 && W == 3) {
         output = transpose_cn(formatted_input_tensor);
     } else if (N == 1 && C == 0 && H == 3 && W == 2) {
-        output = transpose_wh(transpose_cn(formatted_input_tensor));
+        output = prim_permute(formatted_input_tensor);
     } else if (N == 1 && C == 2 && H == 0 && W == 3) {
         output = transpose_hc(transpose_cn(formatted_input_tensor));
     } else if (N == 1 && C == 2 && H == 3 && W == 0) {
@@ -155,13 +159,46 @@ ttnn::Tensor permute_launch(
 }
 
 bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& dims) {
-    if (a.get_shape().rank() <= 1) {
+    // 1) Trivial early-out for rank <= 1
+    const auto rank = a.get_logical_shape().rank();
+    if (rank <= 1) {
         return true;
     }
-    auto normalized_dims = ttnn::SmallVector<uint32_t>(dims.begin(), dims.end());
-    ttnn::SmallVector<uint32_t> seq_dims(dims.size());
+
+    // 2) Check for identity permutation
+    ttnn::SmallVector<uint32_t> seq_dims(rank);
     std::iota(seq_dims.begin(), seq_dims.end(), 0);
-    return normalized_dims == seq_dims;
+    if (dims == seq_dims) {
+        return true;
+    }
+
+    // 3) Build permuted shape
+    const auto& shape = a.get_logical_shape();
+    ttnn::SmallVector<uint32_t> perm_shape(rank);
+    for (uint32_t i = 0; i < rank; ++i) {
+        perm_shape[i] = shape[dims[i]];
+    }
+
+    // 4) If the shape changed, definitely not a no-op
+    if (perm_shape != shape) {
+        return false;
+    }
+
+    // 5) If the shape stayed the same, ensure we didn't
+    //    relocate a dimension with size > 1
+    for (uint32_t i = 0; i < rank; ++i) {
+        const uint32_t j = dims[i];
+        if (i != j && shape[i] > 1) {
+            // Moved a dimension that has > 1 elements
+            // => layout changed => not a no-op.
+            return false;
+        }
+    }
+
+    // If we made it here, we either
+    //    - only moved dimensions of size 1, or
+    //    - didn't move anything at all
+    return true;
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -34,8 +34,13 @@ ttnn::Tensor permute_impl(
 
     // Get the device
     IDevice* device = a.device();
+    uint32_t rank = a.get_shape().rank();
+    if (rank > 4) {
+        if (a.get_layout() == Layout::TILE && ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2)) ||
+            (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
+            return ttnn::prim::permute(a, dims, output_mem_config, std::nullopt);
+        }
 
-    if (a.get_shape().rank() > 4) {
         auto input = a.get_layout() == Layout::TILE
                          ? ttnn::to_layout(a, Layout::ROW_MAJOR, std::nullopt, std::nullopt, (IDevice*)nullptr)
                          : a;


### PR DESCRIPTION
### Ticket
#16465

### Problem description
Part 1 of 3 PRs to add native, generic, and performant support for tiled, interleaved input tensors.

The 3 PRs will address the following cases:

Three part PR is described by #16464.

1. The first case adds support for the N-dimensional permute of tiled, interleaved tensors where the tile is not broken apart.
2. The second case adds support for the N-dimensional permute of tiled, interleaved tensors where the tile height (H) can be broken apart.
3. The third case adds support for the N-dimensional permute of tiled, interleaved tensors where any dimension can swap with any other dimension.

1 -> 3 is most performant to least performant, least complex to write to most complex to write, and least generic to most generic. It is also the order in which the PRs will be formed.

### What's changed
This PR adds support for the N-dimensional permute of tensors where tiles are not broken apart, which is case 1 under Problem description. I also added more NOP checks to improve the performance of several cases.

This (+ some tilize fixes) increases Pytorch2 permute sweep coverage from 86% to 94.5%.

Performance is improved for the case where both CN and WH are transpose (permute dims = {1, 0, 3, 2})
- for transpose CN and WH (perm dims = (1, 0, 3, 2)) on a 32x32x64x64 input, it's 92.7% faster
- for transpose CN and WH (perm dims = (1, 0, 3, 2)) on a 2x2x32x32 input, it's  47% faster

### Checklist
- [ ] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12642953569
- [x] Blackhole Post commit https://github.com/tenstorrent/tt-metal/actions/runs/12605027320
- [x] Model regression CI testing passes https://github.com/tenstorrent/tt-metal/actions/runs/12636379370
- [x] Device performance regression CI testing passes https://github.com/tenstorrent/tt-metal/actions/runs/12636351385/job/35208572133 (matches MNIST failure on main)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
