### PR TITLE
#13901: MaxPool Wide Reductions with Non-8-Tile Multiples

### DIFF
--- a/tests/sweep_framework/sweeps/max_pool2d/short/max_pool2d_short_sweep.py
+++ b/tests/sweep_framework/sweeps/max_pool2d/short/max_pool2d_short_sweep.py
@@ -34,7 +34,7 @@ parameters = {
             [1, 256, 75, 75, 2, 2, 2, 2, 0, 0, 1, 1, True],
             [1, 32, 256, 256, 2, 2, 2, 2, 0, 0, 1, 1, False],
             [1, 320, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],
-            [1, 4, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],
+            [1, 4, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],  # requires padding along C
             [1, 480, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],
             [1, 480, 28, 28, 3, 3, 2, 2, 0, 0, 1, 1, True],
             [1, 512, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, False],
@@ -42,7 +42,7 @@ parameters = {
             [1, 512, 19, 19, 3, 3, 1, 1, 1, 1, 1, 1, False],
             [1, 512, 28, 28, 2, 2, 2, 2, 0, 0, 1, 1, False],
             [1, 512, 38, 38, 2, 2, 2, 2, 0, 0, 1, 1, False],
-            [1, 528, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],
+            [1, 528, 14, 14, 3, 3, 1, 1, 1, 1, 1, 1, True],  # required padding along C
             [1, 64, 112, 112, 3, 3, 2, 2, 0, 0, 1, 1, True],
             [1, 64, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],
             [1, 64, 128, 128, 2, 2, 2, 2, 0, 0, 1, 1, False],
@@ -103,4 +103,46 @@ def run(
         device,
         sharding,
         ceil_mode,
+    )
+
+
+import pytest
+
+
+@pytest.mark.parametrize("input_spec", parameters["max_pool2d_short_sweep_suite"]["input_specs"])
+@pytest.mark.parametrize("dtype", parameters["max_pool2d_short_sweep_suite"]["dtype"])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_max_pool2d_localrun(device, dtype, input_spec):
+    (
+        batch_size,
+        input_channels,
+        input_height,
+        input_width,
+        kernel_height,
+        kernel_width,
+        stride_h,
+        strid_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ceil_mode,
+    ) = input_spec
+    run_max_pool2d(
+        batch_size,
+        input_channels,
+        input_height,
+        input_width,
+        kernel_height,
+        kernel_width,
+        stride_h,
+        strid_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        dtype,
+        device,
+        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode=ceil_mode,
     )

--- a/tests/ttnn/unit_tests/operations/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/test_maxpool2d.py
@@ -71,8 +71,18 @@ def run_max_pool(
             pytest.skip("This case runs out of memory on Grayskull")
         if kernel_h > 3 and kernel_w > 3 and act_shape == [16, 64, 112, 112] and is_grayskull():
             pytest.skip("This case runs out of memory on Grayskull")
-        if kernel_size == (13, 13) and act_shape == [128, 32, 132, 20] and is_grayskull():
+        if (
+            stride == (2, 2)
+            and kernel_size == (13, 13)
+            and act_shape == [1, 800, 32, 32]
+            and not is_x2_harvested(device)
+            and not is_grayskull()
+        ):
+            pytest.skip("This case runs out of memory on Wormhole b0")
+        if kernel_size == (13, 13) and (act_shape == [128, 32, 132, 20] or in_c > 512) and is_grayskull():
             pytest.skip("This case runs out of memory on Grayskull")
+        if kernel_size == (13, 13) and in_c > 768 and is_x2_harvested(device):
+            pytest.skip("This case runs out of memory on Wormhole X2")
         if kernel_h > 5 and kernel_w > 5 and act_shape == [16, 64, 112, 112] and is_x2_harvested(device):
             pytest.skip("This case runs out of memory on Wormhole X2")
         if stride == (1, 1) and act_shape == [128, 32, 132, 20] and is_x2_harvested(device):
@@ -107,7 +117,7 @@ def run_max_pool(
             pytest.skip("This case runs out of memory on Wormhole X2")
         if kernel_h > 5 and kernel_w > 5 and act_shape == [8, 4096, 10, 16] and is_x2_harvested(device):
             pytest.skip("This case runs out of memory on Wormhole X2")
-        if kernel_size == (13, 13) and act_shape == [1, 32768, 10, 10] and is_x2_harvested(device):
+        if kernel_size == (13, 13) and in_c >= 32768 and is_x2_harvested(device):
             pytest.skip("This case runs out of memory on Wormhole X2")
 
     if shard_scheme == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
@@ -275,6 +285,13 @@ def run_max_pool(
             [1, 512, 10, 10],
             [1, 96, 112, 112],
             [1, 192, 132, 20],
+            # wide non-8 multiple tests
+            [1, 800, 32, 32],
+            [1, 640, 32, 32],
+            [1, 576, 32, 32],
+            [1, 384, 32, 32],
+            # C=16 test
+            [1, 16, 10, 10],
         )
     ),
 )
@@ -350,6 +367,11 @@ def test_run_max_pool(act_shape, kernel_size, padding, stride, dilation, device,
             # wide yolo kernel
             [1, 32768, 10, 10],
             [1, 6144, 6, 6],
+            # wide non-8 multiple tests
+            [1, 800 * 64, 8, 8],
+            [1, 640 * 64, 8, 8],
+            [1, 576 * 64, 8, 8],
+            [1, 384 * 64, 8, 8],
         )
     ),
 )
@@ -455,6 +477,11 @@ def test_run_max_pool_width_shard(
             [1, 4096, 10, 10],
             [1, 768, 56, 56],
             [1, 1280, 8, 6],
+            # wide non-8 multiple tests
+            [1, 800 * 8, 16, 16],
+            [1, 640 * 8, 16, 16],
+            [1, 576 * 8, 16, 16],
+            [1, 384 * 8, 16, 16],
         )
     ),
 )

--- a/tt_metal/hw/inc/debug/dprint_pages.h
+++ b/tt_metal/hw/inc/debug/dprint_pages.h
@@ -45,17 +45,6 @@ inline void print_u8_pages(uint32_t l1_addr, uint32_t bytes_per_page, uint32_t n
     }
 }
 
-inline void print_cb_details(uint32_t cb_id) {
-    DPRINT << "cb_id " << cb_id << ": { "
-           << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
-           << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
-           << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
-           << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "
-           << "rd_ptr: " << get_local_cb_interface(cb_id).fifo_rd_ptr << ", "
-           << "wr_ptr: " << get_local_cb_interface(cb_id).fifo_wr_ptr << ", "
-           << "wr_tile_ptr: " << get_local_cb_interface(cb_id).fifo_wr_tile_ptr << " }" << ENDL();
-}
-
 }  // namespace tt::data_movement::common
 
 #endif
@@ -66,43 +55,41 @@ namespace tt::compute::common {
 
 inline void print_tile_rows(uint32_t cb_id, uint32_t rows = 32, uint32_t tile_id = 0, bool untilize = false) {
     for (uint16_t r = 0; r < rows; ++r) {
-        UNPACK(
-            (DPRINT << (uint)r << " :: "
-                    << TileSlice(
-                           cb_id,
-                           tile_id,
-                           SliceRange{
-                               .h0 = (uint8_t)r,
-                               .h1 = (uint8_t)(r + 1),
-                               .hs = (uint8_t)1,
-                               .w0 = (uint8_t)0,
-                               .w1 = (uint8_t)32,
-                               .ws = (uint8_t)1},
-                           true,
-                           untilize)));
+        DPRINT << (uint)r << " :: "
+               << TileSlice(
+                      cb_id,
+                      tile_id,
+                      SliceRange{
+                          .h0 = (uint8_t)r,
+                          .h1 = (uint8_t)(r + 1),
+                          .hs = (uint8_t)1,
+                          .w0 = (uint8_t)0,
+                          .w1 = (uint8_t)32,
+                          .ws = (uint8_t)1},
+                      true,
+                      untilize);
     }
 }
 
 inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
-    UNPACK((DPRINT << "======" << ENDL()));
+    DPRINT << "======" << ENDL();
     for (uint16_t r = 0; r < 32; ++r) {
-        UNPACK(
-            (DPRINT << (uint)r << " : "
-                    << TileSlice(
-                           cb_id,
-                           tile_id,
-                           SliceRange{
-                               .h0 = (uint8_t)r,
-                               .h1 = (uint8_t)(r + 1),
-                               .hs = (uint8_t)1,
-                               .w0 = (uint8_t)0,
-                               .w1 = (uint8_t)32,
-                               .ws = (uint8_t)1},
-                           true,
-                           untilize)
-                    << ENDL()));
+        DPRINT << (uint)r << " : "
+               << TileSlice(
+                      cb_id,
+                      tile_id,
+                      SliceRange{
+                          .h0 = (uint8_t)r,
+                          .h1 = (uint8_t)(r + 1),
+                          .hs = (uint8_t)1,
+                          .w0 = (uint8_t)0,
+                          .w1 = (uint8_t)32,
+                          .ws = (uint8_t)1},
+                      true,
+                      untilize)
+               << ENDL();
     }
-    UNPACK((DPRINT << "++++++" << ENDL()));
+    DPRINT << "++++++" << ENDL();
 }
 
 }  // namespace tt::compute::common

--- a/tt_metal/hw/inc/debug/dprint_pages.h
+++ b/tt_metal/hw/inc/debug/dprint_pages.h
@@ -10,6 +10,7 @@
     !defined(FORCE_DPRINT_OFF)
 
 namespace tt::data_movement::common {
+
 inline void print_bf16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t npages, uint32_t start = 0) {
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * elts_per_page;
     for (uint32_t page = 0; page < npages; ++page) {
@@ -44,6 +45,66 @@ inline void print_u8_pages(uint32_t l1_addr, uint32_t bytes_per_page, uint32_t n
     }
 }
 
+inline void print_cb_details(uint32_t cb_id) {
+    DPRINT << "cb_id " << cb_id << ": { "
+           << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
+           << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
+           << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
+           << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "
+           << "rd_ptr: " << get_local_cb_interface(cb_id).fifo_rd_ptr << ", "
+           << "wr_ptr: " << get_local_cb_interface(cb_id).fifo_wr_ptr << ", "
+           << "wr_tile_ptr: " << get_local_cb_interface(cb_id).fifo_wr_tile_ptr << " }" << ENDL();
+}
+
 }  // namespace tt::data_movement::common
+
+#endif
+
+#if defined(COMPILE_FOR_TRISC) && defined(DEBUG_PRINT_ENABLED) && !defined(FORCE_DPRINT_OFF)
+
+namespace tt::compute::common {
+
+inline void print_tile_rows(uint32_t cb_id, uint32_t rows = 32, uint32_t tile_id = 0, bool untilize = false) {
+    for (uint16_t r = 0; r < rows; ++r) {
+        UNPACK(
+            (DPRINT << (uint)r << " :: "
+                    << TileSlice(
+                           cb_id,
+                           tile_id,
+                           SliceRange{
+                               .h0 = (uint8_t)r,
+                               .h1 = (uint8_t)(r + 1),
+                               .hs = (uint8_t)1,
+                               .w0 = (uint8_t)0,
+                               .w1 = (uint8_t)32,
+                               .ws = (uint8_t)1},
+                           true,
+                           untilize)));
+    }
+}
+
+inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
+    UNPACK((DPRINT << "======" << ENDL()));
+    for (uint16_t r = 0; r < 32; ++r) {
+        UNPACK(
+            (DPRINT << (uint)r << " : "
+                    << TileSlice(
+                           cb_id,
+                           tile_id,
+                           SliceRange{
+                               .h0 = (uint8_t)r,
+                               .h1 = (uint8_t)(r + 1),
+                               .hs = (uint8_t)1,
+                               .w0 = (uint8_t)0,
+                               .w1 = (uint8_t)32,
+                               .ws = (uint8_t)1},
+                           true,
+                           untilize)
+                    << ENDL()));
+    }
+    UNPACK((DPRINT << "++++++" << ENDL()));
+}
+
+}  // namespace tt::compute::common
 
 #endif

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
@@ -12,70 +12,37 @@
 
 #if DEBUG_PRINT == 1
 #include "debug/dprint.h"
-
-inline void print_tile_rows(uint32_t cb_id, uint32_t rows = 32, uint32_t tile_id = 0, bool untilize = false) {
-    // UNPACK(( DPRINT << "======" << ENDL() ));
-    for (uint16_t r = 0; r < rows; ++r) {
-        SliceRange sr = SliceRange{.h0 = r, .h1 = (uint16_t)(r + 1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        UNPACK((DPRINT << (uint)r << " :: " << TileSlice(cb_id, tile_id, sr, true, untilize) << ENDL()));
-    }
-    // UNPACK(( DPRINT << "++++++" << ENDL() ));
-}
-
-inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
-    UNPACK((DPRINT << "======" << ENDL()));
-    for (uint16_t r = 0; r < 32; ++r) {
-        SliceRange sr = SliceRange{.h0 = r, .h1 = (uint16_t)(r + 1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        UNPACK((DPRINT << (uint)r << TileSlice(cb_id, tile_id, sr, true, untilize) << ENDL()));
-    }
-    UNPACK((DPRINT << "++++++" << ENDL()));
-}
-
-inline void print_cb_details(uint32_t cb_id) {
-    DPRINT << "cb_id " << cb_id << ": { "
-           << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
-           << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
-           << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
-           << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "
-           << "rd_ptr: " << get_local_cb_interface(cb_id).fifo_rd_ptr << ", "
-           << "wr_ptr: " << get_local_cb_interface(cb_id).fifo_wr_ptr << ", "
-           << "wr_tile_ptr: " << get_local_cb_interface(cb_id).fifo_wr_tile_ptr << " }" << ENDL();
-}
+#include "debug/dprint_pages.h"
+#include "debug/dprint_tensix.h"
 #endif
 
-template <
-    uint32_t num_output_tiles,
-    bool is_partial_tile,
-    uint32_t split_reader,
-    uint32_t unpA_face_r_dim,
-    uint32_t in_nblocks_c>
+template <uint32_t num_output_tiles, bool is_partial_tile, uint32_t split_reader, uint32_t unpA_face_r_dim>
 inline void reduce_h_fused(
     const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t in_stick_index, const uint32_t out_cb_id) {
     constexpr uint32_t num_faces_in_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
-    for (uint32_t b_i = 0; b_i < in_nblocks_c; ++b_i) {
-        cb_reserve_back(out_cb_id, 1);
-        const uint32_t curr_in_cb_id = split_reader ? (in_cb_id + (in_stick_index & 0x1)) : in_cb_id;
-        cb_wait_front(curr_in_cb_id, 1);
-        tile_regs_acquire();
-        unpack_tilizeA_B_block(
-            curr_in_cb_id,
-            in_scalar_cb_id,
-            num_output_tiles,
-            0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-            num_faces_in_tile /* unpack 1 or 2 faces ) */,
-            unpA_face_r_dim);
-        for (uint32_t c_i = 0; c_i < num_output_tiles; ++c_i) {
-            reduce_tile_math(c_i, num_faces_in_tile /* reduce 1 or 2 faces */);
-        }
-        cb_pop_front(curr_in_cb_id, 1);
-        tile_regs_wait();
-        tile_regs_commit();
-        pack_untilize_dst<num_output_tiles>(
-            out_cb_id, 1 /*out_subblock_h*/, 0, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
-        tile_regs_release();
-        cb_push_back(out_cb_id, 1);
+
+    cb_reserve_back(out_cb_id, num_output_tiles);
+    const uint32_t curr_in_cb_id = split_reader ? (in_cb_id + (in_stick_index & 0x1)) : in_cb_id;
+    cb_wait_front(curr_in_cb_id, 1);
+    tile_regs_acquire();
+    unpack_tilizeA_B_block(
+        curr_in_cb_id,
+        in_scalar_cb_id,
+        num_output_tiles,
+        0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
+        num_faces_in_tile /* unpack 1 or 2 faces ) */,
+        unpA_face_r_dim);
+    for (uint32_t c_i = 0; c_i < num_output_tiles; ++c_i) {
+        reduce_tile_math(c_i, num_faces_in_tile /* reduce 1 or 2 faces */);
     }
+    cb_pop_front(curr_in_cb_id, 1);
+    tile_regs_wait();
+    tile_regs_commit();
+    pack_untilize_dst<num_output_tiles>(
+        out_cb_id, 1 /*out_subblock_h*/, 0, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
+    tile_regs_release();
+    cb_push_back(out_cb_id, num_output_tiles);
 }
 
 namespace NAMESPACE {
@@ -94,7 +61,7 @@ void MAIN {
     constexpr uint32_t in_c = get_compile_time_arg_val(14);
     constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(15);
 
-    constexpr uint32_t in_cb_id = tt::CBIndex::c_0;  // and tt::CBIndex::c_1 for split reader
+    constexpr uint32_t in_cb_id = tt::CBIndex::c_0;  // and CBIndex::c_1 for split reader
     constexpr uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
     constexpr uint32_t in_tiled_cb_id = tt::CBIndex::c_24;
     constexpr uint32_t out_cb_id = tt::CBIndex::c_16;
@@ -104,16 +71,31 @@ void MAIN {
     constexpr uint32_t num_faces_in_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
 
-    constexpr uint32_t num_output_tiles = in_ntiles_c / in_nblocks_c;
-    tilizeA_B_reduce_init<true>(
-        in_cb_id, in_scalar_cb_id, num_output_tiles, out_cb_id, num_faces_in_tile, window_size_hw);
-    // Omitted pasing in_ntiles_c as template argument to pack_untilize_dst_init_short
-    // Workaround for tt-metal#15824
-    pack_untilize_dst_init_short(out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
+    tilizeA_B_reduce_init(in_cb_id, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
+    pack_untilize_dst_init_short(
+        out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
 
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core; ++i) {
-        reduce_h_fused<num_output_tiles, is_partial_tile, split_reader, window_size_hw, in_nblocks_c>(
+        // perform the reduction over the first N - 1 whole chunks
+        for (uint32_t b_i = 0; b_i < in_nblocks_c - 1; ++b_i) {
+            pack_untilize_uninit(out_cb_id);
+            pack_untilize_dst_init_short<max_tiles_per_iter>(
+                out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
+            reduce_h_fused<max_tiles_per_iter, is_partial_tile, split_reader, window_size_hw>(
+                in_cb_id, in_scalar_cb_id, i, out_cb_id);
+        }
+        // perform the reduction over the either whole or partial chunk N
+        pack_untilize_uninit(out_cb_id);
+        pack_untilize_dst_init_short<partial_iter_output_tiles>(
+            out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
+        reduce_h_fused<partial_iter_output_tiles, is_partial_tile, split_reader, window_size_hw>(
             in_cb_id, in_scalar_cb_id, i, out_cb_id);
     }
     cb_pop_front(in_scalar_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core.cpp
@@ -78,8 +78,6 @@ void MAIN {
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
     tilizeA_B_reduce_init(in_cb_id, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
-    pack_untilize_dst_init_short(
-        out_cb_id, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
 
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core; ++i) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core_large_kernel.cpp
@@ -123,7 +123,6 @@ void MAIN {
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
     tilizeA_B_reduce_init<true>(
         in_cb_id, in_scalar_cb_id, max_tiles_per_iter, interm_cb_id, num_faces_in_input_tile, max_rows_for_reduction);
-    pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_output_tile);
 
     uint32_t interm_reduction_chunks = window_size_hw / max_rows_for_reduction;
     cb_wait_front(in_scalar_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/max_pool_multi_core_large_kernel.cpp
@@ -4,64 +4,37 @@
 
 #include <cstdint>
 
-// #include "compute_kernel_api.h"
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tilize.h"
-// #include "tools/profiler/kernel_profiler.hpp"
 
 #define DEBUG_PRINT 0
 
 #if DEBUG_PRINT == 1
 #include "debug/dprint.h"
-// #include "debug_macros.h"
-
-// SliceRange srt = SliceRange{.h0 = 0, .h1 = 32, .hs = 8, .w0 = 0, .w1 = 32, .ws = 4};
-// SliceRange srr = SliceRange{.h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1};
-// SliceRange srr1 = SliceRange{.h0 = 1, .h1 = 2, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1};
-// SliceRange src = SliceRange{.h0 = 0, .h1 = 32, .hs = 1, .w0 = 0, .w1 = 1, .ws = 1};
-
-inline void print_tile_rows(uint32_t cb_id, uint32_t rows = 32, uint32_t tile_id = 0, bool untilize = false) {
-    // UNPACK(( DPRINT << "======" << ENDL() ));
-    for (uint16_t r = 0; r < rows; ++r) {
-        SliceRange sr = SliceRange{.h0 = r, .h1 = (uint16_t)(r + 1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        // UNPACK(( DPRINT << (uint)r << " :: " << TileSlice(cb_id, tile_id, sr, true, untilize) << ENDL() ));
-        UNPACK((DPRINT << (uint)r << " :: " << TileSlice(cb_id, tile_id, sr, true, untilize)));
-    }
-    // UNPACK(( DPRINT << "++++++" << ENDL() ));
-}
-
-inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
-    UNPACK((DPRINT << "======" << ENDL()));
-    for (uint16_t r = 0; r < 32; ++r) {
-        SliceRange sr = SliceRange{.h0 = r, .h1 = (uint16_t)(r + 1), .hs = 1, .w0 = 0, .w1 = 32, .ws = 1};
-        UNPACK((DPRINT << (uint)r << " : " << TileSlice(cb_id, tile_id, sr, true, untilize) << ENDL()));
-    }
-    UNPACK((DPRINT << "++++++" << ENDL()));
-}
-
-// inline void print_cb_details(uint32_t cb_id) {
-//     DPRINT << "cb_id " << cb_id << ": { "
-//             << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
-//             << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
-//             << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
-//             << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "
-//             << "rd_ptr: " << get_local_cb_interface(cb_id).fifo_rd_ptr << ", "
-//             << "wr_ptr: " << get_local_cb_interface(cb_id).fifo_wr_ptr << ", "
-//             << "wr_tile_ptr: " << get_local_cb_interface(cb_id).fifo_wr_tile_ptr << " }" << ENDL();
-// }
+#include "debug/dprint_pages.h"
+#include "debug/dprint_tensix.h"
 #endif
 
-template <uint32_t num_output_tiles, bool is_partial_tile, uint32_t split_reader>
-inline void reduce_h_fused(
+template <
+    uint32_t num_output_tiles,
+    bool is_partial_tile,
+    uint32_t max_rows_for_reduction,
+    uint32_t split_reader,
+    uint32_t unpA_face_r_dim>
+inline void reduce_h_fused_interm(
     const uint32_t in_cb_id,
     const uint32_t in_scalar_cb_id,
     const uint32_t in_stick_index,
-    const uint32_t unpA_face_r_dim) {
-    uint32_t num_faces_in_input_tile = is_partial_tile ? 1 : unpA_face_r_dim < 32 ? 2 : 4;
+    const uint32_t interm_index,
+    const uint32_t interm_cb_id) {
+    constexpr uint32_t num_faces_in_input_tile = is_partial_tile ? 1 : max_rows_for_reduction < 32 ? 2 : 4;
+    constexpr uint32_t num_faces_in_output_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
+
     const uint32_t curr_in_cb_id = split_reader ? (in_cb_id + (in_stick_index & 0x1)) : in_cb_id;
     cb_wait_front(curr_in_cb_id, 1);
+    tile_regs_acquire();
     unpack_tilizeA_B_block(
         curr_in_cb_id,
         in_scalar_cb_id,
@@ -73,6 +46,43 @@ inline void reduce_h_fused(
         reduce_tile_math(c_i, num_faces_in_input_tile /* reduce 1 or 2 faces */);
     }
     cb_pop_front(curr_in_cb_id, 1);
+    tile_regs_wait();
+    tile_regs_commit();
+    pack_untilize_dst<num_output_tiles>(
+        interm_cb_id,
+        1 /*out_subblock_h*/,
+        interm_index,
+        num_out_rows,
+        num_faces_in_output_tile); /* pack 1 row (1x16 or 1x32) */
+    tile_regs_release();
+}
+
+template <uint32_t num_output_tiles, bool is_partial_tile, uint32_t max_rows_for_reduction>
+inline void reduce_h_fused(const uint32_t interm_cb_id, const uint32_t in_scalar_cb_id, const uint32_t out_cb_id) {
+    constexpr uint32_t num_faces_in_input_tile = is_partial_tile ? 1 : max_rows_for_reduction < 32 ? 2 : 4;
+    constexpr uint32_t num_faces_in_output_tile = is_partial_tile ? 1 : 2;
+    constexpr uint32_t num_out_rows = 1;
+
+    cb_reserve_back(out_cb_id, num_output_tiles);
+    cb_wait_front(interm_cb_id, 1);
+    tile_regs_acquire();
+    unpack_tilizeA_B_block(
+        interm_cb_id,
+        in_scalar_cb_id,
+        num_output_tiles,
+        0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
+        num_faces_in_input_tile /* unpack 1 or 2 faces ) */,
+        max_rows_for_reduction);
+    for (uint32_t c_i = 0; c_i < num_output_tiles; ++c_i) {
+        reduce_tile_math(c_i, num_faces_in_input_tile /* reduce 1 or 2 faces */);
+    }
+    cb_pop_front(interm_cb_id, 1);
+    tile_regs_wait();
+    tile_regs_commit();
+    pack_untilize_dst<num_output_tiles>(
+        out_cb_id, 1 /*out_subblock_h*/, 0, num_out_rows, num_faces_in_output_tile); /* pack 1 row (1x16 or 1x32) */
+    tile_regs_release();
+    cb_push_back(out_cb_id, num_output_tiles);
 }
 
 namespace NAMESPACE {
@@ -97,7 +107,7 @@ void MAIN {
     constexpr uint32_t in_scalar_cb_id = tt::CBIndex::c_4;
     constexpr uint32_t in_tiled_cb_id = tt::CBIndex::c_24;
     constexpr uint32_t out_cb_id = tt::CBIndex::c_16;
-    constexpr uint32_t interm_reduction_cb_id = tt::CBIndex::c_25;
+    constexpr uint32_t interm_cb_id = tt::CBIndex::c_25;
 
     constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
 
@@ -107,74 +117,59 @@ void MAIN {
     constexpr uint32_t num_faces_in_output_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
 
-    constexpr uint32_t num_output_tiles = in_ntiles_c / in_nblocks_c;
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
     tilizeA_B_reduce_init<true>(
-        in_cb_id,
-        in_scalar_cb_id,
-        num_output_tiles,
-        interm_reduction_cb_id,
-        num_faces_in_input_tile,
-        max_rows_for_reduction);
+        in_cb_id, in_scalar_cb_id, max_tiles_per_iter, interm_cb_id, num_faces_in_input_tile, max_rows_for_reduction);
+    pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_output_tile);
 
     uint32_t interm_reduction_chunks = window_size_hw / max_rows_for_reduction;
     cb_wait_front(in_scalar_cb_id, 1);
-    cb_reserve_back(out_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; ++i) {
-        for (uint32_t b_i = 0; b_i < in_nblocks_c; b_i++) {
-            // NOTE: Assuming in_ntiles_hw < 8 for now.
-            // TODO: subblocking to support this.
-            uint32_t out_write_idx = i * in_nblocks_c + b_i;
-            pack_untilize_dst_init_short<num_output_tiles>(
-                interm_reduction_cb_id, num_out_rows, num_faces_in_output_tile);
-            cb_reserve_back(interm_reduction_cb_id, 1);
+        for (uint32_t b_i = 0; b_i < in_nblocks_c - 1; b_i++) {
+            // perform the intermediate reductions over the first N - 1 whole chunks
+            pack_untilize_uninit(interm_cb_id);
+            pack_untilize_dst_init_short<max_tiles_per_iter>(interm_cb_id, num_out_rows, num_faces_in_output_tile);
+            cb_reserve_back(interm_cb_id, 1);
             for (uint32_t h = 0; h <= interm_reduction_chunks; h++) {
-                tile_regs_acquire();
-
-                reduce_h_fused<num_output_tiles, is_partial_tile, split_reader>(
-                    in_cb_id, in_scalar_cb_id, i, max_rows_for_reduction);
-                tile_regs_wait();
-                tile_regs_commit();
-                pack_untilize_dst<num_output_tiles>(
-                    interm_reduction_cb_id,
-                    1 /*out_subblock_h*/,
-                    h,
-                    num_out_rows,
-                    num_faces_in_output_tile); /* pack 1 row (1x16 or 1x32) */
-                tile_regs_release();
+                reduce_h_fused_interm<
+                    max_tiles_per_iter,
+                    is_partial_tile,
+                    max_rows_for_reduction,
+                    split_reader,
+                    max_rows_for_reduction>(in_cb_id, in_scalar_cb_id, i, h, interm_cb_id);
             }
-            cb_push_back(interm_reduction_cb_id, 1);
-            pack_untilize_uninit(interm_reduction_cb_id);
-            cb_wait_front(interm_reduction_cb_id, 1);
+            cb_push_back(interm_cb_id, 1);
 
-            pack_untilize_dst_init_short<num_output_tiles>(out_cb_id, num_out_rows, num_faces_in_output_tile);
-
-            tile_regs_acquire();
-            unpack_tilizeA_B_block(
-                interm_reduction_cb_id,
-                in_scalar_cb_id,
-                num_output_tiles,
-                0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-                num_faces_in_input_tile /* unpack 1 or 2 faces ) */,
-                max_rows_for_reduction);
-            for (uint32_t c_i = 0; c_i < num_output_tiles; ++c_i) {
-                reduce_tile_math(c_i, num_faces_in_input_tile /* reduce 1 or 2 faces */);
-            }
-
-            tile_regs_wait();
-            tile_regs_commit();
-
-            pack_untilize_dst<num_output_tiles>(
-                out_cb_id,
-                1 /*out_subblock_h*/,
-                out_write_idx,
-                num_out_rows,
-                num_faces_in_output_tile); /* pack 1 row (1x16 or 1x32) */
-            tile_regs_release();
-            cb_pop_front(interm_reduction_cb_id, 1);
+            // perform the final reduction over the first N - 1 whole chunks
             pack_untilize_uninit(out_cb_id);
+            pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_output_tile);
+            reduce_h_fused<max_tiles_per_iter, is_partial_tile, max_rows_for_reduction>(
+                interm_cb_id, in_scalar_cb_id, out_cb_id);
         }
+
+        // perform the intermediate reduction over chunk N (across the whole chunk even if the last chunk is partial)
+        pack_untilize_uninit(interm_cb_id);
+        pack_untilize_dst_init_short<max_tiles_per_iter>(interm_cb_id, num_out_rows, num_faces_in_output_tile);
+        cb_reserve_back(interm_cb_id, 1);
+        for (uint32_t h = 0; h <= interm_reduction_chunks; h++) {
+            reduce_h_fused_interm<
+                max_tiles_per_iter,
+                is_partial_tile,
+                max_rows_for_reduction,
+                split_reader,
+                max_rows_for_reduction>(in_cb_id, in_scalar_cb_id, i, h, interm_cb_id);
+        }
+        cb_push_back(interm_cb_id, 1);
+
+        // perform the reduction over the either whole or partial chunk N
+        pack_untilize_uninit(out_cb_id);
+        pack_untilize_dst_init_short<partial_iter_output_tiles>(out_cb_id, num_out_rows, num_faces_in_output_tile);
+        reduce_h_fused<partial_iter_output_tiles, is_partial_tile, max_rows_for_reduction>(
+            interm_cb_id, in_scalar_cb_id, out_cb_id);
     }
-    cb_push_back(out_cb_id, 1);
     cb_pop_front(in_scalar_cb_id, 1);
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
@@ -92,13 +92,12 @@ void kernel_main() {
 
     uint32_t in_w_padded = in_w + 2 * pad_w + ceil_pad_w;
 
-    uint32_t read_bytes = in_nbytes_c;
-    if (in_nbytes_c > MAX_ELE_PER_REDUCTION) {
-        read_bytes = MAX_ELE_PER_REDUCTION;  // for now, pow of 2 channels are only supported.
-    }
     uint32_t counter = reader_id;
     uint32_t total_elems_to_reduce = window_h * window_w;
     uint32_t remaining_elems = total_elems_to_reduce % max_rows_for_reduction;
+    bool wide_reduction = in_nblocks_c > 1;
+    uint32_t read_bytes =
+        wide_reduction ? MAX_ELE_PER_REDUCTION : in_nbytes_c;  // in_cb is MAX_ELE_PER_REDUCTION for wide reductions
     while (counter < reader_nindices) {
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
             uint16_t top_left_local_index = reader_indices_ptr[counter];
@@ -106,10 +105,6 @@ void kernel_main() {
             cb_reserve_back(in_cb_id, 1);
             uint32_t out_l1_write_addr_base = get_write_ptr(in_cb_id);
             uint32_t out_l1_write_addr = out_l1_write_addr_base;
-            // fill interm buffer with minus_inf if we have only one chunk
-            if ((total_elems_to_reduce - processed_rows) < max_rows_for_reduction) {
-                fill_with_val(out_l1_write_addr, in_cb_sz, minus_inf);
-            }
             for (uint32_t h = 0; h < window_h; ++h) {
                 for (uint32_t w = 0; w < window_w; w++) {
                     uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_wide.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo_wide.cpp
@@ -85,6 +85,7 @@ void kernel_main() {
 
     uint32_t npages_to_reserve = 1;
     uint32_t counter = reader_id;
+    uint32_t read_bytes = MAX_ELE_PER_REDUCTION;
     while (counter < reader_nindices) {
         uint16_t top_left_local_index = reader_indices_ptr[counter++];
         for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
@@ -97,7 +98,7 @@ void kernel_main() {
                     uint32_t read_offset =
                         in_l1_read_base_addr +
                         (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);  // 2 bytes, max 8 tiles
-                    noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, MAX_ELE_PER_REDUCTION);
+                    noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
                     out_l1_write_addr += MAX_ELE_PER_REDUCTION;
                 }
             }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -5,7 +5,6 @@
 #include "pool_op.hpp"
 
 #include <tt-metalium/math.hpp>
-#include "common/constants.hpp"
 #include <utility>
 
 /**

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -5,6 +5,7 @@
 #include "pool_op.hpp"
 
 #include <tt-metalium/math.hpp>
+#include "common/constants.hpp"
 #include <utility>
 
 /**
@@ -29,11 +30,17 @@ void validate_pool2d(
     TT_FATAL(input.memory_config().is_sharded(), "Input needs to be sharded");
     TT_FATAL(out_mem_config.is_sharded(), "Output memory config needs to be sharded");
 
+    const tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
+    TT_FATAL(
+        (input_shape[3] % tt::constants::TILE_WIDTH == 0) || (input_shape[3] == 16),
+        "Input channels ({}) should be padded to nearest TILE_WIDTH ({}) or should be 16",
+        input_shape[3],
+        tt::constants::TILE_WIDTH);
+
     // check that C dimnenion is a multiple of num_shards_c for all but height sharding
     TensorMemoryLayout in_memory_layout = input.memory_config().memory_layout;
     if (in_memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
         uint32_t num_shards_c = sliding_window_config.num_cores_c;
-        const tt::tt_metal::LegacyShape input_shape = input.get_legacy_shape();
         TT_FATAL(
             input_shape[3] % num_shards_c == 0,
             "For width and block sharding, input channels ({}) should be divisible by num_shards ({})",


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/13901)

### Problem description
MaxPool2D should support wide reductions with non-max tile multiple C dimensions.  This PR implements this feature for non-large kernels.

### What's changed
The number of C tiles has been adjusted to use ceiling instead of a normal divide.  The reader kernel has been updated to read either the max bytes per reduction, or a small remainder.  The compute kernel has been updated to process max tile multiples for the first N-1 blocks, followed by a smaller number of tiles for the last block.

This update applies to both normal and large kernels.

### Checklist

https://github.com/tenstorrent/tt-metal/actions/runs/12894793407

- [X] Post commit CI passes
- [x] Device performance regression CI testing passes (if applicable)
- [X] New/Existing tests provide coverage for changes
