### PR TITLE
Remove dev_mem_map.h usage from watcher_device_reader.cpp

### DIFF
--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -14,7 +14,6 @@
 #include "tt_metal/common/metal_soc_descriptor.h"
 
 // FIXME: Avoid dependence on ARCH_NAME specific includes
-#include "dev_mem_map.h"         // for MEM_BRISC_STAC...
 #include "eth_l1_address_map.h"  // for address_map
 #include "hw/inc/dev_msgs.h"
 
@@ -58,18 +57,11 @@ static const char* get_riscv_name(const CoreCoord& core, uint32_t type) {
 
 // Helper function to get stack size by riscv core type
 static uint32_t get_riscv_stack_size(const CoreDescriptor& core, uint32_t type) {
-    switch (type) {
-        case DebugBrisc: return MEM_BRISC_STACK_SIZE;
-        case DebugNCrisc: return MEM_NCRISC_STACK_SIZE;
-        case DebugErisc: return 0;  // Not managed/checked by us.
-        case DebugIErisc: return MEM_IERISC_STACK_SIZE;
-        case DebugSlaveIErisc: return MEM_BRISC_STACK_SIZE;
-        case DebugTrisc0: return MEM_TRISC0_STACK_SIZE;
-        case DebugTrisc1: return MEM_TRISC1_STACK_SIZE;
-        case DebugTrisc2: return MEM_TRISC2_STACK_SIZE;
-        default: TT_THROW("Watcher data corrupted, unexpected riscv type on core {}: {}", core.coord.str(), type);
+    auto stack_size = hal.get_stack_size(type);
+    if (stack_size == 0xdeadbeef) {
+        TT_THROW("Watcher data corrupted, unexpected riscv type on core {}: {}", core.coord.str(), type);
     }
-    return 0;
+    return stack_size;
 }
 
 // Helper function to get string rep of noc target.
@@ -413,7 +405,7 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
 void WatcherDeviceReader::DumpL1Status(CoreDescriptor& core, const launch_msg_t* launch_msg) {
     // Read L1 address 0, looking for memory corruption
     std::vector<uint32_t> data;
-    data = tt::llrt::read_hex_vec_from_core(device->id(), core.coord, MEM_L1_BASE, sizeof(uint32_t));
+    data = tt::llrt::read_hex_vec_from_core(device->id(), core.coord, HAL_MEM_L1_BASE, sizeof(uint32_t));
     if (data[0] != llrt::generate_risc_startup_addr(false)) {
         LogRunningKernels(core, launch_msg);
         TT_THROW("Watcher found corruption at L1[0] on core {}: read {}", core.coord.str(), data[0]);

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -7,6 +7,7 @@
 
 #include "core_config.h"  // ProgrammableCoreType
 #include "dev_mem_map.h"
+#include "dev_msgs.h"
 #include "noc/noc_parameters.h"
 #include "noc/noc_overlay_parameters.h"
 #include "tensix.h"
@@ -75,6 +76,20 @@ void Hal::initialize_bh() {
     this->noc_xy_encoding_func_ = [](uint32_t x, uint32_t y) { return NOC_XY_ENCODING(x, y); };
     this->noc_multicast_encoding_func_ = [](uint32_t x_start, uint32_t y_start, uint32_t x_end, uint32_t y_end) {
         return NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end);
+    };
+
+    this->stack_size_func_ = [](uint32_t type) -> uint32_t {
+        switch (type) {
+            case DebugBrisc: return MEM_BRISC_STACK_SIZE;
+            case DebugNCrisc: return MEM_NCRISC_STACK_SIZE;
+            case DebugErisc: return 0;  // Not managed/checked by us.
+            case DebugIErisc: return MEM_IERISC_STACK_SIZE;
+            case DebugSlaveIErisc: return MEM_BRISC_STACK_SIZE;
+            case DebugTrisc0: return MEM_TRISC0_STACK_SIZE;
+            case DebugTrisc1: return MEM_TRISC1_STACK_SIZE;
+            case DebugTrisc2: return MEM_TRISC2_STACK_SIZE;
+        }
+        return 0xdeadbeef;
     };
 
     this->num_nocs_ = NUM_NOCS;

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -161,6 +161,20 @@ void Hal::initialize_gs() {
         return NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end);
     };
 
+    this->stack_size_func_ = [](uint32_t type) -> uint32_t {
+        switch (type) {
+            case DebugBrisc: return MEM_BRISC_STACK_SIZE;
+            case DebugNCrisc: return MEM_NCRISC_STACK_SIZE;
+            case DebugErisc: return 0;  // Not managed/checked by us.
+            case DebugIErisc: return MEM_IERISC_STACK_SIZE;
+            case DebugSlaveIErisc: return MEM_BRISC_STACK_SIZE;
+            case DebugTrisc0: return MEM_TRISC0_STACK_SIZE;
+            case DebugTrisc1: return MEM_TRISC1_STACK_SIZE;
+            case DebugTrisc2: return MEM_TRISC2_STACK_SIZE;
+        }
+        return 0xdeadbeef;
+    };
+
     this->num_nocs_ = NUM_NOCS;
     this->coordinate_virtualization_enabled_ = COORDINATE_VIRTUALIZATION_ENABLED;
     this->virtual_worker_start_x_ = VIRTUAL_TENSIX_START_X;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -142,6 +142,7 @@ public:
     using ValidRegAddrFunc = std::function<bool(uint32_t)>;
     using NOCXYEncodingFunc = std::function<uint32_t(uint32_t, uint32_t)>;
     using NOCMulticastEncodingFunc = std::function<uint32_t(uint32_t, uint32_t, uint32_t, uint32_t)>;
+    using StackSizeFunc = std::function<uint32_t(uint32_t)>;
 
 private:
     tt::ARCH arch_;
@@ -163,6 +164,7 @@ private:
     ValidRegAddrFunc valid_reg_addr_func_;
     NOCXYEncodingFunc noc_xy_encoding_func_;
     NOCMulticastEncodingFunc noc_multicast_encoding_func_;
+    StackSizeFunc stack_size_func_;
 
 public:
     Hal();
@@ -223,6 +225,8 @@ public:
     }
 
     uint32_t valid_reg_addr(uint32_t addr) { return valid_reg_addr_func_(addr); }
+
+    uint32_t get_stack_size(uint32_t type) { return stack_size_func_(type); }
 };
 
 inline uint32_t Hal::get_programmable_core_type_count() const { return core_info_.size(); }

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -7,6 +7,7 @@
 
 #include "core_config.h"  // ProgrammableCoreType
 #include "dev_mem_map.h"  // MEM_LOCAL_BASE
+#include "dev_msgs.h"
 #include "noc/noc_parameters.h"
 #include "noc/noc_overlay_parameters.h"
 #include "tensix.h"
@@ -76,6 +77,20 @@ void Hal::initialize_wh() {
     this->noc_xy_encoding_func_ = [](uint32_t x, uint32_t y) { return NOC_XY_ENCODING(x, y); };
     this->noc_multicast_encoding_func_ = [](uint32_t x_start, uint32_t y_start, uint32_t x_end, uint32_t y_end) {
         return NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end);
+    };
+
+    this->stack_size_func_ = [](uint32_t type) -> uint32_t {
+        switch (type) {
+            case DebugBrisc: return MEM_BRISC_STACK_SIZE;
+            case DebugNCrisc: return MEM_NCRISC_STACK_SIZE;
+            case DebugErisc: return 0;  // Not managed/checked by us.
+            case DebugIErisc: return MEM_IERISC_STACK_SIZE;
+            case DebugSlaveIErisc: return MEM_BRISC_STACK_SIZE;
+            case DebugTrisc0: return MEM_TRISC0_STACK_SIZE;
+            case DebugTrisc1: return MEM_TRISC1_STACK_SIZE;
+            case DebugTrisc2: return MEM_TRISC2_STACK_SIZE;
+        }
+        return 0xdeadbeef;
     };
 
     this->num_nocs_ = NUM_NOCS;


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/14321

### Problem description
See issue

### What's changed
Move stack size utility function behind that hal.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/12697770519)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
