### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Eltwise Binary

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -372,7 +372,7 @@ void MAIN {
     constexpr auto cb_out0 =  tt::CBIndex::c_16;
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
 
     for(uint32_t block = 0; block < per_core_block_cnt; ++block) {
 

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_op_init_funcs.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_op_init_funcs.rst
@@ -3,4 +3,4 @@ binary_init_funcs
 
 
 .. doxygenfunction:: binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb)
-.. doxygenfunction:: binary_op_specific_init()
+.. doxygenfunction:: binary_op_specific_init(uint32_t icb0, uint32_t icb1)

--- a/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/Tutorial_Add_Two_Integers_in_a_Compute_Kernel.md
@@ -122,7 +122,7 @@ cb_push_back(cb_id_in1, 1);
 
 12. Unpack, compute, and pack the data:
 ```binary_op_init_common(cb_in0, cb_in1, cb_out0);
-add_tiles_init();
+add_tiles_init(cb_in0, cb_in1);
 
 // wait for a block of tiles in each of input CBs
 cb_wait_front(cb_in0, 1);

--- a/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -157,7 +157,7 @@ The reader kernel reads in a one tile from each of the two source vectors that a
 
 ``` cpp
 binary_op_init_common(cb_in0, cb_in1, cb_out0);
-add_tiles_init();
+add_tiles_init(cb_in0, cb_in1);
 
 // wait for a block of tiles in each of input CBs
 cb_wait_front(cb_in0, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/broadcast.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/broadcast.cpp
@@ -13,7 +13,7 @@ void MAIN {
 #ifndef BCAST_OP_INIT
     init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 #else
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
     BCAST_OP_INIT(tt::CBIndex::c_0, tt::CBIndex::c_1);
 #endif
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -27,9 +27,9 @@ void MAIN {
     constexpr uint32_t do_beta = get_compile_time_arg_val(3);
 
 #ifdef FUSE_PRE_ADD
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 #else
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 #endif
 
     constexpr uint32_t onetile = 1;
@@ -71,7 +71,7 @@ void MAIN {
  * X + Y
  */
 #ifdef FUSE_PRE_ADD
-        add_tiles_init();
+        add_tiles_init(cb_in, cb_inb);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             ACQ();
             // UNPACK(( { DPRINT  << "Waiting on cb_x" << ENDL(); } ));
@@ -134,7 +134,7 @@ void MAIN {
         /* (x - E[x])^2
          * compute temp = xmm*xmm = (x-E[x])^2
          */
-        mul_tiles_init();
+        mul_tiles_init(cb_xmm, cb_xmm);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_xmm, wt + blk);  // cumulative wait
             cb_reserve_back(cb_xmm2, blk);    // can probably use less space for this if we block
@@ -177,7 +177,7 @@ void MAIN {
          * add epsilon E[(x-E[x])^2]+eps
          */
         ACQ();
-        add_tiles_init();
+        add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
         cb_reserve_back(cb_ex2pe, 1);  // 1

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -27,9 +27,9 @@ void MAIN {
     constexpr uint32_t do_beta = get_compile_time_arg_val(3);
 
 #ifdef FUSE_PRE_ADD
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 #else
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 #endif
 
     constexpr uint32_t onetile = 1;
@@ -69,7 +69,7 @@ void MAIN {
  * X + Y
  */
 #ifdef FUSE_PRE_ADD
-        add_tiles_init();
+        add_tiles_init(cb_in, cb_inb);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             ACQ();
             // UNPACK(( { DPRINT  << "Waiting on cb_x" << ENDL(); } ));
@@ -93,7 +93,7 @@ void MAIN {
         /* (x)^2
          * compute temp = x^2
          */
-        mul_tiles_init();
+        mul_tiles_init(cb_x, cb_x);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt + blk);
             cb_reserve_back(cb_x2, blk);  // can probably use less space for this if we block
@@ -134,7 +134,7 @@ void MAIN {
          * add epsilon E[(x-E[x])^2]+eps
          */
         ACQ();
-        add_tiles_init();
+        add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
         cb_reserve_back(cb_ex2pe, 1);  // 1

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rotary_embedding.cpp
@@ -30,7 +30,7 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 // We don't pop in1 in decode which is sin/cos since we don't stream
 #else
     ACQ();
-    mul_tiles_init();
+    mul_tiles_init(in0_cb, in1_cb);
     mul_tiles(in0_cb, in1_cb, 0, 0, 0);
     pack_tile(0, out_cb);
     REL();
@@ -80,7 +80,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(10);
     constexpr uint32_t half_Wt = get_compile_time_arg_val(11);
 
-    binary_op_init_common(in_cb, cos_cb);
+    binary_op_init_common(in_cb, cos_cb, out_cb);
 
     cb_wait_front(scalar_cb, onetile);
 
@@ -134,7 +134,7 @@ void MAIN {
             cb_reserve_back(out_cb, onetile);
 
             ACQ();
-            add_tiles_init();
+            add_tiles_init(cos_interm_cb, sin_interm_cb);
             add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
             pack_tile(0, out_cb);
             REL();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -30,7 +30,7 @@ void MAIN {
     const uint32_t Wt = get_arg_val<uint32_t>(2);
     const uint32_t ndst = get_arg_val<uint32_t>(3);
     const uint32_t start_ht = get_arg_val<uint32_t>(4);
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     constexpr uint32_t onetile = 1;
     // reserve one tile for zeros on cb_in2

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -26,8 +26,8 @@ namespace ckernel {
  * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31                    | True     |
  * | ocb            | The identifier of the circular buffer (CB) containing output  | uint32_t | 0 to 31, defaults to CB 16 | True     |
  */
- // clang-format on
-ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb = 16) {
+// clang-format on
+ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     UNPACK((llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 
@@ -49,7 +49,7 @@ ALWI void mul_tiles_init_f() { MATH((llk_math_eltwise_binary_init<ELWMUL, NONE, 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void mul_tiles_init(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+ALWI void mul_tiles_init(uint32_t icb0, uint32_t icb1) {
     MATH((llk_math_eltwise_binary_init<ELWMUL, NONE, MATH_FIDELITY>()));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 }
@@ -71,8 +71,8 @@ ALWI void add_tiles_init_nof() { MATH((llk_math_eltwise_binary_init<ELWADD, NONE
  * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
  * | acc_to_dest    | If true, operation = A + B + dst_tile_idx of add_tiles        | bool     | 0,1         | False    |
  */
- // clang-format on
-ALWI void add_tiles_init(uint32_t icb0 = 0, uint32_t icb1 = 1, bool acc_to_dest = false) {
+// clang-format on
+ALWI void add_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false) {
     MATH((llk_math_eltwise_binary_init<ELWADD, NONE>(0 /*transpose*/, acc_to_dest)));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, 0 /*transpose*/, acc_to_dest)));
 }
@@ -94,8 +94,8 @@ ALWI void sub_tiles_init_nof() { MATH((llk_math_eltwise_binary_init<ELWSUB, NONE
  * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t | 0 to 31     | True     |
  * | acc_to_dest    | If true, operation = A - B + dst_tile_idx of sub_tiles        | bool     | 0,1         | False    |
  */
- // clang-format on
-ALWI void sub_tiles_init(uint32_t icb0 = 0, uint32_t icb1 = 1, bool acc_to_dest = false) {
+// clang-format on
+ALWI void sub_tiles_init(uint32_t icb0, uint32_t icb1, bool acc_to_dest = false) {
     MATH((llk_math_eltwise_binary_init<ELWSUB, NONE>(0 /*transpose*/, acc_to_dest)));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, 0 /*transpose*/, acc_to_dest)));
 }
@@ -192,11 +192,11 @@ ALWI void binary_op_specific_init()  // TODO(AP): better naming
 {
     if constexpr (full_init) {
         if constexpr (eltwise_binary_op_type == ELWADD) {
-            add_tiles_init();
+            add_tiles_init(0, 1);
         } else if constexpr (eltwise_binary_op_type == ELWSUB) {
-            sub_tiles_init();
+            sub_tiles_init(0, 1);
         } else if constexpr (eltwise_binary_op_type == ELWMUL) {
-            mul_tiles_init();
+            mul_tiles_init(0, 1);
         }
     } else {
         if constexpr (eltwise_binary_op_type == ELWADD) {

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -188,15 +188,15 @@ ALWI void sub_tiles(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itil
  * eltwise_binary_op_type: the binary operation type
  */
 template <bool full_init = false, EltwiseBinaryType eltwise_binary_op_type = ELWADD>
-ALWI void binary_op_specific_init()  // TODO(AP): better naming
+ALWI void binary_op_specific_init(uint32_t icb0, uint32_t icb1)  // TODO(AP): better naming
 {
     if constexpr (full_init) {
         if constexpr (eltwise_binary_op_type == ELWADD) {
-            add_tiles_init(0, 1);
+            add_tiles_init(icb0, icb1);
         } else if constexpr (eltwise_binary_op_type == ELWSUB) {
-            sub_tiles_init(0, 1);
+            sub_tiles_init(icb0, icb1);
         } else if constexpr (eltwise_binary_op_type == ELWMUL) {
-            mul_tiles_init(0, 1);
+            mul_tiles_init(icb0, icb1);
         }
     } else {
         if constexpr (eltwise_binary_op_type == ELWADD) {

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -26,9 +26,9 @@ void MAIN {
 
 #if not defined ELTWISE_DEST_REUSE_TYPE
 #ifdef FULL_INIT
-    binary_op_specific_init<true, ELTWISE_OP_TYPE>();
+    binary_op_specific_init<true, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
 #else
-    binary_op_specific_init<false, ELTWISE_OP_TYPE>();
+    binary_op_specific_init<false, ELTWISE_OP_TYPE>(cb_in0, cb_in1);
 #endif
 #endif
 

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -13,7 +13,7 @@ void MAIN {
     constexpr auto cb_out0 = tt::CBIndex::c_16;
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
 
     // wait for a block of tiles in each of input CBs
     cb_wait_front(cb_in0, 1);

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/add.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/add.cpp
@@ -32,7 +32,7 @@ void MAIN {
     // And we are going to add tiles. This function is only called if we ever need to
     // switch operation to something else. Since we are only adding tiles, this function
     // is only called once before the loop.
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
 
     // Loop over all the tiles and perform the computation
     for (uint32_t i = 0; i < n_tiles; i++) {

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp
@@ -33,7 +33,7 @@ void MAIN {
     // And we are going to add tiles. This function is only called if we ever
     // need to switch operation to something else. Since we are only adding
     // tiles, this function is only called once before the loop.
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
 
     // Calculate the range of tiles this core should process
     const uint32_t tiles_per_core = n_tiles;

--- a/tt_metal/programming_examples/vecadd_sharding/kernels/add_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/kernels/add_sharding.cpp
@@ -32,7 +32,7 @@ void MAIN {
     // And we are going to add tiles. This function is only called if we ever
     // need to switch operation to something else. Since we are only adding
     // tiles, this function is only called once before the loop.
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
 
     // Loop over the assigned tiles and perform the computation
     for (uint32_t i = 0; i < num_tile; i++) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -71,7 +71,7 @@ inline void eltwise_mul_and_add_block_v2(
             cb_push_back(out_cb_id, 1);
             cb_pop_front(eltwise_mul_partials_cb_cb_id, 1);
         } else {
-            add_tiles_init();
+            add_tiles_init(eltwise_mul_partials_cb_cb_id, out_cb_id);
             cb_wait_front(eltwise_mul_partials_cb_cb_id, 1);
             cb_wait_front(out_cb_id, 1);
             ACQ();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -34,7 +34,7 @@ void MAIN {
     binary_op_init_common(cb_inp0, cb_inp1, cb_out0);
 
 #if not PRE_SCALE
-    binary_op_specific_init<false, ELTWISE_OP_TYPE>();
+    binary_op_specific_init<false, ELTWISE_OP_TYPE>(cb_inp0, cb_inp1);
 #endif
 
 #ifdef PACK_RELU
@@ -110,7 +110,7 @@ void MAIN {
         cb_reserve_back(cb_out0, per_core_block_size);
 
 #if PRE_SCALE
-        binary_op_specific_init<true, ELTWISE_OP_TYPE>();
+        binary_op_specific_init<true, ELTWISE_OP_TYPE>(cb_inp0, cb_inp1);
 #endif
 
         tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -44,7 +44,7 @@ ALWI void process_tile(
         cb_reserve_back(cb_out, onetile);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
-        binary_op_specific_init<true, BINARY_OP_TYPE>();
+        binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
@@ -83,7 +83,7 @@ void MAIN {
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
-    binary_op_specific_init<true, BINARY_OP_TYPE>();
+    binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -27,7 +27,7 @@ void MAIN {
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
-    binary_op_specific_init<true, BINARY_OP_TYPE>();
+    binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
     constexpr uint32_t onetile = 1;
@@ -42,7 +42,7 @@ void MAIN {
         cb_reserve_back(cb_out, onetile);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
-        binary_op_specific_init<true, BINARY_OP_TYPE>();
+        binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -26,7 +26,7 @@ void MAIN {
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS))
-    binary_op_specific_init<true, BINARY_OP_TYPE>();
+    binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
 
     constexpr uint32_t onetile = 1;
@@ -41,7 +41,7 @@ void MAIN {
         cb_reserve_back(cb_out, onetile);
 
 #if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)
-        binary_op_specific_init<true, BINARY_OP_TYPE>();
+        binary_op_specific_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
 #endif
         tile_regs_acquire();
         BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/kernels/ssm_prefix_scan.cpp
@@ -67,7 +67,7 @@ FORCE_INLINE void mul(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
     reconfig_data_format(cb_a, cb_b);
     pack_reconfig_data_format(cb_out);
 
-    mul_tiles_init();
+    mul_tiles_init(cb_a, cb_b);
 
     cb_wait_front(cb_a, 1);
     cb_wait_front(cb_b, 1);
@@ -89,7 +89,7 @@ FORCE_INLINE void sum(uint32_t cb_a, uint32_t cb_b, uint32_t cb_out) {
     reconfig_data_format(cb_a, cb_b);
     pack_reconfig_data_format(cb_out);
 
-    add_tiles_init();
+    add_tiles_init(cb_a, cb_b);
 
     cb_wait_front(cb_a, 1);
     cb_wait_front(cb_b, 1);
@@ -149,7 +149,7 @@ void MAIN {
     const uint32_t total_tiles_per_col = get_arg_val<uint32_t>(2);
     const uint32_t num_chunks_per_row = get_arg_val<uint32_t>(3);
 
-    binary_op_init_common(cb_a_in, cb_bx_in);
+    binary_op_init_common(cb_a_in, cb_bx_in, cb_out);
     const uint32_t num_tiles_last_chunk = total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK == 0
                                               ? NUM_TILES_IN_TILIZED_CHUNK
                                               : total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
@@ -25,9 +25,10 @@ void MAIN {
     constexpr uint32_t num_rows_in_one_tile = 32;
 
 #ifdef REPEAT_INTERLEAVE_IN1
-    binary_op_init_common(cb_in0_transposed, cb_in1_bcast_row);  // TODO: Is there a specific one for bcast mul?
+    binary_op_init_common(
+        cb_in0_transposed, cb_in1_bcast_row, cb_id_out);  // TODO: Is there a specific one for bcast mul?
 #else
-    binary_op_init_common(cb_id_in0, cb_id_in1);
+    binary_op_init_common(cb_id_in0, cb_id_in1, cb_id_out);
 #endif
 
     for (uint32_t block_h_id = 0; block_h_id < in1_num_blocks_h; block_h_id++) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/compute/rotary_embedding.cpp
@@ -30,7 +30,7 @@ ALWI void MUL_TILES(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
 // We don't pop in1 in decode which is sin/cos since we don't stream
 #else
     ACQ();
-    mul_tiles_init();
+    mul_tiles_init(in0_cb, in1_cb);
     mul_tiles(in0_cb, in1_cb, 0, 0, 0);
     pack_tile(0, out_cb);
     REL();
@@ -146,7 +146,7 @@ void MAIN {
             reconfig_data_format_srca(rotated_in_cb, cos_interm_cb);
             pack_reconfig_data_format(cos_interm_cb, out_cb);
             ACQ();
-            add_tiles_init();
+            add_tiles_init(cos_interm_cb, sin_interm_cb);
             add_tiles(cos_interm_cb, sin_interm_cb, 0, 0, 0);
             pack_tile(0, out_cb);
             REL();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
@@ -37,7 +37,7 @@ void MAIN {
     const uint32_t my_cos_sin_tiles = my_seq_tiles * Wt;
 
     mm_init();
-    binary_op_init_common(rotated_in_interm_cb, cos_cb);  // General Init for all binary ops
+    binary_op_init_common(rotated_in_interm_cb, cos_cb, out_cb);  // General Init for all binary ops
 
     // Get the trans_mat
     cb_wait_front(trans_mat_cb, onetile);
@@ -77,7 +77,7 @@ void MAIN {
                 cb_push_back(rotated_in_interm_cb, Wt);
                 cb_wait_front(rotated_in_interm_cb, Wt);
 
-                mul_tiles_init();
+                mul_tiles_init(rotated_in_interm_cb, sin_cb);
                 ACQ();
                 for (uint32_t j = 0; j < Wt; ++j) {
                     // sin_interim = rotated * sin
@@ -104,7 +104,7 @@ void MAIN {
 
                 cb_wait_front(sin_interm_cb, Wt);
                 cb_wait_front(cos_interm_cb, Wt);
-                add_tiles_init();
+                add_tiles_init(cos_interm_cb, sin_interm_cb);
                 ACQ();
                 for (uint32_t j = 0; j < Wt; ++j) {
                     // out = cos_interim + sin_interim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -90,7 +90,7 @@ void MAIN {
 
         cb_wait_front(sin_interm_cb, Wt);
         cb_wait_front(cos_interm_cb, Wt);
-        add_tiles_init();
+        add_tiles_init(cos_interm_cb, sin_interm_cb);
         ACQ();
         for (uint32_t j = 0; j < Wt; ++j) {
             // out = cos_interim + sin_interim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/kernels/moreh_abs_pow_kernel.cpp
@@ -37,7 +37,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
     cb_wait_front(cb_one, onetile);      // comes from the reader
     cb_wait_front(cb_decimal, onetile);  // comes from the reader

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/kernels/moreh_adam.cpp
@@ -63,7 +63,7 @@ void MAIN {
     cb_wait_front(cb_scalar_args, 5);
     cb_wait_front(cb_one, onetile);
 
-    binary_op_init_common(cb_param_in, cb_scalar_args);
+    binary_op_init_common(cb_param_in, cb_scalar_args, cb_param_out);
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         // grad += grad + param * weight_decay;
@@ -140,7 +140,7 @@ void MAIN {
         cb_wait_front(cb_tmp1, onetile);
         cb_reserve_back(cb_tmp1, onetile);
         WITH_FP32_DEST_ACC(reconfig_data_format(cb_one, cb_tmp1));
-        sub_tiles_init();
+        sub_tiles_init(cb_one, cb_tmp1);
         sub_tiles(cb_one, cb_tmp1, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
@@ -189,11 +189,11 @@ void MAIN {
         cb_reserve_back(cb_tmp1, onetile);
 
 #ifdef AMSGRAD
-        mul_tiles_init();
+        mul_tiles_init(tmp_cb_max_exp_avg_sq, cb_tmp1);
         WITH_FP32_DEST_ACC(reconfig_data_format(tmp_cb_max_exp_avg_sq, cb_tmp1));
         mul_tiles(tmp_cb_max_exp_avg_sq, cb_tmp1, first_tile, first_tile, dst0);
 #else
-        mul_tiles_init();
+        mul_tiles_init(tmp_cb_exp_avg_sq, cb_tmp1);
         WITH_FP32_DEST_ACC(reconfig_data_format(tmp_cb_exp_avg_sq, cb_tmp1));
         mul_tiles(tmp_cb_exp_avg_sq, cb_tmp1, first_tile, first_tile, dst0);
 #endif
@@ -216,7 +216,7 @@ void MAIN {
         cb_wait_front(cb_tmp1, onetile);
         cb_reserve_back(cb_tmp1, onetile);
         WITH_FP32_DEST_ACC(reconfig_data_format(cb_tmp1, cb_scalar_args));
-        add_tiles_init();
+        add_tiles_init(cb_tmp1, cb_scalar_args);
         add_tiles(cb_tmp1, cb_scalar_args, first_tile, eps_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);
@@ -247,7 +247,7 @@ void MAIN {
         tile_regs_acquire();
         cb_wait_front(cb_tmp2, onetile);
         WITH_FP32_DEST_ACC(reconfig_data_format(cb_one, cb_tmp2));
-        sub_tiles_init();
+        sub_tiles_init(cb_one, cb_tmp2);
         sub_tiles(cb_one, cb_tmp2, first_tile, first_tile, dst0);
         recip_tile_init();
         recip_tile(dst0);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp
@@ -61,7 +61,7 @@ void MAIN {
     cb_wait_front(cb_beta1_exponent, onetile);
     cb_wait_front(cb_beta2_exponent, onetile);
 
-    binary_op_init_common(cb_param_in, cb_scalar_args);
+    binary_op_init_common(cb_param_in, cb_scalar_args, cb_param_out);
 
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         cb_wait_front(cb_param_in, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -45,7 +45,7 @@ void MAIN {
     const auto ht = (origin_h + TILE_H - 1) / TILE_H;
     const auto wt = (origin_w + TILE_W - 1) / TILE_W;
 
-    binary_op_init_common(cb_logx, cb_decimal);
+    binary_op_init_common(cb_logx, cb_decimal, cb_y);
 
     cb_wait_front(cb_decimal, onetile);  // comes from the reader
     cb_wait_front(cb_one, onetile);      // comes from the reader
@@ -115,7 +115,7 @@ void MAIN {
             cb_wait_front(cb_xpowadd, onetile);
             cb_reserve_back(cb_xpowadd, onetile);
 
-            add_tiles_init();
+            add_tiles_init(cb_correct_xpow, cb_xpowadd);
             add_tiles(cb_correct_xpow, cb_xpowadd, 0, 0, dst0);
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
@@ -30,9 +30,9 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
 
     if (num_tiles > 1) {
-        binary_op_init_common(cb_input, cb_x);
+        binary_op_init_common(cb_input, cb_x, cb_y);
     } else {
-        binary_op_init_common(cb_logx, cb_decimal);
+        binary_op_init_common(cb_logx, cb_decimal, cb_y);
     }
 
     cb_wait_front(cb_decimal, onetile);  // comes from the reader
@@ -59,7 +59,7 @@ void MAIN {
             cb_wait_front(cb_x, onetile);
             cb_reserve_back(cb_x, onetile);
 
-            add_tiles_init();
+            add_tiles_init(cb_input, cb_x);
             add_tiles(cb_input, cb_x, 0, 0, dst0);
             cb_pop_front(cb_x, onetile);
             cb_pop_front(cb_input, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/moreh_clip_grad_norm_step3_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/kernels/moreh_clip_grad_norm_step3_kernel.cpp
@@ -19,7 +19,7 @@ void MAIN {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
-    binary_op_init_common(cb_x, cb_clip_coef_clamped);
+    binary_op_init_common(cb_x, cb_clip_coef_clamped, cb_y);
 
     cb_wait_front(cb_clip_coef_clamped, onetile);  // comes from the reader
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/kernels/moreh_cumsum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/kernels/moreh_cumsum_nc.cpp
@@ -23,7 +23,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t first_tile = 0;
 
-    binary_op_init_common(cb_in0, cb_in1);
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
     cb_wait_front(cb_in1, onetile);
 
     for (uint32_t i = 0; i < num_output_tiles_per_core; i++) {
@@ -33,7 +33,7 @@ void MAIN {
             uint32_t cb_add = (enable_reload) ? (cb_intermed0) : (cb_in1);
             cb_wait_front(cb_in0, onetile);
 
-            add_tiles_init();
+            add_tiles_init(cb_in0, cb_add);
             add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
 
             cb_pop_front(cb_in0, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/kernels/moreh_dot.cpp
@@ -15,7 +15,7 @@ namespace NAMESPACE {
 void MAIN {
     constexpr int onetile = 1;
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
     bool enable_reload = false;
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         bool last_out = block == (per_core_block_cnt - 1);
@@ -26,7 +26,7 @@ void MAIN {
         cb_wait_front(tt::CBIndex::c_1, onetile);
 
         cb_reserve_back(tt::CBIndex::c_24, onetile);
-        mul_tiles_init();
+        mul_tiles_init(tt::CBIndex::c_0, tt::CBIndex::c_1);
         // dst0 = c_in0 x c_in1
         mul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0);
         // c_intermed0 = pack(dst0)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_large_kernel.cpp
@@ -22,7 +22,7 @@ void MAIN {
     constexpr bool is_lastdim_layernorm = get_compile_time_arg_val(9) == 1;
     constexpr bool is_groupnorm = get_compile_time_arg_val(10) == 1;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     constexpr auto cb_x = tt::CBIndex::c_0;       // input
     constexpr auto cb_scaler = tt::CBIndex::c_1;  // scaler

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/kernels/moreh_layer_norm_small_kernel.cpp
@@ -22,7 +22,7 @@ void MAIN {
     constexpr bool is_lastdim_layernorm = get_compile_time_arg_val(9) == 1;
     constexpr bool is_groupnorm = get_compile_time_arg_val(10) == 1;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     constexpr auto cb_x = tt::CBIndex::c_0;       // input
     constexpr auto cb_scaler = tt::CBIndex::c_1;  // scaler

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_large_kernel.cpp
@@ -18,7 +18,7 @@ void MAIN {
     constexpr bool is_lastdim_layernorm = get_compile_time_arg_val(5) == 1;
     constexpr bool is_groupnorm = get_compile_time_arg_val(6) == 1;
 
-    binary_op_init_common(tt::CBIndex::c_1, tt::CBIndex::c_2);
+    binary_op_init_common(tt::CBIndex::c_1, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     constexpr auto cb_dy = tt::CBIndex::c_0;         // output_grad(==dy)
     constexpr auto cb_x = tt::CBIndex::c_1;          // input(==x)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/kernels/moreh_layer_norm_backward_input_grad_small_kernel.cpp
@@ -18,7 +18,7 @@ void MAIN {
     constexpr bool is_lastdim_layernorm = get_compile_time_arg_val(5) == 1;
     constexpr bool is_groupnorm = get_compile_time_arg_val(6) == 1;
 
-    binary_op_init_common(tt::CBIndex::c_1, tt::CBIndex::c_2);
+    binary_op_init_common(tt::CBIndex::c_1, tt::CBIndex::c_2, tt::CBIndex::c_16);
 
     constexpr auto cb_dy = tt::CBIndex::c_0;         // output_grad(==dy)
     constexpr auto cb_x = tt::CBIndex::c_1;          // input(==x)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_h.cpp
@@ -25,7 +25,7 @@ void MAIN {
     constexpr auto cb_out = tt::CBIndex::c_16;
     constexpr bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
 
-    binary_op_init_common(cb_input, cb_input);
+    binary_op_init_common(cb_input, cb_input, cb_out);
 
     cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_nc.cpp
@@ -24,7 +24,7 @@ void MAIN {
     constexpr uint32_t dst1 = 1;
     constexpr uint32_t first_tile = 0;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     cb_wait_front(cb_in1, onetile);
     cb_wait_front(cb_scalar, 1);  // scalar tile from the reader

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/moreh_mean_w.cpp
@@ -26,7 +26,7 @@ void MAIN {
     constexpr auto cb_out = tt::CBIndex::c_16;
     constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
 
-    binary_op_init_common(cb_input, cb_input);
+    binary_op_init_common(cb_input, cb_input, cb_out);
 
     cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/kernels/moreh_mean_backward.cpp
@@ -24,7 +24,7 @@ void MAIN {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
     cb_wait_front(cb_in1, onetile);
     for (uint32_t i = 0; i < num_output_tiles; i++) {
         tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/kernels/moreh_nll_loss_step2_kernel.cpp
@@ -24,7 +24,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t onetile = 1;
 
-    binary_op_init_common(cb_tmp_weight, cb_tmp_input);
+    binary_op_init_common(cb_tmp_weight, cb_tmp_input, cb_output);
 
 #if defined(DIVISOR)
     cb_wait_front(cb_divisor, onetile);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -46,7 +46,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     cb_wait_front(cb_one, onetile);              // comes from the reader
     cb_wait_front(cb_decimal, onetile);          // comes from the reader

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_other/kernels/moreh_norm_other_kernel.cpp
@@ -42,7 +42,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     cb_wait_front(cb_one, onetile);              // comes from the reader
     cb_wait_front(cb_decimal, onetile);          // comes from the reader

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -46,7 +46,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
 
     cb_wait_front(cb_one, onetile);              // comes from the reader
     cb_wait_front(cb_decimal, onetile);          // comes from the reader

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -31,7 +31,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
     cb_wait_front(cb_one, onetile);  // comes from the reader
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_nc/kernels/moreh_norm_nc_kernel.cpp
@@ -27,7 +27,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
     cb_wait_front(cb_one, onetile);  // comes from the reader
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/ord_other/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -31,7 +31,7 @@ void MAIN {
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0, tt::CB::c_out0);
 
     cb_wait_front(cb_one, onetile);  // comes from the reader
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/kernels/moreh_norm_backward_kernel.cpp
@@ -48,7 +48,7 @@ void MAIN {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_0, tt::CBIndex::c_16);
     cb_wait_front(cb_decimal, onetile);  // comes from the reader
 
     for (uint32_t idx = 0; idx < num_input_tiles_per_core; ++idx) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/kernels/moreh_sgd.cpp
@@ -26,7 +26,7 @@ void MAIN {
     constexpr uint32_t weight_decay_tile = 3;
     constexpr uint32_t one_tile = 4;
 
-    binary_op_init_common(cb_param_in, cb_param_in);
+    binary_op_init_common(cb_param_in, cb_param_in, cb_param_out);
 
     uint32_t num_tiles = get_compile_time_arg_val(0);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_c_large.cpp
@@ -26,7 +26,7 @@ void MAIN {
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t dim_size = get_compile_time_arg_val(1);
 
-    binary_op_init_common(cb_in0, cb_exps);
+    binary_op_init_common(cb_in0, cb_exps, cb_out0);
 
     for (uint32_t n = 0; n < N; ++n) {
         // find max

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h.cpp
@@ -25,7 +25,7 @@ void MAIN {
     constexpr int dst1 = 1;
     constexpr uint32_t onetile = 1;
 
-    binary_op_init_common(cb_in0, cb_bcast_scaler);
+    binary_op_init_common(cb_in0, cb_bcast_scaler, cb_out0);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Ht = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_h_large.cpp
@@ -21,7 +21,7 @@ void MAIN {
     constexpr auto cb_max = tt::CBIndex::c_27;
     constexpr auto cb_tmp = tt::CBIndex::c_28;
 
-    binary_op_init_common(cb_in0, cb_bcast_scaler);
+    binary_op_init_common(cb_in0, cb_bcast_scaler, cb_out0);
 
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -22,7 +22,7 @@ void MAIN {
     constexpr auto cb_x_m_max = tt::CBIndex::c_27;
     constexpr auto cb_tmp = tt::CBIndex::c_28;
 
-    binary_op_init_common(cb_in0, cb_bcast_scaler);
+    binary_op_init_common(cb_in0, cb_bcast_scaler, cb_out0);
 
     constexpr int dst0 = 0;
     constexpr int dst1 = 1;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -21,7 +21,7 @@ void MAIN {
     constexpr auto cb_max = tt::CBIndex::c_27;
     constexpr auto cb_tmp = tt::CBIndex::c_28;
 
-    binary_op_init_common(cb_in0, cb_bcast_scaler);
+    binary_op_init_common(cb_in0, cb_bcast_scaler, cb_out0);
 
     constexpr uint32_t onetile = 1;
     constexpr int dst0 = 0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_c_large.cpp
@@ -25,7 +25,7 @@ void MAIN {
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t dim_size = get_compile_time_arg_val(1);
 
-    binary_op_init_common(cb_dy, cb_y);
+    binary_op_init_common(cb_dy, cb_y, cb_dx);
 
     constexpr int dst0 = 0;
     for (uint32_t n = 0; n < N; ++n) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h.cpp
@@ -23,7 +23,7 @@ void MAIN {
     constexpr auto cb_sum = tt::CBIndex::c_25;
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
 
-    binary_op_init_common(cb_y, cb_bcast_scaler);
+    binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Ht = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_h_large.cpp
@@ -24,7 +24,7 @@ void MAIN {
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
     constexpr auto cb_add = tt::CBIndex::c_27;
 
-    binary_op_init_common(cb_y, cb_bcast_scaler);
+    binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Ht = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w.cpp
@@ -23,7 +23,7 @@ void MAIN {
     constexpr auto cb_sum = tt::CBIndex::c_25;
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
 
-    binary_op_init_common(cb_y, cb_bcast_scaler);
+    binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/kernels/moreh_softmax_backward_w_large.cpp
@@ -24,7 +24,7 @@ void MAIN {
     constexpr auto cb_inter2 = tt::CBIndex::c_26;
     constexpr auto cb_add = tt::CBIndex::c_27;
 
-    binary_op_init_common(cb_y, cb_bcast_scaler);
+    binary_op_init_common(cb_y, cb_bcast_scaler, cb_dx);
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -159,9 +159,9 @@ void MAIN {
     auto cb_bcast = cb_batch_mean;
     auto cb_other = cb_input;
 
-    binary_op_init_common(cb_bcast, cb_other, cb_output_0);
+    binary_op_init_common(cb_other, cb_bcast, cb_output_0);
 
-    sub_tiles_init();
+    sub_tiles_init(cb_other, cb_bcast);
     uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
     uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
     for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -168,7 +168,7 @@ void MAIN {
             // mask input
             index_h_offset = index_b_offset + index_g_offset;
             reconfig_data_format_srcb(cb_in0, cb_input_mask);
-            mul_tiles_init();
+            mul_tiles_init(cb_in0, cb_input_mask);
             cb_reserve_back(cb_x, block_hw);
             cb_wait_front(cb_input_mask, block_w);
             for (uint32_t i = 0; i < block_h; ++i) {
@@ -263,7 +263,7 @@ void MAIN {
 
             // zero out the garbage values by mult mask again
             reconfig_data_format_srcb(cb_ex_global, cb_input_mask);
-            mul_tiles_init();
+            mul_tiles_init(cb_xmm, cb_input_mask);
             cb_reserve_back(cb_x, block_hw);
             cb_wait_front(cb_xmm, block_hw);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -291,7 +291,7 @@ void MAIN {
 
             // (x - E[x])^2
             index_h_offset = 0;
-            mul_tiles_init();
+            mul_tiles_init(cb_x, cb_x);
             cb_reserve_back(cb_xmm, block_hw);
             cb_wait_front(cb_x, block_hw);
             for (uint32_t i = 0; i < block_h; i++) {
@@ -360,7 +360,7 @@ void MAIN {
             cb_reserve_back(cb_ex2pe, 1);
             // (Var + eps)
             tile_regs_acquire();
-            add_tiles_init();
+            add_tiles_init(cb_ex_global, cb_eps);
             add_tiles(cb_ex_global, cb_eps, 0, 0, dst0);
             tile_regs_wait();
             // sqrt(Var + eps)
@@ -415,7 +415,7 @@ void MAIN {
                 if (copy_or_add == true) {
                     copy_tile_init(cb_xmm);
                 } else {
-                    add_tiles_init();
+                    add_tiles_init(cb_out, cb_xmm);
                 }
 
                 for (uint32_t i = 0; i < block_h; ++i) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -81,7 +81,7 @@ void MAIN {
 #ifdef FUSE_PRE_ADD
         reconfig_data_format(cb_in, cb_inb);
         pack_reconfig_data_format(cb_x);
-        add_tiles_init();
+        add_tiles_init(cb_in, cb_inb);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             ACQ();
             // UNPACK(( { DPRINT  << "Waiting on cb_x" << ENDL(); } ));
@@ -166,7 +166,7 @@ void MAIN {
         /* (x - E[x])^2
          * compute temp = xmm*xmm = (x-E[x])^2
          */
-        mul_tiles_init();
+        mul_tiles_init(cb_xmm, cb_xmm);
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_xmm, wt + blk);  // cumulative wait
             cb_reserve_back(cb_xmm2, blk);    // can probably use less space for this if we block
@@ -219,7 +219,7 @@ void MAIN {
             reconfig_data_format(cb_ex2, cb_eps);
         }
         ACQ();
-        add_tiles_init();
+        add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
         cb_reserve_back(cb_ex2pe, 1);  // 1

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -106,7 +106,7 @@ void MAIN {
 // pre-add x + y
 #ifdef FUSE_PRE_ADD
     reconfig_data_format_srcb(cb_in0, cb_in1);
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
     cb_reserve_back(cb_in, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
@@ -224,7 +224,7 @@ void MAIN {
 #endif
 
     // (x - E[x])^2, cb_mm2 <-- cb_xmm
-    mul_tiles_init();
+    mul_tiles_init(cb_xmm, cb_xmm);
     index_h_offset = 0;
     cb_reserve_back(cb_xmm2, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -311,7 +311,7 @@ void MAIN {
                 cb_wait_front(cb_ex2, 1);
                 cb_reserve_back(cb_ex2pe, 1);
                 tile_regs_acquire();
-                add_tiles_init();
+                add_tiles_init(cb_ex2, cb_eps);
                 add_tiles(cb_ex2, cb_eps, i, 0, dst0);
                 tile_regs_wait();
                 // sqrt(Var + eps)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -145,7 +145,7 @@ void MAIN {
             cb_reserve_back(cb_ex_sqr, 1);
             cb_wait_front(cb_stats_reduced, 1);
             tile_regs_acquire();
-            mul_tiles_init();
+            mul_tiles_init(cb_stats_reduced, cb_stats_reduced);
             mul_tiles(cb_stats_reduced, cb_stats_reduced, 0, 0, dst0);  // first tile in stats is always E(x)
             tile_regs_commit();
             tile_regs_wait();
@@ -161,7 +161,7 @@ void MAIN {
             cb_wait_front(cb_ex_sqr, 1);
             cb_reserve_back(cb_var, 1);
             tile_regs_acquire();
-            sub_tiles_init();
+            sub_tiles_init(cb_ex2, cb_ex_sqr);
             sub_tiles(cb_ex2, cb_ex_sqr, 0, 0, dst0);
             tile_regs_commit();
             tile_regs_wait();
@@ -179,7 +179,7 @@ void MAIN {
             cb_wait_front(cb_eps, 1);
             cb_reserve_back(cb_stats_reduced, 1);
 
-            add_tiles_init();
+            add_tiles_init(cb_var, cb_eps);
             tile_regs_acquire();
             add_tiles(cb_var, cb_eps, 0, 0, dst0);
             tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -83,7 +83,7 @@ void MAIN {
 // pre-add x + y
 #ifdef FUSE_PRE_ADD
     binary_op_init_common(cb_in0, cb_in1, cb_in);
-    add_tiles_init();
+    add_tiles_init(cb_in0, cb_in1);
     cb_reserve_back(cb_in, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -143,7 +143,7 @@ void MAIN {
 #endif  // not RMSNORM
 
     // X^2
-    mul_tiles_init();
+    mul_tiles_init(cb_in0, cb_in0);
     index_h_offset = 0;
     cb_reserve_back(cb_x2, num_tiles_per_block);
     for (uint32_t i = 0; i < block_h; i++) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -125,7 +125,7 @@ void MAIN {
          */
         reconfig_data_format(cb_stats_reduced, cb_stats_reduced);
         pack_reconfig_data_format(cb_mean_squared);
-        mul_tiles_init();
+        mul_tiles_init(cb_stats_reduced, cb_stats_reduced);
         cb_reserve_back(cb_mean_squared, onetile);
         cb_wait_front(cb_stats_reduced, stats_tile_stride);
         ACQ();
@@ -140,7 +140,7 @@ void MAIN {
          */
         reconfig_data_format(cb_stats_reduced, cb_mean_squared);
         pack_reconfig_data_format(cb_var);
-        sub_tiles_init();
+        sub_tiles_init(cb_stats_reduced, cb_mean_squared);
 
         cb_reserve_back(cb_var, onetile);
         cb_wait_front(cb_mean_squared, 1);
@@ -182,7 +182,7 @@ void MAIN {
         reconfig_data_format(cb_var, cb_eps);
         pack_reconfig_data_format(cb_recip_sqrt_var);
 
-        add_tiles_init();
+        add_tiles_init(cb_var, cb_eps);
         ACQ();
         add_tiles(cb_var, cb_eps, 0, 0, 0);
         sqrt_tile_init();

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -132,7 +132,7 @@ void MAIN {
 #endif
 
 #ifdef CAUSAL_MASK
-        add_tiles_init();
+        add_tiles_init(cb_scale_mask, cb_fused_attn);
 #else
         add_bcast_rows_init_short(cb_scale_mask, cb_fused_attn);
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -124,7 +124,7 @@ void MAIN {
         index_subblock_w_offset = 0;
 
 #ifdef CAUSAL_MASK
-        add_tiles_init();
+        add_tiles_init(cb_scale_mask, cb_fused_attn);
 #else
         add_bcast_rows_init_short(cb_scale_mask, cb_fused_attn);
 #endif

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
@@ -90,7 +90,7 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
     reconfig_data_format(in0_cb, in1_cb);
-    mul_tiles_init();
+    mul_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
@@ -41,7 +41,7 @@ void MAIN {
                 tile_regs_release();
             } else {
                 tile_regs_acquire();
-                mul_tiles_init();
+                mul_tiles_init(tt::CBIndex::c_0, tt::CBIndex::c_24);
                 mul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_24, 0, 0, 0);
                 tile_regs_commit();
                 tile_regs_wait();

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
@@ -21,7 +21,7 @@ void MAIN {
     constexpr uint32_t dst1 = 1;
     constexpr uint32_t first_tile = 0;
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1);
+    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
     cb_wait_front(cb_in1, onetile);
 
     for (uint32_t i = 0; i < num_output_tiles; i++) {
@@ -36,7 +36,7 @@ void MAIN {
             }
 
             tile_regs_acquire();
-            mul_tiles_init();
+            mul_tiles_init(cb_in0, cb_add);
             mul_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -90,7 +90,7 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
     reconfig_data_format(in0_cb, in1_cb);
-    add_tiles_init();
+    add_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -192,7 +192,7 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles consumed
 
-    add_tiles_init();
+    add_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
@@ -213,7 +213,7 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
 
-    mul_tiles_init();
+    mul_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
@@ -232,7 +232,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     // Postcondition: out_cb has num_tiles produced
     // Postcondition: in0_cb and in1_cb has num_tiles produced
 
-    sub_tiles_init();
+    sub_tiles_init(in0_cb, in1_cb);
     exp_tile_init<EXP_APPROX_MODE>();
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -217,7 +217,7 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles consumed
 
-    add_tiles_init();
+    add_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
@@ -239,7 +239,7 @@ void add_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_t
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles consumed
 
-    add_tiles_init();
+    add_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
@@ -260,7 +260,7 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
 
-    mul_tiles_init();
+    mul_tiles_init(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
@@ -278,7 +278,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: out_cb has num_tiles produced
     // Postcondition: in0_cb and in1_cb has num_tiles produced
-    sub_tiles_init();
+    sub_tiles_init(in0_cb, in1_cb);
     exp_tile_init<EXP_APPROX_MODE>();
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the eltwise_binary kernel APIs:
- ./tt_metal/include/compute_kernel_api/eltwise_binary.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13162378220)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13162381268) (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
