### PR TITLE
Added check for global non-constexpr uint64_t value in kernel

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp
@@ -4,7 +4,7 @@
 
 #include "debug/assert.h"
 
-const uint64_t global_const_eight_byte_val = 0xABCD0123ABCD0123;
+volatile uint64_t global_eight_byte_val = 0xABCD0123ABCD0123;
 
 volatile uint32_t nonzero[4] = {
     0xAABB0000,
@@ -44,7 +44,7 @@ void MAIN {
     zero[2] = 0xdeadbeef;
     zero[3] = 0xdeadbeef;
 
-    if (global_const_eight_byte_val != 0xABCD0123ABCD0123) {
+    if (global_eight_byte_val != 0xABCD0123ABCD0123) {
         ASSERT(0);
         while (1);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp
@@ -4,6 +4,8 @@
 
 #include "debug/assert.h"
 
+const uint64_t global_const_eight_byte_val = 0xABCD0123ABCD0123;
+
 volatile uint32_t nonzero[4] = {
     0xAABB0000,
     0xAABB0001,
@@ -41,6 +43,11 @@ void MAIN {
     zero[1] = 0xdeadbeef;
     zero[2] = 0xdeadbeef;
     zero[3] = 0xdeadbeef;
+
+    if (global_const_eight_byte_val != 0xABCD0123ABCD0123) {
+        ASSERT(0);
+        while (1);
+    }
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || \
     defined(COMPILE_FOR_IDLE_ERISC)
 }


### PR DESCRIPTION
### Ticket
#990 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
