### PR TITLE
#15450: Remove default values from circular buffer parameters in LLK compute APIs: Matmul

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -125,7 +125,7 @@ kernel:
 ```
 namespace NAMESPACE {
 void MAIN {
-  mm_init();
+  mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
   acquire_dst();
 
   cb_wait_front(tt::CBIndex::c_0, /* number of tiles */ 1);
@@ -297,7 +297,7 @@ with `tile_regs_..()` functions like:
 ```
 namespace NAMESPACE {
 void MAIN {
-  mm_init();
+  mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
   cb_wait_front(tt::CBIndex::c_0, /* number of tiles */ 1);
   cb_wait_front(tt::CBIndex::c_1, /* number of tiles */ 1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -115,7 +115,7 @@ void MAIN {
                         }
                         cb_pop_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
                         // reconfigure init for matmul
-                        mm_init_short();
+                        mm_init_short(in0_cb_id, in1_cb_id);
                         // reconfigure unpacker df for src B
                         reconfig_data_format(in1_cb_id, in0_cb_id);
 #endif

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -115,7 +115,7 @@ void MAIN {
                         }
                         cb_pop_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
                         // reconfigure init for matmul
-                        mm_init_short();
+                        mm_init_short(in0_cb_id, in1_cb_id);
                         // reconfigure unpacker df for src B
                         reconfig_data_format(in1_cb_id, in0_cb_id);
 #endif

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/compute_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/compute_local_l1.cpp
@@ -12,7 +12,7 @@ void MAIN {
 
     constexpr int onetile = 1;
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     for (uint32_t mt = 0; mt < sub_Mt; ++mt) {
         for (uint32_t nt = 0; nt < sub_Nt; ++nt) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
@@ -22,7 +22,7 @@ void MAIN {
     uint32_t Kt = get_compile_time_arg_val(2);
     uint32_t Nt = get_compile_time_arg_val(3);
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     // the simplest possible version of outer product blocked matmul
     // the reader is expected to read the A's and B's tile rows and tile columns for each output tile

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm.cpp
@@ -22,7 +22,7 @@ void MAIN {
     uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
     uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     for (uint32_t b = 0; b < batch; b++) {
         bool spill = num_blocks > 1;
@@ -47,7 +47,7 @@ void MAIN {
                             copy_tile(tt::CBIndex::c_24, i, i);
                         }
                         cb_pop_front(tt::CBIndex::c_24, out_subblock_num_tiles);
-                        mm_init_short();
+                        mm_init_short(tt::CBIndex::c_0, tt::CBIndex::c_1);
                     }
 
                     // Compute output sub-block from in0_subblock x in1_subblock

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -115,7 +115,7 @@ void MAIN {
                         }
                         cb_pop_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
                         // reconfigure init for matmul
-                        mm_init_short();
+                        mm_init_short(in0_cb_id, in1_cb_id);
                         // reconfigure unpacker df for src B
                         reconfig_data_format(in1_cb_id, in0_cb_id);
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm_tilize_untilize.cpp
@@ -147,7 +147,7 @@ void MAIN {
                 bool last_out = (in0_block_w_i == in0_num_blocks_w - 1);
                 if (tilize_in0) {
                     tilize_in(in0_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks, tilized_in0_cb_id);
-                    mm_init_short();
+                    mm_init_short(tilized_in0_cb_id, in1_cb_id);
                     cb_wait_front(tilized_in0_cb_id, in0_block_num_tiles);
                 } else {
                     cb_wait_front(in0_cb_id, in0_block_num_tiles);
@@ -217,7 +217,7 @@ void MAIN {
                             // do not pop front bias as it may be used again for subsequent blocks
                             cb_pop_front(out_for_bias_cb_id, out_subblock_num_tiles);
                             // reconfig for matmul
-                            mm_init_short();
+                            mm_init_short(tilize_in0 ? tilized_in0_cb_id : in0_cb_id, in1_cb_id);
                             // reconfig unpacker df for srcB
                             // reconfig_data_format(in1_cb_id, in0_cb_id);
                         }
@@ -251,7 +251,7 @@ void MAIN {
                             untilize_mode_final_matmul_partials_cb,
                             untilize_mode_reblock_cb,
                             out_cb_id);
-                        mm_init_short();
+                        mm_init_short(tilize_in0 ? tilized_in0_cb_id : in0_cb_id, in1_cb_id);
                     }  // last_out
 #endif
                     in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp
@@ -17,7 +17,7 @@ void MAIN {
     uint32_t in1_block_tile_cnt = get_compile_time_arg_val(5);
     uint32_t out_block_tile_cnt = get_compile_time_arg_val(6);
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     acquire_dst();
     for (uint32_t b = 0; b < block_cnt; ++b) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block.cpp
@@ -135,12 +135,12 @@ void MAIN {
     uint32_t untilize_mode_reblock_cb = tt::CBIndex::c_27;
     uint32_t out0_cb = tt::CBIndex::c_16;
 
-    mm_init();
+    mm_init(in0_cb, tt::CBIndex::c_1, out0_cb);
     for (uint32_t block = 0; block < num_blocks; block++) {
         bool last_out = block == (num_blocks - 1);
         if (tilize_in) {
             tilize_activation(in0_cb, in0_subblock_h, in0_block_w, in0_num_subblocks, tilize_mode_tilized_in0_cb);
-            mm_init_short();
+            mm_init_short(tilize_mode_tilized_in0_cb, tt::CBIndex::c_1);
             cb_wait_front(tilize_mode_tilized_in0_cb, in0_block_num_tiles);
         } else {
             cb_wait_front(in0_cb, in0_block_num_tiles);
@@ -160,7 +160,7 @@ void MAIN {
                         copy_tile(matmul_partials_cb, i, i);
                     }
                     cb_pop_front(matmul_partials_cb, out_subblock_num_tiles);
-                    mm_init_short();
+                    mm_init_short(tilize_in ? tilize_mode_tilized_in0_cb : in0_cb, tt::CBIndex::c_1);
                 }
 
                 // Compute output sub-block from in0_subblock x in1_subblock
@@ -217,7 +217,7 @@ void MAIN {
                         untilize_mode_final_matmul_partials_cb,
                         untilize_mode_reblock_cb,
                         out0_cb);
-                    mm_init_short();
+                    mm_init_short(tilize_in ? tilize_mode_tilized_in0_cb : in0_cb, tt::CBIndex::c_1);
                 }
             }
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_generalized.cpp
@@ -132,7 +132,7 @@ void MAIN {
     uint32_t untilize_mode_final_matmul_partials_cb = tt::CBIndex::c_26;
     uint32_t untilize_mode_reblock_cb = tt::CBIndex::c_27;
     uint32_t out0_cb = tt::CBIndex::c_16;
-    mm_init();
+    mm_init(in0_cb, tt::CBIndex::c_1, out0_cb);
     for (uint32_t block_in0_h = 0; block_in0_h < num_blocks_in0_h; block_in0_h++) {
         for (uint32_t block_in1_w = 0; block_in1_w < num_blocks_in1_w; block_in1_w++) {
             enable_reload = false;
@@ -142,7 +142,7 @@ void MAIN {
                 if (tilize_in) {
                     tilize_activation(
                         in0_cb, in0_subblock_h, in0_block_w, in0_num_subblocks, tilize_mode_tilized_in0_cb);
-                    mm_init_short();
+                    mm_init_short(tilize_mode_tilized_in0_cb, tt::CBIndex::c_1);
                     cb_wait_front(tilize_mode_tilized_in0_cb, in0_block_num_tiles);
 
                 } else {
@@ -164,7 +164,7 @@ void MAIN {
                                 copy_tile(matmul_partials_cb, i, i);
                             }
                             cb_pop_front(matmul_partials_cb, out_subblock_num_tiles);
-                            mm_init_short();
+                            mm_init_short(tilize_in ? tilize_mode_tilized_in0_cb : in0_cb, tt::CBIndex::c_1);
                         }
 
                         // Compute output sub-block from in0_subblock x in1_subblock
@@ -224,7 +224,7 @@ void MAIN {
                                 untilize_mode_final_matmul_partials_cb,
                                 untilize_mode_reblock_cb,
                                 out0_cb);
-                            mm_init_short();
+                            mm_init_short(tilize_in ? tilize_mode_tilized_in0_cb : in0_cb, tt::CBIndex::c_1);
                         }
                     }
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
@@ -24,7 +24,7 @@ void MAIN {
 
     bool spill = num_blocks > uint32_t(1);
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
     bool enable_reload = false;
 
     for (uint32_t block = 0; block < num_blocks; block++) {
@@ -45,7 +45,7 @@ void MAIN {
                         copy_tile(tt::CBIndex::c_24, i, i);
                     }
                     cb_pop_front(tt::CBIndex::c_24, out_subblock_num_tiles);
-                    mm_init_short();
+                    mm_init_short(tt::CBIndex::c_0, tt::CBIndex::c_1);
                 }
 
                 // Compute output sub-block from in0_subblock x in1_subblock

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp
@@ -23,7 +23,7 @@ void MAIN {
 
     acquire_dst();
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
     for (uint32_t b = 0; b < block_cnt; ++b) {
         cb_wait_front(tt::CBIndex::c_0, in0_block_tile_cnt);
         cb_wait_front(tt::CBIndex::c_1, in1_block_tile_cnt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_block_compute.cpp
@@ -25,7 +25,7 @@ void MAIN {
 
     // we are looking at block
     // out = in0[r x k]*in1[k x c]
-    mm_init();
+    mm_init(in0_cb, in1_cb, out_cb);
     for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
         acquire_dst();
         if (block_id > 0) {
@@ -35,7 +35,7 @@ void MAIN {
                 copy_tile(partials_cb, i, i);
             }
             cb_pop_front(partials_cb, out_block_num_tiles);
-            mm_init_short();
+            mm_init_short(in0_cb, in1_cb);
         }
         uint32_t out_tile_index = 0;
         uint32_t in0_index_r_offset = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_tile_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/multi_tile_compute.cpp
@@ -22,7 +22,7 @@ void MAIN {
 
     // we are looking at block
     // out = in0[r x k]*in1[k x c]
-    mm_init();
+    mm_init(in0_cb, in1_cb, out_cb);
     acquire_dst();
 
     uint32_t out_tile_index = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/single_tile_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unit_tests/matmul/single_tile_compute.cpp
@@ -19,7 +19,7 @@ void MAIN {
     const uint32_t in1_tile_index = 0;
     const uint32_t out_tile_index = 0;
     const bool transpose = false;
-    mm_init();
+    mm_init(in0_cb, in1_cb, out_cb);
     cb_reserve_back(out_cb, num_out_tiles);
     acquire_dst();
     cb_wait_front(in0_cb, num_in0_tiles);

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -27,9 +27,8 @@ namespace ckernel {
  * | out_cb_id      | The identifier of the output circular buffer (CB)             | uint32_t | 0 to 31                                            | False    |
  * | transpose      | The transpose flag for performing transpose operation on B    | uint32_t | Any positive value will indicate tranpose is set   | False    |
  */
- // clang-format on
-ALWI void mm_init(
-    uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16, const uint32_t transpose = 0) {
+// clang-format on
+ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, const uint32_t transpose = 0) {
     UNPACK((llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 
@@ -103,8 +102,8 @@ ALWI void matmul_tiles_math(uint32_t idst) {
  * | in1_cb_id      | The identifier of the second input circular buffer (CB)       | uint32_t | 0 to 31                                           | False    |
  * | transpose      | The transpose flag for performing transpose operation on B    | uint32_t | Any positive value will indicate tranpose is set  | False    |
  */
- // clang-format on
-ALWI void mm_init_short(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, const uint32_t transpose = 0) {
+// clang-format on
+ALWI void mm_init_short(uint32_t in0_cb_id, uint32_t in1_cb_id, const uint32_t transpose = 0) {
     MATH((llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, transpose)));
     UNPACK((llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose)));
 }
@@ -125,7 +124,7 @@ ALWI void mm_init_short(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, const ui
  */
  // clang-format on
 ALWI void mm_init_short_with_dt(
-    uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t c_in_old_srca = 2, const uint32_t transpose = 0) {
+    uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t c_in_old_srca, const uint32_t transpose = 0) {
     UNPACK((llk_unpack_reconfig_data_format_srca(c_in_old_srca, in1_cb_id)));
     MATH((llk_math_reconfig_data_format_srca(c_in_old_srca, in1_cb_id)));
     mm_init_short(in0_cb_id, in1_cb_id, transpose);
@@ -148,9 +147,9 @@ ALWI void mm_init_short_with_dt(
  */
  // clang-format on
 ALWI void mm_block_init(
-    uint32_t in0_cb_id = 0,
-    uint32_t in1_cb_id = 1,
-    uint32_t out_cb_id = 16,
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t out_cb_id,
     const uint32_t transpose = 0,
     uint32_t ct_dim = 1,
     uint32_t rt_dim = 1,
@@ -221,8 +220,8 @@ ALWI void matmul_block(
  */
  // clang-format on
 ALWI void mm_block_init_short(
-    uint32_t in0_cb_id = 0,
-    uint32_t in1_cb_id = 1,
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
     const uint32_t transpose = 0,
     uint32_t ct_dim = 1,
     uint32_t rt_dim = 1,
@@ -249,9 +248,9 @@ ALWI void mm_block_init_short(
  */
  // clang-format on
 ALWI void mm_block_init_short_with_dt(
-    uint32_t in0_cb_id = 0,
-    uint32_t in1_cb_id = 1,
-    uint32_t old_in1_cb_id = 2,
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t old_in1_cb_id,
     const uint32_t transpose = 0,
     uint32_t ct_dim = 1,
     uint32_t rt_dim = 1,

--- a/tt_metal/programming_examples/matmul_common/kernels/compute/bmm.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/compute/bmm.cpp
@@ -22,7 +22,7 @@ void MAIN {
     uint32_t Kt = get_compile_time_arg_val(2);
     uint32_t Nt = get_compile_time_arg_val(3);
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     // the simplest possible version of outer product blocked matmul
     // the reader is expected to read the A's and B's tile rows and tile columns for each output tile

--- a/tt_metal/programming_examples/matmul_common/kernels/compute/bmm_large_block_zm.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/compute/bmm_large_block_zm.cpp
@@ -22,7 +22,7 @@ void MAIN {
     uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
     uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     for (uint32_t b = 0; b < batch; b++) {
         bool spill = num_blocks > 1;
@@ -47,7 +47,7 @@ void MAIN {
                             copy_tile(tt::CBIndex::c_24, i, i);
                         }
                         cb_pop_front(tt::CBIndex::c_24, out_subblock_num_tiles);
-                        mm_init_short();
+                        mm_init_short(tt::CBIndex::c_0, tt::CBIndex::c_1);
                     }
 
                     // Compute output sub-block from in0_subblock x in1_subblock

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/bmm_tilize_untilize.cpp
@@ -157,7 +157,7 @@ void MAIN {
                 bool last_out = (in0_block_w_i == in0_num_blocks_w - 1);
                 if (tilize_in0) {
                     tilize_in(in0_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks, tilized_in0_cb_id);
-                    mm_init_short();
+                    mm_init_short(tilized_in0_cb_id, in1_cb_id);
                     cb_wait_front(tilized_in0_cb_id, in0_block_num_tiles);
                 } else {
                     cb_wait_front(in0_cb_id, in0_block_num_tiles);
@@ -229,7 +229,7 @@ void MAIN {
                             // do not pop front bias as it may be used again for subsequent blocks
                             cb_pop_front(out_for_bias_cb_id, out_subblock_num_tiles);
                             // reconfig for matmul
-                            mm_init_short();
+                            mm_init_short(tilize_in0 ? tilized_in0_cb_id : in0_cb_id, in1_cb_id);
                             // reconfig unpacker df for srcB
                             // reconfig_data_format(in1_cb_id, in0_cb_id);
                         }
@@ -266,7 +266,7 @@ void MAIN {
                             untilize_mode_final_matmul_partials_cb,
                             untilize_mode_reblock_cb,
                             out_cb_id);
-                        mm_init_short();
+                        mm_init_short(tilize_in0 ? tilized_in0_cb_id : in0_cb_id, in1_cb_id);
                         reconfig_data_format(in1_cb_id, in0_cb_id);
                     }  // last_out
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
@@ -36,7 +36,7 @@ void MAIN {
     const uint32_t my_seq_tiles = seq_t_end - seq_t_start;
     const uint32_t my_cos_sin_tiles = my_seq_tiles * Wt;
 
-    mm_init();
+    mm_init(in_cb, trans_mat_cb, out_cb);
     binary_op_init_common(rotated_in_interm_cb, cos_cb, out_cb);  // General Init for all binary ops
 
     // Get the trans_mat

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -27,7 +27,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(8);
     constexpr uint32_t Ht = get_compile_time_arg_val(9);  // How many rows (tiles) in n_heads dimension
 
-    mm_init();
+    mm_init(in_cb, trans_mat_cb, out_cb);
     binary_op_init_common(rotated_in_interm_cb, sin_cb, sin_interm_cb);  // General Init for all binary ops
 
     // Get the trans_mat

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp
@@ -23,7 +23,7 @@ void MAIN {
     uint32_t Kt = get_compile_time_arg_val(2);
     uint32_t Nt = get_compile_time_arg_val(3);
 
-    mm_init();
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
     // the simplest possible version of outer product blocked matmul
     // the reader is expected to read the A's and B's tile rows and tile columns for each output tile

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w.cpp
@@ -20,7 +20,7 @@ void MAIN {
 #ifndef REDUCE_ROW_SUM_VIA_MM
     reduce_init<true>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #else
-    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2);
+    mm_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #endif
 
     cb_wait_front(tt::CBIndex::c_2, 1);  // scaler tile from the reader

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/joint_sdpa.cpp
@@ -68,7 +68,7 @@ void MAIN {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
-    mm_init();
+    mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
         for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -76,7 +76,7 @@ void MAIN {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
-    mm_init();
+    mm_init(cb_q_in, cb_k_in, cb_out);
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
         for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -127,7 +127,7 @@ void MAIN {
         num_cores_to_wait = k_num_chunks - 1;
     }
 
-    mm_init();
+    mm_init(cb_q_in, cb_k_in, cb_out_final);
     cb_wait_front(cb_q_in, q_chunk_tiles);
 
     for (uint32_t cur_head_work = 0; cur_head_work < num_heads_per_core; ++cur_head_work) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15450)

### Problem description
Default values for circular buffer arguments in the LLK compute API can cause errors. Forgetting to set these arguments explicitly may lead to errors due to wrong cb usage. This PR is specific to the changes in the matmul kernel APIs:

./tt_metal/include/compute_kernel_api/matmul.h

### What's changed
Default values for the circular buffer parameters have been removed from functions within these files. The call chains invoking these functions have been updated to contain explicit arguments for these parameters.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/13395111513)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/13395116648) (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
