### PR TITLE
Fix double move in TTNN invoke_composite launch_op

### DIFF
--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -97,7 +97,7 @@ auto map_launch_op_args_to_execute_on_worker_thread_args(
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& optional_output_tensors,
-    args_t&&... args) {
+    const args_t&... args) {
     auto input_tensor_index = 0;
     auto optional_input_tensor_index = 0;
     auto optional_output_tensor_index = 0;
@@ -117,7 +117,7 @@ auto map_launch_op_args_to_execute_on_worker_thread_args(
         } else {
             return arg;
         }
-    }(std::forward<args_t>(args))...};
+    }(args)...};
 }
 
 template <typename operation_t, typename T>
@@ -252,26 +252,26 @@ struct registered_operation_t {
         // #8479: Fix and re-enable logging in cpp operation decorator
         // detail::log("Arguments: ", std::forward<args_t>(args)...);
 
-        using execute_on_worker_thread_return_t = decltype(operation_t::invoke(std::forward<decltype(args)>(args)...));
+        using execute_on_worker_thread_return_t = decltype(operation_t::invoke(args...));
 
-        const Tensors input_tensors = detail::extract_args_to_vector<ttnn::Tensor>(std::forward<args_t>(args)...);
+        const Tensors input_tensors = detail::extract_args_to_vector<ttnn::Tensor>(args...);
         const OptionalConstTensors optional_input_tensors =
-            detail::extract_args_to_vector<std::optional<const ttnn::Tensor>>(std::forward<args_t>(args)...);
+            detail::extract_args_to_vector<std::optional<const ttnn::Tensor>>(args...);
 
         auto output_tensors = detail::create_async_output_tensors<operation_t, execute_on_worker_thread_return_t>(
-            input_tensors, optional_input_tensors, std::forward<decltype(args)>(args)...);
+            input_tensors, optional_input_tensors, args...);
 
         const OptionalTensors optional_output_tensors =
-            detail::extract_args_to_vector<std::optional<ttnn::Tensor>>(std::forward<args_t>(args)...);
+            detail::extract_args_to_vector<std::optional<ttnn::Tensor>>(args...);
 
         bool enable_autoformat = false;
         tt::tt_metal::operation::launch_op(
             [args...](
                 const Tensors& input_tensors,
                 const OptionalConstTensors& optional_input_tensors,
-                const OptionalTensors& optional_output_tensors) mutable {
+                const OptionalTensors& optional_output_tensors) {
                 auto execute_on_worker_thread_args = detail::map_launch_op_args_to_execute_on_worker_thread_args(
-                    input_tensors, optional_input_tensors, optional_output_tensors, std::forward<args_t>(args)...);
+                    input_tensors, optional_input_tensors, optional_output_tensors, args...);
                 return std::apply(
                     [](auto&&... args) {
                         return detail::map_execute_on_worker_thread_return_to_launch_op_return<operation_t>(


### PR DESCRIPTION
### Ticket

### Problem description
There is a double move occurring inside invoke_composite / launch_op. The issue is caused by passing a mutable lambda, which changes the argument into launch_op, which in turn calls the lambda multiple times.
This change is a prerequisite for https://github.com/tenstorrent/tt-metal/pull/16484

### What's changed
Remove `mutable` modifier for the passed lambda, removed incorrect usages of `std::forward`.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12685459880)
- [x] [T3K frequent CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12685464588)
- [x] [T3K unit tests CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12687593651)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12685476479)
- [x] [Device performance regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/12685472338)
- [x] New/Existing tests provide coverage for changes
