### PR TITLE
#16492: Add new APIs for setting which sub_device_ids to stall on

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Get started with [simple kernels](https://docs.tenstorrent.com/tt-metalium/lates
 - [Ethernet and Multichip Basics](./tech_reports/EthernetMultichip/BasicEthernetGuide.md) (Updated Sept 20th, 2024)
 - [Collective Communication Library (CCL)](./tech_reports/EthernetMultichip/CclDeveloperGuide.md) (Updated Sept 20th, 2024)
 - [Blackhole Bring-Up Programming Guide](./tech_reports/Blackhole/BlackholeBringUpProgrammingGuide.md) (Updated Dec 18th, 2024)
-- [Sub-Devices](./tech_reports/SubDevices/SubDevices.md) (Updated Jan 2nd, 2025)
+- [Sub-Devices](./tech_reports/SubDevices/SubDevices.md) (Updated Jan 7th, 2025)
 
 ## TT-Metalium Programming Examples
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -20,6 +20,7 @@
 #include "dispatch_test_utils.hpp"
 
 TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
+    auto* device = devices_[0];
     uint32_t local_l1_size = 3200;
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
@@ -41,102 +42,103 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceSynchronization) {
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, shard_config_1.size / sizeof(uint32_t));
 
     std::array sub_device_ids_to_block = {SubDeviceId{0}};
-    for (IDevice* device : devices_) {
-        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
 
-        shard_config_1.device = device;
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
 
-        std::vector<CoreCoord> physical_cores_1;
-        physical_cores_1.reserve(sharded_cores_1_vec.size());
-        for (const auto& core : sharded_cores_1_vec) {
-            physical_cores_1.push_back(device->worker_core_from_logical_core(core));
-        }
+    shard_config_1.device = device;
 
-        device->load_sub_device_manager(sub_device_manager);
-
-        auto [program, syncer_core, global_semaphore] = create_single_sync_program(device, sub_device_2);
-        EnqueueProgram(device->command_queue(), program, false);
-
-        auto buffer_1 = CreateBuffer(shard_config_1, sub_device_ids_to_block[0]);
-
-        // Test blocking synchronize doesn't stall
-        Synchronize(device, 0, sub_device_ids_to_block);
-
-        // Test blocking write buffer doesn't stall
-        EnqueueWriteBuffer(device->command_queue(), buffer_1, input_1, true, sub_device_ids_to_block);
-
-        // Test record event won't cause a stall
-        auto event = std::make_shared<Event>();
-        EnqueueRecordEvent(device->command_queue(), event, sub_device_ids_to_block);
-        Synchronize(device, 0, sub_device_ids_to_block);
-
-        // Test blocking read buffer doesn't stall
-        std::vector<uint32_t> output_1;
-        EnqueueReadBuffer(device->command_queue(), buffer_1, output_1, true, sub_device_ids_to_block);
-        EXPECT_EQ(input_1, output_1);
-        auto input_1_it = input_1.begin();
-        for (const auto& physical_core : physical_cores_1) {
-            auto readback =
-                tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer_1->address(), page_size_1);
-            EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
-            input_1_it += page_size_1 / sizeof(uint32_t);
-        }
-        auto sem_addr = global_semaphore.address();
-        auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
-        tt::llrt::write_hex_vec_to_core(device->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
-
-        // Full synchronization
-        Synchronize(device);
+    std::vector<CoreCoord> physical_cores_1;
+    physical_cores_1.reserve(sharded_cores_1_vec.size());
+    for (const auto& core : sharded_cores_1_vec) {
+        physical_cores_1.push_back(device->worker_core_from_logical_core(core));
     }
+
+    device->load_sub_device_manager(sub_device_manager);
+
+    auto [program, syncer_core, global_semaphore] = create_single_sync_program(device, sub_device_2);
+    EnqueueProgram(device->command_queue(), program, false);
+    device->set_sub_device_stall_group(sub_device_ids_to_block);
+
+    auto buffer_1 = CreateBuffer(shard_config_1, sub_device_ids_to_block[0]);
+
+    // Test blocking synchronize doesn't stall
+    Synchronize(device, 0);
+
+    // Test blocking write buffer doesn't stall
+    EnqueueWriteBuffer(device->command_queue(), buffer_1, input_1, true);
+
+    // Test record event won't cause a stall
+    auto event = std::make_shared<Event>();
+    EnqueueRecordEvent(device->command_queue(), event);
+    Synchronize(device, 0);
+
+    // Test blocking read buffer doesn't stall
+    std::vector<uint32_t> output_1;
+    EnqueueReadBuffer(device->command_queue(), buffer_1, output_1, true);
+    EXPECT_EQ(input_1, output_1);
+    auto input_1_it = input_1.begin();
+    for (const auto& physical_core : physical_cores_1) {
+        auto readback = tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer_1->address(), page_size_1);
+        EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
+        input_1_it += page_size_1 / sizeof(uint32_t);
+    }
+    auto sem_addr = global_semaphore.address();
+    auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
+    tt::llrt::write_hex_vec_to_core(device->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
+
+    // Full synchronization
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
 }
 
 TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicPrograms) {
+    auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
     uint32_t num_iters = 5;
-    for (IDevice* device : devices_) {
-        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-        device->load_sub_device_manager(sub_device_manager);
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    device->load_sub_device_manager(sub_device_manager);
 
-        auto [waiter_program, syncer_program, incrementer_program, global_sem] =
-            create_basic_sync_program(device, sub_device_1, sub_device_2);
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_sync_program(device, sub_device_1, sub_device_2);
 
-        for (uint32_t i = 0; i < num_iters; i++) {
-            EnqueueProgram(device->command_queue(), waiter_program, false);
-            // Test blocking on one sub-device
-            EnqueueProgram(device->command_queue(), syncer_program, true);
-            EnqueueProgram(device->command_queue(), incrementer_program, false);
-        }
-        Synchronize(device);
-        detail::DumpDeviceProfileResults(device);
+    for (uint32_t i = 0; i < num_iters; i++) {
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        device->set_sub_device_stall_group({SubDeviceId{0}});
+        // Test blocking on one sub-device
+        EnqueueProgram(device->command_queue(), syncer_program, true);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        device->reset_sub_device_stall_group();
     }
+    Synchronize(device);
+    detail::DumpDeviceProfileResults(device);
 }
 
 TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthPrograms) {
+    auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     uint32_t num_iters = 5;
-    for (IDevice* device : devices_) {
-        if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
-        }
-        auto eth_core = *device->get_active_ethernet_cores(true).begin();
-        SubDevice sub_device_2(std::array{
-            CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}),
-            CoreRangeSet(CoreRange(eth_core, eth_core))});
-        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-        device->load_sub_device_manager(sub_device_manager);
-
-        auto [waiter_program, syncer_program, incrementer_program, global_sem] =
-            create_basic_eth_sync_program(device, sub_device_1, sub_device_2);
-
-        for (uint32_t i = 0; i < num_iters; i++) {
-            EnqueueProgram(device->command_queue(), waiter_program, false);
-            // Test blocking on one sub-device
-            EnqueueProgram(device->command_queue(), syncer_program, true);
-            EnqueueProgram(device->command_queue(), incrementer_program, false);
-        }
-        Synchronize(device);
-        detail::DumpDeviceProfileResults(device);
+    if (!does_device_have_active_eth_cores(device)) {
+        GTEST_SKIP() << "Skipping test because device " << device->id() << " does not have any active ethernet cores";
     }
+    auto eth_core = *device->get_active_ethernet_cores(true).begin();
+    SubDevice sub_device_2(std::array{
+        CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}),
+        CoreRangeSet(CoreRange(eth_core, eth_core))});
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    device->load_sub_device_manager(sub_device_manager);
+
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_eth_sync_program(device, sub_device_1, sub_device_2);
+
+    for (uint32_t i = 0; i < num_iters; i++) {
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        device->set_sub_device_stall_group({SubDeviceId{0}});
+        // Test blocking on one sub-device
+        EnqueueProgram(device->command_queue(), syncer_program, true);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        device->reset_sub_device_stall_group();
+    }
+    Synchronize(device);
+    detail::DumpDeviceProfileResults(device);
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -19,207 +19,211 @@
 #include "sub_device_test_utils.hpp"
 
 TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceTraceBasicPrograms) {
+    auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
     uint32_t num_iters = 5;
-    for (IDevice* device : devices_) {
-        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-        device->load_sub_device_manager(sub_device_manager);
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    device->load_sub_device_manager(sub_device_manager);
 
-        auto [waiter_program, syncer_program, incrementer_program, global_sem] =
-            create_basic_sync_program(device, sub_device_1, sub_device_2);
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_sync_program(device, sub_device_1, sub_device_2);
 
-        // Compile the programs
+    // Compile the programs
+    EnqueueProgram(device->command_queue(), waiter_program, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    // Test blocking on one sub-device
+    EnqueueProgram(device->command_queue(), syncer_program, true);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
+
+    // Capture the trace
+    auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), waiter_program, false);
+    EnqueueProgram(device->command_queue(), syncer_program, false);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_1);
+
+    auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), syncer_program, false);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_2);
+
+    for (uint32_t i = 0; i < num_iters; i++) {
+        // Regular program execution
         EnqueueProgram(device->command_queue(), waiter_program, false);
         // Test blocking on one sub-device
         EnqueueProgram(device->command_queue(), syncer_program, true);
         EnqueueProgram(device->command_queue(), incrementer_program, false);
-        Synchronize(device);
 
-        // Capture the trace
-        auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+        // Full trace execution
+        ReplayTrace(device, device->command_queue().id(), tid_1, false);
+
+        // Partial trace execution
         EnqueueProgram(device->command_queue(), waiter_program, false);
-        EnqueueProgram(device->command_queue(), syncer_program, false);
-        EnqueueProgram(device->command_queue(), incrementer_program, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_1);
-
-        auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
-        EnqueueProgram(device->command_queue(), syncer_program, false);
-        EnqueueProgram(device->command_queue(), incrementer_program, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_2);
-
-        for (uint32_t i = 0; i < num_iters; i++) {
-            // Regular program execution
-            EnqueueProgram(device->command_queue(), waiter_program, false);
-            // Test blocking on one sub-device
-            EnqueueProgram(device->command_queue(), syncer_program, true);
-            EnqueueProgram(device->command_queue(), incrementer_program, false);
-
-            // Full trace execution
-            ReplayTrace(device, device->command_queue().id(), tid_1, false);
-
-            // Partial trace execution
-            EnqueueProgram(device->command_queue(), waiter_program, false);
-            ReplayTrace(device, device->command_queue().id(), tid_2, false);
-        }
-        Synchronize(device);
-        detail::DumpDeviceProfileResults(device);
+        ReplayTrace(device, device->command_queue().id(), tid_2, false);
     }
+    Synchronize(device);
+    detail::DumpDeviceProfileResults(device);
 }
 
 TEST_F(CommandQueueSingleCardTraceFixture, TensixActiveEthTestSubDeviceTraceBasicEthPrograms) {
+    auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     uint32_t num_iters = 5;
-    for (IDevice* device : devices_) {
-        if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
-        }
-        auto eth_core = *device->get_active_ethernet_cores(true).begin();
-        SubDevice sub_device_2(std::array{
-            CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}),
-            CoreRangeSet(CoreRange(eth_core, eth_core))});
-        auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-        device->load_sub_device_manager(sub_device_manager);
+    if (!does_device_have_active_eth_cores(device)) {
+        GTEST_SKIP() << "Skipping test because device " << device->id() << " does not have any active ethernet cores";
+    }
+    auto eth_core = *device->get_active_ethernet_cores(true).begin();
+    SubDevice sub_device_2(std::array{
+        CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})}),
+        CoreRangeSet(CoreRange(eth_core, eth_core))});
+    auto sub_device_manager = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    device->load_sub_device_manager(sub_device_manager);
 
-        auto [waiter_program, syncer_program, incrementer_program, global_sem] =
-            create_basic_eth_sync_program(device, sub_device_1, sub_device_2);
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_eth_sync_program(device, sub_device_1, sub_device_2);
 
-        // Compile the programs
+    // Compile the programs
+    EnqueueProgram(device->command_queue(), waiter_program, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    // Test blocking on one sub-device
+    EnqueueProgram(device->command_queue(), syncer_program, true);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
+
+    // Capture the trace
+    auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), waiter_program, false);
+    EnqueueProgram(device->command_queue(), syncer_program, false);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_1);
+
+    auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), syncer_program, false);
+    EnqueueProgram(device->command_queue(), incrementer_program, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_2);
+
+    for (uint32_t i = 0; i < num_iters; i++) {
+        // Regular program execution
         EnqueueProgram(device->command_queue(), waiter_program, false);
         // Test blocking on one sub-device
         EnqueueProgram(device->command_queue(), syncer_program, true);
         EnqueueProgram(device->command_queue(), incrementer_program, false);
-        Synchronize(device);
 
-        // Capture the trace
-        auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+        // Full trace execution
+        ReplayTrace(device, device->command_queue().id(), tid_1, false);
+
+        // Partial trace execution
         EnqueueProgram(device->command_queue(), waiter_program, false);
-        EnqueueProgram(device->command_queue(), syncer_program, false);
-        EnqueueProgram(device->command_queue(), incrementer_program, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_1);
-
-        auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
-        EnqueueProgram(device->command_queue(), syncer_program, false);
-        EnqueueProgram(device->command_queue(), incrementer_program, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_2);
-
-        for (uint32_t i = 0; i < num_iters; i++) {
-            // Regular program execution
-            EnqueueProgram(device->command_queue(), waiter_program, false);
-            // Test blocking on one sub-device
-            EnqueueProgram(device->command_queue(), syncer_program, true);
-            EnqueueProgram(device->command_queue(), incrementer_program, false);
-
-            // Full trace execution
-            ReplayTrace(device, device->command_queue().id(), tid_1, false);
-
-            // Partial trace execution
-            EnqueueProgram(device->command_queue(), waiter_program, false);
-            ReplayTrace(device, device->command_queue().id(), tid_2, false);
-        }
-        Synchronize(device);
+        ReplayTrace(device, device->command_queue().id(), tid_2, false);
     }
+    Synchronize(device);
 }
 
 TEST_F(CommandQueueSingleCardTraceFixture, TensixActiveEthTestSubDeviceTraceProgramsReconfigureSubDevices) {
+    auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::array{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
     SubDevice sub_device_3(std::array{CoreRangeSet(std::array{CoreRange({2, 4}, {3, 4}), CoreRange({5, 1}, {6, 3})})});
     uint32_t num_iters = 5;
-    for (IDevice* device : devices_) {
-        if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
-        }
-        auto eth_core = *device->get_active_ethernet_cores(true).begin();
-        SubDevice sub_device_4(std::array{
-            CoreRangeSet(std::array{CoreRange({2, 1}, {2, 2}), CoreRange({1, 5}, {5, 5})}),
-            CoreRangeSet(CoreRange(eth_core, eth_core))});
+    if (!does_device_have_active_eth_cores(device)) {
+        GTEST_SKIP() << "Skipping test because device " << device->id() << " does not have any active ethernet cores";
+    }
+    auto eth_core = *device->get_active_ethernet_cores(true).begin();
+    SubDevice sub_device_4(std::array{
+        CoreRangeSet(std::array{CoreRange({2, 1}, {2, 2}), CoreRange({1, 5}, {5, 5})}),
+        CoreRangeSet(CoreRange(eth_core, eth_core))});
 
-        auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-        auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_3, sub_device_4}, 3200);
+    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_3, sub_device_4}, 3200);
 
+    device->load_sub_device_manager(sub_device_manager_1);
+
+    auto [waiter_program_1, syncer_program_1, incrementer_program_1, global_sem_1] =
+        create_basic_sync_program(device, sub_device_1, sub_device_2);
+
+    // Compile the programs
+    EnqueueProgram(device->command_queue(), waiter_program_1, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    EnqueueProgram(device->command_queue(), syncer_program_1, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_1, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
+
+    // Capture the trace
+    auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), waiter_program_1, false);
+    EnqueueProgram(device->command_queue(), syncer_program_1, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_1, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_1);
+
+    auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), syncer_program_1, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_1, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_2);
+
+    device->load_sub_device_manager(sub_device_manager_2);
+
+    auto [waiter_program_2, syncer_program_2, incrementer_program_2, global_sem_2] =
+        create_basic_eth_sync_program(device, sub_device_3, sub_device_4);
+
+    // Compile the programs
+    EnqueueProgram(device->command_queue(), waiter_program_2, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    EnqueueProgram(device->command_queue(), syncer_program_2, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_2, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
+
+    // Capture the trace
+    auto tid_3 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), waiter_program_2, false);
+    EnqueueProgram(device->command_queue(), syncer_program_2, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_2, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_3);
+
+    auto tid_4 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), syncer_program_2, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_2, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_4);
+
+    for (uint32_t i = 0; i < num_iters; i++) {
         device->load_sub_device_manager(sub_device_manager_1);
-
-        auto [waiter_program_1, syncer_program_1, incrementer_program_1, global_sem_1] =
-            create_basic_sync_program(device, sub_device_1, sub_device_2);
-
-        // Compile the programs
+        // Regular program execution
         EnqueueProgram(device->command_queue(), waiter_program_1, false);
+        // Test blocking on one sub-device
         EnqueueProgram(device->command_queue(), syncer_program_1, false);
         EnqueueProgram(device->command_queue(), incrementer_program_1, false);
-        Synchronize(device);
 
-        // Capture the trace
-        auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+        // Full trace execution
+        ReplayTrace(device, device->command_queue().id(), tid_1, false);
+
+        // Partial trace execution
         EnqueueProgram(device->command_queue(), waiter_program_1, false);
-        EnqueueProgram(device->command_queue(), syncer_program_1, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_1, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_1);
-
-        auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
-        EnqueueProgram(device->command_queue(), syncer_program_1, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_1, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_2);
+        ReplayTrace(device, device->command_queue().id(), tid_2, false);
 
         device->load_sub_device_manager(sub_device_manager_2);
-
-        auto [waiter_program_2, syncer_program_2, incrementer_program_2, global_sem_2] =
-            create_basic_eth_sync_program(device, sub_device_3, sub_device_4);
-
-        // Compile the programs
+        // Regular program execution
         EnqueueProgram(device->command_queue(), waiter_program_2, false);
+        // Test blocking on one sub-device
         EnqueueProgram(device->command_queue(), syncer_program_2, false);
         EnqueueProgram(device->command_queue(), incrementer_program_2, false);
-        Synchronize(device);
 
-        // Capture the trace
-        auto tid_3 = BeginTraceCapture(device, device->command_queue().id());
+        // Full trace execution
+        ReplayTrace(device, device->command_queue().id(), tid_3, false);
+
+        // Partial trace execution
         EnqueueProgram(device->command_queue(), waiter_program_2, false);
-        EnqueueProgram(device->command_queue(), syncer_program_2, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_2, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_3);
-
-        auto tid_4 = BeginTraceCapture(device, device->command_queue().id());
-        EnqueueProgram(device->command_queue(), syncer_program_2, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_2, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_4);
-
-        for (uint32_t i = 0; i < num_iters; i++) {
-            device->load_sub_device_manager(sub_device_manager_1);
-            // Regular program execution
-            EnqueueProgram(device->command_queue(), waiter_program_1, false);
-            // Test blocking on one sub-device
-            EnqueueProgram(device->command_queue(), syncer_program_1, false);
-            EnqueueProgram(device->command_queue(), incrementer_program_1, false);
-
-            // Full trace execution
-            ReplayTrace(device, device->command_queue().id(), tid_1, false);
-
-            // Partial trace execution
-            EnqueueProgram(device->command_queue(), waiter_program_1, false);
-            ReplayTrace(device, device->command_queue().id(), tid_2, false);
-
-            device->load_sub_device_manager(sub_device_manager_2);
-            // Regular program execution
-            EnqueueProgram(device->command_queue(), waiter_program_2, false);
-            // Test blocking on one sub-device
-            EnqueueProgram(device->command_queue(), syncer_program_2, false);
-            EnqueueProgram(device->command_queue(), incrementer_program_2, false);
-
-            // Full trace execution
-            ReplayTrace(device, device->command_queue().id(), tid_3, false);
-
-            // Partial trace execution
-            EnqueueProgram(device->command_queue(), waiter_program_2, false);
-            ReplayTrace(device, device->command_queue().id(), tid_4, false);
-        }
-        Synchronize(device);
+        ReplayTrace(device, device->command_queue().id(), tid_4, false);
     }
+    Synchronize(device);
 }
 
 TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations) {
+    auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
 
@@ -230,58 +234,60 @@ TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations)
             CoreRangeSet(CoreRange({4, 4}, {4, 4})),
             CoreRangeSet(CoreRange({5, 5}, {5, 5}))}),
         std::exception);
-    for (IDevice* device : devices_) {
-        auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
-        auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_2, sub_device_1}, 3200);
-        device->load_sub_device_manager(sub_device_manager_1);
+    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1, sub_device_2}, 3200);
+    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_2, sub_device_1}, 3200);
+    device->load_sub_device_manager(sub_device_manager_1);
 
-        auto [waiter_program_1, syncer_program_1, incrementer_program_1, global_sem_1] =
-            create_basic_sync_program(device, sub_device_1, sub_device_2);
+    auto [waiter_program_1, syncer_program_1, incrementer_program_1, global_sem_1] =
+        create_basic_sync_program(device, sub_device_1, sub_device_2);
 
-        // Compile the programs
-        EnqueueProgram(device->command_queue(), waiter_program_1, false);
-        // Test blocking on one sub-device
-        EnqueueProgram(device->command_queue(), syncer_program_1, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_1, false);
-        Synchronize(device);
+    // Compile the programs
+    EnqueueProgram(device->command_queue(), waiter_program_1, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    // Test blocking on one sub-device
+    EnqueueProgram(device->command_queue(), syncer_program_1, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_1, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
 
-        // Capture the trace
-        auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
-        // Can not load a sub-device manager while tracing
-        EXPECT_THROW(device->load_sub_device_manager(sub_device_manager_2), std::exception);
-        EnqueueProgram(device->command_queue(), waiter_program_1, false);
-        EnqueueProgram(device->command_queue(), syncer_program_1, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_1, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_1);
+    // Capture the trace
+    auto tid_1 = BeginTraceCapture(device, device->command_queue().id());
+    // Can not load a sub-device manager while tracing
+    EXPECT_THROW(device->load_sub_device_manager(sub_device_manager_2), std::exception);
+    EnqueueProgram(device->command_queue(), waiter_program_1, false);
+    EnqueueProgram(device->command_queue(), syncer_program_1, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_1, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_1);
 
-        device->load_sub_device_manager(sub_device_manager_2);
-        auto [waiter_program_2, syncer_program_2, incrementer_program_2, global_sem_2] =
-            create_basic_sync_program(device, sub_device_2, sub_device_1);
+    device->load_sub_device_manager(sub_device_manager_2);
+    auto [waiter_program_2, syncer_program_2, incrementer_program_2, global_sem_2] =
+        create_basic_sync_program(device, sub_device_2, sub_device_1);
 
-        EnqueueProgram(device->command_queue(), waiter_program_2, false);
-        EnqueueProgram(device->command_queue(), syncer_program_2, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_2, false);
-        Synchronize(device);
+    EnqueueProgram(device->command_queue(), waiter_program_2, false);
+    device->set_sub_device_stall_group({SubDeviceId{0}});
+    EnqueueProgram(device->command_queue(), syncer_program_2, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_2, false);
+    device->reset_sub_device_stall_group();
+    Synchronize(device);
 
-        auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
-        EnqueueProgram(device->command_queue(), waiter_program_2, false);
-        EnqueueProgram(device->command_queue(), syncer_program_2, false);
-        EnqueueProgram(device->command_queue(), incrementer_program_2, false);
-        EndTraceCapture(device, device->command_queue().id(), tid_2);
+    auto tid_2 = BeginTraceCapture(device, device->command_queue().id());
+    EnqueueProgram(device->command_queue(), waiter_program_2, false);
+    EnqueueProgram(device->command_queue(), syncer_program_2, false);
+    EnqueueProgram(device->command_queue(), incrementer_program_2, false);
+    EndTraceCapture(device, device->command_queue().id(), tid_2);
 
-        // Regular program execution
-        // Can not run a program on a different sub-device manager
-        EXPECT_THROW(EnqueueProgram(device->command_queue(), waiter_program_1, false), std::exception);
+    // Regular program execution
+    // Can not run a program on a different sub-device manager
+    EXPECT_THROW(EnqueueProgram(device->command_queue(), waiter_program_1, false), std::exception);
 
-        // Full trace execution
-        ReplayTrace(device, device->command_queue().id(), tid_2, false);
+    // Full trace execution
+    ReplayTrace(device, device->command_queue().id(), tid_2, false);
 
-        // Can not replay a trace on a different sub-device manager
-        EXPECT_THROW(ReplayTrace(device, device->command_queue().id(), tid_1, false), std::exception);
+    // Can not replay a trace on a different sub-device manager
+    EXPECT_THROW(ReplayTrace(device, device->command_queue().id(), tid_1, false), std::exception);
 
-        Synchronize(device);
+    Synchronize(device);
 
-        device->remove_sub_device_manager(sub_device_manager_1);
-        EXPECT_THROW(device->load_sub_device_manager(sub_device_manager_1), std::exception);
-    }
+    device->remove_sub_device_manager(sub_device_manager_1);
+    EXPECT_THROW(device->load_sub_device_manager(sub_device_manager_1), std::exception);
 }

--- a/tests/ttnn/unit_tests/test_sub_device.py
+++ b/tests/ttnn/unit_tests/test_sub_device.py
@@ -39,6 +39,9 @@ def run_sub_devices(device, create_fabric_sub_device=False):
     device.load_sub_device_manager(sub_device_manager1)
     ttnn.synchronize_devices(device, sub_device_ids=[ttnn.SubDeviceId(1)])
     ttnn.synchronize_devices(device, sub_device_ids=[ttnn.SubDeviceId(0), ttnn.SubDeviceId(1)])
+    device.set_sub_device_stall_group([ttnn.SubDeviceId(0)])
+    ttnn.synchronize_devices(device)
+    device.reset_sub_device_stall_group()
     ttnn.synchronize_devices(device)
     device.load_sub_device_manager(sub_device_manager2)
     ttnn.synchronize_devices(device, sub_device_ids=[ttnn.SubDeviceId(0)])
@@ -84,6 +87,7 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     device.load_sub_device_manager(sub_device_manager)
 
     x = torch.randn(num_devices, 1, 64, 64, dtype=torch.bfloat16)
+    device.set_sub_device_stall_group([ttnn.SubDeviceId(0)])
     xt = ttnn.from_torch(
         x,
         dtype=ttnn.bfloat16,
@@ -91,18 +95,16 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
         device=device,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         mesh_mapper=inputs_mesh_mapper,
-        sub_device_ids=[ttnn.SubDeviceId(0)],
     )
-
+    device.set_sub_device_stall_group([ttnn.SubDeviceId(1)])
     xt_host = ttnn.from_torch(
         x,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=inputs_mesh_mapper,
-        sub_device_ids=[ttnn.SubDeviceId(1)],
     )
 
-    ttnn.copy_host_to_device_tensor(xt_host, xt, sub_device_ids=[ttnn.SubDeviceId(1)])
+    ttnn.copy_host_to_device_tensor(xt_host, xt)
 
     grid_size = device.compute_with_storage_grid_size()
     shard_size = [32, 64]
@@ -111,12 +113,12 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     yt = ttnn.interleaved_to_sharded(
         xt, grid_size, shard_size, shard_scheme, shard_orientation, output_dtype=ttnn.bfloat16
     )
-    y = ttnn.to_torch(yt, device=device, mesh_composer=output_mesh_composer, sub_device_ids=[ttnn.SubDeviceId(1)])
+    y = ttnn.to_torch(yt, device=device, mesh_composer=output_mesh_composer)
 
     eq = torch.equal(x, y)
     assert eq
-
-    y = ttnn.to_torch(yt.cpu(sub_device_ids=[ttnn.SubDeviceId(0)]), mesh_composer=output_mesh_composer)
+    device.set_sub_device_stall_group([ttnn.SubDeviceId(0)])
+    y = ttnn.to_torch(yt.cpu(), mesh_composer=output_mesh_composer)
 
     eq = torch.equal(x, y)
     assert eq
@@ -128,7 +130,7 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     )
     ttnn.record_event(0, event, [ttnn.SubDeviceId(1)])
     ttnn.wait_for_event(0, event)
-    y2 = ttnn.to_torch(yt2, device=device, mesh_composer=output_mesh_composer, sub_device_ids=[ttnn.SubDeviceId(0)])
+    y2 = ttnn.to_torch(yt2, device=device, mesh_composer=output_mesh_composer)
 
     eq = torch.equal(x, y2)
     assert eq

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -656,6 +656,18 @@ void MeshDevice::remove_sub_device_manager(MeshSubDeviceManagerId mesh_sub_devic
     }
 }
 
+void MeshDevice::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    for (auto* device : this->devices) {
+        device->push_work([device, sub_device_ids=std::vector<SubDeviceId>(sub_device_ids.begin(), sub_device_ids.end())]() { device->set_sub_device_stall_group(sub_device_ids); });
+    }
+}
+
+void MeshDevice::reset_sub_device_stall_group() {
+    for (auto* device : this->devices) {
+        device->push_work([device]() { device->reset_sub_device_stall_group(); });
+    }
+}
+
 MeshSubDeviceManagerId::MeshSubDeviceManagerId(const MeshDevice& mesh_device) {
     this->sub_device_manager_ids.resize(mesh_device.num_devices());
 }

--- a/tt_metal/distributed/mesh_device.hpp
+++ b/tt_metal/distributed/mesh_device.hpp
@@ -165,12 +165,16 @@ public:
 
     MeshSubDeviceManagerId create_sub_device_manager(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
-    // TODO #15944: Temporary api until migration to actual fabric is complete
+    // TODO #16526: Temporary api until migration to actual fabric is complete
     std::tuple<MeshSubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size);
     void load_sub_device_manager(MeshSubDeviceManagerId mesh_sub_device_manager_id);
     void clear_loaded_sub_device_manager();
     void remove_sub_device_manager(MeshSubDeviceManagerId mesh_sub_device_manager_id);
+    // TODO #16492: Add get_sub_device_stall_group once MeshDevice is no longer just a collection of single Devices
+    // and the MeshDevice has a single SubDeviceManager responsible for all Devices.
+    void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void reset_sub_device_stall_group();
 
     static std::shared_ptr<MeshDevice> create(
         const MeshDeviceConfig& config,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1299,6 +1299,8 @@ void Device::reset_sub_devices_state(const std::unique_ptr<detail::SubDeviceMana
     }
     // Reset the launch_message ring buffer state seen on host
     sub_device_manager->reset_worker_launch_message_buffer_state();
+
+    sub_device_manager->reset_sub_device_stall_group();
 }
 
 uint32_t Device::num_sub_devices() const {
@@ -1831,6 +1833,18 @@ void Device::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id)
 
 const std::vector<SubDeviceId> &Device::get_sub_device_ids() const {
     return this->active_sub_device_manager_->get_sub_device_ids();
+}
+
+const std::vector<SubDeviceId> &Device::get_sub_device_stall_group() const {
+    return this->active_sub_device_manager_->get_sub_device_stall_group();
+}
+
+void Device::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    this->active_sub_device_manager_->set_sub_device_stall_group(sub_device_ids);
+}
+
+void Device::reset_sub_device_stall_group() {
+    this->active_sub_device_manager_->reset_sub_device_stall_group();
 }
 
 DeviceAddr Device::get_base_allocator_addr(const HalMemType &mem_type) const {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -213,7 +213,7 @@ public:
 
     void push_work(std::function<void()> work, bool blocking) override;
 
-    // Program cache interface. Syncrhonize with worker worker threads before querying or
+    // Program cache interface. Synchronize with worker worker threads before querying or
     // modifying this structure, since worker threads use this for compiling ops
     void enable_program_cache() override;
     void disable_and_clear_program_cache() override;
@@ -242,6 +242,9 @@ public:
     LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) override;
     CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const override;
     const std::vector<SubDeviceId> &get_sub_device_ids() const override;
+    const std::vector<SubDeviceId> &get_sub_device_stall_group() const override;
+    void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;
+    void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
 
     // TODO #15944: Temporary api until migration to actual fabric is complete

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -156,6 +156,22 @@ bool SubDeviceManager::has_allocations() const {
 
 DeviceAddr SubDeviceManager::local_l1_size() const { return local_l1_size_; }
 
+const std::vector<SubDeviceId>& SubDeviceManager::get_sub_device_stall_group() const { return sub_device_stall_group_; }
+
+void SubDeviceManager::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    TT_FATAL(!sub_device_ids.empty(), "sub_device_ids to stall must not be empty");
+    for (const auto& sub_device_id : sub_device_ids) {
+        TT_FATAL(
+            sub_device_id.to_index() < sub_devices_.size(),
+            "SubDevice index {} out of bounds {}",
+            sub_device_id.to_index(),
+            sub_devices_.size());
+    }
+    sub_device_stall_group_ = std::vector<SubDeviceId>(sub_device_ids.begin(), sub_device_ids.end());
+}
+
+void SubDeviceManager::reset_sub_device_stall_group() { this->set_sub_device_stall_group(sub_device_ids_); }
+
 void SubDeviceManager::set_fabric_sub_device_id(SubDeviceId fabric_sub_device_id) {
     const auto& fabric_sub_device = this->sub_device(fabric_sub_device_id);
     TT_FATAL(
@@ -221,6 +237,7 @@ void SubDeviceManager::populate_sub_device_ids() {
     for (uint8_t i = 0; i < this->num_sub_devices(); ++i) {
         sub_device_ids_[i] = SubDeviceId{i};
     }
+    this->reset_sub_device_stall_group();
 }
 
 void SubDeviceManager::populate_num_cores() {

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -68,7 +68,11 @@ public:
     bool has_allocations() const;
     DeviceAddr local_l1_size() const;
 
-    // #TODO #15944: Temporary until migration to actual fabric is complete
+    const std::vector<SubDeviceId>& get_sub_device_stall_group() const;
+    void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void reset_sub_device_stall_group();
+
+    // TODO #15944: Temporary until migration to actual fabric is complete
     void set_fabric_sub_device_id(SubDeviceId sub_device_id);
     std::optional<SubDeviceId> fabric_sub_device_id() const;
 
@@ -84,6 +88,7 @@ private:
     // TODO: We have a max number of sub-devices, so we can use a fixed size array
     std::vector<SubDevice> sub_devices_;
     std::vector<SubDeviceId> sub_device_ids_;
+    std::vector<SubDeviceId> sub_device_stall_group_;
     IDevice* device_;
 
     DeviceAddr local_l1_size_;

--- a/tt_metal/include/tt_metal/device.hpp
+++ b/tt_metal/include/tt_metal/device.hpp
@@ -255,6 +255,9 @@ public:
     virtual LaunchMessageRingBufferState& get_worker_launch_message_buffer_state(SubDeviceId sub_device_id) = 0;
     virtual CoreCoord virtual_program_dispatch_core(uint8_t cq_id) const = 0;
     virtual const std::vector<SubDeviceId> &get_sub_device_ids() const = 0;
+    virtual const std::vector<SubDeviceId> &get_sub_device_stall_group() const = 0;
+    virtual void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) = 0;
+    virtual void reset_sub_device_stall_group() = 0;
     virtual uint32_t num_sub_devices() const = 0;
 
     // TODO #15944: Temporary api until migration to actual fabric is complete

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -240,6 +240,27 @@ void device_module(py::module& m_device) {
                 Args:
                     sub_device_manager_id (SubDeviceManagerId): The ID of the sub-device manager to remove.
             )doc")
+        .def(
+            "set_sub_device_stall_group",
+            [](IDevice* device, const std::vector<SubDeviceId>& sub_device_ids) {
+                device->push_work([device, sub_device_ids] { device->set_sub_device_stall_group(sub_device_ids); });
+            },
+            py::arg("sub_device_ids"),
+            R"doc(
+                Set the SubDevice IDs that will be stalled on by default for Fast Dispatch commands such as reading, writing, synchronizing.
+                Stalling here refers to the Fast Dispatch cores waiting for programs to complete execution on the specified SubDevices before proceeding with the specified instruction.
+                The default SubDevice IDs to stall on are set to all SubDevice IDs, and whenever a new SubDevice Manager is loaded.
+
+                Args:
+                    sub_device_ids (List[SubDeviceId]): The IDs of the SubDevices to stall on.
+            )doc")
+        .def(
+            "reset_sub_device_stall_group",
+            [](IDevice* device) { device->push_work([device] { device->reset_sub_device_stall_group(); }); },
+            R"doc(
+                Resets the sub_device_ids that will be stalled on by default for Fast Dispatch commands such as reading, writing, synchronizing
+                back to all SubDevice IDs.
+            )doc")
         .def("sfpu_eps", &IDevice::sfpu_eps, R"doc(Returns machine epsilon value for current device.)doc")
         .def("sfpu_nan", &IDevice::sfpu_nan, R"doc(Returns NaN value for current device.)doc")
         .def("sfpu_inf", &IDevice::sfpu_inf, R"doc(Returns Infinity value for current device.)doc");
@@ -536,7 +557,7 @@ void device_module(py::module& m_device) {
                 Args:
                     device (ttnn.device.Device): The device to synchronize with.
                     cq_id (int, optional): The command queue ID to synchronize. Defaults to `None`.
-                    sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to synchronize. Defaults to all sub-devices.
+                    sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to synchronize. Defaults to sub-devices set by set_sub_device_stall_group.
 
                 Returns:
                     `None`: The op ensures that all operations are completed.

--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -42,7 +42,7 @@ void py_module(py::module& module) {
             Args:
                 cq_id (int): The Command Queue on which event completion will be recorded.
                 event (event): The event used to record completion of preceeding commands.
-                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to all sub-devices.
+                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to sub-devices set by set_sub_device_stall_group.
             )doc");
 
     module.def(
@@ -95,7 +95,7 @@ void py_module(py::module& module) {
             Args:
                 cq_id (int): The Command Queue on which event completion will be recorded.
                 event (event): The event used to record completion of preceeding commands.
-                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to all sub-devices.
+                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to record completion for. Defaults to sub-devices set by set_sub_device_stall_group.
             )doc");
 }
 

--- a/ttnn/cpp/pybind11/global_circular_buffer.cpp
+++ b/ttnn/cpp/pybind11/global_circular_buffer.cpp
@@ -31,7 +31,7 @@ void py_module(py::module& module) {
         py::arg("sender_receiver_core_mapping"),
         py::arg("size"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalCircularBuffer Object on a single device.
 
@@ -59,7 +59,7 @@ void py_module(py::module& module) {
         py::arg("sender_receiver_core_mapping"),
         py::arg("size"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalCircularBuffer Object on a single device.
 

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -31,7 +31,7 @@ void py_module(py::module& module) {
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalSemaphore Object on a single device.
 
@@ -64,7 +64,7 @@ void py_module(py::module& module) {
         },
         py::arg("global_semaphore"),
         py::arg("reset_value"),
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Reset the value of the global semaphore.
 
@@ -90,7 +90,7 @@ void py_module(py::module& module) {
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalSemaphore Object on a single device.
 
@@ -123,7 +123,7 @@ void py_module(py::module& module) {
         },
         py::arg("global_semaphore"),
         py::arg("reset_value"),
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Reset the value of the global semaphore.
 

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -75,7 +75,7 @@ void py_module(py::module& module) {
         py::arg("device"),
         py::arg("memory_config") = std::nullopt,
         py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>());
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>());  // TODO #16492: Remove argument
 
     module.def(
         "to_device",
@@ -89,7 +89,7 @@ void py_module(py::module& module) {
         py::arg("device"),
         py::arg("memory_config") = std::nullopt,
         py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Copy tensor from host to device.
 
@@ -118,7 +118,7 @@ void py_module(py::module& module) {
         py::arg("blocking") = true,
         py::kw_only(),
         py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Copy tensor from device to host.
 
@@ -262,7 +262,7 @@ void py_module(py::module& module) {
         py::arg("host_tensor"),
         py::arg("device_tensor"),
         py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>());
+        py::arg("sub_device_ids") = std::vector<SubDeviceId>());  // TODO #16492: Remove argument
 
     module.def(
         "begin_trace_capture",

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1055,7 +1055,7 @@ void pytensor_module(py::module& m_tensor) {
             py::arg("device").noconvert(),
             py::arg("mem_config").noconvert() = MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED},
             py::arg("cq_id") = ttnn::DefaultQueueId,
-            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
             py::keep_alive<0, 2>(),
             R"doc(
             Move TT Tensor from host device to TT accelerator device.
@@ -1097,7 +1097,7 @@ void pytensor_module(py::module& m_tensor) {
             py::arg("mesh_device").noconvert(),
             py::arg("mem_config").noconvert() = MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED},
             py::arg("cq_id") = ttnn::DefaultQueueId,
-            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
             py::keep_alive<0, 2>(),
             R"doc(
             Move TT Tensor from host device to TT accelerator device.
@@ -1180,7 +1180,7 @@ void pytensor_module(py::module& m_tensor) {
             },
             py::arg("blocking") = true,
             py::arg("cq_id") = ttnn::DefaultQueueId,
-            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
+            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
             R"doc(
             Move TT Tensor from TT accelerator device to host device.
 

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -246,6 +246,27 @@ void py_module(py::module& module) {
 
                 Args:
                     mesh_sub_device_manager_id (MeshSubDeviceManagerId): The ID of the sub-device manager to remove.
+            )doc")
+        .def(
+            "set_sub_device_stall_group",
+            [](MeshDevice& self, const std::vector<SubDeviceId>& sub_device_ids) {
+                self.set_sub_device_stall_group(sub_device_ids);
+            },
+            py::arg("sub_device_ids"),
+            R"doc(
+                Set the SubDevice IDs that will be stalled on by default for Fast Dispatch commands such as reading, writing, synchronizing.
+                Stalling here refers to the Fast Dispatch cores waiting for programs to complete execution on the specified SubDevices before proceeding with the specified instruction.
+                The default SubDevice IDs to stall on are set to all SubDevice IDs, and whenever a new SubDevice Manager is loaded.
+
+                Args:
+                    sub_device_ids (List[SubDeviceId]): The IDs of the SubDevices to stall on.
+            )doc")
+        .def(
+            "reset_sub_device_stall_group",
+            &MeshDevice::reset_sub_device_stall_group,
+            R"doc(
+                Resets the sub_device_ids that will be stalled on by default for Fast Dispatch commands such as reading, writing, synchronizing
+                back to all SubDevice IDs.
             )doc");
 
     module.def(

--- a/ttnn/cpp/ttnn/global_circular_buffer.hpp
+++ b/ttnn/cpp/ttnn/global_circular_buffer.hpp
@@ -13,6 +13,9 @@ namespace ttnn::global_circular_buffer {
 struct MultiDeviceGlobalCircularBuffer {
     MultiDeviceGlobalCircularBuffer(MeshDevice* mesh_device);
     std::vector<GlobalCircularBuffer> global_circular_buffers;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("global_circular_buffers");
+    const auto attribute_values() const { return std::forward_as_tuple(this->global_circular_buffers); }
 };
 
 // Single Device APIs

--- a/ttnn/cpp/ttnn/global_semaphore.hpp
+++ b/ttnn/cpp/ttnn/global_semaphore.hpp
@@ -13,6 +13,9 @@ namespace ttnn::global_semaphore {
 struct MultiDeviceGlobalSemaphore {
     MultiDeviceGlobalSemaphore(MeshDevice* mesh_device);
     std::vector<GlobalSemaphore> global_semaphores;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("global_semaphores");
+    const auto attribute_values() const { return std::forward_as_tuple(this->global_semaphores); }
 };
 
 // Single Device APIs

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -159,7 +159,7 @@ def from_torch(
     memory_config: Optional[ttnn.MemoryConfig] = None,
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
-    sub_device_ids: List[ttnn.SubDeviceId] = [],
+    sub_device_ids: List[ttnn.SubDeviceId] = [],  # TODO #16492: Remove argument
 ) -> ttnn.Tensor:
     """
     Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. For bfloat8_b or bfloat4_b format, the function itself is called twice,
@@ -179,7 +179,7 @@ def from_torch(
         memory_config (ttnn.MemoryConfig, optional): The desired `ttnn` memory configuration. Defaults to `None`.
         mesh_mapper (ttnn.TensorToMesh, optional): The desired `ttnn` mesh mapper. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
-        sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on. Defaults to all sub-devices.
+        sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on. Defaults to sub-devices set by set_sub_device_stall_group.
 
     Returns:
         ttnn.Tensor: The resulting `ttnn` tensor.
@@ -273,7 +273,7 @@ def to_torch(
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
     device: Optional[ttnn.Device] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
-    sub_device_ids: List[ttnn.SubDeviceId] = [],
+    sub_device_ids: List[ttnn.SubDeviceId] = [],  # TODO #16492: Remove argument
 ) -> "torch.Tensor":
     """
     Converts the `ttnn.Tensor` tensor into a `torch.Tensor`. It does not call to_layout for bfloat8_b or bfloat4_b as we now convert
@@ -289,7 +289,7 @@ def to_torch(
         mesh_composer (ttnn.MeshToTensor, optional): The desired `ttnn` mesh composer. Defaults to `None`.
         device (ttnn.Device, optional): The `ttnn` device of the input tensor. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
-        sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on. Defaults to all sub-devices.
+        sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on. Defaults to sub-devices set by set_sub_device_stall_group.
 
     Returns:
         torch.Tensor: The converted `torch` tensor.


### PR DESCRIPTION
This lessens the burden on the user to have to track and pass around the ids everywhere. ttnn read/write APIs that were modified to take in sub_device_ids will have the parameter removed in a subsequent PR

### Ticket
https://github.com/tenstorrent/tt-metal/issues/16492

### Problem description
sub_device_ids arg was propogated to many apis, and also puts a lot of burden on the user to track and pass these around everywhere, as by default the runtime will stall on all sub-devices as we want the runtime to be by default safe, however if users have a persistent or semi-persistent programs where sub-devices could depend on each other, they need to pass sub-device ids to all read/write apis (and apis that internally read/write) so that we don't end up stalling on a program that won't terminate.
To simplify this, we keep the default of stalling on all sub-devices, but provide a new API that the user can invoke that adjusts what to stall on for all subsequent commands until user readjusts it. This allows the user to after enqueuing their persistent programs, remove it from the stall list, and this allows them to no longer need to pass sub_device_ids to all the other apis.

### What's changed
Add a new APIs, where the main user fn is `set_sub_device_ids_to_stall`, which enables the user to modify the list of sub-device ids to stall on that is queried by the runtime.

Subsequent PR will remove sub-device ids from the read/write APIs.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/12676185938)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12673362595
