### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Eltwise Unary

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
@@ -12,7 +12,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
-    unary_op_init_common(tt::CBIndex::c_0);
+    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         acquire_dst();
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_print_dest.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_print_dest.cpp
@@ -16,7 +16,7 @@ void MAIN {
     bool remap = get_compile_time_arg_val(1) != 0;
     bool swizzle = get_compile_time_arg_val(2) != 0;
 
-    unary_op_init_common(tt::CBIndex::c_0);
+    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #ifdef ARCH_BLACKHOLE
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_remap_addrs_RMW>(remap);
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_swizzle_32b_RMW>(swizzle);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transpose_wh.cpp
@@ -13,7 +13,7 @@ void MAIN {
 #ifndef SHORT_INIT
     transpose_wh_init(tt::CBIndex::c_0, tt::CBIndex::c_16);
 #else
-    unary_op_init_common(tt::CBIndex::c_0);
+    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     transpose_wh_init_short(tt::CBIndex::c_0);
 #endif
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -14,7 +14,7 @@
 
 namespace ckernel {
 
-ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb = 16) {
+ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/eltwise_copy.cpp
@@ -12,7 +12,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
-    unary_op_init_common(tt::CBIndex::c_0);
+    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         acquire_dst();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/compute/eltwise_copy.cpp
@@ -12,7 +12,7 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_tile_cnt = get_arg_val<uint32_t>(0);
 
-    unary_op_init_common(tt::CBIndex::c_0);
+    unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         acquire_dst();
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -20,7 +20,7 @@ void MAIN {
     constexpr uint32_t cb_chunk_count_scratch = tt::CBIndex::c_25;
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
-    unary_op_init_common(cb_grad);
+    unary_op_init_common(cb_grad, cb_out);
 
     for (uint32_t i = 0; i < input_height; ++i) {
         cb_wait_front(cb_grad, max_tiles_per_core);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK compute API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the eltwise_unary kernel APIs:
- ./tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12675124695)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/12675128091) (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
