### PR TITLE
Quick fix replacing Device* with IDevice in graph tracker

### DIFF
--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -48,7 +48,7 @@ void GraphTracker::track_allocate_cb(
     uint64_t addr,
     uint64_t size,
     bool is_globally_allocated,
-    const Device* device) {
+    const IDevice* device) {
     if (processors.empty()) {
         return;
     }
@@ -57,7 +57,7 @@ void GraphTracker::track_allocate_cb(
     }
 }
 
-void GraphTracker::track_deallocate_cb(const Device* device) {
+void GraphTracker::track_deallocate_cb(const IDevice* device) {
     if (processors.empty()) {
         return;
     }
@@ -66,7 +66,7 @@ void GraphTracker::track_deallocate_cb(const Device* device) {
     }
 }
 
-void GraphTracker::track_program(Program* program, const Device* device) {
+void GraphTracker::track_program(Program* program, const IDevice* device) {
     TT_ASSERT(program);
     TT_ASSERT(device);
     if (processors.empty()) {

--- a/tt_metal/graph/graph_tracking.hpp
+++ b/tt_metal/graph/graph_tracking.hpp
@@ -37,11 +37,11 @@ public:
         uint64_t addr,
         uint64_t size,
         bool is_globally_allocated,
-        const Device* device) {};
+        const IDevice* device) {};
 
-    virtual void track_deallocate_cb(const Device* device) {};
+    virtual void track_deallocate_cb(const IDevice* device) {};
 
-    virtual void track_program(tt::tt_metal::Program* program, const Device* device) {};
+    virtual void track_program(tt::tt_metal::Program* program, const IDevice* device) {};
 
     virtual void track_function_start(std::string_view function_name, std::span<std::any> input_parameters) {};
 
@@ -90,11 +90,11 @@ public:
         uint64_t addr,
         uint64_t size,
         bool is_globally_allocated,
-        const Device* device);
+        const IDevice* device);
 
-    void track_deallocate_cb(const Device* device);
+    void track_deallocate_cb(const IDevice* device);
 
-    void track_program(Program* program, const Device* device);
+    void track_program(Program* program, const IDevice* device);
 
     template <class... Args>
     void track_function_start(std::string_view function_name, Args&&... args) {

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -144,7 +144,7 @@ void GraphProcessor::track_deallocate(tt::tt_metal::Buffer* buffer) {
 
 }
 
-void GraphProcessor::track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated, const tt::tt_metal::Device* device) {
+void GraphProcessor::track_allocate_cb(const CoreRangeSet &core_range_set, uint64_t addr, uint64_t size, bool is_globally_allocated, const tt::tt_metal::IDevice* device) {
     TT_ASSERT(device);
     const std::lock_guard<std::mutex> lock(mutex);
     std::unordered_map<std::string, std::string> params = {
@@ -167,7 +167,7 @@ void GraphProcessor::track_allocate_cb(const CoreRangeSet &core_range_set, uint6
 
 }
 
-void GraphProcessor::track_deallocate_cb(const tt::tt_metal::Device* device) {
+void GraphProcessor::track_deallocate_cb(const tt::tt_metal::IDevice* device) {
     TT_ASSERT(device);
     const std::lock_guard<std::mutex> lock(mutex);
     auto counter = graph.size();
@@ -184,7 +184,7 @@ void GraphProcessor::track_deallocate_cb(const tt::tt_metal::Device* device) {
     }
 }
 
-void GraphProcessor::track_program(tt::tt_metal::Program* program, const tt::tt_metal::Device* device) {
+void GraphProcessor::track_program(tt::tt_metal::Program* program, const tt::tt_metal::IDevice* device) {
     TT_ASSERT(device);
 
     // All previous CBs are deallocated before a new program run

--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -44,11 +44,11 @@ namespace ttnn::graph {
 
         void track_deallocate(tt::tt_metal::Buffer* buffer) override;
 
-        void track_allocate_cb(const CoreRangeSet &core_range, uint64_t addr, uint64_t size, bool is_globally_allocated, const tt::tt_metal::Device* device) override;
+        void track_allocate_cb(const CoreRangeSet &core_range, uint64_t addr, uint64_t size, bool is_globally_allocated, const tt::tt_metal::IDevice* device) override;
 
-        void track_deallocate_cb(const tt::tt_metal::Device* device) override;
+        void track_deallocate_cb(const tt::tt_metal::IDevice* device) override;
 
-        void track_program(tt::tt_metal::Program* program, const tt::tt_metal::Device* device) override;
+        void track_program(tt::tt_metal::Program* program, const tt::tt_metal::IDevice* device) override;
 
         void track_function_start(std::string_view function_name, std::span<std::any> args) override;
 


### PR DESCRIPTION
### Ticket
None

### Problem description
IDevice extraction was merged and in parallel to that we merged the update to the Graph Tracker which used some `Device*`

### What's changed
Replaced Device* with IDevice* in graph tracker 

### Checklist
- [x] Builds locally