### PR TITLE
Remove assert for dtype set while converting to ROW MAJOR layout.

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -143,8 +143,6 @@ Tensor to_layout_impl(
                 throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
             }
         } else if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-            TT_ASSERT(not dtype.has_value(), "dtype cannot be specified when converting to ROW_MAJOR_LAYOUT!");
-
             if (tensor.is_sharded()) {
                 const auto memory_config = tensor.memory_config();
                 output_memory_config =


### PR DESCRIPTION

### Problem description
In debug mode, If tiled tensor is passed with dtype set to be converted to row major, Assert gets triggered as dtype of tensor is set.

### What's changed
Remove assert.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
