### PR TITLE
#0: Track local_cb_size to ensure that remote cb config is correctly sent by FD

### DIFF
--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -307,6 +307,7 @@ void finalize_program_offsets(T& workload, IDevice* device) {
         program_config.sem_size = sem_size;
         program_config.cb_offset = cb_offset;
         program_config.cb_size = cb_size;
+        program_config.local_cb_size = local_cb_size;
         program_config.kernel_text_offset = kernel_text_offset;
         program_config.kernel_text_size = kernel_text_size;
         program.get_program_config_sizes()[index] = offset;


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
`MeshWorkload` refactor broke global CB usage. The issue was that the Local CB size computed in `finalize` was not propagated to the program config -> global CB offset when assembling CB dispatch commands was not correctly computed.

### What's changed
Update `local_cb_size` in `program_config`.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
