### PR TITLE
#16492: Remove sub_device_ids apis from various read/write functions throughout the stack

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<DType> &dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids = {})
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<DType> &dst, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking)

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>&, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
-.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<DType>&, bool blocking)
+.. doxygenfunction:: tt::tt_metal::v0::EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking)

--- a/tech_reports/SubDevices/SubDevices.md
+++ b/tech_reports/SubDevices/SubDevices.md
@@ -136,17 +136,17 @@ Note that global semaphores can only created on tensix cores, as only tensix cor
 
 The following are APIs for creating and interacting with the global semaphores.
 
-* `global_semaphore = ttnn.create_global_semaphore(device=device, cores=tensix_cores0, initial_value=1, buffer_type=ttnn.BufferType.L1, sub_device_ids=[])`
+* `global_semaphore = ttnn.create_global_semaphore(device=device, cores=tensix_cores0, initial_value=1, buffer_type=ttnn.BufferType.L1)`
 
-  This will create a global semaphore object on the specified device and cores using the specified L1 buffer type. It will issue a device stall on the specified sub-device ids before writing the initial semaphore value. Not specifying any sub-device ids means we will stall waiting for all sub-devices to complete.
+  This will create a global semaphore object on the specified device and cores using the specified L1 buffer type.
 
 * `address = ttnn.get_global_semaphore_address(global_semaphore=global_semaphore)`
 
   This will query the address of the global semaphore.
 
-* `ttnn.reset_global_semaphore_value(global_semaphore=global_semaphore, reset_value=1, sub_device_ids=[])`
+* `ttnn.reset_global_semaphore_value(global_semaphore=global_semaphore, reset_value=1)`
 
-  This will issue a write from host of the specified value to global semaphore's address on device. It will issue a device stall on the specified sub-device ids before writing the initial semaphore value. Not specifying any sub-device ids means we will stall waiting for all sub-devices to complete.
+  This will issue a write from host of the specified value to global semaphore's address on device.
 
 ## 3. Global Circular Buffers
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -166,6 +166,7 @@ static SubdeviceInfo create_subdevices(std::vector<IDevice*> const& devices) {
             {device->id(), device->get_sub_device_ids().at(TEST_WORKERS_SUBDEVICE_INDEX)});
         subdevice_info.fabric_subdevice_id.insert(
             {device->id(), device->get_sub_device_ids().at(TEST_EDM_FABRIC_SUBDEVICE_INDEX)});
+        device->set_sub_device_stall_group({subdevice_info.worker_subdevice_id.at(device->id())});
     }
 
     return subdevice_info;
@@ -182,10 +183,7 @@ Correctness run_output_check(
     return run_output_check(inputs, readback_data_vec);
 };
 
-void run_programs(
-    std::vector<Program>& programs,
-    std::vector<IDevice*> const& devices,
-    std::optional<std::unordered_map<chip_id_t, SubDeviceId>> const& sub_device_ids = std::nullopt) {
+void run_programs(std::vector<Program>& programs, const std::vector<IDevice*>& devices) {
     EXPECT_EQ(programs.size(), devices.size());
     const size_t num_programs = programs.size();
     try {
@@ -214,11 +212,7 @@ void run_programs(
 
         log_debug(tt::LogTest, "Calling Finish");
         for (size_t i = 0; i < num_programs; i++) {
-            if (sub_device_ids.has_value()) {
-                tt_metal::Finish(devices.at(i)->command_queue(), {sub_device_ids.value().at(devices.at(i)->id())});
-            } else {
-                tt_metal::Finish(devices.at(i)->command_queue());
-            }
+            tt_metal::Finish(devices.at(i)->command_queue());
         }
     }
 }
@@ -475,11 +469,7 @@ bool RunLoopbackTest(
         devices.push_back(receiver_device);
     }
     log_trace(tt::LogTest, "{} programs, {} devices", programs.size(), devices.size());
-    run_programs(
-        programs,
-        devices,
-        subdevice_managers.has_value() ? subdevice_managers.value().worker_subdevice_id
-                                       : std::optional<std::unordered_map<chip_id_t, SubDeviceId>>{std::nullopt});
+    run_programs(programs, devices);
     log_info(tt::LogTest, "Reading back outputs");
 
     bool pass = true;
@@ -842,34 +832,18 @@ bool RunLocalTestWithMultiInputReaders(
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
-    run_programs(
-        programs,
-        enable_persistent_fabric ? std::vector<IDevice*>{devices[0]} : devices,
-        subdevice_managers.has_value() ? subdevice_managers.value().worker_subdevice_id
-                                       : std::optional<std::unordered_map<chip_id_t, SubDeviceId>>{std::nullopt}
-
-    );
+    run_programs(programs, enable_persistent_fabric ? std::vector<IDevice*>{devices[0]} : devices);
     log_info(tt::LogTest, "Finished");
 
     bool pass = true;
     constexpr bool enable_check = true;
     if constexpr (enable_check) {
         log_info(tt::LogTest, "Reading back outputs");
-        std::vector<SubDeviceId> out_tensor_worker_subdevice_id =
-            subdevice_managers.has_value() ? std::vector<SubDeviceId>{subdevice_managers->worker_subdevice_id.at(
-                                                 devices.at(output_tensor_dest_device_index)->id())}
-                                           : std::vector<SubDeviceId>{};
-        auto output0_cpu = output_tensor0_device.cpu(true, ttnn::DefaultQueueId, out_tensor_worker_subdevice_id);
-        auto output1_cpu = output_tensor1_device.cpu(true, ttnn::DefaultQueueId, out_tensor_worker_subdevice_id);
+        auto output0_cpu = output_tensor0_device.cpu(true, ttnn::DefaultQueueId);
+        auto output1_cpu = output_tensor1_device.cpu(true, ttnn::DefaultQueueId);
 
-        auto in_tensor_worker_subdevice_id =
-            subdevice_managers.has_value()
-                ? std::vector<SubDeviceId>{subdevice_managers->worker_subdevice_id.at(devices.at(0)->id())}
-                : std::vector<SubDeviceId>{};
-        auto in0_tensor_copyback_cpu =
-            input_tensor0_device.cpu(true, ttnn::DefaultQueueId, in_tensor_worker_subdevice_id);
-        auto in1_tensor_copyback_cpu =
-            input_tensor1_device.cpu(true, ttnn::DefaultQueueId, in_tensor_worker_subdevice_id);
+        auto in0_tensor_copyback_cpu = input_tensor0_device.cpu(true, ttnn::DefaultQueueId);
+        auto in1_tensor_copyback_cpu = input_tensor1_device.cpu(true, ttnn::DefaultQueueId);
 
         auto in0_tensor_copyback = tt::tt_metal::owned_buffer::get_as<uint32_t>(in0_tensor_copyback_cpu);
         auto in1_tensor_copyback = tt::tt_metal::owned_buffer::get_as<uint32_t>(in1_tensor_copyback_cpu);
@@ -1027,11 +1001,7 @@ bool RunLineFabricTest(
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    run_programs(
-        programs,
-        devices,
-        subdevice_managers.has_value() ? subdevice_managers.value().worker_subdevice_id
-                                       : std::optional<std::unordered_map<chip_id_t, SubDeviceId>>{std::nullopt});
+    run_programs(programs, devices);
     log_info(tt::LogTest, "Reading back outputs");
 
     bool pass = true;
@@ -1428,18 +1398,14 @@ bool TestMultiInputReaderKernel(
     // All this garbage is to make sure the test sets up buffer addresses correctly so we can safely
     // multicast to a consistent destination address
     for (size_t i = 0; i < devices.size(); i++) {
-        std::vector<SubDeviceId> subdevice_target =
-            subdevice_managers.has_value()
-                ? std::vector<SubDeviceId>{subdevice_managers->worker_subdevice_id.at(devices[i]->id())}
-                : std::vector<SubDeviceId>{};
         input0_tensors_device.push_back(
-            input_tensor0.to(devices.at(i), input_tensor0_mem_config, ttnn::DefaultQueueId, subdevice_target));
+            input_tensor0.to(devices.at(i), input_tensor0_mem_config, ttnn::DefaultQueueId));
         input1_tensors_device.push_back(
-            input_tensor1.to(devices.at(i), input_tensor1_mem_config, ttnn::DefaultQueueId, subdevice_target));
+            input_tensor1.to(devices.at(i), input_tensor1_mem_config, ttnn::DefaultQueueId));
         output0_tensors_device.push_back(
-            output_tensor0.to(devices.at(i), output_tensor0_mem_config, ttnn::DefaultQueueId, subdevice_target));
+            output_tensor0.to(devices.at(i), output_tensor0_mem_config, ttnn::DefaultQueueId));
         output1_tensors_device.push_back(
-            output_tensor1.to(devices.at(i), output_tensor1_mem_config, ttnn::DefaultQueueId, subdevice_target));
+            output_tensor1.to(devices.at(i), output_tensor1_mem_config, ttnn::DefaultQueueId));
     }
     TT_FATAL(
         !enable_persistent_fabric || subdevice_managers.has_value(),
@@ -2924,7 +2890,6 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
             devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
             0,                             // initial value
             tt::tt_metal::BufferType::L1,  // buffer type
-            {SubDeviceId(0)},              // sub_device_ids
             10                             // attempts
         );
 
@@ -2934,7 +2899,6 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
             devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
             0,                             // initial value
             tt::tt_metal::BufferType::L1,  // buffer type
-            {SubDeviceId(0)},              // sub_device_ids
             10                             // attempts
         );
 
@@ -3038,7 +3002,6 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
             devices[0]->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0}),
             0,                             // initial value
             tt::tt_metal::BufferType::L1,  // buffer type
-            {SubDeviceId(0)},              // sub_device_ids
             10                             // attempts
         );
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -192,6 +192,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
     )
     ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
 
+    sub_device_stall_group = []
     if use_all_gather_async:
         compute_grid_size = mesh_device.compute_with_storage_grid_size()
         ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -203,17 +204,17 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
             ]
         )
         worker_sub_device_id = ttnn.SubDeviceId(0)
+        sub_device_stall_group = [worker_sub_device_id]
         if create_persistent_fabric:
             logger.info("Create persistent fabric interface")
             mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
                 mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
             )
             logger.info("Done Create persistent fabric interface")
+            mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
         # create global semaphore handles
-        ccl_semaphore_handles = create_global_semaphore_with_same_address(
-            mesh_device, ccl_sub_device_crs, 0, [worker_sub_device_id]
-        )
+        ccl_semaphore_handles = create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0)
 
     # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
     if trace_mode:
@@ -256,12 +257,12 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
 
         if enable_persistent_fabric:
             logger.info(f"Waiting for op")
-            for d in mesh_device.get_devices():
-                ttnn.synchronize_device(d, sub_device_ids=[worker_sub_device_id])
+            ttnn.synchronize_devices(mesh_device, sub_device_ids=sub_device_stall_group)
             logger.info(f"Done iteration")
 
     if enable_persistent_fabric and teardown_persistent_fabric:
         logger.info("Tearing down persistent fabric interface")
+        mesh_device.reset_sub_device_stall_group()
         teardown_fabric_interface(mesh_device)
         logger.info("Done tearing down persistent fabric interface")
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_common.py
@@ -22,14 +22,11 @@ def create_and_load_sub_device_manager_with_fabric_interface(
 
 def teardown_fabric_interface(mesh_device):
     ttnn.teardown_edm_fabric(mesh_device)
-    for device_id in mesh_device.get_device_ids():
-        ttnn.synchronize_device(mesh_device.get_device(device_id))
+    ttnn.synchronize_devices(mesh_device)
 
 
-def create_global_semaphore_with_same_address(mesh_device, cores, initial_value, sub_device_ids):
-    semaphore_handles = ttnn.create_global_semaphore_with_same_address(
-        mesh_device, cores, initial_value, sub_device_ids=sub_device_ids
-    )
+def create_global_semaphore_with_same_address(mesh_device, cores, initial_value):
+    semaphore_handles = ttnn.create_global_semaphore_with_same_address(mesh_device, cores, initial_value)
     addrs = ttnn.get_global_semaphore_address(semaphore_handles)
     logger.debug(f"from remote semaphore handle addresses: {addrs}")
     # assert all addresses are the same

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -305,15 +305,10 @@ uint32_t CreateSemaphore(
  * | cores          | Range of the Tensix co-ordinates using the semaphore   | const CoreRangeSet &                                      |              | Yes      |
  * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
  * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
- * | sub_device_ids | Sub-device ids to wait on before writing the semaphore | tt::stl::Span<const SubDeviceId>                          |              | No       |
  */
 // clang-format on
 GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    uint32_t initial_value,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
 // clang-format off
 /**
@@ -328,15 +323,10 @@ GlobalSemaphore CreateGlobalSemaphore(
  * | cores          | Range of the Tensix co-ordinates using the semaphore   | CoreRangeSet &&                                           |              | Yes      |
  * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
  * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
- * | sub_device_ids | Sub-device ids to wait on before writing the semaphore | tt::stl::Span<const SubDeviceId>                          |              | No       |
  */
 // clang-format on
 GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    CoreRangeSet&& cores,
-    uint32_t initial_value,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
 // clang-format off
 /**
@@ -607,15 +597,13 @@ RuntimeArgsData& GetCommonRuntimeArgs(const Program& program, KernelHandle kerne
  * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
  * | dst            | The memory where the result will be stored                                        | void*                               |                                        | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                        | No       |
  */
 // clang-format on
 void EnqueueReadBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     void* dst,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    bool blocking);
 
 // clang-format off
 /**
@@ -629,27 +617,16 @@ void EnqueueReadBuffer(
  * | buffer         | The device buffer we are reading from                                             | Buffer & or std::shared_ptr<Buffer> |                                        | Yes      |
  * | dst            | The vector where the results that are read will be stored                         | vector<DType> &                     |                                        | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                | Only blocking mode supported currently | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                        | No       |
  */
 // clang-format on
 template <typename DType>
-void EnqueueReadBuffer(
-    CommandQueue& cq,
-    Buffer& buffer,
-    std::vector<DType>& dst,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
+void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, std::vector<DType>& dst, bool blocking) {
     dst.resize(buffer.page_size() * buffer.num_pages() / sizeof(DType));
-    EnqueueReadBuffer(cq, buffer, static_cast<void*>(dst.data()), blocking, sub_device_ids);
+    EnqueueReadBuffer(cq, buffer, static_cast<void*>(dst.data()), blocking);
 }
 template <typename DType>
-void EnqueueReadBuffer(
-    CommandQueue& cq,
-    std::shared_ptr<Buffer> buffer,
-    std::vector<DType>& dst,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueReadBuffer(cq, *buffer, dst, blocking, sub_device_ids);
+void EnqueueReadBuffer(CommandQueue& cq, std::shared_ptr<Buffer> buffer, std::vector<DType>& dst, bool blocking) {
+    EnqueueReadBuffer(cq, *buffer, dst, blocking);
 }
 
 // clang-format off
@@ -664,8 +641,6 @@ void EnqueueReadBuffer(
  * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
  * | src            | The vector we are writing to the device                                           | vector<DType> &                     |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
-
  */
 // clang-format on
 template <typename DType>
@@ -673,9 +648,8 @@ void EnqueueWriteBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     std::vector<DType>& src,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueWriteBuffer(cq, buffer, src.data(), blocking, sub_device_ids);
+    bool blocking) {
+    EnqueueWriteBuffer(cq, buffer, src.data(), blocking);
 }
 
 // clang-format off
@@ -690,15 +664,13 @@ void EnqueueWriteBuffer(
  * | buffer         | The device buffer we are writing to                                               | Buffer & or std::shared_ptr<Buffer> |                                    | Yes      |
  * | src            | The memory we are writing to the device                                           | HostDataType                        |                                    | Yes      |
  * | blocking       | Whether or not this is a blocking operation                                       | bool                                |                                    | Yes      |
- * | sub_device_ids | The sub-device ids to wait for completion on. If empty, waits for all sub-devices | tt::stl::Span<const uint32_t>       |                                    | No       |
  */
 // clang-format on
 void EnqueueWriteBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    bool blocking);
 
 // clang-format off
 /**

--- a/tt_metal/impl/buffers/global_circular_buffer.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.hpp
@@ -9,7 +9,6 @@
 
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
-#include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/llrt/hal.hpp"
 
 namespace tt::tt_metal {
@@ -31,8 +30,7 @@ public:
         IDevice* device,
         const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
         uint32_t size,
-        BufferType buffer_type = BufferType::L1,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+        BufferType buffer_type = BufferType::L1);
 
     GlobalCircularBuffer(const GlobalCircularBuffer&) = default;
     GlobalCircularBuffer& operator=(const GlobalCircularBuffer&) = default;
@@ -54,8 +52,7 @@ public:
     const auto attribute_values() const { return std::make_tuple(this->sender_receiver_core_mapping_, this->size_); }
 
 private:
-    void setup_cb_buffers(
-        BufferType buffer_type, uint32_t max_num_receivers_per_sender, tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender);
 
     // GlobalCircularBuffer is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions

--- a/tt_metal/impl/buffers/global_semaphore.hpp
+++ b/tt_metal/impl/buffers/global_semaphore.hpp
@@ -9,7 +9,6 @@
 
 #include "tt_metal/common/core_coord.hpp"
 #include "tt_metal/impl/buffers/buffer_constants.hpp"
-#include "tt_metal/impl/sub_device/sub_device_types.hpp"
 #include "tt_metal/llrt/hal.hpp"
 
 namespace tt::tt_metal {
@@ -22,18 +21,10 @@ class IDevice;
 class GlobalSemaphore {
 public:
     GlobalSemaphore(
-        IDevice* device,
-        const CoreRangeSet& cores,
-        uint32_t initial_value,
-        BufferType buffer_type = BufferType::L1,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+        IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
     GlobalSemaphore(
-        IDevice* device,
-        CoreRangeSet&& cores,
-        uint32_t initial_value,
-        BufferType buffer_type = BufferType::L1,
-        tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+        IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
     GlobalSemaphore(const GlobalSemaphore&) = default;
     GlobalSemaphore& operator=(const GlobalSemaphore&) = default;
@@ -45,13 +36,13 @@ public:
 
     DeviceAddr address() const;
 
-    void reset_semaphore_value(uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids = {}) const;
+    void reset_semaphore_value(uint32_t reset_value) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("cores");
     const auto attribute_values() const { return std::make_tuple(this->cores_); }
 
 private:
-    void setup_buffer(uint32_t initial_value, BufferType buffer_type, tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void setup_buffer(uint32_t initial_value, BufferType buffer_type);
 
     // GlobalSemaphore is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -572,11 +572,11 @@ private:
     template <typename T>
     void enqueue_command(T& command, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
 
-    void enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
-    void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
+    void enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
+    void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_write_buffer(
-        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
-    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids);
+        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
+    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking, tt::stl::Span<const SubDeviceId> sub_device_ids={});
     void enqueue_program(Program& program, bool blocking);
     void enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count = false, tt::stl::Span<const SubDeviceId> sub_device_ids = {});
     void enqueue_wait_for_event(const std::shared_ptr<Event>& sync_event, bool clear_count = false);
@@ -594,14 +594,12 @@ private:
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         void* dst,
-        bool blocking,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
+        bool blocking);
     friend void EnqueueWriteBufferImpl(
         CommandQueue& cq,
         std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
         HostDataType src,
-        bool blocking,
-        tt::stl::Span<const SubDeviceId> sub_device_ids);
+        bool blocking);
     friend void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer);
     friend void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event, tt::stl::Span<const SubDeviceId> sub_device_ids);
     friend void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event);

--- a/tt_metal/include/tt_metal/global_circular_buffer.hpp
+++ b/tt_metal/include/tt_metal/global_circular_buffer.hpp
@@ -21,17 +21,14 @@ namespace experimental {
  * @param device The device to create the global circular buffer on.
  * @param sender_receiver_core_mapping The mapping of remote sender to remote receiver cores for the circular buffer.
  * @param size Size of the global circular buffer per core in bytes.
- * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.
- * @param sub_device_ids Sub-device IDs to wait on before writing the global circular buffer config to device. Defaults
- * to waiting on all sub-devices.
+ * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.\
  * @return The allocated global circular buffer.
  */
 GlobalCircularBuffer CreateGlobalCircularBuffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    BufferType buffer_type = BufferType::L1);
 
 }  // namespace experimental
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1176,21 +1176,13 @@ uint32_t CreateSemaphore(
 }
 
 GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    uint32_t initial_value,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return GlobalSemaphore(device, cores, initial_value, buffer_type, sub_device_ids);
+    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
+    return GlobalSemaphore(device, cores, initial_value, buffer_type);
 }
 
 GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    CoreRangeSet&& cores,
-    uint32_t initial_value,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type, sub_device_ids);
+    IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) {
+    return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type);
 }
 
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
@@ -1393,9 +1385,8 @@ GlobalCircularBuffer CreateGlobalCircularBuffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return GlobalCircularBuffer(device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
+    BufferType buffer_type) {
+    return GlobalCircularBuffer(device, sender_receiver_core_mapping, size, buffer_type);
 }
 
 CBHandle CreateCircularBuffer(

--- a/ttnn/cpp/pybind11/global_circular_buffer.cpp
+++ b/ttnn/cpp/pybind11/global_circular_buffer.cpp
@@ -19,57 +19,39 @@ void py_module(py::module& module) {
     // Single Device APIs
     module.def(
         "create_global_circular_buffer",
-        [](IDevice* device,
-           const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
-           uint32_t size,
-           BufferType buffer_type,
-           const std::vector<SubDeviceId>& sub_device_ids) {
-            return ttnn::global_circular_buffer::create_global_circular_buffer(
-                device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
-        },
+        py::overload_cast<IDevice*, const std::vector<std::pair<CoreCoord, CoreRangeSet>>&, uint32_t, BufferType>(
+            &ttnn::global_circular_buffer::create_global_circular_buffer),
         py::arg("device"),
         py::arg("sender_receiver_core_mapping"),
         py::arg("size"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalCircularBuffer Object on a single device.
 
             Args:
                 device (Device): The device on which to create the global circular buffer.
-                sender_receiver_core_mapping (dict): The mapping of remote sender to remote receiver cores for the circular buffer.
+                sender_receiver_core_mapping (List[Tuple[CoreCoord, CoreRangeSet]]): The mapping of remote sender to remote receiver cores for the circular buffer.
                 size (int): Size of the global circular buffer per core in bytes.
-                buffer_type (BufferType): The type of buffer to use for the global circular buffer.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global circular buffer config to device.
-                Defaults to waiting on all sub-devices.
+                buffer_type (BufferType): The type of buffer to use for the global circular buffer.\
             )doc");
 
     // Multi Device APIs
     module.def(
         "create_global_circular_buffer",
-        [](MeshDevice* mesh_device,
-           const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
-           uint32_t size,
-           BufferType buffer_type,
-           const std::vector<SubDeviceId>& sub_device_ids) {
-            return ttnn::global_circular_buffer::create_global_circular_buffer(
-                mesh_device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
-        },
+        py::overload_cast<MeshDevice*, const std::vector<std::pair<CoreCoord, CoreRangeSet>>&, uint32_t, BufferType>(
+            &ttnn::global_circular_buffer::create_global_circular_buffer),
         py::arg("mesh_device"),
         py::arg("sender_receiver_core_mapping"),
         py::arg("size"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalCircularBuffer Object on a single device.
 
             Args:
                 mesh_device (MeshDevice): The mesh device on which to create the global circular buffer.
-                sender_receiver_core_mapping (dict): The mapping of remote sender to remote receiver cores for the circular buffer.
+                sender_receiver_core_mapping (List[Tuple[CoreCoord, CoreRangeSet]]): The mapping of remote sender to remote receiver cores for the circular buffer.
                 size (int): Size of the global circular buffer per core in bytes.
                 buffer_type (BufferType): The type of buffer to use for the global circular buffer.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global circular buffer config to device.
-                Defaults to waiting on all sub-devices.
             )doc");
 }
 

--- a/ttnn/cpp/pybind11/global_semaphore.cpp
+++ b/ttnn/cpp/pybind11/global_semaphore.cpp
@@ -19,19 +19,12 @@ void py_module(py::module& module) {
     // Single Device APIs
     module.def(
         "create_global_semaphore",
-        [](IDevice* device,
-           const CoreRangeSet& cores,
-           uint32_t initial_value,
-           BufferType buffer_type,
-           const std::vector<SubDeviceId>& sub_device_ids) {
-            return ttnn::global_semaphore::create_global_semaphore(
-                device, cores, initial_value, buffer_type, sub_device_ids);
-        },
+        py::overload_cast<IDevice*, const CoreRangeSet&, uint32_t, BufferType>(
+            &ttnn::global_semaphore::create_global_semaphore),
         py::arg("device"),
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalSemaphore Object on a single device.
 
@@ -40,8 +33,6 @@ void py_module(py::module& module) {
                 cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
                 initial_value (int): The initial value of the global semaphore.
                 buffer_type (BufferType): The type of buffer to use for the global semaphore.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
-                Defaults to waiting on all sub-devices.
             )doc");
 
     module.def(
@@ -57,40 +48,26 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        [](const GlobalSemaphore& global_semaphore,
-           uint32_t reset_value,
-           const std::vector<SubDeviceId>& sub_device_ids) {
-            ttnn::global_semaphore::reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);
-        },
+        py::overload_cast<const GlobalSemaphore&, uint32_t>(&reset_global_semaphore_value),
         py::arg("global_semaphore"),
         py::arg("reset_value"),
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Reset the value of the global semaphore.
 
             Args:
                 global_semaphore (GlobalSemaphore): The global semaphore object.
                 reset_value (int): The value to reset the global semaphore to.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
-                Defaults to waiting on all sub-devices.
             )doc");
 
     // Multi Device APIs
     module.def(
         "create_global_semaphore",
-        [](MeshDevice* mesh_device,
-           const CoreRangeSet& cores,
-           uint32_t initial_value,
-           BufferType buffer_type,
-           const std::vector<SubDeviceId>& sub_device_ids) {
-            return ttnn::global_semaphore::create_global_semaphore(
-                mesh_device, cores, initial_value, buffer_type, sub_device_ids);
-        },
+        py::overload_cast<MeshDevice*, const CoreRangeSet&, uint32_t, BufferType>(
+            &ttnn::global_semaphore::create_global_semaphore),
         py::arg("mesh_device"),
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Create a GlobalSemaphore Object on a single device.
 
@@ -99,27 +76,15 @@ void py_module(py::module& module) {
                 cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
                 initial_value (int): The initial value of the global semaphore.
                 buffer_type (BufferType): The type of buffer to use for the global semaphore.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
-                Defaults to waiting on all sub-devices.
             )doc");
 
     module.def(
         "create_global_semaphore_with_same_address",
-        [](MeshDevice* mesh_device,
-           const CoreRangeSet& cores,
-           uint32_t initial_value,
-           BufferType buffer_type,
-           const std::vector<SubDeviceId>& sub_device_ids,
-           uint32_t attempts,
-           bool search_max) {
-            return ttnn::global_semaphore::create_global_semaphore_with_same_address(
-                mesh_device, cores, initial_value, buffer_type, sub_device_ids, attempts, search_max);
-        },
+        &ttnn::global_semaphore::create_global_semaphore_with_same_address,
         py::arg("mesh_device"),
         py::arg("cores"),
         py::arg("initial_value"),
         py::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
         py::arg("attempts") = 1000,
         py::arg("search_max") = false,
         R"doc(
@@ -132,9 +97,7 @@ void py_module(py::module& module) {
                 cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
                 initial_value (int): The initial value of the global semaphore.
                 buffer_type (BufferType): The type of buffer to use for the global semaphore.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
                 attempts (int): The number of attempts to create the global semaphore with the same address.
-                Defaults to waiting on all sub-devices.
                 search_max (bool): Whether to search for the maximum address. (default: False, which searches for the minimum address)
             )doc");
 
@@ -151,21 +114,15 @@ void py_module(py::module& module) {
 
     module.def(
         "reset_global_semaphore_value",
-        [](const MultiDeviceGlobalSemaphore& global_semaphore,
-           uint32_t reset_value,
-           const std::vector<SubDeviceId>& sub_device_ids) {
-            ttnn::global_semaphore::reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);
-        },
+        py::overload_cast<const MultiDeviceGlobalSemaphore&, uint32_t>(&reset_global_semaphore_value),
         py::arg("global_semaphore"),
         py::arg("reset_value"),
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Reset the value of the global semaphore.
 
             Args:
                 global_semaphore (GlobalSemaphore): The global semaphore object.
                 reset_value (int): The value to reset the global semaphore to.
-                sub_device_ids (List[ttnn.SubDeviceIds]): Sub-device IDs to wait on before writing the global semaphore value to device.
             )doc");
 }
 

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -65,31 +65,21 @@ void py_module(py::module& module) {
 
     module.def(
         "to_device",
-        py::overload_cast<
-            const ttnn::Tensor&,
-            IDevice*,
-            const std::optional<MemoryConfig>&,
-            uint8_t,
-            const std::vector<SubDeviceId>&>(&ttnn::operations::core::to_device),
+        py::overload_cast<const ttnn::Tensor&, IDevice*, const std::optional<MemoryConfig>&, uint8_t>(
+            &ttnn::operations::core::to_device),
         py::arg("tensor"),
         py::arg("device"),
         py::arg("memory_config") = std::nullopt,
-        py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>());  // TODO #16492: Remove argument
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "to_device",
-        py::overload_cast<
-            const ttnn::Tensor&,
-            MeshDevice*,
-            const std::optional<MemoryConfig>&,
-            uint8_t,
-            const std::vector<SubDeviceId>&>(&ttnn::operations::core::to_device),
+        py::overload_cast<const ttnn::Tensor&, MeshDevice*, const std::optional<MemoryConfig>&, uint8_t>(
+            &ttnn::operations::core::to_device),
         py::arg("tensor"),
         py::arg("device"),
         py::arg("memory_config") = std::nullopt,
         py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Copy tensor from host to device.
 
@@ -98,8 +88,6 @@ void py_module(py::module& module) {
                 device (ttnn.Device | ttnn.MeshDevice): The target device where the tensor will be copied.
                 memory_config (ttnn.MemoryConfig, optional): The memory configuration to use. Defaults to `None`.
                 cq_id (int, optional): The command queue ID to use. Defaults to `0`.
-                sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on before writing the tensor to device memory.
-                If it is not provided, device will stall for all programs of the specified cq to finish before writing the tensor to device memory.
 
             Returns:
                 ttnn.Tensor: The device tensor copy.
@@ -118,7 +106,6 @@ void py_module(py::module& module) {
         py::arg("blocking") = true,
         py::kw_only(),
         py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
         R"doc(
             Copy tensor from device to host.
 
@@ -128,8 +115,6 @@ void py_module(py::module& module) {
 
             Keyword args:
                 cq_id (int, optional): the command queue ID to use. Defaults to `0`.
-                sub_device_ids (List[ttnn.SubDeviceId], optional): the sub-device IDs to wait on before reading the tensor from device memory.
-                If it is not provided, device will stall for all programs of the specified cq to finish before reading the tensor from device memory.
 
             Returns:
                 ttnn.Tensor: the host tensor copy.
@@ -261,8 +246,7 @@ void py_module(py::module& module) {
         &ttnn::operations::core::copy_host_to_device_tensor,
         py::arg("host_tensor"),
         py::arg("device_tensor"),
-        py::arg("cq_id") = ttnn::DefaultQueueId,
-        py::arg("sub_device_ids") = std::vector<SubDeviceId>());  // TODO #16492: Remove argument
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "begin_trace_capture",

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -1050,21 +1050,15 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             "to",
-            py::overload_cast<IDevice*, const MemoryConfig&, uint8_t, const std::vector<SubDeviceId>&>(
-                &Tensor::to, py::const_),
+            py::overload_cast<IDevice*, const MemoryConfig&, uint8_t>(&Tensor::to, py::const_),
             py::arg("device").noconvert(),
             py::arg("mem_config").noconvert() = MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED},
             py::arg("cq_id") = ttnn::DefaultQueueId,
-            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
             py::keep_alive<0, 2>(),
             R"doc(
             Move TT Tensor from host device to TT accelerator device.
 
             Only BFLOAT16 (in ROW_MAJOR or TILE layout) and BFLOAT8_B, BFLOAT4_B (in TILE layout) are supported on device.
-
-            ``sub_device_ids`` can be used to specify which specific sub devices to wait on before writing the tensor to device memory.
-
-            If it is not provided, device will stall for all programs of the specified cq to finish before writing the tensor to device memory.
 
             If ``arg1`` is not supplied, default ``MemoryConfig`` with ``interleaved`` set to ``True``.
 
@@ -1076,8 +1070,6 @@ void pytensor_module(py::module& m_tensor) {
             | arg1      | MemoryConfig of tensor of TT accelerator device | ttnn.MemoryConfig          |                       | No       |
             +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
             | arg2      | CQ ID of TT accelerator device to use           | uint8_t                    |                       | No       |
-            +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
-            | arg3      | Sub device IDs to wait on before writing tensor | List[ttnn.SubDeviceId]     |                       | No       |
             +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
 
             .. code-block:: python
@@ -1092,21 +1084,15 @@ void pytensor_module(py::module& m_tensor) {
             )doc")
         .def(
             "to",
-            py::overload_cast<MeshDevice*, const MemoryConfig&, uint8_t, const std::vector<SubDeviceId>&>(
-                &Tensor::to, py::const_),
+            py::overload_cast<MeshDevice*, const MemoryConfig&, uint8_t>(&Tensor::to, py::const_),
             py::arg("mesh_device").noconvert(),
             py::arg("mem_config").noconvert() = MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED},
             py::arg("cq_id") = ttnn::DefaultQueueId,
-            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
             py::keep_alive<0, 2>(),
             R"doc(
             Move TT Tensor from host device to TT accelerator device.
 
             Only BFLOAT16 (in ROW_MAJOR or TILE layout) and BFLOAT8_B, BFLOAT4_B (in TILE layout) are supported on device.
-
-            ``sub_device_ids`` can be used to specify which specific sub devices to wait on before writing the tensor to device memory.
-
-            If it is not provided, device will stall for all programs of the specified cq to finish before writing the tensor to device memory.
 
             If ``arg1`` is not supplied, default ``MemoryConfig`` with ``interleaved`` set to ``True``.
 
@@ -1118,8 +1104,6 @@ void pytensor_module(py::module& m_tensor) {
             | arg1      | MemoryConfig of tensor of TT accelerator device | ttnn.MemoryConfig          |                       | No       |
             +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
             | arg2      | CQ ID of TT accelerator device to use           | uint8_t                    |                       | No       |
-            +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
-            | arg3      | Sub device IDs to wait before writing tensor    | List[ttnn.SubDeviceId]     |                       | No       |
             +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
 
             .. code-block:: python
@@ -1175,18 +1159,11 @@ void pytensor_module(py::module& m_tensor) {
         )doc")
         .def(
             "cpu",
-            [](const Tensor& self, bool blocking, uint8_t cq_id, const std::vector<SubDeviceId>& sub_device_ids) {
-                return self.cpu(blocking, cq_id, sub_device_ids);
-            },
+            [](const Tensor& self, bool blocking, uint8_t cq_id) { return self.cpu(blocking, cq_id); },
             py::arg("blocking") = true,
             py::arg("cq_id") = ttnn::DefaultQueueId,
-            py::arg("sub_device_ids") = std::vector<SubDeviceId>(),  // TODO #16492: Remove argument
             R"doc(
             Move TT Tensor from TT accelerator device to host device.
-
-            ``sub_device_ids`` can be used to specify which specific sub devices to wait on before reading the tensor from device memory.
-
-            If it is not provided, device will stall waiting for all programs of the specified cq to finish before reading the tensor from device memory.
 
             .. code-block:: python
 

--- a/ttnn/cpp/ttnn/global_circular_buffer.cpp
+++ b/ttnn/cpp/ttnn/global_circular_buffer.cpp
@@ -21,25 +21,23 @@ GlobalCircularBuffer create_global_circular_buffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    BufferType buffer_type) {
     return tt::tt_metal::v1::experimental::CreateGlobalCircularBuffer(
-        device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids);
+        device, sender_receiver_core_mapping, size, buffer_type);
 }
 
 MultiDeviceGlobalCircularBuffer create_global_circular_buffer(
     MeshDevice* mesh_device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    BufferType buffer_type) {
     MultiDeviceGlobalCircularBuffer multi_device_global_cb(mesh_device);
     auto& global_circular_buffers = multi_device_global_cb.global_circular_buffers;
     const auto& devices = mesh_device->get_devices();
     for (uint32_t i = 0; i < devices.size(); ++i) {
         auto* device = devices[i];
         global_circular_buffers.push_back(
-            create_global_circular_buffer(device, sender_receiver_core_mapping, size, buffer_type, sub_device_ids));
+            create_global_circular_buffer(device, sender_receiver_core_mapping, size, buffer_type));
     }
     return multi_device_global_cb;
 }

--- a/ttnn/cpp/ttnn/global_circular_buffer.hpp
+++ b/ttnn/cpp/ttnn/global_circular_buffer.hpp
@@ -23,15 +23,13 @@ GlobalCircularBuffer create_global_circular_buffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    BufferType buffer_type = BufferType::L1);
 
 // Multi Device APIs
 MultiDeviceGlobalCircularBuffer create_global_circular_buffer(
     MeshDevice* mesh_device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    BufferType buffer_type = BufferType::L1);
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/cpp/ttnn/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn/global_semaphore.cpp
@@ -19,35 +19,26 @@ MultiDeviceGlobalSemaphore::MultiDeviceGlobalSemaphore(MeshDevice* mesh_device) 
 }
 
 GlobalSemaphore create_global_semaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    uint32_t initial_value,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    return CreateGlobalSemaphore(device, cores, initial_value, buffer_type, sub_device_ids);
+    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
+    return CreateGlobalSemaphore(device, cores, initial_value, buffer_type);
 }
 
 tt::tt_metal::DeviceAddr get_global_semaphore_address(const GlobalSemaphore& global_semaphore) {
     return global_semaphore.address();
 }
 
-void reset_global_semaphore_value(
-    const GlobalSemaphore& global_semaphore, uint32_t reset_value, tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    global_semaphore.reset_semaphore_value(reset_value, sub_device_ids);
+void reset_global_semaphore_value(const GlobalSemaphore& global_semaphore, uint32_t reset_value) {
+    global_semaphore.reset_semaphore_value(reset_value);
 }
 
 MultiDeviceGlobalSemaphore create_global_semaphore(
-    MeshDevice* mesh_device,
-    const CoreRangeSet& cores,
-    uint32_t initial_value,
-    BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    MeshDevice* mesh_device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
     MultiDeviceGlobalSemaphore multi_device_global_semaphore(mesh_device);
     auto& global_semaphores = multi_device_global_semaphore.global_semaphores;
     const auto& devices = mesh_device->get_devices();
     for (uint32_t i = 0; i < devices.size(); ++i) {
         auto* device = devices[i];
-        global_semaphores.push_back(create_global_semaphore(device, cores, initial_value, buffer_type, sub_device_ids));
+        global_semaphores.push_back(create_global_semaphore(device, cores, initial_value, buffer_type));
     }
     return multi_device_global_semaphore;
 }
@@ -56,7 +47,6 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
     const CoreRangeSet& cores,
     uint32_t initial_value,
     BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids,
     uint32_t attempts,
     bool search_max) {
     MultiDeviceGlobalSemaphore multi_device_global_semaphore(mesh_device);
@@ -64,7 +54,7 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
     for (uint32_t i = 0; i < devices.size(); ++i) {
         auto* device = devices[i];
         multi_device_global_semaphore.global_semaphores.push_back(
-            create_global_semaphore(device, cores, initial_value, buffer_type, sub_device_ids));
+            create_global_semaphore(device, cores, initial_value, buffer_type));
     }
 
     auto global_semaphores = multi_device_global_semaphore.global_semaphores;
@@ -102,13 +92,12 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
                                &cores,
                                initial_value,
                                buffer_type,
-                               sub_device_ids,
                                global_semaphore = &multi_device_global_semaphore.global_semaphores[i]] {
                 size_t attempt = 0;
                 std::vector<GlobalSemaphore> garbage;
                 tt::log_debug("global_semaphore->address(): {}", get_global_semaphore_address(*global_semaphore));
                 while (get_global_semaphore_address(*global_semaphore) != target_addr) {
-                    auto sem = create_global_semaphore(device, cores, initial_value, buffer_type, sub_device_ids);
+                    auto sem = create_global_semaphore(device, cores, initial_value, buffer_type);
 
                     if (i == 0) {
                         tt::log_debug("chkpt 3, sem->address(): {}", get_global_semaphore_address(sem));
@@ -143,12 +132,9 @@ std::vector<tt::tt_metal::DeviceAddr> get_global_semaphore_address(const MultiDe
     return addresses;
 }
 
-void reset_global_semaphore_value(
-    const MultiDeviceGlobalSemaphore& global_semaphore,
-    uint32_t reset_value,
-    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+void reset_global_semaphore_value(const MultiDeviceGlobalSemaphore& global_semaphore, uint32_t reset_value) {
     for (const auto& global_semaphore : global_semaphore.global_semaphores) {
-        reset_global_semaphore_value(global_semaphore, reset_value, sub_device_ids);
+        reset_global_semaphore_value(global_semaphore, reset_value);
     }
 }
 

--- a/ttnn/cpp/ttnn/global_semaphore.hpp
+++ b/ttnn/cpp/ttnn/global_semaphore.hpp
@@ -20,39 +20,27 @@ struct MultiDeviceGlobalSemaphore {
 
 // Single Device APIs
 GlobalSemaphore create_global_semaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    uint32_t initial_value,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
 tt::tt_metal::DeviceAddr get_global_semaphore_address(const GlobalSemaphore& global_semaphore);
 
-void reset_global_semaphore_value(
-    const GlobalSemaphore& global_semaphore,
-    uint32_t reset_value,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+void reset_global_semaphore_value(const GlobalSemaphore& global_semaphore, uint32_t reset_value);
 
 // Multi Device APIs
 MultiDeviceGlobalSemaphore create_global_semaphore(
     MeshDevice* mesh_device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
-    BufferType buffer_type = BufferType::L1,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    BufferType buffer_type = BufferType::L1);
 MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
     MeshDevice* mesh_device,
     const CoreRangeSet& cores,
     uint32_t initial_value,
     BufferType buffer_type,
-    tt::stl::Span<const SubDeviceId> sub_device_ids,
     uint32_t attempts,
     bool search_max = false);
 std::vector<tt::tt_metal::DeviceAddr> get_global_semaphore_address(const MultiDeviceGlobalSemaphore& global_semaphore);
 
-void reset_global_semaphore_value(
-    const MultiDeviceGlobalSemaphore& global_semaphore,
-    uint32_t reset_value,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+void reset_global_semaphore_value(const MultiDeviceGlobalSemaphore& global_semaphore, uint32_t reset_value);
 
 }  // namespace ttnn::global_semaphore

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -59,17 +59,13 @@ ttnn::Tensor squeeze_from_4D(const ttnn::Tensor& tensor, const int rank) {
 }
 
 ttnn::Tensor to_device(
-    const ttnn::Tensor& tensor,
-    IDevice* device,
-    const std::optional<MemoryConfig>& memory_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids) {
+    const ttnn::Tensor& tensor, IDevice* device, const std::optional<MemoryConfig>& memory_config, uint8_t cq_id) {
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
     if (mem_config.is_sharded() and (device->arch() == tt::ARCH::BLACKHOLE)) {
-        auto interleaved_tensor = tensor.to(device, ttnn::DRAM_MEMORY_CONFIG, cq_id, sub_device_ids);
+        auto interleaved_tensor = tensor.to(device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
         return ttnn::interleaved_to_sharded(ttnn::DefaultQueueId, interleaved_tensor, mem_config, std::nullopt);
     } else {
-        return tensor.to(device, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG), cq_id, sub_device_ids);
+        return tensor.to(device, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG), cq_id);
     }
 }
 
@@ -77,15 +73,14 @@ ttnn::Tensor to_device(
     const ttnn::Tensor& tensor,
     MeshDevice* mesh_device,
     const std::optional<MemoryConfig>& memory_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids) {
+    uint8_t cq_id) {
     auto mem_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
     // Currently no direct sharded write support in BLACKHOLE due to alignment issue
     if (mem_config.is_sharded() and (mesh_device->arch() == tt::ARCH::BLACKHOLE)) {
-        auto interleaved_tensor = tensor.to(mesh_device, ttnn::DRAM_MEMORY_CONFIG, cq_id, sub_device_ids);
+        auto interleaved_tensor = tensor.to(mesh_device, ttnn::DRAM_MEMORY_CONFIG, cq_id);
         return ttnn::interleaved_to_sharded(ttnn::DefaultQueueId, interleaved_tensor, mem_config, std::nullopt);
     } else {
-        return tensor.to(mesh_device, mem_config, cq_id, sub_device_ids);
+        return tensor.to(mesh_device, mem_config, cq_id);
     }
 }
 
@@ -109,22 +104,17 @@ ttnn::Tensor allocate_tensor_on_device(
         shape, data_type, layout, mesh_device->get_devices(), memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG));
 }
 
-void copy_host_to_device_tensor(
-    const ttnn::Tensor& host_tensor,
-    ttnn::Tensor device_tensor,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids) {
-    tt::tt_metal::write_tensor(std::move(host_tensor), std::move(device_tensor), cq_id, sub_device_ids);
+void copy_host_to_device_tensor(const ttnn::Tensor& host_tensor, ttnn::Tensor device_tensor, uint8_t cq_id) {
+    tt::tt_metal::write_tensor(std::move(host_tensor), std::move(device_tensor));
 }
 
-ttnn::Tensor from_device(
-    const ttnn::Tensor& tensor, bool blocking, uint8_t cq_id, const std::vector<SubDeviceId>& sub_device_ids) {
+ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking, uint8_t cq_id) {
     // Currently no direct sharded read support in BLACKHOLE due to alignment issue
     if (tensor.is_sharded() and (tensor.device()->arch() == tt::ARCH::BLACKHOLE)) {
         auto interleaved_tensor = ttnn::sharded_to_interleaved(cq_id, tensor, ttnn::DRAM_MEMORY_CONFIG, std::nullopt);
-        return interleaved_tensor.cpu(blocking, cq_id, sub_device_ids);
+        return interleaved_tensor.cpu(blocking, cq_id);
     } else {
-        return tensor.cpu(blocking, cq_id, sub_device_ids);
+        return tensor.cpu(blocking, cq_id);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -28,15 +28,13 @@ ttnn::Tensor to_device(
     const ttnn::Tensor& tensor,
     IDevice* device,
     const std::optional<MemoryConfig>& memory_config,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    const std::vector<SubDeviceId>& = {});
+    uint8_t cq_id = ttnn::DefaultQueueId);
 
 ttnn::Tensor to_device(
     const ttnn::Tensor& tensor,
     MeshDevice* mesh_device,
     const std::optional<MemoryConfig>& memory_config,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    const std::vector<SubDeviceId>& = {});
+    uint8_t cq_id = ttnn::DefaultQueueId);
 
 ttnn::Tensor allocate_tensor_on_device(
     const Shape& shape,
@@ -53,16 +51,9 @@ ttnn::Tensor allocate_tensor_on_device(
     const std::optional<MemoryConfig>& memory_config);
 
 void copy_host_to_device_tensor(
-    const ttnn::Tensor& host_tensor,
-    ttnn::Tensor device_tensor,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    const std::vector<SubDeviceId>& sub_device_ids = {});
+    const ttnn::Tensor& host_tensor, ttnn::Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
 
-ttnn::Tensor from_device(
-    const ttnn::Tensor& tensor,
-    bool blocking = true,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    const std::vector<SubDeviceId>& sub_device_ids = {});
+ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId);
 
 void deallocate(Tensor& tensor, bool force = true);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -185,6 +185,7 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program(
         this->num_links_preferred,
         this->from_remote_sem,
         this->to_remote_sem,
+        this->sub_device_id,
         this->fabric_handle);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
@@ -107,6 +107,7 @@ operation::ProgramWithCallbacks build_reduce_scatter_async_program(
     std::optional<size_t> num_links_preferred,
     const std::shared_ptr<const GlobalSemaphore>& from_remote_sem,
     const std::shared_ptr<const GlobalSemaphore>& to_remote_sem,
+    const std::optional<SubDeviceId>& sub_device_id,
     std::optional<ttnn::ccl::EdmLineFabricOpInterface>& fabric_handle);
 }
 };  // namespace ccl
@@ -125,7 +126,7 @@ ReduceScatterAsync create_reduce_scatter_struct(
     std::optional<size_t> num_links_preferred,
     const std::vector<std::shared_ptr<const GlobalSemaphore>>& from_remote_sems,
     const std::vector<std::shared_ptr<const GlobalSemaphore>>& to_remote_sems,
-    std::unordered_map<chip_id_t, SubDeviceId>& sub_device_id_map,
+    std::optional<SubDeviceId> sub_device_id,
     std::optional<ttnn::ccl::EdmLineFabricOpInterface>& fabric_handle);
 }  // namespace reduce_scatter_detail
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -725,34 +725,20 @@ template std::vector<uint8_t> Tensor::to_vector<uint8_t>() const;
 template std::vector<uint16_t> Tensor::to_vector<uint16_t>() const;
 template std::vector<uint32_t> Tensor::to_vector<uint32_t>() const;
 
-Tensor Tensor::to(
-    IDevice* target_device,
-    const MemoryConfig& mem_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids) const {
-    return tensor_ops::tensor_to(*this, target_device, mem_config, cq_id, sub_device_ids);
+Tensor Tensor::to(IDevice* target_device, const MemoryConfig& mem_config, uint8_t cq_id) const {
+    return tensor_ops::tensor_to(*this, target_device, mem_config, cq_id);
 }
 
-Tensor Tensor::to(
-    distributed::MeshDevice* mesh_device,
-    const MemoryConfig& mem_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids) const {
+Tensor Tensor::to(distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, uint8_t cq_id) const {
     std::vector<IDevice*> workers_to_use = ttnn::distributed::get_mapped_devices(*this, *mesh_device);
-    return tensor_ops::tensor_to(*this, workers_to_use, mem_config, cq_id, sub_device_ids);
+    return tensor_ops::tensor_to(*this, workers_to_use, mem_config, cq_id);
 }
 
-Tensor Tensor::to(
-    const std::vector<IDevice*>& workers,
-    const MemoryConfig& mem_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids) const {
-    return tensor_ops::tensor_to(*this, workers, mem_config, cq_id, sub_device_ids);
+Tensor Tensor::to(const std::vector<IDevice*>& workers, const MemoryConfig& mem_config, uint8_t cq_id) const {
+    return tensor_ops::tensor_to(*this, workers, mem_config, cq_id);
 }
 
-Tensor Tensor::cpu(bool blocking, uint8_t cq_id, const std::vector<SubDeviceId>& sub_device_ids) const {
-    return tensor_ops::tensor_cpu(*this, blocking, cq_id, sub_device_ids);
-}
+Tensor Tensor::cpu(bool blocking, uint8_t cq_id) const { return tensor_ops::tensor_cpu(*this, blocking, cq_id); }
 
 Tensor Tensor::extract_shard(const CoreCoord& core) const {
     ZoneScoped;
@@ -1033,8 +1019,7 @@ Tensor allocate_tensor_on_devices(
     return device_tensor;
 }
 
-void write_tensor(
-    const Tensor& host_tensor, Tensor device_tensor, uint8_t cq_id, const std::vector<SubDeviceId>& sub_device_ids) {
+void write_tensor(const Tensor& host_tensor, Tensor device_tensor, uint8_t cq_id) {
     // Top level wrapper to copy a host tensor to a preallocated device tensor
     TT_ASSERT(device_tensor.workers.size(), "Workers must be specified for device_tensor in write_tensor");
 
@@ -1050,7 +1035,7 @@ void write_tensor(
 
     for (int worker_index = 0; worker_index < device_tensor.workers.size(); ++worker_index) {
         auto& worker = device_tensor.workers[worker_index];
-        worker->push_work([cq_id, worker, worker_index, async_safe_tensor, device_tensor, sub_device_ids]() mutable {
+        worker->push_work([cq_id, worker, worker_index, async_safe_tensor, device_tensor]() mutable {
             TT_FATAL(
                 device_tensor.storage_type() == StorageType::DEVICE or
                     device_tensor.storage_type() == StorageType::MULTI_DEVICE,
@@ -1062,8 +1047,7 @@ void write_tensor(
                 "Error");
             std::visit(
                 tt::stl::overloaded{
-                    [worker, worker_index, cq_id, &async_safe_tensor, sub_device_ids](
-                        const DeviceStorage& device_storage) {
+                    [worker, worker_index, cq_id, &async_safe_tensor](const DeviceStorage& device_storage) {
                         // Copying from host to a single device.
                         void* host_data = std::visit(
                             tt::stl::overloaded{
@@ -1087,11 +1071,9 @@ void write_tensor(
                             worker->command_queue(cq_id),
                             device_storage.get_buffer(),
                             host_data,
-                            /*blocking=*/false,
-                            sub_device_ids);
+                            /*blocking=*/false);
                     },
-                    [worker, worker_index, cq_id, &async_safe_tensor, sub_device_ids](
-                        const MultiDeviceStorage& device_storage) {
+                    [worker, worker_index, cq_id, &async_safe_tensor](const MultiDeviceStorage& device_storage) {
                         // Copying from host to multi-device.
                         TT_ASSERT(
                             std::holds_alternative<MultiDeviceHostStorage>(async_safe_tensor.get_storage()),
@@ -1104,8 +1086,7 @@ void write_tensor(
                             worker->command_queue(cq_id),
                             device_storage.get_buffer_for_device(worker),
                             host_data,
-                            /*blocking=*/false,
-                            sub_device_ids);
+                            /*blocking=*/false);
                     },
                     [](auto&& s) { TT_THROW("Unreachable"); }},
                 device_tensor.get_storage());

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -177,20 +177,17 @@ struct Tensor {
     Tensor to(
         IDevice* target_device,
         const MemoryConfig& mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
-        uint8_t cq_id = ttnn::DefaultQueueId,
-        const std::vector<SubDeviceId>& sub_device_ids = {}) const;
+        uint8_t cq_id = ttnn::DefaultQueueId) const;
 
     Tensor to(
         distributed::MeshDevice* mesh_device,
         const MemoryConfig& mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
-        uint8_t cq_id = ttnn::DefaultQueueId,
-        const std::vector<SubDeviceId>& sub_device_ids = {}) const;
+        uint8_t cq_id = ttnn::DefaultQueueId) const;
 
     Tensor to(
         const std::vector<IDevice*>& workers,
         const MemoryConfig& mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
-        uint8_t cq_id = ttnn::DefaultQueueId,
-        const std::vector<SubDeviceId>& sub_device_ids = {}) const;
+        uint8_t cq_id = ttnn::DefaultQueueId) const;
 
     Tensor to(Layout target_layout, IDevice* worker = nullptr) const;
 
@@ -201,10 +198,7 @@ struct Tensor {
         const ttnn::SimpleShape& input_tensor_start,
         float pad_value) const;
 
-    Tensor cpu(
-        bool blocking = true,
-        uint8_t cq_id = ttnn::DefaultQueueId,
-        const std::vector<SubDeviceId>& sub_device_ids = {}) const;
+    Tensor cpu(bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId) const;
 
     Tensor unpad(const ttnn::SimpleShape& output_tensor_start, const ttnn::SimpleShape& output_tensor_end) const;
 
@@ -412,11 +406,7 @@ Tensor allocate_tensor_on_devices(
     const std::vector<IDevice*>& devices,
     const MemoryConfig& memory_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED},
     const std::optional<Tile>& tile = std::nullopt);
-void write_tensor(
-    const Tensor& host_tensor,
-    Tensor device_tensor,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    const std::vector<SubDeviceId>& sub_device_ids = {});
+void write_tensor(const Tensor& host_tensor, Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
 
 Tensor set_tensor_id(const Tensor& tensor);
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -195,12 +195,8 @@ DeviceBuffer allocate_buffer_on_device(IDevice* device, const TensorSpec& tensor
 
 template <typename T>
 inline void read_data_from_device_buffer(
-    CommandQueue& cq,
-    DeviceBuffer device_buffer,
-    void* host_buffer_data,
-    bool blocking,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {}) {
-    EnqueueReadBuffer(cq, device_buffer, host_buffer_data, blocking, sub_device_ids);
+    CommandQueue& cq, DeviceBuffer device_buffer, void* host_buffer_data, bool blocking) {
+    EnqueueReadBuffer(cq, device_buffer, host_buffer_data, blocking);
 }
 
 template <typename T>
@@ -213,19 +209,14 @@ inline void read_data_from_device_buffer(DeviceBuffer device_buffer, std::vector
 // ======================================================================================
 
 template <typename T>
-Tensor to_host(
-    const Tensor& tensor,
-    bool blocking = true,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+Tensor to_host(const Tensor& tensor, bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId);
 
 template <typename T>
 Tensor to_device(
     const Tensor& tensor,
     IDevice* target_device,
     const MemoryConfig& memory_config,
-    uint8_t cq_id = ttnn::DefaultQueueId,
-    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    uint8_t cq_id = ttnn::DefaultQueueId);
 
 template <typename T>
 Tensor to_layout(const Tensor& tensor, Layout target_layout);

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -20,26 +20,16 @@ class IDevice;
 
 namespace tt::tt_metal::tensor_ops {
 
-Tensor tensor_to(
-    const Tensor& input_tensor,
-    IDevice* target_device,
-    const MemoryConfig& mem_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids);
+Tensor tensor_to(const Tensor& input_tensor, IDevice* target_device, const MemoryConfig& mem_config, uint8_t cq_id);
 
 Tensor tensor_to(
-    const Tensor& input_tensor,
-    const std::vector<IDevice*>& workers,
-    const MemoryConfig& mem_config,
-    uint8_t cq_id,
-    const std::vector<SubDeviceId>& sub_device_ids);
+    const Tensor& input_tensor, const std::vector<IDevice*>& workers, const MemoryConfig& mem_config, uint8_t cq_id);
 
 Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
 
 Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
 
-Tensor tensor_cpu(
-    const Tensor& input_tensor, bool blocking, uint8_t cq_id, const std::vector<SubDeviceId>& sub_device_ids);
+Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, uint8_t cq_id);
 
 void tensor_print(const Tensor& input_tensor);
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -159,7 +159,6 @@ def from_torch(
     memory_config: Optional[ttnn.MemoryConfig] = None,
     mesh_mapper: Optional[ttnn.TensorToMesh] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
-    sub_device_ids: List[ttnn.SubDeviceId] = [],  # TODO #16492: Remove argument
 ) -> ttnn.Tensor:
     """
     Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. For bfloat8_b or bfloat4_b format, the function itself is called twice,
@@ -179,7 +178,6 @@ def from_torch(
         memory_config (ttnn.MemoryConfig, optional): The desired `ttnn` memory configuration. Defaults to `None`.
         mesh_mapper (ttnn.TensorToMesh, optional): The desired `ttnn` mesh mapper. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
-        sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on. Defaults to sub-devices set by set_sub_device_stall_group.
 
     Returns:
         ttnn.Tensor: The resulting `ttnn` tensor.
@@ -235,7 +233,7 @@ def from_torch(
     if device is not None:
         if memory_config is None:
             memory_config = ttnn.DRAM_MEMORY_CONFIG
-        tensor = ttnn.to_device(tensor, device, memory_config=memory_config, cq_id=cq_id, sub_device_ids=sub_device_ids)
+        tensor = ttnn.to_device(tensor, device, memory_config=memory_config, cq_id=cq_id)
 
     if shape_with_padding is not None and shape_with_padding != tensor.shape and mesh_mapper is None:
         tensor = ttnn.reshape(tensor, shape_with_padding)
@@ -273,7 +271,6 @@ def to_torch(
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
     device: Optional[ttnn.Device] = None,
     cq_id: Optional[int] = ttnn.DefaultQueueId,
-    sub_device_ids: List[ttnn.SubDeviceId] = [],  # TODO #16492: Remove argument
 ) -> "torch.Tensor":
     """
     Converts the `ttnn.Tensor` tensor into a `torch.Tensor`. It does not call to_layout for bfloat8_b or bfloat4_b as we now convert
@@ -289,7 +286,6 @@ def to_torch(
         mesh_composer (ttnn.MeshToTensor, optional): The desired `ttnn` mesh composer. Defaults to `None`.
         device (ttnn.Device, optional): The `ttnn` device of the input tensor. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
-        sub_device_ids (List[ttnn.SubDeviceId], optional): The sub-device IDs to wait on. Defaults to sub-devices set by set_sub_device_stall_group.
 
     Returns:
         torch.Tensor: The converted `torch` tensor.
@@ -305,7 +301,7 @@ def to_torch(
         return mesh_composer.compose(tensor)
 
     if ttnn.is_tensor_storage_on_device(tensor):
-        tensor = ttnn.from_device(tensor, cq_id=cq_id, sub_device_ids=sub_device_ids)
+        tensor = ttnn.from_device(tensor, cq_id=cq_id)
 
     if tensor.storage_type() == ttnn.DEVICE_STORAGE_TYPE:
         raise RuntimeError("ttnn.Tensor cannot be on device when converting to torch.Tensor!")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16492

### Problem description
With the merge of #16473, we can clean up and remove the sub_device_ids propagation that was added to the various apis that do reads/writes.

### What's changed
Remove sub_device_ids parameter from the read/write apis. Replace with usage of `set_sub_device_stall_group` for controlling which sub-devices to stall on.

CI currently in progress

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12705307506
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [x] New/Existing tests provide coverage for changes

T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/12700668486
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12704115423
T3K Freq: https://github.com/tenstorrent/tt-metal/actions/runs/12711234531
TG Unit: https://github.com/tenstorrent/tt-metal/actions/runs/12700675077
TG Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/12700671684