### PR TITLE
Resubmit #16339: parameterize dispatch_constants

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -15,6 +15,7 @@
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 class CommandQueueFixture : public DispatchFixture {
 protected:

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -11,6 +11,7 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 class DeviceFixture : public DispatchFixture {
 protected:

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -12,6 +12,7 @@
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/device.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 // A dispatch-agnostic test fixture
 class DispatchFixture : public ::testing::Test {

--- a/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
@@ -10,6 +10,7 @@
 #include "tt_metal/common/test_tiles.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -11,6 +11,7 @@
 #include "umd/device/types/cluster_descriptor_types.h"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 class MultiDeviceFixture : public DispatchFixture {
 protected:

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "host_api.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 // Helper function to open a file as an fstream, and check that it was opened properly.
 inline bool OpenFile(string &file_name, std::fstream &file_stream, std::ios_base::openmode mode) {

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dispatch_buffer)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dispatch_event)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dispatch_program)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dispatch_trace)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dispatch_util)
 
 add_executable(
     unit_tests_dispatch
@@ -9,6 +10,7 @@ add_executable(
     $<TARGET_OBJECTS:unit_tests_dispatch_event_o>
     $<TARGET_OBJECTS:unit_tests_dispatch_program_o>
     $<TARGET_OBJECTS:unit_tests_dispatch_trace_o>
+    $<TARGET_OBJECTS:unit_tests_dispatch_util_o>
 )
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch)
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(UNIT_TESTS_DISPATCH_UTIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_settings.cpp)
+
+add_library(unit_tests_dispatch_util_o STATIC ${UNIT_TESTS_DISPATCH_UTIL_SRC})
+
+target_link_libraries(unit_tests_dispatch_util_o PRIVATE test_metal_common_libs)
+
+target_include_directories(
+    unit_tests_dispatch_util_o
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/dispatch
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/dispatch/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+
+add_executable(unit_tests_dispatch_util $<TARGET_OBJECTS:unit_tests_dispatch_util_o>)
+
+target_link_libraries(unit_tests_dispatch_util PRIVATE test_metal_common_libs)
+
+set_target_properties(
+    unit_tests_dispatch_util
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)
+
+TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_util)

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <stdexcept>
+#include "command_queue_fixture.hpp"
+#include "common/logger.hpp"
+#include "dispatch/dispatch_constants.hpp"
+#include "gtest/gtest.h"
+#include "llrt/hal.hpp"
+#include "tt_metal/impl/dispatch/util/include/dispatch_settings.hpp"
+#include "tt_metal/impl/dispatch/command_queue_interface.hpp"
+#include "umd/device/tt_core_coordinates.h"
+
+using namespace tt::tt_metal::dispatch;
+
+// Loop through test_func for WORKER, ETH X 1, 2 CQs
+void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, const uint32_t num_hw_cqs)>& test_func) {
+    static constexpr auto core_types_to_test = std::array<CoreType, 2>{CoreType::WORKER, CoreType::ETH};
+    static constexpr auto num_hw_cqs_to_test = std::array<uint32_t, 2>{1, 2};
+
+    for (const auto& core_type : core_types_to_test) {
+        if (core_type == CoreType::ETH &&
+            hal.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
+            // This device does not have the eth core
+            tt::log_info(tt::LogTest, "IDLE_ETH core type is not on this device");
+            continue;
+        }
+        for (const auto& num_hw_cqs : num_hw_cqs_to_test) {
+            test_func(core_type, num_hw_cqs);
+        }
+    }
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsDefaultParity) {
+    ForEachCoreTypeXHWCQs([&](const CoreType& core_type, uint32_t num_hw_cqs) {
+        auto settings = DispatchSettings::defaults(core_type, tt::Cluster::instance(), num_hw_cqs);
+
+        const auto& old_constants = dispatch_constants::get(core_type, num_hw_cqs);
+
+        ASSERT_EQ(settings.num_hw_cqs_, num_hw_cqs);
+
+        ASSERT_EQ(settings.prefetch_q_entries_, old_constants.prefetch_q_entries());
+        ASSERT_EQ(settings.prefetch_q_size_, old_constants.prefetch_q_size());
+        ASSERT_EQ(settings.prefetch_max_cmd_size_, old_constants.max_prefetch_command_size());
+        ASSERT_EQ(settings.prefetch_cmddat_q_size_, old_constants.cmddat_q_size());
+        ASSERT_EQ(settings.prefetch_scratch_db_size_, old_constants.scratch_db_size());
+
+        ASSERT_EQ(settings.prefetch_d_buffer_size_, old_constants.prefetch_d_buffer_size());
+        ASSERT_EQ(settings.prefetch_d_pages_, old_constants.prefetch_d_buffer_pages());
+        ASSERT_EQ(settings.prefetch_d_blocks_, dispatch_constants::PREFETCH_D_BUFFER_BLOCKS);
+
+        ASSERT_EQ(settings.tunneling_buffer_size_ / num_hw_cqs, old_constants.mux_buffer_size(num_hw_cqs));
+        ASSERT_EQ(settings.tunneling_buffer_pages_ / num_hw_cqs, old_constants.mux_buffer_pages(num_hw_cqs));
+
+        ASSERT_EQ(settings.dispatch_pages_, old_constants.dispatch_buffer_pages());
+        ASSERT_EQ(settings.dispatch_pages_per_block_, dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS);
+
+        ASSERT_EQ(settings.dispatch_s_buffer_size_, old_constants.dispatch_s_buffer_size());
+        ASSERT_EQ(settings.dispatch_s_buffer_pages_, old_constants.dispatch_s_buffer_pages());
+
+        EXPECT_NO_THROW(settings.build());
+    });
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsDefaultUnsupportedCoreType) {
+    const auto unsupported_core = CoreType::ARC;
+    EXPECT_THROW(DispatchSettings::defaults(unsupported_core, tt::Cluster::instance(), 1), std::runtime_error);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsMissingArgs) {
+    DispatchSettings settings;
+    EXPECT_THROW(settings.build(), std::runtime_error);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsEq) {
+    static constexpr uint32_t hw_cqs = 2;
+    auto settings = DispatchSettings::worker_defaults(tt::Cluster::instance(), hw_cqs);
+    auto settings_2 = settings; // Copy
+    EXPECT_EQ(settings, settings_2);
+    settings_2.dispatch_size_ += 1;
+    EXPECT_NE(settings, settings_2);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsSetPrefetchDBuffer) {
+    static constexpr uint32_t hw_cqs = 2;
+    static constexpr uint32_t expected_buffer_bytes = 0xcafe;
+    static constexpr uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchConstants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+    auto settings = DispatchSettings::worker_defaults(tt::Cluster::instance(), hw_cqs);
+    settings.prefetch_d_buffer_size(expected_buffer_bytes);
+    EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
+    EXPECT_EQ(settings.prefetch_d_pages_, expected_page_count);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsSetPrefetchQBuffer) {
+    static constexpr uint32_t hw_cqs = 2;
+    static constexpr uint32_t expected_buffer_entries = 0x1000;
+    static constexpr uint32_t expected_buffer_bytes = expected_buffer_entries * sizeof(DispatchConstants::prefetch_q_entry_type);
+    auto settings = DispatchSettings::worker_defaults(tt::Cluster::instance(), hw_cqs);
+    settings.prefetch_q_entries(expected_buffer_entries);
+    EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
+    EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsSetDispatchBuffer) {
+    static constexpr uint32_t hw_cqs = 2;
+    static constexpr uint32_t expected_buffer_bytes = 0x2000;
+    static constexpr uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchConstants::DISPATCH_BUFFER_LOG_PAGE_SIZE);
+    auto settings = DispatchSettings::worker_defaults(tt::Cluster::instance(), hw_cqs);
+    settings.dispatch_size(expected_buffer_bytes);
+    EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
+    EXPECT_EQ(settings.dispatch_pages_, expected_page_count);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsSetDispatchSBuffer) {
+    static constexpr uint32_t hw_cqs = 2;
+    static constexpr uint32_t expected_buffer_bytes = 0x2000;
+    static constexpr uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchConstants::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
+    auto settings = DispatchSettings::worker_defaults(tt::Cluster::instance(), hw_cqs);
+    settings.dispatch_s_buffer_size(expected_buffer_bytes);
+    EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
+    EXPECT_EQ(settings.dispatch_s_buffer_pages_, expected_page_count);
+}
+
+TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsSetTunnelerBuffer) {
+    static constexpr uint32_t hw_cqs = 2;
+    static constexpr uint32_t expected_buffer_bytes = 0x2000;
+    static constexpr uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchConstants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+    auto settings = DispatchSettings::worker_defaults(tt::Cluster::instance(), hw_cqs);
+    settings.tunneling_buffer_size(expected_buffer_bytes);
+    EXPECT_EQ(settings.tunneling_buffer_size_, expected_buffer_bytes);
+    EXPECT_EQ(settings.tunneling_buffer_pages_, expected_page_count);
+}

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -10,7 +10,6 @@
 #include "gtest/gtest.h"
 #include "llrt/hal.hpp"
 #include "tt_metal/impl/dispatch/util/include/dispatch_settings.hpp"
-#include "tt_metal/impl/dispatch/command_queue_interface.hpp"
 #include "umd/device/tt_core_coordinates.h"
 
 using namespace tt::tt_metal::dispatch;
@@ -31,37 +30,6 @@ void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, c
             test_func(core_type, num_hw_cqs);
         }
     }
-}
-
-TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsDefaultParity) {
-    ForEachCoreTypeXHWCQs([&](const CoreType& core_type, uint32_t num_hw_cqs) {
-        auto settings = DispatchSettings::defaults(core_type, tt::Cluster::instance(), num_hw_cqs);
-
-        const auto& old_constants = dispatch_constants::get(core_type, num_hw_cqs);
-
-        ASSERT_EQ(settings.num_hw_cqs_, num_hw_cqs);
-
-        ASSERT_EQ(settings.prefetch_q_entries_, old_constants.prefetch_q_entries());
-        ASSERT_EQ(settings.prefetch_q_size_, old_constants.prefetch_q_size());
-        ASSERT_EQ(settings.prefetch_max_cmd_size_, old_constants.max_prefetch_command_size());
-        ASSERT_EQ(settings.prefetch_cmddat_q_size_, old_constants.cmddat_q_size());
-        ASSERT_EQ(settings.prefetch_scratch_db_size_, old_constants.scratch_db_size());
-
-        ASSERT_EQ(settings.prefetch_d_buffer_size_, old_constants.prefetch_d_buffer_size());
-        ASSERT_EQ(settings.prefetch_d_pages_, old_constants.prefetch_d_buffer_pages());
-        ASSERT_EQ(settings.prefetch_d_blocks_, dispatch_constants::PREFETCH_D_BUFFER_BLOCKS);
-
-        ASSERT_EQ(settings.tunneling_buffer_size_ / num_hw_cqs, old_constants.mux_buffer_size(num_hw_cqs));
-        ASSERT_EQ(settings.tunneling_buffer_pages_ / num_hw_cqs, old_constants.mux_buffer_pages(num_hw_cqs));
-
-        ASSERT_EQ(settings.dispatch_pages_, old_constants.dispatch_buffer_pages());
-        ASSERT_EQ(settings.dispatch_pages_per_block_, dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS);
-
-        ASSERT_EQ(settings.dispatch_s_buffer_size_, old_constants.dispatch_s_buffer_size());
-        ASSERT_EQ(settings.dispatch_s_buffer_pages_, old_constants.dispatch_s_buffer_pages());
-
-        EXPECT_NO_THROW(settings.build());
-    });
 }
 
 TEST_F(CommandQueueSingleCardFixture, TestDispatchSettingsDefaultUnsupportedCoreType) {

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -12,6 +12,7 @@
 #include "host_api.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -12,6 +12,7 @@
 #include "tt_metal/host_api.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "llrt/hal.hpp"
+#include "llrt/llrt.hpp"
 
 inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, const tt::tt_metal::Program& program) {
 #if defined(TRACY_ENABLE)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -14,6 +14,7 @@
 #include "noc/noc_parameters.h"
 
 #include "tt_metal/llrt/hal.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 extern bool debug_g;
 extern bool use_coherent_data_g;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -17,6 +17,7 @@
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp"
 
 #include "llrt/hal.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 #define CQ_PREFETCH_CMD_BARE_MIN_SIZE tt::tt_metal::hal.get_alignment(tt::tt_metal::HalMemType::HOST)
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bi_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bi_tunnel.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
 #include "tt_metal/device.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp
@@ -6,6 +6,7 @@
 
 #include <nlohmann/json.hpp>
 #include "tt_metal/common/core_coord.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 static inline std::string to_string(pkt_dest_size_choices_t choice) {
     switch (choice) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -8,6 +8,7 @@
 #include "tt_metal/llrt/rtoptions.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tunnel_1cq.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tunnel_1cq.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tunnel_2cq.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tunnel_2cq.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/device.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
 #include "utils.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_common.hpp"
 
 using std::vector;
 using namespace tt;

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -30,6 +30,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/demux.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/eth_router.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/eth_tunneler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/util/dispatch_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_server.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/noc_logging.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/debug/watcher_server.cpp

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -13,6 +13,7 @@
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "tt_metal/device.hpp"
+#include "tt_metal/llrt/llrt.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/dispatch_constants.hpp
+++ b/tt_metal/impl/dispatch/dispatch_constants.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <climits>
+#include <cstdint>
+#include <limits>
+#include "tt_metal/impl/dispatch/cq_commands.hpp"
+#include "tt_metal/hw/inc/dev_msgs.h"
+
+namespace tt::tt_metal::dispatch {
+
+// FD Constants
+struct DispatchConstants {
+    // Prefetch Queue entry type // Same as the one in cq_prefetch.cpp
+    using prefetch_q_entry_type = uint16_t;
+
+    // Prefetch Queue pointer type // Same as the one in cq_prefetch.cpp
+    using prefetch_q_ptr_type = uint32_t;
+
+    static constexpr uint32_t MAX_NUM_HW_CQS = 2;
+
+    static constexpr uint32_t DISPATCH_MESSAGE_ENTRIES = 16;
+
+    static constexpr uint32_t DISPATCH_MESSAGES_MAX_OFFSET =
+        std::numeric_limits<decltype(go_msg_t::dispatch_message_offset)>::max();
+
+    static constexpr uint32_t DISPATCH_BUFFER_LOG_PAGE_SIZE = 12;
+
+    static constexpr uint32_t DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES = 64;
+
+    // dispatch_s CB page size is 128 bytes. This should currently be enough to accomodate all commands that
+    // are sent to it. Change as needed, once this endpoint is required to handle more than go signal mcasts.
+    static constexpr uint32_t DISPATCH_S_BUFFER_LOG_PAGE_SIZE = 7;
+
+    static constexpr uint32_t GO_SIGNAL_BITS_PER_TXN_TYPE = 4;
+
+    static constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;
+
+    static constexpr uint32_t LOG_TRANSFER_PAGE_SIZE = 12;
+
+    static constexpr uint32_t TRANSFER_PAGE_SIZE = 1 << LOG_TRANSFER_PAGE_SIZE;
+
+    static constexpr uint32_t PREFETCH_D_BUFFER_LOG_PAGE_SIZE = 12;
+
+    static constexpr uint32_t EVENT_PADDED_SIZE = 16;
+
+    // When page size of buffer to write/read exceeds MAX_PREFETCH_COMMAND_SIZE, the PCIe aligned page size is broken
+    // down into equal sized partial pages BASE_PARTIAL_PAGE_SIZE denotes the initial partial page size to use, it is
+    // incremented by PCIe alignment until page size can be evenly split
+    static constexpr uint32_t BASE_PARTIAL_PAGE_SIZE = 4096;
+
+    static_assert(
+        DISPATCH_MESSAGE_ENTRIES <=
+        sizeof(decltype(CQDispatchCmd::notify_dispatch_s_go_signal.index_bitmask)) * CHAR_BIT);
+
+    static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30;                                        // 1GB
+    static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                     // 256 MB;
+    static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE; // 256 MB;
+};
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "llrt/hal.hpp"
+#include "llrt/tt_cluster.hpp"
+#include "magic_enum/magic_enum.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "include/dispatch_settings.hpp"
+#include "include/helpers.hpp"
+
+namespace tt::tt_metal::dispatch {
+
+DispatchSettings DispatchSettings::worker_defaults(const tt::Cluster& cluster, const uint32_t num_hw_cqs) {
+    uint32_t prefetch_q_entries;
+    if (cluster.is_galaxy_cluster()) {
+        prefetch_q_entries = 1532 / num_hw_cqs;
+    } else {
+        prefetch_q_entries = 1534;
+    }
+
+    return DispatchSettings()
+        .num_hw_cqs(num_hw_cqs)
+        .core_type(CoreType::WORKER)
+        .prefetch_q_entries(prefetch_q_entries)
+        .prefetch_max_cmd_size(128_KB)
+        .prefetch_cmddat_q_size(256_KB)
+        .prefetch_scratch_db_size(128_KB)
+        .prefetch_d_buffer_size(256_KB)
+
+        .dispatch_pages_per_block(4)
+        .dispatch_size(512_KB)
+        .dispatch_s_buffer_size(32_KB)
+        .prefetch_d_blocks(4)
+
+        .with_alignment(hal.get_alignment(HalMemType::L1))
+
+        .tunneling_buffer_size(256_KB)  // same as prefetch_d_buffer_size
+
+        .build();
+}
+
+DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& cluster, const uint32_t num_hw_cqs) {
+    return DispatchSettings()
+        .num_hw_cqs(num_hw_cqs)
+        .core_type(CoreType::ETH)
+        .prefetch_q_entries(128)
+        .prefetch_max_cmd_size(32_KB)
+        .prefetch_cmddat_q_size(64_KB)
+        .prefetch_scratch_db_size(19_KB)
+        .prefetch_d_buffer_size(128_KB)
+
+        .dispatch_pages_per_block(4)
+        .dispatch_size(128_KB)
+        .dispatch_s_buffer_size(32_KB)
+        .prefetch_d_blocks(4)
+
+        .tunneling_buffer_size(128_KB)  // same as prefetch_d_buffer_size
+
+        .with_alignment(hal.get_alignment(HalMemType::L1))
+
+        .build();
+}
+
+DispatchSettings DispatchSettings::defaults(
+    const CoreType& core_type, const tt::Cluster& cluster, const uint32_t num_hw_cqs) {
+    if (!num_hw_cqs) {
+        TT_THROW("0 CQs is invalid");
+    }
+
+    if (core_type == CoreType::WORKER) {
+        return worker_defaults(cluster, num_hw_cqs);
+    } else if (core_type == CoreType::ETH) {
+        return eth_defaults(cluster, num_hw_cqs);
+    }
+
+    TT_THROW("Default settings for core_type {} is not implemented", magic_enum::enum_name(core_type));
+}
+
+std::vector<std::string> DispatchSettings::get_errors() const {
+    std::vector<std::string> msgs;
+
+    if (!prefetch_q_rd_ptr_size_ || !prefetch_q_pcie_rd_ptr_size_ || !dispatch_s_sync_sem_ || !dispatch_message_ ||
+        !other_ptrs_size) {
+        msgs.push_back(fmt::format("configuration with_alignment() is a required\n"));
+    }
+
+    if (!num_hw_cqs_) {
+        msgs.push_back(fmt::format("num_hw_cqs must be set to non zero\n"));
+    } else if (num_hw_cqs_ > DispatchConstants::MAX_NUM_HW_CQS) {
+        msgs.push_back(fmt::format(
+            "{} CQs specified. the maximum number for num_hw_cqs is {}\n",
+            num_hw_cqs_,
+            DispatchConstants::MAX_NUM_HW_CQS));
+    }
+
+    if (prefetch_cmddat_q_size_ < 2 * prefetch_max_cmd_size_) {
+        msgs.push_back(fmt::format(
+            "prefetch_cmddat_q_size_ {} is too small. It must be >= 2 * prefetch_max_cmd_size_\n",
+            prefetch_cmddat_q_size_));
+    }
+    if (prefetch_scratch_db_size_ % 2) {
+        msgs.push_back(fmt::format("prefetch_scratch_db_size_ {} must be even\n", prefetch_scratch_db_size_));
+    }
+    if ((dispatch_size_ & (dispatch_size_ - 1)) != 0) {
+        msgs.push_back(fmt::format("dispatch_block_size_ {} must be power of 2\n", dispatch_size_));
+    }
+
+    return msgs;
+}
+
+DispatchSettings& DispatchSettings::build() {
+    const auto msgs = get_errors();
+    if (msgs.empty()) {
+        return *this;
+    }
+    TT_THROW("Validation errors in dispatch_settings. Call validate() for a list of errors");
+}
+
+}  // namespace tt::tt_metal::dispatch

--- a/tt_metal/impl/dispatch/util/include/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/util/include/dispatch_settings.hpp
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include "llrt/hal.hpp"
+#include "llrt/tt_cluster.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "tt_metal/impl/dispatch/dispatch_constants.hpp"
+
+namespace tt::tt_metal::dispatch {
+
+// Settings for a dispatch core
+struct DispatchSettings {
+    // common
+    uint32_t num_hw_cqs_{0};
+
+    // Rd/Wr/Msg pointer sizes
+    uint32_t prefetch_q_rd_ptr_size_{0};    // configured with alignment
+    uint32_t prefetch_q_pcie_rd_ptr_size_;  // configured with alignment
+    uint32_t dispatch_s_sync_sem_;          // configured with alignment
+    uint32_t dispatch_message_;             // configured with alignment
+    uint32_t other_ptrs_size;               // configured with alignment
+
+    // cq_prefetch
+    uint32_t prefetch_q_entries_{0};
+    uint32_t prefetch_q_size_;
+    uint32_t prefetch_max_cmd_size_;
+    uint32_t prefetch_cmddat_q_size_;
+    uint32_t prefetch_scratch_db_size_;
+    uint32_t prefetch_d_buffer_size_;
+    uint32_t prefetch_d_pages_;  // prefetch_d_buffer_size_ / PREFETCH_D_BUFFER_LOG_PAGE_SIZE
+    uint32_t prefetch_d_blocks_;
+
+    // cq_dispatch
+    uint32_t dispatch_pages_per_block_;  // number of pages per block
+    uint32_t dispatch_size_;             // total buffer size
+    uint32_t dispatch_pages_;            // total buffer size / page size
+    uint32_t dispatch_s_buffer_size_;
+    uint32_t dispatch_s_buffer_pages_;  // dispatch_s_buffer_size_ / DISPATCH_S_BUFFER_LOG_PAGE_SIZE
+
+    // packet_mux, packet_demux, vc_eth_tunneler, vc_packet_router
+    uint32_t tunneling_buffer_size_;
+    uint32_t tunneling_buffer_pages_;  // tunneling_buffer_size_ / PREFETCH_D_BUFFER_LOG_PAGE_SIZE
+
+    CoreType core_type_;  // Which core this settings is for
+
+    bool operator==(const DispatchSettings& other) const {
+        return num_hw_cqs_ == other.num_hw_cqs_ && prefetch_q_rd_ptr_size_ == other.prefetch_q_rd_ptr_size_ &&
+               prefetch_q_pcie_rd_ptr_size_ == other.prefetch_q_pcie_rd_ptr_size_ &&
+               dispatch_s_sync_sem_ == other.dispatch_s_sync_sem_ && dispatch_message_ == other.dispatch_message_ &&
+               other_ptrs_size == other.other_ptrs_size && prefetch_q_entries_ == other.prefetch_q_entries_ &&
+               prefetch_q_size_ == other.prefetch_q_size_ && prefetch_max_cmd_size_ == other.prefetch_max_cmd_size_ &&
+               prefetch_cmddat_q_size_ == other.prefetch_cmddat_q_size_ &&
+               prefetch_scratch_db_size_ == other.prefetch_scratch_db_size_ &&
+               prefetch_d_buffer_size_ == other.prefetch_d_buffer_size_ &&
+               prefetch_d_pages_ == other.prefetch_d_pages_ && prefetch_d_blocks_ == other.prefetch_d_blocks_ &&
+               dispatch_pages_per_block_ == other.dispatch_pages_per_block_ && dispatch_size_ == other.dispatch_size_ &&
+               dispatch_pages_ == other.dispatch_pages_ && dispatch_s_buffer_size_ == other.dispatch_s_buffer_size_ &&
+               dispatch_s_buffer_pages_ == other.dispatch_s_buffer_pages_ &&
+               tunneling_buffer_size_ == other.tunneling_buffer_size_ &&
+               tunneling_buffer_pages_ == other.tunneling_buffer_pages_ && core_type_ == other.core_type_;
+    }
+
+    bool operator!=(const DispatchSettings& other) const {
+        return !(*this == other);
+    }
+
+    // Default settings for WORKER cores
+    static DispatchSettings worker_defaults(const tt::Cluster& cluster, const uint32_t num_hw_cqs);
+
+    // Default settings for ETH cores
+    static DispatchSettings eth_defaults(const tt::Cluster& cluster, const uint32_t num_hw_cqs);
+
+    // Returns default dispatch settings for a core
+    static DispatchSettings defaults(const CoreType& core_type, const tt::Cluster& cluster, const uint32_t num_hw_cqs);
+
+    DispatchSettings& core_type(const CoreType& val) {
+        this->core_type_ = val;
+        return *this;
+    }
+
+    // Trivial setter for num_hw_cqs
+    DispatchSettings& num_hw_cqs(uint32_t val) {
+        this->num_hw_cqs_ = val;
+        return *this;
+    }
+
+    // Trivial setter for prefetch_max_cmd_size
+    DispatchSettings& prefetch_max_cmd_size(uint32_t val) {
+        this->prefetch_max_cmd_size_ = val;
+        return *this;
+    }
+
+    // Trivial setter for prefetch_cmddat_q_size
+    DispatchSettings& prefetch_cmddat_q_size(uint32_t val) {
+        this->prefetch_cmddat_q_size_ = val;
+        return *this;
+    }
+
+    // Trivial setter for prefetch_scratch_db_size
+    DispatchSettings& prefetch_scratch_db_size(uint32_t val) {
+        this->prefetch_scratch_db_size_ = val;
+        return *this;
+    }
+
+    // Setter for prefetch_q_entries and update prefetch_q_size
+    DispatchSettings& prefetch_q_entries(uint32_t val) {
+        this->prefetch_q_entries_ = val;
+        this->prefetch_q_size_ = val * sizeof(DispatchConstants::prefetch_q_entry_type);
+        return *this;
+    }
+
+    // Setter for prefetch_d_buffer_size and update prefetch_d_pages
+    DispatchSettings& prefetch_d_buffer_size(uint32_t val) {
+        this->prefetch_d_buffer_size_ = val;
+        this->prefetch_d_pages_ =
+            this->prefetch_d_buffer_size_ / (1 << DispatchConstants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+
+        return *this;
+    }
+
+    // Trivial setter for dispatch_pages_per_block
+    DispatchSettings& dispatch_pages_per_block(uint32_t val) {
+        this->dispatch_pages_per_block_ = val;
+        return *this;
+    }
+
+    // Trivial setter for prefetch_d_blocks
+    DispatchSettings& prefetch_d_blocks(uint32_t val) {
+        this->prefetch_d_blocks_ = val;
+        return *this;
+    }
+
+    // Setter for dispatch_block_size and update dispatch_pages
+    DispatchSettings& dispatch_size(uint32_t val) {
+        this->dispatch_size_ = val;
+        this->dispatch_pages_ = this->dispatch_size_ / (1 << DispatchConstants::DISPATCH_BUFFER_LOG_PAGE_SIZE);
+        return *this;
+    }
+
+    // Setter for dispatch_s_buffer_size and update dispatch_s_buffer_pages
+    DispatchSettings& dispatch_s_buffer_size(uint32_t val) {
+        this->dispatch_s_buffer_size_ = val;
+        this->dispatch_s_buffer_pages_ =
+            this->dispatch_s_buffer_size_ / (1 << DispatchConstants::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
+        return *this;
+    }
+
+    // Setter for tunneling_buffer_size and update tunneling_buffer_pages
+    DispatchSettings& tunneling_buffer_size(uint32_t val) {
+        this->tunneling_buffer_size_ = val;
+        this->tunneling_buffer_pages_ =
+            this->tunneling_buffer_size_ / (1 << DispatchConstants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE); // match legacy dispatch_constants
+        return *this;
+    }
+
+    // Sets pointer values based on L1 alignment
+    DispatchSettings& with_alignment(uint32_t l1_alignment) {
+        this->prefetch_q_rd_ptr_size_ = sizeof(DispatchConstants::prefetch_q_ptr_type);
+        this->prefetch_q_pcie_rd_ptr_size_ = l1_alignment - sizeof(DispatchConstants::prefetch_q_ptr_type);
+        this->dispatch_s_sync_sem_ = DispatchConstants::DISPATCH_MESSAGE_ENTRIES * l1_alignment;
+        this->dispatch_message_ = DispatchConstants::DISPATCH_MESSAGE_ENTRIES * l1_alignment;
+        this->other_ptrs_size = l1_alignment;
+
+        return *this;
+    }
+
+    // Returns a list of errors
+    std::vector<std::string> get_errors() const;
+
+    // Throws if any settings are not set properly and not empty. Does not confirm if the settings will work.
+    DispatchSettings& build();
+};
+
+struct DispatchSettingsContainerKey {
+    CoreType core_type;
+    uint32_t num_hw_cqs;
+
+    bool operator==(const DispatchSettingsContainerKey& other) const {
+        return core_type == other.core_type && num_hw_cqs == other.num_hw_cqs;
+    }
+};
+
+using DispatchSettingsContainer = std::unordered_map<DispatchSettingsContainerKey, DispatchSettings>;
+
+}  // namespace tt::tt_metal::dispatch
+
+namespace std {
+template <>
+struct hash<tt::tt_metal::dispatch::DispatchSettingsContainerKey> {
+    size_t operator()(const tt::tt_metal::dispatch::DispatchSettingsContainerKey& k) const {
+        const auto h1 = std::hash<uint32_t>{}(static_cast<int>(k.core_type));
+        const auto h2 = std::hash<uint32_t>{}(k.num_hw_cqs);
+        return h1 ^ (h2 << 1);
+    }
+};
+}  // namespace std

--- a/tt_metal/impl/dispatch/util/include/helpers.hpp
+++ b/tt_metal/impl/dispatch/util/include/helpers.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace tt::tt_metal::dispatch {
+
+// Si KB Prefix
+constexpr auto operator""_KB(const unsigned long long v) -> uint32_t { return 1024 * v; }
+
+inline uint32_t align_size(uint32_t sz, uint32_t alignment) {
+    return ((sz + alignment - 1) / alignment * alignment);
+}
+
+inline uint32_t align_addr(uint32_t addr, uint32_t alignment) {
+    return ((addr - 1) | (alignment - 1)) + 1;
+}
+
+}  // namespace tt::tt_metal::dispatch


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16339

### Problem description
Original PR was here https://github.com/tenstorrent/tt-metal/pull/16355. It was reverted due to a hang with an incorrect test case that I added.

### What's changed
I removed the incorrect test case

### Checklist
- [X] Post commit CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/12675116575
https://github.com/tenstorrent/tt-metal/actions/runs/12675113742

- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
