### PR TITLE
fix multi-iter in reduce scatter and adopt runtime arg overrider infra

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
@@ -199,9 +199,9 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
     if input_shard_spec is not None:
         output_shard_shape = list(input_shard_spec.shape)
         if dim == 3:
-            output_shard_shape[1] *= num_devices_per_line
+            output_shard_shape[1] //= num_devices_per_line
         else:
-            output_shard_shape[0] *= num_devices_per_line
+            output_shard_shape[0] //= num_devices_per_line
         output_shard_spec = ttnn.ShardSpec(
             input_shard_spec.grid,
             output_shard_shape,
@@ -257,6 +257,7 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
             num_iter=num_iters,
         )
     else:
+        logger.info(f"Running {num_iters} iterations of reduce scatter")
         for _ in range(num_iters):
             if use_reduce_scatter_async:
                 ttnn_tensor_out = ttnn.experimental.reduce_scatter_async(

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -96,14 +96,18 @@ def run_reduce_scatter_test(
     math_op,
     input_dtype,
     layout,
-    mem_config,
+    _mem_config,
     use_program_cache,
     function_level_defaults,
     num_iters,
+    input_shard_shape=None,
+    shard_grid=None,
+    tensor_mem_layout=None,
     enable_async=True,
     topology=ttnn.Topology.Ring,
     trace_mode=False,
 ):
+    assert num_iters > 0
     enable_persistent_fabric = True
     if len(mesh_device.get_device_ids()) < num_devices:
         pytest.skip(
@@ -112,8 +116,37 @@ def run_reduce_scatter_test(
 
     debug = False
 
+    if input_shard_shape and shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            False,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        output_shard_shape = list(input_shard_shape)
+        if dim == 3:
+            output_shard_shape[1] *= num_devices
+        else:
+            output_shard_shape[0] *= num_devices
+        output_shard_spec = ttnn.ShardSpec(
+            shard_grid,
+            output_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            False,
+        )
+        output_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+        )
+    else:
+        assert _mem_config is not None
+        input_mem_config = _mem_config
+        output_mem_config = _mem_config
+
     (is_known_failure, message) = is_unsupported_case(
-        per_chip_output_shape, dim, math_op, mem_config, num_devices, num_links, input_dtype, layout
+        per_chip_output_shape, dim, math_op, input_mem_config, num_devices, num_links, input_dtype, layout
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
@@ -127,6 +160,7 @@ def run_reduce_scatter_test(
     # Generate input tensors
     canonical_input_shape = per_chip_output_shape.copy()
     canonical_input_shape[dim] *= num_devices
+
     tt_input_tensors = []
 
     numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
@@ -143,20 +177,18 @@ def run_reduce_scatter_test(
                         for yy in range(32):
                             for xx in range(32):
                                 input_tensors[-1][w, z, y + yy, x + xx] = tile_id
-                        # input_tensors[-1][w,z,y:y+32,x:x+32] = tile_id
                         tile_id += 1
     for i, canonical_input_tensor in enumerate(input_tensors):
         logger.info(f"Creating input tensor on device {mesh_device.get_device_ids()[i]}")
         tt_input_tensors.append(
             ttnn.Tensor(canonical_input_tensor, input_dtype)
             .to(layout)
-            .to(mesh_device.get_device(mesh_device.get_device_ids()[i]), mem_config)
+            .to(mesh_device.get_device(mesh_device.get_device_ids()[i]), input_mem_config)
         )
 
     assert len(tt_input_tensors) == num_devices
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
@@ -183,7 +215,7 @@ def run_reduce_scatter_test(
             dim,
             num_links,
             math_op,
-            mem_config,
+            output_mem_config,
             num_iters=num_iters,
             topology=topology,
             subdevice_id=ttnn.SubDeviceId(0),
@@ -198,7 +230,7 @@ def run_reduce_scatter_test(
                 to_remote_multi_device_global_semaphore=to_remote_semaphore_handles,
                 math_op=math_op,
                 num_links=num_links,
-                memory_config=mem_config,
+                memory_config=output_mem_config,
                 topology=topology,
                 subdevice_id=worker_sub_device_id,
             )
@@ -268,7 +300,6 @@ def run_reduce_scatter_test(
     "per_chip_output_shape, dim, layout",
     [
         ([1, 1, 32, 32], 3, ttnn.TILE_LAYOUT),
-        ([1, 1, 32, 32], 3, ttnn.TILE_LAYOUT),
         ([1, 1, 32, 32 * 2], 3, ttnn.TILE_LAYOUT),
         ([1, 1, 64, 32], 3, ttnn.TILE_LAYOUT),
         ([1, 1, 64, 64], 3, ttnn.TILE_LAYOUT),
@@ -291,12 +322,14 @@ def run_reduce_scatter_test(
     "input_dtype",
     [
         ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
@@ -340,7 +373,7 @@ def test_line_reduce_scatter_async_post_commit(
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "num_devices, num_links, per_chip_output_shape, dim, layout",
+    "num_devices, num_links, per_chip_input_shape, dim, layout",
     [
         (2, 1, [1, 2, 32, 1280], 1, ttnn.TILE_LAYOUT),
         (2, 1, [2, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
@@ -350,12 +383,14 @@ def test_line_reduce_scatter_async_post_commit(
     "input_dtype",
     [
         ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "buffer_type",
     [
         ttnn.BufferType.DRAM,
+        ttnn.BufferType.L1,
     ],
 )
 @pytest.mark.parametrize("enable_async", [True])
@@ -364,7 +399,7 @@ def test_line_reduce_scatter_async_post_commit(
 def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
     t3k_mesh_device,
     num_devices,
-    per_chip_output_shape,
+    per_chip_input_shape,
     dim,
     num_links,
     math_op,
@@ -383,7 +418,7 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
     run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
         t3k_mesh_device,
         num_devices,
-        per_chip_output_shape,
+        per_chip_input_shape,
         ttnn.TensorMemoryLayout.INTERLEAVED,
         dim,
         num_links,
@@ -406,7 +441,7 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "num_devices, num_links, per_chip_output_shape, dim, layout",
+    "num_devices, num_links, per_chip_input_shape, dim, layout",
     [
         (4, 1, [1, 4, 32, 1280], 1, ttnn.TILE_LAYOUT),
         (4, 1, [4, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
@@ -416,12 +451,14 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
     "input_dtype",
     [
         ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "buffer_type",
     [
         ttnn.BufferType.DRAM,
+        ttnn.BufferType.L1,
     ],
 )
 @pytest.mark.parametrize("enable_async", [True])
@@ -430,7 +467,7 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
 def test_line_reduce_scatter_async_on_T3K_rows_post_commit(
     t3k_mesh_device,
     num_devices,
-    per_chip_output_shape,
+    per_chip_input_shape,
     dim,
     num_links,
     math_op,
@@ -449,7 +486,7 @@ def test_line_reduce_scatter_async_on_T3K_rows_post_commit(
     run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
         t3k_mesh_device,
         num_devices,
-        per_chip_output_shape,
+        per_chip_input_shape,
         ttnn.TensorMemoryLayout.INTERLEAVED,
         dim,
         num_links,
@@ -463,6 +500,127 @@ def test_line_reduce_scatter_async_on_T3K_rows_post_commit(
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=1,
+        use_reduce_scatter_async=True,
+        enable_persistent_fabric=True,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+    )
+
+
+@pytest.mark.skip(reason="Sharded reduce scatter sometimes hangs")
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (4, 1),
+    ],
+)
+@pytest.mark.parametrize("dim", [3])
+@pytest.mark.parametrize(
+    "tensor_mem_layout",
+    [
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    ],
+)
+@pytest.mark.parametrize("buffer_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "buffer_type",
+    [
+        ttnn.BufferType.L1,
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape,input_shard_shape,shard_grid",
+    (
+        # LLama
+        (
+            (1, 1, 32, 1024),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 4096),
+            (32, 512),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 2048),
+            (32, 256),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 1792),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+        ),
+    ),
+)
+@pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
+@pytest.mark.parametrize("enable_async", [False])
+@pytest.mark.parametrize("replication_factor", [2])
+def test_line_reduce_scatter_cluster_axis_on_T3K_width_sharded_reduce_scatter_post_commit(
+    t3k_mesh_device,
+    num_devices,
+    per_chip_output_shape,
+    input_shard_shape,
+    dim,
+    num_links,
+    buffer_type,
+    math_op,
+    shard_grid,
+    orientation,
+    input_dtype,
+    buffer_layout,
+    tensor_mem_layout,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    replication_factor,
+    num_iters=1,
+    trace_mode=False,
+):
+    if len(t3k_mesh_device.get_devices()) < 8:
+        pytest.skip("Not T3K!")
+
+    per_chip_input_shape = list(per_chip_output_shape)
+    per_chip_input_shape[dim] *= num_devices
+    per_chip_input_shape = tuple(per_chip_input_shape)
+
+    input_shard_spec = ttnn.ShardSpec(
+        shard_grid,
+        tuple(input_shard_shape),
+        orientation,
+        False,
+    )
+
+    run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
+        t3k_mesh_device,
+        num_devices,
+        per_chip_input_shape,
+        tensor_mem_layout,
+        dim,
+        num_links,
+        math_op,
+        input_dtype,
+        buffer_layout,
+        buffer_type,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        input_shard_spec=input_shard_spec,
+        num_reduce_scatter_instances=replication_factor,
+        cluster_axis=1,
+        trace_mode=trace_mode,
         use_reduce_scatter_async=True,
         enable_persistent_fabric=True,
         create_persistent_fabric=True,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -96,7 +96,7 @@ def run_reduce_scatter_test(
     math_op,
     input_dtype,
     layout,
-    _mem_config,
+    mem_config,
     use_program_cache,
     function_level_defaults,
     num_iters,
@@ -141,9 +141,9 @@ def run_reduce_scatter_test(
             tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
         )
     else:
-        assert _mem_config is not None
-        input_mem_config = _mem_config
-        output_mem_config = _mem_config
+        assert mem_config is not None
+        input_mem_config = mem_config
+        output_mem_config = mem_config
 
     (is_known_failure, message) = is_unsupported_case(
         per_chip_output_shape, dim, math_op, input_mem_config, num_devices, num_links, input_dtype, layout

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp
@@ -174,5 +174,7 @@ struct CCLWorkerArgBuilder {
     bool dst_is_dram;
 };
 
+bool can_command_stream_be_lowered_to_noc_commands(const Tensor& input_tensor);
+
 }  // namespace worker_detail
 }  // namespace ttnn::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.cpp
@@ -33,16 +33,19 @@ void tensor_address_runtime_args_overrider::add_runtime_arg_index(size_t tensor_
 
 void tensor_address_runtime_args_overrider::override_runtime_args(
     size_t tensor_idx, uint32_t new_value, tt::tt_metal::RuntimeArgsData& runtime_args_to_modify) const {
+    if (tensor_idx >= tensor_address_runtime_arg_indices.size()) {
+        log_info(tt::LogOp, "Tensor index {} is out of bounds. Skipping override", tensor_idx);
+    }
     TT_FATAL(
         tensor_idx < tensor_address_runtime_arg_indices.size(), "Invalid tensor index when overriding runtime args");
 
     const auto& indices = tensor_address_runtime_arg_indices[tensor_idx];
     TT_FATAL(!indices.empty(), "No runtime arg indices associated with tensor");
 
-    log_trace(tt::LogOp, "Overriding {} runtime args for tensor {} to value {}", indices.size(), tensor_idx, new_value);
+    log_info(tt::LogOp, "Overriding {} runtime args for tensor {} to value {}", indices.size(), tensor_idx, new_value);
     for (size_t idx : indices) {
         TT_FATAL(idx < runtime_args_to_modify.size(), "Runtime arg index out of bounds when overriding args");
-        log_trace(tt::LogOp, "\t- {}", idx);
+        log_info(tt::LogOp, "\t- {}", idx);
         runtime_args_to_modify[idx] = new_value;
     }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.cpp
@@ -34,7 +34,7 @@ void tensor_address_runtime_args_overrider::add_runtime_arg_index(size_t tensor_
 void tensor_address_runtime_args_overrider::override_runtime_args(
     size_t tensor_idx, uint32_t new_value, tt::tt_metal::RuntimeArgsData& runtime_args_to_modify) const {
     if (tensor_idx >= tensor_address_runtime_arg_indices.size()) {
-        log_info(tt::LogOp, "Tensor index {} is out of bounds. Skipping override", tensor_idx);
+        log_trace(tt::LogOp, "Tensor index {} is out of bounds. Skipping override", tensor_idx);
     }
     TT_FATAL(
         tensor_idx < tensor_address_runtime_arg_indices.size(), "Invalid tensor index when overriding runtime args");
@@ -42,10 +42,10 @@ void tensor_address_runtime_args_overrider::override_runtime_args(
     const auto& indices = tensor_address_runtime_arg_indices[tensor_idx];
     TT_FATAL(!indices.empty(), "No runtime arg indices associated with tensor");
 
-    log_info(tt::LogOp, "Overriding {} runtime args for tensor {} to value {}", indices.size(), tensor_idx, new_value);
+    log_trace(tt::LogOp, "Overriding {} runtime args for tensor {} to value {}", indices.size(), tensor_idx, new_value);
     for (size_t idx : indices) {
         TT_FATAL(idx < runtime_args_to_modify.size(), "Runtime arg index out of bounds when overriding args");
-        log_info(tt::LogOp, "\t- {}", idx);
+        log_trace(tt::LogOp, "\t- {}", idx);
         runtime_args_to_modify[idx] = new_value;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -190,13 +190,7 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program(
 
 operation::Hash ReduceScatterAsync::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
     return operation::hash_operation<ReduceScatterAsync>(
-        this->binary_op_type,
-        this->scatter_dim,
-        this->ring_size,
-        this->ring_index,
-        this->topology,
-        this->from_remote_sem,
-        this->to_remote_sem);
+        this->binary_op_type, this->scatter_dim, this->ring_size, this->ring_index, this->topology);
 }
 
 namespace {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -812,7 +812,7 @@ static void generate_partial_reducer_reader_worker_command_streams(
                 //... There is a low-probability race here. To close it we need to have the original writer of
                 //    the global semaphore wait for an ack from this consumer that the reading is complete (else the producer
                 //    of a future iteration could write an increment from that next invocation before this consumer clears the
-                //    value for the current iteration.
+                //    value for the current iteration. ###
                 worker_command_stream0.push_back(ttnn::ccl::cmd::uops::local_core_semaphore_set(in0_tensor_sync.value().get_tensor_sync_semaphore(w), 0));
             }
         }
@@ -831,11 +831,7 @@ static void generate_partial_reducer_reader_worker_command_streams(
                 }
             }
 
-            // Reader must clear the global semaphore so that it can be reused by any future iterations
-            //... There is a low-probability race here. To close it we need to have the original writer of
-            //    the global semaphore wait for an ack from this consumer that the reading is complete (else the producer
-            //    of a future iteration could write an increment from that next invocation before this consumer clears the
-            //    value for the current iteration.
+            // Reader must clear the global semaphore for future program launches. See comment above ###
             worker_command_stream1.push_back(ttnn::ccl::cmd::uops::local_core_semaphore_set(from_remote_input_tensor_sync.value().get_tensor_sync_semaphore(w), 0));
         }
     }
@@ -1149,7 +1145,6 @@ static void create_final_reducer_worker_rt_args_not_end_of_line(
             builder_config.kernel_ids.get().math,
             w_logical,
             math_page_counts_out.at(w_logical));
-        // log_info(tt::LogOp, "Writer kernel on core x={}, y={} has tensor addresses: {} and {}", w_logical.x, w_logical.y, (void*)all_program_tensors.local_final_output_tensor->buffer()->address(), (void*)nullptr);
         generate_multi_input_command_stream_kernel_rt_args(
             builder_config.program,
             builder_config.kernel_ids.get().writer,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -2304,7 +2304,6 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
             // partial reducer writer0 (end of line - start): output_tensor_pt
             // partial reducer writer1 (end of line - end): local_final_output_tensor
 
-            log_info(tt::LogOp, "Overriding runtime args for device {}", topology_config.line_index());
             std::array<size_t, 2> input_tensor_from_remote_idx = {input_tensor_from_remote_forward_direction_idx, input_tensor_from_remote_backward_direction_idx};
             std::array<size_t, 2> partial_output_tensor_idx = {partial_output_tensor_forward_direction_idx, partial_output_tensor_backward_direction_idx};
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -19,6 +19,8 @@
 #include "tt_metal/host_api.hpp"
 #include "ttnn/operation.hpp"
 
+#include "ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp"
+
 // For reduction op
 #include "ttnn/operations/ccl/common/uops/ccl_host_commands.hpp"
 #include "ttnn/operations/eltwise/binary/common/binary_op_types.hpp"
@@ -180,14 +182,19 @@ struct WorkerCoreBundle {
 struct ProgramTensorsBundle {
     Tensor const* input_tensor = nullptr;
     std::optional<TensorSyncSpec> input_tensor_sync;
-    Tensor* local_output_tensor = nullptr;
+    size_t input_tensor_index = std::numeric_limits<size_t>::max();
+    Tensor* local_final_output_tensor = nullptr;
     std::optional<TensorSyncSpec> local_output_sync;
+    size_t local_final_output_tensor_index = std::numeric_limits<size_t>::max();
     std::array<Tensor*, 2> input_tensor_from_remote = {nullptr, nullptr};
     std::array<TensorSyncSpec, 2> input_tensor_from_remote_sync;
+    std::array<size_t, 2> input_tensor_from_remote_index = {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
     std::array<Tensor*, 2> remote_output = {nullptr, nullptr};
     std::array<TensorSyncSpec, 2> remote_output_sync;
+    std::array<size_t, 2> remote_output_index = {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
     std::array<Tensor*, 2> local_output_partial = {nullptr, nullptr};
     std::array<TensorSyncSpec, 2> local_output_partial_sync;
+    std::array<size_t, 2> local_output_partial_index = {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
 
     static Tensor* build_handle(Tensor& tensor) { return &tensor; }
     static Tensor const* build_handle(Tensor const& tensor) { return &tensor; }
@@ -608,7 +615,7 @@ static ReduceScatterKernelHandles build_line_reduce_scatter_worker_ct(
     // Generate the sender kernel
     auto const output_tensor_ptrs = std::vector<Tensor const*>{
         all_tensors.remote_output[0] != nullptr ? all_tensors.remote_output[0] : all_tensors.remote_output[1],
-        all_tensors.local_output_tensor};
+        all_tensors.local_final_output_tensor};
     auto sender_kernel_id = generate_multi_command_stream_kernel_ct_args(
         program,
         {cb_handles.reader_to_writer_shortcut_cb, cb_handles.math_to_writer_cb},
@@ -799,6 +806,15 @@ static void generate_partial_reducer_reader_worker_command_streams(
                     worker_command_stream0.push_back(read_tensor_slice_to_cb_for_eventual_fabric_write(s, get_cb(i)));
                 }
             }
+
+            if (in0_tensor_sync.has_value()) {
+                // Reader must clear the global semaphore so that it can be reused by any future iterations
+                //... There is a low-probability race here. To close it we need to have the original writer of
+                //    the global semaphore wait for an ack from this consumer that the reading is complete (else the producer
+                //    of a future iteration could write an increment from that next invocation before this consumer clears the
+                //    value for the current iteration.
+                worker_command_stream0.push_back(ttnn::ccl::cmd::uops::local_core_semaphore_set(in0_tensor_sync.value().get_tensor_sync_semaphore(w), 0));
+            }
         }
         {
             auto& worker_command_stream1 = worker_command_streams_out.reader_cmds1[w_logical];
@@ -814,6 +830,13 @@ static void generate_partial_reducer_reader_worker_command_streams(
                         read_tensor_slice_to_cb_for_eventual_fabric_write(s, reader_cbs.math_in1));
                 }
             }
+
+            // Reader must clear the global semaphore so that it can be reused by any future iterations
+            //... There is a low-probability race here. To close it we need to have the original writer of
+            //    the global semaphore wait for an ack from this consumer that the reading is complete (else the producer
+            //    of a future iteration could write an increment from that next invocation before this consumer clears the
+            //    value for the current iteration.
+            worker_command_stream1.push_back(ttnn::ccl::cmd::uops::local_core_semaphore_set(from_remote_input_tensor_sync.value().get_tensor_sync_semaphore(w), 0));
         }
     }
 }
@@ -858,10 +881,10 @@ static void generate_partial_reducer_writer_worker_command_streams(
 
     auto const local_partial_output_tensor_slice =
         convert_to_whole_tensor_slice(*local_partial_output_tensor_sync_bundle.tensor);
-    auto const local_output_tensor_slices_per_worker =
+    auto const local_final_output_tensor_slices_per_worker =
         split_tensor_slices_across_workers_page_aligned(num_workers, {local_partial_output_tensor_slice});
     TT_FATAL(
-        local_output_tensor_slices_per_worker.size() == num_workers,
+        local_final_output_tensor_slices_per_worker.size() == num_workers,
         "Local output tensor slices per worker size mismatch");
     TT_FATAL(
         remote_out_worker_tensor_slices.size() == num_workers, "Remote output tensor slices per worker size mismatch");
@@ -949,7 +972,7 @@ static void generate_partial_reducer_writer_worker_command_streams(
             auto& worker_command_stream1 = worker_command_streams.writer_cmds1[worker_cores_vec[w]];
 
             TT_FATAL(
-                local_output_tensor_slices_per_worker[w].size() == 1,
+                local_final_output_tensor_slices_per_worker[w].size() == 1,
                 "Local output tensor expected only to have a single tensor slice");
             // Wait for all-clear from first command stream that "from math" CB is no longer being pulled from
             // Then it's safe to forward to fabric from CB
@@ -957,7 +980,7 @@ static void generate_partial_reducer_writer_worker_command_streams(
             std::ranges::copy(
                 CclHostLowLevelCommandSequence{
                     local_semaphore_wait(internal_command_stream_sync_sem_id, 1),
-                    local_write_cb_to_tensor_slice(local_output_tensor_slices_per_worker[w][0], skip_math_for_last_slice ? writer_cbs.pass_through : writer_cbs.math_out),
+                    local_write_cb_to_tensor_slice(local_final_output_tensor_slices_per_worker[w][0], skip_math_for_last_slice ? writer_cbs.pass_through : writer_cbs.math_out),
                     local_chip_semaphore_inc_mcast(
                         // NOTE: Per worker semaphores
                         local_partial_output_tensor_sync_bundle.sync_spec.value().get_tensor_sync_semaphore(w),
@@ -1020,7 +1043,7 @@ static void create_non_end_of_line_final_reducer_worker_commands(
 
     generate_final_reducer_writer_worker_command_streams(
         builder_config,
-        TensorSyncBundle{all_program_tensors.local_output_tensor, all_program_tensors.local_output_sync},
+        TensorSyncBundle{all_program_tensors.local_final_output_tensor, all_program_tensors.local_output_sync},
         worker_command_streams_out);
 
     TT_FATAL(final_reducer_worker_cores.size() > 0, "Internal error. No final reducer cores were created");
@@ -1094,11 +1117,14 @@ static void create_final_reducer_worker_rt_args_not_end_of_line(
     ReduceScatterBuilderConfig& builder_config,
     fabric_lifetime_mode fabric_mode,
     WorkerCommandStreams& worker_command_streams_out,
-    std::unordered_map<CoreCoord, size_t>& math_page_counts_out) {
+    std::unordered_map<CoreCoord, size_t>& math_page_counts_out,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
 
     auto const& final_reducer_worker_cores = builder_config.worker_cores.get().final_reducers_vec;
     auto const& all_program_tensors = builder_config.all_tensors.get();
+    auto const& all_tensors = builder_config.all_tensors.get();
 
     for (size_t i = 0; i < final_reducer_worker_cores.size(); i++) {
         auto const& w_logical = final_reducer_worker_cores[i];
@@ -1114,16 +1140,20 @@ static void create_final_reducer_worker_rt_args_not_end_of_line(
             worker_command_streams_out.reader_cmds0.at(w_logical),
             worker_command_streams_out.reader_cmds1.at(w_logical),
             std::nullopt,
-            std::nullopt);
+            std::nullopt,
+            std::nullopt,
+            std::vector<size_t>{all_tensors.local_output_partial_index[LineDirection::FORWARD], all_tensors.local_output_partial_index[LineDirection::BACKWARD]},
+            &reader_rt_args_overrider_map[w_logical]);
         set_math_runtime_args(
             builder_config.program,
             builder_config.kernel_ids.get().math,
             w_logical,
             math_page_counts_out.at(w_logical));
+        // log_info(tt::LogOp, "Writer kernel on core x={}, y={} has tensor addresses: {} and {}", w_logical.x, w_logical.y, (void*)all_program_tensors.local_final_output_tensor->buffer()->address(), (void*)nullptr);
         generate_multi_input_command_stream_kernel_rt_args(
             builder_config.program,
             builder_config.kernel_ids.get().writer,
-            {all_program_tensors.local_output_tensor, nullptr},
+            {all_program_tensors.local_final_output_tensor, nullptr},
             {builder_config.page_size, builder_config.page_size},
             builder_config.device,
             builder_config.pages_per_cb_packet,
@@ -1131,7 +1161,10 @@ static void create_final_reducer_worker_rt_args_not_end_of_line(
             worker_command_streams_out.writer_cmds0.at(w_logical),
             ttnn::ccl::cmd::CclHostLowLevelCommandSequence{},
             std::nullopt,
-            std::nullopt);
+            std::nullopt,
+            std::nullopt,
+            std::vector<size_t>{all_tensors.local_final_output_tensor_index},
+            &writer_rt_args_overrider_map[w_logical]);
     }
 }
 
@@ -1139,7 +1172,9 @@ static void populate_partial_reduce_rt_args(
     ReduceScatterBuilderConfig& builder_config,
 
     WorkerCommandStreams& worker_command_streams_out,
-    std::unordered_map<CoreCoord, size_t>& math_page_counts_out) {
+    std::unordered_map<CoreCoord, size_t>& math_page_counts_out,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
     using Direction = ttnn::ccl::EdmLineFabricOpInterface::Direction;
 
@@ -1166,6 +1201,7 @@ static void populate_partial_reduce_rt_args(
         for (size_t i = 0; i < partial_reducer_worker_cores_vec[line_direction].size(); i++) {
             auto const& w_logical = partial_reducer_worker_cores_vec[line_direction][i];
             // Reader kernel RT args
+
             generate_multi_input_command_stream_kernel_rt_args(
                 builder_config.program.get(),
                 kernel_ids.reader,
@@ -1178,11 +1214,16 @@ static void populate_partial_reduce_rt_args(
                 worker_command_streams_out.reader_cmds0.at(w_logical),
                 worker_command_streams_out.reader_cmds1.at(w_logical),
                 std::nullopt,
-                std::nullopt);
+                std::nullopt,
+                std::nullopt,
+                std::vector<size_t>{all_tensors.input_tensor_index, all_tensors.input_tensor_from_remote_index.at(line_direction)},
+                &reader_rt_args_overrider_map[w_logical]);
             set_math_runtime_args(
                 builder_config.program.get(), kernel_ids.math, w_logical, math_page_counts_out[w_logical]);
             auto output_tensor_ptrs = std::vector<Tensor const*>{
                 all_tensors.remote_output[line_direction], all_tensors.local_output_partial[line_direction]};
+            auto output_tensor_indices = std::vector<size_t>{
+                all_tensors.remote_output_index.at(line_direction), all_tensors.local_output_partial_index.at(line_direction)};
             generate_multi_input_command_stream_kernel_rt_args(
                 builder_config.program.get(),
                 kernel_ids.writer,
@@ -1198,17 +1239,22 @@ static void populate_partial_reduce_rt_args(
                 std::unordered_map<const Tensor*, IDevice*>{
                     {output_tensor_ptrs[0],
                      line_direction == LineDirection::FORWARD ? builder_config.forward_device
-                                                              : builder_config.backward_device}});
+                                                              : builder_config.backward_device}},
+                output_tensor_indices,
+                &writer_rt_args_overrider_map[w_logical]);
         }
-        //////////////
     }
 }
 
-static void create_worker_runtime_args_for_inactive_workers(ReduceScatterBuilderConfig& builder_config) {
+static void create_worker_runtime_args_for_inactive_workers(
+    ReduceScatterBuilderConfig& builder_config,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     auto const& inactive_cores = builder_config.worker_cores.get().final_reducers;
     using namespace ttnn::ccl::worker_detail;
     log_trace(tt::LogOp, "--------------------------------------");
     log_trace(tt::LogOp, "CREATE WORKER (inactive - not end. Device={})", builder_config.device->id());
+    auto const& inactive_cores_vec = builder_config.worker_cores.get().final_reducers_vec;
 
     generate_multi_input_command_stream_kernel_rt_args(
         builder_config.program.get(),
@@ -1221,7 +1267,10 @@ static void create_worker_runtime_args_for_inactive_workers(ReduceScatterBuilder
         ttnn::ccl::cmd::CclHostLowLevelCommandSequence{},
         ttnn::ccl::cmd::CclHostLowLevelCommandSequence{},
         std::nullopt,
-        std::nullopt);
+        std::nullopt,
+        std::nullopt,
+        std::vector<size_t>{},
+        &reader_rt_args_overrider_map[inactive_cores_vec[0]]);
 
     tt::tt_metal::SetRuntimeArgs(
         builder_config.program.get(),
@@ -1240,7 +1289,15 @@ static void create_worker_runtime_args_for_inactive_workers(ReduceScatterBuilder
         ttnn::ccl::cmd::CclHostLowLevelCommandSequence{},
         ttnn::ccl::cmd::CclHostLowLevelCommandSequence{},
         std::nullopt,
-        std::nullopt);
+        std::nullopt,
+        std::nullopt,
+        std::vector<size_t>{},
+        &writer_rt_args_overrider_map[inactive_cores_vec[0]]);
+
+    for (size_t i = 1; i < inactive_cores_vec.size(); i++) {
+        reader_rt_args_overrider_map[inactive_cores_vec[i]] = reader_rt_args_overrider_map[inactive_cores_vec[0]];
+        writer_rt_args_overrider_map[inactive_cores_vec[i]] = writer_rt_args_overrider_map[inactive_cores_vec[0]];
+    }
 }
 
 static void validate_end_of_line_worker_tensors(
@@ -1250,7 +1307,7 @@ static void validate_end_of_line_worker_tensors(
     bool teardown_fabric = fabric_mode == fabric_lifetime_mode::TRANSIENT;
 
     TT_FATAL(all_tensors.input_tensor != nullptr, "Input tensor must be populated");
-    TT_FATAL(all_tensors.local_output_tensor != nullptr, "Output tensor must be populated");
+    TT_FATAL(all_tensors.local_final_output_tensor != nullptr, "Output tensor must be populated");
     if (line_topology.is_first_device_in_line(LineDirection::FORWARD)) {
         TT_FATAL(
             all_tensors.input_tensor_from_remote[LineDirection::FORWARD] == nullptr,
@@ -1279,7 +1336,6 @@ static void create_end_of_line_worker_commands(
     ReduceScatterBuilderConfig& builder_config,
     std::unordered_map<CoreCoord, size_t>& worker_math_page_counts_out,
     WorkerCommandStreams& worker_command_streams_out) {
-    // using namespace ttnn::ccl::worker_detail;
     using namespace ttnn::ccl::cmd;
     using namespace ttnn::ccl::cmd::uops;
     using namespace ttnn::ccl::cmd::builder;
@@ -1327,7 +1383,7 @@ static void create_end_of_line_worker_commands(
     std::array<std::vector<CoreCoord>, 2> const reader_worker_cores_per_direction = worker_cores.partial_reducers_vec;
     std::array<std::vector<CoreCoord>, 2> const& writer_worker_cores_per_direction = reader_worker_cores_per_direction;
 
-    auto const local_partial_output_tensor_slice = convert_to_whole_tensor_slice(*all_tensors.local_output_tensor);
+    auto const local_partial_output_tensor_slice = convert_to_whole_tensor_slice(*all_tensors.local_final_output_tensor);
     auto writer_end_of_line_output_worker_slices =
         split_tensor_slices_across_workers_page_aligned(num_workers, {local_partial_output_tensor_slice});
     TT_FATAL(
@@ -1402,9 +1458,14 @@ static void create_end_of_line_worker_commands(
                 in0_cmd_stream.push_back(
                     read_tensor_slice_to_cb(worker_in_slices[0], all_cbs.line_end_reader.math_in0));
                 // NOTE: per worker semaphore
-                in1_cmd_stream.push_back(local_semaphore_wait(from_remote_sync.get_tensor_sync_semaphore(0), 1));
+                constexpr size_t end_of_line_reader_input_from_remote_semaphore_index = 0;
+                auto const& input_from_remote_sync_semaphore = from_remote_sync.get_tensor_sync_semaphore(end_of_line_reader_input_from_remote_semaphore_index);
+                in1_cmd_stream.push_back(local_semaphore_wait(input_from_remote_sync_semaphore, 1));
                 in1_cmd_stream.push_back(
                     read_tensor_slice_to_cb(worker_in_slices.at(0), all_cbs.line_end_reader.math_in1));
+
+                // Reader must clear the global semaphore so that it can be reused by any future iterations
+                in1_cmd_stream.push_back(ttnn::ccl::cmd::uops::local_core_semaphore_set(input_from_remote_sync_semaphore, 0));
 
                 // MATH PAGE COUNTS
                 num_math_pages =
@@ -1427,7 +1488,10 @@ static void create_end_of_line_worker_commands(
 static void create_end_of_line_worker_runtime_args(
     ReduceScatterBuilderConfig& builder_config,
     WorkerCommandStreams& worker_command_streams,
-    std::unordered_map<CoreCoord, size_t> const& worker_math_page_counts) {
+    std::unordered_map<CoreCoord, size_t> const& worker_math_page_counts,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map
+    ) {
     using namespace ttnn::ccl::worker_detail;
     using namespace ttnn::ccl::cmd;
     using Direction = ttnn::ccl::EdmLineFabricOpInterface::Direction;
@@ -1461,14 +1525,21 @@ static void create_end_of_line_worker_runtime_args(
 
         Tensor* output_tensor_ptr = nullptr;
         auto input_tensor_ptrs = std::vector<Tensor const*>{nullptr, nullptr};
+        auto input_tensor_indices = std::vector<size_t>{};
+        auto output_tensor_indices = std::vector<size_t>{};
         input_tensor_ptrs[0] = all_tensors.input_tensor;
+        input_tensor_indices.push_back(all_tensors.input_tensor_index);
 
         if (is_start_of_line) {
             output_tensor_ptr = all_tensors.remote_output[direction];
+            output_tensor_indices.push_back(all_tensors.remote_output_index.at(direction));
         } else {
-            output_tensor_ptr = all_tensors.local_output_tensor;
+            output_tensor_ptr = all_tensors.local_final_output_tensor;
+            output_tensor_indices.push_back(all_tensors.local_final_output_tensor_index);
+
             input_tensor_ptrs[1] = all_tensors.input_tensor_from_remote.at(direction);
             TT_FATAL(input_tensor_ptrs[1] != nullptr, "Internal error. Expected input tensor to be populated");
+            input_tensor_indices.push_back(all_tensors.input_tensor_from_remote_index.at(direction));
         }
 
         for (size_t i = 0; i < num_workers; i++) {
@@ -1494,7 +1565,10 @@ static void create_end_of_line_worker_runtime_args(
                 has_in1_commands ? worker_command_streams.reader_cmds1.at(w_logical)
                                  : std::vector<CclHostLowLevelWorkerCommand>{},
                 std::nullopt,
-                std::nullopt);
+                std::nullopt,
+                std::nullopt,
+                input_tensor_indices,
+                &reader_rt_args_overrider_map[w_logical]);
             set_math_runtime_args(program, kernel_ids.math, w_logical, num_math_pages);
             generate_multi_input_command_stream_kernel_rt_args(
                 program,
@@ -1507,7 +1581,10 @@ static void create_end_of_line_worker_runtime_args(
                 worker_command_streams.writer_cmds0.at(w_logical),
                 std::vector<CclHostLowLevelWorkerCommand>{},
                 fwd_fabric_connection,
-                bwd_fabric_connection);
+                bwd_fabric_connection,
+                std::nullopt,
+                output_tensor_indices,
+                &writer_rt_args_overrider_map[w_logical]);
         }
     }
 }
@@ -1617,12 +1694,14 @@ static void create_worker_runtime_args_not_end_of_line(
     ReduceScatterBuilderConfig& builder_config,
     fabric_lifetime_mode fabric_mode,
     WorkerCommandStreams& worker_command_streams_out,
-    std::unordered_map<CoreCoord, size_t>& math_page_counts_out) {
+    std::unordered_map<CoreCoord, size_t>& math_page_counts_out,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     // Kernel Creation
     create_final_reducer_worker_rt_args_not_end_of_line(
-        builder_config, fabric_mode, worker_command_streams_out, math_page_counts_out);
+        builder_config, fabric_mode, worker_command_streams_out, math_page_counts_out, reader_rt_args_overrider_map, writer_rt_args_overrider_map);
 
-    populate_partial_reduce_rt_args(builder_config, worker_command_streams_out, math_page_counts_out);
+    populate_partial_reduce_rt_args(builder_config, worker_command_streams_out, math_page_counts_out, reader_rt_args_overrider_map, writer_rt_args_overrider_map);
 }
 
 static void validate_tensors(ProgramTensorsBundle const& all_tensors, LineTopology topology_config) {
@@ -1657,7 +1736,7 @@ static void validate_tensors(ProgramTensorsBundle const& all_tensors, LineTopolo
             }
             if (all_tensors.local_output_partial[direction] != nullptr) {
                 TT_FATAL(
-                    all_tensors.local_output_partial[direction]->shape() == all_tensors.local_output_tensor->shape(),
+                    all_tensors.local_output_partial[direction]->shape() == all_tensors.local_final_output_tensor->shape(),
                     "Partial output tensor and local output tensor must have the same shape");
             }
             if (all_tensors.input_tensor_from_remote[direction] != nullptr) {
@@ -1813,13 +1892,16 @@ static void populate_worker_runtime_args(
     ReduceScatterBuilderConfig& builder_config,
     fabric_lifetime_mode fabric_mode,
     WorkerCommandStreams& command_streams,
-    std::unordered_map<CoreCoord, size_t>& math_page_counts) {
+    std::unordered_map<CoreCoord, size_t>& math_page_counts,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map
+    ) {
     bool is_end_of_line = builder_config.topology_config.get().is_at_end_of_line();
     if (is_end_of_line) {
-        create_worker_runtime_args_for_inactive_workers(builder_config);
-        create_end_of_line_worker_runtime_args(builder_config, command_streams, math_page_counts);
+        create_worker_runtime_args_for_inactive_workers(builder_config, reader_rt_args_overrider_map, writer_rt_args_overrider_map);
+        create_end_of_line_worker_runtime_args(builder_config, command_streams, math_page_counts, reader_rt_args_overrider_map, writer_rt_args_overrider_map);
     } else {
-        create_worker_runtime_args_not_end_of_line(builder_config, fabric_mode, command_streams, math_page_counts);
+        create_worker_runtime_args_not_end_of_line(builder_config, fabric_mode, command_streams, math_page_counts, reader_rt_args_overrider_map, writer_rt_args_overrider_map);
     }
 }
 
@@ -1936,6 +2018,72 @@ static void log_worker_command_streams(WorkerCommandStreams const& command_strea
     }
 }
 
+void lower_command_streams_to_noc_commands(
+    WorkerCommandStreams& command_streams,
+    ReduceScatterBuilderConfig& builder_config,
+    size_t local_input_tensor_idx,
+    size_t local_final_output_tensor_idx,
+    size_t input_tensor_from_remote_forward_direction_idx,
+    size_t input_tensor_from_remote_backward_direction_idx,
+    size_t partial_output_tensor_forward_direction_idx,
+    size_t partial_output_tensor_backward_direction_idx) {
+
+    size_t packet_size_bytes = builder_config.fabric.get().get_edm_buffer_size_bytes();
+
+    auto lower_command_streams = [packet_size_bytes](
+        std::vector<CoreCoord> const& cores,
+        std::unordered_map<CoreCoord, std::vector<ttnn::ccl::cmd::CclHostLowLevelWorkerCommand>>& command_streams,
+        Tensor const& tensor
+        ) {
+        for (const auto& core : cores) {
+            command_streams[core] =
+                ttnn::ccl::tensor_slice_commands_to_noc_commands(
+                    command_streams[core],
+                    tensor,
+                    packet_size_bytes);
+        }
+    };
+
+    for (const auto& direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
+        bool is_end_of_line = builder_config.topology_config.get().is_first_device_in_line(direction);
+        bool is_start_of_line = builder_config.topology_config.get().is_last_device_in_line(direction);
+
+        auto const& partial_reducers = builder_config.worker_cores.get().partial_reducers_vec[direction];
+        auto const& final_reducers = builder_config.worker_cores.get().final_reducers_vec;
+
+        lower_command_streams(
+            partial_reducers, command_streams.reader_cmds0, *builder_config.all_tensors.get().input_tensor);
+
+        if (is_start_of_line) {
+            lower_command_streams(
+                partial_reducers, command_streams.writer_cmds0, *builder_config.all_tensors.get().input_tensor_from_remote[direction]);
+        } else if (is_end_of_line) {
+            lower_command_streams(
+                partial_reducers, command_streams.reader_cmds1, *builder_config.all_tensors.get().input_tensor_from_remote[direction]);
+            lower_command_streams(
+                partial_reducers, command_streams.writer_cmds1, *builder_config.all_tensors.get().local_output_partial[direction]);
+        } else {
+            lower_command_streams(
+                partial_reducers, command_streams.reader_cmds1, *builder_config.all_tensors.get().input_tensor_from_remote[direction]);
+            lower_command_streams(
+                partial_reducers, command_streams.writer_cmds0, *builder_config.all_tensors.get().remote_output[direction]);
+            lower_command_streams(
+                partial_reducers, command_streams.writer_cmds1, *builder_config.all_tensors.get().local_output_partial[direction]);
+
+        }
+    }
+
+    const auto& final_reducers = builder_config.worker_cores.get().final_reducers_vec;
+    bool is_end_of_line = builder_config.topology_config.get().is_at_end_of_line();
+    if (!is_end_of_line) {
+        lower_command_streams(
+            final_reducers, command_streams.reader_cmds0, *builder_config.all_tensors.get().local_output_partial[LineDirection::FORWARD]);
+        lower_command_streams(
+            final_reducers, command_streams.reader_cmds1, *builder_config.all_tensors.get().local_output_partial[LineDirection::FORWARD]);
+        lower_command_streams(
+            final_reducers, command_streams.reader_cmds0, *builder_config.all_tensors.get().local_final_output_tensor);
+    }
+}
 
 operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
     Program& program,
@@ -1943,7 +2091,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
     std::optional<IDevice*> forward_device,
     std::optional<IDevice*> backward_device,
     Tensor const& input_tensor,
-    Tensor& local_output_tensor,
+    Tensor& local_final_output_tensor,
     Tensor& input_tensor_from_remote_forward_direction,
     Tensor& input_tensor_from_remote_backward_direction,
     Tensor& local_partial_output_tensor_from_forward_direction,
@@ -1985,14 +2133,23 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
     auto const& topology_config = LineTopology(line_size, line_index);
 
     auto const& worker_cores = select_worker_cores(topology, num_links, device);
+
+    constexpr size_t local_input_tensor_idx = 0;
+    constexpr size_t local_final_output_tensor_idx = 1;
+    constexpr size_t input_tensor_from_remote_forward_direction_idx = 2;
+    constexpr size_t input_tensor_from_remote_backward_direction_idx = 3;
+    constexpr size_t partial_output_tensor_forward_direction_idx = 4;
+    constexpr size_t partial_output_tensor_backward_direction_idx = 5;
     ProgramTensorsBundle all_tensors = {
         // local input tensor
         ProgramTensorsBundle::build_handle(input_tensor),
         {},
+        local_input_tensor_idx,
 
         // local output tensor
-        ProgramTensorsBundle::build_handle(local_output_tensor),
+        ProgramTensorsBundle::build_handle(local_final_output_tensor),
         {},
+        local_final_output_tensor_idx,
 
         // input tensor from remote
         {topology_config.is_first_device_in_line(LineDirection::FORWARD)
@@ -2002,6 +2159,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
              ? nullptr
              : ProgramTensorsBundle::build_handle(input_tensor_from_remote_backward_direction)},
         {},
+        {input_tensor_from_remote_forward_direction_idx, input_tensor_from_remote_backward_direction_idx},
 
         // output partial tensor on remote chip
         {topology_config.is_last_device_in_line(LineDirection::FORWARD)
@@ -2011,15 +2169,21 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
              ? nullptr
              : ProgramTensorsBundle::build_handle(input_tensor_from_remote_backward_direction)},
         {},
+        {input_tensor_from_remote_forward_direction_idx, input_tensor_from_remote_backward_direction_idx},
 
         // local partial output tensor for final reducer
         {ProgramTensorsBundle::build_handle(local_partial_output_tensor_from_forward_direction),
          ProgramTensorsBundle::build_handle(local_partial_output_tensor_from_backward_direction)},
-        {}};
+        {},
+        {partial_output_tensor_forward_direction_idx, partial_output_tensor_backward_direction_idx},
+        };
+
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider> reader_rt_args_overrider_map;
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider> writer_rt_args_overrider_map;
 
     log_debug(tt::LogOp,
         "input_tensor.addr: {}, \n"
-        "local_output_tensor.addr: {}, \n"
+        "local_final_output_tensor.addr: {}, \n"
         "input_tensor_from_remote_forward_direction.addr: {}, \n"
         "input_tensor_from_remote_backward_direction.addr: {}, \n"
         "output_tensor_on_remote_chip_forward_direction.addr: {}, \n"
@@ -2027,7 +2191,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
         "local_partial_output_tensor_from_forward_direction.addr: {}, \n"
         "local_partial_output_tensor_from_backward_direction.addr: {} \n",
             all_tensors.input_tensor != nullptr ? (void*)all_tensors.input_tensor->buffer()->address() : nullptr,
-            all_tensors.local_output_tensor != nullptr ? (void*)all_tensors.local_output_tensor->buffer()->address() : nullptr,
+            all_tensors.local_final_output_tensor != nullptr ? (void*)all_tensors.local_final_output_tensor->buffer()->address() : nullptr,
             all_tensors.input_tensor_from_remote[LineDirection::FORWARD] != nullptr ? (void*)all_tensors.input_tensor_from_remote[LineDirection::FORWARD]->buffer()->address() : nullptr,
             all_tensors.input_tensor_from_remote[LineDirection::BACKWARD] != nullptr ? (void*)all_tensors.input_tensor_from_remote[LineDirection::BACKWARD]->buffer()->address() : nullptr,
             all_tensors.remote_output[LineDirection::FORWARD] != nullptr ? (void*)all_tensors.remote_output[LineDirection::FORWARD]->buffer()->address() : nullptr,
@@ -2082,28 +2246,81 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
 
     log_worker_command_streams(command_streams, device);
 
-    populate_worker_runtime_args(builder_config, fabric_mode, command_streams, math_page_counts);
+    constexpr bool command_lowering_enabled_in_reduce_scatter = false; // #Issue: https://github.com/tenstorrent/tt-metal/issues/16529
+    if (command_lowering_enabled_in_reduce_scatter && ttnn::ccl::worker_detail::can_command_stream_be_lowered_to_noc_commands(input_tensor)) {
+        lower_command_streams_to_noc_commands(
+            command_streams,
+            builder_config,
+            local_input_tensor_idx,
+            local_final_output_tensor_idx,
+            input_tensor_from_remote_forward_direction_idx,
+            input_tensor_from_remote_backward_direction_idx,
+            partial_output_tensor_forward_direction_idx,
+            partial_output_tensor_backward_direction_idx);
+        log_worker_command_streams(command_streams, device);
+    }
+
+    populate_worker_runtime_args(
+        builder_config,
+        fabric_mode,
+        command_streams,
+        math_page_counts,
+        reader_rt_args_overrider_map,
+        writer_rt_args_overrider_map);
 
     // Synchronous mode kernel invocation
     auto override_runtime_arguments_callback =
-        [topology_config, from_remote_sems, to_remote_sem, kernel_ids, worker_cores](
+        [topology_config,
+         reader_rt_args_overrider_map,
+         writer_rt_args_overrider_map,
+         local_input_tensor_idx,
+         local_final_output_tensor_idx,
+         input_tensor_from_remote_forward_direction_idx,
+         input_tensor_from_remote_backward_direction_idx,
+         partial_output_tensor_forward_direction_idx,
+         partial_output_tensor_backward_direction_idx,
+         from_remote_sems,
+         to_remote_sem,
+         kernel_ids,
+         worker_cores](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<Tensor>& output_tensors) {
-            const auto& input = input_tensors.at(0);
-            const auto& output = output_tensors.at(0);
+            // Partial reducer reader0: input_tensor
+            // Partial reducer reader1: input_tensor_from_remote
+            // Partial reducer writer0: remote_output[line_direction]
+            // Partial reducer writer1: local_output_partial[line_direction]
 
-            auto& input_tensor = input_tensors.at(0);
+            // final reducer reader0 (not end of line): local_output_partial[LineDirection::FORWARD]
+            // final reducer reader1 (not end of line): local_output_partial[LineDirection::BACKWARD]
+            // final reducer writer0 (not end of line): local_final_output_tensor
+            // final reducer writer1 (not end of line): None
 
-            auto& final_output_tensor = output_tensors.at(0);
-            auto& input_tensor_from_remote_forward_direction = output_tensors.at(1);
-            auto& input_tensor_from_remote_backward_direction = output_tensors.at(2);
+            // final reducer reader0 (end of line): None
+            // final reducer reader1 (end of line): None
+            // final reducer writer0 (end of line): None
+            // final reducer writer1 (end of line): None
+
+            // partial reducer reader0 (end of line): input_tensor
+            // partial reducer reader1 (end of line - start): None
+            // partial reducer reader1 (end of line - end): input_tensor_from_remote
+            // partial reducer writer0 (end of line - start): output_tensor_pt
+            // partial reducer writer1 (end of line - end): local_final_output_tensor
+
+            log_info(tt::LogOp, "Overriding runtime args for device {}", topology_config.line_index());
+            std::array<size_t, 2> input_tensor_from_remote_idx = {input_tensor_from_remote_forward_direction_idx, input_tensor_from_remote_backward_direction_idx};
+            std::array<size_t, 2> partial_output_tensor_idx = {partial_output_tensor_forward_direction_idx, partial_output_tensor_backward_direction_idx};
+
+            auto& input_tensor = input_tensors.at(local_input_tensor_idx);
+            auto& local_final_output_tensor = output_tensors.at(local_final_output_tensor_idx - input_tensors.size());
+            auto& input_tensor_from_remote_forward_direction = output_tensors.at(input_tensor_from_remote_forward_direction_idx - input_tensors.size());
+            auto& input_tensor_from_remote_backward_direction = output_tensors.at(input_tensor_from_remote_backward_direction_idx - input_tensors.size());
             std::array<const Tensor*, 2> input_tensor_from_remote = {
                 &input_tensor_from_remote_forward_direction, &input_tensor_from_remote_backward_direction};
-            auto& partial_output_tensor_forward_direction = output_tensors.at(3);
-            auto& partial_output_tensor_backward_direction = output_tensors.at(4);
+            auto& partial_output_tensor_forward_direction = output_tensors.at(partial_output_tensor_forward_direction_idx - input_tensors.size());
+            auto& partial_output_tensor_backward_direction = output_tensors.at(partial_output_tensor_backward_direction_idx - input_tensors.size());
             std::array<const Tensor*, 2> partial_output_tensor = {
                 &partial_output_tensor_forward_direction, &partial_output_tensor_backward_direction};
 
@@ -2111,28 +2328,32 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
             auto& worker_writer_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.writer);
             if (topology_config.is_at_end_of_line()) {
 
-                for (auto const& core : worker_cores.final_reducers_vec) {
-                    auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                    worker_reader_runtime_args.at(0) = partial_output_tensor[LineDirection::FORWARD]->buffer()->address();;
-                    worker_reader_runtime_args.at(1) = partial_output_tensor[LineDirection::BACKWARD]->buffer()->address();;
-
-                    auto& worker_writer_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                    worker_writer_runtime_args.at(0) = final_output_tensor.buffer()->address();;
-                }
                 for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
                     bool is_start_of_line = topology_config.is_first_device_in_line(direction);
                     for (auto const& core : worker_cores.partial_reducers_vec[direction]) {
                         auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                        worker_reader_runtime_args.at(0) = input_tensor.buffer()->address();
-                        if (is_start_of_line) {
-                            worker_reader_runtime_args.at(1) = input_tensor_from_remote.at(direction)->buffer()->address();
+                        reader_rt_args_overrider_map.at(core).override_runtime_args(
+                            local_input_tensor_idx,
+                            input_tensor.buffer()->address(),
+                            worker_reader_runtime_args);
+                        if (!is_start_of_line) {
+                            reader_rt_args_overrider_map.at(core).override_runtime_args(
+                                input_tensor_from_remote_idx[direction],
+                                input_tensor_from_remote.at(direction)->buffer()->address(),
+                                worker_reader_runtime_args);
                         }
 
-                        auto& worker_writer_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
+                        auto& worker_writer_runtime_args = worker_writer_runtime_args_by_core[core.x][core.y];
                         if (is_start_of_line) {
-                            worker_writer_runtime_args.at(0) = input_tensor_from_remote[direction]->buffer()->address();;
+                            writer_rt_args_overrider_map.at(core).override_runtime_args(
+                                input_tensor_from_remote_idx[direction],
+                                input_tensor_from_remote.at(direction)->buffer()->address(),
+                                worker_writer_runtime_args);
                         } else {
-                            worker_writer_runtime_args.at(0) = final_output_tensor.buffer()->address();;
+                            writer_rt_args_overrider_map.at(core).override_runtime_args(
+                                local_final_output_tensor_idx,
+                                local_final_output_tensor.buffer()->address(),
+                                worker_writer_runtime_args);
                         }
                     }
                 }
@@ -2140,39 +2361,58 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
                 for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
                     for (auto const &core : worker_cores.partial_reducers_vec[direction]) {
                         auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                        auto& worker_writer_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                        worker_reader_runtime_args.at(0) = input_tensor.buffer()->address();
-                        worker_reader_runtime_args.at(1) = input_tensor_from_remote[direction]->buffer()->address();
+                        auto& worker_writer_runtime_args = worker_writer_runtime_args_by_core[core.x][core.y];
+                        reader_rt_args_overrider_map.at(core).override_runtime_args(
+                            local_input_tensor_idx,
+                            input_tensor.buffer()->address(),
+                            worker_reader_runtime_args);
+                        reader_rt_args_overrider_map.at(core).override_runtime_args(
+                            input_tensor_from_remote_idx[direction],
+                            input_tensor_from_remote.at(direction)->buffer()->address(),
+                            worker_reader_runtime_args);
 
                         // input_tensor_from_remote and remote output partial result tensor share the same addresses
                         // because the input from remote of one chip is the partial result remote output of another
-                        worker_writer_runtime_args.at(0) = input_tensor_from_remote[direction]->buffer()->address();
-                        worker_writer_runtime_args.at(1) = partial_output_tensor[direction]->buffer()->address();
+                        writer_rt_args_overrider_map.at(core).override_runtime_args(
+                            input_tensor_from_remote_idx[direction],
+                            input_tensor_from_remote.at(direction)->buffer()->address(),
+                            worker_writer_runtime_args);
+                        writer_rt_args_overrider_map.at(core).override_runtime_args(
+                            partial_output_tensor_idx[direction],
+                            partial_output_tensor.at(direction)->buffer()->address(),
+                            worker_writer_runtime_args);
                     }
                 }
 
                 for (auto const& core : worker_cores.final_reducers_vec) {
                     auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
 
-                    worker_reader_runtime_args.at(0) = partial_output_tensor[LineDirection::FORWARD]->buffer()->address();
-                    worker_reader_runtime_args.at(1) = partial_output_tensor[LineDirection::BACKWARD]->buffer()->address();
+                    reader_rt_args_overrider_map.at(core).override_runtime_args(
+                        partial_output_tensor_idx[LineDirection::FORWARD],
+                        partial_output_tensor[LineDirection::FORWARD]->buffer()->address(),
+                        worker_reader_runtime_args);
+                    reader_rt_args_overrider_map.at(core).override_runtime_args(
+                        partial_output_tensor_idx[LineDirection::BACKWARD],
+                        partial_output_tensor[LineDirection::BACKWARD]->buffer()->address(),
+                        worker_reader_runtime_args);
 
-                    auto& worker_writer_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                    worker_writer_runtime_args.at(0) = final_output_tensor.buffer()->address();
+                    auto& worker_writer_runtime_args = worker_writer_runtime_args_by_core[core.x][core.y];
+                    writer_rt_args_overrider_map.at(core).override_runtime_args(
+                        local_final_output_tensor_idx,
+                        local_final_output_tensor.buffer()->address(),
+                        worker_writer_runtime_args);
                 }
             }
-
-
         };
 
-    log_trace(tt::LogOp, "Done program factory");
+    log_trace(tt::LogOp, "\n\nDone program factory\n\n");
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
 operation::ProgramWithCallbacks build_reduce_scatter_async_program(
     Tensor const& input_tensor,
-    Tensor& local_output_tensor,
+    Tensor& local_final_output_tensor,
     Tensor& input_tensor_from_remote_forward_direction,
     Tensor& input_tensor_from_remote_backward_direction,
     Tensor& local_partial_output_tensor_from_forward_direction,
@@ -2217,7 +2457,7 @@ operation::ProgramWithCallbacks build_reduce_scatter_async_program(
         forward_device,
         backward_device,
         input_tensor,
-        local_output_tensor,
+        local_final_output_tensor,
         input_tensor_from_remote_forward_direction,
         input_tensor_from_remote_backward_direction,
         local_partial_output_tensor_from_forward_direction,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16530)

### Problem description
Multi-iteration support wasn't enabled correctly for reduce scatter.

### What's changed
Fix it. Also do some renaming for further clarity. Additionally some changes were included to add code-paths to enable lowering of slice to noc read/write burst commands (but that code-path is disabled due to some bug). 

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/12675667373
- [x] T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12675683771
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] Device performance regression CI testing passes (if applicable): N/A
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes: N/A
- [x] New/Existing tests provide coverage for changes
