### PR TITLE
Logical sharding for input tensor and halo output

### DIFF
--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -279,7 +279,7 @@ def run_conv2d_short_sweep(
         if has_bias:
             tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16)
 
-        tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
+        tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, device=device)
         conv_config = ttnn.Conv2dConfig()
 
     start_time = start_measuring_time()
@@ -359,7 +359,7 @@ def run_conv1d_short_sweep(
     if has_bias:
         tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16)
 
-    tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, device=device)
 
     start_time = start_measuring_time()
     [tt_output_tensor_on_device, out_length, [weights_device, bias_device]] = ttnn.Conv1d(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -261,10 +261,17 @@ std::vector<TensorSpec> OptimizedConvNew::compute_output_specs(const std::vector
                 TensorLayout::fromLegacyPaddedShape(
                     dtype, PageConfig(output_layout), mem_config, ttnn::Shape(output_shape)))};
         } else if (this->memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+            auto shard_grid = this->memory_config.shard_spec.value().grid;
+            auto shard_spec = ShardSpec{
+                shard_grid,
+                this->memory_config.shard_spec.value().shape,
+                this->memory_config.shard_spec.value().orientation};
+            auto mem_config = this->memory_config;
+            mem_config.shard_spec = shard_spec;
             return {TensorSpec(
                 output_shape.logical_shape(),
                 TensorLayout::fromLegacyPaddedShape(
-                    dtype, PageConfig(output_layout), memory_config, ttnn::Shape(output_shape)))};
+                    dtype, PageConfig(output_layout), mem_config, ttnn::Shape(output_shape)))};
         } else {
             TT_THROW("Unsupported shard scheme");
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -206,12 +206,12 @@ operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor& input, Ten
     auto shard_spec = input.shard_spec().value();
     auto shard_shape = shard_spec.shape;
     auto shard_grid = shard_spec.grid;
-    auto input_shape = input.get_legacy_shape();
+    auto input_shape = input.get_logical_shape();
     auto input_dtype = input.get_dtype();
     auto input_layout = input.get_layout();
     TT_FATAL(
         input_layout == output.get_layout() && input_dtype == output.get_dtype() &&
-            shard_shape == output.shard_spec().value().shape && input_shape == output.get_legacy_shape(),
+            shard_shape == output.shard_spec().value().shape && input_shape == output.get_logical_shape(),
         "Error");
     const uint32_t src_cb_sharded = tt::CBIndex::c_0;
     const uint32_t dst_cb_sharded = tt::CBIndex::c_1;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_program_factory.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
+#include <array>
 
 namespace ttnn::operations::sliding_window::halo {
 
@@ -69,8 +70,14 @@ std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vec
     }
 
     auto out_mem_config = output_memory_config_;
-    out_mem_config.shard_spec->shape[0] = tt::div_up(output_shape[0] * output_shape[2], config_.num_cores_nhw);
-    out_mem_config.shard_spec->shape[1] = input_tensor.memory_config().shard_spec->shape[1];
+    std::array<uint32_t, 2> shard_shape = {
+        tt::div_up(output_shape[0] * output_shape[2], config_.num_cores_nhw),
+        input_tensor.memory_config().shard_spec->shape[1]};
+    out_mem_config.shard_spec = ShardSpec{
+        output_memory_config_.shard_spec->grid,
+        shard_shape,
+        shard_shape,
+        output_memory_config_.shard_spec->orientation};
     return {TensorSpec(
         output_shape,
         TensorLayout::fromLegacyPaddedShape(


### PR DESCRIPTION
To reach parity on pytorch traces between input
tensor being on device vs being on host, logical
sharding is forced in case input tensor is interleaved and I2S needs to be run.
If tensor is on host then ttnn::to_device is used
and tesor being allocated in that codepath is going to use way less memory (x2) in many cases.
To reach parithy with to_device codepath, logical
sharding is used for I2S codepath.

Output of halo op is also switched to use logical
sharding which saves memory in many cases.

Output of the conv2d op is forced to be physical
sharding to avoid failiours in models as subsequent op after conv2d won't handle logical sharding properly in many cases.

Switching to logical sharding in output would save even more memory in some case, and should eventually be done.

Before this change number of failing cases in pytorch traces if input is on device was 26 and with this change is 16 same as if input is on host.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12660199810
- [x] Device performance regression CI testing passes (if applicable) - https://github.com/tenstorrent/tt-metal/actions/runs/12660196015
- [x] (Single-card) Nightly model and ttnn tests - https://github.com/tenstorrent/tt-metal/actions/runs/12660204921
