### PR TITLE
Minor SDPA optimizations

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -58,7 +58,7 @@ void reduce_c() {
 
     reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
-    const uint32_t num_tiles = rows * cols;
+    constexpr uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);
     cb_wait_front(in0_cb, num_tiles);
     cb_reserve_back(out_cb, rows);
@@ -105,7 +105,6 @@ void sub_exp_block_bcast_cols_inplace() {
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
     // Postcondition: in1_cb has rows produced
-
     sub_bcast_cols_init_short(in0_cb, in1_cb);
     exp_tile_init<true>();
     cb_wait_front(in0_cb, rows * cols);
@@ -290,7 +289,6 @@ void matmul_blocks(
     // preconditino: in1_cb has K*N produced
     // postcondition: in0_cb is full, in1_cb is empty
     // postcondition: out_cb has M*N produced
-
     mm_block_init_short(
         in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -528,10 +528,7 @@ void MAIN {
                     cb_pop_front(cb_qk_im, qk_chunk_tiles);
 
                     /* OUT_ACC += OUT_IM */
-                    if (k_chunk == 0) {
-                        // Instead of copy, swap.
-                        std::swap(alias_cur_sum, alias_prev_sum);
-                    } else {
+                    if (k_chunk > 0) {
                         /* cb_exp_max_diff = torch.exp(cb_prev_max - cb_cur_max) */
                         sub_exp_block(cb_prev_max, cb_cur_max, cb_exp_max_diff, Sq_chunk_t);
                         cb_pop_front(cb_prev_max, Sq_chunk_t);
@@ -541,15 +538,14 @@ void MAIN {
                         /* cb_cur_sum += cb_prev_sum */
                         add_block_inplace(alias_cur_sum, alias_prev_sum, Sq_chunk_t);
 
-                        // Swap alias_prev_sum and alias_cur_sum
-                        std::swap(alias_prev_sum, alias_cur_sum);
-
                         /* cb_out_accumulate_im *= cb_exp_max_diff */
                         mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(cb_out_accumulate_im, cb_exp_max_diff);
 
                         add_block_inplace(cb_out_accumulate_im, cb_out_im, out_chunk_tiles);
                     }
 
+                    // Swap alias_prev_sum and alias_cur_sum
+                    std::swap(alias_prev_sum, alias_cur_sum);
                     // Set cb_prev_sum and cb_prev_max
                     copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -132,25 +132,34 @@ void sub_exp_block_bcast_cols_inplace() {
     }
 }
 
-void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t rows, uint32_t cols) {
+template <uint32_t rows, uint32_t cols>
+void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
     // Postcondition: in1_cb has rows consumed
 
-    uint32_t num_tiles = rows * cols;
+    constexpr uint32_t num_tiles = rows * cols;
+    constexpr uint32_t dst_tiles = DHT_GRANULARITY;
+    constexpr uint32_t granularity = cols >> LOG2_DHT_GRANULARITY;
     mul_bcast_cols_init_short(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, rows);
     for (uint32_t i = 0; i < rows; ++i) {
-        for (uint32_t j = 0; j < cols; ++j) {
-            acquire_dst();
-            mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
-            cb_pop_front(in0_cb, 1);
-            cb_reserve_back(in0_cb, 1);
-            pack_tile(0, in0_cb);
-            cb_push_back(in0_cb, 1);
-            release_dst();
+        for (uint32_t u = 0; u < granularity; ++u) {
+            tile_regs_acquire();
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                mul_tiles_bcast_cols(in0_cb, in1_cb, j, i, j);
+            }
+            tile_regs_commit();
+            cb_pop_front(in0_cb, dst_tiles);
+            cb_reserve_back(in0_cb, dst_tiles);
+            tile_regs_wait();
+            for (uint32_t j = 0; j < dst_tiles; ++j) {
+                pack_tile(j, in0_cb);
+            }
+            cb_push_back(in0_cb, dst_tiles);
+            tile_regs_release();
         }
     }
     cb_pop_front(in1_cb, rows);
@@ -426,6 +435,10 @@ void MAIN {
                 }
                 cb_wait_front(cb_q_in, q_chunk_tiles);
 
+                // On (k_chunk == 0), mm2 should store directly in cb_out_accumulate_im
+                uint32_t alias_mm2_out = cb_out_accumulate_im;
+                // TODO: alias cur_sum to prev_sum in first iteration
+
                 // loop while k_low < q_high
                 for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
                     const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
@@ -502,7 +515,7 @@ void MAIN {
                     matmul_blocks(
                         cb_qk_im,
                         cb_v_in,
-                        cb_out_im,
+                        alias_mm2_out,
                         Sq_chunk_t,
                         DHt,
                         Sk_chunk_t,
@@ -515,12 +528,12 @@ void MAIN {
                         false /*transpose*/);
 
                     reconfig_data_format_srca(cb_out_im);
+                    // After first iteration, mm2 should store in cb_out_im
+                    alias_mm2_out = cb_out_im;
                     cb_pop_front(cb_qk_im, qk_chunk_tiles);
 
                     /* OUT_ACC += OUT_IM */
                     if (k_chunk == 0) {
-                        copy_block(cb_out_im, cb_out_accumulate_im, out_chunk_tiles);
-
                         copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
                     } else {
                         /* cb_exp_max_diff = torch.exp(cb_prev_max - cb_cur_max) */
@@ -531,7 +544,7 @@ void MAIN {
                         mul_block_inplace(cb_prev_sum, cb_exp_max_diff, Sq_chunk_t);
 
                         /* cb_out_accumulate_im *= cb_exp_max_diff */
-                        mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_exp_max_diff, Sq_chunk_t, DHt);
+                        mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(cb_out_accumulate_im, cb_exp_max_diff);
 
                         /* cb_cur_sum += cb_prev_sum */
                         add_block_inplace(cb_prev_sum, cb_cur_sum, Sq_chunk_t);
@@ -548,7 +561,7 @@ void MAIN {
                 recip_block_inplace(cb_prev_sum, Sq_chunk_t);
 
                 /* cb_out_accumulate_im *= cb_cur_sum */
-                mul_block_bcast_cols_inplace(cb_out_accumulate_im, cb_prev_sum, Sq_chunk_t, DHt);
+                mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(cb_out_accumulate_im, cb_prev_sum);
                 pack_reconfig_data_format(cb_out);
                 copy_block(cb_out_accumulate_im, cb_out, out_chunk_tiles);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -17,8 +17,8 @@
 #include "compute_kernel_api/reduce.h"
 
 namespace NAMESPACE {
-template <uint32_t in0, uint32_t in1, uint32_t num_tiles>
-void max_block_inplace() {
+template <uint32_t num_tiles>
+void max_block_inplace(uint32_t in0, uint32_t in1) {
     // inputs come in full, outputs go out full
     copy_tile_to_dst_init_short(in0);
     max_tile_init();
@@ -92,8 +92,8 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     }
 }
 
-template <uint32_t in0_cb, uint32_t in1_cb, uint32_t rows, uint32_t cols>
-void sub_exp_block_bcast_cols_inplace() {
+template <uint32_t in0_cb, uint32_t rows, uint32_t cols>
+void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb) {
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
@@ -388,8 +388,8 @@ void MAIN {
     constexpr uint32_t cb_qk_im = tt::CBIndex::c_24;
     constexpr uint32_t cb_out_im_A = tt::CBIndex::c_25;
     constexpr uint32_t cb_out_im_B = tt::CBIndex::c_26;
-    constexpr uint32_t cb_cur_max = tt::CBIndex::c_27;
-    constexpr uint32_t cb_prev_max = tt::CBIndex::c_28;
+    constexpr uint32_t cb_max_A = tt::CBIndex::c_27;
+    constexpr uint32_t cb_max_B = tt::CBIndex::c_28;
     constexpr uint32_t cb_sum_A = tt::CBIndex::c_29;
     constexpr uint32_t cb_sum_B = tt::CBIndex::c_30;
     constexpr uint32_t cb_exp_max_diff = tt::CBIndex::c_31;
@@ -430,6 +430,8 @@ void MAIN {
                 // Set up ping pong buffers
                 uint32_t alias_prev_sum = cb_sum_A;
                 uint32_t alias_cur_sum = cb_sum_B;
+                uint32_t alias_prev_max = cb_max_A;
+                uint32_t alias_cur_max = cb_max_B;
                 uint32_t alias_mm2_prev_out = cb_out_im_A;
                 uint32_t alias_mm2_cur_out = cb_out_im_B;
 
@@ -485,15 +487,15 @@ void MAIN {
                         cb_qk_im,
                         cb_identity_scale_in,
                         Sq_chunk_t,
-                        Sk_chunk_t>(cb_cur_max);
+                        Sk_chunk_t>(alias_cur_max);
 
                     if (k_chunk > 0) {
-                        max_block_inplace<cb_cur_max, cb_prev_max, Sq_chunk_t>();
+                        max_block_inplace<Sq_chunk_t>(alias_cur_max, alias_prev_max);
                     }
 
                     /* QK -= cb_cur_max */
                     /* QK = exp(QK)*/
-                    sub_exp_block_bcast_cols_inplace<cb_qk_im, cb_cur_max, Sq_chunk_t, Sk_chunk_t>();
+                    sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, Sk_chunk_t>(alias_cur_max);
 
                     /* cb_cur_sum = sum(cb_qk_im, dim=-1) */
                     reduce_c<
@@ -526,8 +528,8 @@ void MAIN {
                     /* OUT_ACC += OUT_IM */
                     if (k_chunk > 0) {
                         /* cb_exp_max_diff = torch.exp(cb_prev_max - cb_cur_max) */
-                        sub_exp_block(cb_prev_max, cb_cur_max, cb_exp_max_diff, Sq_chunk_t);
-                        cb_pop_front(cb_prev_max, Sq_chunk_t);
+                        sub_exp_block(alias_prev_max, alias_cur_max, cb_exp_max_diff, Sq_chunk_t);
+                        cb_pop_front(alias_prev_max, Sq_chunk_t);
 
                         /* cb_prev_sum *= cb_exp_max_diff */
                         mul_block_inplace(alias_prev_sum, cb_exp_max_diff, Sq_chunk_t);
@@ -542,21 +544,21 @@ void MAIN {
                     // Swap alias_prev_sum and alias_cur_sum
                     std::swap(alias_prev_sum, alias_cur_sum);
                     std::swap(alias_mm2_prev_out, alias_mm2_cur_out);
-                    // Set cb_prev_sum and cb_prev_max
-                    copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
+                    std::swap(alias_prev_max, alias_cur_max);
                 }
 
                 /* cb_cur_sum = 1.0 / cb_cur_sum */
                 recip_block_inplace(alias_prev_sum, Sq_chunk_t);
 
                 /* cb_out_accumulate_im *= cb_cur_sum */
+                // NOTE: PCC bug if we modify below function to directy output to cb_out.
                 mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_mm2_prev_out, alias_prev_sum);
                 pack_reconfig_data_format(cb_out);
                 copy_block(alias_mm2_prev_out, cb_out, out_chunk_tiles);
 
                 cb_pop_front(cb_q_in, q_chunk_tiles);
                 // free up cb_prev_max after K chunks
-                cb_pop_front(cb_prev_max, Sq_chunk_t);
+                cb_pop_front(alias_prev_max, Sq_chunk_t);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -294,12 +294,12 @@ void matmul_blocks(
     mm_block_init_short(
         in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 
-    reconfig_data_format(in1_cb, in0_cb);
-    cb_wait_front(in1_cb, K * N);
-
     uint32_t output_num_tiles = M * N;
     uint32_t out_subblock_num_tiles = subblock_h * subblock_w;
     uint32_t in0_index_offset = 0;
+
+    reconfig_data_format(in1_cb, in0_cb);
+    cb_wait_front(in1_cb, K * N);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; ++in0_subblock) {
         uint32_t in1_index_offset = 0;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -78,6 +78,8 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     // Postcondition: in_cb has num_tiles produced
     copy_tile_to_dst_init_short(in_cb);
     recip_tile_init();
+    reconfig_data_format_srca(in_cb);
+    pack_reconfig_data_format(in_cb);
 
     cb_wait_front(in_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
@@ -522,8 +524,8 @@ void MAIN {
                         out_subblock_w,
                         false /*transpose*/);
 
-                    reconfig_data_format_srca(alias_mm2_cur_out);
                     cb_pop_front(cb_qk_im, qk_chunk_tiles);
+                    reconfig_data_format(alias_prev_max, alias_cur_max);
 
                     /* OUT_ACC += OUT_IM */
                     if (k_chunk > 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -417,10 +417,13 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                             .set_page_size(tt::CBIndex::c_2, v_tile_size);
     auto cb_in2_id = CreateCircularBuffer(program, core_grid, c_in2_config);
 
-    // attn_mask input
-    auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CBIndex::c_3, mask_df}})
-                            .set_page_size(tt::CBIndex::c_3, mask_tile_size);
-    auto cb_in3_id = CreateCircularBuffer(program, core_grid, c_in3_config);
+    // Only create mask buffer if it's going to be used
+    if (use_provided_mask or is_causal) {
+        // attn_mask input
+        auto c_in3_config = CircularBufferConfig(mask_tiles * mask_tile_size, {{tt::CB::c_in3, mask_df}})
+                                .set_page_size(tt::CB::c_in3, mask_tile_size);
+        auto cb_in3_id = CreateCircularBuffer(program, core_grid, c_in3_config);
+    }
 
     // scale input
     auto c_in4_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_4, scalar_df}})

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -242,6 +242,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
 
     const uint32_t dht_granularity = std::min(DHt, dst_size);
     const uint32_t log2_dht_granularity = std::log2(dht_granularity);
+    TT_FATAL(dht_granularity == (1 << log2_dht_granularity), "Error");
 
     // Log these
     tt::log_debug("stats_granularity: {}", stats_granularity);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -240,8 +240,13 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     const uint32_t log2_mul_bcast_granularity = std::log2(mul_bcast_granularity);
     TT_FATAL(mul_bcast_granularity == (1 << log2_mul_bcast_granularity), "Error");
 
-    const uint32_t dht_granularity = std::min(DHt, dst_size);
-    const uint32_t log2_dht_granularity = std::log2(dht_granularity);
+    uint32_t dht_granularity = std::min(DHt, dst_size);
+    uint32_t log2_dht_granularity = std::log2(dht_granularity);
+    // Sometimes DHt is not a power of 2, so granularity should be 1
+    if (dht_granularity != (1 << log2_dht_granularity)) {
+        dht_granularity = 1;
+        log2_dht_granularity = 0;
+    }
     TT_FATAL(dht_granularity == (1 << log2_dht_granularity), "Error");
 
     // Log these


### PR DESCRIPTION
### Ticket
Subtask of #16557

### Problem description
SDPA has quite a few unnecessary operations which make it inefficient, especially as sequence length grows.

### What's changed
- Remove all block copies by efficiently ping-ponging buffers with aliases and `std::swap`
- Use L1 accumulation to update intermediate output to avoid an extra unpack/add/pack
- Reuse DST in `mul_block_bcast_cols_accumulate`
- Fix bug with DST reuse and `dhead=96`
- Don't allocate CB for mask if a mask isn't used. This reduces memory waste and enables larger chunk sizes

For the following test case, we get a nice **1.084x speedup**. 
`tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py::test_sdpa_tt_large_seq[1-8-1-131072-128-k128-q128-bf16]`
```
ID  Total %  Bound  OP Code                    Device Time   Op-to-Op Gap  Cores  DRAM  DRAM %  FLOPs  FLOPs %  Math Fidelity
----------------------------------------------------------------------------------------------------------------------------------
2  100.0 %         OLD ScaledDotProductAttention  1,949,831 us                   64                                BF16, BF16 => BF16
2  100.0 %         NEW ScaledDotProductAttention  1,798,710 us                   64                                BF16, BF16 => BF16
 ```

 
### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12831544820
- [x] Model regression CI testing passes https://github.com/tenstorrent/tt-metal/actions/runs/12831557373
