### PR TITLE
#16495: reduce grid for falcon7b mlp matmul

### DIFF
--- a/tests/ttnn/integration_tests/falcon7b/test_falcon_mlp.py
+++ b/tests/ttnn/integration_tests/falcon7b/test_falcon_mlp.py
@@ -10,7 +10,6 @@ from loguru import logger
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
 
 torch.manual_seed(0)
 
@@ -31,7 +30,7 @@ def torch_functional_falcon_mlp(hidden_states, *, parameters):
 
 
 def ttnn_functional_falcon_linear(hidden_states, parameters):
-    hidden_states = ttnn.matmul(hidden_states, parameters.weight, core_grid=ttnn.CoreGrid(y=4,x=4))
+    hidden_states = ttnn.matmul(hidden_states, parameters.weight, core_grid=ttnn.CoreGrid(y=4, x=4))
     if parameters.get("bias", None):
         hidden_states = hidden_states + parameters.bias
     return hidden_states
@@ -63,7 +62,6 @@ def test_torch_functional_falcon_mlp(model_name, batch_size, sequence_length):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0("#16495: ND PCC failure needs to be investigated")
 @pytest.mark.parametrize("model_name", ["tiiuae/falcon-7b-instruct"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_length", [128])

--- a/tests/ttnn/integration_tests/falcon7b/test_falcon_mlp.py
+++ b/tests/ttnn/integration_tests/falcon7b/test_falcon_mlp.py
@@ -16,7 +16,7 @@ torch.manual_seed(0)
 
 
 def torch_functional_falcon_linear(hidden_states, parameters):
-    hidden_states = hidden_states @ parameters.weight
+    hidden_states = ttnn.matmul(hidden_states, parameters.weight, core_grid=ttnn.CoreGrid(y=4,x=4))
     if parameters.get("bias", None):
         hidden_states = hidden_states + parameters.bias
     return hidden_states

--- a/tests/ttnn/integration_tests/falcon7b/test_falcon_mlp.py
+++ b/tests/ttnn/integration_tests/falcon7b/test_falcon_mlp.py
@@ -16,7 +16,7 @@ torch.manual_seed(0)
 
 
 def torch_functional_falcon_linear(hidden_states, parameters):
-    hidden_states = ttnn.matmul(hidden_states, parameters.weight, core_grid=ttnn.CoreGrid(y=4,x=4))
+    hidden_states = hidden_states @ parameters.weight
     if parameters.get("bias", None):
         hidden_states = hidden_states + parameters.bias
     return hidden_states
@@ -31,7 +31,7 @@ def torch_functional_falcon_mlp(hidden_states, *, parameters):
 
 
 def ttnn_functional_falcon_linear(hidden_states, parameters):
-    hidden_states = hidden_states @ parameters.weight
+    hidden_states = ttnn.matmul(hidden_states, parameters.weight, core_grid=ttnn.CoreGrid(y=4,x=4))
     if parameters.get("bias", None):
         hidden_states = hidden_states + parameters.bias
     return hidden_states


### PR DESCRIPTION
### Ticket
#16495

### Problem description
falcon7b mlp test using full grid matmul was failing in pipelines

### What's changed
use a smaller grid and enable test

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12716177001
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes

Ran the pipeline where the test was failing previously four times. Test passed (in FD WH N150 ttnn nightly wormhole)
- https://github.com/tenstorrent/tt-metal/actions/runs/12716191994
- https://github.com/tenstorrent/tt-metal/actions/runs/12716195770
- https://github.com/tenstorrent/tt-metal/actions/runs/12716180298
- https://github.com/tenstorrent/tt-metal/actions/runs/12716184526