### PR TITLE
#16510: Eltwise sweep test for add and mul + silu - LLama

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -145,6 +145,7 @@ on:
           - eltwise.unary.reciprocal.reciprocal_sharded
           - eltwise.unary.silu.silu
           - eltwise.unary.silu.silu_pytorch2
+          - eltwise.unary.silu.silu_llama
           - eltwise.unary.glu.glu
           - eltwise.unary.geglu.geglu
           - eltwise.unary.swiglu.swiglu
@@ -316,6 +317,7 @@ on:
           - eltwise.binary.multiply.multiply_scalar_pytorch2
           - eltwise.binary.multiply.multiply_forge
           - eltwise.binary.multiply.multiply_llama
+          - eltwise.binary.multiply.mul_no_act_llama
           - eltwise.binary.div.div
           - eltwise.binary.div.div_tensor_pytorch2
           - eltwise.binary.div.div_forge

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -288,6 +288,7 @@ on:
           - eltwise.binary.add.add_set2_pytorch2
           - eltwise.binary.add.add_different_memory_configs
           - eltwise.binary.add.add_forge
+          - eltwise.binary.add.add_llama
           - eltwise.unary.gtz.gtz
           - eltwise.unary.ltz.ltz
           - eltwise.unary.gez.gez
@@ -314,6 +315,7 @@ on:
           - eltwise.binary.multiply.mul_tensor_pytorch2
           - eltwise.binary.multiply.multiply_scalar_pytorch2
           - eltwise.binary.multiply.multiply_forge
+          - eltwise.binary.multiply.multiply_llama
           - eltwise.binary.div.div
           - eltwise.binary.div.div_tensor_pytorch2
           - eltwise.binary.div.div_forge

--- a/tests/sweep_framework/sweeps/eltwise/binary/add/add_llama.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/add/add_llama.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+
+
+parameters = {
+    "nightly": {
+        "input_shape": [
+            {"self": [1, 1, 32, 1024], "other": [1, 1, 32, 1024], "input_dtype": "ttnn.bfloat16"},
+            {"self": [1, 1, 32, 4096], "other": [1, 1, 32, 4096], "input_dtype": "ttnn.bfloat16"},
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT or test_vector["input_b_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_shape,
+    input_a_layout,
+    input_b_layout,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+    if input_shape["input_dtype"] == "ttnn.bfloat16":
+        input_dtype = ttnn.bfloat16
+    elif input_shape["input_dtype"] == "ttnn.float32":
+        input_dtype = ttnn.float32
+    elif input_shape["input_dtype"] == "ttnn.int32":
+        input_dtype = ttnn.int32
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape["self"])
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_shape["other"])
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_shape["self"],
+        core_grid=ttnn.CoreGrid(y=4, x=8),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=False,
+        halo=0,
+        tile_layout=True,
+    )
+    golden_function = ttnn.get_golden_function(ttnn.add)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.add(input_tensor_a, input_tensor_b, memory_config=sharded_config)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/multiply/mul_no_act_llama.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/multiply/mul_no_act_llama.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+
+
+parameters = {
+    "nightly": {
+        "input_spec": [
+            {"self": [1, 1, 32, 3584], "other": [1, 1, 32, 3584], "input_dtype": "ttnn.bfloat16", "y": 2},
+            {"self": [1, 1, 32, 14336], "other": [1, 1, 32, 14336], "input_dtype": "ttnn.bfloat16", "y": 4},
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT or test_vector["input_b_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_a_layout,
+    input_b_layout,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+    if input_spec["input_dtype"] == "ttnn.bfloat16":
+        input_dtype = ttnn.bfloat16
+    elif input_spec["input_dtype"] == "ttnn.float32":
+        input_dtype = ttnn.float32
+    elif input_spec["input_dtype"] == "ttnn.int32":
+        input_dtype = ttnn.int32
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_spec["self"])
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_spec["other"])
+
+    golden_function = ttnn.get_golden_function(ttnn.multiply)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_spec["self"],
+        core_grid=ttnn.CoreGrid(y=input_spec["y"], x=8),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=False,
+        halo=0,
+        tile_layout=True,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.multiply(input_tensor_a, input_tensor_b, memory_config=sharded_config)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_llama.py
+++ b/tests/sweep_framework/sweeps/eltwise/binary/multiply/multiply_llama.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+
+
+parameters = {
+    "nightly": {
+        "input_spec": [
+            {"self": [1, 1, 32, 3584], "other": [1, 1, 32, 3584], "input_dtype": "ttnn.bfloat16", "y": 2},
+            {"self": [1, 1, 32, 14336], "other": [1, 1, 32, 14336], "input_dtype": "ttnn.bfloat16", "y": 4},
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT or test_vector["input_b_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_a_layout,
+    input_b_layout,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+    if input_spec["input_dtype"] == "ttnn.bfloat16":
+        input_dtype = ttnn.bfloat16
+    elif input_spec["input_dtype"] == "ttnn.float32":
+        input_dtype = ttnn.float32
+    elif input_spec["input_dtype"] == "ttnn.int32":
+        input_dtype = ttnn.int32
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_spec["self"])
+    torch_input_tensor_b = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_spec["other"])
+
+    golden_function = ttnn.get_golden_function(ttnn.multiply)
+    torch_output_tensor = golden_function(torch.nn.functional.silu(torch_input_tensor_a), torch_input_tensor_b)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_spec["self"],
+        core_grid=ttnn.CoreGrid(y=input_spec["y"], x=8),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=False,
+        halo=0,
+        tile_layout=True,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.multiply(
+        input_tensor_a, input_tensor_b, input_tensor_a_activation=ttnn.UnaryOpType.SILU, memory_config=sharded_config
+    )
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]

--- a/tests/sweep_framework/sweeps/eltwise/unary/silu/silu_llama.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/silu/silu_llama.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from functools import partial
+
+import torch
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
+
+from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
+from models.utility_functions import torch_random
+
+
+# Parameters provided to the test vector generator are defined here.
+# They are defined as dict-type suites that contain the arguments to the run function as keys, and lists of possible inputs as values.
+# Each suite has a key name (in this case "suite_1" and "suite_2") which will associate the test vectors to this specific suite of inputs.
+# Developers can create their own generator functions and pass them to the parameters as inputs.
+
+
+parameters = {
+    "nightly": {
+        "input_spec": [
+            {"self": [1, 1, 32, 3584], "input_dtype": "ttnn.bfloat16", "y": 2},
+            {"self": [1, 1, 32, 14336], "input_dtype": "ttnn.bfloat16", "y": 4},
+        ],
+        "input_a_layout": [ttnn.TILE_LAYOUT],
+        "input_b_layout": [ttnn.TILE_LAYOUT],
+    },
+}
+
+
+# Invalidate vector is called during the generation phase where each vector will be passed in.
+# If invalidated, the vector will still be stored but will be skipped.
+# Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
+def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
+    if test_vector["input_a_layout"] == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Row Major layout is not supported"
+    return False, None
+
+
+# This is the run instructions for the test, defined by the developer.
+# The run function must take the above-defined parameters as inputs.
+# The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+def run(
+    input_spec,
+    input_a_layout,
+    input_b_layout,
+    *,
+    device,
+) -> list:
+    torch.manual_seed(0)
+    if input_spec["input_dtype"] == "ttnn.bfloat16":
+        input_dtype = ttnn.bfloat16
+    elif input_spec["input_dtype"] == "ttnn.float32":
+        input_dtype = ttnn.float32
+    elif input_spec["input_dtype"] == "ttnn.int32":
+        input_dtype = ttnn.int32
+
+    torch_input_tensor_a = gen_func_with_cast_tt(
+        partial(torch_random, low=-100, high=100, dtype=torch.float32), input_dtype
+    )(input_spec["self"])
+
+    golden_function = ttnn.get_golden_function(ttnn.silu)
+    torch_output_tensor = golden_function(torch_input_tensor_a)
+
+    sharded_config = ttnn.create_sharded_memory_config_(
+        shape=input_spec["self"],
+        core_grid=ttnn.CoreGrid(y=input_spec["y"], x=8),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=False,
+        halo=0,
+        tile_layout=True,
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=sharded_config,
+    )
+
+    start_time = start_measuring_time()
+    result = ttnn.silu(input_tensor_a, memory_config=sharded_config)
+    output_tensor = ttnn.to_torch(result)
+    e2e_perf = stop_measuring_time(start_time)
+
+    return [check_with_pcc(torch_output_tensor, output_tensor, 0.999), e2e_perf]


### PR DESCRIPTION
### Ticket
#16510 

### Problem description
To add element-wise sweep test for the ops that are involved in llama

### What's changed
Added sweep files for add and mul (with silu activation) along with shared configs provided #16013 

### Checklist

#### WHB0
- [ttnn Sweep - Silu](https://github.com/tenstorrent/tt-metal/actions/runs/12882969743)
- [ttnn Sweep - Add](https://github.com/tenstorrent/tt-metal/actions/runs/12882960883)
- [ttnn Sweep - Mul no act](https://github.com/tenstorrent/tt-metal/actions/runs/12882952660)
- [ttnn Sweep - Mul](https://github.com/tenstorrent/tt-metal/actions/runs/12882943301)



