### PR TITLE
Enable multi-core and fixing bfloat8 for untilize with unpadding 

### DIFF
--- a/tests/ttnn/unit_tests/test_untilize_bfloat8_b.py
+++ b/tests/ttnn/unit_tests/test_untilize_bfloat8_b.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+from models.utility_functions import is_grayskull, is_blackhole, torch_random, skip_for_grayskull
+
+
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("use_multicore", [False, True])
+@pytest.mark.parametrize("use_pack_untilize", [False, True])
+@pytest.mark.parametrize("N", [1, 3, 5])
+@pytest.mark.parametrize("C", [1, 2])
+@pytest.mark.parametrize("H", [32, 448])
+@pytest.mark.parametrize("W", [256, 672])
+def test_untilize(device, in_dtype, use_multicore, use_pack_untilize, N, C, H, W):
+    torch_input_shape = [N, C, H, W]
+
+    torch_input = torch.randn(torch_input_shape).bfloat16()
+
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.TILE_LAYOUT)
+
+    output_tt = ttnn.untilize(ttnn_input, use_multicore=use_multicore, use_pack_untilize=use_pack_untilize)
+    output_torch = ttnn.to_torch(output_tt)
+
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_input, output_torch)
+    logger.info(pcc_msg)
+    assert passing
+
+
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("use_multicore", [False, True])
+@pytest.mark.parametrize("use_pack_untilize", [False, True])
+@pytest.mark.parametrize("N", [1, 2])
+@pytest.mark.parametrize("C", [1, 7])
+@pytest.mark.parametrize("H", [128, 480])
+@pytest.mark.parametrize("W", [32, 416])
+@pytest.mark.parametrize("i_h", [10, 20])
+@pytest.mark.parametrize("i_w", [2, 3])
+def test_untilize_with_unpadding(device, in_dtype, use_multicore, use_pack_untilize, N, C, H, W, i_h, i_w):
+    torch_input_shape = [N, C, H, W]
+
+    torch_input = torch.randn(torch_input_shape).bfloat16()
+
+    ttnn_input = ttnn.from_torch(torch_input, device=device, dtype=in_dtype, layout=ttnn.TILE_LAYOUT)
+
+    output_tt = ttnn.untilize_with_unpadding(
+        ttnn_input, [N - 1, C - 1, H - i_h, W - i_w], use_multicore=use_multicore, use_pack_untilize=use_pack_untilize
+    )
+    output_torch = ttnn.to_torch(output_tt)
+    torch_input = torch_input[:, :, : H - i_h + 1, : W - i_w + 1]
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_input, output_torch)
+    logger.info(pcc_msg)
+    assert passing

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -228,8 +228,16 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
 
     bool has_cliff = core_range_cliff.size() > 0;
 
-    uint32_t padded_row_size_bytes = input_shape[-1] * a.element_size();     // Assuming bfloat16 dataformat
-    uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();  // Assuming bfloat16 dataformat
+    uint32_t padded_row_size_bytes;
+    uint32_t unpadded_row_size_bytes;
+
+    if (a.get_dtype() == DataType::BFLOAT8_B) {
+        padded_row_size_bytes = input_shape[-1] * output.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * output.element_size();
+    } else {
+        padded_row_size_bytes = input_shape[-1] * a.element_size();
+        unpadded_row_size_bytes = output_shape[-1] * a.element_size();
+    }
 
     create_cb(tt::CBIndex::c_0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);
     create_cb(tt::CBIndex::c_16, program, all_cores, output_single_tile_size, num_tiles_per_row, output_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -15,14 +15,14 @@ struct ExecuteUntilizeWithUnpadding {
         const ttnn::Tensor& input_tensor,
         const tt::tt_metal::LegacyShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
-        bool use_multicore = false,
+        bool use_multicore = true,
         bool use_pack_untilize = true);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const tt::tt_metal::LegacyShape& output_tensor_end,
         const std::optional<MemoryConfig>& memory_config,
-        bool use_multicore = false,
+        bool use_multicore = true,
         bool use_pack_untilize = true);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding_pybind.hpp
@@ -55,7 +55,7 @@ void bind_untilize_with_unpadding(py::module& module) {
             py::arg("output_tensor_end"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("use_multicore") = false,
+            py::arg("use_multicore") = true,
             py::arg("use_pack_untilize") = true,
             py::arg("queue_id") = 0,
         });


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/16554

### Problem description
Untilize with unpadding used only a single core
bfloat8_b datatype was buggy for this op

### What's changed
Enabled multicore flag for this op, and fixed bfloat8 bug
Added test cases for bfloat8

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12677652863
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
