### PR TITLE
#16312: Fix full op to query physical shape for buffer volume

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_full.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_full.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+import torch.nn as nn
+import ttnn
+from models.utility_functions import comp_allclose
+from loguru import logger
+
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [1, 3],  # single tile
+        [32, 32],  # single tile
+        [5, 17, 31],  # multiple tiles
+    ],
+)
+@pytest.mark.parametrize(
+    "fill_value",
+    [3, -1],
+)
+def test_full_int(device, input_shape, fill_value):
+    torch_any = torch.randint(0, 100, (input_shape), dtype=torch.int32)
+    torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
+
+    any = ttnn.from_torch(torch_any, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_output = ttnn.moreh_full(input_shape, fill_value, any)
+    assert ttnn.is_tensor_storage_on_device(tt_output)
+    tt_output_cpu = ttnn.to_torch(tt_output)
+
+    assert torch.equal(torch_output, tt_output_cpu)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [1, 3],  # single tile
+        [32, 32],  # single tile
+        [5, 96, 64],  # multiple tiles
+    ],
+)
+@pytest.mark.parametrize(
+    "fill_value",
+    [
+        3.14,
+        2.00781250,  # mantissa: 0000 0001, bf16 round down test
+        2.00830080,  # mantissa: 0000 0001 0001, bf16 round up test
+        2.02343750,  # mantissa: 0000 0011, bf16 round up test
+        -3.9921875,  # test mantissa overflow. answer should be 4
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bfloat16,
+        torch.float32,
+    ],
+)
+def test_full_float(device, input_shape, fill_value, dtype):
+    torch_any = torch.rand((input_shape), dtype=dtype)
+
+    torch_output = torch.full(input_shape, fill_value, dtype=dtype)
+    any = ttnn.from_torch(torch_any, device=device, layout=ttnn.TILE_LAYOUT)
+    tt_output = ttnn.moreh_full(input_shape, fill_value, any)
+    assert ttnn.is_tensor_storage_on_device(tt_output)
+    tt_output_cpu = ttnn.to_torch(tt_output)
+
+    assert torch.equal(torch_output, tt_output_cpu)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [32, 32],  # single tile
+    ],
+)
+@pytest.mark.parametrize(
+    "fill_value",
+    [3],
+)
+@pytest.mark.parametrize(
+    "layout",
+    [
+        ttnn.TILE_LAYOUT,  # Currently only support tile layout
+    ],
+)
+def test_full_callback(device, input_shape, fill_value, layout, use_program_cache):
+    for i in range(2):
+        torch_any = torch.randint(0, 100, (input_shape), dtype=torch.int32)
+        torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
+
+        any = ttnn.from_torch(torch_any, device=device, layout=ttnn.TILE_LAYOUT)
+        tt_output = ttnn.moreh_full(input_shape, fill_value, any)
+        assert ttnn.is_tensor_storage_on_device(tt_output)
+        tt_output_cpu = ttnn.to_torch(tt_output)
+        torch_dummy = torch.randn([32, 32])
+        ttnn_dummy = ttnn.from_torch(torch_dummy, device=device)
+        if i == 0:
+            num_program_cache_entries = device.num_program_cache_entries()
+            assert num_program_cache_entries > 0
+        else:
+            assert device.num_program_cache_entries() == num_program_cache_entries
+
+        assert torch.equal(torch_output, tt_output_cpu)

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1038,6 +1038,12 @@ void pytensor_module(py::module& m_tensor) {
                     ttnn.Tensor(py_tensor, ttnn.bfloat16, device, ttnn.TILE_LAYOUT)
             )doc")
         .def_property_readonly("shape", [](const Tensor& self) { return self.get_shape(); })
+        .def_property_readonly(
+            "logical_shape",
+            [](const Tensor& self) {
+                auto logical_shape = self.get_logical_shape();
+                return std::vector<uint32_t>(logical_shape.cbegin(), logical_shape.cend());
+            })
         .def_property_readonly("dtype", [](const Tensor& self) { return self.get_dtype(); })
         .def_property_readonly("layout", [](const Tensor& self) { return self.get_layout(); })
         .def_property_readonly("tile", [](const Tensor& self) { return self.get_tensor_spec().tile(); })

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -121,7 +121,8 @@ static Tensor full_impl(
     TensorSpec tensor_spec(
         shape.logical_shape(),
         TensorLayout::fromLegacyPaddedShape(data_type, PageConfig(layout), MemoryConfig{}, shape));
-    auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(tensor_spec.padded_shape().volume());
+    auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(
+        tensor_spec.physical_shape().height() * tensor_spec.physical_shape().width());
     // TODO: 15061 - Generalize the header to support generic vector / view types.
     std::fill(std::begin(owned_buffer), std::end(owned_buffer), value);
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -319,9 +319,16 @@ def to_torch(
             tensor = tensor.to(ttnn.ROW_MAJOR_LAYOUT, device)
 
         shape_without_tile_padding = tuple(tensor.shape)
+        logical_shape_rank = len(tensor.logical_shape)
+
         tensor = tensor.to_torch()
         slices = [slice(None, x) for x in shape_without_tile_padding]
         tensor = tensor[slices]
+
+        while len(tensor.shape) > logical_shape_rank:
+            if tensor.shape[0] != 1:
+                raise RuntimeError("ttnn: Unable to squeeze to desired rank!")
+            tensor = tensor.squeeze(0)
 
     if torch_rank is not None:
         while len(tensor.shape) > torch_rank:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16312)

### Problem description
Recently added a check for total buffer size to match expected buffer size when moving tensors to device. This broke `full` op when `rank == 1` and `layout == TILE` since padded shape doesn't properly account for physical shape being rank 2.                                                                                                                                                                                                                                                                                                                                  

### What's changed
Switch to use physical shape to get volume instead in `full` op for buffer initialization.

### Checklist
- [ ] Post commit CI passes
  - post-commit all: https://github.com/tenstorrent/tt-metal/actions/runs/12698806522
  - nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/12698870504
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
