### PR TITLE
Quick fix how to storage/access for devices in the DevicePool

### DIFF
--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -74,6 +74,7 @@ private:
     void activate_device(chip_id_t id);
     void initialize_device(IDevice* dev) const;
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
+    IDevice* get_device(chip_id_t id) const;
     static DevicePool* _inst;
 };
 


### PR DESCRIPTION
### Ticket
None

### Problem description
We got a segfault in t3k unit tests

### What's changed
The root cause was that I made a mistake in the IDevice extraction PR when was replacing DeviceHandle with IDevice*.
I missed that we store things in the vector and there was an expectation that index in vector is the same as `device->id()`.
My changes caused a situation, when 4 devices with ids like 0,1,4,5 would actually make the vector size 6, leaving some slots nullptr.

This PR addresses the issue, but changing the "contract". We now simply store devices in the vector. If someone wants to get a device by id, there is a new method `IDevice* get_device(chip_id_t id) const`. 

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/12685625913)
- [x] [t3k tests ](https://github.com/tenstorrent/tt-metal/actions/runs/12685617736)