### PR TITLE
Add option to raise error on failed local/global tensor comparison

### DIFF
--- a/tech_reports/ttnn/comparison-mode.md
+++ b/tech_reports/ttnn/comparison-mode.md
@@ -1,0 +1,24 @@
+# TT-NN Comparison Mode
+Sometimes when debugging a long sequence of operations (such as a model forward pass) it is useful to be able to automatically check the correctness of each individual operation against a known reference.
+
+TT-NN provides a mechanism for doing this called "comparison mode". In this mode, the runtime will automatically insert correctness checks after each operation and report to the user if the output does not match the expected value.
+
+Comparisons are currently done by computing PCC between the operation output and the reference operation output. The sensitivity of this comparison can be modified using the TTNN configuration (see below).
+
+## How to Use it?
+
+To enable comparison mode, the user must update their TTNN configuration. This can be done easily through the `TTNN_CONFIG_OVERRIDES` environment variable:
+
+```sh
+export TTNN_CONFIG_OVERRIDES='{
+    "enable_fast_runtime_mode": false,
+    "enable_comparison_mode": true,
+    "comparison_mode_should_raise_exception": true,
+    "comparison_mode_pcc": 0.999
+}'
+```
+
+- `enable_fast_runtime_mode`: This option controls whether fast runtime mode is enabled or not. Comparison mode currently requires that this feature is disabled. Defaults to `true`.
+- `enable_comparison_mode`: When set to `true`, comparison mode is activated. Defaults to `false`.
+- `comparison_mode_should_raise_exception`: When set to `true`, comparison mode will raise an exception, ending op execution, when encountering an op that fails comparison checks. This is useful for localizing a failing operations when you are running a full model, or want to integrate comparison mode checks into a unit test. Defaults to `false`.
+- `comparison_mode_pcc`: Sets the PCC threshold used in comparison mode.

--- a/tests/ttnn/unit_tests/test_comparison_mode.py
+++ b/tests/ttnn/unit_tests/test_comparison_mode.py
@@ -46,3 +46,29 @@ def test_exp(device, batch_size, h, w):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+
+
+@pytest.mark.requires_fast_runtime_mode_off
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("dim", [-1])
+def test_failed_comparison(device, batch_size, h, w, dim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
+
+    ttnn.softmax.golden_function = lambda x, **_: x  # override the proper golden function implementation
+
+    def run():
+        input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+        input_tensor = ttnn.to_device(input_tensor, device)
+        ttnn.softmax(input_tensor, dim=dim)
+
+    with ttnn.manage_config("enable_comparison_mode", True), ttnn.manage_config("comparison_mode_pcc", 0.99):
+        with ttnn.manage_config("comparison_mode_should_raise_exception", False):
+            run()
+
+        with ttnn.manage_config("comparison_mode_should_raise_exception", True):
+            with pytest.raises(RuntimeError):
+                run()

--- a/ttnn/cpp/ttnn/config.hpp
+++ b/ttnn/cpp/ttnn/config.hpp
@@ -31,6 +31,7 @@ struct Config {
         bool enable_detailed_buffer_report = false;
         bool enable_detailed_tensor_report = false;
         bool enable_comparison_mode = false;
+        bool comparison_mode_should_raise_exception = false;
         float comparison_mode_pcc = 0.9999;
         std::filesystem::path root_report_path = "generated/ttnn/reports";
         std::optional<std::filesystem::path> report_name = std::nullopt;
@@ -86,6 +87,15 @@ public:
                         "Logging cannot be enabled in fast runtime mode. Please disable fast runtime mode if you want "
                         "to enable logging.");
                 }
+            }
+        }
+
+        if (name == "enable_comparison_mode") {
+            if (this->attributes.enable_fast_runtime_mode && this->attributes.enable_comparison_mode) {
+                tt::log_warning(
+                    tt::LogAlways,
+                    "Comparison mode is currently not supported with fast runtime mode enabled. Please disable fast "
+                    "runtime mode ('enable_fast_runtime_mode = false') to use tensor comparison mode.");
             }
         }
 

--- a/ttnn/ttnn/experimental_loader/golden_functions.py
+++ b/ttnn/ttnn/experimental_loader/golden_functions.py
@@ -87,5 +87,6 @@ def _nop_golden_function(input_tensor, *args, **kwargs):
 
 
 ttnn.attach_golden_function(ttnn.interleaved_to_sharded, _nop_golden_function)
+ttnn.attach_golden_function(ttnn.sharded_to_interleaved, _nop_golden_function)
 ttnn.attach_golden_function(ttnn.reshard, _nop_golden_function)
 ttnn.attach_golden_function(ttnn.tilize, _nop_golden_function)


### PR DESCRIPTION
### What's changed
- Add option to raise error on failed local/global tensor comparison
  - Enabling '`comparison_model_should_raise_exception`' will cause the program to crash when an invalid comparison is encountered. 
  - This is useful for finding bugs in scenarios where a large number of operations are being run, since you can use the stack trace to localize bad comparison.
  - Add unit test to validate this new functionality
- Add a warning to tell users that comparison mode cannot be used with fast dispatch.
- Add golden function implementation for `ttnn.conv2d`, `ttnn.max_pool2d`, `ttnn.sharded_to_interleaved`
- Add user documentation for comparison mode

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/12709829447, https://github.com/tenstorrent/tt-metal/actions/runs/12790956554
