### PR TITLE
#16434: DPRINT to read buffer once

### DIFF
--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -23,7 +23,7 @@ Note that the core coordinates are logical coordinates, so worker cores and ethe
 
     export TT_METAL_DPRINT_CORES=0,0                    # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
     export TT_METAL_DPRINT_ETH_CORES=0,0                # optional, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
-    export TT_METAL_DPRINT_CHIPS=0                      # optional, comma separated list of chips
+    export TT_METAL_DPRINT_CHIPS=0                      # optional, comma separated list of chips OR all. Default is all.
     export TT_METAL_DPRINT_RISCVS=BR                    # optional, default is all RISCs. Use a subset of BR,NC,TR0,TR1,TR2
     export TT_METAL_DPRINT_FILE=log.txt                 # optional, default is to print to the screen
     export TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC=0   # optional, enabled by default. Prepends prints with <device id>:(<core x>, <core y>):<RISC>:.

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
@@ -197,6 +197,9 @@ static void RunTest(DPrintFixture* fixture, IDevice* device, tt::DataFormat data
     CircularBufferConfig cb_src0_config = CircularBufferConfig(tile_size, {{CBIndex::c_0, data_format}})
                                               .set_page_size(CBIndex::c_0, tile_size);
     CBHandle cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    CircularBufferConfig cb_intermed_config =
+        CircularBufferConfig(tile_size, {{CBIndex::c_1, data_format}}).set_page_size(CBIndex::c_1, tile_size);
+    CBHandle cb_intermed = tt_metal::CreateCircularBuffer(program, core, cb_intermed_config);
 
     // Dram buffer to send data to, device will read it out of here to print
     tt_metal::InterleavedBufferConfig dram_config{
@@ -208,31 +211,35 @@ static void RunTest(DPrintFixture* fixture, IDevice* device, tt::DataFormat data
     KernelHandle brisc_print_kernel_id = CreateKernel(
         program,
         llrt::RunTimeOptions::get_instance().get_root_dir() +
-            "tests/tt_metal/tt_metal/test_kernels/misc/print_tile.cpp",
+            "tests/tt_metal/tt_metal/test_kernels/misc/print_tile_brisc.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
     KernelHandle ncrisc_print_kernel_id = CreateKernel(
         program,
         llrt::RunTimeOptions::get_instance().get_root_dir() +
-            "tests/tt_metal/tt_metal/test_kernels/misc/print_tile.cpp",
+            "tests/tt_metal/tt_metal/test_kernels/misc/print_tile_ncrisc.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
     KernelHandle trisc_print_kernel_id = CreateKernel(
         program,
         llrt::RunTimeOptions::get_instance().get_root_dir() +
-            "tests/tt_metal/tt_metal/test_kernels/misc/print_tile.cpp",
+            "tests/tt_metal/tt_metal/test_kernels/misc/print_tile_trisc.cpp",
         core,
         ComputeConfig{});
 
-    // BRISC kernel needs dram info via rtargs
-    tt_metal::SetRuntimeArgs(program, brisc_print_kernel_id, core, {dram_buffer_src_addr, (std::uint32_t)0});
+    // BRISC kernel needs dram info via rtargs, every risc needs to know if data is tilized
+    bool is_tilized = (data_format == tt::DataFormat::Bfp8_b) || (data_format == tt::DataFormat::Bfp4_b);
+    tt_metal::SetRuntimeArgs(
+        program, brisc_print_kernel_id, core, {dram_buffer_src_addr, (std::uint32_t)0, is_tilized});
+    tt_metal::SetRuntimeArgs(program, ncrisc_print_kernel_id, core, {is_tilized});
+    tt_metal::SetRuntimeArgs(program, trisc_print_kernel_id, core, {is_tilized});
 
     // Create input tile
     std::vector<uint32_t> u32_vec = GenerateInputTile(data_format);
     /*for (int idx = 0; idx < u32_vec.size(); idx+= 16) {
         string tmp = fmt::format("data[{:#03}:{:#03}]:", idx - 1, idx - 16);
         for (int i = 0; i < 16; i++)
-            tmp += fmt::format(" {:#08x}", u32_vec[idx + 15 - i]);
+            tmp += fmt::format(" 0x{:08x}", u32_vec[idx + 15 - i]);
         log_info("{}", tmp);
     }*/
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_tile_brisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_tile_brisc.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dprint.h"
+#include "debug/ring_buffer.h"
+
+#include "dataflow_api.h"
+void kernel_main() {
+    // Read out the tile we want to print using BRISC, put it in c_in0
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_intermed = tt::CBIndex::c_1;
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t is_tilized = get_arg_val<uint32_t>(2);
+    uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(src_bank_id, src_addr);
+    cb_reserve_back(cb_id, 1);
+    noc_async_read(src_noc_addr, get_write_ptr(cb_id), get_tile_size(cb_id));
+    noc_async_read_barrier();
+    cb_push_back(cb_id, 1);
+
+    cb_wait_front(cb_id, 1);
+    // Print the tile from each RISC, one after another
+    DPRINT << "Print tile from Data0:" << ENDL();
+    DPRINT << TSLICE(cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_RD_PTR, true, is_tilized) << ENDL();
+    DPRINT << RAISE{1};
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_tile_ncrisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_tile_ncrisc.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dprint.h"
+#include "debug/ring_buffer.h"
+#include "dataflow_api.h"
+void dump_tile(uint32_t cb_id) {
+    uint32_t cb1_rd_addr = CB_RD_PTR(cb_id);
+    volatile tt_l1_ptr uint32_t* p = (volatile tt_l1_ptr uint32_t*)cb1_rd_addr;
+    for (int r = 0; r < 17; r++) {
+        DPRINT << DEC() << "[" << SETW(3) << (r - 1) * 16 << ":" << SETW(3) << r * 16 - 1 << "]: " << HEX();
+        for (int c = 15; c >= 0; c--) {
+            DPRINT << "0x" << SETW(8) << p[r * 16 + c] << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
+
+void kernel_main() {
+    // Read out the tile we want to print using BRISC, put it in c_in0
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_intermed = tt::CBIndex::c_1;
+    uint32_t is_tilized = get_arg_val<uint32_t>(0);
+
+    cb_wait_front(cb_id, 1);
+    if (is_tilized) {
+        cb_wait_front(cb_intermed, 1);
+    }
+    DPRINT << WAIT{4};
+    DPRINT << "Print tile from Data1:" << ENDL();
+    // Use NCRISC to test printing untilized
+    DPRINT
+        << TSLICE(
+               is_tilized ? cb_intermed : cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_RD_PTR, true, false)
+        << ENDL();
+}

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -844,20 +844,6 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
     // compute the buffer address for the requested hart
     uint32_t base_addr = GetDprintBufAddr(device, phys_core, hart_id);
     chip_id_t chip_id = device->id();
-
-    // Device is incrementing wpos
-    // Host is reading wpos and incrementing local rpos up to wpos
-    // Device is filling the buffer and in the end waits on host to write rpos
-
-    // TODO(AP) - compare 8-bytes transfer and full buffer transfer latency
-    // First probe only 8 bytes to see if there's anything to read
-    constexpr int eightbytes = 8;
-    auto from_dev = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, eightbytes);
-    uint32_t wpos = from_dev[0], rpos = from_dev[1];
-    uint32_t counter = 0;
-    uint32_t sigval = 0;
-    char val = 0;
-
     HartKey hart_key{chip_id, logical_core, hart_id};
 
     if (!risc_to_prev_type_[hart_key]) {
@@ -910,9 +896,14 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
     }
     raise_wait_lock_.unlock();
 
+    // Device is incrementing wpos
+    // Host is reading wpos and incrementing local rpos up to wpos
+    // Device is filling the buffer and in the end waits on host to write rpos
+    auto from_dev = tt::llrt::read_hex_vec_from_core(chip_id, phys_core, base_addr, DPRINT_BUFFER_SIZE);
+    DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
+    uint32_t rpos = l->aux.rpos;
+    uint32_t wpos = l->aux.wpos;
     if (rpos < wpos) {
-        // Now read the entire buffer
-        from_dev = tt::llrt::read_hex_vec_from_core(chip_id, phys_core, base_addr, DPRINT_BUFFER_SIZE);
         // at this point rpos,wpos can be stale but not reset to 0 by the producer
         // it's ok for the consumer to be behind the latest wpos+rpos from producer
         // since the corresponding data in buffer for stale rpos+wpos will not be overwritten
@@ -920,9 +911,9 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
         // The producer only updates rpos in case of buffer overflow.
         // Then it waits for rpos to first catch up to wpos (rpos update by the consumer) before proceeding
 
-        DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
         constexpr uint32_t bufsize = sizeof(DebugPrintMemLayout::data);
         // parse the input codes
+        uint32_t sigval = 0;
         while (rpos < wpos) {
             DPrintTypeID code = static_cast<DPrintTypeID>(l->data[rpos++]);
             TT_ASSERT(rpos <= bufsize);
@@ -975,12 +966,13 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                     TransferToAndFlushOutputStream(hart_key, intermediate_stream);
                     AssertSize(sz, 1);
                     break;
-                case DPrintSETW:
-                    val = CAST_U8P(ptr)[0];
+                case DPrintSETW: {
+                    char val = CAST_U8P(ptr)[0];
                     *intermediate_stream << setw(val);
                     most_recent_setw = val;
                     AssertSize(sz, 1);
                     break;
+                }
                 case DPrintSETPRECISION:
                     *intermediate_stream << std::setprecision(*ptr);
                     AssertSize(sz, 1);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -300,6 +300,11 @@ void RunTimeOptions::ParseFeatureChipIds(RunTimeDebugFeatures feature, const std
 
     // If the environment variable is not empty, parse it.
     while (env_var_str != nullptr) {
+        // Can also have "all"
+        if (strcmp(env_var_str, "all") == 0) {
+            feature_targets[feature].all_chips = true;
+            break;
+        }
         uint32_t chip;
         if (sscanf(env_var_str, "%d", &chip) != 1) {
             TT_THROW("Invalid {}", env_var_str);
@@ -311,9 +316,9 @@ void RunTimeOptions::ParseFeatureChipIds(RunTimeDebugFeatures feature, const std
         }
     }
 
-    // Default is no chips are specified is chip 0.
+    // Default is no chips are specified is all
     if (chips.size() == 0) {
-        chips.push_back(0);
+        feature_targets[feature].all_chips = true;
     }
     feature_targets[feature].chip_ids = chips;
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16434

Also including a fix for https://github.com/tenstorrent/tt-metal/issues/15694, as well as changing the default TT_METAL_DPRINT_CHIPS to all (an issue run into by model team on TG/TGG)

### Problem description
@miawangTT hit what appears to be a very specific race condition w/ dprint + inter-risc dependencies resulting in some old data being read (specifically wpos was out of sync with print data). Although I have so far been unable to determine exact location where this race is coming from, switching dprint from a double read to single read does seem to fix the cases where I was able to reproduce this.

I do think single read is correct over what we had before, since we were using wpos/rpos from the first read and data from the second read.

### What's changed
Switch DPRINT from reading buffer twice (once first 8 bytes, then conditional second) to a single read. Wasn't sure if the previous method even gave any performance benefit, but it should be fine either way since this is a debug only path.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/12820424793
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) tests passes
- [ ] New/Existing tests provide coverage for changes
