### PR TITLE
#0: Bump E2E perf threshold for host bound WH Resnet variants

### DIFF
--- a/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -13,7 +13,7 @@ from models.demos.ttnn_resnet.tests.perf_e2e_resnet50 import run_perf_resnet
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
-    ((16, 0.0080, 30),),
+    ((16, 0.0087, 30),),
 )
 def test_perf(
     device,
@@ -73,7 +73,7 @@ def test_perf_trace(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
-    ((16, 0.0080, 30),),
+    ((16, 0.0087, 30),),
 )
 def test_perf_2cqs(
     device,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
perf for host bound WH Resnet variants unstable on main.

### What's changed
Relax threshold so tests can consistently pass. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/12672715352
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes
