### PR TITLE
#16503: Optimize CoreRangeSets for CBs and semaphores

### DIFF
--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -404,6 +404,14 @@ CoreRange CoreRangeSet::bounding_box() const {
     return {{min_x, min_y}, {max_x, max_y}};
 }
 
+CoreRangeSet CoreRangeSet::merge_ranges() const {
+    if (this->ranges_.size() <= 1) {
+        return *this;
+    }
+    // Merging incidentally optimizes the resulting CoreRangeSet.
+    return CoreRangeSet().merge(*this);
+}
+
 void CoreRangeSet::validate_no_overlap() {
     if (this->ranges_.size() < 2) {
         return;

--- a/tt_metal/common/core_coord.hpp
+++ b/tt_metal/common/core_coord.hpp
@@ -169,6 +169,12 @@ public:
 
     CoreRange bounding_box() const;
 
+    // Return a CoreRangeSet with the same set of cores covered, but with as
+    // small a number of CoreRanges as possible. This is useful to reduce the
+    // amount of redundant per-core-range processing and NOC transactions for
+    // code that uses this CoreRangeSet.
+    CoreRangeSet merge_ranges() const;
+
 private:
     void validate_no_overlap();
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1152,7 +1152,8 @@ uint32_t CreateSemaphore(
             if constexpr (std::is_same_v<T, CoreRange>) {
                 crs = CoreRangeSet(c);
             } else {
-                crs = c;
+                // Merge ranges to reduce the number of multicasts needed to initialize semaphores.
+                crs = c.merge_ranges();
             }
             std::optional<uint32_t> semaphore_id;
             TT_FATAL(crs.ranges().size() > 0, "Expecting a non-empty CoreRangeSet!");


### PR DESCRIPTION
### Ticket
#16503 

### Problem description
CoreRangeSets passed in from users may contain more CoreRanges than needed to properly represent the range, which can lead to inefficiency and redundant multicasts. 

### What's changed
Optimize the CoreRangeSets used for CBs and semaphores to improve that.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
