### PR TITLE
[Llama3] Add max prefill chunk sizes for different model/device combinations

### DIFF
--- a/models/common/rmsnorm.py
+++ b/models/common/rmsnorm.py
@@ -81,17 +81,18 @@ class RMSNorm(LightweightModule):
             mesh_mapper=ttnn.ReplicateTensorToMesh(device) if is_mesh_device else None,
         )
 
-        self.weight_distributed = ttnn.as_tensor(
-            torch_weight,
-            device=device,
-            dtype=weight_dtype,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            memory_config=weight_memory_config,
-            cache_file_name=cache_name,
-            mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(None, 2), mesh_shape=list(device.shape))
-            if is_mesh_device
-            else None,
-        )
+        if self.is_distributed:
+            self.weight_distributed = ttnn.as_tensor(
+                torch_weight,
+                device=device,
+                dtype=weight_dtype,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=weight_memory_config,
+                cache_file_name=cache_name,
+                mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(None, 2), mesh_shape=list(device.shape))
+                if is_mesh_device
+                else None,
+            )
 
         self.sharded_output_config = sharded_output_config
         self.sharded_program_config = sharded_program_config

--- a/models/demos/llama3/README.md
+++ b/models/demos/llama3/README.md
@@ -15,7 +15,9 @@ All the above llama models (with the exception of 70B due to its large size) are
 - T3000 (8-chips)
 - TG (32-chips)
 
-**Note**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 64k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below:
+**Max Context Lengths**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 64k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below.
+
+**Max Prefill Chunk Sizes**:
 |              |      N150     |      N300     |      T3K       |      TG     |
 |--------------|---------------|---------------|----------------|-------------|
 | Llama3.2-1B  | 128k tokens   | 128k tokens   | 128k tokens    | 128k tokens |
@@ -23,7 +25,7 @@ All the above llama models (with the exception of 70B due to its large size) are
 | Llama3.1-8B  | 4k tokens     | 64k tokens    | 128k tokens    | 128k tokens |
 | Llama3.2-11B | 4k tokens     | 64k tokens    | 128k tokens    | 128k tokens |
 | Llama3.1-70B | Not supported | Not supported | 32k tokens     | 128k tokens |
-
+- These max chunk sizes are specific to max context length 128k and are configured via `MAX_PREFILL_CHUNK_SIZES_DIV1024` in [model_config.py](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3/tt/model_config.py). If the max context length is set to a smaller value using the `max_seq_len` flag (see [Run the demo](#run-the-demo)), these chunk sizes can possibly be increased due to using a smaller KV cache.
 
 ## How to Run
 

--- a/models/demos/llama3/README.md
+++ b/models/demos/llama3/README.md
@@ -15,9 +15,9 @@ All the above llama models (with the exception of 70B due to its large size) are
 - T3000 (8-chips)
 - TG (32-chips)
 
-**Max Context Lengths**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 64k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below.
+**Max Context Lengths (text-only)**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 64k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below.
 
-**Max Prefill Chunk Sizes**:
+Max Prefill Chunk Sizes (text-only):
 |              |      N150     |      N300     |      T3K       |      TG     |
 |--------------|---------------|---------------|----------------|-------------|
 | Llama3.2-1B  | 128k tokens   | 128k tokens   | 128k tokens    | 128k tokens |
@@ -26,6 +26,8 @@ All the above llama models (with the exception of 70B due to its large size) are
 | Llama3.2-11B | 4k tokens     | 64k tokens    | 128k tokens    | 128k tokens |
 | Llama3.1-70B | Not supported | Not supported | 32k tokens     | 128k tokens |
 - These max chunk sizes are specific to max context length 128k and are configured via `MAX_PREFILL_CHUNK_SIZES_DIV1024` in [model_config.py](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3/tt/model_config.py). If the max context length is set to a smaller value using the `max_seq_len` flag (see [Run the demo](#run-the-demo)), these chunk sizes can possibly be increased due to using a smaller KV cache.
+
+**Max Context Lengths (Llama3.2-11B multimodal)**: Llama3.2-11B multimodal is currently only supported on N300 and T3000. On N300, a max prefill context length of 8k is supported, while T3000 supports a max context length of 128k.
 
 ## How to Run
 

--- a/models/demos/llama3/README.md
+++ b/models/demos/llama3/README.md
@@ -15,19 +15,14 @@ All the above llama models (with the exception of 70B due to its large size) are
 - T3000 (8-chips)
 - TG (32-chips)
 
-Below is an updated table with max prefill context-length support for our demo. These were tested on both accuracy and performance mode.
-
-The main reason for a long context length not fitting on device is lack of memory memory. Any exceptions are marked in the table in appendix.
-
+**Note**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 64k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below:
 |              |      N150     |      N300     |      T3K       |      TG     |
 |--------------|---------------|---------------|----------------|-------------|
 | Llama3.2-1B  | 128k tokens   | 128k tokens   | 128k tokens    | 128k tokens |
-| Llama3.2-3B  | 32k tokens    | 128k tokens   | 128k tokens    | 128k tokens |
-| Llama3.1-8B  | 16k tokens    | 64k tokens    | 128k tokens    | 128k tokens |
-| Llama3.2-11B | 16k tokens    | 64k tokens    | 128k tokens    | 128k tokens |
-| Llama3.1-70B | Not supported | Not supported | 64k tokens [1] | 128k tokens |
-
-[1] Although longer prefill context-lengths are not supported due to model size and available memory, you can still decode (generate) tokens up to a maximum of 128k tokens.
+| Llama3.2-3B  | 8k tokens     | 128k tokens   | 128k tokens    | 128k tokens |
+| Llama3.1-8B  | 4k tokens     | 64k tokens    | 128k tokens    | 128k tokens |
+| Llama3.2-11B | 4k tokens     | 64k tokens    | 128k tokens    | 128k tokens |
+| Llama3.1-70B | Not supported | Not supported | 32k tokens     | 128k tokens |
 
 
 ## How to Run

--- a/models/demos/llama3/demo/demo.py
+++ b/models/demos/llama3/demo/demo.py
@@ -233,38 +233,15 @@ def run_llama3_demo(
     llama_model_name = model_args.model_name  # ["3.2-1B", "3.2-3B", "3.1-8B", "3.2-11B", "3.1-70B"]
     tt_device_name = model_args.device_name  # ["N150", "N300", "T3K", "TG"]
 
-    if llama_model_name == "3.2-1B":
+    if llama_model_name in ["3.1-8B", "3.2-11B"] and tt_device_name == "N150":
         assert (
-            max_seq_len <= 128 * 1024
-        ), "Llama3.2-1B supports the official max context length of 128k tokens across all architectures"
-    if llama_model_name == "3.2-3B":
-        if tt_device_name == "N150":
-            assert max_seq_len <= 32 * 1024, "N150 only supports a max context length of 32k tokens for Llama3.2-3B"
-        else:  # N300, T3K and TG
-            assert (
-                max_seq_len <= 128 * 1024
-            ), "N300, T3K and TG support the official max context length of 128k tokens for Llama3.2-3B"
-    if llama_model_name in ["3.1-8B", "3.2-11B"]:
-        if tt_device_name == "N150":
-            assert (
-                max_seq_len <= 16 * 1024
-            ), "N150 only supports a max context length of 16k tokens for Llama3.1-8B and Llama3.2-11B"
-        elif tt_device_name == "N300":
-            assert (
-                max_seq_len <= 64 * 1024
-            ), "N300 only supports a max context length of 64k tokens for Llama3.1-8B and Llama3.2-11B"
-        else:  # T3K and TG
-            assert (
-                max_seq_len <= 128 * 1024
-            ), "T3K only supports a max context length of 128k tokens for Llama3.1-8B and Llama3.2-11B"
+            max_seq_len <= 64 * 1024
+        ), "N150 only supports a max context length of 64k tokens for Llama3.1-8B and Llama3.2-11B"
+    else:
+        assert max_seq_len <= 128 * 1024, f"Llama{llama_model_name} supports a max context length of 128k tokens"
+
     if llama_model_name == "3.1-70B":
         assert tt_device_name in ["T3K", "TG"], "Llama3.1-70B is only supported on T3K or TG"
-        if tt_device_name == "T3K":
-            assert max_seq_len <= 64 * 1024, "T3K only supports a max context length of 64k tokens for Llama3.1-70B"
-        else:  # TG
-            assert (
-                max_seq_len <= 128 * 1024
-            ), "TG supports the official max context length of 128k tokens for Llama3.1-70B"
 
     logger.info("Loading weights...")
     profiler.start("weight_loading")

--- a/models/demos/llama3/tt/generator.py
+++ b/models/demos/llama3/tt/generator.py
@@ -145,6 +145,8 @@ class LlamaGenerator:
                 if chunk_start == last_chunk_start:
                     logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx_in_chunk % 32))
                     return logits
+                else:
+                    del tt_logits
         else:
             prefill_input, rot_mats_prefill, page_table_tt, _ = self.model.prepare_inputs_prefill(
                 tokens,

--- a/models/demos/llama3/tt/generator_vllm.py
+++ b/models/demos/llama3/tt/generator_vllm.py
@@ -59,11 +59,12 @@ def input_processor_for_mllama(ctx: InputContext, inputs: Union[DecoderOnlyInput
 
 
 def input_processor_for_llama_text(ctx: InputContext, inputs: Union[DecoderOnlyInputs, EncoderDecoderInputs]):
-    if "3.1-8B" in ctx.model_config.hf_config._name_or_path and os.environ.get("MESH_DEVICE") == "N150":
+    hf_model_name = ctx.model_config.hf_config._name_or_path
+    if ("3.1-8B" in hf_model_name or "3.2-11B" in hf_model_name) and os.environ.get("MESH_DEVICE") == "N150":
         prompt_len = len(inputs.get("prompt_token_ids"))
         if prompt_len > 65536:
             raise ValueError(
-                f"TT-LLama8B does not support prompts longer than 65536 tokens on N150 (received prompt with {prompt_len} tokens)"
+                f"TT-LLama8B and TT-Llama11B do not support prompts longer than 65536 tokens on N150 (received prompt with {prompt_len} tokens)"
             )
     return inputs
 

--- a/models/demos/llama3/tt/generator_vllm.py
+++ b/models/demos/llama3/tt/generator_vllm.py
@@ -34,6 +34,13 @@ def input_processor_for_mllama(ctx: InputContext, inputs: Union[DecoderOnlyInput
     if inputs.get("prompt") is None:
         inputs["prompt"] = inputs["encoder_prompt"]
         inputs["prompt_token_ids"] = inputs["encoder_prompt_token_ids"]
+        if os.environ.get("MESH_DEVICE") == "N300":
+            prompt_len = len(inputs.get("prompt_token_ids"))
+            MAX_PROMPT_LEN = 8192
+            if prompt_len > MAX_PROMPT_LEN:
+                raise ValueError(
+                    f"TT-LLama11B-Vision does not support prompts longer than {MAX_PROMPT_LEN} tokens on N300 (received prompt with {prompt_len} tokens)"
+                )
 
     multi_modal_data = inputs.get("encoder_multi_modal_data")
     if multi_modal_data is None or "image" not in multi_modal_data or multi_modal_data["image"] is None:
@@ -62,9 +69,10 @@ def input_processor_for_llama_text(ctx: InputContext, inputs: Union[DecoderOnlyI
     hf_model_name = ctx.model_config.hf_config._name_or_path
     if ("3.1-8B" in hf_model_name or "3.2-11B" in hf_model_name) and os.environ.get("MESH_DEVICE") == "N150":
         prompt_len = len(inputs.get("prompt_token_ids"))
-        if prompt_len > 65536:
+        MAX_PROMPT_LEN = 65536
+        if prompt_len > MAX_PROMPT_LEN:
             raise ValueError(
-                f"TT-LLama8B and TT-Llama11B do not support prompts longer than 65536 tokens on N150 (received prompt with {prompt_len} tokens)"
+                f"TT-LLama8B and TT-Llama11B do not support prompts longer than {MAX_PROMPT_LEN} tokens on N150 (received prompt with {prompt_len} tokens)"
             )
     return inputs
 
@@ -80,7 +88,7 @@ class TtMllamaForConditionalGeneration(LlamaGenerator, SupportsMultiModal):
 
     @classmethod
     def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size):
-        max_seq_len = 512  # TODO: Increase to 131072 once it's verified to work
+        max_seq_len = 131072
         model_args, model = create_multimodal_model(mesh_device, max_batch_size, max_seq_len, use_paged_kv_cache=True)
         return cls(model, model_args, mesh_device)
 

--- a/models/demos/llama3/tt/model_config.py
+++ b/models/demos/llama3/tt/model_config.py
@@ -98,7 +98,6 @@ class TtModelArgs:
         self.max_batch_size = max_batch_size
         self.tile_size = 32
         self.is_70b = False
-        self.max_prefill_chunk_size = max_seq_len
 
         LLAMA_DIR = os.getenv("LLAMA_DIR")
         if LLAMA_DIR:
@@ -156,10 +155,23 @@ class TtModelArgs:
             self.model_name = "3.1-70B"
             self.rope_scaling_factor = 8
             self.is_70b = True  # self.dim == 8192 and self.n_layers == 80
-            self.max_prefill_chunk_size = 64 * 1024  # 70B on T3K maxes out at 64k tokens prefill
         else:
             # NOTE: 3.2-90B and 3.3-70B also use scaling factor of 8
             raise ValueError(f"Unsupported LLAMA model: {LLAMA_DIR}")
+
+        # Set the max number of tokens for each prefill chunk based on the model and device
+        MAX_PREFILL_CHUNK_SIZES_DIV1024 = {
+            "3.2-1B": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128},
+            "3.2-3B": {"N150": 8, "N300": 128, "T3K": 128, "TG": 128},
+            "3.1-8B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
+            "3.2-11B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128},
+            "3.1-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128},
+        }
+        max_prefill_chunk_size_div1024 = MAX_PREFILL_CHUNK_SIZES_DIV1024[self.model_name][self.device_name]
+        assert (
+            max_prefill_chunk_size_div1024 is not None
+        ), f"Unsupported model {self.model_name} on device {self.device_name}"
+        self.max_prefill_chunk_size = max_prefill_chunk_size_div1024 * 1024
 
         if callable(optimizations):
             self.optimizations = optimizations(self.model_name)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The max prefill chunk size was not set properly for all model/device combinations, limiting the max context length for various cases

### What's changed
- Added a matrix of max prefill chunk sizes to `model_config.py` for different model/device configs
- Update the llama3 readme to indicate that all models now support up to 128k context (except 8b/11b on n150 which support up to 64k), and changed the max seq len table to instead indicate the max chunk sizes
- Removed asserts restricting max context lengths in demo for cases that now support 128k via chunked prefill
- Added max prompt length checks (for 8b/11b text on n150 and 11b vision on n300) to vLLM input processors in `generator_vllm.py`

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] Device performance regression CI testing passes (if applicable)
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
