### PR TITLE
[Llama3] Change prefill padding in LlamaGenerator to nearest 2048 and optimize chunked prefill readback

### DIFF
--- a/models/demos/llama3/tests/test_llama_chunked_generation.py
+++ b/models/demos/llama3/tests/test_llama_chunked_generation.py
@@ -47,7 +47,7 @@ from models.utility_functions import skip_for_grayskull
 )
 @pytest.mark.parametrize(
     "seq_len, prefill_chunk_size",
-    [(4096, 1024)],
+    [(4096, 2048)],
 )
 @pytest.mark.parametrize(
     "optimizations",

--- a/models/demos/llama3/tt/generator.py
+++ b/models/demos/llama3/tt/generator.py
@@ -141,9 +141,9 @@ class LlamaGenerator:
                     get_last_token=(last_token_idx_in_chunk // 32) * 32,
                     kv_cache=kv_cache,
                 )
-                logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx_in_chunk % 32))
 
                 if chunk_start == last_chunk_start:
+                    logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx_in_chunk % 32))
                     return logits
         else:
             prefill_input, rot_mats_prefill, page_table_tt, _ = self.model.prepare_inputs_prefill(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The prefill qkv matmul in llama attention assumed that the seq len was divisible by 2048 but seq lens were being padded to the nearest 1024
- Chunked prefill was reading back logits for every chunk instead of only the last one (reducing perf)

### What's changed
- Modified `llama_common.py::get_padded_prefill_len` and `llama_common.py::get_max_prefill_chunk_size` to determine padded prefill len / chunk size based on multiples of 2048 instead of 1024
- Removed `llama_vision_model.py::_get_padded_prefill_seqlen` since it's now a duplicate of `llama_common.py::get_padded_prefill_len`
- Added `MAX_QKV_MM_SEQ_LEN` to model config, replacing hard-coded values of 2048 in `llama_attention.py::prefill_forward`
- Added assert in `llama_attention.py::prefill_forward` before qkv matmul checking divisibility
- Modified chunked prefill to read back logits only for last chunk

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
