### PR TITLE
Resolve reduce-scatter-async sharded tensor correctness bug & hang

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -354,19 +354,6 @@ def test_line_reduce_scatter_async_post_commit(
     trace_mode,
     num_iters=16,
 ):
-    # known_l1_failure_shapes = (
-    #     (1, 1, 128, 4096),
-    #     (1, 4, 32, 2304),
-    #     (1, 8, 1024, 1024),
-    #     (1, 4, 2048, 1024),
-    #     (1, 1, 128, 8192),
-    # )
-
-    # if mem_config.buffer_type == ttnn.BufferType.L1 and any(
-    #     tuple(per_chip_output_shape) == s for s in known_l1_failure_shapes
-    # ):
-    #     pytest.skip("Skipping known failure")
-
     run_reduce_scatter_test(
         t3k_mesh_device,
         num_devices,
@@ -624,10 +611,6 @@ def test_line_reduce_scatter_cluster_axis_on_T3K_width_sharded_reduce_scatter_po
 ):
     if len(t3k_mesh_device.get_devices()) < 8:
         pytest.skip("Not T3K!")
-
-    # per_chip_input_shape = list(per_chip_output_shape)
-    # per_chip_input_shape[dim] *= num_devices
-    # per_chip_input_shape = tuple(per_chip_input_shape)
 
     input_shard_spec = ttnn.ShardSpec(
         shard_grid,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -114,8 +114,6 @@ def run_reduce_scatter_test(
             f"Not enough devices on machine to implement test case. Wanted {num_devices} but found {len(mesh_device.get_device_ids())}"
         )
 
-    debug = False
-
     if input_shard_shape and shard_grid:
         input_shard_spec = ttnn.ShardSpec(
             shard_grid,
@@ -155,6 +153,26 @@ def run_reduce_scatter_test(
     if enable_async:
         logger.info(f"Using Async Mode for Reduce Scatter Op Dispatch")
 
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
+    )
+
+    # create global semaphore handles
+    from_remote_semaphore_handles = create_global_semaphore_with_same_address(
+        mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]  # , search_max=True
+    )
+    to_remote_semaphore_handles = create_global_semaphore_with_same_address(
+        mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]  # , search_max=True
+    )
+    mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+    debug = False
+
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}, dim: {dim}")
 
     # Generate input tensors
@@ -189,23 +207,6 @@ def run_reduce_scatter_test(
     assert len(tt_input_tensors) == num_devices
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
-    compute_grid_size = mesh_device.compute_with_storage_grid_size()
-    ccl_sub_device_crs = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
-    )
-    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
-    worker_sub_device_id = ttnn.SubDeviceId(0)
-    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
-        mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
-    )
-
-    # create global semaphore handles
-    from_remote_semaphore_handles = create_global_semaphore_with_same_address(
-        mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]  # , search_max=True
-    )
-    to_remote_semaphore_handles = create_global_semaphore_with_same_address(
-        mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]  # , search_max=True
-    )
 
     # Run the op
     if trace_mode:
@@ -240,7 +241,6 @@ def run_reduce_scatter_test(
             ttnn.synchronize_device(mesh_device.get_device(device_id), sub_device_ids=[worker_sub_device_id])
         logger.info(f"Done iterations")
 
-    teardown_fabric_interface(mesh_device)
     # Compute golden
     # TODO: Make it model how reduce scatter actually works for numerical correctness/ordering
     golden_canonical_out_tensor = torch.zeros(canonical_input_shape).bfloat16()
@@ -284,6 +284,8 @@ def run_reduce_scatter_test(
 
         else:
             logger.info(f"output match for tensor {i}")
+    teardown_fabric_interface(mesh_device)
+
     assert not mismatch, f"{i} FAILED: {output}"
 
 
@@ -352,18 +354,18 @@ def test_line_reduce_scatter_async_post_commit(
     trace_mode,
     num_iters=16,
 ):
-    known_l1_failure_shapes = (
-        (1, 1, 128, 4096),
-        (1, 4, 32, 2304),
-        (1, 8, 1024, 1024),
-        (1, 4, 2048, 1024),
-        (1, 1, 128, 8192),
-    )
+    # known_l1_failure_shapes = (
+    #     (1, 1, 128, 4096),
+    #     (1, 4, 32, 2304),
+    #     (1, 8, 1024, 1024),
+    #     (1, 4, 2048, 1024),
+    #     (1, 1, 128, 8192),
+    # )
 
-    if mem_config.buffer_type == ttnn.BufferType.L1 and any(
-        tuple(per_chip_output_shape) == s for s in known_l1_failure_shapes
-    ):
-        pytest.skip("Skipping known failure")
+    # if mem_config.buffer_type == ttnn.BufferType.L1 and any(
+    #     tuple(per_chip_output_shape) == s for s in known_l1_failure_shapes
+    # ):
+    #     pytest.skip("Skipping known failure")
 
     run_reduce_scatter_test(
         t3k_mesh_device,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -1643,17 +1643,17 @@ std::vector<uint32_t> CCLWorkerArgBuilder::generate_sender_writer_kernel_ct_args
     return args;
 }
 
-bool can_command_stream_be_lowered_to_noc_commands(const Tensor& input_tensor) {
+bool can_command_stream_be_lowered_to_noc_commands(const Tensor& tensor) {
     static constexpr size_t baseline_arg_count = 12;
     // approximately... this is only very rough estimate until unlimited command stream length is enabled
     static constexpr size_t args_per_noc_command = 4;
     static constexpr size_t max_noc_commands = 256;
     size_t page_num_elements =
-        input_tensor.layout() == Layout::TILE ? tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH : input_tensor.padded_shape()[-1];
-    size_t num_tensor_pages = input_tensor.padded_shape().volume() / page_num_elements;
+        tensor.layout() == Layout::TILE ? tensor.get_tensor_spec().tile().get_tile_hw(): tensor.padded_shape()[-1];
+    size_t num_tensor_pages = tensor.padded_shape().volume() / page_num_elements;
 
     // Interleaved tensors are currently not iterable on host so we can't resolve the page locations
-    return input_tensor.is_sharded() &&
+    return tensor.is_sharded() &&
            (num_tensor_pages * args_per_noc_command + baseline_arg_count < max_noc_commands);
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -806,7 +806,6 @@ KernelHandle generate_multi_command_stream_kernel_ct_args(
     DataMovementConfig datamovement_kernel_config,
     const size_t num_command_streams,
     std::optional<chip_id_t> my_chip_id) {
-    TT_FATAL(cb_indices.size() == tensors.size(), "Number of CB indices must match number of tensors");
     TT_FATAL(
         num_command_streams > 0 && num_command_streams <= 2,
         "Invalid number of command streams: {}. Must be 1 or 2",
@@ -841,12 +840,6 @@ KernelHandle generate_multi_command_stream_kernel_ct_args(
         }
     }
 
-    for (auto i : cb_indices) {
-        TT_FATAL(
-            i != tt::CB::c_in7 && i != tt::CB::c_in6,
-            "Command processor kernel reserves cb in7 for use but user specified CBs included it. Please choose "
-            "another CB besides c_in6 and c_in7.");
-    }
 
     // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
     const auto reserved_packet_header_CB_index =
@@ -878,7 +871,7 @@ KernelHandle generate_multi_command_stream_kernel_ct_args(
                         tensors[i]->buffer()->buffer_layout()),  // TODO: refactor out to generate_tensor_ct_args
                     static_cast<uint32_t>(tensors[i]->buffer()->buffer_type()),
                     static_cast<uint32_t>(tensors[i]->layout()),
-                    static_cast<uint32_t>(cb_indices[i])},
+                    static_cast<uint32_t>(0)},
                 std::back_inserter(ct_args));
         }
         for (size_t i = 0; i < tensors.size(); i++) {
@@ -1133,6 +1126,8 @@ void generate_multi_input_command_stream_kernel_rt_args(
 
     for (Tensor const* t : tensors) {
         if (t) {
+            bool rt_args_enabled = true;
+            rt_args.push_back(rt_args_enabled);
             if (tensor_device_override.has_value() and
                 tensor_device_override.value().find(t) != tensor_device_override.value().end()) {
                 std::ranges::copy(
@@ -1143,6 +1138,9 @@ void generate_multi_input_command_stream_kernel_rt_args(
                     ttnn::ccl::emit_address_generator_runtime_args(t->buffer()->device(), *t),
                     std::back_inserter(rt_args));
             }
+        } else {
+            bool rt_args_enabled = false;
+            rt_args.push_back(rt_args_enabled);
         }
         // else: Interleaved addrgen passes no additional args - we specify interleaved addrgen as the default
     }

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -181,6 +181,7 @@ FORCE_INLINE auto build_source_address_generator(
 
     using addrgen_type = typename source_tensor_addrgen<tensor_layout, buffer_type, page_layout>::type;
 
+    bool addrgen_enabled = get_arg_val<uint32_t>(arg_idx++) != 0;
     if constexpr (tensor_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
         if constexpr (is_row_major_layout) {
             return addrgen_type{.bank_base_address = tensor_address, .page_size = page_size};
@@ -194,12 +195,18 @@ FORCE_INLINE auto build_source_address_generator(
         tensor_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
         // We don't use these args at the moment but we keep them here for now to avoid a rewrite in the very
         // near future where we'll want to support custom shard grid.
-        uint8_t input_shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);
-        const auto* const input_shard_grid_row_map = reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
-        arg_idx += input_shard_grid_nrows;
-        uint8_t input_shard_grid_ncols = get_arg_val<uint32_t>(arg_idx++);
-        const auto* const input_shard_grid_col_map = reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
-        arg_idx += input_shard_grid_ncols;
+        uint8_t input_shard_grid_nrows = 0;
+        uint8_t input_shard_grid_ncols = 0;
+        uint32_t* input_shard_grid_row_map = nullptr;
+        uint32_t* input_shard_grid_col_map = nullptr;
+        if (addrgen_enabled) {
+            input_shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);
+            input_shard_grid_row_map = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+            arg_idx += input_shard_grid_nrows;
+            input_shard_grid_ncols = get_arg_val<uint32_t>(arg_idx++);
+            input_shard_grid_col_map = reinterpret_cast<uint32_t*>(get_arg_addr(arg_idx));
+            arg_idx += input_shard_grid_ncols;
+        }
 
         return tt::tt_metal::address_generators::build_sharded_addr_gen<tensor_layout>(
             tt::tt_metal::address_generators::VirtualCoordWormholeWorkerToNocLookup(),
@@ -340,6 +347,8 @@ struct command_context_t final {
             } break;
             case ttnn::ccl::cmd::CclCommandCode::WAIT_VALUE:
             case ttnn::ccl::cmd::CclCommandCode::ATOMIC_INC:
+            case ttnn::ccl::cmd::CclCommandCode::NOC_READ_BURST:
+            case ttnn::ccl::cmd::CclCommandCode::NOC_WRITE_BURST:
             case ttnn::ccl::cmd::CclCommandCode::RAW_INLINE_WRITE_BYTES: break;
             default: ASSERT(false);
         }

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/command_lowering.cpp
@@ -24,12 +24,14 @@ void generate_noc_transfer_burst_for_tensor_slice(
     size_t packet_space_in_bytes_left = packet_size_bytes;
     noc_transfer_burst_out.transfer_burst_groupings.push_back({});
     bool closed_out_last_group = false;
+    bool empty_last_group = false;
     for (size_t w = 0; w < tensor_slice.tensor_slice_shape.w; w++) {
         for (size_t z = 0; z < tensor_slice.tensor_slice_shape.z; z++) {
             for (size_t y = 0; y < tensor_slice.tensor_slice_shape.y; y++) {
                 size_t pages_read = 0;
                 for (size_t x = 0; x < tensor_slice.tensor_slice_shape.x; x += pages_read) {
                     closed_out_last_group = false;
+                    empty_last_group = false;
                     auto offset = ttnn::ccl::Shape4D<uint32_t>{w, z, y, x} + tensor_slice.tensor_slice_offset;
                     auto& transfer_burst_grouping = noc_transfer_burst_out.transfer_burst_groupings.back();
                     const size_t curr_page_idx = get_flat_index_from_shape(tensor_slice.tensor_shape, offset);
@@ -57,7 +59,11 @@ void generate_noc_transfer_burst_for_tensor_slice(
                         bool last_z = z == tensor_slice.tensor_slice_shape.z - 1;
                         bool last_y = y == tensor_slice.tensor_slice_shape.y - 1;
                         bool last_x = x + pages_read == tensor_slice.tensor_slice_shape.x;
+                        TT_FATAL(
+                            x + pages_read <= tensor_slice.tensor_slice_shape.x,
+                            "Internal error: Last x is out of bounds");
                         if (!(last_w && last_z && last_y && last_x)) {
+                            empty_last_group = true;
                             noc_transfer_burst_out.transfer_burst_groupings.push_back({});
                         }
                     }
@@ -65,6 +71,10 @@ void generate_noc_transfer_burst_for_tensor_slice(
             }
         }
     }
+    TT_FATAL(!empty_last_group, "Internal error: Empty last group");
+    TT_FATAL(
+        noc_transfer_burst_out.transfer_burst_groupings.back().num_transfers_per_packet > 0,
+        "Internal error: No transfers per packet");
 }
 
 void validate_lowered_noc_commands(const ttnn::ccl::cmd::HostCclCommandNocTransferBurst& noc_transfer_burst) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_program.cpp
@@ -131,9 +131,11 @@ struct CircularBufferSpec {
 };
 
 struct ReduceScatterKernelHandles {
-    KernelHandle reader = -1;
+    std::array<KernelHandle, 2> partial_reader = {-1, -1};
+    std::array<KernelHandle, 2> partial_writer = {-1, -1};
+    KernelHandle final_reader = -1;
+    KernelHandle final_writer = -1;
     KernelHandle math = -1;
-    KernelHandle writer = -1;
 };
 
 // We really need something like a graph here to describe the dependencies generically but for
@@ -484,43 +486,6 @@ static WorkerCoreBundle select_worker_cores_for_line_topology(size_t num_links, 
 }
 
 
-
-/*
- * Core range sets for line topology
- * BORROWED FROM REDUCE SCATTER but modified a fair bit
- * TODO: COMMONIZE
- */
-/*
-static WorkerCoreBundle select_worker_cores_for_line_topology(size_t num_links) {
-    static constexpr std::size_t num_directions_per_line = 2;
-    WorkerCoreBundle worker_cores;
-    size_t current_chunk = 0;
-    for (size_t d = 0; d < num_directions_per_line; d++) {
-        worker_cores.partial_reducers[d] =
-            CoreRangeSet(CoreRange(CoreCoord(0, current_chunk), CoreCoord(num_links - 1, current_chunk)));
-        current_chunk++;
-    }
-    worker_cores.final_reducers =
-        CoreRangeSet(CoreRange(CoreCoord(0, current_chunk), CoreCoord(num_links - 1, current_chunk)));
-    current_chunk++;
-
-    // Merge them all into the global set for convenience anywhere we want to access all worker cores easily
-    for (size_t d = 0; d < num_directions_per_line; d++) {
-        worker_cores.all_worker_cores = worker_cores.all_worker_cores.merge(worker_cores.partial_reducers[d]);
-    }
-    worker_cores.all_worker_cores = worker_cores.all_worker_cores.merge(worker_cores.final_reducers);
-    log_trace(tt::LogOp, "Worker cores: ", worker_cores.all_worker_cores);
-
-    worker_cores.all_worker_cores_vec = corerange_to_cores(worker_cores.all_worker_cores, std::nullopt, true);
-    worker_cores.final_reducers_vec = corerange_to_cores(worker_cores.final_reducers, std::nullopt, true);
-    for (size_t d = 0; d < num_directions_per_line; d++) {
-        worker_cores.partial_reducers_vec[d] = corerange_to_cores(worker_cores.partial_reducers[d], std::nullopt, true);
-    }
-
-    return worker_cores;
-}
-*/
-
 /*
  * Returns 1 or 2 core range sets. Typically returns only one but in the case of a line reduce scatter where we are at
  * the end of the line, then we must split the core range in half (and return 2), one for each direction where half the
@@ -563,39 +528,107 @@ static ReduceScatterKernelHandles build_line_reduce_scatter_worker_ct(
     Program& program,
     ProgramTensorsBundle const& all_tensors,
     ReduceScatterCircularBuffers const& cb_handles,
-    CoreRangeSet const& worker_core_range,
+    WorkerCoreBundle const& worker_cores,
+    LineTopology const& topology_config,
     ttnn::operations::binary::BinaryOpType reduce_op) {
     using namespace ttnn::ccl::worker_detail;
+    // Why does something as simple as calling `CreateKernel` need to be so complicated to coelesce kernel launches?
+    // Surely there must be a better way to do this - it introduces a lot of complexity, unneccesary code, and is error prone
+    // Would be great if we could do something like `DefineKernel` to create a temporary handle which can later be used to
+    // merge with other kernels (if all args are identical), to produce a merged kernel.
 
-    // Summary:
-    // == READER ==
-    //  - First CB: shortcut to writer
-    //  - Second CB: to math (local input)
-    //  - Third CB: to math (remote input)
-
-    static std::string const& receiver_kernel_path =
-        "ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp";
-    static std::string const& forward_sender_kernel_path = receiver_kernel_path;
     static std::string const& reduce_kernel_path =
         "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp";
 
-    // Generate the reader kernel
-    auto input_tensor_ptrs = std::vector<Tensor const*>{
-        all_tensors.input_tensor,
-        all_tensors.input_tensor_from_remote[0] != nullptr ? all_tensors.input_tensor_from_remote[0]
-                                                           : all_tensors.input_tensor_from_remote[1]};
-    TT_FATAL(
-        input_tensor_ptrs[0] != nullptr && input_tensor_ptrs[1] != nullptr,
-        "Internal error. Input tensor pointers are null");
-    auto reader_kernel_id = generate_multi_command_stream_kernel_ct_args(
-        program,
-        // the CBs don't actuall matter for CT args - they will be removed as CT args in the near future
-        {cb_handles.reader_to_math_operand1_cb /*cb_handles.reader_to_writer_shortcut_cb*/,
-         cb_handles.reader_to_math_operand0_cb},
-        input_tensor_ptrs,
-        worker_core_range,
-        ReaderDataMovementConfig{});
+    // legacy part of kernel builder API - to be removed so we can just put dummy values until then
+    auto dummy_cbs = std::vector<uint32_t>{0, 0};
+    auto build_kernel = [&program, &dummy_cbs](DataMovementConfig const& config, std::vector<const Tensor*> const& tensors, CoreRangeSet const& cores) {
+        return generate_multi_command_stream_kernel_ct_args(
+            program,
+            dummy_cbs,
+            tensors,
+            cores,
+            config);
+    };
+    auto build_reader = std::bind(build_kernel, ReaderDataMovementConfig{}, std::placeholders::_1, std::placeholders::_2);
+    auto build_writer = std::bind(build_kernel, WriterDataMovementConfig{}, std::placeholders::_1, std::placeholders::_2);
 
+    std::array<KernelHandle, 2> partial_reader_kernel_ids = {std::numeric_limits<KernelHandle>::max(), std::numeric_limits<KernelHandle>::max()};
+    std::array<KernelHandle, 2> partial_writer_kernel_ids = {std::numeric_limits<KernelHandle>::max(), std::numeric_limits<KernelHandle>::max()};
+    KernelHandle final_reader_kernel_id = std::numeric_limits<KernelHandle>::max();
+    KernelHandle final_writer_kernel_id = std::numeric_limits<KernelHandle>::max();
+
+    Tensor const* a_dummy_tensor_to_get_second_cmd_q = all_tensors.input_tensor;
+    if (topology_config.is_at_end_of_line()) {
+        // This is a hack because at the moment, command processor infra has a 1:1 mapping between tensor and command queue
+        // some of our use cases here require two command queues but only one tensor
+        bool fwd_is_line_start = topology_config.is_first_device_in_line(LineDirection::FORWARD);
+        auto line_start_dir = fwd_is_line_start ? LineDirection::FORWARD : LineDirection::BACKWARD;
+        auto line_end_dir = fwd_is_line_start ? LineDirection::BACKWARD : LineDirection::FORWARD;
+        auto reducer_line_start_inputs = std::vector<const Tensor*>{all_tensors.input_tensor, a_dummy_tensor_to_get_second_cmd_q};
+        auto reducer_line_start_outputs =
+            std::vector<const Tensor*>{all_tensors.remote_output[line_start_dir], a_dummy_tensor_to_get_second_cmd_q};
+        auto reducer_line_end_inputs = std::vector<const Tensor*>{
+            all_tensors.input_tensor, all_tensors.input_tensor_from_remote[line_end_dir]};
+        auto reducer_line_end_outputs = std::vector<const Tensor*>{all_tensors.local_final_output_tensor, a_dummy_tensor_to_get_second_cmd_q};
+
+        auto& forward_inputs = fwd_is_line_start ? reducer_line_start_inputs : reducer_line_end_inputs;
+        auto& forward_outputs =
+            fwd_is_line_start ? reducer_line_start_outputs : reducer_line_end_outputs;
+        auto& backward_inputs =
+            !fwd_is_line_start ? reducer_line_start_inputs : reducer_line_end_inputs;
+        auto& backward_outputs =
+            !fwd_is_line_start ? reducer_line_start_outputs : reducer_line_end_outputs;
+        std::vector<std::reference_wrapper<std::vector<const Tensor*>>> inputs = {forward_inputs, backward_inputs};
+        std::vector<std::reference_wrapper<std::vector<const Tensor*>>> outputs = {forward_outputs, backward_outputs};
+
+        for (auto d : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
+            partial_reader_kernel_ids[d] = build_reader(inputs[d], worker_cores.partial_reducers[d]);
+            partial_writer_kernel_ids[d] = build_writer(outputs[d], worker_cores.partial_reducers[d]);
+        }
+
+        // final_reduces are inactive so we can give them any tensors
+        // assign_tensors_to_cores(worker_cores.final_reducers_vec, inputs[LineDirection::FORWARD], reader_tensor_map);
+        // assign_tensors_to_cores(worker_cores.final_reducers_vec, outputs[LineDirection::FORWARD], writer_tensor_map);
+        // Final reducer is inactive so we can initialize it arbitrarily. TODO: optimize this away for end of line
+        final_reader_kernel_id = build_reader(forward_inputs, worker_cores.final_reducers);
+        final_writer_kernel_id = build_writer(forward_outputs, worker_cores.final_reducers);
+
+    } else {
+        // setup the partial reducer kernels
+        const auto& fwd_reducer_cores_vec = worker_cores.partial_reducers_vec[LineDirection::FORWARD];
+        const auto& bwd_reducer_cores_vec = worker_cores.partial_reducers_vec[LineDirection::BACKWARD];
+        auto all_partial_reducer_cores = worker_cores.partial_reducers[LineDirection::FORWARD].merge(
+            worker_cores.partial_reducers[LineDirection::BACKWARD]);
+        auto all_partial_reducer_cores_vec = std::vector<CoreCoord>();
+        all_partial_reducer_cores_vec.reserve(fwd_reducer_cores_vec.size() + bwd_reducer_cores_vec.size());
+        std::copy(
+            fwd_reducer_cores_vec.begin(), fwd_reducer_cores_vec.end(), std::back_inserter(all_partial_reducer_cores_vec));
+        std::copy(
+            bwd_reducer_cores_vec.begin(), bwd_reducer_cores_vec.end(), std::back_inserter(all_partial_reducer_cores_vec));
+
+        // Generate the reader kernel
+        auto partial_input_tensor_ptrs = std::vector<const Tensor*>{
+            all_tensors.input_tensor, all_tensors.input_tensor_from_remote[LineDirection::FORWARD]};
+        const auto partial_output_tensor_ptrs = std::vector<const Tensor*>{
+            all_tensors.remote_output[LineDirection::FORWARD],
+            all_tensors.local_output_partial[LineDirection::FORWARD]};
+        const auto final_input_tensor_ptrs = std::vector<const Tensor*>{
+            all_tensors.local_output_partial[LineDirection::FORWARD],
+            all_tensors.local_output_partial[LineDirection::BACKWARD]};
+        const auto final_output_tensor_ptrs =
+            std::vector<const Tensor*>{all_tensors.local_final_output_tensor, a_dummy_tensor_to_get_second_cmd_q};
+
+        final_reader_kernel_id = build_reader(final_input_tensor_ptrs, worker_cores.final_reducers);
+        final_writer_kernel_id = build_writer(final_output_tensor_ptrs, worker_cores.final_reducers);
+
+        partial_reader_kernel_ids[LineDirection::FORWARD] = build_reader(partial_input_tensor_ptrs, all_partial_reducer_cores);
+        partial_writer_kernel_ids[LineDirection::FORWARD] = build_writer(partial_output_tensor_ptrs, all_partial_reducer_cores);
+        partial_reader_kernel_ids[LineDirection::BACKWARD] = partial_reader_kernel_ids[LineDirection::FORWARD];
+        partial_writer_kernel_ids[LineDirection::BACKWARD] = partial_writer_kernel_ids[LineDirection::FORWARD];
+    }
+
+    // Math kernel is setup universally regardless of being in a partial or final reducer
     // Generate the math/reducer kernel
     std::vector<uint32_t> compute_kernel_args = {};
     constexpr bool fp32_dest_acc_en = false;
@@ -604,7 +637,7 @@ static ReduceScatterKernelHandles build_line_reduce_scatter_worker_ct(
     auto math_kernel_id = tt::tt_metal::CreateKernel(
         program,
         reduce_kernel_path,
-        worker_core_range,
+        worker_cores.all_worker_cores,
         tt::tt_metal::ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
             .fp32_dest_acc_en = fp32_dest_acc_en,
@@ -612,18 +645,19 @@ static ReduceScatterKernelHandles build_line_reduce_scatter_worker_ct(
             .compile_args = compute_kernel_args,
             .defines = eltwise_defines});
 
-    // Generate the sender kernel
-    auto const output_tensor_ptrs = std::vector<Tensor const*>{
-        all_tensors.remote_output[0] != nullptr ? all_tensors.remote_output[0] : all_tensors.remote_output[1],
-        all_tensors.local_final_output_tensor};
-    auto sender_kernel_id = generate_multi_command_stream_kernel_ct_args(
-        program,
-        {cb_handles.reader_to_writer_shortcut_cb, cb_handles.math_to_writer_cb},
-        output_tensor_ptrs,
-        worker_core_range,
-        WriterDataMovementConfig{});
+    TT_FATAL(partial_reader_kernel_ids[LineDirection::FORWARD] != std::numeric_limits<KernelHandle>::max(), "Partial reader kernel not created");
+    TT_FATAL(partial_reader_kernel_ids[LineDirection::BACKWARD] != std::numeric_limits<KernelHandle>::max(), "Partial reader kernel not created");
+    TT_FATAL(partial_writer_kernel_ids[LineDirection::FORWARD] != std::numeric_limits<KernelHandle>::max(), "Partial writer kernel not created");
+    TT_FATAL(partial_writer_kernel_ids[LineDirection::BACKWARD] != std::numeric_limits<KernelHandle>::max(), "Partial writer kernel not created");
+    TT_FATAL(final_reader_kernel_id != std::numeric_limits<KernelHandle>::max(), "Final reader kernel not created");
+    TT_FATAL(final_writer_kernel_id != std::numeric_limits<KernelHandle>::max(), "Final writer kernel not created");
 
-    return ReduceScatterKernelHandles{reader_kernel_id, math_kernel_id, sender_kernel_id};
+    return ReduceScatterKernelHandles{
+        partial_reader_kernel_ids,
+        partial_writer_kernel_ids,
+        final_reader_kernel_id,
+        final_writer_kernel_id,
+        math_kernel_id};
 }
 
 static size_t get_page_size(const Tensor& tensor) {
@@ -1126,7 +1160,7 @@ static void create_final_reducer_worker_rt_args_not_end_of_line(
         auto const& w_logical = final_reducer_worker_cores[i];
         generate_multi_input_command_stream_kernel_rt_args(
             builder_config.program,
-            builder_config.kernel_ids.get().reader,
+            builder_config.kernel_ids.get().final_reader,
             {all_program_tensors.local_output_partial[LineDirection::FORWARD],
              all_program_tensors.local_output_partial[LineDirection::BACKWARD]},
             {builder_config.page_size, builder_config.page_size},
@@ -1147,7 +1181,7 @@ static void create_final_reducer_worker_rt_args_not_end_of_line(
             math_page_counts_out.at(w_logical));
         generate_multi_input_command_stream_kernel_rt_args(
             builder_config.program,
-            builder_config.kernel_ids.get().writer,
+            builder_config.kernel_ids.get().final_writer,
             {all_program_tensors.local_final_output_tensor, nullptr},
             {builder_config.page_size, builder_config.page_size},
             builder_config.device,
@@ -1199,7 +1233,7 @@ static void populate_partial_reduce_rt_args(
 
             generate_multi_input_command_stream_kernel_rt_args(
                 builder_config.program.get(),
-                kernel_ids.reader,
+                kernel_ids.partial_reader[line_direction],
                 std::vector<Tensor const*>{
                     all_tensors.input_tensor, all_tensors.input_tensor_from_remote[line_direction]},
                 {builder_config.page_size, builder_config.page_size},
@@ -1221,7 +1255,7 @@ static void populate_partial_reduce_rt_args(
                 all_tensors.remote_output_index.at(line_direction), all_tensors.local_output_partial_index.at(line_direction)};
             generate_multi_input_command_stream_kernel_rt_args(
                 builder_config.program.get(),
-                kernel_ids.writer,
+                kernel_ids.partial_writer[line_direction],
                 output_tensor_ptrs,
                 {builder_config.page_size, builder_config.page_size},
                 builder_config.device,
@@ -1253,7 +1287,7 @@ static void create_worker_runtime_args_for_inactive_workers(
 
     generate_multi_input_command_stream_kernel_rt_args(
         builder_config.program.get(),
-        builder_config.kernel_ids.get().reader,
+        builder_config.kernel_ids.get().final_reader,
         {nullptr, nullptr},
         {0, 0},
         builder_config.device,
@@ -1275,7 +1309,7 @@ static void create_worker_runtime_args_for_inactive_workers(
 
     generate_multi_input_command_stream_kernel_rt_args(
         builder_config.program.get(),
-        builder_config.kernel_ids.get().writer,
+        builder_config.kernel_ids.get().final_writer,
         {nullptr, nullptr},
         {0, 0},
         builder_config.device,
@@ -1485,8 +1519,7 @@ static void create_end_of_line_worker_runtime_args(
     WorkerCommandStreams& worker_command_streams,
     std::unordered_map<CoreCoord, size_t> const& worker_math_page_counts,
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
-    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map
-    ) {
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     using namespace ttnn::ccl::worker_detail;
     using namespace ttnn::ccl::cmd;
     using Direction = ttnn::ccl::EdmLineFabricOpInterface::Direction;
@@ -1550,7 +1583,7 @@ static void create_end_of_line_worker_runtime_args(
                 worker_command_streams.reader_cmds1.find(w_logical) != worker_command_streams.reader_cmds1.end();
             generate_multi_input_command_stream_kernel_rt_args(
                 program,
-                kernel_ids.reader,
+                kernel_ids.partial_reader[direction],
                 input_tensor_ptrs,
                 {builder_config.page_size, builder_config.page_size},
                 device,
@@ -1567,7 +1600,7 @@ static void create_end_of_line_worker_runtime_args(
             set_math_runtime_args(program, kernel_ids.math, w_logical, num_math_pages);
             generate_multi_input_command_stream_kernel_rt_args(
                 program,
-                kernel_ids.writer,
+                kernel_ids.partial_writer[direction],
                 {output_tensor_ptr, nullptr},
                 {builder_config.page_size, builder_config.page_size},
                 device,
@@ -1784,8 +1817,8 @@ static void initialize_op_internal_tensor_syncs(
 
             // remote output sync
             if (neighbour_devices[direction] != nullptr) {
-                all_tensors.remote_output_sync[direction].semaphore_ids.push_back(to_remote_sem.get());// = all_tensors.input_tensor_from_remote_sync[direction];
-                all_tensors.remote_output_sync[direction].completion_target_value_per_semaphore.push_back(1);// = all_tensors.input_tensor_from_remote_sync[direction];
+                all_tensors.remote_output_sync[direction].semaphore_ids.push_back(to_remote_sem.get());
+                all_tensors.remote_output_sync[direction].completion_target_value_per_semaphore.push_back(1);
                 all_tensors.remote_output_sync[direction] = all_tensors.input_tensor_from_remote_sync[direction];
                 all_tensors.remote_output_sync[direction].targets.back() = TensorSyncSpec::target_rect{
                     neighbour_devices[direction]->worker_core_from_logical_core(worker_core).x,
@@ -1889,8 +1922,7 @@ static void populate_worker_runtime_args(
     WorkerCommandStreams& command_streams,
     std::unordered_map<CoreCoord, size_t>& math_page_counts,
     std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& reader_rt_args_overrider_map,
-    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map
-    ) {
+    std::unordered_map<CoreCoord, ttnn::ccl::tensor_address_runtime_args_overrider>& writer_rt_args_overrider_map) {
     bool is_end_of_line = builder_config.topology_config.get().is_at_end_of_line();
     if (is_end_of_line) {
         create_worker_runtime_args_for_inactive_workers(builder_config, reader_rt_args_overrider_map, writer_rt_args_overrider_map);
@@ -2056,6 +2088,8 @@ void lower_command_streams_to_noc_commands(
             lower_command_streams(
                 partial_reducers, command_streams.reader_cmds1, *builder_config.all_tensors.get().input_tensor_from_remote[direction]);
             lower_command_streams(
+                partial_reducers, command_streams.writer_cmds0, *builder_config.all_tensors.get().local_final_output_tensor);
+            lower_command_streams(
                 partial_reducers, command_streams.writer_cmds1, *builder_config.all_tensors.get().local_output_partial[direction]);
         } else {
             lower_command_streams(
@@ -2074,7 +2108,7 @@ void lower_command_streams_to_noc_commands(
         lower_command_streams(
             final_reducers, command_streams.reader_cmds0, *builder_config.all_tensors.get().local_output_partial[LineDirection::FORWARD]);
         lower_command_streams(
-            final_reducers, command_streams.reader_cmds1, *builder_config.all_tensors.get().local_output_partial[LineDirection::FORWARD]);
+            final_reducers, command_streams.reader_cmds1, *builder_config.all_tensors.get().local_output_partial[LineDirection::BACKWARD]);
         lower_command_streams(
             final_reducers, command_streams.reader_cmds0, *builder_config.all_tensors.get().local_final_output_tensor);
     }
@@ -2215,7 +2249,7 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
         page_size);
 
     auto kernel_ids =
-        build_line_reduce_scatter_worker_ct(program, all_tensors, cb_handles, worker_cores.all_worker_cores, reduce_op);
+        build_line_reduce_scatter_worker_ct(program, all_tensors, cb_handles, worker_cores, topology_config, reduce_op);
 
     const size_t pages_per_cb_packet = fabric.get_edm_buffer_size_bytes() / cb_page_size;
     auto builder_config = ReduceScatterBuilderConfig{
@@ -2318,83 +2352,87 @@ operation::ProgramWithCallbacks reduce_scatter_async_on_instantiated_edm_fabric(
             std::array<const Tensor*, 2> partial_output_tensor = {
                 &partial_output_tensor_forward_direction, &partial_output_tensor_backward_direction};
 
-            auto& worker_reader_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.reader);
-            auto& worker_writer_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.writer);
+            auto& worker_final_reducer_reader_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.final_reader);
+            auto& worker_final_reducer_writer_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.final_writer);
             if (topology_config.is_at_end_of_line()) {
 
                 for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
+                    auto& worker_partial_reducer_reader_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.partial_reader[direction]);
+                    auto& worker_partial_reducer_writer_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.partial_writer[direction]);
                     bool is_start_of_line = topology_config.is_first_device_in_line(direction);
                     for (auto const& core : worker_cores.partial_reducers_vec[direction]) {
-                        auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
+                        auto &worker_partial_reducer_reader_runtime_args = worker_partial_reducer_reader_runtime_args_by_core[core.x][core.y];
                         reader_rt_args_overrider_map.at(core).override_runtime_args(
                             local_input_tensor_idx,
                             input_tensor.buffer()->address(),
-                            worker_reader_runtime_args);
+                            worker_partial_reducer_reader_runtime_args);
                         if (!is_start_of_line) {
                             reader_rt_args_overrider_map.at(core).override_runtime_args(
                                 input_tensor_from_remote_idx[direction],
                                 input_tensor_from_remote.at(direction)->buffer()->address(),
-                                worker_reader_runtime_args);
+                                worker_partial_reducer_reader_runtime_args);
                         }
 
-                        auto& worker_writer_runtime_args = worker_writer_runtime_args_by_core[core.x][core.y];
+                        auto& worker_partial_reducer_writer_runtime_args = worker_partial_reducer_writer_runtime_args_by_core[core.x][core.y];
                         if (is_start_of_line) {
                             writer_rt_args_overrider_map.at(core).override_runtime_args(
                                 input_tensor_from_remote_idx[direction],
                                 input_tensor_from_remote.at(direction)->buffer()->address(),
-                                worker_writer_runtime_args);
+                                worker_partial_reducer_writer_runtime_args);
                         } else {
                             writer_rt_args_overrider_map.at(core).override_runtime_args(
                                 local_final_output_tensor_idx,
                                 local_final_output_tensor.buffer()->address(),
-                                worker_writer_runtime_args);
+                                worker_partial_reducer_writer_runtime_args);
                         }
                     }
                 }
             } else {
                 for (auto direction : {LineDirection::FORWARD, LineDirection::BACKWARD}) {
+                    auto& worker_partial_reducer_reader_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.partial_reader[direction]);
+                    auto& worker_partial_reducer_writer_runtime_args_by_core = GetRuntimeArgs(program, kernel_ids.partial_writer[direction]);
                     for (auto const &core : worker_cores.partial_reducers_vec[direction]) {
-                        auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
-                        auto& worker_writer_runtime_args = worker_writer_runtime_args_by_core[core.x][core.y];
+                        auto &worker_partial_reducer_reader_runtime_args = worker_partial_reducer_reader_runtime_args_by_core[core.x][core.y];
+                        auto& worker_partial_reducer_writer_runtime_args = worker_partial_reducer_writer_runtime_args_by_core[core.x][core.y];
                         reader_rt_args_overrider_map.at(core).override_runtime_args(
                             local_input_tensor_idx,
                             input_tensor.buffer()->address(),
-                            worker_reader_runtime_args);
+                            worker_partial_reducer_reader_runtime_args);
                         reader_rt_args_overrider_map.at(core).override_runtime_args(
                             input_tensor_from_remote_idx[direction],
                             input_tensor_from_remote.at(direction)->buffer()->address(),
-                            worker_reader_runtime_args);
+                            worker_partial_reducer_reader_runtime_args);
 
                         // input_tensor_from_remote and remote output partial result tensor share the same addresses
                         // because the input from remote of one chip is the partial result remote output of another
                         writer_rt_args_overrider_map.at(core).override_runtime_args(
                             input_tensor_from_remote_idx[direction],
                             input_tensor_from_remote.at(direction)->buffer()->address(),
-                            worker_writer_runtime_args);
+                            worker_partial_reducer_writer_runtime_args);
                         writer_rt_args_overrider_map.at(core).override_runtime_args(
                             partial_output_tensor_idx[direction],
                             partial_output_tensor.at(direction)->buffer()->address(),
-                            worker_writer_runtime_args);
+                            worker_partial_reducer_writer_runtime_args);
                     }
                 }
 
                 for (auto const& core : worker_cores.final_reducers_vec) {
-                    auto &worker_reader_runtime_args = worker_reader_runtime_args_by_core[core.x][core.y];
+                    auto &worker_final_reducer_reader_runtime_args = worker_final_reducer_reader_runtime_args_by_core[core.x][core.y];
 
                     reader_rt_args_overrider_map.at(core).override_runtime_args(
                         partial_output_tensor_idx[LineDirection::FORWARD],
                         partial_output_tensor[LineDirection::FORWARD]->buffer()->address(),
-                        worker_reader_runtime_args);
+                        worker_final_reducer_reader_runtime_args);
                     reader_rt_args_overrider_map.at(core).override_runtime_args(
                         partial_output_tensor_idx[LineDirection::BACKWARD],
                         partial_output_tensor[LineDirection::BACKWARD]->buffer()->address(),
-                        worker_reader_runtime_args);
+                        worker_final_reducer_reader_runtime_args);
 
-                    auto& worker_writer_runtime_args = worker_writer_runtime_args_by_core[core.x][core.y];
+                    auto& worker_final_reducer_writer_runtime_args = worker_final_reducer_writer_runtime_args_by_core[core.x][core.y];
                     writer_rt_args_overrider_map.at(core).override_runtime_args(
                         local_final_output_tensor_idx,
                         local_final_output_tensor.buffer()->address(),
-                        worker_writer_runtime_args);
+                        worker_final_reducer_writer_runtime_args);
                 }
             }
         };


### PR DESCRIPTION
Fix sharding support in reduce-scatter-async

the implementation was buggy because it was sharing kernel IDs for partial reducer workers in all cases. However, for end-of-line devices, the designated partial reducer cores have different input and output tensor configurations, which means their address generators are not sharable. Addrgens are compile time defined (and for sharded, the shard spec info is also specified at compile time), so these kernels are incompatible.

The end result was that some workers would have the incorrect address generator.

The issue has been resolved and kernels are created correctly to account for this.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16529)

### Problem description
Reduce scatter async wasn't handling sharded tensors correctly.

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/12684597457
- [x] T3K nightly, unit, frequent: https://github.com/tenstorrent/tt-metal/actions/runs/12684594110
- [x] TG nightly, frequent: https://github.com/tenstorrent/tt-metal/actions/runs/12684595143
  - same failures as main
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] Device performance regression CI testing passes (if applicable): N/A
- [x] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes: N/A
- [x] New/Existing tests provide coverage for changes
