### PR TITLE
#16171: Assert that NCRISC NOC is idle at kernel end.

### DIFF
--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -32,4 +32,15 @@ void kernel_launch(uint32_t kernel_base_addr) {
     noc_local_state_init(NOC_INDEX);
 
     kernel_main();
+    if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
+        WAYPOINT("NKFW");
+        // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC
+        // interface is in a known idle state for the next kernel.
+        ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
+        ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
+        ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
+        ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
+        ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+        WAYPOINT("NKFD");
+    }
 }

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -47,5 +47,16 @@ void kernel_launch(uint32_t kernel_base_addr) {
     ALIGN_LOCAL_CBS_TO_REMOTE_CBS
 #endif
     kernel_main();
+    if constexpr (NOC_MODE == DM_DEDICATED_NOC) {
+        WAYPOINT("NKFW");
+        // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC
+        // interface is in a known idle state for the next kernel.
+        ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
+        ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
+        ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
+        ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
+        ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+        WAYPOINT("NKFD");
+    }
 #endif
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1774,6 +1774,27 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
 }
 
 /**
+ * This blocking call waits for all the outstanding read, write, and atomic NOC
+ * transactions issued on the current Tensix core to complete. After returning
+ * from this call all transaction queues will be empty for the current Tensix
+ * core.
+ *
+ * Return value: None
+ */
+FORCE_INLINE
+void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
+    WAYPOINT("NFBW");
+    do {
+        invalidate_l1_cache();
+    } while (!ncrisc_noc_reads_flushed(noc_idx));
+    while (!ncrisc_noc_nonposted_writes_sent(noc_idx));
+    while (!ncrisc_noc_nonposted_writes_flushed(noc_idx));
+    while (!ncrisc_noc_nonposted_atomics_flushed(noc_idx));
+    while (!ncrisc_noc_posted_writes_sent(noc_idx));
+    WAYPOINT("NFBD");
+}
+
+/**
  * A blocking call that waits until the value of a local L1 memory address on
  * the Tensix core executing this function becomes equal to a target value.
  * This L1 memory address is used as a semaphore of size 4 Bytes, as a

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1252,5 +1252,7 @@ void kernel_main() {
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_dispatch_cb_sem_id>(upstream_total_acquired_page_count);
 
+    noc_async_full_barrier();
+
     DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": out" << ENDL();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1458,5 +1458,7 @@ void kernel_main() {
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_downstream_cb_sem_id>(downstream_cb_pages);
 
+    noc_async_full_barrier();
+
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": out" << ENDL();
 }

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -277,4 +277,5 @@ void kernel_main() {
         write_test_results(test_results, PQ_TEST_STATUS_INDEX, PACKET_QUEUE_TEST_PASS);
         write_test_results(test_results, PQ_TEST_MISC_INDEX, 0xff00005);
     }
+    noc_async_full_barrier();
 }

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -232,4 +232,6 @@ void kernel_main() {
         write_test_results(test_results, PQ_TEST_STATUS_INDEX, PACKET_QUEUE_TEST_PASS);
         write_test_results(test_results, PQ_TEST_MISC_INDEX, 0xff00005);
     }
+
+    noc_async_full_barrier();
 }

--- a/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
+++ b/tt_metal/impl/dispatch/kernels/vc_packet_router.cpp
@@ -303,4 +303,6 @@ void kernel_main() {
         write_kernel_status(kernel_status, PQ_TEST_STATUS_INDEX, PACKET_QUEUE_TEST_PASS);
         write_kernel_status(kernel_status, PQ_TEST_MISC_INDEX, 0xff00005);
     }
+
+    noc_async_full_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -53,4 +53,6 @@ void kernel_main() {
     }
 
     reader.close();
+
+    noc_async_full_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
@@ -581,4 +581,6 @@ void kernel_main() {
 
     reader.close();
     WAYPOINT("DONE");
+
+    noc_async_full_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -167,4 +167,6 @@ void kernel_main() {
             cb_push_back(cb_id_in0, in0_block_num_tiles);
         }
     }
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -232,4 +232,5 @@ void kernel_main() {
         }
         in0_tensor_start_tile_id += MtKt;
     }
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -137,4 +137,6 @@ void kernel_main() {
         noc_async_write(out_addr, dst_noc_addr, out_stick_size);
         noc_async_write_barrier();
     }
+
+    noc_async_atomic_barrier();
 }


### PR DESCRIPTION

### Ticket
#16171 

### Problem description
Outstanding NOC transactions can cause incorrect values to be set when noc_local_state_init is called before starting the next kernel. This hasn't been a problem until now because dispatch took long enough that all outstanding NOC transactions would complete by that point, but as we optimize the dispatcher that will soon no longer be the case.

### What's changed
To fix that, in DM_DEDICATED_NOC mode we can assert at the end of the kernel_launch that no transactions are outstanding. In DM_DYNAMIC_NOC mode brisc.cc waits for transactions to complete, so we don't need to worry about that mode. We could delay the wait until later, but brisc.cc doesn't have access to the NCRISC's local NOC state when DM_DEDICATED_NOC is in use. We could also have the ncrisck.cc wait for transactions instead of just asserting that they're completed, but it could be faster for kernels to skip waits for transactions types they don't use.

Some important NCRISC kernels have been fixed to ensure they perform a full barrier.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
